### PR TITLE
Fix PersonaPlex phone integration latency and audio conversion

### DIFF
--- a/atlas_brain/services/personaplex/config.py
+++ b/atlas_brain/services/personaplex/config.py
@@ -29,10 +29,15 @@ def _str_to_bool(value: str) -> bool:
     return value.lower() in ("true", "1", "yes", "on")
 
 
+import logging
+
+logger = logging.getLogger("atlas.personaplex.config")
+
+
 @lru_cache(maxsize=1)
 def get_personaplex_config() -> PersonaPlexConfig:
     """Load PersonaPlex configuration from environment variables."""
-    return PersonaPlexConfig(
+    config = PersonaPlexConfig(
         host=os.environ.get("ATLAS_PERSONAPLEX_HOST", "localhost"),
         port=int(os.environ.get("ATLAS_PERSONAPLEX_PORT", "8998")),
         use_ssl=_str_to_bool(
@@ -48,3 +53,10 @@ def get_personaplex_config() -> PersonaPlexConfig:
             os.environ.get("ATLAS_PERSONAPLEX_READ_TIMEOUT", "30.0")
         ),
     )
+    logger.info(
+        "PersonaPlex config: host=%s port=%d ssl=%s",
+        config.host,
+        config.port,
+        config.use_ssl,
+    )
+    return config


### PR DESCRIPTION
## Summary
- Add Opus frame buffering (1920 samples/80ms) to match Mimi codec frame rate
- Fix sphn library usage for Opus encoding/decoding with proper frame sizes
- Add PersonaPlex pre-warming on inbound webhook to reduce ~6s connection delay
- Stream handler waits for pre-warm completion before processing audio
- Add diagnostic logging throughout audio pipeline for debugging

## Test plan
- [ ] Make phone call to SignalWire number
- [ ] Verify PersonaPlex pre-warms during webhook (check logs for "Pre-warming PersonaPlex")
- [ ] Verify audio flows bidirectionally (check logs for TX/RX audio)
- [ ] Verify reduced initial delay (should be faster than 6s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)