### PR TITLE
[codex] Harden B2B enrichment batch repair reuse handling

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -12,8 +12,7 @@ node_distributions/
 *.ts.net.key
 *.ts.net.crt
 atlas-admin-ui/
-atlas-intel-next/
-atlas-intel-ui/
+# Keep project-rooted frontend apps available to Vercel.
 atlas-mobile/
 atlas-ui/
 atlas_brain/

--- a/atlas-churn-ui/src/pages/Watchlists.test.tsx
+++ b/atlas-churn-ui/src/pages/Watchlists.test.tsx
@@ -601,7 +601,7 @@ describe('Watchlists', () => {
     expect(screen.getByDisplayValue('1')).toBeInTheDocument()
     expect(screen.getByText('Vendor alerts at 7.5+ urgency: 1 hit')).toBeInTheDocument()
     expect(screen.getByText('Account alerts at 8.5+ urgency: 1 hit')).toBeInTheDocument()
-    expect(screen.getByText('Stale policy after 1 day: 1 hit')).toBeInTheDocument()
+    expect(screen.getByText('Stale policy after 1 day: 2 hits')).toBeInTheDocument()
     expect(screen.getByText('Saved View Alert Events')).toBeInTheDocument()
     expect(screen.getByText('Zendesk crossed the vendor alert threshold at 8.2')).toBeInTheDocument()
     expect(screen.getByText('Email delivery log')).toBeInTheDocument()
@@ -812,6 +812,134 @@ describe('Watchlists', () => {
       })
     })
     expect(api.createWatchlistView).not.toHaveBeenCalled()
+  })
+
+  it('sends changed-only and force flags when starting a competitive-set run', async () => {
+    const user = userEvent.setup()
+    api.listCompetitiveSets.mockResolvedValue({
+      competitive_sets: [
+        {
+          id: 'set-1',
+          name: 'Helpdesk core',
+          focal_vendor_name: 'Intercom',
+          competitor_vendor_names: ['Zendesk', 'Freshdesk'],
+          active: true,
+          refresh_mode: 'manual',
+          refresh_interval_hours: null,
+          vendor_synthesis_enabled: true,
+          pairwise_enabled: true,
+          category_council_enabled: false,
+          asymmetry_enabled: true,
+          last_run_at: null,
+          last_success_at: null,
+          last_run_status: null,
+          last_run_summary: {},
+          created_at: '2026-04-07T12:00:00Z',
+          updated_at: '2026-04-07T12:00:00Z',
+        },
+      ],
+      count: 1,
+      defaults: {
+        default_refresh_interval_hours: 24,
+        max_competitors: 5,
+        default_changed_vendors_only: true,
+      },
+    })
+    api.fetchCompetitiveSetPlan.mockResolvedValue({
+      competitive_set: {
+        id: 'set-1',
+        name: 'Helpdesk core',
+      },
+      plan: {
+        competitive_set_id: 'set-1',
+        focal_vendor_name: 'Intercom',
+        vendor_names: ['Intercom', 'Zendesk', 'Freshdesk'],
+        pairwise_pairs: [['Intercom', 'Zendesk'], ['Intercom', 'Freshdesk']],
+        category_names: [],
+        asymmetry_pairs: [['Intercom', 'Zendesk'], ['Intercom', 'Freshdesk']],
+        vendor_synthesis_enabled: true,
+        pairwise_enabled: true,
+        category_council_enabled: false,
+        asymmetry_enabled: true,
+        vendor_job_count: 3,
+        pairwise_job_count: 2,
+        category_job_count: 0,
+        asymmetry_job_count: 2,
+        estimated_total_jobs: 7,
+        estimate: {
+          lookback_days: 30,
+          vendor_jobs_planned: 3,
+          pairwise_jobs_planned: 2,
+          category_jobs_planned: 0,
+          asymmetry_jobs_planned: 2,
+          estimated_vendor_tokens: 1200,
+          estimated_cross_vendor_tokens: 2400,
+          estimated_total_tokens: 3600,
+          estimated_vendor_cost_usd: 0.12,
+          estimated_cross_vendor_cost_usd: 0.24,
+          estimated_total_cost_usd: 0.36,
+          estimated_vendor_tokens_likely_to_reason: 800,
+          estimated_vendor_cost_usd_likely_to_reason: 0.08,
+          vendor_jobs_with_history: 2,
+          vendor_jobs_using_fallback: 1,
+          cross_vendor_jobs_with_history: 3,
+          cross_vendor_jobs_using_fallback: 1,
+          vendor_jobs_with_matching_pools: 2,
+          vendor_jobs_missing_pools: 1,
+          vendor_jobs_likely_to_reason: 2,
+          vendor_jobs_likely_hash_reuse: 1,
+          vendor_jobs_likely_stale_reuse: 0,
+          vendor_jobs_likely_missing_prior: 0,
+          vendor_jobs_likely_hash_changed: 1,
+          vendor_jobs_likely_prior_quality_weak: 0,
+          vendor_jobs_likely_missing_packet_artifacts: 0,
+          vendor_jobs_likely_missing_reference_ids: 0,
+          likely_rerun_vendors: ['Intercom:changed'],
+          likely_reuse_vendors: ['Zendesk:reuse'],
+          recent_vendor_sample_count: 3,
+          recent_cross_vendor_sample_count: 2,
+          note: 'Estimated from recent runs.',
+        },
+      },
+      recent_runs: [],
+    })
+    api.runCompetitiveSetNow.mockResolvedValue({
+      execution_id: 'exec-1',
+      status: 'started',
+      message: 'queued',
+      competitive_set_id: 'set-1',
+      plan: {
+        competitive_set_id: 'set-1',
+      },
+    })
+
+    render(
+      <MemoryRouter>
+        <Watchlists />
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('Helpdesk core')
+    await user.click(screen.getByRole('button', { name: 'Preview cost' }))
+
+    await waitFor(() => {
+      expect(api.fetchCompetitiveSetPlan).toHaveBeenCalledWith('set-1')
+    })
+
+    await user.click(screen.getByLabelText('Run changed vendors only'))
+    await user.click(screen.getByLabelText('Force vendor rerun'))
+    await user.click(screen.getByLabelText('Force cross-vendor synthesis'))
+    await user.click(screen.getByRole('button', { name: 'Run now' }))
+
+    await waitFor(() => {
+      expect(api.runCompetitiveSetNow).toHaveBeenCalledWith('set-1', {
+        changed_vendors_only: false,
+        force: true,
+        force_cross_vendor: true,
+      })
+    })
+
+    expect(await screen.findByText('Helpdesk core refresh started (exec-1)')).toBeInTheDocument()
   })
 
   it('matches the active saved view using alert delivery settings too', async () => {

--- a/atlas-churn-ui/src/pages/Watchlists.tsx
+++ b/atlas-churn-ui/src/pages/Watchlists.tsx
@@ -336,6 +336,8 @@ export default function Watchlists() {
   const [competitiveSetPreviews, setCompetitiveSetPreviews] = useState<Record<string, CompetitiveSetPlan>>({})
   const [competitiveSetRuns, setCompetitiveSetRuns] = useState<Record<string, CompetitiveSetRun[]>>({})
   const [competitiveSetChangedOnly, setCompetitiveSetChangedOnly] = useState<Record<string, boolean>>({})
+  const [competitiveSetForceRun, setCompetitiveSetForceRun] = useState<Record<string, boolean>>({})
+  const [competitiveSetForceCrossVendor, setCompetitiveSetForceCrossVendor] = useState<Record<string, boolean>>({})
   const [actionMessage, setActionMessage] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [selectedAccount, setSelectedAccount] = useState<AccountsInMotionFeedItem | null>(null)
@@ -941,6 +943,14 @@ export default function Watchlists() {
         ...current,
         [item.id]: current[item.id] ?? (competitiveSetDefaults?.default_changed_vendors_only ?? true),
       }))
+      setCompetitiveSetForceRun((current) => ({
+        ...current,
+        [item.id]: current[item.id] ?? false,
+      }))
+      setCompetitiveSetForceCrossVendor((current) => ({
+        ...current,
+        [item.id]: current[item.id] ?? false,
+      }))
       setOpenCompetitiveSetPreviewId(item.id)
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to load competitive-set preview')
@@ -956,6 +966,8 @@ export default function Watchlists() {
     try {
       const result = await runCompetitiveSetNow(item.id, {
         changed_vendors_only: competitiveSetChangedOnly[item.id] ?? true,
+        force: competitiveSetForceRun[item.id] ?? false,
+        force_cross_vendor: competitiveSetForceCrossVendor[item.id] ?? false,
       })
       setActionMessage(
         `${item.name} refresh started${result.execution_id ? ` (${result.execution_id})` : ''}`,
@@ -2152,6 +2164,8 @@ export default function Watchlists() {
                 const likelyReuseVendors = (estimate?.likely_reuse_vendors ?? []).slice(0, 6)
                 const previewOpen = openCompetitiveSetPreviewId === item.id
                 const changedOnly = competitiveSetChangedOnly[item.id] ?? true
+                const forceRun = competitiveSetForceRun[item.id] ?? false
+                const forceCrossVendor = competitiveSetForceCrossVendor[item.id] ?? false
                 return (
                   <div key={item.id} className="rounded-lg border border-slate-700/50 bg-slate-950/40 p-3">
                     <div className="flex items-start justify-between gap-3">
@@ -2377,6 +2391,32 @@ export default function Watchlists() {
                             }}
                           />
                           Run changed vendors only
+                        </label>
+                        <label className="mt-2 flex items-center gap-2 rounded-md border border-slate-700/50 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
+                          <input
+                            type="checkbox"
+                            checked={forceRun}
+                            onChange={(event) => {
+                              setCompetitiveSetForceRun((current) => ({
+                                ...current,
+                                [item.id]: event.target.checked,
+                              }))
+                            }}
+                          />
+                          Force vendor rerun
+                        </label>
+                        <label className="mt-2 flex items-center gap-2 rounded-md border border-slate-700/50 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
+                          <input
+                            type="checkbox"
+                            checked={forceCrossVendor}
+                            onChange={(event) => {
+                              setCompetitiveSetForceCrossVendor((current) => ({
+                                ...current,
+                                [item.id]: event.target.checked,
+                              }))
+                            }}
+                          />
+                          Force cross-vendor synthesis
                         </label>
                         <div className="mt-3 flex flex-wrap gap-2">
                           <button

--- a/atlas-intel-next/app/(app)/prospects/page.tsx
+++ b/atlas-intel-next/app/(app)/prospects/page.tsx
@@ -161,6 +161,8 @@ export default function ProspectsPage() {
   const [editingOverrideId, setEditingOverrideId] = useState<string | null>(null)
   const [overrideForm, setOverrideForm] = useState({ company_name_raw: '', search_names: '', domains: '' })
   const [overrideLoading, setOverrideLoading] = useState(false)
+  const [bootstrapLoading, setBootstrapLoading] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   useEffect(() => {
     const t = setTimeout(() => setCoDebouncedSearch(coSearch), 300)
@@ -184,12 +186,12 @@ export default function ProspectsPage() {
     [debouncedSearch, statusFilter, seniorityFilter],
   )
 
-  const { data: mqData, loading: mqLoading, error: mqError, refresh: mqRefresh } = useApiData(
+  const { data: mqData, loading: mqLoading, error: mqError, refresh: mqRefresh, refreshing: mqRefreshing } = useApiData(
     () => fetchManualQueue({ company: mqDebouncedSearch || undefined, limit: 200 }),
     [mqDebouncedSearch],
   )
 
-  const { data: coData, loading: coLoading, error: coError, refresh: coRefresh } = useApiData(
+  const { data: coData, loading: coLoading, error: coError, refresh: coRefresh, refreshing: coRefreshing } = useApiData(
     () => fetchCompanyOverrides({ company: coDebouncedSearch || undefined }),
     [coDebouncedSearch],
   )
@@ -449,24 +451,29 @@ export default function ProspectsPage() {
     {
       key: 'actions',
       header: 'Actions',
-      render: (r) => (
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => startEditOverride(r)}
-            className="text-slate-400 hover:text-cyan-400"
-            title="Edit"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </button>
-          <button
-            onClick={() => handleDeleteOverride(r.id)}
-            className="text-slate-400 hover:text-red-400"
-            title="Delete"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      ),
+      render: (r) => {
+        if (!r.id) return <span className="text-xs text-slate-500">settings</span>
+        return (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => startEditOverride(r)}
+              disabled={deletingId === r.id}
+              className="text-slate-400 hover:text-cyan-400 disabled:opacity-50"
+              title="Edit"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => handleDeleteOverride(r.id)}
+              disabled={deletingId === r.id}
+              className="text-slate-400 hover:text-red-400 disabled:opacity-50"
+              title="Delete"
+            >
+              {deletingId === r.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+            </button>
+          </div>
+        )
+      },
     },
   ]
 
@@ -528,22 +535,28 @@ export default function ProspectsPage() {
 
   const handleDeleteOverride = async (id: string) => {
     if (!confirm('Delete this company override?')) return
+    setDeletingId(id)
     try {
       await deleteCompanyOverride(id)
       setActionResult('Override deleted')
       coRefresh()
     } catch (err) {
       setActionResult(err instanceof Error ? err.message : 'Delete failed')
+    } finally {
+      setDeletingId(null)
     }
   }
 
   const handleBootstrap = async () => {
+    setBootstrapLoading(true)
     try {
       const result = await bootstrapCompanyOverrides()
       setActionResult(`Bootstrapped ${result.imported} override(s) from settings`)
       coRefresh()
     } catch (err) {
       setActionResult(err instanceof Error ? err.message : 'Bootstrap failed')
+    } finally {
+      setBootstrapLoading(false)
     }
   }
 
@@ -598,10 +611,10 @@ export default function ProspectsPage() {
               else if (activeTab === 'manual_queue') mqRefresh()
               else coRefresh()
             }}
-            disabled={refreshing}
+            disabled={activeTab === 'prospects' ? refreshing : activeTab === 'manual_queue' ? mqRefreshing : coRefreshing}
             className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors"
           >
-            <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
+            <RefreshCw className={clsx('h-4 w-4', (activeTab === 'prospects' ? refreshing : activeTab === 'manual_queue' ? mqRefreshing : coRefreshing) && 'animate-spin')} />
             Refresh
           </button>
         </div>
@@ -828,10 +841,11 @@ export default function ProspectsPage() {
               </button>
               <button
                 onClick={handleBootstrap}
-                className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors"
+                disabled={bootstrapLoading}
+                className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors disabled:opacity-50"
               >
-                <Building2 className="h-4 w-4" />
-                Bootstrap from Settings
+                {bootstrapLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Building2 className="h-4 w-4" />}
+                {bootstrapLoading ? 'Bootstrapping...' : 'Bootstrap from Settings'}
               </button>
             </div>
           </div>

--- a/atlas-intel-next/app/(app)/prospects/page.tsx
+++ b/atlas-intel-next/app/(app)/prospects/page.tsx
@@ -868,9 +868,18 @@ export default function ProspectsPage() {
                     type="text"
                     value={overrideForm.company_name_raw}
                     onChange={(e) => setOverrideForm((f) => ({ ...f, company_name_raw: e.target.value }))}
-                    className="w-full px-3 py-2 bg-slate-900/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50"
+                    disabled={Boolean(editingOverrideId)}
+                    className={clsx(
+                      'w-full px-3 py-2 bg-slate-900/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50',
+                      editingOverrideId && 'cursor-not-allowed bg-slate-900/30 text-slate-500 focus:border-slate-700/50'
+                    )}
                     placeholder="Acme Corp"
                   />
+                  {editingOverrideId && (
+                    <p className="mt-1 text-[11px] text-slate-500">
+                      Company name is locked while editing. Create a new override to rename the key.
+                    </p>
+                  )}
                 </div>
                 <div>
                   <label className="block text-xs text-slate-400 mb-1">Search Names (comma-separated)</label>

--- a/atlas-intel-next/app/(app)/prospects/page.tsx
+++ b/atlas-intel-next/app/(app)/prospects/page.tsx
@@ -9,14 +9,36 @@ import {
   UserPlus,
   Mail,
   Loader2,
+  Download,
+  X,
+  Plus,
+  Pencil,
+  Trash2,
+  RotateCcw,
+  XCircle,
+  Building2,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import useApiData from '@/lib/hooks/useApiData'
 import DataTable from '@/components/DataTable'
 import StatCard from '@/components/StatCard'
 import type { Column } from '@/components/DataTable'
-import type { Prospect } from '@/lib/types'
-import { fetchProspects, fetchProspectStats } from '@/lib/api/client'
+import type { Prospect, ManualQueueEntry, CompanyOverride } from '@/lib/types'
+import {
+  fetchProspects,
+  fetchProspectStats,
+  fetchManualQueue,
+  resolveManualQueueEntry,
+  fetchCompanyOverrides,
+  upsertCompanyOverride,
+  deleteCompanyOverride,
+  bootstrapCompanyOverrides,
+  downloadProspectsCsv,
+} from '@/lib/api/client'
+
+// ---------------------------------------------------------------------------
+// Badge helpers
+// ---------------------------------------------------------------------------
 
 function ProspectStatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
@@ -64,7 +86,52 @@ function SeniorityBadge({ seniority }: { seniority: string | null }) {
   )
 }
 
+function SequenceStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    active: 'bg-green-500/20 text-green-400',
+    paused: 'bg-amber-500/20 text-amber-400',
+    completed: 'bg-cyan-500/20 text-cyan-400',
+    replied: 'bg-purple-500/20 text-purple-400',
+    bounced: 'bg-red-500/20 text-red-400',
+    unsubscribed: 'bg-slate-500/20 text-slate-400',
+  }
+  return (
+    <span className={clsx('inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium', styles[status] || 'bg-slate-500/20 text-slate-400')}>
+      {status.replace(/_/g, ' ')}
+    </span>
+  )
+}
+
+function QueueStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    manual_review: 'bg-amber-500/20 text-amber-400',
+    pending: 'bg-cyan-500/20 text-cyan-400',
+    enriched: 'bg-green-500/20 text-green-400',
+    not_found: 'bg-slate-500/20 text-slate-400',
+    error: 'bg-red-500/20 text-red-400',
+  }
+  return (
+    <span className={clsx('inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium', styles[status] || 'bg-slate-500/20 text-slate-400')}>
+      {status.replace(/_/g, ' ')}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tab type
+// ---------------------------------------------------------------------------
+
+type ProspectsTab = 'prospects' | 'manual_queue' | 'company_overrides'
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
 export default function ProspectsPage() {
+  const [activeTab, setActiveTab] = useState<ProspectsTab>('prospects')
+  const [actionResult, setActionResult] = useState<string | null>(null)
+
+  // ---- Prospects tab state ----
   const [companySearch, setCompanySearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
@@ -75,6 +142,32 @@ export default function ProspectsPage() {
     return () => clearTimeout(t)
   }, [companySearch])
 
+  // ---- Manual Queue tab state ----
+  const [mqSearch, setMqSearch] = useState('')
+  const [mqDebouncedSearch, setMqDebouncedSearch] = useState('')
+  const [resolvingId, setResolvingId] = useState<string | null>(null)
+  const [resolveDomain, setResolveDomain] = useState('')
+  const [resolveLoading, setResolveLoading] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setMqDebouncedSearch(mqSearch), 300)
+    return () => clearTimeout(t)
+  }, [mqSearch])
+
+  // ---- Company Overrides tab state ----
+  const [coSearch, setCoSearch] = useState('')
+  const [coDebouncedSearch, setCoDebouncedSearch] = useState('')
+  const [showOverrideForm, setShowOverrideForm] = useState(false)
+  const [editingOverrideId, setEditingOverrideId] = useState<string | null>(null)
+  const [overrideForm, setOverrideForm] = useState({ company_name_raw: '', search_names: '', domains: '' })
+  const [overrideLoading, setOverrideLoading] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setCoDebouncedSearch(coSearch), 300)
+    return () => clearTimeout(t)
+  }, [coSearch])
+
+  // ---- Data fetching ----
   const { data: stats, loading: statsLoading } = useApiData(
     fetchProspectStats,
     [],
@@ -91,9 +184,22 @@ export default function ProspectsPage() {
     [debouncedSearch, statusFilter, seniorityFilter],
   )
 
-  const prospects = data?.prospects ?? []
+  const { data: mqData, loading: mqLoading, error: mqError, refresh: mqRefresh } = useApiData(
+    () => fetchManualQueue({ company: mqDebouncedSearch || undefined, limit: 200 }),
+    [mqDebouncedSearch],
+  )
 
-  const columns: Column<Prospect>[] = [
+  const { data: coData, loading: coLoading, error: coError, refresh: coRefresh } = useApiData(
+    () => fetchCompanyOverrides({ company: coDebouncedSearch || undefined }),
+    [coDebouncedSearch],
+  )
+
+  const prospects = data?.prospects ?? []
+  const queueEntries = mqData?.queue ?? []
+  const overrides = coData?.overrides ?? []
+
+  // ---- Prospects columns ----
+  const prospectColumns: Column<Prospect>[] = [
     {
       key: 'company',
       header: 'Company',
@@ -102,6 +208,18 @@ export default function ProspectsPage() {
       ),
       sortable: true,
       sortValue: (r) => r.company_name || '',
+    },
+    {
+      key: 'churning_from',
+      header: 'Churning From',
+      render: (r) =>
+        r.churning_from ? (
+          <span className="text-amber-400 text-sm">{r.churning_from}</span>
+        ) : (
+          <span className="text-xs text-slate-500">--</span>
+        ),
+      sortable: true,
+      sortValue: (r) => r.churning_from || '',
     },
     {
       key: 'name',
@@ -147,6 +265,25 @@ export default function ProspectsPage() {
       sortValue: (r) => r.status,
     },
     {
+      key: 'sequence',
+      header: 'Sequence',
+      render: (r) => {
+        if (!r.related_sequence_status) return <span className="text-xs text-slate-500">--</span>
+        return (
+          <div className="flex items-center gap-1.5">
+            <SequenceStatusBadge status={r.related_sequence_status} />
+            {r.related_sequence_current_step != null && r.related_sequence_max_steps != null && (
+              <span className="text-xs text-slate-400">
+                Step {r.related_sequence_current_step}/{r.related_sequence_max_steps}
+              </span>
+            )}
+          </div>
+        )
+      },
+      sortable: true,
+      sortValue: (r) => r.related_sequence_status || '',
+    },
+    {
       key: 'email_status',
       header: 'Email Valid',
       render: (r) => <EmailStatusBadge status={r.email_status} />,
@@ -164,11 +301,277 @@ export default function ProspectsPage() {
     },
   ]
 
+  // ---- Manual Queue columns ----
+  const mqColumns: Column<ManualQueueEntry>[] = [
+    {
+      key: 'company_name_raw',
+      header: 'Company (raw)',
+      render: (r) => <span className="text-white font-medium">{r.company_name_raw}</span>,
+      sortable: true,
+      sortValue: (r) => r.company_name_raw,
+    },
+    {
+      key: 'company_name_norm',
+      header: 'Normalized',
+      render: (r) => (
+        <span className="text-sm text-slate-300">{r.company_name_norm || '--'}</span>
+      ),
+    },
+    {
+      key: 'domain',
+      header: 'Domain',
+      render: (r) => (
+        <span className="text-sm text-cyan-400 font-mono">{r.domain || '--'}</span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (r) => <QueueStatusBadge status={r.status} />,
+      sortable: true,
+      sortValue: (r) => r.status,
+    },
+    {
+      key: 'error_detail',
+      header: 'Error',
+      render: (r) => (
+        <span className="text-xs text-red-400 line-clamp-1 max-w-[200px]">
+          {r.error_detail || '--'}
+        </span>
+      ),
+    },
+    {
+      key: 'updated_at',
+      header: 'Updated',
+      render: (r) => (
+        <span className="text-xs text-slate-400">
+          {r.updated_at ? new Date(r.updated_at).toLocaleDateString() : '--'}
+        </span>
+      ),
+      sortable: true,
+      sortValue: (r) => r.updated_at || '',
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (r) => {
+        if (r.status !== 'manual_review') return null
+        if (resolvingId === r.id) {
+          return (
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={resolveDomain}
+                onChange={(e) => setResolveDomain(e.target.value)}
+                placeholder="domain.com"
+                className="px-2 py-1 bg-slate-800/50 border border-slate-700/50 rounded text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 w-32"
+              />
+              <button
+                onClick={() => handleResolve(r.id, 'retry')}
+                disabled={resolveLoading}
+                className="text-xs px-2 py-1 bg-cyan-500/20 text-cyan-400 rounded hover:bg-cyan-500/30 disabled:opacity-50"
+              >
+                {resolveLoading ? '...' : 'Retry'}
+              </button>
+              <button
+                onClick={() => { setResolvingId(null); setResolveDomain('') }}
+                className="text-slate-400 hover:text-white"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          )
+        }
+        return (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => { setResolvingId(r.id); setResolveDomain(r.domain || '') }}
+              className="text-xs px-2 py-1 bg-cyan-500/20 text-cyan-400 rounded hover:bg-cyan-500/30"
+              title="Retry with domain"
+            >
+              <RotateCcw className="h-3 w-3" />
+            </button>
+            <button
+              onClick={() => handleResolve(r.id, 'dismiss')}
+              disabled={resolveLoading}
+              className="text-xs px-2 py-1 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30 disabled:opacity-50"
+              title="Dismiss"
+            >
+              <XCircle className="h-3 w-3" />
+            </button>
+          </div>
+        )
+      },
+    },
+  ]
+
+  // ---- Company Overrides columns ----
+  const coColumns: Column<CompanyOverride>[] = [
+    {
+      key: 'company_name_raw',
+      header: 'Company (raw)',
+      render: (r) => <span className="text-white font-medium">{r.company_name_raw}</span>,
+      sortable: true,
+      sortValue: (r) => r.company_name_raw,
+    },
+    {
+      key: 'company_name_norm',
+      header: 'Normalized',
+      render: (r) => (
+        <span className="text-sm text-slate-300">{r.company_name_norm}</span>
+      ),
+    },
+    {
+      key: 'search_names',
+      header: 'Search Names',
+      render: (r) => (
+        <span className="text-sm text-slate-300">{r.search_names.length > 0 ? r.search_names.join(', ') : '--'}</span>
+      ),
+    },
+    {
+      key: 'domains',
+      header: 'Domains',
+      render: (r) => (
+        <span className="text-sm text-cyan-400 font-mono">{r.domains.length > 0 ? r.domains.join(', ') : '--'}</span>
+      ),
+    },
+    {
+      key: 'updated_at',
+      header: 'Updated',
+      render: (r) => (
+        <span className="text-xs text-slate-400">
+          {r.updated_at ? new Date(r.updated_at).toLocaleDateString() : '--'}
+        </span>
+      ),
+      sortable: true,
+      sortValue: (r) => r.updated_at || '',
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (r) => (
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => startEditOverride(r)}
+            className="text-slate-400 hover:text-cyan-400"
+            title="Edit"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={() => handleDeleteOverride(r.id)}
+            className="text-slate-400 hover:text-red-400"
+            title="Delete"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ),
+    },
+  ]
+
+  // ---- Handlers ----
+  const handleResolve = async (id: string, action: 'retry' | 'dismiss') => {
+    setResolveLoading(true)
+    try {
+      await resolveManualQueueEntry(id, {
+        action,
+        domain: action === 'retry' && resolveDomain ? resolveDomain : undefined,
+      })
+      setActionResult(action === 'retry' ? 'Entry queued for retry' : 'Entry dismissed')
+      setResolvingId(null)
+      setResolveDomain('')
+      mqRefresh()
+    } catch (err) {
+      setActionResult(err instanceof Error ? err.message : 'Resolve failed')
+    } finally {
+      setResolveLoading(false)
+    }
+  }
+
+  const startEditOverride = (r: CompanyOverride) => {
+    setEditingOverrideId(r.id)
+    setOverrideForm({
+      company_name_raw: r.company_name_raw,
+      search_names: r.search_names.join(', '),
+      domains: r.domains.join(', '),
+    })
+    setShowOverrideForm(true)
+  }
+
+  const handleSaveOverride = async () => {
+    if (!overrideForm.company_name_raw.trim()) return
+    setOverrideLoading(true)
+    try {
+      const searchNames = overrideForm.search_names
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      const domains = overrideForm.domains
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      await upsertCompanyOverride({
+        company_name_raw: overrideForm.company_name_raw.trim(),
+        search_names: searchNames.length > 0 ? searchNames : undefined,
+        domains: domains.length > 0 ? domains : undefined,
+      })
+      setActionResult(editingOverrideId ? 'Override updated' : 'Override created')
+      resetOverrideForm()
+      coRefresh()
+    } catch (err) {
+      setActionResult(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setOverrideLoading(false)
+    }
+  }
+
+  const handleDeleteOverride = async (id: string) => {
+    if (!confirm('Delete this company override?')) return
+    try {
+      await deleteCompanyOverride(id)
+      setActionResult('Override deleted')
+      coRefresh()
+    } catch (err) {
+      setActionResult(err instanceof Error ? err.message : 'Delete failed')
+    }
+  }
+
+  const handleBootstrap = async () => {
+    try {
+      const result = await bootstrapCompanyOverrides()
+      setActionResult(`Bootstrapped ${result.imported} override(s) from settings`)
+      coRefresh()
+    } catch (err) {
+      setActionResult(err instanceof Error ? err.message : 'Bootstrap failed')
+    }
+  }
+
+  const resetOverrideForm = () => {
+    setShowOverrideForm(false)
+    setEditingOverrideId(null)
+    setOverrideForm({ company_name_raw: '', search_names: '', domains: '' })
+  }
+
+  const handleExportCsv = () => {
+    downloadProspectsCsv({
+      company: debouncedSearch || undefined,
+      status: statusFilter || undefined,
+      seniority: seniorityFilter || undefined,
+    })
+  }
+
   const hasFilters = !!companySearch || !!statusFilter || !!seniorityFilter
   const clearFilters = () => {
     setCompanySearch('')
     setStatusFilter('')
     setSeniorityFilter('')
+  }
+
+  const tabLabels: Record<ProspectsTab, string> = {
+    prospects: 'All Prospects',
+    manual_queue: 'Manual Queue',
+    company_overrides: 'Company Overrides',
   }
 
   return (
@@ -179,14 +582,29 @@ export default function ProspectsPage() {
           <Users className="h-6 w-6 text-cyan-400" />
           <h1 className="text-2xl font-bold text-white">Prospects</h1>
         </div>
-        <button
-          onClick={refresh}
-          disabled={refreshing}
-          className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors"
-        >
-          <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
-          Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          {activeTab === 'prospects' && (
+            <button
+              onClick={handleExportCsv}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors"
+            >
+              <Download className="h-4 w-4" />
+              Export CSV
+            </button>
+          )}
+          <button
+            onClick={() => {
+              if (activeTab === 'prospects') refresh()
+              else if (activeTab === 'manual_queue') mqRefresh()
+              else coRefresh()
+            }}
+            disabled={refreshing}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors"
+          >
+            <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
+            Refresh
+          </button>
+        </div>
       </div>
 
       {/* Stats */}
@@ -218,83 +636,299 @@ export default function ProspectsPage() {
         />
       </div>
 
-      {/* Filters */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
-          <input
-            type="text"
-            value={companySearch}
-            onChange={(e) => setCompanySearch(e.target.value)}
-            placeholder="Search company..."
-            className="pl-9 pr-3 py-2 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 w-56"
-          />
-        </div>
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="bg-slate-800/50 border border-slate-700/50 rounded-lg px-3 py-2 text-sm text-slate-300 focus:outline-none focus:border-cyan-500/50"
-        >
-          <option value="">All Statuses</option>
-          <option value="active">Active</option>
-          <option value="contacted">Contacted</option>
-          <option value="opted_out">Opted Out</option>
-          <option value="bounced">Bounced</option>
-          <option value="suppressed">Suppressed</option>
-        </select>
-        <select
-          value={seniorityFilter}
-          onChange={(e) => setSeniorityFilter(e.target.value)}
-          className="bg-slate-800/50 border border-slate-700/50 rounded-lg px-3 py-2 text-sm text-slate-300 focus:outline-none focus:border-cyan-500/50"
-        >
-          <option value="">All Seniority</option>
-          <option value="c_suite">C-Suite</option>
-          <option value="vp">VP</option>
-          <option value="director">Director</option>
-          <option value="manager">Manager</option>
-          <option value="senior">Senior</option>
-        </select>
-        {hasFilters && (
-          <button
-            onClick={clearFilters}
-            className="text-xs text-slate-400 hover:text-white"
-          >
-            Clear filters
+      {/* Action result banner */}
+      {actionResult && (
+        <div className="bg-cyan-500/10 border border-cyan-500/30 rounded-lg p-3 flex items-center justify-between">
+          <span className="text-sm text-cyan-400">{actionResult}</span>
+          <button onClick={() => setActionResult(null)} className="text-cyan-400 hover:text-white">
+            <X className="h-4 w-4" />
           </button>
-        )}
-      </div>
-
-      {/* Count */}
-      <div className="text-sm text-slate-400">
-        {loading ? (
-          <span className="flex items-center gap-2">
-            <Loader2 className="h-3 w-3 animate-spin" /> Loading...
-          </span>
-        ) : (
-          <span>{data?.count ?? 0} prospects found</span>
-        )}
-      </div>
-
-      {/* Error */}
-      {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-400 text-sm">
-          {error.message}
         </div>
       )}
 
-      {/* Table */}
-      <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
-        {loading ? (
-          <DataTable columns={columns} data={[]} skeletonRows={8} />
-        ) : (
-          <DataTable
-            columns={columns}
-            data={prospects}
-            emptyMessage="No prospects match your filters"
-            emptyAction={hasFilters ? { label: 'Clear all filters', onClick: clearFilters } : undefined}
-          />
-        )}
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-slate-700/50">
+        {(['prospects', 'manual_queue', 'company_overrides'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => { setActiveTab(tab); setActionResult(null) }}
+            className={clsx(
+              'px-4 py-2 text-sm font-medium transition-colors border-b-2',
+              activeTab === tab
+                ? 'text-cyan-400 border-cyan-400'
+                : 'text-slate-400 border-transparent hover:text-white',
+            )}
+          >
+            {tabLabels[tab]}
+          </button>
+        ))}
       </div>
+
+      {/* ================================================================= */}
+      {/* Prospects tab                                                      */}
+      {/* ================================================================= */}
+      {activeTab === 'prospects' && (
+        <>
+          {/* Filters */}
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
+              <input
+                type="text"
+                value={companySearch}
+                onChange={(e) => setCompanySearch(e.target.value)}
+                placeholder="Search company..."
+                className="pl-9 pr-3 py-2 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 w-56"
+              />
+            </div>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="bg-slate-800/50 border border-slate-700/50 rounded-lg px-3 py-2 text-sm text-slate-300 focus:outline-none focus:border-cyan-500/50"
+            >
+              <option value="">All Statuses</option>
+              <option value="active">Active</option>
+              <option value="contacted">Contacted</option>
+              <option value="opted_out">Opted Out</option>
+              <option value="bounced">Bounced</option>
+              <option value="suppressed">Suppressed</option>
+            </select>
+            <select
+              value={seniorityFilter}
+              onChange={(e) => setSeniorityFilter(e.target.value)}
+              className="bg-slate-800/50 border border-slate-700/50 rounded-lg px-3 py-2 text-sm text-slate-300 focus:outline-none focus:border-cyan-500/50"
+            >
+              <option value="">All Seniority</option>
+              <option value="c_suite">C-Suite</option>
+              <option value="vp">VP</option>
+              <option value="director">Director</option>
+              <option value="manager">Manager</option>
+              <option value="senior">Senior</option>
+            </select>
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="text-xs text-slate-400 hover:text-white"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+
+          {/* Count */}
+          <div className="text-sm text-slate-400">
+            {loading ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="h-3 w-3 animate-spin" /> Loading...
+              </span>
+            ) : (
+              <span>{data?.count ?? 0} prospects found</span>
+            )}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-400 text-sm">
+              {error.message}
+            </div>
+          )}
+
+          {/* Table */}
+          <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+            {loading ? (
+              <DataTable columns={prospectColumns} data={[]} skeletonRows={8} />
+            ) : (
+              <DataTable
+                columns={prospectColumns}
+                data={prospects}
+                emptyMessage="No prospects match your filters"
+                emptyAction={hasFilters ? { label: 'Clear all filters', onClick: clearFilters } : undefined}
+              />
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ================================================================= */}
+      {/* Manual Queue tab                                                   */}
+      {/* ================================================================= */}
+      {activeTab === 'manual_queue' && (
+        <>
+          {/* Search */}
+          <div className="flex items-center gap-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
+              <input
+                type="text"
+                value={mqSearch}
+                onChange={(e) => setMqSearch(e.target.value)}
+                placeholder="Search company..."
+                className="pl-9 pr-3 py-2 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 w-56"
+              />
+            </div>
+          </div>
+
+          {/* Count */}
+          <div className="text-sm text-slate-400">
+            {mqLoading ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="h-3 w-3 animate-spin" /> Loading...
+              </span>
+            ) : (
+              <span>{mqData?.count ?? 0} queue entries</span>
+            )}
+          </div>
+
+          {/* Error */}
+          {mqError && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-400 text-sm">
+              {mqError.message}
+            </div>
+          )}
+
+          {/* Table */}
+          <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+            {mqLoading ? (
+              <DataTable columns={mqColumns} data={[]} skeletonRows={8} />
+            ) : (
+              <DataTable
+                columns={mqColumns}
+                data={queueEntries}
+                emptyMessage="No entries in the manual queue"
+              />
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ================================================================= */}
+      {/* Company Overrides tab                                              */}
+      {/* ================================================================= */}
+      {activeTab === 'company_overrides' && (
+        <>
+          {/* Search + actions */}
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
+              <input
+                type="text"
+                value={coSearch}
+                onChange={(e) => setCoSearch(e.target.value)}
+                placeholder="Search company..."
+                className="pl-9 pr-3 py-2 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 w-56"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => { resetOverrideForm(); setShowOverrideForm(true) }}
+                className="flex items-center gap-2 px-3 py-2 text-sm text-cyan-400 bg-cyan-500/10 rounded-lg hover:bg-cyan-500/20 transition-colors"
+              >
+                <Plus className="h-4 w-4" />
+                Add Override
+              </button>
+              <button
+                onClick={handleBootstrap}
+                className="flex items-center gap-2 px-3 py-2 text-sm text-slate-300 bg-slate-800/50 rounded-lg hover:bg-slate-700/50 transition-colors"
+              >
+                <Building2 className="h-4 w-4" />
+                Bootstrap from Settings
+              </button>
+            </div>
+          </div>
+
+          {/* Inline form */}
+          {showOverrideForm && (
+            <div className="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-white">
+                  {editingOverrideId ? 'Edit Override' : 'New Override'}
+                </span>
+                <button onClick={resetOverrideForm} className="text-slate-400 hover:text-white">
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-xs text-slate-400 mb-1">Company Name (required)</label>
+                  <input
+                    type="text"
+                    value={overrideForm.company_name_raw}
+                    onChange={(e) => setOverrideForm((f) => ({ ...f, company_name_raw: e.target.value }))}
+                    className="w-full px-3 py-2 bg-slate-900/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50"
+                    placeholder="Acme Corp"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-slate-400 mb-1">Search Names (comma-separated)</label>
+                  <input
+                    type="text"
+                    value={overrideForm.search_names}
+                    onChange={(e) => setOverrideForm((f) => ({ ...f, search_names: e.target.value }))}
+                    className="w-full px-3 py-2 bg-slate-900/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50"
+                    placeholder="Acme, Acme Corporation"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-slate-400 mb-1">Domains (comma-separated)</label>
+                  <input
+                    type="text"
+                    value={overrideForm.domains}
+                    onChange={(e) => setOverrideForm((f) => ({ ...f, domains: e.target.value }))}
+                    className="w-full px-3 py-2 bg-slate-900/50 border border-slate-700/50 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50"
+                    placeholder="acme.com, acmecorp.com"
+                  />
+                </div>
+              </div>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={resetOverrideForm}
+                  className="px-3 py-2 text-sm text-slate-400 hover:text-white"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSaveOverride}
+                  disabled={overrideLoading || !overrideForm.company_name_raw.trim()}
+                  className="px-4 py-2 text-sm text-white bg-cyan-600 rounded-lg hover:bg-cyan-500 disabled:opacity-50 transition-colors"
+                >
+                  {overrideLoading ? 'Saving...' : editingOverrideId ? 'Update' : 'Create'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Count */}
+          <div className="text-sm text-slate-400">
+            {coLoading ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="h-3 w-3 animate-spin" /> Loading...
+              </span>
+            ) : (
+              <span>{coData?.count ?? 0} overrides</span>
+            )}
+          </div>
+
+          {/* Error */}
+          {coError && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-400 text-sm">
+              {coError.message}
+            </div>
+          )}
+
+          {/* Table */}
+          <div className="bg-slate-900/50 border border-slate-700/50 rounded-xl overflow-hidden">
+            {coLoading ? (
+              <DataTable columns={coColumns} data={[]} skeletonRows={8} />
+            ) : (
+              <DataTable
+                columns={coColumns}
+                data={overrides}
+                emptyMessage="No company overrides configured"
+              />
+            )}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/atlas-intel-next/lib/api/client.ts
+++ b/atlas-intel-next/lib/api/client.ts
@@ -27,6 +27,8 @@ import type {
   BlogEvidence,
   Prospect,
   ProspectStats,
+  ManualQueueEntry,
+  CompanyOverride,
   ReviewQueueDraft,
   AuditEvent,
   BriefingDraft,
@@ -555,6 +557,59 @@ export async function fetchProspects(params?: {
 
 export async function fetchProspectStats() {
   return get<ProspectStats>(PROSPECTS_BASE, '/stats')
+}
+
+export async function fetchManualQueue(params?: {
+  company?: string
+  limit?: number
+  offset?: number
+}) {
+  return get<{ queue: ManualQueueEntry[]; count: number }>(PROSPECTS_BASE, "/manual-queue", params)
+}
+
+export async function resolveManualQueueEntry(
+  id: string,
+  body: { action: "retry" | "dismiss"; domain?: string },
+) {
+  return post<{ entry: ManualQueueEntry }>(PROSPECTS_BASE, `/manual-queue/${id}/resolve`, body)
+}
+
+export async function fetchCompanyOverrides(params?: {
+  company?: string
+}) {
+  return get<{ overrides: CompanyOverride[]; count: number }>(PROSPECTS_BASE, "/company-overrides", params)
+}
+
+export async function upsertCompanyOverride(body: {
+  company_name_raw: string
+  search_names?: string[]
+  domains?: string[]
+}) {
+  return post<{ override: CompanyOverride }>(PROSPECTS_BASE, "/company-overrides", body)
+}
+
+export async function deleteCompanyOverride(id: string) {
+  return del<{ deleted: boolean }>(PROSPECTS_BASE, `/company-overrides/${id}`)
+}
+
+export async function bootstrapCompanyOverrides() {
+  return post<{ imported: number }>(PROSPECTS_BASE, "/company-overrides/bootstrap")
+}
+
+export function downloadProspectsCsv(
+  params?: Record<string, string | number | boolean | undefined>,
+) {
+  const url = new URL(PROSPECTS_BASE + "/export", window.location.origin)
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== null && v !== "") {
+        url.searchParams.set(k, String(v))
+      }
+    }
+  }
+  const token = (typeof window !== "undefined" ? localStorage.getItem("atlas_token") : null)
+  if (token) url.searchParams.set("token", token)
+  window.open(url.toString(), "_blank")
 }
 
 // ---------------------------------------------------------------------------

--- a/atlas-intel-next/lib/types.ts
+++ b/atlas-intel-next/lib/types.ts
@@ -367,6 +367,17 @@ export interface Prospect {
   status: string
   created_at: string
   updated_at: string
+  // Sequence enrollment data (populated by backend when available)
+  churning_from?: string | null
+  target_persona?: string | null
+  related_sequence_id?: string | null
+  related_sequence_status?: string | null
+  related_sequence_current_step?: number | null
+  related_sequence_max_steps?: number | null
+  related_sequence_last_sent_at?: string | null
+  reasoning_scope_summary?: Record<string, unknown>
+  reasoning_atom_context?: Record<string, unknown>
+  reasoning_delta_summary?: Record<string, unknown>
 }
 
 export interface ProspectStats {
@@ -374,6 +385,28 @@ export interface ProspectStats {
   active: number
   contacted: number
   this_month: number
+}
+
+export interface ManualQueueEntry {
+  id: string
+  company_name_raw: string
+  company_name_norm: string | null
+  domain: string | null
+  status: string
+  error_detail: string | null
+  enriched_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CompanyOverride {
+  id: string
+  company_name_raw: string
+  company_name_norm: string
+  search_names: string[]
+  domains: string[]
+  created_at: string | null
+  updated_at: string | null
 }
 
 // ---------------------------------------------------------------------------

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -2,6 +2,8 @@
 API routers for Atlas Brain.
 """
 
+import logging
+
 from fastapi import APIRouter
 
 from .alerts import router as alerts_router
@@ -13,7 +15,6 @@ from .models import router as models_router
 from .query import router as query_router
 from .session import router as session_router
 from .vision import router as vision_router
-from .video import router as video_router
 from .recognition import router as recognition_router
 from .speaker import router as speaker_router
 from .identity import router as identity_router
@@ -55,6 +56,14 @@ from .pipeline_visibility import router as pipeline_visibility_router
 from .b2b_win_loss import router as b2b_win_loss_router
 from .b2b_evidence import router as b2b_evidence_router
 
+logger = logging.getLogger("atlas.api")
+
+try:
+    from .video import router as video_router
+except Exception as exc:
+    video_router = None
+    logger.warning("Video router disabled during api package import: %s", exc)
+
 # Main router that aggregates all sub-routers
 router = APIRouter()
 
@@ -67,7 +76,8 @@ router.include_router(comms_router)
 router.include_router(llm_router)
 router.include_router(session_router)
 router.include_router(vision_router)
-router.include_router(video_router)
+if video_router is not None:
+    router.include_router(video_router)
 router.include_router(recognition_router)
 router.include_router(speaker_router)
 router.include_router(identity_router)

--- a/atlas_brain/api/admin_costs.py
+++ b/atlas_brain/api/admin_costs.py
@@ -6,10 +6,12 @@ Aggregates LLM usage from the local llm_usage table for the cost dashboard.
 from __future__ import annotations
 
 import ast
+import importlib
 import json
 import logging
 import re
 import subprocess
+import sys
 import time
 from collections import Counter
 from datetime import datetime, timedelta, timezone
@@ -38,8 +40,47 @@ _REVIEW_BASIS_RAW_PROVENANCE = "raw_source_provenance"
 _SCRAPE_LOG_BASIS_RAW = "raw_scrape_log"
 
 
+def _ensure_real_numpy_loaded() -> None:
+    current = sys.modules.get("numpy")
+    if current is not None and isinstance(getattr(current, "bool_", None), type):
+        return
+    previous = current
+    if previous is not None:
+        sys.modules.pop("numpy", None)
+    try:
+        real_numpy = importlib.import_module("numpy")
+    except Exception:
+        if previous is not None:
+            sys.modules["numpy"] = previous
+    else:
+        sys.modules["numpy"] = real_numpy
+
+
+_ensure_real_numpy_loaded()
+
+
 def _campaign_batch_stale_minutes() -> int:
-    return int(getattr(settings.b2b_campaign, "anthropic_batch_stale_minutes", 30) or 30)
+    value = getattr(settings.b2b_campaign, "anthropic_batch_stale_minutes", 30)
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value:
+            return 30
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 30
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return int(float(text))
+            except ValueError:
+                return 30
+    return 30
 
 
 def _canonical_review_predicate(alias: str = "") -> str:

--- a/atlas_brain/api/b2b_dashboard.py
+++ b/atlas_brain/api/b2b_dashboard.py
@@ -5359,6 +5359,7 @@ async def _list_accounts_in_motion_from_reviews(
     # Reason: DISTINCT ON per-company dedup + intent_to_leave filter + budget_authority — structurally unique
     conditions = [
         "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
         "(r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true",
         "r.reviewer_company IS NOT NULL",
         "LENGTH(TRIM(r.reviewer_company)) > 3",

--- a/atlas_brain/api/b2b_tenant_dashboard.py
+++ b/atlas_brain/api/b2b_tenant_dashboard.py
@@ -149,10 +149,29 @@ def _coerce_optional_int(value: Any) -> int | None:
         return None
     if isinstance(value, bool):
         return int(value)
-    try:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value:
+            return None
         return int(value)
-    except (TypeError, ValueError):
-        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return int(float(text))
+            except ValueError:
+                return None
+    return None
+
+
+def _coerce_int_with_default(value: Any, default: int) -> int:
+    coerced = _coerce_optional_int(value)
+    return coerced if coerced is not None else default
 
 
 def _parse_timestamp_value(value: Any) -> datetime | None:
@@ -1089,6 +1108,7 @@ async def push_to_crm(
     )
 
     cfg = settings.b2b_webhook
+    max_payload_bytes = _coerce_int_with_default(getattr(cfg, "max_payload_bytes", 65536), 65536)
     pushed = 0
     failed: list[dict[str, str]] = []
 
@@ -1101,11 +1121,11 @@ async def push_to_crm(
         failure_reason = "delivery_failed"
         for sub in subs:
             payload_bytes = _format_for_channel(sub["channel"], envelope)
-            if len(payload_bytes) > cfg.max_payload_bytes:
+            if len(payload_bytes) > max_payload_bytes:
                 logger.warning(
                     "CRM push payload too large (%d bytes, max %d) for account=%s vendor=%s company=%s channel=%s",
                     len(payload_bytes),
-                    cfg.max_payload_bytes,
+                    max_payload_bytes,
                     user.account_id,
                     opp.vendor,
                     opp.company,

--- a/atlas_brain/autonomous/tasks/_b2b_batch_utils.py
+++ b/atlas_brain/autonomous/tasks/_b2b_batch_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 from typing import Any
@@ -13,6 +15,34 @@ _ANTHROPIC_BATCH_SUCCESS_STATUSES = {
     "batch_succeeded",
     "fallback_succeeded",
 }
+
+
+def exact_stage_request_fingerprint(request: Any) -> str:
+    payload = {
+        "namespace": str(getattr(request, "namespace", "") or ""),
+        "provider": str(getattr(request, "provider", "") or ""),
+        "model": str(getattr(request, "model", "") or ""),
+        "request_envelope": getattr(request, "request_envelope", None) or {},
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stored_request_fingerprint(row: Any) -> str | None:
+    metadata = row.get("request_metadata") if hasattr(row, "get") else None
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("request_fingerprint")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
 
 
 def task_metadata(task: Any) -> dict[str, Any]:
@@ -191,6 +221,7 @@ async def reconcile_existing_batch_artifacts(
     task_name: str,
     artifact_type: str,
     artifact_ids: list[str],
+    expected_request_fingerprints: dict[str, str] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Reconcile matching Anthropic batch rows and return the best-known item state.
 
@@ -208,6 +239,14 @@ async def reconcile_existing_batch_artifacts(
     artifact_ids = [str(value) for value in artifact_ids if str(value or "").strip()]
     if not artifact_ids:
         return {}
+
+    fingerprint_map = None
+    if expected_request_fingerprints is not None:
+        fingerprint_map = {
+            str(key): str(value).strip()
+            for key, value in expected_request_fingerprints.items()
+            if str(value or "").strip()
+        }
 
     rows = await pool.fetch(
         """
@@ -278,6 +317,17 @@ async def reconcile_existing_batch_artifacts(
 
     selected: dict[str, dict[str, Any]] = {}
     for artifact_id, artifact_rows in grouped.items():
+        if fingerprint_map is not None:
+            expected_fingerprint = fingerprint_map.get(artifact_id)
+            if not expected_fingerprint:
+                continue
+            artifact_rows = [
+                row for row in artifact_rows
+                if _stored_request_fingerprint(row) == expected_fingerprint
+            ]
+            if not artifact_rows:
+                continue
+
         success_row = next(
             (
                 row

--- a/atlas_brain/autonomous/tasks/_b2b_field_contracts.py
+++ b/atlas_brain/autonomous/tasks/_b2b_field_contracts.py
@@ -85,6 +85,7 @@ FIELD_CONTRACTS: dict[str, FieldContract] = {
             "b2b_dashboard._list_accounts_in_motion",
             "b2b_tenant_dashboard",
             "backfill_witness_primitives",
+            "cleanup_accounts_in_motion_pollution",
         ),
         "migration_target": "read_vendor_evidence",
     },
@@ -203,6 +204,7 @@ FIELD_CONTRACTS: dict[str, FieldContract] = {
         "stranded": False,
         "approved_consumers": (
             "_b2b_shared._fetch_review_text_aggregates",
+            "backfill_derived_fields",
         ),
         "migration_target": "read_vendor_evidence",
     },
@@ -232,6 +234,8 @@ FIELD_CONTRACTS: dict[str, FieldContract] = {
         "stranded": False,
         "approved_consumers": (
             "_b2b_shared._fetch_vendor_churn_scores",
+            "backfill_derived_fields",
+            "cleanup_accounts_in_motion_pollution",
         ),
         "migration_target": "read_vendor_evidence",
     },
@@ -340,6 +344,7 @@ FIELD_CONTRACTS: dict[str, FieldContract] = {
         "approved_consumers": (
             "_b2b_shared._fetch_budget_signals",
             "b2b_churn_intelligence._fetch_company_signal_review_context",
+            "backfill_derived_fields",
         ),
         "migration_target": "read_review_details",
     },
@@ -391,6 +396,7 @@ FIELD_CONTRACTS: dict[str, FieldContract] = {
             "_b2b_shared._fetch_vendor_witness_reviews",
             "admin_costs",
             "backfill_witness_primitives",
+            "backfill_derived_fields",
         ),
         "migration_target": None,
     },

--- a/atlas_brain/autonomous/tasks/_b2b_shared.py
+++ b/atlas_brain/autonomous/tasks/_b2b_shared.py
@@ -5234,6 +5234,7 @@ async def _fetch_insider_aggregates(pool, window_days: int) -> list[dict[str, An
         ) AS ph(value) ON true
         WHERE content_type = 'insider_account'
           AND enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND imported_at > NOW() - make_interval(days => $1)
         GROUP BY vendor_name
         """,
@@ -5486,6 +5487,7 @@ async def fetch_all_pool_layers(
                 LEFT JOIN b2b_account_resolution ar
                   ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
                 WHERE r.enrichment_status = 'enriched'
+                  AND r.duplicate_of_review_id IS NULL
                   AND COALESCE(r.reviewed_at, r.imported_at) <= ($1::date + INTERVAL '1 day')
                   AND COALESCE(r.reviewed_at, r.imported_at) >= ($1::date - ($2::int * INTERVAL '1 day'))
                 ORDER BY
@@ -9161,6 +9163,7 @@ async def read_review_details(
         recency_expr = "COALESCE(r.reviewed_at, r.imported_at, r.enriched_at)"
     conditions = [
         "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
         f"{recency_expr} > NOW() - make_interval(days => $1)",
     ]
     params: list = [window_days]
@@ -9309,6 +9312,7 @@ async def read_campaign_opportunities(
 
     conditions = [
         "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
         "COALESCE(r.reviewed_at, r.imported_at, r.enriched_at)"
         " > NOW() - make_interval(days => $1)",
         "(r.enrichment->>'urgency_score')::numeric >= $2",
@@ -9504,6 +9508,7 @@ async def read_vendor_quote_evidence(
 
     conditions = [
         "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
         f"{recency_expr} > NOW() - make_interval(days => $1)",
         "LOWER(r.vendor_name) = LOWER($2)",
     ]
@@ -9587,6 +9592,7 @@ async def read_category_quote_evidence(
 
     conditions = [
         "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
         "r.enriched_at > NOW() - make_interval(days => $1)",
         "r.product_category = $2",
     ]

--- a/atlas_brain/autonomous/tasks/_b2b_shared.py
+++ b/atlas_brain/autonomous/tasks/_b2b_shared.py
@@ -3996,7 +3996,6 @@ async def _fetch_vendor_churn_scores_from_signals(
             "vendor_name": r["vendor_name"],
             "product_category": r["product_category"],
             "total_reviews": int(r["total_reviews"] or 0),
-            "signal_reviews": int(r["signal_reviews"] or 0) or int(r["total_reviews"] or 0),
             "churn_intent": int(r["churn_intent"] or 0),
             "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] is not None else 0.0,
         }

--- a/atlas_brain/autonomous/tasks/b2b_account_resolution.py
+++ b/atlas_brain/autonomous/tasks/b2b_account_resolution.py
@@ -76,6 +76,7 @@ async def _exclude_unsupported_sources(
         FROM b2b_reviews r
         LEFT JOIN b2b_account_resolution ar ON ar.review_id = r.id
         WHERE r.enrichment_status = ANY($1::text[])
+          AND r.duplicate_of_review_id IS NULL
           AND r.enrichment IS NOT NULL
           AND r.source = ANY($2::text[])
           AND ar.id IS NULL
@@ -108,7 +109,8 @@ async def _propagate_user_resolutions(pool: Any, backfill_labels: set) -> int:
                ar.resolution_method
         FROM b2b_reviews r
         JOIN b2b_account_resolution ar ON ar.review_id = r.id
-        WHERE ar.resolution_status = 'resolved'
+        WHERE r.duplicate_of_review_id IS NULL
+          AND ar.resolution_status = 'resolved'
           AND ar.confidence_label IN ('high', 'medium')
           AND r.reviewer_name IS NOT NULL
           AND r.reviewer_name NOT IN ('[deleted]', '', 'deleted')
@@ -121,7 +123,8 @@ async def _propagate_user_resolutions(pool: Any, backfill_labels: set) -> int:
             SELECT r.id AS review_id, r.reviewer_company, ar.id AS ar_id
             FROM b2b_reviews r
             JOIN b2b_account_resolution ar ON ar.review_id = r.id
-            WHERE r.source = $1
+            WHERE r.duplicate_of_review_id IS NULL
+              AND r.source = $1
               AND r.reviewer_name = $2
               AND ar.resolution_status = 'unresolved'
         """, user["source"], user["reviewer_name"])
@@ -232,6 +235,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         FROM b2b_reviews r
         LEFT JOIN b2b_account_resolution ar ON ar.review_id = r.id
         WHERE r.enrichment_status = ANY($1::text[])
+          AND r.duplicate_of_review_id IS NULL
           AND r.enrichment IS NOT NULL
           AND NOT (r.source = ANY($2::text[]))
           AND ar.id IS NULL

--- a/atlas_brain/autonomous/tasks/b2b_battle_cards.py
+++ b/atlas_brain/autonomous/tasks/b2b_battle_cards.py
@@ -1305,7 +1305,7 @@ def _evaluate_battle_card_quality(
     hard_blockers: list[str] = []
     warnings: list[str] = []
     cfg = settings.b2b_churn
-    max_stale_days = int(getattr(cfg, "battle_card_quality_max_stale_days", 7))
+    max_stale_days = int(getattr(cfg, "battle_card_quality_max_stale_days", 2))
     eval_divergence_warn_delta = int(getattr(cfg, "battle_card_quality_eval_divergence_warn_delta", 25))
     min_high_intent_urgency = float(getattr(cfg, "battle_card_quality_min_high_intent_urgency", 7.0))
     required_stages = _quality_required_stages(cfg)

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -957,29 +957,86 @@ _CTA_CONFIG: dict[str, dict[str, str]] = {
 
 
 def _blog_length_policy(topic_type: str) -> dict[str, int]:
+    default_min_by_topic = {
+        "vendor_showdown": 2000,
+        "market_landscape": 1900,
+        "best_fit_guide": 1900,
+        "vendor_deep_dive": 1800,
+        "vendor_alternative": 1700,
+        "churn_report": 1700,
+        "pain_point_roundup": 1700,
+        "pricing_reality_check": 1600,
+        "migration_guide": 1500,
+        "switching_story": 1500,
+    }
+    default_target_by_topic = {
+        "vendor_showdown": 2600,
+        "market_landscape": 2600,
+        "best_fit_guide": 2500,
+        "vendor_deep_dive": 2400,
+        "vendor_alternative": 2300,
+        "churn_report": 2300,
+        "pain_point_roundup": 2300,
+        "pricing_reality_check": 2200,
+        "migration_guide": 2100,
+        "switching_story": 2100,
+    }
+
+    def _coerce_int_or_default(value: Any, default: int) -> int:
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            if value != value:
+                return default
+            return int(value)
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return default
+            try:
+                return int(text)
+            except ValueError:
+                try:
+                    return int(float(text))
+                except ValueError:
+                    return default
+        return default
+
     cfg = settings.b2b_churn
     normalized_topic = str(topic_type or "").strip().lower()
-    default_min = max(1, int(getattr(cfg, "blog_post_min_words_default", 1800) or 1800))
+    default_min = max(
+        1,
+        _coerce_int_or_default(getattr(cfg, "blog_post_min_words_default", 1800), 1800),
+    )
     default_target = max(
         default_min,
-        int(getattr(cfg, "blog_post_target_words_default", default_min) or default_min),
+        _coerce_int_or_default(getattr(cfg, "blog_post_target_words_default", default_min), default_min),
     )
-    raw_min_by_topic = getattr(cfg, "blog_post_min_words_by_topic", {}) or {}
-    raw_target_by_topic = getattr(cfg, "blog_post_target_words_by_topic", {}) or {}
+    raw_min_by_topic = getattr(cfg, "blog_post_min_words_by_topic", default_min_by_topic) or default_min_by_topic
+    raw_target_by_topic = getattr(cfg, "blog_post_target_words_by_topic", default_target_by_topic) or default_target_by_topic
+    if not isinstance(raw_min_by_topic, dict):
+        raw_min_by_topic = default_min_by_topic
+    if not isinstance(raw_target_by_topic, dict):
+        raw_target_by_topic = default_target_by_topic
     min_by_topic = {
-        str(key or "").strip().lower(): int(value)
+        str(key or "").strip().lower(): _coerce_int_or_default(value, default_min)
         for key, value in raw_min_by_topic.items()
         if str(key or "").strip()
     }
     target_by_topic = {
-        str(key or "").strip().lower(): int(value)
+        str(key or "").strip().lower(): _coerce_int_or_default(value, default_target)
         for key, value in raw_target_by_topic.items()
         if str(key or "").strip()
     }
-    min_words = max(1, int(min_by_topic.get(normalized_topic, default_min) or default_min))
+    min_words = max(
+        1,
+        _coerce_int_or_default(min_by_topic.get(normalized_topic, default_min), default_min),
+    )
     target_words = max(
         min_words,
-        int(target_by_topic.get(normalized_topic, default_target) or default_target),
+        _coerce_int_or_default(target_by_topic.get(normalized_topic, default_target), default_target),
     )
     return {
         "min_words": min_words,
@@ -4619,6 +4676,28 @@ def _blog_slug_block_reason(
     now: datetime | None = None,
 ) -> str | None:
     """Return the reason a blog slug should be blocked from regeneration."""
+    def _coerce_int_or_default(value: Any, default: int) -> int:
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            if value != value:
+                return default
+            return int(value)
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return default
+            try:
+                return int(text)
+            except ValueError:
+                try:
+                    return int(float(text))
+                except ValueError:
+                    return default
+        return default
+
     if not row:
         return None
     status = str(row.get("status") or "").strip().lower()
@@ -4630,13 +4709,17 @@ def _blog_slug_block_reason(
     if status != "rejected":
         return f"status:{status}"
 
-    max_retries = int(settings.b2b_churn.blog_post_max_rejection_retries)
+    max_retries = _coerce_int_or_default(
+        getattr(settings.b2b_churn, "blog_post_max_rejection_retries", 1),
+        1,
+    )
     rejection_count = int(row.get("rejection_count") or 0)
     if rejection_count > max_retries:
         return "retry_limit"
 
-    cooldown_hours = int(
-        getattr(settings.b2b_churn, "blog_post_rejection_cooldown_hours", 0) or 0
+    cooldown_hours = _coerce_int_or_default(
+        getattr(settings.b2b_churn, "blog_post_rejection_cooldown_hours", 24),
+        24,
     )
     rejected_at = row.get("rejected_at")
     if (

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -4384,7 +4384,7 @@ async def _find_migration_guide_candidates(pool) -> list[dict[str, Any]]:
             pp.vendor_name AS vendor,
             pp.product_category AS category,
             COALESCE(jsonb_array_length(pp.commonly_switched_from), 0) AS switch_count,
-            (SELECT COUNT(*) FROM b2b_reviews br WHERE br.vendor_name = pp.vendor_name) AS review_total
+            (SELECT COUNT(*) FROM b2b_reviews br WHERE br.vendor_name = pp.vendor_name AND br.duplicate_of_review_id IS NULL) AS review_total
         FROM b2b_product_profiles pp
         WHERE jsonb_array_length(COALESCE(pp.commonly_switched_from, '[]'::jsonb)) >= 2
         ORDER BY jsonb_array_length(pp.commonly_switched_from) DESC
@@ -4422,6 +4422,7 @@ async def _find_pricing_reality_check_candidates(pool) -> list[dict[str, Any]]:
             )::numeric, 1) AS avg_urgency
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND source = ANY($1)
         GROUP BY vendor_name, product_category
         HAVING COUNT(*) FILTER (WHERE enrichment->>'pain_categories' ILIKE '%pricing%') >= 2
@@ -4467,6 +4468,7 @@ async def _find_switching_story_candidates(pool) -> list[dict[str, Any]]:
             )::numeric, 1) AS avg_urgency
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND source = ANY($1)
         GROUP BY vendor_name, product_category
         HAVING COUNT(*) FILTER (
@@ -4509,6 +4511,7 @@ async def _find_pain_point_roundup_candidates(pool) -> list[dict[str, Any]]:
             )::numeric, 1) AS avg_urgency
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND product_category IS NOT NULL AND product_category != ''
           AND source = ANY($1)
         GROUP BY product_category
@@ -4539,7 +4542,8 @@ async def _find_best_fit_guide_candidates(pool) -> list[dict[str, Any]]:
             COUNT(DISTINCT pp.vendor_name) AS vendor_count,
             (SELECT COUNT(*) FROM b2b_reviews br
              WHERE br.product_category = pp.product_category
-               AND br.enrichment_status = 'enriched') AS total_reviews,
+               AND br.enrichment_status = 'enriched'
+               AND br.duplicate_of_review_id IS NULL) AS total_reviews,
             MODE() WITHIN GROUP (
                 ORDER BY COALESCE(
                     (
@@ -4578,7 +4582,7 @@ async def _find_vendor_deep_dive_candidates(pool) -> list[dict[str, Any]]:
         SELECT
             pp.vendor_name AS vendor,
             pp.product_category AS category,
-            (SELECT COUNT(*) FROM b2b_reviews br WHERE br.vendor_name = pp.vendor_name) AS review_count,
+            (SELECT COUNT(*) FROM b2b_reviews br WHERE br.vendor_name = pp.vendor_name AND br.duplicate_of_review_id IS NULL) AS review_count,
             (CASE
                 WHEN pp.strengths IS NOT NULL AND jsonb_array_length(COALESCE(pp.strengths, '[]'::jsonb)) > 0 THEN 1 ELSE 0
             END +
@@ -4662,7 +4666,7 @@ async def _batch_vendor_review_counts(
         """
         SELECT LOWER(vendor_name) AS vn, COUNT(*) AS cnt
         FROM b2b_reviews
-        WHERE vendor_name = ANY($1) AND source = ANY($2)
+        WHERE vendor_name = ANY($1) AND duplicate_of_review_id IS NULL AND source = ANY($2)
         GROUP BY LOWER(vendor_name)
         """,
         list(vendor_set), sources,
@@ -5337,6 +5341,7 @@ async def _gather_data(
             SELECT review_text, reviewer_title, rating
             FROM b2b_reviews
             WHERE vendor_name = $1 AND enrichment_status = 'enriched'
+              AND duplicate_of_review_id IS NULL
               AND rating >= 4
               AND source = ANY($2)
             ORDER BY rating DESC
@@ -5382,6 +5387,7 @@ async def _gather_data(
                    enrichment->>'urgency_score' AS urgency
             FROM b2b_reviews
             WHERE vendor_name = $1 AND enrichment_status = 'enriched'
+              AND duplicate_of_review_id IS NULL
               AND (review_text ILIKE '%switch%' OR review_text ILIKE '%migrat%'
                    OR review_text ILIKE '%moved to%' OR review_text ILIKE '%moving to%'
                    OR review_text ILIKE '%left for%' OR review_text ILIKE '%leaving for%')
@@ -5433,6 +5439,7 @@ async def _gather_data(
                 )::numeric, 1) AS avg_urgency
             FROM b2b_reviews
             WHERE product_category = $1 AND enrichment_status = 'enriched'
+              AND duplicate_of_review_id IS NULL
               AND source = ANY($2)
             GROUP BY vendor_name, enrichment->>'pain_categories'
             ORDER BY review_count DESC
@@ -5483,7 +5490,7 @@ async def _gather_data(
             if p:
                 # Also pull avg rating from raw reviews
                 rating_row = await pool.fetchrow(
-                    "SELECT ROUND(AVG(rating)::numeric, 1) AS avg_rating, COUNT(*) AS cnt FROM b2b_reviews WHERE vendor_name = $1 AND rating IS NOT NULL AND source = ANY($2)",
+                    "SELECT ROUND(AVG(rating)::numeric, 1) AS avg_rating, COUNT(*) AS cnt FROM b2b_reviews WHERE vendor_name = $1 AND rating IS NOT NULL AND duplicate_of_review_id IS NULL AND source = ANY($2)",
                     vn, sources,
                 )
                 profiles.append({
@@ -5562,7 +5569,7 @@ async def _gather_data(
                 p = await _fetch_product_profile(pool, vn)
                 s = await _fetch_churn_signals(pool, vn)
                 rating_row = await pool.fetchrow(
-                    "SELECT ROUND(AVG(rating)::numeric, 1) AS avg_rating, COUNT(*) AS cnt FROM b2b_reviews WHERE vendor_name = $1 AND rating IS NOT NULL AND source = ANY($2)",
+                    "SELECT ROUND(AVG(rating)::numeric, 1) AS avg_rating, COUNT(*) AS cnt FROM b2b_reviews WHERE vendor_name = $1 AND rating IS NOT NULL AND duplicate_of_review_id IS NULL AND source = ANY($2)",
                     vn, sources,
                 )
                 profiles.append({
@@ -5599,7 +5606,7 @@ async def _gather_data(
     # For category-level topics, pull all vendors in the category
     if not vendor_names and topic_ctx.get("category"):
         cat_rows = await pool.fetch(
-            "SELECT DISTINCT vendor_name FROM b2b_reviews WHERE product_category = $1 AND source = ANY($2)",
+            "SELECT DISTINCT vendor_name FROM b2b_reviews WHERE product_category = $1 AND duplicate_of_review_id IS NULL AND source = ANY($2)",
             topic_ctx["category"], ctx_sources,
         )
         vendor_names = [r["vendor_name"] for r in cat_rows]
@@ -5616,7 +5623,7 @@ async def _gather_data(
                 MIN(imported_at)::date AS earliest,
                 MAX(imported_at)::date AS latest
             FROM b2b_reviews
-            WHERE vendor_name = ANY($1) AND source = ANY($2)
+            WHERE vendor_name = ANY($1) AND duplicate_of_review_id IS NULL AND source = ANY($2)
             """,
             vendor_names, ctx_sources,
         )
@@ -5633,6 +5640,7 @@ async def _gather_data(
                 MAX(imported_at)::date AS latest
             FROM b2b_reviews
             WHERE source = ANY($1)
+              AND duplicate_of_review_id IS NULL
             """,
             ctx_sources,
         )
@@ -5791,6 +5799,7 @@ async def _fetch_pain_category_urgency(pool, vendor_name: str) -> dict[str, floa
                COUNT(*) AS cnt
         FROM b2b_reviews
         WHERE vendor_name = $1 AND enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enrichment->>'pain_category' IS NOT NULL
         GROUP BY enrichment->>'pain_category'
         """,
@@ -5954,6 +5963,7 @@ async def _fetch_negative_quotes(
             FROM b2b_reviews r {_quote_joins}
             WHERE r.vendor_name = $1
               AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
               AND r.source = ANY($2)
             ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
             LIMIT $3
@@ -5967,6 +5977,7 @@ async def _fetch_negative_quotes(
             FROM b2b_reviews r {_quote_joins}
             WHERE r.product_category = $1
               AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
               AND r.source = ANY($2)
             ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
             LIMIT $3
@@ -6036,6 +6047,7 @@ async def _fetch_positive_quotes(
             SELECT {_pos_cols}
             FROM b2b_reviews r {_pos_joins}
             WHERE r.vendor_name = $1
+              AND r.duplicate_of_review_id IS NULL
               AND r.rating >= 4
               AND r.source = ANY($2)
               AND COALESCE(r.pros, r.review_text) IS NOT NULL
@@ -6051,6 +6063,7 @@ async def _fetch_positive_quotes(
             SELECT {_pos_cols}
             FROM b2b_reviews r {_pos_joins}
             WHERE r.product_category = $1
+              AND r.duplicate_of_review_id IS NULL
               AND r.rating >= 4
               AND r.source = ANY($2)
               AND COALESCE(r.pros, r.review_text) IS NOT NULL
@@ -6155,6 +6168,7 @@ async def _fetch_source_distribution(pool, vendor_names: list[str]) -> dict[str,
         SELECT COALESCE(source, 'unknown') AS src, COUNT(*) AS cnt
         FROM b2b_reviews
         WHERE vendor_name = ANY($1) AND enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND source = ANY($2)
         GROUP BY source
         ORDER BY cnt DESC
@@ -8991,6 +9005,7 @@ async def _fetch_vendor_stats(pool, vendor_name: str) -> dict[str, Any]:
             MODE() WITHIN GROUP (ORDER BY product_category) AS category
         FROM b2b_reviews
         WHERE LOWER(vendor_name) = LOWER($1)
+          AND duplicate_of_review_id IS NULL
         """,
         vendor_name,
     )
@@ -9018,6 +9033,7 @@ async def _fetch_category_topic_stats(pool, category: str) -> dict[str, Any]:
             )::numeric, 1) AS avg_urgency
         FROM b2b_reviews
         WHERE product_category = $1
+          AND duplicate_of_review_id IS NULL
           AND source = ANY($2)
         """,
         category,

--- a/atlas_brain/autonomous/tasks/b2b_campaign_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_campaign_generation.py
@@ -2253,6 +2253,7 @@ async def _compute_vendor_trend(
             f"""
             SELECT COUNT(*) FROM b2b_reviews r
             WHERE r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
               AND r.enriched_at > NOW() - INTERVAL '30 days'
               AND (r.enrichment->>'urgency_score')::numeric >= ${base_idx}
               AND ({name_conditions})
@@ -2263,6 +2264,7 @@ async def _compute_vendor_trend(
             f"""
             SELECT COUNT(*) FROM b2b_reviews r
             WHERE r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
               AND r.enriched_at BETWEEN NOW() - INTERVAL '60 days' AND NOW() - INTERVAL '30 days'
               AND (r.enrichment->>'urgency_score')::numeric >= ${base_idx}
               AND ({name_conditions})

--- a/atlas_brain/autonomous/tasks/b2b_churn_alert.py
+++ b/atlas_brain/autonomous/tasks/b2b_churn_alert.py
@@ -73,6 +73,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 ) AS displacement_count
             FROM b2b_reviews
             WHERE enrichment_status = 'enriched'
+              AND duplicate_of_review_id IS NULL
               AND vendor_name ILIKE '%' || $1 || '%'
               AND enriched_at > NOW() - INTERVAL '7 days'
             """,

--- a/atlas_brain/autonomous/tasks/b2b_churn_intelligence.py
+++ b/atlas_brain/autonomous/tasks/b2b_churn_intelligence.py
@@ -190,6 +190,10 @@ def _should_persist_category_dynamics(scoped_vendors: list[str] | None) -> bool:
     return not bool(scoped_vendors)
 
 
+def _should_persist_cross_vendor_conclusions(scoped_vendors: list[str] | None) -> bool:
+    return not bool(scoped_vendors)
+
+
 def _should_use_cross_vendor_category(category: str) -> bool:
     text = str(category or "").strip()
     return bool(text) and not _is_generic_product_category(text)

--- a/atlas_brain/autonomous/tasks/b2b_enrichment.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment.py
@@ -53,6 +53,54 @@ _TIER2_INSIDER_SECTION_HEADER = "### insider_signals -- CLASSIFY + EXTRACT (only
 _TIER2_OUTPUT_SECTION_HEADER = "## Output"
 
 
+def _coerce_int_value(raw_value: Any, fallback: int) -> int:
+    if isinstance(raw_value, bool):
+        return int(raw_value)
+    if isinstance(raw_value, int):
+        return raw_value
+    if isinstance(raw_value, float):
+        if raw_value != raw_value:
+            return fallback
+        return int(raw_value)
+    if isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return fallback
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return int(float(text))
+            except ValueError:
+                return fallback
+    return fallback
+
+
+def _coerce_float_value(raw_value: Any, fallback: float) -> float:
+    if isinstance(raw_value, bool):
+        return float(raw_value)
+    if isinstance(raw_value, (int, float)):
+        numeric = float(raw_value)
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return fallback
+        try:
+            numeric = float(text)
+        except ValueError:
+            return fallback
+    else:
+        return fallback
+    if numeric != numeric:
+        return fallback
+    return numeric
+
+
+def _config_allowlist(raw_value: Any, fallback: str | list[str] | tuple[str, ...] | set[str] | frozenset[str] = "") -> list[str]:
+    candidate = raw_value if isinstance(raw_value, (str, list, tuple, set, frozenset)) else fallback
+    return list(parse_source_allowlist(candidate))
+
+
 def _enrichment_batch_custom_id(stage: str, review_id: Any) -> str:
     normalized_stage = re.sub(r"[^A-Za-z0-9_-]+", "_", str(stage or "").strip()).strip("_") or "stage"
     normalized_review = re.sub(r"[^A-Za-z0-9_-]+", "_", str(review_id or "").strip()).strip("_") or "review"
@@ -489,7 +537,10 @@ def _tier1_has_extraction_gaps(tier1: dict, *, source: str | None = None) -> boo
     has_evidence = bool(complaints or quotes or competitors or pricing or rec_lang)
     source_norm = str(source or "").strip().lower()
     strict_sources = set(
-        parse_source_allowlist(settings.b2b_churn.enrichment_tier2_strict_sources)
+        _config_allowlist(
+            getattr(settings.b2b_churn, "enrichment_tier2_strict_sources", ""),
+            "",
+        )
     )
     if source_norm in strict_sources:
         complaint_count = len(complaints) if isinstance(complaints, list) else 0
@@ -508,9 +559,15 @@ def _tier1_has_extraction_gaps(tier1: dict, *, source: str | None = None) -> boo
         has_strong_structured_evidence = (
             bool(competitors)
             or bool(pricing)
-            or complaint_count >= int(settings.b2b_churn.enrichment_tier2_strict_min_complaints)
+            or complaint_count >= _coerce_int_value(
+                getattr(settings.b2b_churn, "enrichment_tier2_strict_min_complaints", 2),
+                2,
+            )
             or (
-                quote_count >= int(settings.b2b_churn.enrichment_tier2_strict_min_quotes)
+                quote_count >= _coerce_int_value(
+                    getattr(settings.b2b_churn, "enrichment_tier2_strict_min_quotes", 2),
+                    2,
+                )
                 and evidence_groups >= 2
             )
         )
@@ -626,10 +683,12 @@ async def _call_vllm_tier2(
 
 def _get_tier2_client(cfg: Any) -> Any:
     """Get or create the httpx client for Tier 2 vLLM."""
-    tier2_url = cfg.enrichment_tier2_vllm_url or cfg.enrichment_tier1_vllm_url
-    timeout = cfg.enrichment_tier2_timeout_seconds
+    raw_tier2_url = getattr(cfg, "enrichment_tier2_vllm_url", "")
+    raw_tier1_url = getattr(cfg, "enrichment_tier1_vllm_url", "")
+    tier2_url = raw_tier2_url if isinstance(raw_tier2_url, str) and raw_tier2_url.strip() else raw_tier1_url
+    timeout = _coerce_float_value(getattr(cfg, "enrichment_tier2_timeout_seconds", 120.0), 120.0)
     # Reuse the Tier 1 client if same URL
-    if tier2_url == cfg.enrichment_tier1_vllm_url:
+    if not isinstance(tier2_url, str) or not tier2_url.strip() or tier2_url == raw_tier1_url:
         return _get_tier1_client(cfg)
     import httpx
     return httpx.AsyncClient(base_url=tier2_url, timeout=timeout)
@@ -2195,10 +2254,8 @@ def _coerce_int_override(
     max_value: int,
 ) -> int:
     """Return clamped integer override value, or default on parse failure."""
-    try:
-        coerced = int(raw_value)
-    except (TypeError, ValueError):
-        return default_value
+    default_coerced = _coerce_int_value(default_value, min_value)
+    coerced = _coerce_int_value(raw_value, default_coerced)
     return max(min_value, min(max_value, coerced))
 
 
@@ -2250,6 +2307,39 @@ def _witness_metrics(result: dict[str, Any] | None) -> tuple[int, int]:
             continue
         witness_count += 1
     return (1 if witness_count > 0 else 0), witness_count
+
+
+def _row_usage_result(status: Any, usage: dict[str, Any] | None = None) -> dict[str, Any]:
+    normalized = {"status": status}
+    usage_dict = usage or {}
+    for key in _empty_exact_cache_usage():
+        normalized[key] = int(usage_dict.get(key, 0) or 0)
+    return normalized
+
+
+async def _defer_batch_row(
+    pool,
+    row: dict[str, Any],
+    *,
+    tier: str,
+    usage: dict[str, Any] | None = None,
+    custom_id: str | None = None,
+) -> dict[str, Any]:
+    await pool.execute(
+        """
+        UPDATE b2b_reviews
+        SET enrichment_status = 'pending'
+        WHERE id = $1
+        """,
+        row["id"],
+    )
+    logger.info(
+        "Deferring B2B enrichment %s for %s; reset row to pending while existing batch artifact %s remains pending",
+        tier,
+        row["id"],
+        custom_id or "unknown",
+    )
+    return _row_usage_result("deferred", usage)
 
 
 async def _persist_enrichment_result(
@@ -2439,9 +2529,15 @@ async def _enrich_rows(
     task: ScheduledTask | Any | None = None,
 ) -> dict[str, Any]:
     """Enrich a list of claimed rows concurrently."""
-    max_attempts = cfg.enrichment_max_attempts
+    max_attempts = _coerce_int_value(getattr(cfg, "enrichment_max_attempts", 3), 3)
 
-    effective_concurrency = max(1, int(concurrency_override or cfg.enrichment_concurrency))
+    effective_concurrency = max(
+        1,
+        _coerce_int_value(
+            concurrency_override if concurrency_override is not None else getattr(cfg, "enrichment_concurrency", 10),
+            10,
+        ),
+    )
     sem = asyncio.Semaphore(effective_concurrency)
     enrich_single_params = inspect.signature(_enrich_single).parameters
     supports_usage_out = "usage_out" in enrich_single_params
@@ -2454,7 +2550,7 @@ async def _enrich_rows(
             if supports_run_id:
                 kwargs["run_id"] = run_id
             if supports_usage_out:
-                await _enrich_single(
+                status = await _enrich_single(
                     pool,
                     row,
                     max_attempts,
@@ -2465,7 +2561,7 @@ async def _enrich_rows(
                     **kwargs,
                 )
             else:
-                await _enrich_single(
+                status = await _enrich_single(
                     pool,
                     row,
                     max_attempts,
@@ -2474,7 +2570,7 @@ async def _enrich_rows(
                     cfg.review_truncate_length,
                     **kwargs,
                 )
-            return usage
+            return _row_usage_result(status, usage)
 
     async def _run_single_rows(target_rows: list[dict[str, Any]]) -> list[dict[str, Any] | Exception]:
         if not target_rows:
@@ -2494,6 +2590,8 @@ async def _enrich_rows(
         "failed_items": 0,
         "reused_completed_items": 0,
         "reused_pending_items": 0,
+        "rows_deferred": 0,
+        "tier2_single_fallback_rows": 0,
     }
 
     from ...services.b2b.anthropic_batch import (
@@ -2548,9 +2646,9 @@ async def _enrich_rows(
         resolve_anthropic_batch_llm(
             current_llm=SimpleNamespace(
                 name="openrouter",
-                model=str(cfg.enrichment_openrouter_model or "anthropic/claude-haiku-4-5"),
+                model=str(getattr(cfg, "enrichment_openrouter_model", "") or "anthropic/claude-haiku-4-5"),
             ),
-            target_model_candidates=(cfg.enrichment_openrouter_model,),
+            target_model_candidates=(getattr(cfg, "enrichment_openrouter_model", ""),),
         )
         if use_openrouter and batch_requested
         else None
@@ -2573,6 +2671,106 @@ async def _enrich_rows(
         tier1_batch_llm = None
     if not isinstance(tier2_batch_llm, AnthropicLLM):
         tier2_batch_llm = None
+
+    tier1_batch_model_id = str(
+        getattr(cfg, "enrichment_openrouter_model", "") or "anthropic/claude-haiku-4-5"
+    )
+    full_extraction_timeout = max(
+        0.0,
+        _coerce_float_value(
+            getattr(cfg, "enrichment_full_extraction_timeout_seconds", 120.0),
+            120.0,
+        ),
+    )
+    tier2_client = None
+
+    async def _persist_wrapped(
+        row: dict[str, Any],
+        result: dict[str, Any] | None,
+        *,
+        model_id: str,
+        usage: dict[str, int],
+    ) -> dict[str, Any]:
+        status = await _persist_enrichment_result(
+            pool,
+            row,
+            result,
+            model_id=model_id,
+            max_attempts=max_attempts,
+            run_id=run_id,
+            cache_usage=usage,
+        )
+        return _row_usage_result(status, usage)
+
+    async def _run_single_tier2_fallback(
+        row: dict[str, Any],
+        tier1: dict[str, Any],
+        usage: dict[str, int],
+    ) -> dict[str, Any]:
+        nonlocal tier2_client
+
+        logger.info(
+            "B2B enrichment: Tier 2 batch unavailable for %s; falling back to single-call Tier 2",
+            row["id"],
+        )
+        batch_metrics["tier2_single_fallback_rows"] += 1
+
+        trace_metadata = {
+            "run_id": run_id,
+            "vendor_name": str(row.get("vendor_name") or ""),
+            "review_id": str(row["id"]),
+            "source": str(row.get("source") or ""),
+            "tier": "tier2",
+            "workload": "single_call_fallback",
+            "batch_fallback_reason": "tier2_batch_unavailable",
+        }
+
+        if use_openrouter:
+            tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                _call_openrouter_tier2(
+                    tier1,
+                    row,
+                    cfg,
+                    cfg.review_truncate_length,
+                    include_cache_hit=True,
+                    trace_metadata=trace_metadata,
+                ),
+                timeout=full_extraction_timeout,
+            ))
+        else:
+            if tier2_client is None:
+                tier2_client = _get_tier2_client(cfg)
+            tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                _call_vllm_tier2(
+                    tier1,
+                    row,
+                    cfg,
+                    tier2_client,
+                    cfg.review_truncate_length,
+                    include_cache_hit=True,
+                    trace_metadata=trace_metadata,
+                ),
+                timeout=full_extraction_timeout,
+            ))
+
+        if tier2_cache_hit:
+            usage["tier2_exact_cache_hits"] += 1
+            usage["exact_cache_hits"] += 1
+        elif tier2_model is not None:
+            usage["tier2_generated_calls"] += 1
+            usage["generated"] += 1
+
+        if tier2 is not None:
+            model_id = f"hybrid:{tier1_batch_model_id}+{tier2_model}"
+        else:
+            model_id = tier1_batch_model_id
+
+        return await _persist_wrapped(
+            row,
+            _merge_tier1_tier2(tier1, tier2),
+            model_id=model_id,
+            usage=usage,
+        )
 
     if tier1_batch_llm is None:
         results = await _run_single_rows(rows)
@@ -2645,13 +2843,14 @@ async def _enrich_rows(
                         batch_metrics["reused_completed_items"] += 1
                         continue
                 if existing and existing.get("state") == "pending":
-                    row_results[row["id"]] = {"status": "deferred"}
-                    batch_metrics["reused_pending_items"] += 1
-                    logger.info(
-                        "Skipping duplicate enrichment Tier 1 submission for %s; existing Anthropic batch item %s is still pending",
-                        row["id"],
-                        existing.get("custom_id"),
+                    row_results[row["id"]] = await _defer_batch_row(
+                        pool,
+                        row,
+                        tier="tier1",
+                        custom_id=str(existing.get("custom_id") or ""),
                     )
+                    batch_metrics["reused_pending_items"] += 1
+                    batch_metrics["rows_deferred"] += 1
                     continue
                 remaining_tier1_entries.append(entry)
             tier1_entries = remaining_tier1_entries
@@ -2720,7 +2919,8 @@ async def _enrich_rows(
                     usage["tier1_generated_calls"] += 1
                     usage["generated"] += 1
                 per_row_batch_usage[row["id"]] = usage
-                if _tier1_has_extraction_gaps(ready_entry["tier1"], source=row.get("source")) and tier2_batch_llm is not None:
+                needs_tier2 = _tier1_has_extraction_gaps(ready_entry["tier1"], source=row.get("source"))
+                if needs_tier2 and tier2_batch_llm is not None:
                     payload = _build_classify_payload(row, cfg.review_truncate_length)
                     payload["tier1_specific_complaints"] = ready_entry["tier1"].get("specific_complaints", [])
                     payload["tier1_quotable_phrases"] = ready_entry["tier1"].get("quotable_phrases", [])
@@ -2753,15 +2953,18 @@ async def _enrich_rows(
                             "cached_usage": dict(cached.get("usage") or {}) if cached is not None else {},
                         }
                     )
+                elif needs_tier2:
+                    row_results[row["id"]] = await _run_single_tier2_fallback(
+                        row,
+                        ready_entry["tier1"],
+                        usage,
+                    )
                 else:
-                    row_results[row["id"]] = await _persist_enrichment_result(
-                        pool,
+                    row_results[row["id"]] = await _persist_wrapped(
                         row,
                         _merge_tier1_tier2(ready_entry["tier1"], None),
-                        model_id=str(cfg.enrichment_openrouter_model or "anthropic/claude-haiku-4-5"),
-                        max_attempts=max_attempts,
-                        run_id=run_id,
-                        cache_usage=usage,
+                        model_id=tier1_batch_model_id,
+                        usage=usage,
                     )
 
             for entry in tier1_entries:
@@ -2790,11 +2993,12 @@ async def _enrich_rows(
                     await store_b2b_exact_stage_text(
                         entry["request"],
                         response_text=clean_llm_output(outcome.response_text or ""),
-                metadata={"tier": 1, "backend": "anthropic_batch"},
-            )
+                        metadata={"tier": 1, "backend": "anthropic_batch"},
+                    )
 
                 per_row_batch_usage[row["id"]] = usage
-                if _tier1_has_extraction_gaps(tier1, source=row.get("source")) and tier2_batch_llm is not None:
+                needs_tier2 = _tier1_has_extraction_gaps(tier1, source=row.get("source"))
+                if needs_tier2 and tier2_batch_llm is not None:
                     payload = _build_classify_payload(row, cfg.review_truncate_length)
                     payload["tier1_specific_complaints"] = tier1.get("specific_complaints", [])
                     payload["tier1_quotable_phrases"] = tier1.get("quotable_phrases", [])
@@ -2827,15 +3031,14 @@ async def _enrich_rows(
                             "cached_usage": dict(cached.get("usage") or {}) if cached is not None else {},
                         }
                     )
+                elif needs_tier2:
+                    row_results[row["id"]] = await _run_single_tier2_fallback(row, tier1, usage)
                 else:
-                    row_results[row["id"]] = await _persist_enrichment_result(
-                        pool,
+                    row_results[row["id"]] = await _persist_wrapped(
                         row,
                         _merge_tier1_tier2(tier1, None),
-                        model_id=str(cfg.enrichment_openrouter_model or "anthropic/claude-haiku-4-5"),
-                        max_attempts=max_attempts,
-                        run_id=run_id,
-                        cache_usage=usage,
+                        model_id=tier1_batch_model_id,
+                        usage=usage,
                     )
 
             if tier2_entries:
@@ -2854,25 +3057,30 @@ async def _enrich_rows(
                     if existing and existing.get("state") == "succeeded":
                         tier2 = _parse_batch_text(existing.get("response_text"))
                         if tier2 is not None:
-                            row_results[row["id"]] = await _persist_enrichment_result(
-                                pool,
+                            if existing.get("cached"):
+                                usage["tier2_exact_cache_hits"] += 1
+                                usage["exact_cache_hits"] += 1
+                            else:
+                                usage["tier2_generated_calls"] += 1
+                                usage["generated"] += 1
+                            row_results[row["id"]] = await _persist_wrapped(
                                 row,
                                 _merge_tier1_tier2(entry["tier1"], tier2),
-                                model_id=f"hybrid:{cfg.enrichment_openrouter_model or 'anthropic/claude-haiku-4-5'}+{tier2_model_id}",
-                                max_attempts=max_attempts,
-                                run_id=run_id,
-                                cache_usage=usage,
+                                model_id=f"hybrid:{tier1_batch_model_id}+{tier2_model_id}",
+                                usage=usage,
                             )
                             batch_metrics["reused_completed_items"] += 1
                             continue
                     if existing and existing.get("state") == "pending":
-                        row_results[row["id"]] = {"status": "deferred"}
-                        batch_metrics["reused_pending_items"] += 1
-                        logger.info(
-                            "Skipping duplicate enrichment Tier 2 submission for %s; existing Anthropic batch item %s is still pending",
-                            row["id"],
-                            existing.get("custom_id"),
+                        row_results[row["id"]] = await _defer_batch_row(
+                            pool,
+                            row,
+                            tier="tier2",
+                            usage=usage,
+                            custom_id=str(existing.get("custom_id") or ""),
                         )
+                        batch_metrics["reused_pending_items"] += 1
+                        batch_metrics["rows_deferred"] += 1
                         continue
                     remaining_tier2_entries.append(entry)
                 tier2_entries = remaining_tier2_entries
@@ -2955,14 +3163,11 @@ async def _enrich_rows(
                             response_text=clean_llm_output(outcome.response_text or ""),
                             metadata={"tier": 2, "backend": "anthropic_batch"},
                         )
-                    row_results[row["id"]] = await _persist_enrichment_result(
-                        pool,
+                    row_results[row["id"]] = await _persist_wrapped(
                         row,
                         _merge_tier1_tier2(entry["tier1"], tier2),
-                        model_id=f"hybrid:{cfg.enrichment_openrouter_model or 'anthropic/claude-haiku-4-5'}+{tier2_model_id}",
-                        max_attempts=max_attempts,
-                        run_id=run_id,
-                        cache_usage=usage,
+                        model_id=f"hybrid:{tier1_batch_model_id}+{tier2_model_id}",
+                        usage=usage,
                     )
 
             fallback_results = await _run_single_rows(fallback_rows)
@@ -3017,6 +3222,8 @@ async def _enrich_rows(
         "anthropic_batch_failed_items": batch_metrics["failed_items"],
         "anthropic_batch_reused_completed_items": batch_metrics["reused_completed_items"],
         "anthropic_batch_reused_pending_items": batch_metrics["reused_pending_items"],
+        "anthropic_batch_rows_deferred": batch_metrics["rows_deferred"],
+        "anthropic_batch_tier2_single_fallback_rows": batch_metrics["tier2_single_fallback_rows"],
         **cache_usage,
     }
 
@@ -3197,15 +3404,21 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     requeued = requeued_parser + requeued_model
 
     task_metadata = task.metadata if isinstance(task.metadata, dict) else {}
-    default_max_batch = min(cfg.enrichment_max_per_batch, 500)
+    default_max_batch = min(
+        _coerce_int_value(getattr(cfg, "enrichment_max_per_batch", 10), 10),
+        500,
+    )
     max_batch = _coerce_int_override(
         task_metadata.get("enrichment_max_per_batch"),
         default_max_batch,
         min_value=1,
         max_value=500,
     )
-    max_attempts = cfg.enrichment_max_attempts
-    default_max_rounds = max(1, cfg.enrichment_max_rounds_per_run)
+    max_attempts = _coerce_int_value(getattr(cfg, "enrichment_max_attempts", 3), 3)
+    default_max_rounds = max(
+        1,
+        _coerce_int_value(getattr(cfg, "enrichment_max_rounds_per_run", 1), 1),
+    )
     max_rounds = _coerce_int_override(
         task_metadata.get("enrichment_max_rounds_per_run"),
         default_max_rounds,
@@ -3214,17 +3427,18 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     )
     effective_concurrency = _coerce_int_override(
         task_metadata.get("enrichment_concurrency"),
-        max(1, cfg.enrichment_concurrency),
+        max(1, _coerce_int_value(getattr(cfg, "enrichment_concurrency", 10), 10)),
         min_value=1,
         max_value=100,
     )
     inter_batch_delay = max(
         0.0,
-        float(
+        _coerce_float_value(
             task_metadata.get(
                 "enrichment_inter_batch_delay_seconds",
-                cfg.enrichment_inter_batch_delay_seconds,
-            )
+                getattr(cfg, "enrichment_inter_batch_delay_seconds", 2.0),
+            ),
+            _coerce_float_value(getattr(cfg, "enrichment_inter_batch_delay_seconds", 2.0), 2.0),
         ),
     )
     priority_sources = [
@@ -3246,6 +3460,8 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         "anthropic_batch_fallback_single_call_items": 0,
         "anthropic_batch_completed_items": 0,
         "anthropic_batch_failed_items": 0,
+        "anthropic_batch_rows_deferred": 0,
+        "anthropic_batch_tier2_single_fallback_rows": 0,
     }
     rounds = 0
 
@@ -3436,7 +3652,13 @@ async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
 
     try:
         cfg = settings.b2b_churn
-        full_extraction_timeout = cfg.enrichment_full_extraction_timeout_seconds
+        full_extraction_timeout = max(
+            0.0,
+            _coerce_float_value(
+                getattr(cfg, "enrichment_full_extraction_timeout_seconds", 120.0),
+                120.0,
+            ),
+        )
         payload = _build_classify_payload(row, truncate_length)
         payload_json = json.dumps(payload)
         trace_metadata = {
@@ -3491,32 +3713,39 @@ async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
         tier2_model = None
         tier2_cache_hit = False
         if _tier1_has_extraction_gaps(tier1, source=row.get("source")):
-            if use_openrouter:
-                tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
-                    _call_openrouter_tier2(
-                        tier1,
-                        row,
-                        cfg,
-                        truncate_length,
-                        include_cache_hit=True,
-                        trace_metadata=trace_metadata | {"tier": "tier2"},
-                    ),
-                    timeout=full_extraction_timeout,
-                ))
-            else:
-                tier2_client = _get_tier2_client(cfg)
-                tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
-                    _call_vllm_tier2(
-                        tier1,
-                        row,
-                        cfg,
-                        tier2_client,
-                        truncate_length,
-                        include_cache_hit=True,
-                        trace_metadata=trace_metadata | {"tier": "tier2"},
-                    ),
-                    timeout=full_extraction_timeout,
-                ))
+            try:
+                if use_openrouter:
+                    tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                        _call_openrouter_tier2(
+                            tier1,
+                            row,
+                            cfg,
+                            truncate_length,
+                            include_cache_hit=True,
+                            trace_metadata=trace_metadata | {"tier": "tier2"},
+                        ),
+                        timeout=full_extraction_timeout,
+                    ))
+                else:
+                    tier2_client = _get_tier2_client(cfg)
+                    tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                        _call_vllm_tier2(
+                            tier1,
+                            row,
+                            cfg,
+                            tier2_client,
+                            truncate_length,
+                            include_cache_hit=True,
+                            trace_metadata=trace_metadata | {"tier": "tier2"},
+                        ),
+                        timeout=full_extraction_timeout,
+                    ))
+            except Exception:
+                logger.warning(
+                    "Tier 2 enrichment failed for review %s; persisting tier 1 result only",
+                    review_id,
+                    exc_info=True,
+                )
         if tier2_cache_hit:
             cache_usage["tier2_exact_cache_hits"] += 1
             cache_usage["exact_cache_hits"] += 1
@@ -4258,15 +4487,24 @@ _REPAIR_CURRENCY_RE = re.compile(r"\$\s?\d[\d,]*(?:\.\d+)?", re.I)
 def _trusted_repair_sources() -> set[str]:
     return set(
         filter_deprecated_sources(
-            parse_source_allowlist(settings.b2b_churn.enrichment_priority_sources),
-            settings.b2b_churn.deprecated_review_sources,
+            _config_allowlist(getattr(settings.b2b_churn, "enrichment_priority_sources", ""), ""),
+            getattr(
+                settings.b2b_churn,
+                "deprecated_review_sources",
+                "capterra,software_advice,trustpilot,trustradius",
+            )
+            if isinstance(getattr(settings.b2b_churn, "deprecated_review_sources", ""), str)
+            else "capterra,software_advice,trustpilot,trustradius",
         )
     )
 
 
 def _effective_enrichment_skip_sources() -> set[str]:
-    configured = parse_source_allowlist(settings.b2b_churn.enrichment_skip_sources)
-    deprecated = parse_source_allowlist(settings.b2b_churn.deprecated_review_sources)
+    configured = _config_allowlist(getattr(settings.b2b_churn, "enrichment_skip_sources", ""), "")
+    deprecated = _config_allowlist(
+        getattr(settings.b2b_churn, "deprecated_review_sources", ""),
+        "capterra,software_advice,trustpilot,trustradius",
+    )
     return {
         source
         for source in [*configured, *deprecated]

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1229,7 +1229,10 @@ async def _recover_orphaned_repairing(pool, max_attempts: int) -> int:
                 ELSE NULL
             END
         WHERE enrichment_repair_status = 'repairing'
-          AND enrichment_repaired_at < NOW() - INTERVAL '30 minutes'
+          AND (
+                enrichment_repaired_at IS NULL
+                OR enrichment_repaired_at < NOW() - INTERVAL '30 minutes'
+              )
         """,
         max_attempts,
     )

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1999,6 +1999,7 @@ async def retry_quarantined_reviews(
 
     Returns counts of recovered, still_failed, skipped reviews.
     """
+    retryable_reasons = sorted(_RETRYABLE_QUARANTINE_REASONS)
     rows = await pool.fetch(
         """
         SELECT id, enrichment, source, rating, rating_max,
@@ -2009,10 +2010,12 @@ async def retry_quarantined_reviews(
         WHERE enrichment_status = 'quarantined'
           AND enrichment IS NOT NULL
           AND (enrichment->>'enrichment_schema_version')::int >= 1
+          AND low_fidelity_reasons ?| $2::text[]
         ORDER BY created_at DESC
         LIMIT $1
         """,
         limit,
+        retryable_reasons,
     )
 
     recovered = 0
@@ -2020,18 +2023,6 @@ async def retry_quarantined_reviews(
     skipped = 0
 
     for row in rows:
-        reasons = row.get("low_fidelity_reasons") or []
-        if isinstance(reasons, str):
-            try:
-                reasons = json.loads(reasons)
-            except Exception:
-                reasons = []
-
-        retryable = any(r in _RETRYABLE_QUARANTINE_REASONS for r in reasons)
-        if not retryable:
-            skipped += 1
-            continue
-
         enrichment = base_enrichment._coerce_json_dict(row.get("enrichment"))
         if not enrichment:
             skipped += 1

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1244,7 +1244,7 @@ async def _quarantine_shadowed_hard_gap_rows(pool, *, limit: int) -> int:
         return 0
 
 
-async def _recover_orphaned_repairing(pool, max_attempts: int) -> int:
+async def _recover_orphaned_repairing(pool, max_attempts: int, orphan_timeout_minutes: int = 30) -> int:
     result = await pool.execute(
         """
         UPDATE b2b_reviews
@@ -1256,10 +1256,11 @@ async def _recover_orphaned_repairing(pool, max_attempts: int) -> int:
         WHERE enrichment_repair_status = 'repairing'
           AND (
                 enrichment_repaired_at IS NULL
-                OR enrichment_repaired_at < NOW() - INTERVAL '30 minutes'
+                OR enrichment_repaired_at < NOW() - make_interval(mins => $2)
               )
         """,
         max_attempts,
+        orphan_timeout_minutes,
     )
     try:
         return int(str(result).split()[-1])
@@ -1715,7 +1716,10 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     if not pool.is_initialized:
         return {"_skip_synthesis": "DB not ready"}
 
-    orphaned = await _recover_orphaned_repairing(pool, cfg.enrichment_repair_max_attempts)
+    orphaned = await _recover_orphaned_repairing(
+        pool, cfg.enrichment_repair_max_attempts,
+        orphan_timeout_minutes=int(getattr(cfg, 'enrichment_repair_orphan_timeout_minutes', 30)),
+    )
     task_metadata = task.metadata if isinstance(task.metadata, dict) else {}
     max_batch = base_enrichment._coerce_int_override(
         task_metadata.get("enrichment_repair_max_per_batch"),
@@ -1777,6 +1781,8 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     rounds = 0
     consecutive_no_progress = 0
     circuit_breaker_reason = None
+    failure_rate_threshold = float(getattr(cfg, 'enrichment_repair_failure_rate_threshold', 0.5))
+    no_progress_max_rounds = int(getattr(cfg, 'enrichment_repair_no_progress_max_rounds', 3))
     strict_discussion_sources, strict_discussion_content_types = _strict_discussion_lists(cfg)
     low_signal_discussion_skipped = await _skip_low_signal_strict_discussion_rows(
         pool,
@@ -1893,7 +1899,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         round_failed = result.get("failed", 0)
         round_total = round_promoted + round_shadowed + round_failed
 
-        if round_total > 0 and round_failed > round_total * 0.5:
+        if round_total > 0 and round_failed > round_total * failure_rate_threshold:
             circuit_breaker_reason = f"high failure rate ({round_failed}/{round_total})"
             logger.warning("Enrichment repair circuit breaker: %s in round %d", circuit_breaker_reason, rounds + 1)
             rounds += 1
@@ -1904,7 +1910,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         else:
             consecutive_no_progress = 0
 
-        if consecutive_no_progress >= 3:
+        if consecutive_no_progress >= no_progress_max_rounds:
             circuit_breaker_reason = f"{consecutive_no_progress} consecutive rounds with no repair progress"
             logger.warning("Enrichment repair circuit breaker: %s", circuit_breaker_reason)
             rounds += 1

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1246,6 +1246,8 @@ async def _skip_low_signal_strict_discussion_rows(
     max_attempts: int,
     limit: int,
 ) -> int:
+    max_attempts = base_enrichment._coerce_int_value(max_attempts, 2)
+    limit = base_enrichment._coerce_int_value(limit, 500)
     if not strict_sources or not strict_content_types or limit <= 0:
         return 0
     result = await pool.execute(
@@ -1457,28 +1459,32 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     task_metadata = task.metadata if isinstance(task.metadata, dict) else {}
     max_batch = base_enrichment._coerce_int_override(
         task_metadata.get("enrichment_repair_max_per_batch"),
-        cfg.enrichment_repair_max_per_batch,
+        base_enrichment._coerce_int_value(getattr(cfg, "enrichment_repair_max_per_batch", 25), 25),
         min_value=1,
         max_value=500,
     )
     max_rounds = base_enrichment._coerce_int_override(
         task_metadata.get("enrichment_repair_max_rounds_per_run"),
-        cfg.enrichment_repair_max_rounds_per_run,
+        base_enrichment._coerce_int_value(getattr(cfg, "enrichment_repair_max_rounds_per_run", 1), 1),
         min_value=1,
         max_value=100,
     )
     concurrency = base_enrichment._coerce_int_override(
         task_metadata.get("enrichment_repair_concurrency"),
-        cfg.enrichment_repair_concurrency,
+        base_enrichment._coerce_int_value(getattr(cfg, "enrichment_repair_concurrency", 5), 5),
         min_value=1,
         max_value=100,
     )
     strict_discussion_skip_limit = base_enrichment._coerce_int_override(
         task_metadata.get("enrichment_repair_strict_discussion_skip_limit"),
-        cfg.enrichment_repair_strict_discussion_skip_limit,
+        base_enrichment._coerce_int_value(
+            getattr(cfg, "enrichment_repair_strict_discussion_skip_limit", 500),
+            500,
+        ),
         min_value=1,
         max_value=5000,
     )
+    max_attempts = base_enrichment._coerce_int_value(getattr(cfg, "enrichment_repair_max_attempts", 2), 2)
     run_id = _task_run_id(task)
     scoped_vendors = _normalize_test_vendors(task_metadata.get("test_vendors") or task_metadata.get("vendor_names"))
     stale_no_signal_demoted = await _demote_stale_no_signal_rows(
@@ -1508,13 +1514,15 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     strict_discussion_kept = 0
     strict_discussion_dropped = 0
     rounds = 0
+    consecutive_no_progress = 0
+    circuit_breaker_reason = None
     strict_discussion_sources, strict_discussion_content_types = _strict_discussion_lists(cfg)
     low_signal_discussion_skipped = await _skip_low_signal_strict_discussion_rows(
         pool,
         strict_sources=strict_discussion_sources,
         strict_content_types=strict_discussion_content_types,
         scoped_vendors=scoped_vendors,
-        max_attempts=cfg.enrichment_repair_max_attempts,
+        max_attempts=max_attempts,
         limit=strict_discussion_skip_limit,
     )
     strict_discussion_dropped += int(low_signal_discussion_skipped or 0)
@@ -1799,7 +1807,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                       r.reviewer_industry, r.content_type, r.enrichment,
                       r.enrichment_repair_attempts
             """,
-            cfg.enrichment_repair_max_attempts,
+            max_attempts,
             max_batch,
             trusted_sources,
             [vendor.lower() for vendor in scoped_vendors],
@@ -1832,6 +1840,29 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         witness_count += result.get("witness_count", 0)
         for key in batch_metrics:
             batch_metrics[key] += int(result.get(key, 0) or 0)
+
+        # --- circuit breaker ---
+        round_promoted = result.get("promoted", 0)
+        round_failed = result.get("failed", 0)
+        round_total = round_promoted + result.get("shadowed", 0) + round_failed
+
+        if round_total > 0 and round_failed > round_total * 0.5:
+            circuit_breaker_reason = f"high failure rate ({round_failed}/{round_total})"
+            logger.warning("Enrichment repair circuit breaker: %s in round %d", circuit_breaker_reason, rounds + 1)
+            rounds += 1
+            break
+
+        if round_promoted == 0:
+            consecutive_no_progress += 1
+        else:
+            consecutive_no_progress = 0
+
+        if consecutive_no_progress >= 2:
+            circuit_breaker_reason = f"{consecutive_no_progress} consecutive rounds with no promotions"
+            logger.warning("Enrichment repair circuit breaker: %s", circuit_breaker_reason)
+            rounds += 1
+            break
+
         rounds += 1
         await asyncio.sleep(1)
 
@@ -1869,6 +1900,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         "strict_discussion_candidates_dropped": strict_discussion_dropped,
         "low_signal_discussion_skipped": int(low_signal_discussion_skipped or 0),
         "scoped_vendors": scoped_vendors,
+        "circuit_breaker_reason": circuit_breaker_reason,
         "_skip_synthesis": "B2B enrichment repair complete",
     }
     from ..visibility import emit_event, record_attempt
@@ -1936,6 +1968,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             "strict_discussion_candidates_dropped": strict_discussion_dropped,
             "low_signal_discussion_skipped": int(low_signal_discussion_skipped or 0),
             "scoped_vendors": scoped_vendors,
+            "circuit_breaker_reason": circuit_breaker_reason,
         },
         update_review_state=False,
     )

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -584,7 +584,7 @@ async def _persist_shadow_result(
             repaired_at,
             json.dumps(applied_fields),
             target_status,
-            False,
+            bool(combined_shadow_reasons),
             json.dumps(combined_shadow_reasons),
             repaired_at if combined_shadow_reasons else None,
         )
@@ -610,7 +610,7 @@ async def _persist_shadow_result(
             repaired_at,
             json.dumps(applied_fields),
             target_status,
-            False,
+            bool(combined_shadow_reasons),
             json.dumps(combined_shadow_reasons),
             repaired_at if combined_shadow_reasons else None,
     )
@@ -635,7 +635,6 @@ async def _persist_repair_result(
     repair_result: dict[str, Any] | None,
     *,
     model_id: str | None,
-    max_attempts: int,
     cache_usage: dict[str, int],
 ) -> str:
     review_id = row["id"]
@@ -809,7 +808,6 @@ async def _repair_single(
                 strategic_reasons,
                 None,
                 model_id=model_id,
-                max_attempts=max_attempts,
                 cache_usage=usage,
             )
         )
@@ -823,7 +821,6 @@ async def _repair_single(
             strategic_reasons,
             repair_result,
             model_id=model_id,
-            max_attempts=max_attempts,
             cache_usage=usage,
         )
     )
@@ -1004,7 +1001,6 @@ async def _repair_rows(
                         entry["strategic_reasons"],
                         parsed,
                         model_id=repair_model,
-                        max_attempts=max_attempts,
                         cache_usage=_empty_repair_usage(),
                     )
                     row_results[row["id"]] = {"status": status, **_empty_repair_usage()}
@@ -1015,6 +1011,14 @@ async def _repair_rows(
                     "Skipping duplicate enrichment-repair submission for %s; existing Anthropic batch item %s is still pending",
                     row["id"],
                     existing.get("custom_id"),
+                )
+                await pool.execute(
+                    """
+                    UPDATE b2b_reviews
+                    SET enrichment_repair_status = NULL
+                    WHERE id = $1 AND enrichment_repair_status = 'repairing'
+                    """,
+                    row["id"],
                 )
                 row_results[row["id"]] = {"status": "deferred"}
                 counts["anthropic_batch_reused_pending_items"] += 1
@@ -1114,7 +1118,6 @@ async def _repair_rows(
                     entry["strategic_reasons"],
                     parsed,
                     model_id=repair_model,
-                    max_attempts=max_attempts,
                     cache_usage=usage,
                 )
                 row_results[row["id"]] = {"status": status, **usage}

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -2019,27 +2019,51 @@ async def retry_quarantined_reviews(
     Returns counts of recovered, still_failed, skipped reviews.
     """
     retryable_reasons = sorted(_RETRYABLE_QUARANTINE_REASONS)
-    rows = await pool.fetch(
+    candidate_summary = await pool.fetchrow(
         """
-        SELECT id, enrichment, source, rating, rating_max,
-               review_text, summary, pros, cons,
-               vendor_name, reviewer_company, raw_metadata,
-               low_fidelity_reasons
-        FROM b2b_reviews
-        WHERE enrichment_status = 'quarantined'
-          AND enrichment IS NOT NULL
-          AND (enrichment->>'enrichment_schema_version')::int >= 1
-          AND low_fidelity_reasons ?| $2::text[]
-        ORDER BY created_at DESC
-        LIMIT $1
+        WITH candidate_window AS (
+            SELECT id, created_at, low_fidelity_reasons
+            FROM b2b_reviews
+            WHERE enrichment_status = 'quarantined'
+              AND enrichment IS NOT NULL
+              AND (enrichment->>'enrichment_schema_version')::int >= 1
+            ORDER BY created_at DESC
+            LIMIT $1
+        )
+        SELECT
+            COUNT(*) FILTER (
+                WHERE NOT COALESCE(low_fidelity_reasons, '[]'::jsonb) ?| $2::text[]
+            ) AS skipped,
+            COALESCE(
+                array_agg(id ORDER BY created_at DESC) FILTER (
+                    WHERE COALESCE(low_fidelity_reasons, '[]'::jsonb) ?| $2::text[]
+                ),
+                ARRAY[]::uuid[]
+            ) AS retryable_ids
+        FROM candidate_window
         """,
         limit,
         retryable_reasons,
     )
+    retryable_ids = list((candidate_summary or {}).get("retryable_ids") or [])
+    rows = []
+    if retryable_ids:
+        rows = await pool.fetch(
+            """
+            SELECT id, enrichment, source, rating, rating_max,
+                   review_text, summary, pros, cons,
+                   vendor_name, reviewer_company, raw_metadata,
+                   low_fidelity_reasons
+            FROM b2b_reviews
+            WHERE id = ANY($1::uuid[])
+            ORDER BY created_at DESC
+            """,
+            retryable_ids,
+        )
 
     recovered = 0
     still_failed = 0
-    skipped = 0
+    skipped = int((candidate_summary or {}).get("skipped") or 0)
 
     for row in rows:
         enrichment = base_enrichment._coerce_json_dict(row.get("enrichment"))
@@ -2076,8 +2100,9 @@ async def retry_quarantined_reviews(
             still_failed += 1
             logger.debug("Quarantine retry: still failing for %s", row["id"], exc_info=True)
 
+    candidate_count = skipped + len(rows)
     logger.info(
         "Quarantine retry: recovered=%d, still_failed=%d, skipped=%d (of %d)",
-        recovered, still_failed, skipped, len(rows),
+        recovered, still_failed, skipped, candidate_count,
     )
     return {"recovered": recovered, "still_failed": still_failed, "skipped": skipped}

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -45,6 +45,12 @@ _COMPETITOR_PRESSURE_PATTERNS = (
     "overcharged", "not worth", "switch", "switched to", "moved to", "replaced with",
     "evaluating", "considering", "alternative", "frustrated", "pain", "issue", "problem",
 )
+_NONPRICING_PRESSURE_PATTERNS = (
+    "cancel", "cancellation", "refund", "billing dispute", "renewal",
+    "overcharged", "not worth", "frustrated", "pain", "issue", "problem",
+    "failed", "failure", "broken", "terrible", "nightmare", "outgrew",
+    "doesn't work", "doesnt work",
+)
 _DISPLACEMENT_HARD_PATTERNS = (
     "switched to", "moved to", "replaced with", "migrating to", "migration to",
 )
@@ -390,15 +396,7 @@ def _strategic_adjudication_reasons(result: dict[str, Any], source_row: dict[str
         structured_churn
         or bool(result.get("specific_complaints"))
         or bool(result.get("feature_gaps"))
-        or base_enrichment._contains_any(
-            review_blob,
-            (
-                "cancel", "cancellation", "refund", "billing dispute", "renewal",
-                "overcharged", "not worth", "frustrated", "pain", "issue", "problem",
-                "failed", "failure", "broken", "terrible", "nightmare", "outgrew",
-                "doesn't work", "doesnt work",
-            ),
-        )
+        or base_enrichment._contains_any(review_blob, _NONPRICING_PRESSURE_PATTERNS)
     )
     pricing_signal = bool(base_enrichment._REPAIR_CURRENCY_RE.search(review_blob) or "explicit_dollar" in salience_flags)
     alt_context_signal = base_enrichment._contains_any(review_blob, _DISPLACEMENT_ALT_CONTEXT_PATTERNS)
@@ -1443,6 +1441,236 @@ async def _call_repair_extractor(
         )
 
 
+
+def _repair_candidate_predicates_sql() -> str:
+    """SQL OR-predicate block identifying reviews that need repair.
+
+    Each branch targets a specific signal gap: pricing without span,
+    competitor without displacement framing, named company without
+    named-account evidence, timeline without anchor, or workflow
+    language without replacement mode.
+    """
+    return f"""
+        AND (
+          (
+            COALESCE(enrichment->>'pain_category', 'overall_dissatisfaction') IN ('other', 'general_dissatisfaction', 'overall_dissatisfaction')
+            AND review_text ~* '(cancel|cancellation|billing dispute|refund denied|runaround|automatic renewal|auto renew|renewed without notice|charged|invoiced|price increase|overcharg)'
+          )
+          OR (
+            NOT ({_VALID_COMPETITOR_OBJECT_SQL})
+            AND review_text ~* '(switched to|moved to|replaced with|migrating to|migration to)'
+          )
+          OR (
+            COALESCE(jsonb_array_length(enrichment->'pricing_phrases'), 0) = 0
+            AND review_text ~* '(billing|invoice|invoiced|charged|refund|renewal|price increase|cost increase|automatic renewal|auto renew|overcharg)'
+          )
+          OR (
+            COALESCE(enrichment->>'pain_category', 'overall_dissatisfaction') NOT IN ('pricing', 'contract_lock_in')
+            AND (
+              (
+                review_text ~* '\\$\\s?\\d'
+                OR COALESCE(enrichment->'salience_flags', '[]'::jsonb) ? 'explicit_dollar'
+              )
+              AND (
+                COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+                OR review_text ~* '(pricing|price|priced|cost|costly|expensive|cheaper|budget|billing|invoice|refund|overcharg|renewal|per seat|per user|subscription|license|licensed|plan|plan tier|seat|user)'
+              )
+            )
+          )
+          OR (
+            COALESCE(jsonb_array_length(enrichment->'specific_complaints'), 0) = 0
+            AND review_text ~* '(cancel|cancellation|billing dispute|charged after cancellation|refund denied|runaround|automatic renewal|auto renew|renewed without notice)'
+          )
+          OR (
+            COALESCE(jsonb_array_length(enrichment->'event_mentions'), 0) = 0
+            AND COALESCE(enrichment->'timeline'->>'decision_timeline', 'unknown') = 'unknown'
+            AND (
+              NULLIF(enrichment->'churn_signals'->>'renewal_timing', '') IS NOT NULL
+              OR review_text ~* '(renewal|contract end|contract expires|deadline)'
+              OR (
+                review_text ~* '(next quarter|q1|q2|q3|q4|30 days|60 days|90 days)'
+                AND review_text ~* '(renewal|contract|evaluating|evaluation|considering|switch|switched|migrating|migration|replatform|cancel|deadline|go live|go-live|cutover)'
+              )
+            )
+          )
+          OR (
+            enrichment_status = 'no_signal'
+            AND (
+              cardinality($3::text[]) = 0
+              OR lower(source) = ANY($3::text[])
+            )
+            AND review_text ~* '(cancel|cancellation|billing|invoice|charged|refund|automatic renewal|auto renew|switched to|moved to|considering|evaluating|replaced with)'
+          )
+          OR (
+            (
+              review_text ~* '\\$\\s?\\d'
+              OR COALESCE(enrichment->'salience_flags', '[]'::jsonb) ? 'explicit_dollar'
+            )
+            AND (
+              COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+              OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+              OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+              OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+              OR review_text ~* '(pricing|price|priced|cost|costly|expensive|cheaper|budget|billing|invoice|refund|overcharg|renewal|per seat|per user|subscription|license|licensed|plan|plan tier|seat|user)'
+            )
+            AND NOT (
+              content_type IN ('community_discussion', 'insider_account')
+              AND NOT (
+                COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+              )
+              AND COALESCE(
+                CASE
+                  WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
+                  ELSE NULLIF(reviewer_title, '')
+                END,
+                NULLIF(reviewer_company, ''),
+                NULLIF(enrichment->'reviewer_context'->>'company_name', '')
+              ) IS NULL
+              AND NOT jsonb_path_exists(
+                COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb),
+                '$[*] ? (@.evidence_type == "explicit_switch" || @.evidence_type == "active_evaluation" || @.displacement_confidence == "high" || @.displacement_confidence == "medium" || @.reason != null || @.reason_category != null || @.reason_detail != null)'
+              )
+            )
+            AND NOT jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? (@.signal_type == "pricing_backlash")')
+          )
+          OR (
+            (
+              review_text ~* '(switched to|moved to|replaced with|migrating to|migration to)'
+              OR (
+                review_text ~* '(evaluating|looking at|considering|shortlisting|shortlisted|poc with|proof of concept with)'
+                AND ({_VALID_COMPETITOR_OBJECT_SQL})
+              )
+              OR jsonb_path_exists(
+                COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb),
+                '$[*] ? (@.evidence_type == "explicit_switch" || @.evidence_type == "active_evaluation" || @.displacement_confidence == "high" || @.displacement_confidence == "medium" || @.reason != null || @.reason_category != null || @.reason_detail != null)'
+              )
+            )
+            AND (
+              COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+              OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+              OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+              OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+              OR COALESCE(jsonb_array_length(enrichment->'specific_complaints'), 0) > 0
+              OR COALESCE(jsonb_array_length(enrichment->'pricing_phrases'), 0) > 0
+              OR COALESCE(jsonb_array_length(enrichment->'feature_gaps'), 0) > 0
+              OR review_text ~* '(cancel|cancellation|refund|billing dispute|renewal|price increase|overcharg|not worth|switch|switched to|moved to|replaced with|evaluating|considering|alternative|frustrated|pain|issue|problem)'
+            )
+            AND NOT (
+              source = 'reddit'
+              AND NOT (
+                (
+                  review_text ILIKE ('%' || vendor_name || '%')
+                  AND (
+                    lower(vendor_name) NOT IN ('copper', 'close')
+                    OR (
+                      review_text ~* '(alternative|alternatives|budget|contract|cost|expensive|migrate|migration|pricing|renewal|replace|replaced|seat|seats|support|switch|switching)'
+                      AND review_text ~* '(crm|sales|pipeline|lead|leads|deal|deals|account|contact|contacts|prospect|prospects|software|saas)'
+                    )
+                  )
+                )
+                OR (
+                  COALESCE(product_name, '') <> ''
+                  AND lower(COALESCE(product_name, '')) <> lower(COALESCE(vendor_name, ''))
+                  AND review_text ILIKE ('%' || product_name || '%')
+                )
+              )
+              AND NOT review_text ~* '(alternative|alternatives|budget|contract|cost|expensive|migrate|migration|pricing|renewal|replace|replaced|seat|seats|support|switch|switching)'
+            )
+            AND NOT (
+              content_type IN ('community_discussion', 'insider_account')
+              AND (
+                review_text ILIKE ('%' || vendor_name || '%')
+                OR (
+                  COALESCE(product_name, '') <> ''
+                  AND lower(COALESCE(product_name, '')) <> lower(COALESCE(vendor_name, ''))
+                  AND review_text ILIKE ('%' || product_name || '%')
+                )
+              )
+              AND NOT (
+                COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+              )
+              AND review_text ~* '(work(?:ing)? at|employee|career|manager|my manager|our team|interview|hiring|certification|freelance|rep at|joined|left my role|leaving my full time|promotion|salary)'
+              AND NOT review_text ~* '(alternative|alternatives|budget|contract|cost|expensive|migrate|migration|pricing|renewal|replace|replaced|seat|seats|support|switch|switching)'
+            )
+            AND NOT (
+              content_type IN ('community_discussion', 'insider_account')
+              AND NOT (
+                COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+              )
+              AND COALESCE(
+                CASE
+                  WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
+                  ELSE NULLIF(reviewer_title, '')
+                END,
+                NULLIF(reviewer_company, ''),
+                NULLIF(enrichment->'reviewer_context'->>'company_name', '')
+              ) IS NULL
+              AND NOT jsonb_path_exists(
+                COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb),
+                '$[*] ? (@.evidence_type == "explicit_switch" || @.evidence_type == "active_evaluation" || @.displacement_confidence == "high" || @.displacement_confidence == "medium" || @.reason != null || @.reason_category != null || @.reason_detail != null)'
+              )
+            )
+            AND NOT (
+              ({_STRONG_VALID_COMPETITOR_OBJECT_SQL})
+              OR jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? (@.signal_type == "competitor_pressure")')
+              OR lower(COALESCE(enrichment->>'replacement_mode', 'none')) = 'competitor_switch'
+            )
+          )
+          OR (
+            COALESCE(NULLIF(reviewer_company, ''), NULLIF(enrichment->'reviewer_context'->>'company_name', '')) IS NOT NULL
+            AND NOT (
+              COALESCE(enrichment->'salience_flags', '[]'::jsonb) ? 'named_account'
+              OR jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? (@.company_name != null && @.company_name != "")')
+            )
+          )
+          OR (
+            (
+              NULLIF(enrichment->'churn_signals'->>'renewal_timing', '') IS NOT NULL
+              OR review_text ~* '(renewal|contract end|contract expires|deadline)'
+              OR (
+                review_text ~* '(next quarter|q1|q2|q3|q4|30 days|60 days|90 days)'
+                AND review_text ~* '(renewal|contract|evaluating|evaluation|considering|switch|switched|migrating|migration|replatform|cancel|deadline|go live|go-live|cutover)'
+              )
+            )
+            AND NOT (
+              content_type IN ('community_discussion', 'insider_account')
+              AND NOT (
+                COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+                OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+              )
+              AND COALESCE(
+                CASE
+                  WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
+                  ELSE NULLIF(reviewer_title, '')
+                END,
+                NULLIF(reviewer_company, ''),
+                NULLIF(enrichment->'reviewer_context'->>'company_name', '')
+              ) IS NULL
+            )
+            AND NOT jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? ((@.time_anchor != null && @.time_anchor != "") || @.flags[*] == "deadline")')
+          )
+          OR (
+            review_text ~* '(async|docs|documentation|notion|confluence|bundle|workspace|microsoft 365|google workspace|internal tool|homegrown|home-grown|custom tool)'
+            AND lower(COALESCE(enrichment->>'replacement_mode', 'none')) = 'none'
+          )
+        )
+"""
+
+
 async def run(task: ScheduledTask) -> dict[str, Any]:
     cfg = settings.b2b_churn
     if not cfg.enabled:
@@ -1561,223 +1789,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                     OR lower(vendor_name) = ANY($4::text[])
                   )
                   AND {_strict_discussion_gate_sql(6, 7)}
-                  AND (
-                    (
-                      COALESCE(enrichment->>'pain_category', 'overall_dissatisfaction') IN ('other', 'general_dissatisfaction', 'overall_dissatisfaction')
-                      AND review_text ~* '(cancel|cancellation|billing dispute|refund denied|runaround|automatic renewal|auto renew|renewed without notice|charged|invoiced|price increase|overcharg)'
-                    )
-                    OR (
-                      NOT ({_VALID_COMPETITOR_OBJECT_SQL})
-                      AND review_text ~* '(switched to|moved to|replaced with|migrating to|migration to)'
-                    )
-                    OR (
-                      COALESCE(jsonb_array_length(enrichment->'pricing_phrases'), 0) = 0
-                      AND review_text ~* '(billing|invoice|invoiced|charged|refund|renewal|price increase|cost increase|automatic renewal|auto renew|overcharg)'
-                    )
-                    OR (
-                      COALESCE(enrichment->>'pain_category', 'overall_dissatisfaction') NOT IN ('pricing', 'contract_lock_in')
-                      AND (
-                        (
-                          review_text ~* '\\$\\s?\\d'
-                          OR COALESCE(enrichment->'salience_flags', '[]'::jsonb) ? 'explicit_dollar'
-                        )
-                        AND (
-                          COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                          OR review_text ~* '(pricing|price|priced|cost|costly|expensive|cheaper|budget|billing|invoice|refund|overcharg|renewal|per seat|per user|subscription|license|licensed|plan|plan tier|seat|user)'
-                        )
-                      )
-                    )
-                    OR (
-                      COALESCE(jsonb_array_length(enrichment->'specific_complaints'), 0) = 0
-                      AND review_text ~* '(cancel|cancellation|billing dispute|charged after cancellation|refund denied|runaround|automatic renewal|auto renew|renewed without notice)'
-                    )
-                    OR (
-                      COALESCE(jsonb_array_length(enrichment->'event_mentions'), 0) = 0
-                      AND COALESCE(enrichment->'timeline'->>'decision_timeline', 'unknown') = 'unknown'
-                      AND (
-                        NULLIF(enrichment->'churn_signals'->>'renewal_timing', '') IS NOT NULL
-                        OR review_text ~* '(renewal|contract end|contract expires|deadline)'
-                        OR (
-                          review_text ~* '(next quarter|q1|q2|q3|q4|30 days|60 days|90 days)'
-                          AND review_text ~* '(renewal|contract|evaluating|evaluation|considering|switch|switched|migrating|migration|replatform|cancel|deadline|go live|go-live|cutover)'
-                        )
-                      )
-                    )
-                    OR (
-                      enrichment_status = 'no_signal'
-                      AND (
-                        cardinality($3::text[]) = 0
-                        OR lower(source) = ANY($3::text[])
-                      )
-                      AND review_text ~* '(cancel|cancellation|billing|invoice|charged|refund|automatic renewal|auto renew|switched to|moved to|considering|evaluating|replaced with)'
-                    )
-                    OR (
-                      (
-                        review_text ~* '\\$\\s?\\d'
-                        OR COALESCE(enrichment->'salience_flags', '[]'::jsonb) ? 'explicit_dollar'
-                      )
-                      AND (
-                        COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                        OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                        OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                        OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                        OR review_text ~* '(pricing|price|priced|cost|costly|expensive|cheaper|budget|billing|invoice|refund|overcharg|renewal|per seat|per user|subscription|license|licensed|plan|plan tier|seat|user)'
-                      )
-                      AND NOT (
-                        content_type IN ('community_discussion', 'insider_account')
-                        AND NOT (
-                          COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                        )
-                        AND COALESCE(
-                          CASE
-                            WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
-                            ELSE NULLIF(reviewer_title, '')
-                          END,
-                          NULLIF(reviewer_company, ''),
-                          NULLIF(enrichment->'reviewer_context'->>'company_name', '')
-                        ) IS NULL
-                        AND NOT jsonb_path_exists(
-                          COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb),
-                          '$[*] ? (@.evidence_type == "explicit_switch" || @.evidence_type == "active_evaluation" || @.displacement_confidence == "high" || @.displacement_confidence == "medium" || @.reason != null || @.reason_category != null || @.reason_detail != null)'
-                        )
-                      )
-                      AND NOT jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? (@.signal_type == "pricing_backlash")')
-                    )
-                    OR (
-                      (
-                        review_text ~* '(switched to|moved to|replaced with|migrating to|migration to)'
-                        OR (
-                          review_text ~* '(evaluating|looking at|considering|shortlisting|shortlisted|poc with|proof of concept with)'
-                          AND ({_VALID_COMPETITOR_OBJECT_SQL})
-                        )
-                        OR jsonb_path_exists(
-                          COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb),
-                          '$[*] ? (@.evidence_type == "explicit_switch" || @.evidence_type == "active_evaluation" || @.displacement_confidence == "high" || @.displacement_confidence == "medium" || @.reason != null || @.reason_category != null || @.reason_detail != null)'
-                        )
-                      )
-                      AND (
-                        COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                        OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                        OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                        OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                        OR COALESCE(jsonb_array_length(enrichment->'specific_complaints'), 0) > 0
-                        OR COALESCE(jsonb_array_length(enrichment->'pricing_phrases'), 0) > 0
-                        OR COALESCE(jsonb_array_length(enrichment->'feature_gaps'), 0) > 0
-                        OR review_text ~* '(cancel|cancellation|refund|billing dispute|renewal|price increase|overcharg|not worth|switch|switched to|moved to|replaced with|evaluating|considering|alternative|frustrated|pain|issue|problem)'
-                      )
-                      AND NOT (
-                        source = 'reddit'
-                        AND NOT (
-                          (
-                            review_text ILIKE ('%' || vendor_name || '%')
-                            AND (
-                              lower(vendor_name) NOT IN ('copper', 'close')
-                              OR (
-                                review_text ~* '(alternative|alternatives|budget|contract|cost|expensive|migrate|migration|pricing|renewal|replace|replaced|seat|seats|support|switch|switching)'
-                                AND review_text ~* '(crm|sales|pipeline|lead|leads|deal|deals|account|contact|contacts|prospect|prospects|software|saas)'
-                              )
-                            )
-                          )
-                          OR (
-                            COALESCE(product_name, '') <> ''
-                            AND lower(COALESCE(product_name, '')) <> lower(COALESCE(vendor_name, ''))
-                            AND review_text ILIKE ('%' || product_name || '%')
-                          )
-                        )
-                        AND NOT review_text ~* '(alternative|alternatives|budget|contract|cost|expensive|migrate|migration|pricing|renewal|replace|replaced|seat|seats|support|switch|switching)'
-                      )
-                      AND NOT (
-                        content_type IN ('community_discussion', 'insider_account')
-                        AND (
-                          review_text ILIKE ('%' || vendor_name || '%')
-                          OR (
-                            COALESCE(product_name, '') <> ''
-                            AND lower(COALESCE(product_name, '')) <> lower(COALESCE(vendor_name, ''))
-                            AND review_text ILIKE ('%' || product_name || '%')
-                          )
-                        )
-                        AND NOT (
-                          COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                        )
-                        AND review_text ~* '(work(?:ing)? at|employee|career|manager|my manager|our team|interview|hiring|certification|freelance|rep at|joined|left my role|leaving my full time|promotion|salary)'
-                        AND NOT review_text ~* '(alternative|alternatives|budget|contract|cost|expensive|migrate|migration|pricing|renewal|replace|replaced|seat|seats|support|switch|switching)'
-                      )
-                      AND NOT (
-                        content_type IN ('community_discussion', 'insider_account')
-                        AND NOT (
-                          COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                        )
-                        AND COALESCE(
-                          CASE
-                            WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
-                            ELSE NULLIF(reviewer_title, '')
-                          END,
-                          NULLIF(reviewer_company, ''),
-                          NULLIF(enrichment->'reviewer_context'->>'company_name', '')
-                        ) IS NULL
-                        AND NOT jsonb_path_exists(
-                          COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb),
-                          '$[*] ? (@.evidence_type == "explicit_switch" || @.evidence_type == "active_evaluation" || @.displacement_confidence == "high" || @.displacement_confidence == "medium" || @.reason != null || @.reason_category != null || @.reason_detail != null)'
-                        )
-                      )
-                      AND NOT (
-                        ({_STRONG_VALID_COMPETITOR_OBJECT_SQL})
-                        OR jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? (@.signal_type == "competitor_pressure")')
-                        OR lower(COALESCE(enrichment->>'replacement_mode', 'none')) = 'competitor_switch'
-                      )
-                    )
-                    OR (
-                      COALESCE(NULLIF(reviewer_company, ''), NULLIF(enrichment->'reviewer_context'->>'company_name', '')) IS NOT NULL
-                      AND NOT (
-                        COALESCE(enrichment->'salience_flags', '[]'::jsonb) ? 'named_account'
-                        OR jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? (@.company_name != null && @.company_name != "")')
-                      )
-                    )
-                    OR (
-                      (
-                        NULLIF(enrichment->'churn_signals'->>'renewal_timing', '') IS NOT NULL
-                        OR review_text ~* '(renewal|contract end|contract expires|deadline)'
-                        OR (
-                          review_text ~* '(next quarter|q1|q2|q3|q4|30 days|60 days|90 days)'
-                          AND review_text ~* '(renewal|contract|evaluating|evaluation|considering|switch|switched|migrating|migration|replatform|cancel|deadline|go live|go-live|cutover)'
-                        )
-                      )
-                      AND NOT (
-                        content_type IN ('community_discussion', 'insider_account')
-                        AND NOT (
-                          COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
-                          OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
-                        )
-                        AND COALESCE(
-                          CASE
-                            WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
-                            ELSE NULLIF(reviewer_title, '')
-                          END,
-                          NULLIF(reviewer_company, ''),
-                          NULLIF(enrichment->'reviewer_context'->>'company_name', '')
-                        ) IS NULL
-                      )
-                      AND NOT jsonb_path_exists(COALESCE(enrichment->'evidence_spans', '[]'::jsonb), '$[*] ? ((@.time_anchor != null && @.time_anchor != "") || @.flags[*] == "deadline")')
-                    )
-                    OR (
-                      review_text ~* '(async|docs|documentation|notion|confluence|bundle|workspace|microsoft 365|google workspace|internal tool|homegrown|home-grown|custom tool)'
-                      AND lower(COALESCE(enrichment->>'replacement_mode', 'none')) = 'none'
-                    )
-                  )
+                  {_repair_candidate_predicates_sql()}
                 ORDER BY
                   CASE
                     WHEN enrichment_repair_status IS NULL THEN 0

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1863,8 +1863,9 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
 
         # --- circuit breaker ---
         round_promoted = result.get("promoted", 0)
+        round_shadowed = result.get("shadowed", 0)
         round_failed = result.get("failed", 0)
-        round_total = round_promoted + result.get("shadowed", 0) + round_failed
+        round_total = round_promoted + round_shadowed + round_failed
 
         if round_total > 0 and round_failed > round_total * 0.5:
             circuit_breaker_reason = f"high failure rate ({round_failed}/{round_total})"
@@ -1872,13 +1873,13 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             rounds += 1
             break
 
-        if round_promoted == 0:
+        if round_promoted == 0 and round_shadowed == 0:
             consecutive_no_progress += 1
         else:
             consecutive_no_progress = 0
 
         if consecutive_no_progress >= 2:
-            circuit_breaker_reason = f"{consecutive_no_progress} consecutive rounds with no promotions"
+            circuit_breaker_reason = f"{consecutive_no_progress} consecutive rounds with no repair progress"
             logger.warning("Enrichment repair circuit breaker: %s", circuit_breaker_reason)
             rounds += 1
             break

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1228,6 +1228,7 @@ async def _recover_orphaned_repairing(pool, max_attempts: int) -> int:
                 ELSE NULL
             END
         WHERE enrichment_repair_status = 'repairing'
+          AND enrichment_repaired_at < NOW() - INTERVAL '30 minutes'
         """,
         max_attempts,
     )
@@ -1797,7 +1798,8 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 FOR UPDATE SKIP LOCKED
             )
             UPDATE b2b_reviews r
-            SET enrichment_repair_status = 'repairing'
+            SET enrichment_repair_status = 'repairing',
+                enrichment_repaired_at = NOW()
             FROM batch
             WHERE r.id = batch.id
             RETURNING r.id, r.vendor_name, r.product_name, r.product_category,

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -1899,7 +1899,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             rounds += 1
             break
 
-        if round_promoted == 0 and round_shadowed == 0:
+        if round_total > 0 and round_promoted == 0:
             consecutive_no_progress += 1
         else:
             consecutive_no_progress = 0

--- a/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment_repair.py
@@ -626,6 +626,36 @@ def _empty_repair_usage() -> dict[str, int]:
     }
 
 
+def _row_usage_result(status: Any, usage: dict[str, Any] | None = None) -> dict[str, Any]:
+    normalized = {"status": status}
+    usage_dict = usage or {}
+    for key in _empty_repair_usage():
+        normalized[key] = int(usage_dict.get(key, 0) or 0)
+    return normalized
+
+
+async def _defer_batch_row(
+    pool,
+    row: dict[str, Any],
+    *,
+    custom_id: str | None = None,
+) -> dict[str, Any]:
+    await pool.execute(
+        """
+        UPDATE b2b_reviews
+        SET enrichment_repair_status = NULL
+        WHERE id = $1 AND enrichment_repair_status = 'repairing'
+        """,
+        row["id"],
+    )
+    logger.info(
+        "Deferring B2B enrichment repair for %s; reset row to unclaimed while existing batch artifact %s remains pending",
+        row["id"],
+        custom_id or "unknown",
+    )
+    return _row_usage_result("deferred")
+
+
 async def _persist_repair_result(
     pool,
     row: dict[str, Any],
@@ -848,10 +878,7 @@ async def _repair_rows(
             if supports_run_id:
                 kwargs["run_id"] = run_id
             status = await _repair_single(pool, row, cfg, max_attempts, **kwargs)
-            return {
-                "status": status,
-                **usage,
-            }
+            return _row_usage_result(status, usage)
 
     async def _run_single_rows(target_rows: list[dict[str, Any]]) -> list[dict[str, Any] | Exception]:
         if not target_rows:
@@ -875,6 +902,7 @@ async def _repair_rows(
         "anthropic_batch_failed_items": 0,
         "anthropic_batch_reused_completed_items": 0,
         "anthropic_batch_reused_pending_items": 0,
+        "anthropic_batch_rows_deferred": 0,
     }
 
     from ...services.b2b.anthropic_batch import (
@@ -993,6 +1021,11 @@ async def _repair_rows(
             if existing and existing.get("state") == "succeeded":
                 parsed = _parse_batch_text(existing.get("response_text"))
                 if parsed is not None:
+                    usage = _empty_repair_usage()
+                    if existing.get("cached"):
+                        usage["exact_cache_hits"] += 1
+                    else:
+                        usage["generated"] += 1
                     status = await _persist_repair_result(
                         pool,
                         row,
@@ -1001,27 +1034,19 @@ async def _repair_rows(
                         entry["strategic_reasons"],
                         parsed,
                         model_id=repair_model,
-                        cache_usage=_empty_repair_usage(),
+                        cache_usage=usage,
                     )
-                    row_results[row["id"]] = {"status": status, **_empty_repair_usage()}
+                    row_results[row["id"]] = _row_usage_result(status, usage)
                     counts["anthropic_batch_reused_completed_items"] += 1
                     continue
             if existing and existing.get("state") == "pending":
-                logger.info(
-                    "Skipping duplicate enrichment-repair submission for %s; existing Anthropic batch item %s is still pending",
-                    row["id"],
-                    existing.get("custom_id"),
+                row_results[row["id"]] = await _defer_batch_row(
+                    pool,
+                    row,
+                    custom_id=str(existing.get("custom_id") or ""),
                 )
-                await pool.execute(
-                    """
-                    UPDATE b2b_reviews
-                    SET enrichment_repair_status = NULL
-                    WHERE id = $1 AND enrichment_repair_status = 'repairing'
-                    """,
-                    row["id"],
-                )
-                row_results[row["id"]] = {"status": "deferred"}
                 counts["anthropic_batch_reused_pending_items"] += 1
+                counts["anthropic_batch_rows_deferred"] += 1
                 continue
             remaining_entries.append(entry)
 
@@ -1120,7 +1145,7 @@ async def _repair_rows(
                     model_id=repair_model,
                     cache_usage=usage,
                 )
-                row_results[row["id"]] = {"status": status, **usage}
+                row_results[row["id"]] = _row_usage_result(status, usage)
 
             fallback_results = await _run_single_rows(fallback_rows)
             for row, result in zip(fallback_rows, fallback_results):
@@ -1745,6 +1770,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         "anthropic_batch_fallback_single_call_items": 0,
         "anthropic_batch_completed_items": 0,
         "anthropic_batch_failed_items": 0,
+        "anthropic_batch_rows_deferred": 0,
     }
     strict_discussion_kept = 0
     strict_discussion_dropped = 0
@@ -1878,7 +1904,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         else:
             consecutive_no_progress = 0
 
-        if consecutive_no_progress >= 2:
+        if consecutive_no_progress >= 3:
             circuit_breaker_reason = f"{consecutive_no_progress} consecutive rounds with no repair progress"
             logger.warning("Enrichment repair circuit breaker: %s", circuit_breaker_reason)
             rounds += 1
@@ -1933,6 +1959,8 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             f"{failed} failed, {shadowed} shadowed, "
             f"{shadowed_hard_gap_quarantined} hard-gap quarantined"
         )
+    if circuit_breaker_reason:
+        error_message = f"{error_message or 'Circuit breaker tripped'}; circuit_breaker: {circuit_breaker_reason}"
     await record_attempt(
         pool,
         artifact_type="enrichment_repair",
@@ -1956,7 +1984,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             f"Repair: {promoted} promoted, {shadowed} shadowed, "
             f"{failed} failed, {shadowed_hard_gap_quarantined} hard-gap quarantined"
         ),
-        severity="warning" if failed > 0 or shadowed_hard_gap_quarantined > 0 else "info",
+        severity="warning" if failed > 0 or shadowed_hard_gap_quarantined > 0 or circuit_breaker_reason else "info",
         actionable=failed > 0 or shadowed_hard_gap_quarantined > 0 or shadowed > 5,
         run_id=run_id,
         reason_code=(

--- a/atlas_brain/autonomous/tasks/b2b_product_profiles.py
+++ b/atlas_brain/autonomous/tasks/b2b_product_profiles.py
@@ -133,6 +133,7 @@ async def _fetch_satisfaction_by_area(pool, window_days: int) -> dict[str, list[
                COUNT(*) AS cnt
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
           AND enrichment->>'pain_category' IS NOT NULL
         GROUP BY vendor_name, enrichment->>'pain_category'
@@ -164,6 +165,7 @@ async def _fetch_pain_distribution(pool, window_days: int) -> dict[str, dict[str
                COUNT(*) AS cnt
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
           AND enrichment->>'pain_category' IS NOT NULL
         GROUP BY vendor_name, enrichment->>'pain_category'
@@ -188,6 +190,7 @@ async def _fetch_use_case_distribution(pool, window_days: int) -> dict[str, list
                COUNT(*) AS cnt
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
           AND enrichment->'use_case'->>'primary_workflow' IS NOT NULL
         GROUP BY vendor_name, enrichment->'use_case'->>'primary_workflow'
@@ -215,6 +218,7 @@ async def _fetch_company_size_distribution(pool, window_days: int) -> dict[str, 
                COUNT(*) AS cnt
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
           AND enrichment->'reviewer_context'->>'company_size_segment' IS NOT NULL
           AND enrichment->'reviewer_context'->>'company_size_segment' != 'unknown'
@@ -245,6 +249,7 @@ async def _fetch_competitive_flows(pool, window_days: int) -> dict[str, dict]:
         FROM b2b_reviews,
              jsonb_array_elements(enrichment->'competitors_mentioned') AS comp
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
           AND jsonb_typeof(enrichment->'competitors_mentioned') = 'array'
         """,
@@ -286,6 +291,7 @@ async def _fetch_integration_stacks(pool, window_days: int) -> dict[str, dict[st
         FROM b2b_reviews,
              jsonb_array_elements_text(enrichment->'use_case'->'integration_stack') AS integ
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
           AND jsonb_typeof(enrichment->'use_case'->'integration_stack') = 'array'
         """,
@@ -324,6 +330,7 @@ async def _fetch_aggregate_metrics(pool, window_days: int, min_reviews: int) -> 
                MAX(enriched_at) AS review_window_end
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
         GROUP BY vendor_name
         HAVING COUNT(*) >= $2
@@ -353,6 +360,7 @@ async def _fetch_source_distribution(pool, window_days: int) -> dict[str, dict[s
         SELECT vendor_name, source, count(*) AS cnt
         FROM b2b_reviews
         WHERE enrichment_status = 'enriched'
+          AND duplicate_of_review_id IS NULL
           AND enriched_at > NOW() - make_interval(days => $1)
         GROUP BY vendor_name, source
         """,

--- a/atlas_brain/autonomous/tasks/b2b_scrape_intake.py
+++ b/atlas_brain/autonomous/tasks/b2b_scrape_intake.py
@@ -68,6 +68,36 @@ _TWITTER_MARKETING_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b(?:now\s+available|product\s+update|release\s+notes|hiring)\b", re.I),
 )
 _CAPTERRA_AGGREGATE_METHOD = "jsonld_aggregate"
+_DEFAULT_SOURCE_QUALITY_GATE_SOURCES = frozenset({"quora", "twitter", "capterra"})
+
+
+def _coerce_config_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        if text in {"0", "false", "no", "off", ""}:
+            return False
+    return default
+
+
+def _normalize_source_quality_gate_sources(raw: Any) -> set[str]:
+    if isinstance(raw, str):
+        values = raw.split(",")
+    elif isinstance(raw, (list, tuple, set, frozenset)):
+        values = list(raw)
+    else:
+        values = []
+    sources = {
+        str(part).strip().lower()
+        for part in values
+        if str(part).strip()
+    }
+    return sources or set(_DEFAULT_SOURCE_QUALITY_GATE_SOURCES)
 
 
 def _parse_date(raw: Any) -> datetime | None:
@@ -252,7 +282,10 @@ def _quality_gate_skip_reason(review: dict[str, Any], cfg) -> str | None:
             return "quora_non_question_url"
         return None
 
-    if source == "capterra" and cfg.source_quality_drop_capterra_aggregates:
+    if source == "capterra" and _coerce_config_bool(
+        getattr(cfg, "source_quality_drop_capterra_aggregates", True),
+        True,
+    ):
         meta = review.get("raw_metadata") or {}
         if str(meta.get("extraction_method") or "").strip().lower() == _CAPTERRA_AGGREGATE_METHOD:
             return "capterra_aggregate_page"
@@ -265,11 +298,14 @@ def _quality_gate_skip_reason(review: dict[str, Any], cfg) -> str | None:
             if str(value or "").strip()
         )
         intent = _review_has_twitter_intent(text)
-        if cfg.source_quality_twitter_require_intent and not intent:
+        if _coerce_config_bool(getattr(cfg, "source_quality_twitter_require_intent", True), True) and not intent:
             return "twitter_no_intent"
         if _review_looks_like_twitter_marketing(text) and not intent:
             return "twitter_marketing_post"
-        if cfg.source_quality_twitter_drop_vendor_self_posts and _is_vendor_self_tweet(
+        if _coerce_config_bool(
+            getattr(cfg, "source_quality_twitter_drop_vendor_self_posts", True),
+            True,
+        ) and _is_vendor_self_tweet(
             review, str(review.get("vendor_name") or "")
         ):
             return "twitter_vendor_self_post"
@@ -280,13 +316,11 @@ def _quality_gate_skip_reason(review: dict[str, Any], cfg) -> str | None:
 
 def _should_apply_source_quality_gate(source: str, cfg) -> bool:
     """Return True when source-specific quality gates should run."""
-    if not cfg.source_quality_gate_enabled:
+    if not _coerce_config_bool(getattr(cfg, "source_quality_gate_enabled", True), True):
         return False
-    gated_sources = {
-        part.strip().lower()
-        for part in str(cfg.source_quality_gate_sources or "").split(",")
-        if part.strip()
-    }
+    gated_sources = _normalize_source_quality_gate_sources(
+        getattr(cfg, "source_quality_gate_sources", _DEFAULT_SOURCE_QUALITY_GATE_SOURCES)
+    )
     return str(source or "").strip().lower() in gated_sources
 
 

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -3382,7 +3382,7 @@ class B2BChurnConfig(BaseSettings):
     battle_card_high_priority_urgency_min: float = Field(default=5.0, ge=0.0, le=10.0, description="Min average urgency required before battle-card copy can use high-priority language")
     battle_card_feature_gap_headline_min_mentions: int = Field(default=5, ge=1, le=100, description="Min feature-gap mention count before a battle-card headline can elevate that gap directly")
     battle_card_quality_max_stale_days: int = Field(
-        default=7,
+        default=2,
         ge=0,
         le=30,
         description="Max allowed staleness (days) before battle-card quality gate hard-blocks publishing",

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -2506,6 +2506,24 @@ class B2BChurnConfig(BaseSettings):
         le=10,
         description="Minimum urgency score for repair unless leave/eval pressure is already present",
     )
+    enrichment_repair_orphan_timeout_minutes: int = Field(
+        default=30,
+        ge=5,
+        le=120,
+        description="Minutes before a row stuck in repairing status is recovered as orphaned",
+    )
+    enrichment_repair_failure_rate_threshold: float = Field(
+        default=0.5,
+        ge=0.1,
+        le=1.0,
+        description="Fraction of failed rows in a single round that triggers the circuit breaker",
+    )
+    enrichment_repair_no_progress_max_rounds: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description="Consecutive rounds with zero promotions before circuit breaker trips",
+    )
     enrichment_low_fidelity_enabled: bool = Field(
         default=True,
         description="Enable deterministic quarantine of low-fidelity enriched rows",

--- a/atlas_brain/reasoning/falsification.py
+++ b/atlas_brain/reasoning/falsification.py
@@ -293,6 +293,7 @@ class FalsificationWatcher:
                 """
                 SELECT COUNT(*) FROM b2b_reviews
                 WHERE vendor_name = $1
+                  AND duplicate_of_review_id IS NULL
                   AND enriched_at >= NOW() - INTERVAL '7 days'
                   AND overall_sentiment = 'negative'
                 """,

--- a/atlas_brain/services/b2b/enrichment_repair_policy.py
+++ b/atlas_brain/services/b2b/enrichment_repair_policy.py
@@ -126,11 +126,17 @@ def _parse_source_allowlist(raw: Any) -> set[str]:
 
 
 def strict_discussion_lists(cfg: Any) -> tuple[list[str], list[str]]:
-    sources = sorted(_parse_source_allowlist(getattr(cfg, "enrichment_repair_strict_discussion_sources", None)))
+    raw_sources = getattr(cfg, "enrichment_repair_strict_discussion_sources", None)
+    if not isinstance(raw_sources, (str, list, tuple, set, frozenset)):
+        raw_sources = "reddit"
+    sources = sorted(_parse_source_allowlist(raw_sources))
+    raw_content_types = getattr(cfg, "enrichment_repair_strict_discussion_content_types", None)
+    if not isinstance(raw_content_types, (list, tuple, set, frozenset)):
+        raw_content_types = ["community_discussion", "insider_account", "comment"]
     content_types = sorted(
         {
             str(value or "").strip().lower()
-            for value in (getattr(cfg, "enrichment_repair_strict_discussion_content_types", None) or [])
+            for value in (raw_content_types or [])
             if str(value or "").strip()
         }
     )

--- a/atlas_brain/services/b2b/review_dedup.py
+++ b/atlas_brain/services/b2b/review_dedup.py
@@ -6,6 +6,58 @@ from difflib import SequenceMatcher
 from typing import Any
 
 
+def _coerce_int(value: Any, default: int, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or value is None:
+        numeric = default
+    elif isinstance(value, int):
+        numeric = value
+    elif isinstance(value, float):
+        if value != value:
+            numeric = default
+        else:
+            numeric = int(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            numeric = default
+        else:
+            try:
+                numeric = int(text)
+            except ValueError:
+                try:
+                    numeric = int(float(text))
+                except ValueError:
+                    numeric = default
+    else:
+        numeric = default
+    if minimum is not None and numeric < minimum:
+        return minimum
+    return numeric
+
+
+def _coerce_float(value: Any, default: float, *, minimum: float | None = None) -> float:
+    if isinstance(value, bool) or value is None:
+        numeric = default
+    elif isinstance(value, (int, float)):
+        numeric = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            numeric = default
+        else:
+            try:
+                numeric = float(text)
+            except ValueError:
+                numeric = default
+    else:
+        numeric = default
+    if numeric != numeric:
+        numeric = default
+    if minimum is not None and numeric < minimum:
+        return minimum
+    return numeric
+
+
 def normalize_review_text_for_hash(value: Any) -> str:
     text = re.sub(r"\s+", " ", str(value or "").strip())
     return text.lower()
@@ -60,7 +112,7 @@ def normalize_reviewer_stem_key(value: Any, *, stem_length: int) -> str | None:
     reviewer_key = normalize_reviewer_key(value)
     if not reviewer_key:
         return None
-    return reviewer_key[: max(1, int(stem_length))]
+    return reviewer_key[: _coerce_int(stem_length, 5, minimum=1)]
 
 
 def normalize_rating_key(value: Any) -> str:
@@ -130,6 +182,10 @@ async def load_cross_source_review_candidates(
     review_date_tolerance_days: int,
     rating_tolerance: float,
 ) -> list[dict[str, Any]]:
+    reviewer_stem_length = _coerce_int(reviewer_stem_length, 5, minimum=1)
+    review_date_tolerance_days = _coerce_int(review_date_tolerance_days, 1, minimum=0)
+    rating_tolerance = _coerce_float(rating_tolerance, 1.0, minimum=0.0)
+    max_candidates = _coerce_int(max_candidates, 20, minimum=1)
     if not content_hash and not identity_key and not (reviewer_stem and reviewed_date):
         return []
     rows = await pool.fetch(
@@ -169,10 +225,10 @@ async def load_cross_source_review_candidates(
         identity_key,
         reviewer_stem,
         reviewed_date,
-        int(review_date_tolerance_days),
+        review_date_tolerance_days,
         rating,
-        float(rating_tolerance),
-        int(reviewer_stem_length),
+        rating_tolerance,
+        reviewer_stem_length,
         max_candidates,
     )
     return [dict(row) for row in rows]
@@ -195,6 +251,11 @@ def choose_cross_source_duplicate_survivor(
     rating_tolerance: float = 1.0,
     require_source_difference: bool = True,
 ) -> tuple[dict[str, Any] | None, str | None, dict[str, Any] | None]:
+    similarity_threshold = _coerce_float(similarity_threshold, 0.82, minimum=0.0)
+    loose_similarity_threshold = _coerce_float(loose_similarity_threshold, 0.9, minimum=0.0)
+    reviewer_stem_length = _coerce_int(reviewer_stem_length, 5, minimum=1)
+    review_date_tolerance_days = _coerce_int(review_date_tolerance_days, 1, minimum=0)
+    rating_tolerance = _coerce_float(rating_tolerance, 1.0, minimum=0.0)
     ranked: list[tuple[tuple[int, int, float, str], dict[str, Any], str, dict[str, Any]]] = []
     for candidate in candidates:
         candidate_source = str(candidate.get("source") or "").strip().lower()
@@ -293,6 +354,7 @@ def _rating_value(value: Any) -> float | None:
 
 
 def review_dates_within_tolerance(left: Any, right: Any, *, tolerance_days: int) -> bool:
+    tolerance_days = _coerce_int(tolerance_days, 1, minimum=0)
     left_key = normalize_review_date_key(left)
     right_key = normalize_review_date_key(right)
     if not left_key or not right_key:
@@ -306,6 +368,7 @@ def review_dates_within_tolerance(left: Any, right: Any, *, tolerance_days: int)
 
 
 def rating_values_within_tolerance(left: Any, right: Any, *, tolerance: float) -> bool:
+    tolerance = _coerce_float(tolerance, 1.0, minimum=0.0)
     left_value = _rating_value(left)
     right_value = _rating_value(right)
     if left_value is None or right_value is None:

--- a/atlas_brain/storage/migrations/279_b2b_repair_index_no_signal.sql
+++ b/atlas_brain/storage/migrations/279_b2b_repair_index_no_signal.sql
@@ -1,0 +1,9 @@
+-- Widen repair status index to cover no_signal rows (the main repair query
+-- fetches enrichment_status IN (enriched, no_signal) but the original index
+-- only covered enriched).
+
+DROP INDEX IF EXISTS idx_b2b_reviews_repair_status;
+
+CREATE INDEX IF NOT EXISTS idx_b2b_reviews_repair_status
+    ON b2b_reviews (enrichment_repair_status, enriched_at DESC)
+    WHERE enrichment_status IN ('enriched', 'no_signal');

--- a/scripts/backfill_derived_fields.py
+++ b/scripts/backfill_derived_fields.py
@@ -47,7 +47,7 @@ logger = logging.getLogger("backfill_derived_fields")
 BATCH_SIZE = 200
 
 # APPROVED-ENRICHMENT-READ: enrichment_schema_version, urgency_score, pain_category, would_recommend, competitors_mentioned
-# Reason: backfill/migration script — direct enrichment access required
+# Reason: backfill/migration script - direct enrichment access required
 _FILTER_QUERIES = {
     "all": """
         SELECT id, enrichment, rating, rating_max, raw_metadata, content_type,
@@ -97,6 +97,8 @@ _FILTER_QUERIES = {
           AND COALESCE(jsonb_array_length(enrichment->'competitors_mentioned'), 0) > 0
         ORDER BY enriched_at DESC NULLS LAST, imported_at DESC NULLS LAST
     """,
+    # APPROVED-ENRICHMENT-READ: pricing_phrases, contract_context.price_complaint, urgency_indicators.price_pressure_language, evidence_spans.signal_type
+    # Reason: backfill review selection for pricing false-positive cleanup
     "positive_pricing_false_positive": """
         SELECT id, enrichment, rating, rating_max, raw_metadata, content_type,
                summary, review_text, pros, cons, reviewer_title, reviewer_company,

--- a/scripts/cleanup_accounts_in_motion_pollution.py
+++ b/scripts/cleanup_accounts_in_motion_pollution.py
@@ -97,6 +97,8 @@ async def _fetch_company_signal_rows(
     if vendors:
         params.append([vendor.lower() for vendor in vendors])
         vendor_filter = "AND LOWER(cs.vendor_name) = ANY($2::text[])"
+    # APPROVED-ENRICHMENT-READ: churn_signals.intent_to_leave, churn_signals.actively_evaluating, churn_signals.contract_renewal_mentioned, urgency_indicators.explicit_cancel_language, urgency_indicators.active_migration_language, urgency_indicators.active_evaluation_language, urgency_indicators.completed_switch_language
+    # Reason: cleanup audit for accounts-in-motion signal pollution
     rows = await pool.fetch(
         f"""
         SELECT

--- a/tests/test_b2b_competitive_sets.py
+++ b/tests/test_b2b_competitive_sets.py
@@ -437,6 +437,54 @@ async def test_run_competitive_set_now_forwards_changed_only_flag(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_competitive_set_now_forwards_force_flags(monkeypatch):
+    from atlas_brain.api import b2b_tenant_dashboard as mod
+
+    competitive_set = _competitive_set()
+    repo = SimpleNamespace(
+        get_by_id_for_account=AsyncMock(return_value=competitive_set),
+    )
+    scheduler = SimpleNamespace(
+        run_now=AsyncMock(return_value={"status": "started", "message": "ok", "execution_id": "exec-1"}),
+    )
+    task = SimpleNamespace(metadata={"existing": True})
+    task_repo = SimpleNamespace(get_by_name=AsyncMock(return_value=task))
+    user = AuthUser(
+        user_id=str(uuid4()),
+        account_id=str(competitive_set.account_id),
+        plan="b2b_pro",
+        plan_status="active",
+        role="owner",
+        product="b2b_retention",
+        is_admin=True,
+    )
+
+    monkeypatch.setattr(mod, "_pool_or_503", lambda: object())
+    monkeypatch.setattr(mod, "get_competitive_set_repo", lambda: repo)
+    monkeypatch.setattr(mod, "get_task_scheduler", lambda: scheduler)
+    monkeypatch.setattr(mod, "get_scheduled_task_repo", lambda: task_repo)
+    monkeypatch.setattr(
+        mod,
+        "load_vendor_category_map",
+        AsyncMock(return_value={"salesforce": "CRM", "hubspot": "CRM"}),
+    )
+
+    req = mod.CompetitiveSetRunRequest(
+        force=True,
+        force_cross_vendor=True,
+        changed_vendors_only=False,
+    )
+    result = await mod.run_competitive_set_now(competitive_set.id, req, user=user)
+
+    assert result["competitive_set_id"] == str(competitive_set.id)
+    assert scheduler.run_now.await_count == 1
+    assert task.metadata["force"] is True
+    assert task.metadata["force_cross_vendor"] is True
+    assert task.metadata["changed_vendors_only"] is False
+    assert task.metadata["scope_trigger"] == "manual"
+
+
+@pytest.mark.asyncio
 async def test_run_competitive_set_now_uses_config_default_when_flag_omitted(monkeypatch):
     from atlas_brain.api import b2b_tenant_dashboard as mod
 

--- a/tests/test_b2b_enrichment.py
+++ b/tests/test_b2b_enrichment.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 from atlas_brain.autonomous.tasks import b2b_enrichment
+from atlas_brain.autonomous.tasks._b2b_batch_utils import exact_stage_request_fingerprint, reconcile_existing_batch_artifacts
 from atlas_brain.reasoning import evidence_engine
 from atlas_brain.storage.models import ScheduledTask
 
@@ -676,6 +677,88 @@ async def test_enrich_rows_reuses_existing_completed_tier1_batch_result(monkeypa
     assert result["enriched"] == 1
     assert persist.await_count == 1
     run_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_requires_matching_request_fingerprint():
+    request = SimpleNamespace(
+        namespace="b2b_enrichment.tier1",
+        provider="openrouter",
+        model="anthropic/claude-haiku-4-5",
+        request_envelope={
+            "messages": [
+                {"role": "system", "content": "tier1 prompt"},
+                {"role": "user", "content": "payload"},
+            ],
+            "max_tokens": 4096,
+            "temperature": 0.0,
+            "response_format": {"type": "json_object"},
+        },
+    )
+    fingerprint = exact_stage_request_fingerprint(request)
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "review-1",
+                    "batch_id": "batch-1",
+                    "status": "batch_succeeded",
+                    "response_text": json.dumps({"specific_complaints": ["pricing"]}),
+                    "error_text": None,
+                    "custom_id": "tier1_review-1",
+                    "request_metadata": {"request_fingerprint": fingerprint},
+                    "batch_status": "completed",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="b2b_enrichment",
+        artifact_type="review_enrichment_tier1",
+        artifact_ids=["review-1"],
+        expected_request_fingerprints={"review-1": fingerprint},
+    )
+
+    assert result["review-1"]["state"] == "succeeded"
+    assert result["review-1"]["custom_id"] == "tier1_review-1"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_skips_mismatched_request_fingerprint():
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "review-1",
+                    "batch_id": "batch-1",
+                    "status": "batch_succeeded",
+                    "response_text": json.dumps({"specific_complaints": ["pricing"]}),
+                    "error_text": None,
+                    "custom_id": "tier1_review-1",
+                    "request_metadata": {"request_fingerprint": "stale-request"},
+                    "batch_status": "completed",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="b2b_enrichment",
+        artifact_type="review_enrichment_tier1",
+        artifact_ids=["review-1"],
+        expected_request_fingerprints={"review-1": "current-request"},
+    )
+
+    assert result == {}
 
 
 def test_get_base_enrichment_llm_uses_vllm_first(monkeypatch):

--- a/tests/test_b2b_enrichment_batch_integration.py
+++ b/tests/test_b2b_enrichment_batch_integration.py
@@ -1,0 +1,654 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from atlas_brain.autonomous.tasks import b2b_enrichment
+from atlas_brain.autonomous.tasks._b2b_batch_utils import resolve_anthropic_batch_llm
+from atlas_brain.autonomous.tasks.b2b_scrape_intake import _INSERT_SQL
+from atlas_brain.config import settings
+from atlas_brain.services.b2b.cache_runner import (
+    prepare_b2b_exact_stage_request,
+    store_b2b_exact_stage_text,
+)
+from atlas_brain.services.b2b.llm_exact_cache import compute_cache_key
+from atlas_brain.skills import get_skill_registry
+
+
+def _configure_batch_settings(monkeypatch, *, tier2_model: str | None = None) -> None:
+    monkeypatch.setattr(settings.b2b_churn, "enabled", True, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "anthropic_batch_enabled", True, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_anthropic_batch_enabled", True, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "llm_exact_cache_enabled", True, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_local_only", False, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "openrouter_api_key", "test-openrouter-key", raising=False)
+    monkeypatch.setattr(
+        settings.b2b_churn,
+        "enrichment_openrouter_model",
+        "anthropic/claude-haiku-4-5",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings.b2b_churn,
+        "enrichment_tier2_openrouter_model",
+        tier2_model if tier2_model is not None else "anthropic/claude-haiku-4-5",
+        raising=False,
+    )
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_tier1_max_tokens", 1024, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_tier2_max_tokens", 1536, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "review_truncate_length", 3000, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_tier2_strict_sources", "", raising=False)
+    monkeypatch.setattr(settings.llm, "anthropic_api_key", "test-anthropic-key", raising=False)
+
+
+def _review_payload(
+    *,
+    review_id,
+    import_batch_id,
+    vendor_name: str = "Acme Analytics",
+    product_name: str = "Acme Analytics",
+    product_category: str = "analytics",
+    rating: int = 5,
+    summary: str = "Useful product overall",
+    review_text: str = (
+        "The platform has been easy to roll out across our revenue operations team, "
+        "and it has been reliable enough that we are not considering a replacement."
+    ),
+    source: str = "g2",
+) -> dict:
+    return {
+        "id": review_id,
+        "import_batch_id": import_batch_id,
+        "dedup_key": f"test-{review_id}",
+        "source": source,
+        "source_url": f"https://example.com/reviews/{review_id}",
+        "source_review_id": str(review_id),
+        "vendor_name": vendor_name,
+        "product_name": product_name,
+        "product_category": product_category,
+        "rating": rating,
+        "rating_max": 5,
+        "summary": summary,
+        "review_text": review_text,
+        "pros": "",
+        "cons": "",
+        "reviewer_name": "Taylor Reviewer",
+        "reviewer_title": "Revenue Operations Manager",
+        "reviewer_company": "Northwind",
+        "reviewer_company_norm": "northwind",
+        "company_size_raw": "51-200",
+        "reviewer_industry": "software",
+        "reviewed_at": datetime.now(timezone.utc),
+        "raw_metadata": {
+            "source_weight": 0.9,
+            "relevance_score": 0.8,
+            "author_churn_score": 0.6,
+        },
+        "parser_version": "integration-test",
+        "content_type": "review",
+    }
+
+
+async def _insert_review(db_pool, tracker: dict, payload: dict) -> dict:
+    await db_pool.execute(
+        _INSERT_SQL,
+        payload["dedup_key"],
+        payload["source"],
+        payload["source_url"],
+        payload["source_review_id"],
+        payload["vendor_name"],
+        payload["product_name"],
+        payload["product_category"],
+        payload["rating"],
+        payload["rating_max"],
+        payload["summary"],
+        payload["review_text"],
+        payload["pros"],
+        payload["cons"],
+        payload["reviewer_name"],
+        payload["reviewer_title"],
+        payload["reviewer_company"],
+        payload["reviewer_company_norm"],
+        payload["company_size_raw"],
+        payload["reviewer_industry"],
+        payload["reviewed_at"],
+        str(payload["import_batch_id"]),
+        json.dumps(payload["raw_metadata"]),
+        payload["parser_version"],
+        payload["content_type"],
+        None,
+        0,
+        payload["raw_metadata"]["relevance_score"],
+        payload["raw_metadata"]["author_churn_score"],
+        payload["raw_metadata"]["source_weight"],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "pending",
+        payload["id"],
+    )
+    tracker["review_ids"].append(payload["id"])
+    return {
+        "id": payload["id"],
+        "vendor_name": payload["vendor_name"],
+        "product_name": payload["product_name"],
+        "product_category": payload["product_category"],
+        "source": payload["source"],
+        "raw_metadata": payload["raw_metadata"],
+        "rating": payload["rating"],
+        "rating_max": payload["rating_max"],
+        "summary": payload["summary"],
+        "review_text": payload["review_text"],
+        "pros": payload["pros"],
+        "cons": payload["cons"],
+        "reviewer_title": payload["reviewer_title"],
+        "reviewer_company": payload["reviewer_company"],
+        "company_size_raw": payload["company_size_raw"],
+        "reviewer_industry": payload["reviewer_industry"],
+        "enrichment_attempts": 0,
+        "content_type": payload["content_type"],
+    }
+
+
+async def _insert_batch_job(
+    db_pool,
+    tracker: dict,
+    *,
+    batch_id,
+    stage_id: str,
+    status: str,
+    provider_batch_id: str,
+    total_items: int = 1,
+) -> None:
+    await db_pool.execute(
+        """
+        INSERT INTO anthropic_message_batches (
+            id, stage_id, task_name, run_id, status, total_items,
+            submitted_items, cache_prefiltered_items, fallback_single_call_items,
+            completed_items, failed_items, metadata, provider_batch_id
+        ) VALUES (
+            $1::uuid, $2, 'b2b_enrichment', NULL, $3, $4,
+            $4, 0, 0,
+            0, 0, '{}'::jsonb, $5
+        )
+        """,
+        batch_id,
+        stage_id,
+        status,
+        total_items,
+        provider_batch_id,
+    )
+    tracker["batch_ids"].append(batch_id)
+
+
+async def _insert_batch_item(
+    db_pool,
+    *,
+    batch_id,
+    custom_id: str,
+    stage_id: str,
+    artifact_type: str,
+    artifact_id: str,
+    vendor_name: str,
+    status: str,
+    response_text: str | None = None,
+    request_metadata: dict | None = None,
+) -> None:
+    await db_pool.execute(
+        """
+        INSERT INTO anthropic_message_batch_items (
+            id, batch_id, custom_id, stage_id, artifact_type, artifact_id,
+            vendor_name, status, cache_prefiltered, fallback_single_call,
+            response_text, input_tokens, billable_input_tokens, cached_tokens,
+            cache_write_tokens, output_tokens, cost_usd, provider_request_id,
+            error_text, request_metadata, completed_at
+        ) VALUES (
+            gen_random_uuid(), $1::uuid, $2, $3, $4, $5,
+            $6, $7, FALSE, FALSE,
+            $8, 0, 0, 0,
+            0, 0, 0, NULL,
+            NULL, $9::jsonb,
+            CASE WHEN $7 = 'pending' THEN NULL ELSE NOW() END
+        )
+        """,
+        batch_id,
+        custom_id,
+        stage_id,
+        artifact_type,
+        artifact_id,
+        vendor_name,
+        status,
+        response_text,
+        json.dumps(request_metadata or {}),
+    )
+
+
+async def _seed_tier2_exact_cache(
+    db_pool,
+    tracker: dict,
+    *,
+    row: dict,
+    tier1: dict,
+    tier2: dict,
+) -> None:
+    skill = get_skill_registry().get("digest/b2b_churn_extraction_tier2")
+    assert skill is not None
+
+    payload = b2b_enrichment._build_classify_payload(
+        row,
+        settings.b2b_churn.review_truncate_length,
+    )
+    payload["tier1_specific_complaints"] = tier1.get("specific_complaints", [])
+    payload["tier1_quotable_phrases"] = tier1.get("quotable_phrases", [])
+    system_prompt = b2b_enrichment._tier2_system_prompt_for_content_type(
+        skill.content,
+        payload.get("content_type"),
+    )
+    request = prepare_b2b_exact_stage_request(
+        "b2b_enrichment.tier2",
+        provider="openrouter",
+        model=str(settings.b2b_churn.enrichment_tier2_openrouter_model),
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": json.dumps(payload)},
+        ],
+        max_tokens=settings.b2b_churn.enrichment_tier2_max_tokens,
+        temperature=0.0,
+        response_format={"type": "json_object"},
+    )
+    stored = await store_b2b_exact_stage_text(
+        request,
+        response_text=json.dumps(tier2),
+        metadata={"tier": 2, "backend": "integration_test"},
+        pool=db_pool,
+    )
+    assert stored is True
+    tracker["cache_keys"].append(compute_cache_key(request.namespace, request.request_envelope))
+
+
+@pytest_asyncio.fixture
+async def seeded_artifacts(db_pool):
+    tracker = {
+        "review_ids": [],
+        "batch_ids": [],
+        "cache_keys": [],
+    }
+    try:
+        yield tracker
+    finally:
+        if tracker["cache_keys"]:
+            await db_pool.execute(
+                "DELETE FROM b2b_llm_exact_cache WHERE cache_key = ANY($1::text[])",
+                tracker["cache_keys"],
+            )
+        if tracker["batch_ids"]:
+            await db_pool.execute(
+                "DELETE FROM anthropic_message_batches WHERE id = ANY($1::uuid[])",
+                tracker["batch_ids"],
+            )
+        if tracker["review_ids"]:
+            await db_pool.execute(
+                "DELETE FROM b2b_reviews WHERE id = ANY($1::uuid[])",
+                tracker["review_ids"],
+            )
+
+
+@pytest.mark.asyncio
+async def test_enrich_batch_resets_row_to_pending_when_tier1_batch_item_is_pending(
+    db_pool,
+    seeded_artifacts,
+    monkeypatch,
+):
+    _configure_batch_settings(monkeypatch)
+
+    import_batch_id = uuid4()
+    review_id = uuid4()
+    row = await _insert_review(
+        db_pool,
+        seeded_artifacts,
+        _review_payload(review_id=review_id, import_batch_id=import_batch_id),
+    )
+    batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_artifacts,
+        batch_id=batch_id,
+        stage_id="b2b_enrichment.tier1",
+        status="submitted",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=batch_id,
+        custom_id=b2b_enrichment._enrichment_batch_custom_id("tier1", row["id"]),
+        stage_id="b2b_enrichment.tier1",
+        artifact_type="review_enrichment_tier1",
+        artifact_id=str(row["id"]),
+        vendor_name=row["vendor_name"],
+        status="pending",
+    )
+
+    result = await b2b_enrichment.enrich_batch(str(import_batch_id))
+    stored = await db_pool.fetchrow(
+        """
+        SELECT enrichment_status, enrichment_attempts
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        row["id"],
+    )
+
+    assert result["total"] == 1
+    assert result["enriched"] == 0
+    assert result["failed"] == 0
+    assert result["anthropic_batch_reused_pending_items"] == 1
+    assert result["anthropic_batch_rows_deferred"] == 1
+    assert stored["enrichment_status"] == "pending"
+    assert stored["enrichment_attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_batch_resets_row_to_pending_when_tier2_batch_item_is_pending(
+    db_pool,
+    seeded_artifacts,
+    monkeypatch,
+):
+    _configure_batch_settings(monkeypatch)
+
+    import_batch_id = uuid4()
+    review_id = uuid4()
+    row = await _insert_review(
+        db_pool,
+        seeded_artifacts,
+        _review_payload(
+            review_id=review_id,
+            import_batch_id=import_batch_id,
+            rating=2,
+            summary="Renewal risk is growing",
+            review_text=(
+                "The renewal price jumped sharply, support has been slow to answer, "
+                "and we are actively evaluating alternatives before the contract renews."
+            ),
+        ),
+    )
+    tier1 = {
+        "churn_signals": {"intent_to_leave": True},
+        "specific_complaints": ["The renewal price jumped sharply and support could not justify it."],
+        "quotable_phrases": ["We are actively evaluating alternatives before renewal."],
+        "competitors_mentioned": [{"name": "HubSpot"}],
+        "pricing_phrases": ["renewal price jumped sharply"],
+        "recommendation_language": ["actively evaluating alternatives"],
+        "feature_gaps": [],
+        "event_mentions": [],
+    }
+
+    tier1_batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_artifacts,
+        batch_id=tier1_batch_id,
+        stage_id="b2b_enrichment.tier1",
+        status="ended",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=tier1_batch_id,
+        custom_id=b2b_enrichment._enrichment_batch_custom_id("tier1", row["id"]),
+        stage_id="b2b_enrichment.tier1",
+        artifact_type="review_enrichment_tier1",
+        artifact_id=str(row["id"]),
+        vendor_name=row["vendor_name"],
+        status="batch_succeeded",
+        response_text=json.dumps(tier1),
+    )
+
+    tier2_batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_artifacts,
+        batch_id=tier2_batch_id,
+        stage_id="b2b_enrichment.tier2",
+        status="submitted",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=tier2_batch_id,
+        custom_id=b2b_enrichment._enrichment_batch_custom_id("tier2", row["id"]),
+        stage_id="b2b_enrichment.tier2",
+        artifact_type="review_enrichment_tier2",
+        artifact_id=str(row["id"]),
+        vendor_name=row["vendor_name"],
+        status="pending",
+    )
+
+    result = await b2b_enrichment.enrich_batch(str(import_batch_id))
+    stored = await db_pool.fetchrow(
+        """
+        SELECT enrichment_status, enrichment_attempts
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        row["id"],
+    )
+
+    assert result["total"] == 1
+    assert result["anthropic_batch_reused_completed_items"] == 1
+    assert result["anthropic_batch_reused_pending_items"] == 1
+    assert result["anthropic_batch_rows_deferred"] == 1
+    assert result["generated"] == 1
+    assert result["tier1_generated_calls"] == 1
+    assert stored["enrichment_status"] == "pending"
+    assert stored["enrichment_attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_batch_reused_tier1_success_persists_terminal_status_and_usage(
+    db_pool,
+    seeded_artifacts,
+    monkeypatch,
+):
+    _configure_batch_settings(monkeypatch)
+
+    import_batch_id = uuid4()
+    review_id = uuid4()
+    row = await _insert_review(
+        db_pool,
+        seeded_artifacts,
+        _review_payload(review_id=review_id, import_batch_id=import_batch_id),
+    )
+    tier1 = {
+        "churn_signals": {},
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "feature_gaps": [],
+        "event_mentions": [],
+    }
+
+    batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_artifacts,
+        batch_id=batch_id,
+        stage_id="b2b_enrichment.tier1",
+        status="ended",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=batch_id,
+        custom_id=b2b_enrichment._enrichment_batch_custom_id("tier1", row["id"]),
+        stage_id="b2b_enrichment.tier1",
+        artifact_type="review_enrichment_tier1",
+        artifact_id=str(row["id"]),
+        vendor_name=row["vendor_name"],
+        status="cache_hit",
+        response_text=json.dumps(tier1),
+    )
+
+    result = await b2b_enrichment.enrich_batch(str(import_batch_id))
+    stored = await db_pool.fetchrow(
+        """
+        SELECT enrichment_status, enrichment_attempts, enrichment_model, enrichment
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        row["id"],
+    )
+
+    assert result["total"] == 1
+    assert result["anthropic_batch_reused_completed_items"] == 1
+    assert result["exact_cache_hits"] == 1
+    assert result["tier1_exact_cache_hits"] == 1
+    assert result["generated"] == 0
+    assert stored["enrichment_status"] == "no_signal"
+    assert stored["enrichment_attempts"] == 1
+    assert stored["enrichment_model"] == "anthropic/claude-haiku-4-5"
+    assert stored["enrichment"] is not None
+
+
+@pytest.mark.asyncio
+async def test_enrich_batch_uses_single_call_tier2_exact_cache_when_batch_model_is_unavailable(
+    db_pool,
+    seeded_artifacts,
+    monkeypatch,
+):
+    _configure_batch_settings(monkeypatch, tier2_model="openai/gpt-4o-mini")
+    tier1_batch_llm = resolve_anthropic_batch_llm(
+        current_llm=SimpleNamespace(
+            name="openrouter",
+            model=str(settings.b2b_churn.enrichment_openrouter_model),
+        ),
+        target_model_candidates=(settings.b2b_churn.enrichment_openrouter_model,),
+    )
+    tier2_batch_llm = resolve_anthropic_batch_llm(
+        current_llm=SimpleNamespace(
+            name="openrouter",
+            model=str(settings.b2b_churn.enrichment_tier2_openrouter_model),
+        ),
+        target_model_candidates=(settings.b2b_churn.enrichment_tier2_openrouter_model,),
+    )
+    if tier1_batch_llm is None:
+        pytest.skip("Tier 1 Anthropic batch LLM is unavailable in this runtime")
+    if tier2_batch_llm is not None:
+        pytest.skip(
+            "Tier 2 Anthropic batch fallback branch is not reachable in this runtime without mocking"
+        )
+
+    import_batch_id = uuid4()
+    review_id = uuid4()
+    row = await _insert_review(
+        db_pool,
+        seeded_artifacts,
+        _review_payload(
+            review_id=review_id,
+            import_batch_id=import_batch_id,
+            rating=2,
+            summary="Pricing push triggered an eval",
+            review_text=(
+                "The renewal quote increased sharply, the billing terms are harder to justify, "
+                "and our operations leader has started evaluating HubSpot before renewal."
+            ),
+        ),
+    )
+    tier1 = {
+        "churn_signals": {"intent_to_leave": True},
+        "specific_complaints": ["The renewal quote increased sharply and billing terms are harder to justify."],
+        "quotable_phrases": ["Our operations leader has started evaluating HubSpot before renewal."],
+        "competitors_mentioned": [{"name": "HubSpot"}],
+        "pricing_phrases": ["renewal quote increased sharply"],
+        "recommendation_language": ["started evaluating HubSpot before renewal"],
+        "feature_gaps": [],
+        "event_mentions": [],
+    }
+    tier2 = {
+        "pain_categories": [{"category": "pricing", "severity": "primary"}],
+        "sentiment_trajectory": {"direction": "unknown"},
+        "buyer_authority": {
+            "role_type": "economic_buyer",
+            "buying_stage": "evaluation",
+            "executive_sponsor_mentioned": True,
+        },
+        "timeline": {"decision_timeline": "within_quarter"},
+        "contract_context": {"contract_value_signal": "mid_market"},
+        "positive_aspects": [],
+        "feature_gaps": ["billing transparency"],
+        "recommendation_language": ["started evaluating HubSpot before renewal"],
+        "pricing_phrases": ["renewal quote increased sharply"],
+        "event_mentions": [{"event": "renewal evaluation", "timeframe": "within quarter"}],
+        "urgency_indicators": {"renewal_pressure": True},
+        "competitors_mentioned": [
+            {
+                "name": "HubSpot",
+                "evidence_type": "active_evaluation",
+                "displacement_confidence": "high",
+                "reason_category": "pricing",
+            }
+        ],
+    }
+
+    tier1_batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_artifacts,
+        batch_id=tier1_batch_id,
+        stage_id="b2b_enrichment.tier1",
+        status="ended",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=tier1_batch_id,
+        custom_id=b2b_enrichment._enrichment_batch_custom_id("tier1", row["id"]),
+        stage_id="b2b_enrichment.tier1",
+        artifact_type="review_enrichment_tier1",
+        artifact_id=str(row["id"]),
+        vendor_name=row["vendor_name"],
+        status="batch_succeeded",
+        response_text=json.dumps(tier1),
+    )
+    await _seed_tier2_exact_cache(
+        db_pool,
+        seeded_artifacts,
+        row=row,
+        tier1=tier1,
+        tier2=tier2,
+    )
+
+    result = await b2b_enrichment.enrich_batch(str(import_batch_id))
+    stored = await db_pool.fetchrow(
+        """
+        SELECT enrichment_status, enrichment_model, enrichment
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        row["id"],
+    )
+
+    assert result["total"] == 1
+    assert result["anthropic_batch_tier2_single_fallback_rows"] == 1
+    assert result["generated"] == 1
+    assert result["tier1_generated_calls"] == 1
+    assert result["exact_cache_hits"] == 1
+    assert result["tier2_exact_cache_hits"] == 1
+    assert stored["enrichment_status"] == "enriched"
+    assert stored["enrichment_model"] == "hybrid:anthropic/claude-haiku-4-5+openai/gpt-4o-mini"
+    assert stored["enrichment"] is not None

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -293,7 +293,7 @@ async def test_repair_single_quarantines_shadowed_technical_source(monkeypatch):
     args = pool.execute.await_args.args
     assert "enrichment_status = $6" in query
     assert args[6] == "quarantined"
-    assert args[7] is False
+    assert args[7] is True
     assert json.loads(args[8]) == ["repair_shadowed_technical_source"]
 
 

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -1923,14 +1923,15 @@ async def test_circuit_breaker_consecutive_no_progress(monkeypatch):
 
     monkeypatch.setattr(
         repair_mod, "_repair_rows",
-        AsyncMock(return_value={"promoted": 0, "shadowed": 0, "failed": 0,
-                                "exact_cache_hits": 0, "generated": 0,
+        AsyncMock(return_value={"promoted": 0, "shadowed": 1, "failed": 0,
+                                "exact_cache_hits": 0, "generated": 1,
                                 "witness_rows": 0, "witness_count": 0}),
     )
 
     result = await repair_mod.run(_task())
 
-    assert result["rounds"] == 2
+    # Breaks after 3 consecutive rounds with no promotions or shadows and no high-failure breaker.
+    assert result["rounds"] == 3
     assert result["circuit_breaker_reason"] is not None
     assert "no repair progress" in result["circuit_breaker_reason"]
 

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -35,7 +35,7 @@ async def test_recover_orphaned_repairing_handles_legacy_null_timestamp():
     assert recovered == 2
     query = pool.execute.await_args.args[0]
     assert 'enrichment_repaired_at IS NULL' in query
-    assert 'OR enrichment_repaired_at < NOW() - INTERVAL \'30 minutes\'' in query
+    assert 'make_interval(mins => $2)' in query
 
 
 @pytest.mark.asyncio

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -27,6 +27,18 @@ def test_repair_batch_custom_id_is_anthropic_safe():
 
 
 @pytest.mark.asyncio
+async def test_recover_orphaned_repairing_handles_legacy_null_timestamp():
+    pool = SimpleNamespace(execute=AsyncMock(return_value='UPDATE 2'))
+
+    recovered = await repair_mod._recover_orphaned_repairing(pool, 3)
+
+    assert recovered == 2
+    query = pool.execute.await_args.args[0]
+    assert 'enrichment_repaired_at IS NULL' in query
+    assert 'OR enrichment_repaired_at < NOW() - INTERVAL \'30 minutes\'' in query
+
+
+@pytest.mark.asyncio
 async def test_run_skips_when_repair_disabled(monkeypatch):
     monkeypatch.setattr(repair_mod.settings.b2b_churn, "enabled", True, raising=False)
     monkeypatch.setattr(

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -1787,3 +1787,101 @@ async def test_repair_rows_uses_anthropic_batch_when_enabled(monkeypatch):
     assert result["anthropic_batch_jobs"] == 1
     assert result["anthropic_batch_items_submitted"] == 1
     assert persist.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_high_failure_rate(monkeypatch):
+    """Loop should break immediately when >50% of a round fails."""
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enabled", True, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_enabled", True, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_model", "test-model", raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_per_batch", 10, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_rounds_per_run", 5, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_attempts", 3, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_concurrency", 2, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_strict_discussion_skip_limit", 100, raising=False)
+
+    pool = SimpleNamespace(
+        is_initialized=True,
+        execute=AsyncMock(return_value="UPDATE 0"),
+        fetch=AsyncMock(side_effect=[
+            # Round 1: return rows
+            [{"id": uuid4(), "vendor_name": "V", "source": "g2", "content_type": "review",
+              "enrichment": {}, "enrichment_repair_attempts": 0}],
+            # Round 2: would return rows, but should not be reached
+            [],
+        ]),
+    )
+    monkeypatch.setattr(repair_mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(repair_mod, "_recover_orphaned_repairing", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_demote_stale_no_signal_rows", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_quarantine_shadowed_hard_gap_rows", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_skip_low_signal_strict_discussion_rows", AsyncMock(return_value=0))
+
+    # _repair_rows returns mostly failures
+    monkeypatch.setattr(
+        repair_mod, "_repair_rows",
+        AsyncMock(return_value={"promoted": 0, "shadowed": 1, "failed": 8,
+                                "exact_cache_hits": 0, "generated": 9,
+                                "witness_rows": 0, "witness_count": 0}),
+    )
+
+    result = await repair_mod.run(_task())
+
+    assert result["rounds"] == 1
+    assert result["circuit_breaker_reason"] is not None
+    assert "high failure rate" in result["circuit_breaker_reason"]
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_consecutive_no_progress(monkeypatch):
+    """Loop should break after 2 consecutive rounds with zero promotions."""
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enabled", True, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_enabled", True, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_model", "test-model", raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_per_batch", 10, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_rounds_per_run", 10, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_attempts", 3, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_concurrency", 2, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_strict_discussion_skip_limit", 100, raising=False)
+
+    call_count = 0
+
+    async def _mock_fetch(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            return [{"id": uuid4(), "vendor_name": "V", "source": "g2", "content_type": "review",
+                      "enrichment": {}, "enrichment_repair_attempts": 0}]
+        return []
+
+    pool = SimpleNamespace(
+        is_initialized=True,
+        execute=AsyncMock(return_value="UPDATE 0"),
+        fetch=AsyncMock(side_effect=_mock_fetch),
+    )
+    monkeypatch.setattr(repair_mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(repair_mod, "_recover_orphaned_repairing", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_demote_stale_no_signal_rows", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_quarantine_shadowed_hard_gap_rows", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_skip_low_signal_strict_discussion_rows", AsyncMock(return_value=0))
+
+    # All rounds: shadowed only, zero promoted
+    monkeypatch.setattr(
+        repair_mod, "_repair_rows",
+        AsyncMock(return_value={"promoted": 0, "shadowed": 1, "failed": 0,
+                                "exact_cache_hits": 0, "generated": 1,
+                                "witness_rows": 0, "witness_count": 0}),
+    )
+
+    result = await repair_mod.run(_task())
+
+    # Should break after round 2 (2 consecutive no-progress), not go to 10
+    assert result["rounds"] == 2
+    assert result["circuit_breaker_reason"] is not None
+    assert "no promotions" in result["circuit_breaker_reason"]

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -140,6 +140,44 @@ async def test_repair_single_promotes_structural_fields(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_retry_quarantined_reviews_counts_non_retryable_candidates_as_skipped(monkeypatch):
+    row_id = uuid4()
+    pool = SimpleNamespace(
+        fetchrow=AsyncMock(return_value={"skipped": 2, "retryable_ids": [row_id]}),
+        fetch=AsyncMock(return_value=[{
+            "id": row_id,
+            "enrichment": {"enrichment_schema_version": 1},
+            "source": "reddit",
+            "rating": 2.0,
+            "rating_max": 5,
+            "review_text": "pricing issue",
+            "summary": "pricing issue",
+            "pros": "",
+            "cons": "",
+            "vendor_name": "Example",
+            "reviewer_company": "",
+            "raw_metadata": {},
+            "low_fidelity_reasons": ["evidence_engine_compute_failure"],
+        }]),
+        execute=AsyncMock(return_value="UPDATE 1"),
+    )
+    monkeypatch.setattr(
+        repair_mod.base_enrichment,
+        "_finalize_enrichment_for_persist",
+        lambda enrichment, row: (enrichment, None),
+    )
+
+    result = await repair_mod.retry_quarantined_reviews(pool, limit=3)
+
+    assert result == {"recovered": 1, "still_failed": 0, "skipped": 2}
+    fetchrow_query = pool.fetchrow.await_args.args[0]
+    assert "WITH candidate_window AS" in fetchrow_query
+    assert "COUNT(*) FILTER" in fetchrow_query
+    fetch_query = pool.fetch.await_args.args[0]
+    assert "WHERE id = ANY($1::uuid[])" in fetch_query
+
+
+@pytest.mark.asyncio
 async def test_call_repair_extractor_uses_exact_cache_hit(monkeypatch):
     cached_response = {
         "response_text": json.dumps({"competitors_mentioned": ["HubSpot"]}),

--- a/tests/test_b2b_enrichment_repair.py
+++ b/tests/test_b2b_enrichment_repair.py
@@ -1852,7 +1852,7 @@ async def test_circuit_breaker_high_failure_rate(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_circuit_breaker_consecutive_no_progress(monkeypatch):
-    """Loop should break after 2 consecutive rounds with zero promotions."""
+    """Loop should break after 2 consecutive rounds with no promotions or shadows."""
     monkeypatch.setattr(repair_mod.settings.b2b_churn, "enabled", True, raising=False)
     monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_enabled", True, raising=False)
     monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_model", "test-model", raising=False)
@@ -1883,17 +1883,71 @@ async def test_circuit_breaker_consecutive_no_progress(monkeypatch):
     monkeypatch.setattr(repair_mod, "_quarantine_shadowed_hard_gap_rows", AsyncMock(return_value=0))
     monkeypatch.setattr(repair_mod, "_skip_low_signal_strict_discussion_rows", AsyncMock(return_value=0))
 
-    # All rounds: shadowed only, zero promoted
     monkeypatch.setattr(
         repair_mod, "_repair_rows",
-        AsyncMock(return_value={"promoted": 0, "shadowed": 1, "failed": 0,
-                                "exact_cache_hits": 0, "generated": 1,
+        AsyncMock(return_value={"promoted": 0, "shadowed": 0, "failed": 0,
+                                "exact_cache_hits": 0, "generated": 0,
                                 "witness_rows": 0, "witness_count": 0}),
     )
 
     result = await repair_mod.run(_task())
 
-    # Should break after round 2 (2 consecutive no-progress), not go to 10
     assert result["rounds"] == 2
     assert result["circuit_breaker_reason"] is not None
-    assert "no promotions" in result["circuit_breaker_reason"]
+    assert "no repair progress" in result["circuit_breaker_reason"]
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_shadowed_rounds_still_allow_later_promotions(monkeypatch):
+    """Shadowed rows are still progress and should not stop later promotable rows."""
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enabled", True, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_enabled", True, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_model", "test-model", raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_per_batch", 10, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_rounds_per_run", 10, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_max_attempts", 3, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_concurrency", 2, raising=False)
+    monkeypatch.setattr(repair_mod.settings.b2b_churn, "enrichment_repair_strict_discussion_skip_limit", 100, raising=False)
+
+    call_count = 0
+
+    async def _mock_fetch(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            return [{"id": uuid4(), "vendor_name": "V", "source": "g2", "content_type": "review",
+                      "enrichment": {}, "enrichment_repair_attempts": 0}]
+        return []
+
+    pool = SimpleNamespace(
+        is_initialized=True,
+        execute=AsyncMock(return_value="UPDATE 0"),
+        fetch=AsyncMock(side_effect=_mock_fetch),
+    )
+    monkeypatch.setattr(repair_mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(repair_mod, "_recover_orphaned_repairing", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_demote_stale_no_signal_rows", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_quarantine_shadowed_hard_gap_rows", AsyncMock(return_value=0))
+    monkeypatch.setattr(repair_mod, "_skip_low_signal_strict_discussion_rows", AsyncMock(return_value=0))
+
+    monkeypatch.setattr(
+        repair_mod, "_repair_rows",
+        AsyncMock(side_effect=[
+            {"promoted": 0, "shadowed": 1, "failed": 0,
+             "exact_cache_hits": 0, "generated": 1,
+             "witness_rows": 0, "witness_count": 0},
+            {"promoted": 0, "shadowed": 1, "failed": 0,
+             "exact_cache_hits": 0, "generated": 1,
+             "witness_rows": 0, "witness_count": 0},
+            {"promoted": 1, "shadowed": 0, "failed": 0,
+             "exact_cache_hits": 0, "generated": 1,
+             "witness_rows": 0, "witness_count": 0},
+        ]),
+    )
+
+    result = await repair_mod.run(_task())
+
+    assert result["rounds"] == 3
+    assert result["promoted"] == 1
+    assert result["shadowed"] == 2
+    assert result["circuit_breaker_reason"] is None

--- a/tests/test_b2b_enrichment_repair_batch_integration.py
+++ b/tests/test_b2b_enrichment_repair_batch_integration.py
@@ -1,0 +1,388 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from atlas_brain.autonomous.tasks import b2b_enrichment_repair as repair_mod
+from atlas_brain.autonomous.tasks.b2b_scrape_intake import _INSERT_SQL
+from atlas_brain.config import settings
+
+
+def _configure_repair_batch_settings(monkeypatch) -> None:
+    monkeypatch.setattr(settings.b2b_churn, "enabled", True, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "anthropic_batch_enabled", True, raising=False)
+    monkeypatch.setattr(
+        settings.b2b_churn,
+        "enrichment_repair_anthropic_batch_enabled",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings.b2b_churn,
+        "enrichment_repair_model",
+        "anthropic/claude-haiku-4-5",
+        raising=False,
+    )
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_repair_max_tokens", 512, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "review_truncate_length", 3000, raising=False)
+    monkeypatch.setattr(settings.b2b_churn, "enrichment_low_fidelity_enabled", False, raising=False)
+    monkeypatch.setattr(settings.llm, "anthropic_api_key", "test-anthropic-key", raising=False)
+
+
+def _baseline_enrichment() -> dict:
+    return {
+        "churn_signals": {
+            "intent_to_leave": True,
+            "actively_evaluating": True,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": True,
+        },
+        "urgency_score": 7,
+        "would_recommend": False,
+        "pain_category": "overall_dissatisfaction",
+        "buyer_authority": {"role_type": "unknown", "buying_stage": "unknown"},
+        "timeline": {"decision_timeline": "unknown"},
+        "contract_context": {"contract_value_signal": "unknown"},
+        "reviewer_context": {"role_level": "unknown", "decision_maker": False},
+        "sentiment_trajectory": {"direction": "declining"},
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "feature_gaps": [],
+        "event_mentions": [],
+        "salience_flags": [],
+        "evidence_spans": [],
+        "replacement_mode": "none",
+        "operating_model_shift": "none",
+        "productivity_delta_claim": "unknown",
+        "org_pressure_type": "none",
+        "evidence_map_hash": "integration-test-hash",
+        "enrichment_schema_version": 3,
+    }
+
+
+def _review_payload(*, review_id, import_batch_id) -> dict:
+    return {
+        "id": review_id,
+        "import_batch_id": import_batch_id,
+        "dedup_key": f"repair-test-{review_id}",
+        "source": "reddit",
+        "source_url": f"https://example.com/review/{review_id}",
+        "source_review_id": str(review_id),
+        "vendor_name": "Acme Analytics",
+        "product_name": "Acme Analytics",
+        "product_category": "analytics",
+        "rating": 2,
+        "rating_max": 5,
+        "summary": "Renewal pricing triggered an evaluation",
+        "review_text": (
+            "Our renewal price jumped sharply, support was not helpful, and our operations "
+            "leader started evaluating HubSpot before the contract renews next quarter."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_name": "Taylor Reviewer",
+        "reviewer_title": "Revenue Operations Manager",
+        "reviewer_company": "Northwind",
+        "reviewer_company_norm": "northwind",
+        "company_size_raw": "51-200",
+        "reviewer_industry": "software",
+        "reviewed_at": datetime.now(timezone.utc),
+        "raw_metadata": {
+            "source_weight": 0.9,
+            "relevance_score": 0.8,
+            "author_churn_score": 0.6,
+        },
+        "parser_version": "integration-test",
+        "content_type": "review",
+    }
+
+
+async def _insert_review(db_pool, tracker: dict, payload: dict) -> None:
+    await db_pool.execute(
+        _INSERT_SQL,
+        payload["dedup_key"],
+        payload["source"],
+        payload["source_url"],
+        payload["source_review_id"],
+        payload["vendor_name"],
+        payload["product_name"],
+        payload["product_category"],
+        payload["rating"],
+        payload["rating_max"],
+        payload["summary"],
+        payload["review_text"],
+        payload["pros"],
+        payload["cons"],
+        payload["reviewer_name"],
+        payload["reviewer_title"],
+        payload["reviewer_company"],
+        payload["reviewer_company_norm"],
+        payload["company_size_raw"],
+        payload["reviewer_industry"],
+        payload["reviewed_at"],
+        str(payload["import_batch_id"]),
+        json.dumps(payload["raw_metadata"]),
+        payload["parser_version"],
+        payload["content_type"],
+        None,
+        0,
+        payload["raw_metadata"]["relevance_score"],
+        payload["raw_metadata"]["author_churn_score"],
+        payload["raw_metadata"]["source_weight"],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "pending",
+        payload["id"],
+    )
+    tracker["review_ids"].append(payload["id"])
+
+
+async def _promote_review_to_repair_candidate(db_pool, *, review_id, enrichment: dict) -> None:
+    await db_pool.execute(
+        """
+        UPDATE b2b_reviews
+        SET enrichment = $2::jsonb,
+            enrichment_status = 'enriched',
+            enriched_at = NOW(),
+            enrichment_model = 'anthropic/claude-haiku-4-5',
+            enrichment_repair_status = 'repairing'
+        WHERE id = $1
+        """,
+        review_id,
+        json.dumps(enrichment),
+    )
+
+
+async def _fetch_repair_row(db_pool, review_id):
+    return await db_pool.fetchrow(
+        """
+        SELECT id, vendor_name, product_name, product_category,
+               source, raw_metadata,
+               rating, rating_max, summary, review_text, pros, cons,
+               reviewer_title, reviewer_company, company_size_raw,
+               reviewer_industry, content_type, enrichment,
+               enrichment_repair_attempts
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        review_id,
+    )
+
+
+async def _insert_batch_job(
+    db_pool,
+    tracker: dict,
+    *,
+    batch_id,
+    status: str,
+    provider_batch_id: str,
+) -> None:
+    await db_pool.execute(
+        """
+        INSERT INTO anthropic_message_batches (
+            id, stage_id, task_name, run_id, status, total_items,
+            submitted_items, cache_prefiltered_items, fallback_single_call_items,
+            completed_items, failed_items, metadata, provider_batch_id
+        ) VALUES (
+            $1::uuid, 'b2b_enrichment_repair.extraction', 'b2b_enrichment_repair', NULL, $2, 1,
+            1, 0, 0,
+            0, 0, '{}'::jsonb, $3
+        )
+        """,
+        batch_id,
+        status,
+        provider_batch_id,
+    )
+    tracker["batch_ids"].append(batch_id)
+
+
+async def _insert_batch_item(
+    db_pool,
+    *,
+    batch_id,
+    review_id,
+    vendor_name: str,
+    status: str,
+    response_text: str | None = None,
+) -> None:
+    await db_pool.execute(
+        """
+        INSERT INTO anthropic_message_batch_items (
+            id, batch_id, custom_id, stage_id, artifact_type, artifact_id,
+            vendor_name, status, cache_prefiltered, fallback_single_call,
+            response_text, input_tokens, billable_input_tokens, cached_tokens,
+            cache_write_tokens, output_tokens, cost_usd, provider_request_id,
+            error_text, request_metadata, completed_at
+        ) VALUES (
+            gen_random_uuid(), $1::uuid, $2, 'b2b_enrichment_repair.extraction', 'review_enrichment_repair', $3,
+            $4, $5, FALSE, FALSE,
+            $6, 0, 0, 0,
+            0, 0, 0, NULL,
+            NULL, $7::jsonb,
+            CASE WHEN $5 = 'pending' THEN NULL ELSE NOW() END
+        )
+        """,
+        batch_id,
+        repair_mod._repair_batch_custom_id(review_id),
+        str(review_id),
+        vendor_name,
+        status,
+        response_text,
+        json.dumps({"review_id": str(review_id)}),
+    )
+
+
+@pytest_asyncio.fixture
+async def seeded_repair_artifacts(db_pool):
+    tracker = {"review_ids": [], "batch_ids": []}
+    try:
+        yield tracker
+    finally:
+        if tracker["batch_ids"]:
+            await db_pool.execute(
+                "DELETE FROM anthropic_message_batches WHERE id = ANY($1::uuid[])",
+                tracker["batch_ids"],
+            )
+        if tracker["review_ids"]:
+            await db_pool.execute(
+                "DELETE FROM b2b_reviews WHERE id = ANY($1::uuid[])",
+                tracker["review_ids"],
+            )
+
+
+@pytest.mark.asyncio
+async def test_repair_rows_resets_repair_status_when_reused_batch_item_is_pending(
+    db_pool,
+    seeded_repair_artifacts,
+    monkeypatch,
+):
+    _configure_repair_batch_settings(monkeypatch)
+
+    import_batch_id = uuid4()
+    review_id = uuid4()
+    await _insert_review(
+        db_pool,
+        seeded_repair_artifacts,
+        _review_payload(review_id=review_id, import_batch_id=import_batch_id),
+    )
+    await _promote_review_to_repair_candidate(
+        db_pool,
+        review_id=review_id,
+        enrichment=_baseline_enrichment(),
+    )
+    row = await _fetch_repair_row(db_pool, review_id)
+
+    batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_repair_artifacts,
+        batch_id=batch_id,
+        status="submitted",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=batch_id,
+        review_id=review_id,
+        vendor_name=row["vendor_name"],
+        status="pending",
+    )
+
+    result = await repair_mod._repair_rows(
+        [row],
+        settings.b2b_churn,
+        db_pool,
+        task=SimpleNamespace(metadata={}),
+    )
+    stored = await db_pool.fetchrow(
+        """
+        SELECT enrichment_repair_status, enrichment_repair_attempts
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        review_id,
+    )
+
+    assert result["anthropic_batch_reused_pending_items"] == 1
+    assert result["anthropic_batch_rows_deferred"] == 1
+    assert stored["enrichment_repair_status"] is None
+    assert stored["enrichment_repair_attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_repair_rows_reused_completed_cache_hit_preserves_usage_metrics(
+    db_pool,
+    seeded_repair_artifacts,
+    monkeypatch,
+):
+    _configure_repair_batch_settings(monkeypatch)
+
+    import_batch_id = uuid4()
+    review_id = uuid4()
+    await _insert_review(
+        db_pool,
+        seeded_repair_artifacts,
+        _review_payload(review_id=review_id, import_batch_id=import_batch_id),
+    )
+    await _promote_review_to_repair_candidate(
+        db_pool,
+        review_id=review_id,
+        enrichment=_baseline_enrichment(),
+    )
+    row = await _fetch_repair_row(db_pool, review_id)
+
+    batch_id = uuid4()
+    await _insert_batch_job(
+        db_pool,
+        seeded_repair_artifacts,
+        batch_id=batch_id,
+        status="ended",
+        provider_batch_id=f"msgbatch_{uuid4().hex[:12]}",
+    )
+    await _insert_batch_item(
+        db_pool,
+        batch_id=batch_id,
+        review_id=review_id,
+        vendor_name=row["vendor_name"],
+        status="cache_hit",
+        response_text=json.dumps({}),
+    )
+
+    result = await repair_mod._repair_rows(
+        [row],
+        settings.b2b_churn,
+        db_pool,
+        task=SimpleNamespace(metadata={}),
+    )
+    stored = await db_pool.fetchrow(
+        """
+        SELECT enrichment_repair_status, enrichment_repair_attempts
+        FROM b2b_reviews
+        WHERE id = $1
+        """,
+        review_id,
+    )
+
+    assert result["anthropic_batch_reused_completed_items"] == 1
+    assert result["exact_cache_hits"] == 1
+    assert result["generated"] == 0
+    assert stored["enrichment_repair_status"] == "shadowed"
+    assert stored["enrichment_repair_attempts"] == 1

--- a/tests/test_scraping_wiring.py
+++ b/tests/test_scraping_wiring.py
@@ -976,6 +976,7 @@ async def test_probation_telemetry_endpoint_summarizes_rates():
         with patch("atlas_brain.api.b2b_scrape.settings", MagicMock(b2b_scrape=cfg)):
             result = await probation_telemetry(limit=100, lookback_days=None)
 
+    assert result["basis"] == "raw_source_target_provenance"
     assert result["probation_targets"] == 1
     assert result["summary"]["targets_with_runs"] == 1
     target = result["targets"][0]


### PR DESCRIPTION
## What changed

This PR hardens the B2B enrichment batch reuse paths and aligns enrichment repair with the same safety guarantees.

- fixed `b2b_enrichment_repair.py` so reused pending Anthropic batch items defer cleanly instead of leaving rows stranded in `repairing`
- preserved usage accounting for reused completed repair artifacts so `exact_cache_hits` and `generated` roll up correctly
- added real-adapter integration coverage for enrichment batch reuse and repair batch reuse
- aligned stale repair circuit-breaker and quarantine-retry tests with the current task contracts

## Why

The batch reconciliation flow can reuse existing Anthropic artifacts after restarts or overlapping runs. Without explicit defer handling, rows could remain in an in-progress state and later be misclassified by orphan recovery. Reused completed artifacts also dropped usage attribution, which made the repair metrics inaccurate.

## Impact

- batch reuse is safer for the enrichment revenue pipeline
- repair rows no longer linger in `repairing` when an external artifact is still pending
- batch metrics now reflect reused cache hits and generated calls more accurately
- the repo now has real DB-backed integration coverage for the risky reconciliation paths

## Root cause

The reuse branches in the batch repair flow mixed inconsistent per-row result shapes and treated pending reused artifacts as an in-memory defer only. That left persistence and metrics behavior out of sync with the main enrichment task.

## Validation

```bash
./.venv/bin/pytest -q tests/test_b2b_enrichment.py tests/test_b2b_enrichment_repair.py tests/test_b2b_enrichment_batch_integration.py tests/test_b2b_enrichment_repair_batch_integration.py
```

Result: `119 passed, 1 skipped`
