### PR TITLE
[codex] Land B2B enrichment batch infrastructure prerequisites

### DIFF
--- a/atlas_brain/autonomous/tasks/_b2b_batch_utils.py
+++ b/atlas_brain/autonomous/tasks/_b2b_batch_utils.py
@@ -1,0 +1,378 @@
+"""Shared helpers for B2B Anthropic batch enablement."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("atlas.autonomous.tasks._b2b_batch_utils")
+
+_ANTHROPIC_BATCH_SUCCESS_STATUSES = {
+    "cache_hit",
+    "batch_succeeded",
+    "fallback_succeeded",
+}
+
+
+def exact_stage_request_fingerprint(request: Any) -> str:
+    payload = {
+        "namespace": str(getattr(request, "namespace", "") or ""),
+        "provider": str(getattr(request, "provider", "") or ""),
+        "model": str(getattr(request, "model", "") or ""),
+        "request_envelope": getattr(request, "request_envelope", None) or {},
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stored_request_fingerprint(row: Any) -> str | None:
+    metadata = row.get("request_metadata") if hasattr(row, "get") else None
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("request_fingerprint")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def task_metadata(task: Any) -> dict[str, Any]:
+    metadata = getattr(task, "metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def metadata_bool(metadata: dict[str, Any], keys: tuple[str, ...], default: bool) -> bool:
+    for key in keys:
+        if key not in metadata:
+            continue
+        value = metadata.get(key)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off"}:
+                return False
+        if isinstance(value, (int, float)):
+            return bool(value)
+        logger.warning("Ignoring invalid %s=%r on task metadata", key, value)
+    return bool(default)
+
+
+def metadata_int(
+    metadata: dict[str, Any],
+    keys: tuple[str, ...],
+    default: int,
+    *,
+    min_value: int = 1,
+) -> int:
+    for key in keys:
+        if key not in metadata:
+            continue
+        value = metadata.get(key)
+        try:
+            if value is not None:
+                return max(min_value, int(value))
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid %s=%r on task metadata", key, value)
+    return max(min_value, int(default))
+
+
+def anthropic_batch_requested(
+    task: Any,
+    *,
+    global_default: bool,
+    task_default: bool,
+    global_keys: tuple[str, ...] = ("anthropic_batch_enabled",),
+    task_keys: tuple[str, ...] = (),
+) -> bool:
+    metadata = task_metadata(task)
+    global_enabled = metadata_bool(metadata, global_keys, global_default)
+    task_enabled = metadata_bool(metadata, task_keys, task_default)
+    return bool(global_enabled and task_enabled)
+
+
+def anthropic_batch_min_items(
+    task: Any,
+    *,
+    default: int,
+    keys: tuple[str, ...],
+    min_value: int = 1,
+) -> int:
+    return metadata_int(task_metadata(task), keys, default, min_value=min_value)
+
+
+def anthropic_model_name(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.startswith("anthropic/"):
+        text = text.split("/", 1)[1].strip()
+    if text.startswith("claude"):
+        return text
+    return None
+
+
+def is_anthropic_llm(value: Any) -> bool:
+    provider = str(getattr(value, "name", "") or "").strip().lower()
+    if provider == "anthropic":
+        return True
+    if provider:
+        return False
+    model = getattr(value, "model", "") or getattr(value, "model_id", "")
+    if anthropic_model_name(model) is not None:
+        return True
+    class_name = type(value).__name__.strip().lower()
+    module_name = str(getattr(type(value), "__module__", "") or "").strip().lower()
+    return "anthropic" in class_name or module_name.endswith(".anthropic") or ".anthropic." in module_name
+
+
+def anthropic_model_candidates(*values: Any, current_llm: Any | None = None) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(value: Any) -> None:
+        model = anthropic_model_name(value)
+        if model and model not in seen:
+            seen.add(model)
+            candidates.append(model)
+
+    if current_llm is not None:
+        provider = str(getattr(current_llm, "name", "") or "").strip().lower()
+        model = str(getattr(current_llm, "model", "") or "").strip()
+        if provider in {"anthropic", "openrouter"}:
+            _add(model)
+    for value in values:
+        _add(value)
+    return candidates
+
+
+def resolve_anthropic_batch_llm(
+    *,
+    current_llm: Any | None = None,
+    target_model_candidates: tuple[Any, ...] = (),
+):
+    from ...config import settings
+    from ...pipelines.llm import get_pipeline_llm
+    from ...services import llm_registry
+
+    candidates = anthropic_model_candidates(*target_model_candidates, current_llm=current_llm)
+
+    if is_anthropic_llm(current_llm):
+        current_model = anthropic_model_name(getattr(current_llm, "model", ""))
+        if not candidates or current_model in candidates:
+            return current_llm
+
+    batch_llm = get_pipeline_llm(workload="anthropic")
+    if is_anthropic_llm(batch_llm):
+        current_model = anthropic_model_name(getattr(batch_llm, "model", ""))
+        if not candidates or current_model in candidates:
+            return batch_llm
+
+    target_model = candidates[0] if candidates else None
+    if not target_model:
+        return batch_llm if is_anthropic_llm(batch_llm) else None
+
+    api_key = (
+        settings.llm.anthropic_api_key
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("ATLAS_LLM_ANTHROPIC_API_KEY", "")
+    )
+    if not api_key:
+        logger.warning(
+            "Anthropic batch requested for %s but no Anthropic API key is configured",
+            target_model,
+        )
+        return batch_llm if is_anthropic_llm(batch_llm) else None
+
+    slot_name = f"b2b_batch_anthropic::{target_model}"
+    existing_slot = llm_registry.get_slot(slot_name)
+    if is_anthropic_llm(existing_slot):
+        existing_model = anthropic_model_name(getattr(existing_slot, "model", ""))
+        if existing_model == target_model:
+            return existing_slot
+
+    try:
+        return llm_registry.activate_slot(
+            slot_name,
+            "anthropic",
+            model=target_model,
+            api_key=api_key,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to activate Anthropic batch slot %s for model %s: %s",
+            slot_name,
+            target_model,
+            exc,
+        )
+    return batch_llm if is_anthropic_llm(batch_llm) else None
+
+
+async def reconcile_existing_batch_artifacts(
+    *,
+    pool: Any,
+    llm: Any | None,
+    task_name: str,
+    artifact_type: str,
+    artifact_ids: list[str],
+    expected_request_fingerprints: dict[str, str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Reconcile matching Anthropic batch rows and return the best-known item state.
+
+    This lets a rerun reuse already-completed provider work and avoid duplicating
+    requests that are still in flight after a process restart.
+    """
+    if (
+        not artifact_ids
+        or pool is None
+        or not getattr(pool, "is_initialized", False)
+        or not hasattr(pool, "fetch")
+    ):
+        return {}
+
+    artifact_ids = [str(value) for value in artifact_ids if str(value or "").strip()]
+    if not artifact_ids:
+        return {}
+
+    fingerprint_map = None
+    if expected_request_fingerprints is not None:
+        fingerprint_map = {
+            str(key): str(value).strip()
+            for key, value in expected_request_fingerprints.items()
+            if str(value or "").strip()
+        }
+
+    rows = await pool.fetch(
+        """
+        SELECT
+            i.*,
+            b.status AS batch_status,
+            b.provider_batch_id,
+            b.created_at AS batch_created_at
+        FROM anthropic_message_batch_items i
+        JOIN anthropic_message_batches b ON b.id = i.batch_id
+        WHERE b.task_name = $1
+          AND i.artifact_type = $2
+          AND i.artifact_id = ANY($3::text[])
+        ORDER BY i.artifact_id ASC, b.created_at DESC, i.created_at DESC
+        """,
+        task_name,
+        artifact_type,
+        artifact_ids,
+    )
+    if not rows:
+        return {}
+
+    batch_ids_to_reconcile = {
+        str(row["batch_id"])
+        for row in rows
+        if str(row.get("batch_status") or "") == "in_progress"
+        and str(row.get("provider_batch_id") or "").strip()
+    }
+    if batch_ids_to_reconcile and llm is not None:
+        from ...services.b2b.anthropic_batch import reconcile_anthropic_message_batch
+
+        for batch_id in sorted(batch_ids_to_reconcile):
+            try:
+                await reconcile_anthropic_message_batch(
+                    llm=llm,
+                    local_batch_id=batch_id,
+                    pool=pool,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed reconciling existing Anthropic batch %s for %s/%s",
+                    batch_id,
+                    task_name,
+                    artifact_type,
+                )
+        rows = await pool.fetch(
+            """
+            SELECT
+                i.*,
+                b.status AS batch_status,
+                b.provider_batch_id,
+                b.created_at AS batch_created_at
+            FROM anthropic_message_batch_items i
+            JOIN anthropic_message_batches b ON b.id = i.batch_id
+            WHERE b.task_name = $1
+              AND i.artifact_type = $2
+              AND i.artifact_id = ANY($3::text[])
+            ORDER BY i.artifact_id ASC, b.created_at DESC, i.created_at DESC
+            """,
+            task_name,
+            artifact_type,
+            artifact_ids,
+        )
+
+    grouped: dict[str, list[Any]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["artifact_id"]), []).append(row)
+
+    selected: dict[str, dict[str, Any]] = {}
+    for artifact_id, artifact_rows in grouped.items():
+        if fingerprint_map is not None:
+            expected_fingerprint = fingerprint_map.get(artifact_id)
+            if not expected_fingerprint:
+                continue
+            artifact_rows = [
+                row for row in artifact_rows
+                if _stored_request_fingerprint(row) == expected_fingerprint
+            ]
+            if not artifact_rows:
+                continue
+
+        success_row = next(
+            (
+                row
+                for row in artifact_rows
+                if str(row.get("status") or "") in _ANTHROPIC_BATCH_SUCCESS_STATUSES
+                and str(row.get("response_text") or "").strip()
+            ),
+            None,
+        )
+        if success_row is not None:
+            status = str(success_row.get("status") or "")
+            selected[artifact_id] = {
+                "state": "succeeded",
+                "status": status,
+                "cached": status == "cache_hit",
+                "response_text": str(success_row.get("response_text") or ""),
+                "error_text": str(success_row.get("error_text") or "") or None,
+                "batch_id": str(success_row["batch_id"]),
+                "custom_id": str(success_row["custom_id"]),
+            }
+            continue
+
+        pending_row = next(
+            (
+                row
+                for row in artifact_rows
+                if str(row.get("status") or "") == "pending"
+                and str(row.get("provider_batch_id") or "").strip()
+            ),
+            None,
+        )
+        if pending_row is not None:
+            selected[artifact_id] = {
+                "state": "pending",
+                "status": str(pending_row.get("status") or ""),
+                "cached": False,
+                "response_text": None,
+                "error_text": str(pending_row.get("error_text") or "") or None,
+                "batch_id": str(pending_row["batch_id"]),
+                "custom_id": str(pending_row["custom_id"]),
+            }
+
+    return selected

--- a/atlas_brain/autonomous/tasks/_b2b_witnesses.py
+++ b/atlas_brain/autonomous/tasks/_b2b_witnesses.py
@@ -1,0 +1,940 @@
+"""Deterministic review evidence spans and vendor witness-pack assembly.
+
+This module is the bridge between per-review extraction and vendor-level
+reasoning synthesis. It keeps witness selection deterministic and inspectable:
+reviews emit stable evidence spans, then Stage 4 builds a compact witness pack
+plus section packets from those spans.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger("atlas.witnesses")
+
+_CURRENCY_RE = re.compile(r"\$\s?\d[\d,]*(?:\.\d+)?(?:\s*/\s*(?:mo|month|yr|year|seat))?", re.I)
+_NUMBER_RE = re.compile(r"\b\d[\d,]*(?:\.\d+)?\b")
+_TIMING_PATTERNS = (
+    "renewal", "deadline", "quarter", "q1", "q2", "q3", "q4",
+    "30 days", "60 days", "90 days", "this month", "this week", "next quarter",
+)
+_WORKFLOW_SUBSTITUTION_PATTERNS = (
+    "async", "documentation", "docs", "wiki", "notion", "confluence",
+    "spreadsheet", "ticketing", "tickets", "email", "shared doc", "shared docs",
+)
+_BUNDLE_PATTERNS = (
+    "bundle", "bundled", "suite", "workspace", "microsoft 365", "google workspace",
+    "already included", "included with", "all-in-one", "one platform",
+    "single system", "one place", "everything in one place", "source of truth",
+)
+_INTERNAL_TOOL_PATTERNS = (
+    "internal tool", "in-house", "homegrown", "home-grown", "custom tool",
+    "built our own",
+)
+_PRODUCTIVITY_POSITIVE_PATTERNS = (
+    "more productive", "faster without", "better without", "easier without",
+    "more efficient", "save time", "saves time", "time savings", "sped up",
+    "streamlined workflow", "reduced manual work", "less manual work",
+    "less labor-intensive", "less labour-intensive", "eliminating manual data entry",
+    "faster incident response", "speeds incident response",
+)
+_PRODUCTIVITY_NEGATIVE_PATTERNS = (
+    "less productive", "slower now", "harder to work", "lost productivity",
+    "slowed us down", "time consuming", "takes too long", "waste of time",
+    "more manual work", "too many manual steps",
+)
+_PRODUCTIVITY_POSITIVE_REGEXES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bstreamlin(?:e|ed|es|ing)\b", re.I),
+    re.compile(r"\bsimplif(?:y|ies|ied|ying)\b.{0,40}\b(process(?:es)?|workflow(?:s)?|management|tasks?|work)\b", re.I),
+    re.compile(r"\breduc(?:e|ed|es|ing)\b.{0,40}\b(administrative complexity|manual data entry|response time)\b", re.I),
+    re.compile(r"\bfre(?:e|ed|es|ing)\b.{0,40}\b(team|soc team|staff)\b.{0,40}\bfocus\b", re.I),
+    re.compile(r"\bboost(?:ed|ing)?\b.{0,40}\b(productivity|roi)\b", re.I),
+)
+_PRODUCTIVITY_NEGATIVE_REGEXES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bmanual\b.{0,24}\bnightmare\b", re.I),
+    re.compile(r"\bslower\b.{0,24}\bresponse\b", re.I),
+)
+_PROCUREMENT_PATTERNS = (
+    "procurement", "vendor standardization", "approved vendor", "approved software",
+    "approved list", "security review", "legal review", "vendor review",
+)
+_STANDARDIZATION_PATTERNS = (
+    "standardized on", "standardisation", "standardization", "preferred vendor",
+    "company standard", "it standard", "standard tool",
+)
+_BUDGET_FREEZE_PATTERNS = (
+    "budget freeze", "spend freeze", "cost cutting", "cost-cutting",
+    "budget cuts", "spend reduction",
+)
+_PRICING_CONTEXT_PATTERNS = (
+    "pricing", "price", "priced", "cost", "costs", "costly", "expensive",
+    "cheaper", "budget", "billing", "invoice", "refund", "overcharg",
+    "renewal", "quoted", "quote", "per seat", "per user", "subscription",
+    "license", "licensed", "plan", "monthly", "annually", "/mo", "/month",
+    "/yr", "/year", "seat", "user",
+)
+_QUOTA_ORDER: tuple[tuple[str, int], ...] = (
+    ("common_pattern", 2),
+    ("named_account", 2),
+    ("displacement", 2),
+    ("timing", 1),
+    ("outlier", 1),
+    ("category_shift", 1),
+    ("counterevidence", 1),
+)
+_GENERIC_WITNESS_PATTERNS = (
+    "great tool",
+    "great platform",
+    "good tool",
+    "good platform",
+    "easy to use",
+    "easy-to-use",
+    "works well",
+    "working well",
+    "very helpful",
+    "super helpful",
+)
+_CONCRETE_PAIN_PATTERNS = (
+    "pricing",
+    "renewal",
+    "seat",
+    "integration",
+    "workflow",
+    "contract",
+    "budget",
+    "support",
+    "security",
+    "migration",
+    "implementation",
+    "downtime",
+    "latency",
+)
+_MIN_GENERIC_ANCHOR_SCORE = 2.0
+_SHORT_GENERIC_EXCERPT_CHARS = 55
+_LONG_EXCERPT_CHARS = 80
+_DEFAULT_SPECIFICITY_WEIGHTS: dict[str, float] = {
+    "currency": 2.0,
+    "number": 1.0,
+    "timing": 1.0,
+    "competitor": 1.0,
+    "reviewer_company": 1.0,
+    "pain_category": 0.75,
+    "replacement_mode": 0.75,
+    "operating_model_shift": 0.75,
+    "productivity_delta_claim": 0.75,
+    "signal_type": 0.5,
+    "long_excerpt": 0.5,
+    "concrete_pattern": 0.5,
+    "generic_phrase_penalty": 2.5,
+    "short_excerpt_penalty": 1.5,
+}
+
+
+def _coerce_json_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _normalize_list(values: Any) -> list[str]:
+    items: list[str] = []
+    for value in values or []:
+        text = str(value or "").strip()
+        if text:
+            items.append(text)
+    return items
+
+
+def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(needle in lowered for needle in needles)
+
+
+def _matches_any_regex(text: str, patterns: tuple[re.Pattern[str], ...]) -> bool:
+    lowered = text.lower()
+    return any(pattern.search(lowered) for pattern in patterns)
+
+
+def _has_pricing_currency_signal(text: str) -> bool:
+    lowered = str(text or "").lower()
+    if not lowered:
+        return False
+    for match in _CURRENCY_RE.finditer(lowered):
+        start = max(0, match.start() - 48)
+        end = min(len(lowered), match.end() + 48)
+        window = lowered[start:end]
+        if _contains_any(window, _PRICING_CONTEXT_PATTERNS):
+            return True
+    return False
+
+
+def _normalize_key(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    return re.sub(r"\s+", " ", text)
+
+
+def _excerpt_text(summary: Any, review_text: Any, phrase: str) -> tuple[str, int | None, int | None]:
+    full_text = " ".join(
+        part.strip() for part in (str(summary or ""), str(review_text or ""))
+        if str(part or "").strip()
+    )
+    if not full_text:
+        return phrase, None, None
+    haystack = full_text.lower()
+    needle = phrase.strip().lower()
+    if not needle:
+        excerpt = full_text[:180].strip()
+        return excerpt, None, None
+    idx = haystack.find(needle)
+    if idx < 0:
+        excerpt = phrase[:220].strip() or full_text[:180].strip()
+        return excerpt, None, None
+    start = max(0, idx - 40)
+    end = min(len(full_text), idx + len(phrase) + 40)
+    excerpt = full_text[start:end].strip()
+    return excerpt, idx, idx + len(phrase)
+
+
+def _extract_numeric_literals(text: str) -> dict[str, Any]:
+    literals: dict[str, Any] = {}
+    amounts = _CURRENCY_RE.findall(text)
+    if amounts:
+        literals["currency_mentions"] = amounts[:3]
+    numbers = _NUMBER_RE.findall(text)
+    if numbers:
+        literals["numbers"] = numbers[:5]
+    return literals
+
+
+def derive_replacement_mode(result: dict[str, Any], source_row: dict[str, Any]) -> str:
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    ).lower()
+    competitors = result.get("competitors_mentioned") or []
+    churn = _coerce_json_dict(result.get("churn_signals"))
+    if competitors and any(
+        str(comp.get("evidence_type") or "").strip().lower() in {"explicit_switch", "active_evaluation"}
+        for comp in competitors if isinstance(comp, dict)
+    ):
+        return "competitor_switch"
+    if _contains_any(review_blob, _BUNDLE_PATTERNS):
+        return "bundled_suite_consolidation"
+    if _contains_any(review_blob, _WORKFLOW_SUBSTITUTION_PATTERNS):
+        return "workflow_substitution"
+    if _contains_any(review_blob, _INTERNAL_TOOL_PATTERNS):
+        return "internal_tool"
+    if bool(churn.get("migration_in_progress")) and competitors:
+        return "competitor_switch"
+    return "none"
+
+
+def derive_operating_model_shift(result: dict[str, Any], source_row: dict[str, Any]) -> str:
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    ).lower()
+    if "async" in review_blob and _contains_any(review_blob, ("docs", "documentation", "wiki", "notion", "confluence")):
+        return "sync_to_async"
+    if _contains_any(review_blob, ("chat", "slack")) and _contains_any(review_blob, ("docs", "notion", "confluence", "wiki")):
+        return "chat_to_docs"
+    if _contains_any(review_blob, ("chat", "slack")) and _contains_any(review_blob, ("ticket", "ticketing", "help desk", "helpdesk")):
+        return "chat_to_ticketing"
+    if _contains_any(review_blob, _BUNDLE_PATTERNS):
+        return "consolidation"
+    return "none"
+
+
+def derive_productivity_delta_claim(source_row: dict[str, Any]) -> str:
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    ).lower()
+    if (
+        _contains_any(review_blob, _PRODUCTIVITY_POSITIVE_PATTERNS)
+        or _matches_any_regex(review_blob, _PRODUCTIVITY_POSITIVE_REGEXES)
+    ):
+        return "more_productive"
+    if (
+        _contains_any(review_blob, _PRODUCTIVITY_NEGATIVE_PATTERNS)
+        or _matches_any_regex(review_blob, _PRODUCTIVITY_NEGATIVE_REGEXES)
+    ):
+        return "less_productive"
+    if "no change" in review_blob:
+        return "no_change"
+    return "unknown"
+
+
+def derive_org_pressure_type(source_row: dict[str, Any]) -> str:
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    ).lower()
+    if _contains_any(review_blob, _PROCUREMENT_PATTERNS):
+        return "procurement_mandate"
+    if _contains_any(review_blob, _STANDARDIZATION_PATTERNS):
+        return "standardization_mandate"
+    if _contains_any(review_blob, _BUNDLE_PATTERNS):
+        return "bundle_pressure"
+    if _contains_any(review_blob, _BUDGET_FREEZE_PATTERNS):
+        return "budget_freeze"
+    return "none"
+
+
+def derive_salience_flags(result: dict[str, Any], source_row: dict[str, Any]) -> list[str]:
+    churn = _coerce_json_dict(result.get("churn_signals"))
+    budget = _coerce_json_dict(result.get("budget_signals"))
+    reviewer = _coerce_json_dict(result.get("reviewer_context"))
+    timeline = _coerce_json_dict(result.get("timeline"))
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    )
+    price_text = " ".join(_normalize_list(result.get("pricing_phrases")))
+    flags: list[str] = []
+
+    def _add(flag: str, condition: bool) -> None:
+        if condition and flag not in flags:
+            flags.append(flag)
+
+    _add("explicit_cancel", bool(churn.get("intent_to_leave")))
+    _add("active_evaluation", bool(churn.get("actively_evaluating")))
+    _add("migration_in_progress", bool(churn.get("migration_in_progress")))
+    _add(
+        "renewal_window",
+        bool(churn.get("contract_renewal_mentioned"))
+        or (
+            str(timeline.get("decision_timeline") or "").strip().lower()
+            not in {"", "unknown", "none"}
+        )
+        or _contains_any(review_blob, _TIMING_PATTERNS),
+    )
+    _add(
+        "explicit_dollar",
+        bool(budget.get("annual_spend_estimate") or budget.get("price_per_seat"))
+        or _has_pricing_currency_signal(price_text)
+        or _has_pricing_currency_signal(review_blob),
+    )
+    _add("named_account", bool(source_row.get("reviewer_company") or reviewer.get("company_name")))
+    _add("decision_maker", bool(reviewer.get("decision_maker")))
+    _add("named_competitor", bool(result.get("competitors_mentioned")))
+    _add("productivity_claim", derive_productivity_delta_claim(source_row) != "unknown")
+    _add("workflow_substitution", derive_replacement_mode(result, source_row) in {"workflow_substitution", "bundled_suite_consolidation", "internal_tool"})
+    return flags
+
+
+def derive_evidence_spans(
+    result: dict[str, Any],
+    source_row: dict[str, Any],
+    *,
+    max_spans: int = 8,
+) -> list[dict[str, Any]]:
+    """Build stable evidence units from extracted phrase arrays plus raw review text."""
+    review_id = str(source_row.get("id") or "unknown")
+    reviewer_company = str(source_row.get("reviewer_company") or "").strip() or None
+    reviewer_title = str(source_row.get("reviewer_title") or "").strip() or None
+    timeline = _coerce_json_dict(result.get("timeline"))
+    budget = _coerce_json_dict(result.get("budget_signals"))
+    replacement_mode = derive_replacement_mode(result, source_row)
+    operating_model_shift = derive_operating_model_shift(result, source_row)
+    productivity_delta = derive_productivity_delta_claim(source_row)
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    )
+    contract_context = _coerce_json_dict(result.get("contract_context"))
+    company_name = reviewer_company or _coerce_json_dict(result.get("reviewer_context")).get("company_name")
+    default_pain = str(result.get("pain_category") or "").strip() or None
+    default_time_anchor = (
+        str(timeline.get("evaluation_deadline") or "").strip()
+        or str(timeline.get("contract_end") or "").strip()
+        or (
+            str(timeline.get("decision_timeline") or "").strip()
+            if str(timeline.get("decision_timeline") or "").strip().lower() not in {"", "unknown", "none"}
+            else ""
+        )
+        or str(_coerce_json_dict(result.get("churn_signals")).get("renewal_timing") or "").strip()
+        or None
+    )
+    competitors = [
+        comp for comp in (result.get("competitors_mentioned") or [])
+        if isinstance(comp, dict) and str(comp.get("name") or "").strip()
+    ]
+    primary_competitor = str(competitors[0].get("name") or "").strip() if competitors else None
+    item_sources: list[tuple[str, list[Any], str | None, str | None]] = [
+        (
+            "pricing_backlash",
+            (result.get("pricing_phrases") or []) if bool(contract_context.get("price_complaint")) else [],
+            "pricing",
+            None,
+        ),
+        ("complaint", result.get("specific_complaints") or [], default_pain, None),
+        ("feature_gap", result.get("feature_gaps") or [], "features", None),
+        ("recommendation", result.get("recommendation_language") or [], default_pain, None),
+        ("positive_anchor", result.get("positive_aspects") or [], None, None),
+    ]
+    for comp in competitors:
+        reasons = [
+            comp.get("reason_detail"),
+            comp.get("reason"),
+        ]
+        texts = [text for text in reasons if str(text or "").strip()]
+        if not texts and primary_competitor:
+            texts = [f"considering {primary_competitor}"]
+        item_sources.append((
+            "competitor_pressure",
+            texts,
+            str(comp.get("reason_category") or "").strip() or default_pain,
+            str(comp.get("name") or "").strip() or None,
+        ))
+    for event in result.get("event_mentions") or []:
+        if not isinstance(event, dict):
+            continue
+        item_sources.append((
+            "event",
+            [event.get("event")],
+            default_pain,
+            None,
+        ))
+
+    spans: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _append_span(
+        *,
+        signal_type: str,
+        raw_text: Any,
+        pain_category: str | None,
+        competitor: str | None,
+        time_anchor: str | None,
+    ) -> None:
+        phrase = str(raw_text or "").strip()
+        if not phrase:
+            return
+        key = _normalize_key(phrase)
+        if key in seen:
+            return
+        excerpt, start_char, end_char = _excerpt_text(
+            source_row.get("summary"),
+            source_row.get("review_text"),
+            phrase,
+        )
+        flags: list[str] = []
+        if _has_pricing_currency_signal(excerpt):
+            flags.append("explicit_dollar")
+        if company_name:
+            flags.append("named_org")
+        if time_anchor or _contains_any(excerpt, _TIMING_PATTERNS):
+            flags.append("deadline")
+        if primary_competitor and primary_competitor.lower() in excerpt.lower():
+            flags.append("named_competitor")
+        if replacement_mode != "none":
+            flags.append(replacement_mode)
+        if operating_model_shift != "none":
+            flags.append(operating_model_shift)
+        span_id = (
+            f"review:{review_id}:span:{start_char}-{end_char}"
+            if start_char is not None and end_char is not None
+            else f"review:{review_id}:span:{len(spans)}"
+        )
+        spans.append({
+            "span_id": span_id,
+            "_sid": span_id,
+            "text": excerpt,
+            "start_char": start_char,
+            "end_char": end_char,
+            "signal_type": signal_type,
+            "pain_category": pain_category or None,
+            "competitor": competitor or None,
+            "company_name": company_name,
+            "reviewer_title": reviewer_title,
+            "time_anchor": time_anchor or default_time_anchor,
+            "numeric_literals": _extract_numeric_literals(excerpt),
+            "flags": flags,
+            "replacement_mode": replacement_mode,
+            "operating_model_shift": operating_model_shift,
+            "productivity_delta_claim": productivity_delta,
+            "_review_id": review_id,
+        })
+        seen.add(key)
+
+    for signal_type, raw_values, pain_category, competitor in item_sources:
+        for raw_value in raw_values:
+            time_anchor = None
+            if signal_type == "event":
+                time_anchor = default_time_anchor
+            _append_span(
+                signal_type=signal_type,
+                raw_text=raw_value,
+                pain_category=pain_category,
+                competitor=competitor,
+                time_anchor=time_anchor,
+            )
+            if len(spans) >= max_spans:
+                return spans
+
+    if not spans and review_blob.strip():
+        excerpt, start_char, end_char = _excerpt_text("", source_row.get("review_text"), review_blob[:160])
+        spans.append({
+            "span_id": f"review:{review_id}:span:fallback",
+            "_sid": f"review:{review_id}:span:fallback",
+            "text": excerpt,
+            "start_char": start_char,
+            "end_char": end_char,
+            "signal_type": "review_context",
+            "pain_category": default_pain,
+            "competitor": primary_competitor,
+            "company_name": company_name,
+            "reviewer_title": reviewer_title,
+            "time_anchor": default_time_anchor,
+            "numeric_literals": _extract_numeric_literals(excerpt),
+            "flags": derive_salience_flags(result, source_row),
+            "replacement_mode": replacement_mode,
+            "operating_model_shift": operating_model_shift,
+            "productivity_delta_claim": productivity_delta,
+            "_review_id": review_id,
+        })
+
+    if budget.get("annual_spend_estimate") and spans:
+        spans[0]["numeric_literals"].setdefault(
+            "annual_spend_estimate", budget.get("annual_spend_estimate"),
+        )
+    if budget.get("price_per_seat") and spans:
+        spans[0]["numeric_literals"].setdefault(
+            "price_per_seat", budget.get("price_per_seat"),
+        )
+    return spans[:max_spans]
+
+
+def _recency_bonus(reviewed_at: Any) -> float:
+    if not reviewed_at:
+        return 0.4
+    if isinstance(reviewed_at, str):
+        try:
+            reviewed_at = datetime.fromisoformat(reviewed_at.replace("Z", "+00:00"))
+        except ValueError:
+            return 0.4
+    if not isinstance(reviewed_at, datetime):
+        return 0.4
+    if reviewed_at.tzinfo is None:
+        reviewed_at = reviewed_at.replace(tzinfo=timezone.utc)
+    days_old = max((datetime.now(timezone.utc) - reviewed_at).days, 0)
+    if days_old <= 30:
+        return 1.0
+    if days_old <= 90:
+        return 0.7
+    if days_old <= 180:
+        return 0.5
+    return 0.2
+
+
+def _witness_salience(review: dict[str, Any], enrichment: dict[str, Any], span: dict[str, Any]) -> float:
+    churn = _coerce_json_dict(enrichment.get("churn_signals"))
+    reviewer = _coerce_json_dict(enrichment.get("reviewer_context"))
+    source_weight = _coerce_json_dict(review.get("raw_metadata")).get("source_weight")
+    try:
+        source_weight = float(source_weight)
+    except (TypeError, ValueError):
+        source_weight = 0.7
+    score = 0.0
+    if churn.get("intent_to_leave"):
+        score += 3.0
+    if churn.get("migration_in_progress"):
+        score += 3.0
+    if churn.get("actively_evaluating"):
+        score += 2.0
+    if churn.get("contract_renewal_mentioned"):
+        score += 2.0
+    if reviewer.get("decision_maker"):
+        score += 1.5
+    if review.get("reviewer_company"):
+        score += 1.5
+    if span.get("competitor"):
+        score += 1.5
+    flags = {str(flag).strip().lower() for flag in span.get("flags") or []}
+    if "explicit_dollar" in flags:
+        score += 2.0
+    if span.get("operating_model_shift") not in {None, "", "none"}:
+        score += 1.5
+    if span.get("productivity_delta_claim") in {"more_productive", "less_productive"}:
+        score += 1.5
+    try:
+        rating = float(review.get("rating") or 0)
+        rating_max = float(review.get("rating_max") or 5)
+    except (TypeError, ValueError):
+        rating = 0.0
+        rating_max = 5.0
+    if rating_max > 0 and rating and rating / rating_max <= 0.5:
+        score += 1.0
+    score += _recency_bonus(review.get("reviewed_at")) * 1.5
+    score += max(min(source_weight, 1.5), 0.0)
+    return round(score, 2)
+
+
+def _candidate_types(review: dict[str, Any], enrichment: dict[str, Any], span: dict[str, Any], primary_pains: set[str]) -> set[str]:
+    types = {"flex"}
+    reviewer = _coerce_json_dict(enrichment.get("reviewer_context"))
+    churn = _coerce_json_dict(enrichment.get("churn_signals"))
+    flags = {str(flag).strip().lower() for flag in span.get("flags") or []}
+    if span.get("pain_category") and str(span.get("pain_category")) in primary_pains:
+        types.add("common_pattern")
+    if review.get("reviewer_company") or reviewer.get("decision_maker"):
+        types.add("named_account")
+    if span.get("competitor") or churn.get("migration_in_progress") or churn.get("actively_evaluating"):
+        types.add("displacement")
+    if span.get("time_anchor") or "deadline" in flags or churn.get("contract_renewal_mentioned"):
+        types.add("timing")
+    if "explicit_dollar" in flags or len(flags.intersection({"named_org", "named_competitor"})) == 2:
+        types.add("outlier")
+    if span.get("replacement_mode") not in {None, "", "none"} or span.get("operating_model_shift") not in {None, "", "none"}:
+        types.add("category_shift")
+    if enrichment.get("would_recommend") is True or str(_coerce_json_dict(enrichment.get("sentiment_trajectory")).get("direction") or "") == "stable_positive":
+        types.add("counterevidence")
+    if span.get("signal_type") == "positive_anchor":
+        types.add("counterevidence")
+    return types
+
+
+def _top_primary_pains(reviews: list[dict[str, Any]]) -> set[str]:
+    counts: dict[str, int] = {}
+    for review in reviews:
+        enrichment = _coerce_json_dict(review.get("enrichment"))
+        for item in enrichment.get("pain_categories") or []:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("severity") or "").strip().lower() != "primary":
+                continue
+            cat = str(item.get("category") or "").strip()
+            if not cat:
+                continue
+            counts[cat] = counts.get(cat, 0) + 1
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return {cat for cat, _ in ranked[:2]}
+
+
+def _normalized_excerpt_key(text: str) -> str:
+    return re.sub(r"\s+", " ", str(text or "").strip().lower())
+
+
+def _witness_specificity_signals(
+    candidate: dict[str, Any],
+    *,
+    generic_patterns: tuple[str, ...],
+    concrete_patterns: tuple[str, ...],
+    short_excerpt_chars: int,
+    long_excerpt_chars: int,
+    weights: dict[str, float],
+) -> tuple[float, list[str]]:
+    excerpt = str(candidate.get("excerpt_text") or "").strip()
+    lowered = excerpt.lower()
+    score = 0.0
+    reasons: list[str] = []
+    anchor_count = 0
+
+    if _CURRENCY_RE.search(excerpt):
+        score += float(weights.get("currency", 2.0))
+        anchor_count += 1
+    if _NUMBER_RE.search(excerpt):
+        score += float(weights.get("number", 1.0))
+        anchor_count += 1
+    if candidate.get("time_anchor") or _contains_any(lowered, _TIMING_PATTERNS):
+        score += float(weights.get("timing", 1.0))
+        anchor_count += 1
+    if candidate.get("competitor"):
+        score += float(weights.get("competitor", 1.0))
+        anchor_count += 1
+    if candidate.get("reviewer_company"):
+        score += float(weights.get("reviewer_company", 1.0))
+        anchor_count += 1
+    if candidate.get("pain_category"):
+        score += float(weights.get("pain_category", 0.75))
+    if candidate.get("replacement_mode") not in {None, "", "none"}:
+        score += float(weights.get("replacement_mode", 0.75))
+        anchor_count += 1
+    if candidate.get("operating_model_shift") not in {None, "", "none"}:
+        score += float(weights.get("operating_model_shift", 0.75))
+        anchor_count += 1
+    if candidate.get("productivity_delta_claim") in {"more_productive", "less_productive"}:
+        score += float(weights.get("productivity_delta_claim", 0.75))
+        anchor_count += 1
+    if candidate.get("signal_type"):
+        score += float(weights.get("signal_type", 0.5))
+    if len(excerpt) >= long_excerpt_chars:
+        score += float(weights.get("long_excerpt", 0.5))
+    if _contains_any(lowered, concrete_patterns):
+        score += float(weights.get("concrete_pattern", 0.5))
+        anchor_count += 1
+
+    if _contains_any(lowered, generic_patterns):
+        score -= float(weights.get("generic_phrase_penalty", 2.5))
+        reasons.append("boilerplate_phrase")
+    if len(excerpt) < short_excerpt_chars and anchor_count == 0:
+        score -= float(weights.get("short_excerpt_penalty", 1.5))
+        reasons.append("too_short_without_anchors")
+    if anchor_count == 0 and not reasons:
+        reasons.append("no_specific_anchor")
+
+    return round(score, 2), reasons
+
+
+def compute_witness_hash(witness: dict[str, Any]) -> str:
+    payload = {
+        "witness_id": str(witness.get("witness_id") or witness.get("_sid") or "").strip(),
+        "review_id": str(witness.get("review_id") or "").strip(),
+        "excerpt_text": _normalized_excerpt_key(witness.get("excerpt_text")),
+        "source": str(witness.get("source") or "").strip().lower(),
+        "source_span_id": str(witness.get("source_span_id") or "").strip().lower(),
+        "signal_type": str(witness.get("signal_type") or "").strip().lower(),
+        "pain_category": str(witness.get("pain_category") or "").strip().lower(),
+        "competitor": str(witness.get("competitor") or "").strip().lower(),
+        "time_anchor": str(witness.get("time_anchor") or "").strip().lower(),
+        "replacement_mode": str(witness.get("replacement_mode") or "").strip().lower(),
+        "operating_model_shift": str(witness.get("operating_model_shift") or "").strip().lower(),
+        "productivity_delta_claim": str(witness.get("productivity_delta_claim") or "").strip().lower(),
+        "signal_tags": sorted(
+            str(tag or "").strip().lower()
+            for tag in (witness.get("signal_tags") or [])
+            if str(tag or "").strip()
+        ),
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()[:24]
+
+
+def build_vendor_witness_artifacts(
+    vendor_name: str,
+    reviews: list[dict[str, Any]] | None,
+    *,
+    max_witnesses: int = 12,
+    min_specificity_score: float = _MIN_GENERIC_ANCHOR_SCORE,
+    fallback_min_witnesses: int = 4,
+    generic_patterns: tuple[str, ...] | list[str] | None = None,
+    concrete_patterns: tuple[str, ...] | list[str] | None = None,
+    short_excerpt_chars: int = _SHORT_GENERIC_EXCERPT_CHARS,
+    long_excerpt_chars: int = _LONG_EXCERPT_CHARS,
+    specificity_weights: dict[str, float] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Select a deterministic witness pack and compact section packets."""
+    reviews = list(reviews or [])
+    primary_pains = _top_primary_pains(reviews)
+    generic_patterns = tuple(generic_patterns or _GENERIC_WITNESS_PATTERNS)
+    concrete_patterns = tuple(concrete_patterns or _CONCRETE_PAIN_PATTERNS)
+    weights = {
+        **_DEFAULT_SPECIFICITY_WEIGHTS,
+        **(specificity_weights or {}),
+    }
+    candidates: list[dict[str, Any]] = []
+    _spans_persisted = 0
+    _spans_fallback = 0
+
+    for review in reviews:
+        enrichment = _coerce_json_dict(review.get("enrichment"))
+        if not enrichment:
+            continue
+        spans = enrichment.get("evidence_spans")
+        if not isinstance(spans, list) or not spans:
+            spans = derive_evidence_spans(enrichment, review)
+            _spans_fallback += 1
+        else:
+            _spans_persisted += 1
+        for idx, raw_span in enumerate(spans):
+            if not isinstance(raw_span, dict):
+                continue
+            span = dict(raw_span)
+            excerpt_text = str(span.get("text") or "").strip()
+            if not excerpt_text:
+                continue
+            review_id = str(review.get("id") or span.get("_review_id") or "unknown")
+            types = _candidate_types(review, enrichment, span, primary_pains)
+            witness_id = f"witness:{review_id}:{idx}"
+            candidate = {
+                "witness_id": witness_id,
+                "_sid": witness_id,
+                "vendor_name": vendor_name,
+                "review_id": review_id,
+                "excerpt_text": excerpt_text[:320],
+                "source": str(review.get("source") or "").strip(),
+                "reviewed_at": review.get("reviewed_at"),
+                "reviewer_company": review.get("reviewer_company"),
+                "reviewer_title": review.get("reviewer_title"),
+                "pain_category": span.get("pain_category"),
+                "competitor": span.get("competitor"),
+                "signal_type": span.get("signal_type"),
+                "signal_tags": list(span.get("flags") or []),
+                "replacement_mode": span.get("replacement_mode"),
+                "operating_model_shift": span.get("operating_model_shift"),
+                "productivity_delta_claim": span.get("productivity_delta_claim"),
+                "time_anchor": span.get("time_anchor"),
+                "salience_score": _witness_salience(review, enrichment, span),
+                "candidate_types": sorted(types),
+                "selection_reason": "",
+                "source_span_id": span.get("span_id"),
+            }
+            specificity_score, generic_reasons = _witness_specificity_signals(
+                candidate,
+                generic_patterns=generic_patterns,
+                concrete_patterns=concrete_patterns,
+                short_excerpt_chars=short_excerpt_chars,
+                long_excerpt_chars=long_excerpt_chars,
+                weights=weights,
+            )
+            candidate["specificity_score"] = specificity_score
+            candidate["generic_reason"] = (
+                ",".join(generic_reasons)
+                if specificity_score < min_specificity_score and generic_reasons
+                else (
+                    "low_specificity_score"
+                    if specificity_score < min_specificity_score
+                    else None
+                )
+            )
+            candidates.append(candidate)
+
+    ranked = sorted(
+        candidates,
+        key=lambda item: (-float(item.get("salience_score") or 0.0), item["witness_id"]),
+    )
+    specific_ranked = [
+        item for item in ranked
+        if not str(item.get("generic_reason") or "").strip()
+    ]
+    generic_ranked = [
+        item for item in ranked
+        if str(item.get("generic_reason") or "").strip()
+    ]
+    selected: list[dict[str, Any]] = []
+    selected_ids: set[str] = set()
+    seen_excerpts: set[str] = set()
+
+    def _select_for(
+        kind: str,
+        pool: list[dict[str, Any]],
+        *,
+        generic_fallback: bool = False,
+    ) -> bool:
+        for candidate in pool:
+            if candidate["witness_id"] in selected_ids:
+                continue
+            if kind not in set(candidate.get("candidate_types") or []):
+                continue
+            excerpt_key = _normalized_excerpt_key(candidate.get("excerpt_text"))
+            if excerpt_key in seen_excerpts:
+                continue
+            clone = dict(candidate)
+            clone["witness_type"] = kind
+            clone["selection_reason"] = (
+                f"selected_for_{kind}_generic_fallback"
+                if generic_fallback
+                else f"selected_for_{kind}"
+            )
+            clone["witness_hash"] = compute_witness_hash(clone)
+            selected.append(clone)
+            selected_ids.add(clone["witness_id"])
+            seen_excerpts.add(excerpt_key)
+            return True
+        return False
+
+    for kind, quota in _QUOTA_ORDER:
+        for _ in range(quota):
+            if len(selected) >= max_witnesses:
+                break
+            if not _select_for(kind, specific_ranked):
+                break
+
+    for candidate in specific_ranked:
+        if len(selected) >= max_witnesses:
+            break
+        if candidate["witness_id"] in selected_ids:
+            continue
+        excerpt_key = _normalized_excerpt_key(candidate.get("excerpt_text"))
+        if excerpt_key in seen_excerpts:
+            continue
+        clone = dict(candidate)
+        clone["witness_type"] = "flex"
+        clone["selection_reason"] = "selected_for_flex"
+        clone["witness_hash"] = compute_witness_hash(clone)
+        selected.append(clone)
+        selected_ids.add(clone["witness_id"])
+        seen_excerpts.add(excerpt_key)
+
+    fallback_target = min(max_witnesses, max(0, int(fallback_min_witnesses)))
+    if len(selected) < fallback_target:
+        for kind, quota in _QUOTA_ORDER:
+            for _ in range(quota):
+                if len(selected) >= fallback_target:
+                    break
+                if not _select_for(kind, generic_ranked, generic_fallback=True):
+                    break
+        for candidate in generic_ranked:
+            if len(selected) >= fallback_target:
+                break
+            if candidate["witness_id"] in selected_ids:
+                continue
+            excerpt_key = _normalized_excerpt_key(candidate.get("excerpt_text"))
+            if excerpt_key in seen_excerpts:
+                continue
+            clone = dict(candidate)
+            clone["witness_type"] = "flex"
+            clone["selection_reason"] = "selected_for_generic_fallback"
+            clone["witness_hash"] = compute_witness_hash(clone)
+            selected.append(clone)
+            selected_ids.add(clone["witness_id"])
+            seen_excerpts.add(excerpt_key)
+
+    selected.sort(
+        key=lambda item: (
+            str(item.get("witness_type") or ""),
+            -float(item.get("salience_score") or 0.0),
+            str(item.get("witness_id") or ""),
+        ),
+    )
+
+    def _ids_for(kind: str) -> list[str]:
+        return [item["witness_id"] for item in selected if item.get("witness_type") == kind]
+
+    section_packets = {
+        "causal_packet": {
+            "witness_ids": [item["witness_id"] for item in selected if item.get("witness_type") != "counterevidence"],
+            "primary_pain_categories": sorted(primary_pains),
+        },
+        "timing_packet": {"witness_ids": _ids_for("timing")},
+        "displacement_packet": {"witness_ids": _ids_for("displacement")},
+        "segment_packet": {"witness_ids": _ids_for("named_account")},
+        "retention_packet": {"witness_ids": _ids_for("counterevidence")},
+        "anchor_examples": {
+            "common_pattern": _ids_for("common_pattern")[:1],
+            "outlier_or_named_account": (_ids_for("outlier") + _ids_for("named_account"))[:1],
+            "counterevidence": _ids_for("counterevidence")[:1],
+        },
+        "_witness_governance": {
+            "filtered_generic_candidates": len(generic_ranked),
+            "selected_specific_witnesses": sum(
+                1 for item in selected if not str(item.get("generic_reason") or "").strip()
+            ),
+            "selected_generic_fallback_witnesses": sum(
+                1 for item in selected if str(item.get("generic_reason") or "").strip()
+            ),
+            "thin_specific_witness_pool": any(
+                str(item.get("generic_reason") or "").strip() for item in selected
+            ),
+            "spans_persisted": _spans_persisted,
+            "spans_fallback": _spans_fallback,
+        },
+    }
+    if _spans_fallback > 0:
+        logger.info(
+            "Witness fallback: %s -- %d/%d reviews missing persisted evidence_spans, recomputed from raw enrichment",
+            vendor_name, _spans_fallback, _spans_persisted + _spans_fallback,
+        )
+    return selected, section_packets

--- a/atlas_brain/autonomous/tasks/_execution_progress.py
+++ b/atlas_brain/autonomous/tasks/_execution_progress.py
@@ -17,6 +17,29 @@ def _task_execution_id(task: ScheduledTask) -> UUID | None:
         return None
 
 
+def task_run_id(task: ScheduledTask | Any) -> str | None:
+    """Return the best correlation id for a task execution.
+
+    Prefer the scheduler-injected execution id so one scheduled task can be
+    correlated across multiple runs. Fall back to explicit metadata keys and
+    finally the task id for ad-hoc/manual contexts that do not have an
+    execution row.
+    """
+    exec_id = _task_execution_id(task)
+    if exec_id is not None:
+        return str(exec_id)
+    metadata = getattr(task, "metadata", None)
+    if isinstance(metadata, dict):
+        for key in ("run_id", "task_id", "invocation_id"):
+            value = metadata.get(key)
+            if value:
+                return str(value)
+    task_id = getattr(task, "id", None)
+    if task_id:
+        return str(task_id)
+    return None
+
+
 async def _update_execution_progress(
     task: ScheduledTask,
     *,

--- a/atlas_brain/autonomous/tasks/b2b_enrichment.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment.py
@@ -1,26 +1,46 @@
 """
-B2B review enrichment: extract churn signals from pending reviews via LLM
-using the b2b_churn_extraction skill.
+B2B review enrichment: extract churn signals from pending reviews via the
+current two-tier pipeline.
 
-Single-pass enrichment (one LLM call per review). Polls b2b_reviews WHERE
-enrichment_status = 'pending', calls LLM, stores result in enrichment JSONB
-column, sets status to 'enriched'.
+Flow:
+  1. Tier 1 extraction for base factual fields
+  2. Conditional Tier 2 classification when Tier 1 leaves extraction gaps
+  3. Deterministic finalize/validation before persistence
+
+Polls b2b_reviews WHERE enrichment_status = 'pending', stores the finalized
+enrichment JSONB payload, and sets status to `enriched`, `no_signal`, or
+`quarantined`.
 
 Runs on an interval (default 5 min). Returns _skip_synthesis so the
 runner does not double-synthesize.
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import re
+import time
+import unicodedata
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 
 from ...config import settings
+from ...services.b2b.reviewer_identity import sanitize_reviewer_title
 from ...services.company_normalization import normalize_company_name
+from ...services.scraping.sources import filter_deprecated_sources, parse_source_allowlist
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
+from ._b2b_witnesses import (
+    derive_evidence_spans,
+    derive_operating_model_shift,
+    derive_org_pressure_type,
+    derive_productivity_delta_claim,
+    derive_replacement_mode,
+    derive_salience_flags,
+)
+from ._execution_progress import task_run_id as _task_run_id
 
 logger = logging.getLogger("atlas.autonomous.tasks.b2b_enrichment")
 
@@ -29,6 +49,62 @@ _TIER1_JSON_SCHEMA: dict[str, Any] = {
     "type": "object",
     "additionalProperties": True,
 }
+_TIER2_INSIDER_SECTION_HEADER = "### insider_signals -- CLASSIFY + EXTRACT (only for insider_account)"
+_TIER2_OUTPUT_SECTION_HEADER = "## Output"
+
+
+def _coerce_int_value(raw_value: Any, fallback: int) -> int:
+    if isinstance(raw_value, bool):
+        return int(raw_value)
+    if isinstance(raw_value, int):
+        return raw_value
+    if isinstance(raw_value, float):
+        if raw_value != raw_value:
+            return fallback
+        return int(raw_value)
+    if isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return fallback
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return int(float(text))
+            except ValueError:
+                return fallback
+    return fallback
+
+
+def _coerce_float_value(raw_value: Any, fallback: float) -> float:
+    if isinstance(raw_value, bool):
+        return float(raw_value)
+    if isinstance(raw_value, (int, float)):
+        numeric = float(raw_value)
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return fallback
+        try:
+            numeric = float(text)
+        except ValueError:
+            return fallback
+    else:
+        return fallback
+    if numeric != numeric:
+        return fallback
+    return numeric
+
+
+def _config_allowlist(raw_value: Any, fallback: str | list[str] | tuple[str, ...] | set[str] | frozenset[str] = "") -> list[str]:
+    candidate = raw_value if isinstance(raw_value, (str, list, tuple, set, frozenset)) else fallback
+    return list(parse_source_allowlist(candidate))
+
+
+def _enrichment_batch_custom_id(stage: str, review_id: Any) -> str:
+    normalized_stage = re.sub(r"[^A-Za-z0-9_-]+", "_", str(stage or "").strip()).strip("_") or "stage"
+    normalized_review = re.sub(r"[^A-Za-z0-9_-]+", "_", str(review_id or "").strip()).strip("_") or "review"
+    return f"{normalized_stage}_{normalized_review}"[:64]
 
 def _get_base_enrichment_llm(local_only: bool):
     """Resolve the deterministic local enrichment model from vLLM only."""
@@ -39,6 +115,19 @@ def _get_base_enrichment_llm(local_only: bool):
         try_openrouter=False,
         auto_activate_ollama=False,
     )
+
+
+def _tier2_system_prompt_for_content_type(prompt: str, content_type: str | None) -> str:
+    """Skip insider-account instructions for non-insider rows to save tokens."""
+    if str(content_type or "").strip().lower() == "insider_account":
+        return prompt
+    before, marker, after = prompt.partition(_TIER2_INSIDER_SECTION_HEADER)
+    if not marker:
+        return prompt
+    _insider_body, output_marker, output_tail = after.partition(_TIER2_OUTPUT_SECTION_HEADER)
+    if not output_marker:
+        return prompt
+    return f"{before.rstrip()}\n\n{_TIER2_OUTPUT_SECTION_HEADER}{output_tail}"
 
 
 _tier1_client = None
@@ -80,28 +169,199 @@ def _get_tier1_client(cfg):
     return _tier1_client
 
 
-async def _call_vllm_tier1(payload_json: str, cfg, client) -> tuple[dict | None, str | None]:
+async def _lookup_cached_json_response(
+    namespace: str,
+    *,
+    provider: str,
+    model: str,
+    system_prompt: str,
+    user_content: str,
+    max_tokens: int,
+    temperature: float,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any], bool]:
+    """Lookup a cached structured response and return the envelope either way."""
+    from ...pipelines.llm import clean_llm_output, parse_json_response
+    from ...services.b2b.cache_runner import (
+        lookup_b2b_exact_stage_text,
+        prepare_b2b_exact_stage_request,
+    )
+
+    request = prepare_b2b_exact_stage_request(
+        namespace,
+        provider=provider,
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ],
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        guided_json=guided_json,
+    )
+    cached = await lookup_b2b_exact_stage_text(request)
+    if cached is None:
+        return None, request.request_envelope, False
+
+    text = clean_llm_output(cached["response_text"])
+    parsed = parse_json_response(text, recover_truncated=True)
+    if isinstance(parsed, dict) and not parsed.get("_parse_fallback"):
+        return parsed, request.request_envelope, True
+    return None, request.request_envelope, False
+
+
+def _unpack_cached_lookup_result(
+    result: tuple[Any, ...],
+) -> tuple[dict[str, Any] | None, dict[str, Any], bool]:
+    if len(result) == 3:
+        cached, request_envelope, cache_hit = result
+        return cached, request_envelope, bool(cache_hit)
+    if len(result) == 2:
+        cached, request_envelope = result
+        return cached, request_envelope, cached is not None
+    raise ValueError(f"Unexpected cached lookup result shape: {len(result)}")
+
+
+def _unpack_stage_result(
+    result: tuple[Any, ...],
+) -> tuple[dict[str, Any] | None, str | None, bool]:
+    if len(result) == 3:
+        parsed, model_id, cache_hit = result
+        return parsed, model_id, bool(cache_hit)
+    if len(result) == 2:
+        parsed, model_id = result
+        return parsed, model_id, False
+    raise ValueError(f"Unexpected stage result shape: {len(result)}")
+
+
+def _pack_stage_result(
+    parsed: dict[str, Any] | None,
+    model_id: str | None,
+    cache_hit: bool,
+    *,
+    include_cache_hit: bool,
+) -> tuple[dict[str, Any] | None, str | None] | tuple[dict[str, Any] | None, str | None, bool]:
+    if include_cache_hit:
+        return parsed, model_id, cache_hit
+    return parsed, model_id
+
+
+def _trace_enrichment_llm_call(
+    span_name: str,
+    *,
+    provider: str,
+    model: str | None,
+    messages: list[dict[str, str]],
+    usage: dict[str, Any] | None,
+    metadata: dict[str, Any] | None,
+    duration_ms: float,
+    api_endpoint: str | None = None,
+    provider_request_id: str | None = None,
+) -> None:
+    from ...pipelines.llm import _trace_cache_metrics, trace_llm_call
+
+    usage_dict = usage if isinstance(usage, dict) else {}
+    normalized_usage = {
+        "input_tokens": usage_dict.get("input_tokens", usage_dict.get("prompt_tokens", 0)),
+        "output_tokens": usage_dict.get("output_tokens", usage_dict.get("completion_tokens", 0)),
+        "billable_input_tokens": usage_dict.get("billable_input_tokens", usage_dict.get("prompt_tokens")),
+    }
+    cached_tokens, cache_write_tokens, billable_input_tokens = _trace_cache_metrics(normalized_usage, {})
+    trace_llm_call(
+        span_name,
+        input_tokens=int(normalized_usage.get("input_tokens") or 0),
+        output_tokens=int(normalized_usage.get("output_tokens") or 0),
+        cached_tokens=cached_tokens,
+        cache_write_tokens=cache_write_tokens,
+        billable_input_tokens=billable_input_tokens,
+        model=str(model or ""),
+        provider=provider,
+        duration_ms=duration_ms,
+        metadata=metadata or {},
+        input_data={"messages": [{"role": msg["role"], "content": (msg["content"] or "")[:500]} for msg in messages]},
+        api_endpoint=api_endpoint,
+        provider_request_id=provider_request_id,
+    )
+
+
+async def _store_cached_json_response(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    provider: str,
+    model: str,
+    response_text: str,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Store a validated structured response for later exact reuse."""
+    from ...services.b2b.cache_runner import (
+        bind_b2b_exact_stage_request,
+        store_b2b_exact_stage_text,
+    )
+
+    request = bind_b2b_exact_stage_request(
+        namespace,
+        provider=provider,
+        model=model,
+        request_envelope=request_envelope,
+    )
+    await store_b2b_exact_stage_text(
+        request,
+        response_text=response_text,
+        metadata=metadata,
+    )
+
+
+async def _call_vllm_tier1(
+    payload_json: str,
+    cfg,
+    client,
+    *,
+    include_cache_hit: bool = False,
+    trace_metadata: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None] | tuple[dict | None, str | None, bool]:
     """Tier 1 extraction: deterministic fields via local vLLM.
 
-    Returns (result_dict, model_id) or (None, None) on failure.
+    Returns (result_dict, model_id, cache_hit) or (None, None, False) on failure.
     """
     from ...skills import get_skill_registry
 
     skill = get_skill_registry().get("digest/b2b_churn_extraction_tier1")
     if not skill:
         logger.warning("Skill 'digest/b2b_churn_extraction_tier1' not found")
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
     model_id = cfg.enrichment_tier1_model
+    request_envelope: dict[str, Any] | None = None
+    messages = [
+        {"role": "system", "content": skill.content},
+        {"role": "user", "content": payload_json},
+    ]
     try:
+        cached, request_envelope, cache_hit = _unpack_cached_lookup_result(
+            await _lookup_cached_json_response(
+            "b2b_enrichment.tier1",
+            provider="vllm",
+            model=model_id,
+            system_prompt=skill.content,
+            user_content=payload_json,
+            max_tokens=cfg.enrichment_tier1_max_tokens,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+            guided_json=_TIER1_JSON_SCHEMA,
+            )
+        )
+        if cached is not None:
+            return _pack_stage_result(cached, model_id, cache_hit, include_cache_hit=include_cache_hit)
+
+        call_started = time.monotonic()
         resp = await client.post(
             "/v1/chat/completions",
             json={
                 "model": cfg.enrichment_tier1_model,
-                "messages": [
-                    {"role": "system", "content": skill.content},
-                    {"role": "user", "content": payload_json},
-                ],
+                "messages": messages,
                 "max_tokens": cfg.enrichment_tier1_max_tokens,
                 "temperature": 0.0,
                 "guided_json": _TIER1_JSON_SCHEMA,
@@ -109,25 +369,51 @@ async def _call_vllm_tier1(payload_json: str, cfg, client) -> tuple[dict | None,
             },
         )
         resp.raise_for_status()
-        text = resp.json()["choices"][0]["message"]["content"].strip()
+        body = resp.json()
+        _trace_enrichment_llm_call(
+            "task.b2b_enrichment.tier1",
+            provider="vllm",
+            model=model_id,
+            messages=messages,
+            usage=body.get("usage", {}),
+            metadata=trace_metadata,
+            duration_ms=(time.monotonic() - call_started) * 1000,
+            api_endpoint=f"{str(getattr(client, 'base_url', '')).rstrip('/')}/v1/chat/completions",
+        )
+        text = body["choices"][0]["message"]["content"].strip()
         if not text:
-            return None, model_id
+            return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
 
         from ...pipelines.llm import clean_llm_output, parse_json_response
         text = clean_llm_output(text)
         parsed = parse_json_response(text, recover_truncated=True)
         if isinstance(parsed, dict) and not parsed.get("_parse_fallback"):
-            return parsed, model_id
-        return None, model_id
+            if request_envelope is not None:
+                await _store_cached_json_response(
+                    "b2b_enrichment.tier1",
+                    request_envelope,
+                    provider="vllm",
+                    model=model_id,
+                    response_text=text,
+                    metadata={"tier": 1, "backend": "vllm"},
+                )
+            return _pack_stage_result(parsed, model_id, False, include_cache_hit=include_cache_hit)
+        return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
     except (json.JSONDecodeError, ValueError):
         logger.warning("Tier 1 vLLM returned invalid JSON")
-        return None, model_id
+        return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
     except Exception:
         logger.exception("Tier 1 vLLM call failed")
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
 
-async def _call_openrouter_tier1(payload_json: str, cfg) -> tuple[dict | None, str | None]:
+async def _call_openrouter_tier1(
+    payload_json: str,
+    cfg,
+    *,
+    include_cache_hit: bool = False,
+    trace_metadata: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None] | tuple[dict | None, str | None, bool]:
     """Tier 1 extraction via OpenRouter (cloud model, no guided_json)."""
     import httpx
     from ...skills import get_skill_registry
@@ -135,16 +421,37 @@ async def _call_openrouter_tier1(payload_json: str, cfg) -> tuple[dict | None, s
     skill = get_skill_registry().get("digest/b2b_churn_extraction_tier1")
     if not skill:
         logger.warning("Skill 'digest/b2b_churn_extraction_tier1' not found")
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
     api_key = cfg.openrouter_api_key
     if not api_key:
         logger.warning("OpenRouter API key not configured for enrichment")
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
-    model_id = cfg.enrichment_openrouter_model or "openai/gpt-oss-120b"
+    model_id = cfg.enrichment_openrouter_model or "anthropic/claude-haiku-4-5"
+    request_envelope: dict[str, Any] | None = None
+    messages = [
+        {"role": "system", "content": skill.content},
+        {"role": "user", "content": payload_json},
+    ]
     try:
+        cached, request_envelope, cache_hit = _unpack_cached_lookup_result(
+            await _lookup_cached_json_response(
+            "b2b_enrichment.tier1",
+            provider="openrouter",
+            model=model_id,
+            system_prompt=skill.content,
+            user_content=payload_json,
+            max_tokens=max(cfg.enrichment_tier1_max_tokens, 4096),
+            temperature=0.0,
+            response_format={"type": "json_object"},
+            )
+        )
+        if cached is not None:
+            return _pack_stage_result(cached, model_id, cache_hit, include_cache_hit=include_cache_hit)
+
         async with httpx.AsyncClient(timeout=httpx.Timeout(90.0, connect=10.0)) as client:
+            call_started = time.monotonic()
             resp = await client.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 headers={
@@ -153,10 +460,7 @@ async def _call_openrouter_tier1(payload_json: str, cfg) -> tuple[dict | None, s
                 },
                 json={
                     "model": model_id,
-                    "messages": [
-                        {"role": "system", "content": skill.content},
-                        {"role": "user", "content": payload_json},
-                    ],
+                    "messages": messages,
                     "max_tokens": max(cfg.enrichment_tier1_max_tokens, 4096),
                     "temperature": 0.0,
                     "response_format": {"type": "json_object"},
@@ -164,10 +468,21 @@ async def _call_openrouter_tier1(payload_json: str, cfg) -> tuple[dict | None, s
             )
             resp.raise_for_status()
             body = resp.json()
+            _trace_enrichment_llm_call(
+                "task.b2b_enrichment.tier1",
+                provider="openrouter",
+                model=model_id,
+                messages=messages,
+                usage=body.get("usage", {}),
+                metadata=trace_metadata,
+                duration_ms=(time.monotonic() - call_started) * 1000,
+                api_endpoint="https://openrouter.ai/api/v1/chat/completions",
+                provider_request_id=resp.headers.get("x-request-id") or body.get("id"),
+            )
             choices = body.get("choices") or []
             if not choices:
                 logger.warning("OpenRouter returned no choices")
-                return None, model_id
+                return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
             msg = choices[0].get("message") or {}
             text = msg.get("content") or ""
             # Reasoning models (o1/o3/gpt-oss) may put output in reasoning field
@@ -181,21 +496,30 @@ async def _call_openrouter_tier1(payload_json: str, cfg) -> tuple[dict | None, s
             text = text.strip()
             if not text:
                 logger.warning("OpenRouter returned empty content")
-                return None, model_id
+                return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
 
             from ...pipelines.llm import clean_llm_output, parse_json_response
             text = clean_llm_output(text)
             parsed = parse_json_response(text, recover_truncated=True)
             if isinstance(parsed, dict) and not parsed.get("_parse_fallback"):
-                return parsed, model_id
+                if request_envelope is not None:
+                    await _store_cached_json_response(
+                        "b2b_enrichment.tier1",
+                        request_envelope,
+                        provider="openrouter",
+                        model=model_id,
+                        response_text=text,
+                        metadata={"tier": 1, "backend": "openrouter"},
+                    )
+                return _pack_stage_result(parsed, model_id, False, include_cache_hit=include_cache_hit)
             logger.warning("OpenRouter tier 1 returned unparseable JSON")
-            return None, model_id
+            return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
     except Exception:
         logger.exception("OpenRouter tier 1 call failed")
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
 
-def _tier1_has_extraction_gaps(tier1: dict) -> bool:
+def _tier1_has_extraction_gaps(tier1: dict, *, source: str | None = None) -> bool:
     """Check if tier 1 left gaps that tier 2 should fill.
 
     Tier 2 adds: pain_categories, competitor classification, buyer_authority,
@@ -211,6 +535,43 @@ def _tier1_has_extraction_gaps(tier1: dict) -> bool:
     churn = tier1.get("churn_signals") or {}
     has_churn = any(bool(v) for v in churn.values())
     has_evidence = bool(complaints or quotes or competitors or pricing or rec_lang)
+    source_norm = str(source or "").strip().lower()
+    strict_sources = set(
+        _config_allowlist(
+            getattr(settings.b2b_churn, "enrichment_tier2_strict_sources", ""),
+            "",
+        )
+    )
+    if source_norm in strict_sources:
+        complaint_count = len(complaints) if isinstance(complaints, list) else 0
+        quote_count = len(quotes) if isinstance(quotes, list) else 0
+        evidence_groups = sum(
+            1
+            for present in (
+                bool(complaints),
+                bool(quotes),
+                bool(competitors),
+                bool(pricing),
+                bool(rec_lang),
+            )
+            if present
+        )
+        has_strong_structured_evidence = (
+            bool(competitors)
+            or bool(pricing)
+            or complaint_count >= _coerce_int_value(
+                getattr(settings.b2b_churn, "enrichment_tier2_strict_min_complaints", 2),
+                2,
+            )
+            or (
+                quote_count >= _coerce_int_value(
+                    getattr(settings.b2b_churn, "enrichment_tier2_strict_min_quotes", 2),
+                    2,
+                )
+                and evidence_groups >= 2
+            )
+        )
+        return has_churn or has_strong_structured_evidence
     # Tier 2 fires when the review has substance worth classifying:
     # 1. Any churn signal or negative evidence -> need pain classification
     # 2. Competitors mentioned -> need evidence_type + displacement scoring
@@ -224,19 +585,22 @@ async def _call_vllm_tier2(
     cfg: Any,
     client: Any,
     truncate_length: int,
-) -> tuple[dict | None, str | None]:
+    *,
+    include_cache_hit: bool = False,
+    trace_metadata: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None] | tuple[dict | None, str | None, bool]:
     """Tier 2 extraction: classify + extract via local vLLM.
 
     Receives Tier 1 output as context so it can reference extracted complaints
     and quotes when classifying pain and detecting indicators.
-    Returns (result_dict, model_id) or (None, None) on failure.
+    Returns (result_dict, model_id, cache_hit) or (None, None, False) on failure.
     """
     from ...skills import get_skill_registry
 
     skill = get_skill_registry().get("digest/b2b_churn_extraction_tier2")
     if not skill:
         logger.warning("Skill 'digest/b2b_churn_extraction_tier2' not found")
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
     tier2_model = cfg.enrichment_tier2_model or cfg.enrichment_tier1_model
     payload = _build_classify_payload(row, truncate_length)
@@ -244,46 +608,212 @@ async def _call_vllm_tier2(
     payload["tier1_specific_complaints"] = tier1_result.get("specific_complaints", [])
     payload["tier1_quotable_phrases"] = tier1_result.get("quotable_phrases", [])
     payload_json = json.dumps(payload)
+    system_prompt = _tier2_system_prompt_for_content_type(
+        skill.content,
+        payload.get("content_type"),
+    )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": payload_json},
+    ]
 
     try:
+        request_envelope: dict[str, Any] | None
+        cached, request_envelope, cache_hit = _unpack_cached_lookup_result(
+            await _lookup_cached_json_response(
+            "b2b_enrichment.tier2",
+            provider="vllm",
+            model=tier2_model,
+            system_prompt=system_prompt,
+            user_content=payload_json,
+            max_tokens=cfg.enrichment_tier2_max_tokens,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+            )
+        )
+        if cached is not None:
+            return _pack_stage_result(cached, tier2_model, cache_hit, include_cache_hit=include_cache_hit)
+
+        call_started = time.monotonic()
         resp = await client.post(
             "/v1/chat/completions",
             json={
                 "model": tier2_model,
-                "messages": [
-                    {"role": "system", "content": skill.content},
-                    {"role": "user", "content": payload_json},
-                ],
+                "messages": messages,
                 "max_tokens": cfg.enrichment_tier2_max_tokens,
                 "temperature": 0.0,
                 "response_format": {"type": "json_object"},
             },
         )
         resp.raise_for_status()
-        text = resp.json()["choices"][0]["message"]["content"].strip()
+        body = resp.json()
+        _trace_enrichment_llm_call(
+            "task.b2b_enrichment.tier2",
+            provider="vllm",
+            model=tier2_model,
+            messages=messages,
+            usage=body.get("usage", {}),
+            metadata=trace_metadata,
+            duration_ms=(time.monotonic() - call_started) * 1000,
+            api_endpoint=f"{str(getattr(client, 'base_url', '')).rstrip('/')}/v1/chat/completions",
+        )
+        text = body["choices"][0]["message"]["content"].strip()
         if not text:
-            return None, tier2_model
+            return _pack_stage_result(None, tier2_model, False, include_cache_hit=include_cache_hit)
 
         from ...pipelines.llm import clean_llm_output, parse_json_response
         text = clean_llm_output(text)
         parsed = parse_json_response(text, recover_truncated=True)
         if isinstance(parsed, dict) and not parsed.get("_parse_fallback"):
-            return parsed, tier2_model
-        return None, tier2_model
+            if request_envelope is not None:
+                await _store_cached_json_response(
+                    "b2b_enrichment.tier2",
+                    request_envelope,
+                    provider="vllm",
+                    model=tier2_model,
+                    response_text=text,
+                    metadata={"tier": 2, "backend": "vllm"},
+                )
+            return _pack_stage_result(parsed, tier2_model, False, include_cache_hit=include_cache_hit)
+        return _pack_stage_result(None, tier2_model, False, include_cache_hit=include_cache_hit)
     except Exception:
         logger.warning("Tier 2 vLLM call failed", exc_info=True)
-        return None, None
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
 
 def _get_tier2_client(cfg: Any) -> Any:
     """Get or create the httpx client for Tier 2 vLLM."""
-    tier2_url = cfg.enrichment_tier2_vllm_url or cfg.enrichment_tier1_vllm_url
-    timeout = cfg.enrichment_tier2_timeout_seconds
+    raw_tier2_url = getattr(cfg, "enrichment_tier2_vllm_url", "")
+    raw_tier1_url = getattr(cfg, "enrichment_tier1_vllm_url", "")
+    tier2_url = raw_tier2_url if isinstance(raw_tier2_url, str) and raw_tier2_url.strip() else raw_tier1_url
+    timeout = _coerce_float_value(getattr(cfg, "enrichment_tier2_timeout_seconds", 120.0), 120.0)
     # Reuse the Tier 1 client if same URL
-    if tier2_url == cfg.enrichment_tier1_vllm_url:
+    if not isinstance(tier2_url, str) or not tier2_url.strip() or tier2_url == raw_tier1_url:
         return _get_tier1_client(cfg)
     import httpx
     return httpx.AsyncClient(base_url=tier2_url, timeout=timeout)
+
+
+async def _call_openrouter_tier2(
+    tier1_result: dict,
+    row: dict,
+    cfg: Any,
+    truncate_length: int,
+    *,
+    include_cache_hit: bool = False,
+    trace_metadata: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None] | tuple[dict | None, str | None, bool]:
+    """Tier 2 extraction via OpenRouter (cloud model).
+
+    Mirrors _call_openrouter_tier1 but uses the tier2 skill and injects
+    Tier 1 extractions for context so the model can classify pain categories
+    and evidence types against already-extracted complaints and quotes.
+    """
+    import httpx
+    from ...skills import get_skill_registry
+
+    skill = get_skill_registry().get("digest/b2b_churn_extraction_tier2")
+    if not skill:
+        logger.warning("Skill 'digest/b2b_churn_extraction_tier2' not found for OpenRouter tier 2")
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
+
+    api_key = cfg.openrouter_api_key
+    if not api_key:
+        logger.warning("OpenRouter API key not configured for tier 2 enrichment")
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
+
+    model_id = (
+        cfg.enrichment_tier2_openrouter_model
+        or cfg.enrichment_openrouter_model
+        or "anthropic/claude-haiku-4-5"
+    )
+    payload = _build_classify_payload(row, truncate_length)
+    payload["tier1_specific_complaints"] = tier1_result.get("specific_complaints", [])
+    payload["tier1_quotable_phrases"] = tier1_result.get("quotable_phrases", [])
+    payload_json = json.dumps(payload)
+    system_prompt = _tier2_system_prompt_for_content_type(
+        skill.content,
+        payload.get("content_type"),
+    )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": payload_json},
+    ]
+
+    try:
+        request_envelope: dict[str, Any] | None
+        cached, request_envelope, cache_hit = _unpack_cached_lookup_result(
+            await _lookup_cached_json_response(
+            "b2b_enrichment.tier2",
+            provider="openrouter",
+            model=model_id,
+            system_prompt=system_prompt,
+            user_content=payload_json,
+            max_tokens=cfg.enrichment_tier2_max_tokens,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+            )
+        )
+        if cached is not None:
+            return _pack_stage_result(cached, model_id, cache_hit, include_cache_hit=include_cache_hit)
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(cfg.enrichment_tier2_timeout_seconds, connect=10.0)) as client:
+            call_started = time.monotonic()
+            resp = await client.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model_id,
+                    "messages": messages,
+                    "max_tokens": cfg.enrichment_tier2_max_tokens,
+                    "temperature": 0.0,
+                    "response_format": {"type": "json_object"},
+                },
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            _trace_enrichment_llm_call(
+                "task.b2b_enrichment.tier2",
+                provider="openrouter",
+                model=model_id,
+                messages=messages,
+                usage=body.get("usage", {}),
+                metadata=trace_metadata,
+                duration_ms=(time.monotonic() - call_started) * 1000,
+                api_endpoint="https://openrouter.ai/api/v1/chat/completions",
+                provider_request_id=resp.headers.get("x-request-id") or body.get("id"),
+            )
+            choices = body.get("choices") or []
+            if not choices:
+                logger.warning("OpenRouter tier 2 returned no choices")
+                return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
+            text = (choices[0].get("message") or {}).get("content") or ""
+            text = text.strip()
+            if not text:
+                logger.warning("OpenRouter tier 2 returned empty content")
+                return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
+            from ...pipelines.llm import clean_llm_output, parse_json_response
+            text = clean_llm_output(text)
+            parsed = parse_json_response(text, recover_truncated=True)
+            if isinstance(parsed, dict) and not parsed.get("_parse_fallback"):
+                if request_envelope is not None:
+                    await _store_cached_json_response(
+                        "b2b_enrichment.tier2",
+                        request_envelope,
+                        provider="openrouter",
+                        model=model_id,
+                        response_text=text,
+                        metadata={"tier": 2, "backend": "openrouter"},
+                    )
+                return _pack_stage_result(parsed, model_id, False, include_cache_hit=include_cache_hit)
+            logger.warning("OpenRouter tier 2 returned unparseable JSON")
+            return _pack_stage_result(None, model_id, False, include_cache_hit=include_cache_hit)
+    except Exception:
+        logger.warning("OpenRouter tier 2 call failed", exc_info=True)
+        return _pack_stage_result(None, None, False, include_cache_hit=include_cache_hit)
 
 
 def _merge_tier1_tier2(tier1: dict, tier2: dict | None) -> dict:
@@ -443,7 +973,7 @@ def _derive_pain_categories(result: dict) -> list[dict[str, str]]:
     ranked = [(score, category) for category, score in scored.items() if score > 0]
     ranked.sort(reverse=True)
     if not ranked:
-        return [{"category": "other", "severity": "primary"}]
+        return [{"category": "overall_dissatisfaction", "severity": "primary"}]
     categories = [{"category": ranked[0][1], "severity": "primary"}]
     for _score, category in ranked[1:3]:
         if category != categories[0]["category"]:
@@ -460,13 +990,53 @@ _COMPETITOR_RECOVERY_BLOCKLIST = {
     "a", "an", "the", "another tool", "another vendor", "other tool", "other vendor",
     "new tool", "new vendor", "options", "alternative", "alternatives",
     "alternative platform", "alternative platforms", "crm",
+    "provider", "providers", "competing provider", "competing providers",
 }
 
 _GENERIC_COMPETITOR_TOKENS = {
     "alternative", "alternatives", "platform", "platforms", "tool", "tools",
     "vendor", "vendors", "software", "solutions", "solution", "service",
     "services", "system", "systems", "crm", "suite", "app", "apps",
+    "provider", "providers", "competing",
 }
+
+_COMPETITOR_CONTEXT_PATTERNS = (
+    "switched to", "moved to", "replaced with", "migrating to", "migration to",
+    "evaluating", "looking at", "considering", "shortlisting", "shortlisted",
+    "poc with", "proof of concept with", "instead of", "compared to", "versus", " vs ",
+)
+
+
+def _is_generic_competitor_name(name: str) -> bool:
+    normalized = normalize_company_name(name) or str(name or "").strip().lower()
+    if not normalized:
+        return True
+    if normalized in _COMPETITOR_RECOVERY_BLOCKLIST:
+        return True
+    tokens = [
+        token.lower()
+        for token in re.findall(r"[A-Za-z0-9]+", str(name or ""))
+        if token
+    ]
+    return bool(tokens) and all(token in _GENERIC_COMPETITOR_TOKENS for token in tokens)
+
+
+def _has_named_competitor_context(name: str, source_row: dict[str, Any]) -> bool:
+    candidate = str(name or "").strip()
+    if not candidate:
+        return False
+    review_blob = " ".join(
+        str(source_row.get(field) or "")
+        for field in ("summary", "review_text", "pros", "cons")
+    ).lower()
+    name_lower = candidate.lower()
+    for match in re.finditer(re.escape(name_lower), review_blob):
+        start = max(0, match.start() - 96)
+        end = min(len(review_blob), match.end() + 96)
+        window = review_blob[start:end]
+        if any(pattern in window for pattern in _COMPETITOR_CONTEXT_PATTERNS):
+            return True
+    return False
 
 
 def _recover_competitor_mentions(result: dict, source_row: dict[str, Any]) -> list[dict[str, Any]]:
@@ -524,11 +1094,14 @@ def _derive_competitor_annotations(result: dict, source_row: dict[str, Any]) -> 
             continue
         merged = dict(comp)
         name = str(comp.get("name") or "").strip()
+        if _is_generic_competitor_name(name):
+            continue
         comp_blob = " ".join(
             [name]
             + _normalize_text_list(comp.get("features"))
             + [str(comp.get("reason_detail") or "")]
         ).lower()
+        named_context = _has_named_competitor_context(name, source_row)
         switch_patterns = (
             f"switched to {name.lower()}",
             f"moved to {name.lower()}",
@@ -554,6 +1127,8 @@ def _derive_competitor_annotations(result: dict, source_row: dict[str, Any]) -> 
             evidence_type = "active_evaluation"
         elif merged.get("reason_detail") or merged.get("features"):
             evidence_type = "implied_preference"
+        elif named_context:
+            evidence_type = "implied_preference"
         else:
             evidence_type = "neutral_mention"
         confidence = "low"
@@ -569,11 +1144,310 @@ def _derive_competitor_annotations(result: dict, source_row: dict[str, Any]) -> 
             str(merged.get("reason_detail") or ""),
             comp_blob,
         )
+        if (
+            merged["evidence_type"] == "neutral_mention"
+            and merged["displacement_confidence"] == "low"
+            and not str(merged.get("reason_detail") or "").strip()
+            and not str(merged.get("reason_category") or "").strip()
+            and not _normalize_text_list(merged.get("features"))
+            and not named_context
+        ):
+            continue
         comps.append(merged)
     return comps
 
 
-def _derive_decision_timeline(result: dict) -> str:
+_TIMELINE_IMMEDIATE_PATTERNS = ("asap", "immediately", "right away", "this week", "today", "urgent")
+_TIMELINE_QUARTER_PATTERNS = ("next quarter", "this quarter", "q1", "q2", "q3", "q4", "30 days", "60 days", "90 days")
+_TIMELINE_YEAR_PATTERNS = ("this year", "next year", "12 months", "end of year", "2026", "2027")
+_TIMELINE_DECISION_PATTERNS = (
+    "decide", "decision", "renewal", "contract", "evaluate", "evaluation",
+    "considering", "switch", "switching", "migration", "migrate",
+    "deadline", "cutover", "go live", "go-live",
+)
+_TIMELINE_EXPLICIT_ANCHOR_PHRASES = (
+    "end of quarter", "quarter end", "end of month", "month end",
+    "end of year", "next quarter", "this quarter", "next month", "this month",
+    "this week", "next week", "a few weeks", "few weeks", "a few days", "few days",
+    "30 days", "60 days", "90 days", "12 months", "next year", "this year",
+    "asap", "immediately", "right away", "today", "tomorrow",
+)
+_TIMELINE_RELATIVE_ANCHOR_RE = re.compile(
+    r"\b(?:\d+\s*-\s*\d+|\d+|one|two|three|four|five|six|seven|eight|nine|ten|a few|few)"
+    r"(?:\s+to\s+(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten))?"
+    r"\s+(?:business\s+days?|days?|weeks?|months?)\b",
+    re.IGNORECASE,
+)
+_TIMELINE_MONTH_DAY_RE = re.compile(
+    r"\b(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|"
+    r"aug|august|sep|sept|september|oct|october|nov|november|dec|december)\.?"
+    r"\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?\b",
+    re.IGNORECASE,
+)
+_TIMELINE_SLASH_DATE_RE = re.compile(r"\b\d{1,2}/\d{1,2}(?:/\d{2,4})?\b")
+_TIMELINE_ISO_DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+_TIMELINE_CONTRACT_END_PATTERNS = (
+    "contract end", "contract ends", "contract expires", "expiration date",
+    "expiry date", "renewal date", "renewal window", "term ends", "term expires",
+    "auto renew", "auto-renew", "automatic renewal", "at renewal", "upon renewal",
+    "final month of", "current contract",
+)
+_TIMELINE_DECISION_DEADLINE_PATTERNS = (
+    "notice", "notice period", "before renewal", "before the contract ends",
+    "before the contract expires", "deadline", "decide", "decision", "evaluating",
+    "evaluation", "considering", "switch", "switching", "migrate", "migration",
+    "cutover", "go live", "go-live", "cancel by",
+)
+_TIMELINE_CONTRACT_EVENT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b(?:at|upon)\s+(?:the\s+)?renewal\b", re.I),
+    re.compile(r"\b(?:auto[- ]?renew(?:al)?|annual renewal|next renewal|renewal date|renewal window)\b", re.I),
+    re.compile(r"\bfinal month of (?:my|our|the) current contract\b", re.I),
+    re.compile(r"\b(?:current|existing)\s+contract\b", re.I),
+)
+_TIMELINE_AMBIGUOUS_VENDOR_TOKENS = {"copper", "close"}
+_TIMELINE_AMBIGUOUS_VENDOR_PRODUCT_CONTEXT_PATTERNS = (
+    "crm", "sales", "pipeline", "lead", "leads", "deal", "deals", "account",
+    "contact", "contacts", "prospect", "prospects", "software", "saas",
+)
+_BUDGET_CURRENCY_TOKEN_RE = re.compile(
+    r"(?P<raw>(?:\$|usd\s*)\s?\d[\d,]*(?:\.\d+)?\s*(?:[km])?)",
+    re.IGNORECASE,
+)
+_BUDGET_ANY_AMOUNT_TOKEN_RE = re.compile(
+    r"(?:\$|usd\s*|\u20ac|eur\s*|\u00a3|gbp\s*)\s?\d[\d,]*(?:\.\d+)?\s*(?:[km])?",
+    re.IGNORECASE,
+)
+_BUDGET_ANNUAL_AMOUNT_RE = re.compile(
+    r"(?P<raw>(?:\$|usd\s*)\s?\d[\d,]*(?:\.\d+)?\s*(?:[km])?)"
+    r"\s*(?P<period>(?:/\s*|\bper\b\s*|\ba\b\s*)?(?:yr|year)\b|annually\b|annual\b|yearly\b)",
+    re.IGNORECASE,
+)
+_BUDGET_PRICE_PER_SEAT_RE = re.compile(
+    r"(?P<raw>(?:\$|usd\s*)\s?\d[\d,]*(?:\.\d+)?\s*(?:[km])?)"
+    r"\s*(?:/|\bper\b)\s*(?:seat|user|license|licence)\b"
+    r"(?:\s*(?:/|\bper\b)\s*(?:monthly|month|mo|annually|annual|year|yr))?",
+    re.IGNORECASE,
+)
+_BUDGET_SEAT_COUNT_RE = re.compile(
+    r"\b(?P<count>\d[\d,]{0,6})\s+(?P<unit>seats?|users?|licenses?|licences?)\b",
+    re.IGNORECASE,
+)
+_BUDGET_PRICE_INCREASE_RE = re.compile(
+    r"\b(?:\d+(?:\.\d+)?%\s+(?:price\s+)?(?:increase|higher|more|jump|hike)"
+    r"|(?:price|pricing|renewal)\s+(?:increase|jump|hike)"
+    r"|(?:raised|increased)\s+(?:our\s+)?(?:price|pricing|renewal|invoice))\b",
+    re.IGNORECASE,
+)
+_BUDGET_PRICE_INCREASE_DETAIL_RE = re.compile(
+    r"\b(?:\d+(?:\.\d+)?%\s+(?:price\s+)?(?:increase|higher|more|jump|hike)"
+    r"|(?:price|pricing|renewal)\s+(?:increase|jump|hike)[^.!,;]{0,80}"
+    r"|(?:raised|increased)[^.!,;]{0,80})",
+    re.IGNORECASE,
+)
+_BUDGET_COMMERCIAL_CONTEXT_PATTERNS = (
+    "pricing", "price", "priced", "cost", "costs", "costly", "expensive",
+    "budget", "billing", "invoice", "overcharg", "renewal", "quote", "quoted",
+    "contract", "subscription", "license", "licence", "plan", "seat", "user",
+)
+_BUDGET_ANNUAL_CONTEXT_PATTERNS = (
+    "renewal", "quote", "quoted", "contract", "subscription", "license",
+    "licence", "annual", "annually", "yearly", "per year", "/year", "/yr",
+)
+_BUDGET_MONTHLY_PERIOD_PATTERNS = (
+    "monthly", "per month", "/month", "/mo", "a month",
+)
+_BUDGET_ANNUAL_PERIOD_PATTERNS = (
+    "annual", "annually", "yearly", "per year", "/year", "/yr", "a year", "a yr",
+)
+_BUDGET_PER_UNIT_PATTERNS = (
+    "per seat", "/seat", "per user", "/user", "per license", "/license",
+    "per licence", "/licence", "per agent", "/agent", "per person", "/person",
+    "per employee", "/employee", "per endpoint", "/endpoint", "per device", "/device",
+    "per member", "/member", "per contact", "/contact",
+)
+_BUDGET_NOISE_PATTERNS = (
+    "salary", "salaries", "compensation", "bonus", "payroll", "hourly",
+    "per hour", "an hour", "wage", "wages", "job offer", "interview", "intern",
+    "income", "revenue", "profit", "arr", "mrr", "valuation", "mortgage",
+    "rent", "tuition", "commission",
+)
+
+
+def _normalize_timeline_anchor(anchor: Any) -> str | None:
+    text = re.sub(r"\s+", " ", str(anchor or "")).strip(" \t\r\n'\".,;:()[]{}")
+    return text.lower() if text else None
+
+
+def _extract_concrete_timeline_anchor(text: Any) -> str | None:
+    raw_text = str(text or "")
+    if not raw_text.strip():
+        return None
+    for pattern in (_TIMELINE_MONTH_DAY_RE, _TIMELINE_SLASH_DATE_RE, _TIMELINE_ISO_DATE_RE):
+        match = pattern.search(raw_text)
+        if match:
+            return _normalize_timeline_anchor(match.group(0))
+    lowered = raw_text.lower()
+    for phrase in _TIMELINE_EXPLICIT_ANCHOR_PHRASES:
+        index = lowered.find(phrase)
+        if index >= 0:
+            return _normalize_timeline_anchor(raw_text[index:index + len(phrase)])
+    match = _TIMELINE_RELATIVE_ANCHOR_RE.search(raw_text)
+    if match:
+        return _normalize_timeline_anchor(match.group(0))
+    return None
+
+
+def _extract_contract_end_event_anchor(text: Any) -> str | None:
+    raw_text = str(text or "")
+    if not raw_text.strip():
+        return None
+    for pattern in _TIMELINE_CONTRACT_EVENT_PATTERNS:
+        match = pattern.search(raw_text)
+        if not match:
+            continue
+        anchor = _normalize_timeline_anchor(match.group(0))
+        if not anchor:
+            continue
+        if "renew" in anchor:
+            return "renewal"
+        if "current contract" in anchor:
+            return "current contract end"
+        return anchor
+    return None
+
+
+def _has_timeline_commercial_signal(
+    result: dict,
+    source_row: dict[str, Any] | None = None,
+) -> bool:
+    churn = result.get("churn_signals") or {}
+    review_norm = ""
+    review_blob = ""
+    source = ""
+    if source_row is not None:
+        review_blob = " ".join(
+            str(source_row.get(field) or "")
+            for field in ("summary", "review_text", "pros", "cons")
+        )
+        source = str(source_row.get("source") or "").strip().lower()
+        review_norm = _normalize_compare_text(review_blob)
+
+    structured_churn = any((
+        bool(churn.get("intent_to_leave")),
+        bool(churn.get("actively_evaluating")),
+        bool(churn.get("migration_in_progress")),
+        bool(churn.get("contract_renewal_mentioned")),
+    ))
+    strong_signal = any((
+        structured_churn,
+        bool(result.get("competitors_mentioned")),
+        bool(result.get("pricing_phrases")),
+        _has_strong_commercial_context(review_norm),
+    ))
+    soft_signal = any((
+        bool(result.get("specific_complaints")),
+        bool(result.get("event_mentions")),
+    ))
+    if source_row is not None:
+        noisy_sources = {
+            item.strip().lower()
+            for item in str(settings.b2b_churn.enrichment_low_fidelity_noisy_sources or "").split(",")
+            if item.strip()
+        }
+        if source in noisy_sources:
+            vendor_norm = _normalize_compare_text(source_row.get("vendor_name"))
+            product_norm = _normalize_compare_text(source_row.get("product_name"))
+            product_hit = (
+                bool(source_row.get("product_name"))
+                and product_norm != vendor_norm
+                and _text_mentions_name(review_norm, source_row.get("product_name"))
+            )
+            vendor_hit = (
+                bool(source_row.get("vendor_name"))
+                and _text_mentions_name(review_norm, source_row.get("vendor_name"))
+            )
+            if vendor_norm in _TIMELINE_AMBIGUOUS_VENDOR_TOKENS and vendor_hit:
+                vendor_hit = _contains_any(review_blob, _TIMELINE_AMBIGUOUS_VENDOR_PRODUCT_CONTEXT_PATTERNS)
+            vendor_reference = product_hit or vendor_hit
+            if not vendor_reference and not structured_churn:
+                return False
+
+    return any((
+        strong_signal,
+        soft_signal and _has_commercial_context(review_norm),
+    ))
+
+
+def _derive_concrete_timeline_fields(
+    result: dict,
+    source_row: dict[str, Any] | None = None,
+) -> tuple[str | None, str | None]:
+    churn = result.get("churn_signals") or {}
+    timeline = result.get("timeline") or {}
+    contract_end = _normalize_timeline_anchor(timeline.get("contract_end"))
+    evaluation_deadline = _normalize_timeline_anchor(timeline.get("evaluation_deadline"))
+    if contract_end and evaluation_deadline:
+        return contract_end, evaluation_deadline
+
+    candidates: list[tuple[str, str]] = []
+    for event in result.get("event_mentions") or []:
+        if not isinstance(event, dict):
+            continue
+        anchor = _extract_concrete_timeline_anchor(event.get("timeframe"))
+        if not anchor:
+            continue
+        context = " ".join(
+            str(event.get(key) or "")
+            for key in ("event", "detail", "timeframe")
+        )
+        candidates.append((anchor, context.lower()))
+
+    if source_row is not None and _has_timeline_commercial_signal(result, source_row):
+        review_blob = " ".join(
+            str(source_row.get(field) or "")
+            for field in ("summary", "review_text", "pros", "cons")
+        )
+        anchor = _extract_concrete_timeline_anchor(review_blob)
+        if anchor:
+            candidates.append((anchor, review_blob.lower()))
+
+    for anchor, context in candidates:
+        if not evaluation_deadline and (
+            _contains_any(context, _TIMELINE_DECISION_DEADLINE_PATTERNS)
+            or " before " in context
+        ):
+            evaluation_deadline = anchor
+            continue
+        if not contract_end and (
+            _contains_any(context, _TIMELINE_CONTRACT_END_PATTERNS)
+            or bool(churn.get("contract_renewal_mentioned"))
+        ):
+            contract_end = anchor
+            continue
+        if not evaluation_deadline and (
+            bool(churn.get("actively_evaluating"))
+            or bool(churn.get("migration_in_progress"))
+            or bool(churn.get("intent_to_leave"))
+        ):
+            evaluation_deadline = anchor
+            continue
+
+    if not contract_end and source_row is not None and _has_timeline_commercial_signal(result, source_row):
+        review_blob = " ".join(
+            str(source_row.get(field) or "")
+            for field in ("summary", "review_text", "pros", "cons")
+        )
+        contract_event_anchor = _extract_contract_end_event_anchor(review_blob)
+        if contract_event_anchor:
+            contract_end = contract_event_anchor
+
+    return contract_end, evaluation_deadline
+
+
+def _derive_decision_timeline(
+    result: dict,
+    source_row: dict[str, Any] | None = None,
+) -> str:
     churn = result.get("churn_signals") or {}
     timeline = result.get("timeline") or {}
     event_mentions = result.get("event_mentions") or []
@@ -586,20 +1460,328 @@ def _derive_decision_timeline(result: dict) -> str:
         if isinstance(event, dict):
             parts.append(str(event.get("timeframe") or ""))
     text = " ".join(parts).lower()
-    if _contains_any(text, ("asap", "immediately", "right away", "this week", "today", "urgent")):
+    if _contains_any(text, _TIMELINE_IMMEDIATE_PATTERNS):
         return "immediate"
-    if _contains_any(text, ("next quarter", "this quarter", "q1", "q2", "q3", "q4", "30 days", "60 days", "90 days")):
+    if _contains_any(text, _TIMELINE_QUARTER_PATTERNS):
         return "within_quarter"
-    if _contains_any(text, ("this year", "next year", "12 months", "end of year", "2026", "2027")):
+    if _contains_any(text, _TIMELINE_YEAR_PATTERNS):
         return "within_year"
+
+    if source_row is not None:
+        review_blob = " ".join(
+            str(source_row.get(field) or "")
+            for field in ("summary", "review_text", "pros", "cons")
+        ).lower()
+        has_commercial_signal = _has_timeline_commercial_signal(result, source_row)
+        if has_commercial_signal and _contains_any(review_blob, _TIMELINE_DECISION_PATTERNS):
+            if _contains_any(review_blob, _TIMELINE_IMMEDIATE_PATTERNS):
+                return "immediate"
+            if _contains_any(review_blob, _TIMELINE_QUARTER_PATTERNS):
+                return "within_quarter"
+            if _contains_any(review_blob, _TIMELINE_YEAR_PATTERNS):
+                return "within_year"
     return "unknown"
+
+
+def _budget_match_window(text: str, match: re.Match[str], radius: int = 56) -> str:
+    start = max(0, match.start() - radius)
+    end = min(len(text), match.end() + radius)
+    return text[start:end].lower()
+
+
+def _normalize_budget_value_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    text = text.lower()
+    text = re.sub(r"\busd\b\s*", "$", text)
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"\$\s+", "$", text)
+    text = re.sub(r"(?<=[0-9km])a(year|yr)\b", r" a \1", text)
+    text = re.sub(r"\s*/\s*", "/", text)
+    text = re.sub(r"\bper\s+", "per ", text)
+    text = re.sub(r"\ba\s+(year|yr)\b", r"a \1", text)
+    text = text.strip()
+    return text or None
+
+
+def _normalize_budget_detail_text(value: Any) -> str | None:
+    text = re.sub(r"\s+", " ", str(value or "")).strip(" \t\r\n'\".,;:()[]{}")
+    return text or None
+
+
+def _extract_budget_currency_marker(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    lowered = text.lower()
+    if lowered.startswith("usd") or "$" in text:
+        return "$"
+    if lowered.startswith("eur") or "\u20ac" in text:
+        return "\u20ac"
+    if lowered.startswith("gbp") or "\u00a3" in text:
+        return "\u00a3"
+    return None
+
+
+def _extract_single_budget_amount(value: Any) -> tuple[str | None, float | None]:
+    text = str(value or "").strip()
+    if not text:
+        return None, None
+    matches = list(_BUDGET_ANY_AMOUNT_TOKEN_RE.finditer(text))
+    if len(matches) != 1:
+        return None, None
+    raw_amount = matches[0].group(0)
+    currency = _extract_budget_currency_marker(raw_amount)
+    amount = _extract_numeric_amount(raw_amount)
+    if currency is None or amount is None:
+        return None, None
+    return currency, amount
+
+
+def _extract_budget_period_multiplier(value: Any) -> int | None:
+    text = str(value or "").lower()
+    if not text:
+        return None
+    if _contains_any(text, _BUDGET_ANNUAL_PERIOD_PATTERNS):
+        return 1
+    if _contains_any(text, _BUDGET_MONTHLY_PERIOD_PATTERNS):
+        return 12
+    return None
+
+
+def _format_annual_budget_amount(currency: str, amount: float) -> str | None:
+    if amount <= 0 or amount > 1_000_000_000_000:
+        return None
+    if amount >= 1_000_000:
+        scaled = amount / 1_000_000
+        suffix = "m"
+    elif amount >= 1_000:
+        scaled = amount / 1_000
+        suffix = "k"
+    else:
+        scaled = amount
+        suffix = ""
+
+    if abs(scaled - round(scaled)) < 1e-9:
+        value_text = str(int(round(scaled)))
+    elif scaled >= 100:
+        value_text = f"{scaled:.0f}"
+    elif scaled >= 10:
+        value_text = f"{scaled:.1f}".rstrip("0").rstrip(".")
+    else:
+        value_text = f"{scaled:.2f}".rstrip("0").rstrip(".")
+    return f"{currency}{value_text}{suffix}/year"
+
+
+def _derive_annual_spend_from_unit_price(budget: dict[str, Any]) -> str | None:
+    try:
+        seat_count = int(budget.get("seat_count"))
+    except (TypeError, ValueError):
+        return None
+    if not (1 <= seat_count <= 1_000_000):
+        return None
+
+    currency, unit_amount = _extract_single_budget_amount(budget.get("price_per_seat"))
+    if currency is None or unit_amount is None:
+        return None
+
+    period_multiplier = _extract_budget_period_multiplier(budget.get("price_per_seat"))
+    if period_multiplier is None:
+        return None
+
+    return _format_annual_budget_amount(currency, unit_amount * seat_count * period_multiplier)
+
+
+def _has_budget_noise_context(text: str) -> bool:
+    return _contains_any(str(text or "").lower(), _BUDGET_NOISE_PATTERNS)
+
+
+def _has_budget_commercial_signal(
+    result: dict,
+    source_row: dict[str, Any] | None = None,
+) -> bool:
+    churn = result.get("churn_signals") or {}
+    pricing_phrases = _normalize_text_list(result.get("pricing_phrases"))
+    summary_text = str((source_row or {}).get("summary") or "").strip().lower()
+    review_blob = _combined_source_text(source_row)
+    review_norm = _normalize_compare_text(review_blob)
+    structured_churn = any((
+        bool(churn.get("intent_to_leave")),
+        bool(churn.get("actively_evaluating")),
+        bool(churn.get("migration_in_progress")),
+        bool(churn.get("contract_renewal_mentioned")),
+    ))
+    if not (pricing_phrases or structured_churn or _has_commercial_context(review_norm)):
+        return False
+    if source_row is None:
+        return True
+
+    noisy_sources = {
+        item.strip().lower()
+        for item in str(settings.b2b_churn.enrichment_low_fidelity_noisy_sources or "").split(",")
+        if item.strip()
+    }
+    source = str(source_row.get("source") or "").strip().lower()
+    if source not in noisy_sources:
+        return True
+
+    vendor_norm = _normalize_compare_text(source_row.get("vendor_name"))
+    product_norm = _normalize_compare_text(source_row.get("product_name"))
+    product_hit = (
+        bool(source_row.get("product_name"))
+        and product_norm != vendor_norm
+        and _text_mentions_name(review_norm, source_row.get("product_name"))
+    )
+    vendor_hit = (
+        bool(source_row.get("vendor_name"))
+        and _text_mentions_name(review_norm, source_row.get("vendor_name"))
+    )
+    if vendor_norm in _TIMELINE_AMBIGUOUS_VENDOR_TOKENS and vendor_hit:
+        vendor_hit = _contains_any(review_blob, _TIMELINE_AMBIGUOUS_VENDOR_PRODUCT_CONTEXT_PATTERNS)
+    if _has_consumer_context(review_norm) and not (product_hit or vendor_hit or structured_churn):
+        return False
+    if _has_technical_context(summary_text, review_norm) and not structured_churn:
+        return False
+    return any((
+        product_hit,
+        vendor_hit,
+        structured_churn,
+        _has_strong_commercial_context(review_norm) and not _has_budget_noise_context(review_blob),
+    ))
+
+
+def _derive_budget_signals(result: dict, source_row: dict[str, Any]) -> dict[str, Any]:
+    budget = result.get("budget_signals")
+    if not isinstance(budget, dict):
+        budget = {}
+        result["budget_signals"] = budget
+
+    if not _has_budget_commercial_signal(result, source_row):
+        return budget
+
+    candidates: list[str] = []
+    seen_candidates: set[str] = set()
+    for phrase in _normalize_text_list(result.get("pricing_phrases")):
+        lowered = phrase.lower()
+        if lowered not in seen_candidates:
+            seen_candidates.add(lowered)
+            candidates.append(phrase)
+    review_blob = _combined_source_text(source_row)
+    if review_blob.strip():
+        candidates.append(review_blob)
+
+    if not budget.get("price_per_seat"):
+        for text in candidates:
+            match = _BUDGET_PRICE_PER_SEAT_RE.search(text)
+            if not match:
+                continue
+            window = _budget_match_window(text, match)
+            if _has_budget_noise_context(window):
+                continue
+            normalized = _normalize_budget_value_text(match.group(0))
+            if normalized:
+                budget["price_per_seat"] = normalized
+                break
+
+    if not budget.get("annual_spend_estimate"):
+        for text in candidates:
+            match = _BUDGET_ANNUAL_AMOUNT_RE.search(text)
+            if not match:
+                continue
+            window = _budget_match_window(text, match)
+            if _has_budget_noise_context(window):
+                continue
+            normalized = _normalize_budget_value_text(match.group(0))
+            if normalized:
+                budget["annual_spend_estimate"] = normalized
+                break
+        if not budget.get("annual_spend_estimate"):
+            for text in candidates:
+                for match in _BUDGET_CURRENCY_TOKEN_RE.finditer(text):
+                    window = _budget_match_window(text, match)
+                    if _has_budget_noise_context(window):
+                        continue
+                    if _contains_any(window, _BUDGET_PER_UNIT_PATTERNS):
+                        continue
+                    if _contains_any(window, _BUDGET_MONTHLY_PERIOD_PATTERNS):
+                        continue
+                    if not _contains_any(window, _BUDGET_ANNUAL_CONTEXT_PATTERNS):
+                        continue
+                    normalized = _normalize_budget_value_text(match.group("raw"))
+                    if normalized:
+                        budget["annual_spend_estimate"] = normalized
+                        break
+                if budget.get("annual_spend_estimate"):
+                    break
+
+    if not budget.get("seat_count"):
+        for text in candidates:
+            for match in _BUDGET_SEAT_COUNT_RE.finditer(text):
+                window = _budget_match_window(text, match)
+                if _has_budget_noise_context(window):
+                    continue
+                if not _contains_any(window, _BUDGET_COMMERCIAL_CONTEXT_PATTERNS):
+                    continue
+                try:
+                    count = int(match.group("count").replace(",", ""))
+                except ValueError:
+                    continue
+                if 1 <= count <= 1_000_000:
+                    budget["seat_count"] = count
+                    break
+            if budget.get("seat_count"):
+                break
+
+    if not budget.get("annual_spend_estimate"):
+        derived_annual_spend = _derive_annual_spend_from_unit_price(budget)
+        if derived_annual_spend:
+            budget["annual_spend_estimate"] = derived_annual_spend
+
+    if not _coerce_bool(budget.get("price_increase_mentioned")):
+        for text in candidates:
+            match = _BUDGET_PRICE_INCREASE_RE.search(text)
+            if not match:
+                continue
+            window = _budget_match_window(text, match)
+            if _has_budget_noise_context(window):
+                continue
+            if not _contains_any(window, _BUDGET_COMMERCIAL_CONTEXT_PATTERNS):
+                continue
+            budget["price_increase_mentioned"] = True
+            if not budget.get("price_increase_detail"):
+                detail_match = _BUDGET_PRICE_INCREASE_DETAIL_RE.search(text)
+                detail = _normalize_budget_detail_text(
+                    detail_match.group(0) if detail_match else match.group(0)
+                )
+                if detail:
+                    budget["price_increase_detail"] = detail
+            break
+    elif not budget.get("price_increase_detail"):
+        for text in candidates:
+            detail_match = _BUDGET_PRICE_INCREASE_DETAIL_RE.search(text)
+            if detail_match:
+                detail = _normalize_budget_detail_text(detail_match.group(0))
+                if detail:
+                    budget["price_increase_detail"] = detail
+                    break
+
+    return budget
 
 
 def _extract_numeric_amount(value: Any) -> float | None:
     if value in (None, ""):
         return None
-    match = re.search(r"(\d+(?:\.\d+)?)", str(value))
-    return float(match.group(1)) if match else None
+    match = re.search(r"(\d[\d,]*(?:\.\d+)?)(?:\s*([km]))?", str(value).lower())
+    if not match:
+        return None
+    amount = float(match.group(1).replace(",", ""))
+    suffix = match.group(2)
+    if suffix == "k":
+        amount *= 1_000
+    elif suffix == "m":
+        amount *= 1_000_000
+    return amount
 
 
 def _derive_contract_value_signal(result: dict) -> str:
@@ -663,7 +1845,12 @@ def _derive_buyer_authority_fields(result: dict, source_row: dict[str, Any]) -> 
     return role_type, executive_sponsor_mentioned, buying_stage
 
 
-def _derive_urgency_indicators(result: dict, source_row: dict[str, Any]) -> dict[str, bool]:
+def _derive_urgency_indicators(
+    result: dict,
+    source_row: dict[str, Any],
+    *,
+    price_complaint: bool = False,
+) -> dict[str, bool]:
     churn = result.get("churn_signals") or {}
     budget = result.get("budget_signals") or {}
     timeline = result.get("timeline") or {}
@@ -673,7 +1860,6 @@ def _derive_urgency_indicators(result: dict, source_row: dict[str, Any]) -> dict
         str(source_row.get(field) or "")
         for field in ("summary", "review_text", "pros", "cons")
     ).lower()
-    pricing_phrases = result.get("pricing_phrases") or []
     price_text = " ".join(_normalize_text_list(result.get("pricing_phrases"))).lower()
     recommendation_text = " ".join(_normalize_text_list(result.get("recommendation_language"))).lower()
     named_alt_with_reason = any(
@@ -695,7 +1881,7 @@ def _derive_urgency_indicators(result: dict, source_row: dict[str, Any]) -> dict
         "comparison_shopping_language": _contains_any(review_blob, ("vs ", "alternative", "which should", "looking for options")),
         "named_alternative_with_reason": named_alt_with_reason,
         "frustration_without_alternative": bool(complaints) and not competitors,
-        "price_pressure_language": bool(result.get("pricing_phrases")) or _contains_any(
+        "price_pressure_language": bool(price_complaint) or _contains_any(
             review_blob + " " + price_text,
             (
                 "price increase",
@@ -742,6 +1928,9 @@ def _is_no_signal_result(result: dict, source_row: dict[str, Any]) -> bool:
         return False
     if result.get("event_mentions") or result.get("feature_gaps"):
         return False
+    content_type = str(source_row.get("content_type") or "").strip().lower()
+    if content_type in {"community_discussion", "comment"}:
+        return True
     rating = source_row.get("rating")
     try:
         return float(rating or 0) >= 3.0
@@ -773,13 +1962,13 @@ def _compute_derived_fields(result: dict, source_row: dict[str, Any]) -> dict:
     pricing_phrases = result.get("pricing_phrases", [])
     rec_lang = result.get("recommendation_language", [])
     events = result.get("event_mentions", [])
-    budget = result.get("budget_signals", {})
     reviewer = result.get("reviewer_context", {})
 
     # 0. deterministic replacements for deprecated Tier 2 classify path
     result["pain_categories"] = _derive_pain_categories(result)
     result["competitors_mentioned"] = _recover_competitor_mentions(result, source_row)
     result["competitors_mentioned"] = _derive_competitor_annotations(result, source_row)
+    _derive_budget_signals(result, source_row)
 
     ba = result.get("buyer_authority")
     if not isinstance(ba, dict):
@@ -796,14 +1985,24 @@ def _compute_derived_fields(result: dict, source_row: dict[str, Any]) -> dict:
     if not isinstance(timeline, dict):
         timeline = {}
         result["timeline"] = timeline
-    timeline["decision_timeline"] = _derive_decision_timeline(result)
+    contract_end, evaluation_deadline = _derive_concrete_timeline_fields(result, source_row)
+    if contract_end and not str(timeline.get("contract_end") or "").strip():
+        timeline["contract_end"] = contract_end
+    if evaluation_deadline and not str(timeline.get("evaluation_deadline") or "").strip():
+        timeline["evaluation_deadline"] = evaluation_deadline
+    timeline["decision_timeline"] = _derive_decision_timeline(result, source_row)
 
     cc = result.get("contract_context")
     if not isinstance(cc, dict):
         cc = {}
         result["contract_context"] = cc
     cc["contract_value_signal"] = _derive_contract_value_signal(result)
-    result["urgency_indicators"] = _derive_urgency_indicators(result, source_row)
+    price_complaint = engine.derive_price_complaint(result)
+    result["urgency_indicators"] = _derive_urgency_indicators(
+        result,
+        source_row,
+        price_complaint=price_complaint,
+    )
 
     indicators = result.get("urgency_indicators", {})
     pain_cats = result.get("pain_categories", [])
@@ -814,15 +2013,15 @@ def _compute_derived_fields(result: dict, source_row: dict[str, Any]) -> dict:
     )
 
     # 2. pain_category (backward compat top-level field)
-    primary_pain = "other"
+    primary_pain = "overall_dissatisfaction"
     if pain_cats:
         primary_list = [p for p in pain_cats if isinstance(p, dict) and p.get("severity") == "primary"]
         if primary_list:
-            primary_pain = primary_list[0].get("category", "other")
+            primary_pain = primary_list[0].get("category", "overall_dissatisfaction")
         elif isinstance(pain_cats[0], dict):
-            primary_pain = pain_cats[0].get("category", "other")
+            primary_pain = pain_cats[0].get("category", "overall_dissatisfaction")
     result["pain_category"] = engine.override_pain(
-        primary_pain,
+        _normalize_pain_category(primary_pain),
         complaints,
         quotable,
         _normalize_text_list(result.get("pricing_phrases")),
@@ -833,12 +2032,29 @@ def _compute_derived_fields(result: dict, source_row: dict[str, Any]) -> dict:
     # 3. would_recommend
     result["would_recommend"] = engine.derive_recommend(rec_lang, rating, rating_max)
 
-    # 4. sentiment_trajectory.direction = "unknown" per-review (cross-review later)
+    # 4. sentiment_trajectory.direction -- derived deterministically from rating,
+    #    churn signals, and would_recommend. "declining" / "improving" require
+    #    multi-review time context and are left for future cross-review jobs;
+    #    per-review we classify as positive, negative, or unknown.
     st = result.get("sentiment_trajectory")
     if not isinstance(st, dict):
         st = {}
         result["sentiment_trajectory"] = st
-    st["direction"] = "unknown"
+    rating_norm = (rating / rating_max) if rating is not None and rating_max else None
+    churn_signals_raw = result.get("churn_signals") or {}
+    intent_to_leave = bool(churn_signals_raw.get("intent_to_leave")) if isinstance(churn_signals_raw, dict) else False
+    would_rec = result.get("would_recommend")
+    if rating_norm is not None:
+        if rating_norm <= 0.4 or (rating_norm <= 0.6 and intent_to_leave):
+            st["direction"] = "consistently_negative"
+        elif rating_norm >= 0.8 and would_rec is True:
+            st["direction"] = "stable_positive"
+        elif rating_norm >= 0.7 and would_rec is not False:
+            st["direction"] = "stable_positive"
+        else:
+            st["direction"] = "unknown"
+    else:
+        st["direction"] = "unknown"
 
     # 5. sentiment_trajectory.turning_point from event_mentions
     if events and isinstance(events, list) and len(events) > 0:
@@ -858,14 +2074,92 @@ def _compute_derived_fields(result: dict, source_row: dict[str, Any]) -> dict:
     ba["has_budget_authority"] = engine.derive_budget_authority(result)
 
     # 7. contract_context.price_complaint + price_context
-    cc["price_complaint"] = engine.derive_price_complaint(result)
+    cc["price_complaint"] = price_complaint
     cc["price_context"] = pricing_phrases[0] if pricing_phrases else None
+
+    # 8. witness-oriented deterministic evidence primitives
+    result["replacement_mode"] = derive_replacement_mode(result, source_row)
+    result["operating_model_shift"] = derive_operating_model_shift(result, source_row)
+    result["productivity_delta_claim"] = derive_productivity_delta_claim(source_row)
+    result["org_pressure_type"] = derive_org_pressure_type(source_row)
+    result["salience_flags"] = derive_salience_flags(result, source_row)
+    result["evidence_spans"] = derive_evidence_spans(result, source_row)
 
     # Mark schema version + evidence map hash for recomputation tracking
     result["enrichment_schema_version"] = 3
     result["evidence_map_hash"] = engine.map_hash
 
     return result
+
+
+def _missing_witness_primitives(result: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+
+    if str(result.get("replacement_mode") or "").strip() not in _KNOWN_REPLACEMENT_MODES:
+        missing.append("replacement_mode")
+    if str(result.get("operating_model_shift") or "").strip() not in _KNOWN_OPERATING_MODEL_SHIFTS:
+        missing.append("operating_model_shift")
+    if str(result.get("productivity_delta_claim") or "").strip() not in _KNOWN_PRODUCTIVITY_DELTA_CLAIMS:
+        missing.append("productivity_delta_claim")
+    if str(result.get("org_pressure_type") or "").strip() not in _KNOWN_ORG_PRESSURE_TYPES:
+        missing.append("org_pressure_type")
+
+    salience_flags = result.get("salience_flags")
+    if not isinstance(salience_flags, list):
+        missing.append("salience_flags")
+
+    evidence_spans = result.get("evidence_spans")
+    if not isinstance(evidence_spans, list):
+        missing.append("evidence_spans")
+
+    if not str(result.get("evidence_map_hash") or "").strip():
+        missing.append("evidence_map_hash")
+
+    return missing
+
+
+def _schema_version(result: dict[str, Any]) -> int:
+    try:
+        return int(result.get("enrichment_schema_version") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _finalize_enrichment_for_persist(
+    result: dict[str, Any],
+    source_row: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(result, dict):
+        return None, "invalid_payload"
+
+    payload = json.loads(json.dumps(result))
+    try:
+        payload = _compute_derived_fields(payload, source_row)
+    except Exception:
+        logger.warning(
+            "Evidence engine compute failed while finalizing enrichment for %s",
+            source_row.get("id"),
+            exc_info=True,
+        )
+        return None, "compute_failed"
+
+    if not _validate_enrichment(payload, source_row):
+        return None, "validation_failed"
+
+    return payload, None
+
+
+def _trusted_reviewer_company_name(source_row: dict[str, Any] | None) -> str | None:
+    """Return a safe reviewer company candidate from trusted raw fields."""
+    row = source_row if isinstance(source_row, dict) else {}
+    company = str(row.get("reviewer_company") or "").strip()
+    if not company:
+        return None
+    company_norm = normalize_company_name(company) or company.lower()
+    vendor_norm = normalize_company_name(str(row.get("vendor_name") or "")) or ""
+    if vendor_norm and company_norm == vendor_norm:
+        return None
+    return company
 
 
 async def _notify_high_urgency(
@@ -960,11 +2254,269 @@ def _coerce_int_override(
     max_value: int,
 ) -> int:
     """Return clamped integer override value, or default on parse failure."""
-    try:
-        coerced = int(raw_value)
-    except (TypeError, ValueError):
-        return default_value
+    default_coerced = _coerce_int_value(default_value, min_value)
+    coerced = _coerce_int_value(raw_value, default_coerced)
     return max(min_value, min(max_value, coerced))
+
+
+def _empty_exact_cache_usage() -> dict[str, int]:
+    return {
+        "exact_cache_hits": 0,
+        "tier1_exact_cache_hits": 0,
+        "tier2_exact_cache_hits": 0,
+        "generated": 0,
+        "tier1_generated_calls": 0,
+        "tier2_generated_calls": 0,
+        "witness_rows": 0,
+        "witness_count": 0,
+        "secondary_write_hits": 0,
+    }
+
+
+def _accumulate_exact_cache_usage(
+    totals: dict[str, int],
+    usage: dict[str, Any] | None,
+) -> None:
+    if not usage:
+        return
+    for key in (
+        "exact_cache_hits",
+        "tier1_exact_cache_hits",
+        "tier2_exact_cache_hits",
+        "generated",
+        "tier1_generated_calls",
+        "tier2_generated_calls",
+        "witness_rows",
+        "witness_count",
+        "secondary_write_hits",
+    ):
+        totals[key] = int(totals.get(key, 0) or 0) + int(usage.get(key, 0) or 0)
+
+
+def _witness_metrics(result: dict[str, Any] | None) -> tuple[int, int]:
+    if not isinstance(result, dict):
+        return 0, 0
+    spans = result.get("evidence_spans")
+    if not isinstance(spans, list):
+        return 0, 0
+    witness_count = 0
+    for span in spans:
+        if not isinstance(span, dict):
+            continue
+        if not str(span.get("text") or "").strip():
+            continue
+        witness_count += 1
+    return (1 if witness_count > 0 else 0), witness_count
+
+
+def _row_usage_result(status: Any, usage: dict[str, Any] | None = None) -> dict[str, Any]:
+    normalized = {"status": status}
+    usage_dict = usage or {}
+    for key in _empty_exact_cache_usage():
+        normalized[key] = int(usage_dict.get(key, 0) or 0)
+    return normalized
+
+
+async def _defer_batch_row(
+    pool,
+    row: dict[str, Any],
+    *,
+    tier: str,
+    usage: dict[str, Any] | None = None,
+    custom_id: str | None = None,
+) -> dict[str, Any]:
+    await pool.execute(
+        """
+        UPDATE b2b_reviews
+        SET enrichment_status = 'pending'
+        WHERE id = $1
+        """,
+        row["id"],
+    )
+    logger.info(
+        "Deferring B2B enrichment %s for %s; reset row to pending while existing batch artifact %s remains pending",
+        tier,
+        row["id"],
+        custom_id or "unknown",
+    )
+    return _row_usage_result("deferred", usage)
+
+
+async def _persist_enrichment_result(
+    pool,
+    row: dict[str, Any],
+    result: dict[str, Any] | None,
+    *,
+    model_id: str,
+    max_attempts: int,
+    run_id: str | None,
+    cache_usage: dict[str, int],
+) -> bool | str:
+    review_id = row["id"]
+    cfg = settings.b2b_churn
+
+    if result:
+        result, finalize_error = _finalize_enrichment_for_persist(result, row)
+        if finalize_error == "compute_failed":
+            logger.warning(
+                "Evidence engine compute failed for %s -- quarantining to prevent model-dependent output",
+                review_id, exc_info=True,
+            )
+            await pool.execute(
+                """
+                UPDATE b2b_reviews
+                SET enrichment_status = 'quarantined',
+                    enrichment_attempts = enrichment_attempts + 1,
+                    low_fidelity = true,
+                    low_fidelity_reasons = $2::jsonb
+                WHERE id = $1
+                """,
+                review_id,
+                json.dumps(["evidence_engine_compute_failure"]),
+            )
+            from ..visibility import record_quarantine
+
+            await record_quarantine(
+                pool,
+                review_id=str(review_id),
+                vendor_name=row.get("vendor_name"),
+                source=row.get("source"),
+                reason_code="evidence_engine_compute_failure",
+                severity="error",
+                actionable=True,
+                summary=f"Evidence engine failed for {row.get('vendor_name')} review",
+                run_id=run_id,
+            )
+            return "quarantined"
+        if finalize_error == "validation_failed":
+            logger.warning(
+                "Enrichment validation failed for %s -- quarantining",
+                review_id,
+            )
+            await pool.execute(
+                """
+                UPDATE b2b_reviews
+                SET enrichment_status = 'quarantined',
+                    enrichment_attempts = enrichment_attempts + 1,
+                    low_fidelity = true,
+                    low_fidelity_reasons = $2::jsonb
+                WHERE id = $1
+                """,
+                review_id,
+                json.dumps(["enrichment_validation_failed"]),
+            )
+            from ..visibility import record_quarantine
+
+            await record_quarantine(
+                pool,
+                review_id=str(review_id),
+                vendor_name=row.get("vendor_name"),
+                source=row.get("source"),
+                reason_code="enrichment_validation_failed",
+                severity="warning",
+                actionable=True,
+                summary=f"Validation failed for {row.get('vendor_name')} review",
+                run_id=run_id,
+            )
+            return "quarantined"
+
+    if result:
+        st = result.get("sentiment_trajectory") or {}
+        st_direction = st.get("direction") if isinstance(st, dict) else None
+        st_tenure = st.get("tenure") if isinstance(st, dict) else None
+        st_turning = st.get("turning_point") if isinstance(st, dict) else None
+        witness_rows, witness_count = _witness_metrics(result)
+        cache_usage["witness_rows"] += witness_rows
+        cache_usage["witness_count"] += witness_count
+        low_fidelity_reasons = (
+            _detect_low_fidelity_reasons(row, result)
+            if cfg.enrichment_low_fidelity_enabled
+            else []
+        )
+        detected_at = datetime.now(timezone.utc)
+        if not low_fidelity_reasons and _is_no_signal_result(result, row):
+            target_status = "no_signal"
+        else:
+            target_status = "quarantined" if low_fidelity_reasons else "enriched"
+
+        await pool.execute(
+            """
+            UPDATE b2b_reviews
+            SET enrichment = $1,
+                enrichment_status = $8,
+                enrichment_attempts = enrichment_attempts + 1,
+                enriched_at = $2,
+                enrichment_model = $4,
+                sentiment_direction = $5,
+                sentiment_tenure = $6,
+                sentiment_turning_point = $7,
+                low_fidelity = $9,
+                low_fidelity_reasons = $10::jsonb,
+                low_fidelity_detected_at = $11
+            WHERE id = $3
+            """,
+            json.dumps(result),
+            detected_at,
+            review_id,
+            model_id,
+            st_direction,
+            st_tenure,
+            st_turning if st_turning and st_turning != "null" else None,
+            target_status,
+            bool(low_fidelity_reasons),
+            json.dumps(low_fidelity_reasons),
+            detected_at if low_fidelity_reasons else None,
+        )
+
+        if low_fidelity_reasons:
+            from ..visibility import record_quarantine
+
+            await record_quarantine(
+                pool,
+                review_id=str(review_id),
+                vendor_name=row.get("vendor_name"),
+                source=row.get("source"),
+                reason_code=low_fidelity_reasons[0],
+                severity="warning",
+                summary=f"Low-fidelity: {', '.join(low_fidelity_reasons[:3])}",
+                evidence={"reasons": low_fidelity_reasons, "source": row.get("source")},
+                run_id=run_id,
+            )
+
+        try:
+            urgency = result.get("urgency_score", 0)
+            threshold = settings.b2b_churn.high_churn_urgency_threshold
+            if urgency >= threshold:
+                signals = result.get("churn_signals", {})
+                await _notify_high_urgency(
+                    vendor_name=row["vendor_name"],
+                    reviewer_company=row.get("reviewer_company") or "",
+                    urgency=urgency,
+                    pain_category=result.get("pain_category", ""),
+                    intent_to_leave=bool(signals.get("intent_to_leave")),
+                )
+        except Exception:
+            logger.warning("ntfy notification failed for review %s, enrichment preserved", review_id)
+
+        try:
+            _ctx = result.get("reviewer_context") or {}
+            _extracted_company = (_ctx.get("company_name") or "").strip()
+            if _extracted_company and not (row.get("reviewer_company") or "").strip():
+                _extracted_company_norm = normalize_company_name(_extracted_company) or None
+                await pool.execute(
+                    "UPDATE b2b_reviews SET reviewer_company = $1, reviewer_company_norm = $2 WHERE id = $3",
+                    _extracted_company,
+                    _extracted_company_norm,
+                    review_id,
+                )
+                cache_usage["secondary_write_hits"] += 1
+        except Exception:
+            logger.debug("Company name backfill failed for %s (non-fatal)", review_id)
+
+        return "quarantined" if target_status == "quarantined" else True
+
+    await _increment_attempts(pool, review_id, row["enrichment_attempts"], max_attempts)
+    return False
 
 
 async def _enrich_rows(
@@ -973,26 +2525,667 @@ async def _enrich_rows(
     pool,
     *,
     concurrency_override: int | None = None,
+    run_id: str | None = None,
+    task: ScheduledTask | Any | None = None,
 ) -> dict[str, Any]:
     """Enrich a list of claimed rows concurrently."""
-    max_attempts = cfg.enrichment_max_attempts
+    max_attempts = _coerce_int_value(getattr(cfg, "enrichment_max_attempts", 3), 3)
 
-    effective_concurrency = max(1, int(concurrency_override or cfg.enrichment_concurrency))
+    effective_concurrency = max(
+        1,
+        _coerce_int_value(
+            concurrency_override if concurrency_override is not None else getattr(cfg, "enrichment_concurrency", 10),
+            10,
+        ),
+    )
     sem = asyncio.Semaphore(effective_concurrency)
+    enrich_single_params = inspect.signature(_enrich_single).parameters
+    supports_usage_out = "usage_out" in enrich_single_params
+    supports_run_id = "run_id" in enrich_single_params
 
     async def _bounded_enrich(row):
         async with sem:
-            return await _enrich_single(pool, row, max_attempts, cfg.enrichment_local_only,
-                                        cfg.enrichment_max_tokens, cfg.review_truncate_length)
+            usage = _empty_exact_cache_usage()
+            kwargs: dict[str, Any] = {}
+            if supports_run_id:
+                kwargs["run_id"] = run_id
+            if supports_usage_out:
+                status = await _enrich_single(
+                    pool,
+                    row,
+                    max_attempts,
+                    cfg.enrichment_local_only,
+                    cfg.enrichment_max_tokens,
+                    cfg.review_truncate_length,
+                    usage_out=usage,
+                    **kwargs,
+                )
+            else:
+                status = await _enrich_single(
+                    pool,
+                    row,
+                    max_attempts,
+                    cfg.enrichment_local_only,
+                    cfg.enrichment_max_tokens,
+                    cfg.review_truncate_length,
+                    **kwargs,
+                )
+            return _row_usage_result(status, usage)
 
-    results = await asyncio.gather(
-        *[_bounded_enrich(row) for row in rows],
-        return_exceptions=True,
+    async def _run_single_rows(target_rows: list[dict[str, Any]]) -> list[dict[str, Any] | Exception]:
+        if not target_rows:
+            return []
+        return await asyncio.gather(
+            *[_bounded_enrich(row) for row in target_rows],
+            return_exceptions=True,
+        )
+
+    results: list[dict[str, Any] | Exception] = []
+    batch_metrics = {
+        "jobs": 0,
+        "submitted_items": 0,
+        "cache_prefiltered_items": 0,
+        "fallback_single_call_items": 0,
+        "completed_items": 0,
+        "failed_items": 0,
+        "reused_completed_items": 0,
+        "reused_pending_items": 0,
+        "rows_deferred": 0,
+        "tier2_single_fallback_rows": 0,
+    }
+
+    from ...services.b2b.anthropic_batch import (
+        AnthropicBatchItem,
+        mark_batch_fallback_result,
+        run_anthropic_message_batch,
     )
+    from ...services.b2b.cache_runner import (
+        lookup_b2b_exact_stage_text,
+        prepare_b2b_exact_stage_request,
+        store_b2b_exact_stage_text,
+    )
+    from ...services.llm.anthropic import AnthropicLLM
+    from ...services.protocols import Message
+    from ...pipelines.llm import clean_llm_output, parse_json_response
+    from ...skills import get_skill_registry
+    from ._b2b_batch_utils import (
+        anthropic_batch_min_items,
+        anthropic_batch_requested,
+        reconcile_existing_batch_artifacts,
+        resolve_anthropic_batch_llm,
+    )
+
+    def _eligible_for_batch(row: dict[str, Any]) -> bool:
+        review_text = row.get("review_text") or ""
+        if len(review_text) < _MIN_REVIEW_TEXT_LENGTH:
+            return False
+        source = str(row.get("source") or "").strip().lower()
+        return source not in _effective_enrichment_skip_sources()
+
+    def _parse_batch_text(text: str | None) -> dict[str, Any] | None:
+        if not text:
+            return None
+        cleaned = clean_llm_output(text)
+        parsed = parse_json_response(cleaned, recover_truncated=True)
+        if isinstance(parsed, dict) and not parsed.get("_parse_fallback"):
+            return parsed
+        return None
+
+    use_openrouter = (
+        not cfg.enrichment_local_only
+        and bool(getattr(cfg, "enrichment_openrouter_model", ""))
+        and bool(getattr(cfg, "openrouter_api_key", ""))
+    )
+    batch_requested = anthropic_batch_requested(
+        task,
+        global_default=bool(getattr(settings.b2b_churn, "anthropic_batch_enabled", False)),
+        task_default=True,
+        task_keys=("enrichment_anthropic_batch_enabled",),
+    )
+    tier1_batch_llm = (
+        resolve_anthropic_batch_llm(
+            current_llm=SimpleNamespace(
+                name="openrouter",
+                model=str(getattr(cfg, "enrichment_openrouter_model", "") or "anthropic/claude-haiku-4-5"),
+            ),
+            target_model_candidates=(getattr(cfg, "enrichment_openrouter_model", ""),),
+        )
+        if use_openrouter and batch_requested
+        else None
+    )
+    tier2_model_id = (
+        getattr(cfg, "enrichment_tier2_openrouter_model", "")
+        or getattr(cfg, "enrichment_openrouter_model", "")
+        or "anthropic/claude-haiku-4-5"
+    )
+    tier2_batch_llm = (
+        resolve_anthropic_batch_llm(
+            current_llm=SimpleNamespace(name="openrouter", model=str(tier2_model_id)),
+            target_model_candidates=(tier2_model_id,),
+        )
+        if use_openrouter and batch_requested
+        else None
+    )
+
+    if not isinstance(tier1_batch_llm, AnthropicLLM):
+        tier1_batch_llm = None
+    if not isinstance(tier2_batch_llm, AnthropicLLM):
+        tier2_batch_llm = None
+
+    tier1_batch_model_id = str(
+        getattr(cfg, "enrichment_openrouter_model", "") or "anthropic/claude-haiku-4-5"
+    )
+    full_extraction_timeout = max(
+        0.0,
+        _coerce_float_value(
+            getattr(cfg, "enrichment_full_extraction_timeout_seconds", 120.0),
+            120.0,
+        ),
+    )
+    tier2_client = None
+
+    async def _persist_wrapped(
+        row: dict[str, Any],
+        result: dict[str, Any] | None,
+        *,
+        model_id: str,
+        usage: dict[str, int],
+    ) -> dict[str, Any]:
+        status = await _persist_enrichment_result(
+            pool,
+            row,
+            result,
+            model_id=model_id,
+            max_attempts=max_attempts,
+            run_id=run_id,
+            cache_usage=usage,
+        )
+        return _row_usage_result(status, usage)
+
+    async def _run_single_tier2_fallback(
+        row: dict[str, Any],
+        tier1: dict[str, Any],
+        usage: dict[str, int],
+    ) -> dict[str, Any]:
+        nonlocal tier2_client
+
+        logger.info(
+            "B2B enrichment: Tier 2 batch unavailable for %s; falling back to single-call Tier 2",
+            row["id"],
+        )
+        batch_metrics["tier2_single_fallback_rows"] += 1
+
+        trace_metadata = {
+            "run_id": run_id,
+            "vendor_name": str(row.get("vendor_name") or ""),
+            "review_id": str(row["id"]),
+            "source": str(row.get("source") or ""),
+            "tier": "tier2",
+            "workload": "single_call_fallback",
+            "batch_fallback_reason": "tier2_batch_unavailable",
+        }
+
+        if use_openrouter:
+            tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                _call_openrouter_tier2(
+                    tier1,
+                    row,
+                    cfg,
+                    cfg.review_truncate_length,
+                    include_cache_hit=True,
+                    trace_metadata=trace_metadata,
+                ),
+                timeout=full_extraction_timeout,
+            ))
+        else:
+            if tier2_client is None:
+                tier2_client = _get_tier2_client(cfg)
+            tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                _call_vllm_tier2(
+                    tier1,
+                    row,
+                    cfg,
+                    tier2_client,
+                    cfg.review_truncate_length,
+                    include_cache_hit=True,
+                    trace_metadata=trace_metadata,
+                ),
+                timeout=full_extraction_timeout,
+            ))
+
+        if tier2_cache_hit:
+            usage["tier2_exact_cache_hits"] += 1
+            usage["exact_cache_hits"] += 1
+        elif tier2_model is not None:
+            usage["tier2_generated_calls"] += 1
+            usage["generated"] += 1
+
+        if tier2 is not None:
+            model_id = f"hybrid:{tier1_batch_model_id}+{tier2_model}"
+        else:
+            model_id = tier1_batch_model_id
+
+        return await _persist_wrapped(
+            row,
+            _merge_tier1_tier2(tier1, tier2),
+            model_id=model_id,
+            usage=usage,
+        )
+
+    if tier1_batch_llm is None:
+        results = await _run_single_rows(rows)
+    else:
+        tier1_skill = get_skill_registry().get("digest/b2b_churn_extraction_tier1")
+        tier2_skill = get_skill_registry().get("digest/b2b_churn_extraction_tier2")
+        if not tier1_skill or not tier2_skill:
+            results = await _run_single_rows(rows)
+        else:
+            direct_rows = [row for row in rows if not _eligible_for_batch(row)]
+            batched_rows = [row for row in rows if _eligible_for_batch(row)]
+            row_results: dict[Any, dict[str, Any] | Exception] = {}
+
+            if direct_rows:
+                direct_results = await _run_single_rows(direct_rows)
+                for row, result in zip(direct_rows, direct_results):
+                    row_results[row["id"]] = result
+
+            tier1_entries: list[dict[str, Any]] = []
+            for row in batched_rows:
+                payload_json = json.dumps(_build_classify_payload(row, cfg.review_truncate_length))
+                messages = [
+                    {"role": "system", "content": tier1_skill.content},
+                    {"role": "user", "content": payload_json},
+                ]
+                request = prepare_b2b_exact_stage_request(
+                    "b2b_enrichment.tier1",
+                    provider="openrouter",
+                    model=str(cfg.enrichment_openrouter_model or "anthropic/claude-haiku-4-5"),
+                    messages=messages,
+                    max_tokens=max(cfg.enrichment_tier1_max_tokens, 4096),
+                    temperature=0.0,
+                    response_format={"type": "json_object"},
+                )
+                cached = await lookup_b2b_exact_stage_text(request)
+                tier1_entries.append(
+                    {
+                        "row": row,
+                        "payload_json": payload_json,
+                        "messages": messages,
+                        "request": request,
+                        "cached_response_text": str(cached["response_text"] or "") if cached is not None else None,
+                        "cached_usage": dict(cached.get("usage") or {}) if cached is not None else {},
+                    }
+                )
+
+            existing_tier1_results = await reconcile_existing_batch_artifacts(
+                pool=pool,
+                llm=tier1_batch_llm,
+                task_name="b2b_enrichment",
+                artifact_type="review_enrichment_tier1",
+                artifact_ids=[str(entry["row"]["id"]) for entry in tier1_entries],
+            )
+            tier1_ready_entries: list[dict[str, Any]] = []
+            remaining_tier1_entries: list[dict[str, Any]] = []
+            for entry in tier1_entries:
+                row = entry["row"]
+                existing = existing_tier1_results.get(str(row["id"]))
+                if existing and existing.get("state") == "succeeded":
+                    tier1 = _parse_batch_text(existing.get("response_text"))
+                    if tier1 is not None:
+                        tier1_ready_entries.append(
+                            {
+                                "row": row,
+                                "tier1": tier1,
+                                "cached": bool(existing.get("cached")),
+                                "request": entry["request"],
+                            }
+                        )
+                        batch_metrics["reused_completed_items"] += 1
+                        continue
+                if existing and existing.get("state") == "pending":
+                    row_results[row["id"]] = await _defer_batch_row(
+                        pool,
+                        row,
+                        tier="tier1",
+                        custom_id=str(existing.get("custom_id") or ""),
+                    )
+                    batch_metrics["reused_pending_items"] += 1
+                    batch_metrics["rows_deferred"] += 1
+                    continue
+                remaining_tier1_entries.append(entry)
+            tier1_entries = remaining_tier1_entries
+
+            if tier1_entries:
+                tier1_execution = await run_anthropic_message_batch(
+                    llm=tier1_batch_llm,
+                    stage_id="b2b_enrichment.tier1",
+                    task_name="b2b_enrichment",
+                    items=[
+                        AnthropicBatchItem(
+                            custom_id=_enrichment_batch_custom_id("tier1", entry["row"]["id"]),
+                            artifact_type="review_enrichment_tier1",
+                            artifact_id=str(entry["row"]["id"]),
+                            vendor_name=str(entry["row"].get("vendor_name") or "") or None,
+                            messages=[
+                                Message(role=str(message["role"]), content=str(message["content"]))
+                                for message in entry["messages"]
+                            ],
+                            max_tokens=max(cfg.enrichment_tier1_max_tokens, 4096),
+                            temperature=0.0,
+                            trace_span_name="task.b2b_enrichment.tier1",
+                            trace_metadata={
+                                "run_id": run_id,
+                                "vendor_name": str(entry["row"].get("vendor_name") or ""),
+                                "review_id": str(entry["row"]["id"]),
+                                "source": str(entry["row"].get("source") or ""),
+                                "tier": "tier1",
+                                "workload": "anthropic_batch",
+                            },
+                            request_metadata={"review_id": str(entry["row"]["id"]), "tier": 1},
+                            cached_response_text=entry["cached_response_text"],
+                            cached_usage=entry["cached_usage"],
+                        )
+                        for entry in tier1_entries
+                    ],
+                    run_id=run_id,
+                    min_batch_size=anthropic_batch_min_items(
+                        task,
+                        default=2,
+                        keys=("enrichment_anthropic_batch_min_items",),
+                    ),
+                    batch_metadata={"stage": "tier1"},
+                    pool=pool,
+                )
+                batch_metrics["jobs"] += 1 if tier1_execution.provider_batch_id else 0
+                batch_metrics["submitted_items"] += int(tier1_execution.submitted_items or 0)
+                batch_metrics["cache_prefiltered_items"] += int(tier1_execution.cache_prefiltered_items or 0)
+                batch_metrics["fallback_single_call_items"] += int(tier1_execution.fallback_single_call_items or 0)
+                batch_metrics["completed_items"] += int(tier1_execution.completed_items or 0)
+                batch_metrics["failed_items"] += int(tier1_execution.failed_items or 0)
+            else:
+                tier1_execution = SimpleNamespace(results_by_custom_id={})
+
+            tier2_entries: list[dict[str, Any]] = []
+            fallback_rows: list[dict[str, Any]] = []
+            per_row_batch_usage: dict[Any, dict[str, int]] = {}
+
+            for ready_entry in tier1_ready_entries:
+                row = ready_entry["row"]
+                usage = _empty_exact_cache_usage()
+                if ready_entry["cached"]:
+                    usage["tier1_exact_cache_hits"] += 1
+                    usage["exact_cache_hits"] += 1
+                else:
+                    usage["tier1_generated_calls"] += 1
+                    usage["generated"] += 1
+                per_row_batch_usage[row["id"]] = usage
+                needs_tier2 = _tier1_has_extraction_gaps(ready_entry["tier1"], source=row.get("source"))
+                if needs_tier2 and tier2_batch_llm is not None:
+                    payload = _build_classify_payload(row, cfg.review_truncate_length)
+                    payload["tier1_specific_complaints"] = ready_entry["tier1"].get("specific_complaints", [])
+                    payload["tier1_quotable_phrases"] = ready_entry["tier1"].get("quotable_phrases", [])
+                    payload_json = json.dumps(payload)
+                    system_prompt = _tier2_system_prompt_for_content_type(
+                        tier2_skill.content,
+                        payload.get("content_type"),
+                    )
+                    messages = [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": payload_json},
+                    ]
+                    request = prepare_b2b_exact_stage_request(
+                        "b2b_enrichment.tier2",
+                        provider="openrouter",
+                        model=str(tier2_model_id),
+                        messages=messages,
+                        max_tokens=cfg.enrichment_tier2_max_tokens,
+                        temperature=0.0,
+                        response_format={"type": "json_object"},
+                    )
+                    cached = await lookup_b2b_exact_stage_text(request)
+                    tier2_entries.append(
+                        {
+                            "row": row,
+                            "tier1": ready_entry["tier1"],
+                            "messages": messages,
+                            "request": request,
+                            "cached_response_text": str(cached["response_text"] or "") if cached is not None else None,
+                            "cached_usage": dict(cached.get("usage") or {}) if cached is not None else {},
+                        }
+                    )
+                elif needs_tier2:
+                    row_results[row["id"]] = await _run_single_tier2_fallback(
+                        row,
+                        ready_entry["tier1"],
+                        usage,
+                    )
+                else:
+                    row_results[row["id"]] = await _persist_wrapped(
+                        row,
+                        _merge_tier1_tier2(ready_entry["tier1"], None),
+                        model_id=tier1_batch_model_id,
+                        usage=usage,
+                    )
+
+            for entry in tier1_entries:
+                row = entry["row"]
+                usage = _empty_exact_cache_usage()
+                tier1_custom_id = _enrichment_batch_custom_id("tier1", row["id"])
+                outcome = tier1_execution.results_by_custom_id.get(tier1_custom_id)
+                tier1 = _parse_batch_text(outcome.response_text if outcome is not None else None)
+                if tier1 is None:
+                    fallback_rows.append(row)
+                    if outcome is not None:
+                        await mark_batch_fallback_result(
+                            batch_id=tier1_execution.local_batch_id,
+                            custom_id=tier1_custom_id,
+                            succeeded=False,
+                            error_text=outcome.error_text or "tier1_batch_parse_failed",
+                            pool=pool,
+                        )
+                    continue
+                if outcome is not None and outcome.cached:
+                    usage["tier1_exact_cache_hits"] += 1
+                    usage["exact_cache_hits"] += 1
+                else:
+                    usage["tier1_generated_calls"] += 1
+                    usage["generated"] += 1
+                    await store_b2b_exact_stage_text(
+                        entry["request"],
+                        response_text=clean_llm_output(outcome.response_text or ""),
+                        metadata={"tier": 1, "backend": "anthropic_batch"},
+                    )
+
+                per_row_batch_usage[row["id"]] = usage
+                needs_tier2 = _tier1_has_extraction_gaps(tier1, source=row.get("source"))
+                if needs_tier2 and tier2_batch_llm is not None:
+                    payload = _build_classify_payload(row, cfg.review_truncate_length)
+                    payload["tier1_specific_complaints"] = tier1.get("specific_complaints", [])
+                    payload["tier1_quotable_phrases"] = tier1.get("quotable_phrases", [])
+                    payload_json = json.dumps(payload)
+                    system_prompt = _tier2_system_prompt_for_content_type(
+                        tier2_skill.content,
+                        payload.get("content_type"),
+                    )
+                    messages = [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": payload_json},
+                    ]
+                    request = prepare_b2b_exact_stage_request(
+                        "b2b_enrichment.tier2",
+                        provider="openrouter",
+                        model=str(tier2_model_id),
+                        messages=messages,
+                        max_tokens=cfg.enrichment_tier2_max_tokens,
+                        temperature=0.0,
+                        response_format={"type": "json_object"},
+                    )
+                    cached = await lookup_b2b_exact_stage_text(request)
+                    tier2_entries.append(
+                        {
+                            "row": row,
+                            "tier1": tier1,
+                            "messages": messages,
+                            "request": request,
+                            "cached_response_text": str(cached["response_text"] or "") if cached is not None else None,
+                            "cached_usage": dict(cached.get("usage") or {}) if cached is not None else {},
+                        }
+                    )
+                elif needs_tier2:
+                    row_results[row["id"]] = await _run_single_tier2_fallback(row, tier1, usage)
+                else:
+                    row_results[row["id"]] = await _persist_wrapped(
+                        row,
+                        _merge_tier1_tier2(tier1, None),
+                        model_id=tier1_batch_model_id,
+                        usage=usage,
+                    )
+
+            if tier2_entries:
+                existing_tier2_results = await reconcile_existing_batch_artifacts(
+                    pool=pool,
+                    llm=tier2_batch_llm,
+                    task_name="b2b_enrichment",
+                    artifact_type="review_enrichment_tier2",
+                    artifact_ids=[str(entry["row"]["id"]) for entry in tier2_entries],
+                )
+                remaining_tier2_entries: list[dict[str, Any]] = []
+                for entry in tier2_entries:
+                    row = entry["row"]
+                    existing = existing_tier2_results.get(str(row["id"]))
+                    usage = per_row_batch_usage[row["id"]]
+                    if existing and existing.get("state") == "succeeded":
+                        tier2 = _parse_batch_text(existing.get("response_text"))
+                        if tier2 is not None:
+                            if existing.get("cached"):
+                                usage["tier2_exact_cache_hits"] += 1
+                                usage["exact_cache_hits"] += 1
+                            else:
+                                usage["tier2_generated_calls"] += 1
+                                usage["generated"] += 1
+                            row_results[row["id"]] = await _persist_wrapped(
+                                row,
+                                _merge_tier1_tier2(entry["tier1"], tier2),
+                                model_id=f"hybrid:{tier1_batch_model_id}+{tier2_model_id}",
+                                usage=usage,
+                            )
+                            batch_metrics["reused_completed_items"] += 1
+                            continue
+                    if existing and existing.get("state") == "pending":
+                        row_results[row["id"]] = await _defer_batch_row(
+                            pool,
+                            row,
+                            tier="tier2",
+                            usage=usage,
+                            custom_id=str(existing.get("custom_id") or ""),
+                        )
+                        batch_metrics["reused_pending_items"] += 1
+                        batch_metrics["rows_deferred"] += 1
+                        continue
+                    remaining_tier2_entries.append(entry)
+                tier2_entries = remaining_tier2_entries
+
+                if tier2_entries:
+                    tier2_execution = await run_anthropic_message_batch(
+                        llm=tier2_batch_llm,
+                        stage_id="b2b_enrichment.tier2",
+                        task_name="b2b_enrichment",
+                        items=[
+                            AnthropicBatchItem(
+                                custom_id=_enrichment_batch_custom_id("tier2", entry["row"]["id"]),
+                                artifact_type="review_enrichment_tier2",
+                                artifact_id=str(entry["row"]["id"]),
+                                vendor_name=str(entry["row"].get("vendor_name") or "") or None,
+                                messages=[
+                                    Message(role=str(message["role"]), content=str(message["content"]))
+                                    for message in entry["messages"]
+                                ],
+                                max_tokens=cfg.enrichment_tier2_max_tokens,
+                                temperature=0.0,
+                                trace_span_name="task.b2b_enrichment.tier2",
+                                trace_metadata={
+                                    "run_id": run_id,
+                                    "vendor_name": str(entry["row"].get("vendor_name") or ""),
+                                    "review_id": str(entry["row"]["id"]),
+                                    "source": str(entry["row"].get("source") or ""),
+                                    "tier": "tier2",
+                                    "workload": "anthropic_batch",
+                                },
+                                request_metadata={"review_id": str(entry["row"]["id"]), "tier": 2},
+                                cached_response_text=entry["cached_response_text"],
+                                cached_usage=entry["cached_usage"],
+                            )
+                            for entry in tier2_entries
+                        ],
+                        run_id=run_id,
+                        min_batch_size=anthropic_batch_min_items(
+                            task,
+                            default=2,
+                            keys=("enrichment_anthropic_batch_min_items",),
+                        ),
+                        batch_metadata={"stage": "tier2"},
+                        pool=pool,
+                    )
+                    batch_metrics["jobs"] += 1 if tier2_execution.provider_batch_id else 0
+                    batch_metrics["submitted_items"] += int(tier2_execution.submitted_items or 0)
+                    batch_metrics["cache_prefiltered_items"] += int(tier2_execution.cache_prefiltered_items or 0)
+                    batch_metrics["fallback_single_call_items"] += int(tier2_execution.fallback_single_call_items or 0)
+                    batch_metrics["completed_items"] += int(tier2_execution.completed_items or 0)
+                    batch_metrics["failed_items"] += int(tier2_execution.failed_items or 0)
+                else:
+                    tier2_execution = SimpleNamespace(results_by_custom_id={})
+
+                for entry in tier2_entries:
+                    row = entry["row"]
+                    usage = per_row_batch_usage[row["id"]]
+                    tier2_custom_id = _enrichment_batch_custom_id("tier2", row["id"])
+                    outcome = tier2_execution.results_by_custom_id.get(tier2_custom_id)
+                    tier2 = _parse_batch_text(outcome.response_text if outcome is not None else None)
+                    if tier2 is None:
+                        fallback_rows.append(row)
+                        if outcome is not None:
+                            await mark_batch_fallback_result(
+                                batch_id=tier2_execution.local_batch_id,
+                                custom_id=tier2_custom_id,
+                                succeeded=False,
+                                error_text=outcome.error_text or "tier2_batch_parse_failed",
+                                pool=pool,
+                            )
+                        continue
+                    if outcome is not None and outcome.cached:
+                        usage["tier2_exact_cache_hits"] += 1
+                        usage["exact_cache_hits"] += 1
+                    else:
+                        usage["tier2_generated_calls"] += 1
+                        usage["generated"] += 1
+                        await store_b2b_exact_stage_text(
+                            entry["request"],
+                            response_text=clean_llm_output(outcome.response_text or ""),
+                            metadata={"tier": 2, "backend": "anthropic_batch"},
+                        )
+                    row_results[row["id"]] = await _persist_wrapped(
+                        row,
+                        _merge_tier1_tier2(entry["tier1"], tier2),
+                        model_id=f"hybrid:{tier1_batch_model_id}+{tier2_model_id}",
+                        usage=usage,
+                    )
+
+            fallback_results = await _run_single_rows(fallback_rows)
+            for row, result in zip(fallback_rows, fallback_results):
+                row_results[row["id"]] = result
+
+            results = [row_results[row["id"]] for row in rows]
 
     for row, result in zip(rows, results):
         if isinstance(result, Exception):
             logger.error("Unexpected enrichment error for %s: %s", row["id"], result, exc_info=result)
+
+    cache_usage = _empty_exact_cache_usage()
+    for result in results:
+        if isinstance(result, Exception):
+            continue
+        if isinstance(result, dict):
+            _accumulate_exact_cache_usage(cache_usage, result)
 
     batch_ids = [row["id"] for row in rows]
     status_rows = await pool.fetch(
@@ -1021,6 +3214,17 @@ async def _enrich_rows(
         "quarantined": quarantined,
         "no_signal": no_signal or 0,
         "failed": failed,
+        "anthropic_batch_jobs": batch_metrics["jobs"],
+        "anthropic_batch_items_submitted": batch_metrics["submitted_items"],
+        "anthropic_batch_cache_prefiltered_items": batch_metrics["cache_prefiltered_items"],
+        "anthropic_batch_fallback_single_call_items": batch_metrics["fallback_single_call_items"],
+        "anthropic_batch_completed_items": batch_metrics["completed_items"],
+        "anthropic_batch_failed_items": batch_metrics["failed_items"],
+        "anthropic_batch_reused_completed_items": batch_metrics["reused_completed_items"],
+        "anthropic_batch_reused_pending_items": batch_metrics["reused_pending_items"],
+        "anthropic_batch_rows_deferred": batch_metrics["rows_deferred"],
+        "anthropic_batch_tier2_single_fallback_rows": batch_metrics["tier2_single_fallback_rows"],
+        **cache_usage,
     }
 
 
@@ -1200,15 +3404,21 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     requeued = requeued_parser + requeued_model
 
     task_metadata = task.metadata if isinstance(task.metadata, dict) else {}
-    default_max_batch = min(cfg.enrichment_max_per_batch, 500)
+    default_max_batch = min(
+        _coerce_int_value(getattr(cfg, "enrichment_max_per_batch", 10), 10),
+        500,
+    )
     max_batch = _coerce_int_override(
         task_metadata.get("enrichment_max_per_batch"),
         default_max_batch,
         min_value=1,
         max_value=500,
     )
-    max_attempts = cfg.enrichment_max_attempts
-    default_max_rounds = max(1, cfg.enrichment_max_rounds_per_run)
+    max_attempts = _coerce_int_value(getattr(cfg, "enrichment_max_attempts", 3), 3)
+    default_max_rounds = max(
+        1,
+        _coerce_int_value(getattr(cfg, "enrichment_max_rounds_per_run", 1), 1),
+    )
     max_rounds = _coerce_int_override(
         task_metadata.get("enrichment_max_rounds_per_run"),
         default_max_rounds,
@@ -1217,17 +3427,18 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     )
     effective_concurrency = _coerce_int_override(
         task_metadata.get("enrichment_concurrency"),
-        max(1, cfg.enrichment_concurrency),
+        max(1, _coerce_int_value(getattr(cfg, "enrichment_concurrency", 10), 10)),
         min_value=1,
         max_value=100,
     )
     inter_batch_delay = max(
         0.0,
-        float(
+        _coerce_float_value(
             task_metadata.get(
                 "enrichment_inter_batch_delay_seconds",
-                cfg.enrichment_inter_batch_delay_seconds,
-            )
+                getattr(cfg, "enrichment_inter_batch_delay_seconds", 2.0),
+            ),
+            _coerce_float_value(getattr(cfg, "enrichment_inter_batch_delay_seconds", 2.0), 2.0),
         ),
     )
     priority_sources = [
@@ -1235,11 +3446,23 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         for source in str(cfg.enrichment_priority_sources or "").split(",")
         if source.strip()
     ]
+    run_id = _task_run_id(task)
 
     total_enriched = 0
     total_failed = 0
     total_no_signal = 0
     total_quarantined = 0
+    cache_usage = _empty_exact_cache_usage()
+    batch_metrics = {
+        "anthropic_batch_jobs": 0,
+        "anthropic_batch_items_submitted": 0,
+        "anthropic_batch_cache_prefiltered_items": 0,
+        "anthropic_batch_fallback_single_call_items": 0,
+        "anthropic_batch_completed_items": 0,
+        "anthropic_batch_failed_items": 0,
+        "anthropic_batch_rows_deferred": 0,
+        "anthropic_batch_tier2_single_fallback_rows": 0,
+    }
     rounds = 0
 
     while rounds < max_rounds:
@@ -1281,12 +3504,17 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             cfg,
             pool,
             concurrency_override=effective_concurrency,
+            run_id=run_id,
+            task=task,
         )
         total_enriched += result.get("enriched", 0)
         batch_failed = result.get("failed", 0)
         total_failed += batch_failed
         total_no_signal += result.get("no_signal", 0)
         total_quarantined += result.get("quarantined", 0)
+        _accumulate_exact_cache_usage(cache_usage, result)
+        for key in batch_metrics:
+            batch_metrics[key] += int(result.get(key, 0) or 0)
         rounds += 1
 
         # If most of the batch failed, vLLM is likely overwhelmed -- stop the loop
@@ -1301,18 +3529,75 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     if rounds == 0:
         return {"_skip_synthesis": "No B2B reviews to enrich"}
 
+    secondary_write_breakdown = {
+        "company_backfills": int(cache_usage.get("secondary_write_hits", 0) or 0),
+        "orphaned_requeued": int(orphaned or 0),
+        "exhausted_marked_failed": int(exhausted or 0),
+        "version_upgrade_requeued": int(requeued or 0),
+    }
+    secondary_write_hits = sum(secondary_write_breakdown.values())
     result = {
         "enriched": total_enriched,
         "quarantined": total_quarantined,
         "failed": total_failed,
         "no_signal": total_no_signal,
+        **cache_usage,
         "rounds": rounds,
         "orphaned_requeued": orphaned,
         "exhausted_marked_failed": exhausted,
+        "witness_rows": int(cache_usage.get("witness_rows", 0) or 0),
+        "witness_count": int(cache_usage.get("witness_count", 0) or 0),
+        "reviews_processed": total_enriched + total_quarantined + total_failed + total_no_signal,
+        "secondary_write_hits": secondary_write_hits,
+        "secondary_write_breakdown": secondary_write_breakdown,
+        **batch_metrics,
         "_skip_synthesis": "B2B enrichment complete",
     }
     if requeued:
         result["version_upgrade_requeued"] = requeued
+
+    # Record enrichment run summary
+    from ..visibility import record_attempt, emit_event
+    total_processed = total_enriched + total_quarantined + total_failed + total_no_signal
+    await record_attempt(
+        pool, artifact_type="enrichment", artifact_id="batch",
+        run_id=run_id, stage="enrichment",
+        status="succeeded" if total_failed == 0 else "failed",
+        score=total_enriched,
+        blocker_count=total_failed,
+        warning_count=total_quarantined,
+        error_message=f"{total_failed} failed, {total_quarantined} quarantined" if total_failed else None,
+    )
+    if total_failed > 0 or total_quarantined > 0 or secondary_write_hits > 0:
+        if total_failed > 0:
+            reason_code = "enrichment_failures"
+        elif total_quarantined > 0:
+            reason_code = "enrichment_quarantines"
+        else:
+            reason_code = "enrichment_secondary_writes"
+        await emit_event(
+            pool, stage="extraction", event_type="enrichment_run_summary",
+            entity_type="pipeline", entity_id="enrichment",
+            summary=f"Enrichment: {total_enriched} enriched, {total_failed} failed, {total_quarantined} quarantined",
+            severity="warning" if total_failed > 0 else "info",
+            actionable=total_failed > 5,
+            run_id=run_id,
+            reason_code=reason_code,
+            detail={
+                "enriched": total_enriched,
+                "failed": total_failed,
+                "quarantined": total_quarantined,
+                "no_signal": total_no_signal,
+                "processed": total_processed,
+                "witness_rows": int(cache_usage.get("witness_rows", 0) or 0),
+                "witness_count": int(cache_usage.get("witness_count", 0) or 0),
+                "exact_cache_hits": int(cache_usage.get("exact_cache_hits", 0) or 0),
+                "generated": int(cache_usage.get("generated", 0) or 0),
+                "secondary_write_hits": secondary_write_hits,
+                "secondary_write_breakdown": secondary_write_breakdown,
+            },
+        )
+
     return result
 
 
@@ -1322,9 +3607,18 @@ _MIN_REVIEW_TEXT_LENGTH = 80  # Skip LLM calls for reviews shorter than this
 
 
 async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
-                         max_tokens: int, truncate_length: int = 3000) -> bool:
-    """Enrich a single B2B review with churn signals. Returns True on success."""
+                         max_tokens: int, truncate_length: int = 3000,
+                         run_id: str | None = None,
+                         usage_out: dict[str, int] | None = None) -> bool | str:
+    """Enrich a single B2B review and optionally report exact-cache usage."""
     review_id = row["id"]
+    cache_usage = _empty_exact_cache_usage()
+
+    def _finish(status: bool | str) -> bool | str:
+        if usage_out is not None:
+            usage_out.clear()
+            usage_out.update(cache_usage)
+        return status
 
     # Skip reviews with insufficient text -- title-only scrapes can't yield 47 fields
     review_text = row.get("review_text") or ""
@@ -1333,14 +3627,10 @@ async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
             "UPDATE b2b_reviews SET enrichment_status = 'not_applicable' WHERE id = $1",
             review_id,
         )
-        return False
+        return _finish(False)
 
     source = str(row.get("source") or "").strip().lower()
-    skip_sources = {
-        item.strip().lower()
-        for item in str(settings.b2b_churn.enrichment_skip_sources or "").split(",")
-        if item.strip()
-    }
+    skip_sources = _effective_enrichment_skip_sources()
     if source in skip_sources:
         await pool.execute(
             """
@@ -1358,13 +3648,25 @@ async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
             source,
             review_id,
         )
-        return False
+        return _finish(False)
 
     try:
         cfg = settings.b2b_churn
-        full_extraction_timeout = cfg.enrichment_full_extraction_timeout_seconds
+        full_extraction_timeout = max(
+            0.0,
+            _coerce_float_value(
+                getattr(cfg, "enrichment_full_extraction_timeout_seconds", 120.0),
+                120.0,
+            ),
+        )
         payload = _build_classify_payload(row, truncate_length)
         payload_json = json.dumps(payload)
+        trace_metadata = {
+            "run_id": run_id,
+            "vendor_name": str(row.get("vendor_name") or ""),
+            "review_id": str(review_id),
+            "source": str(row.get("source") or ""),
+        }
         client = _get_tier1_client(cfg)
 
         # Tier 1: deterministic extraction (base fields)
@@ -1375,144 +3677,98 @@ async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
             and bool(cfg.openrouter_api_key)
         )
         if use_openrouter:
-            tier1, tier1_model = await asyncio.wait_for(
-                _call_openrouter_tier1(payload_json, cfg),
+            tier1, tier1_model, tier1_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                _call_openrouter_tier1(
+                    payload_json,
+                    cfg,
+                    include_cache_hit=True,
+                    trace_metadata=trace_metadata | {"tier": "tier1"},
+                ),
                 timeout=full_extraction_timeout,
-            )
+            ))
         else:
-            tier1, tier1_model = await asyncio.wait_for(
-                _call_vllm_tier1(payload_json, cfg, client),
+            tier1, tier1_model, tier1_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                _call_vllm_tier1(
+                    payload_json,
+                    cfg,
+                    client,
+                    include_cache_hit=True,
+                    trace_metadata=trace_metadata | {"tier": "tier1"},
+                ),
                 timeout=full_extraction_timeout,
-            )
+            ))
+        if tier1_cache_hit:
+            cache_usage["tier1_exact_cache_hits"] += 1
+            cache_usage["exact_cache_hits"] += 1
+        elif tier1_model is not None:
+            cache_usage["tier1_generated_calls"] += 1
+            cache_usage["generated"] += 1
         if tier1 is None:
             logger.debug("Tier 1 returned None for %s, deferring to next cycle", review_id)
             await _increment_attempts(pool, review_id, row["enrichment_attempts"], max_attempts)
-            return False
+            return _finish(False)
 
-        # Tier 2: conditional — only fire when tier 1 left extraction gaps
+        # Tier 2: conditional -- only fire when tier 1 left extraction gaps
         tier2 = None
         tier2_model = None
-        if _tier1_has_extraction_gaps(tier1):
-            tier2_client = _get_tier2_client(cfg)
-            tier2, tier2_model = await asyncio.wait_for(
-                _call_vllm_tier2(tier1, row, cfg, tier2_client, truncate_length),
-                timeout=full_extraction_timeout,
-            )
+        tier2_cache_hit = False
+        if _tier1_has_extraction_gaps(tier1, source=row.get("source")):
+            try:
+                if use_openrouter:
+                    tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                        _call_openrouter_tier2(
+                            tier1,
+                            row,
+                            cfg,
+                            truncate_length,
+                            include_cache_hit=True,
+                            trace_metadata=trace_metadata | {"tier": "tier2"},
+                        ),
+                        timeout=full_extraction_timeout,
+                    ))
+                else:
+                    tier2_client = _get_tier2_client(cfg)
+                    tier2, tier2_model, tier2_cache_hit = _unpack_stage_result(await asyncio.wait_for(
+                        _call_vllm_tier2(
+                            tier1,
+                            row,
+                            cfg,
+                            tier2_client,
+                            truncate_length,
+                            include_cache_hit=True,
+                            trace_metadata=trace_metadata | {"tier": "tier2"},
+                        ),
+                        timeout=full_extraction_timeout,
+                    ))
+            except Exception:
+                logger.warning(
+                    "Tier 2 enrichment failed for review %s; persisting tier 1 result only",
+                    review_id,
+                    exc_info=True,
+                )
+        if tier2_cache_hit:
+            cache_usage["tier2_exact_cache_hits"] += 1
+            cache_usage["exact_cache_hits"] += 1
+        elif tier2_model is not None:
+            cache_usage["tier2_generated_calls"] += 1
+            cache_usage["generated"] += 1
         if tier2 is not None:
             model_id = f"hybrid:{tier1_model}+{tier2_model}"
         else:
             model_id = tier1_model or ""
 
         result = _merge_tier1_tier2(tier1, tier2)
-
-        # Layer 3: compute derived fields from indicators (urgency, pain, recommend, etc.)
-        # Hard-fail if compute breaks -- do NOT fall back to model-dependent output.
-        if result:
-            try:
-                result = _compute_derived_fields(result, row)
-            except Exception:
-                logger.warning(
-                    "Evidence engine compute failed for %s -- quarantining to prevent model-dependent output",
-                    review_id, exc_info=True,
-                )
-                await pool.execute(
-                    """
-                    UPDATE b2b_reviews
-                    SET enrichment_status = 'quarantined',
-                        enrichment_attempts = enrichment_attempts + 1,
-                        low_fidelity = true,
-                        low_fidelity_reasons = $2::jsonb
-                    WHERE id = $1
-                    """,
-                    review_id,
-                    json.dumps(["evidence_engine_compute_failure"]),
-                )
-                return "quarantined"
-
-        if result and _validate_enrichment(result, row):
-            # Extract sentiment_trajectory subfields for indexed columns
-            st = result.get("sentiment_trajectory") or {}
-            st_direction = st.get("direction") if isinstance(st, dict) else None
-            st_tenure = st.get("tenure") if isinstance(st, dict) else None
-            st_turning = st.get("turning_point") if isinstance(st, dict) else None
-            low_fidelity_reasons = (
-                _detect_low_fidelity_reasons(row, result)
-                if cfg.enrichment_low_fidelity_enabled
-                else []
+        return _finish(
+            await _persist_enrichment_result(
+                pool,
+                row,
+                result,
+                model_id=model_id,
+                max_attempts=max_attempts,
+                run_id=run_id,
+                cache_usage=cache_usage,
             )
-            detected_at = datetime.now(timezone.utc)
-            if not low_fidelity_reasons and _is_no_signal_result(result, row):
-                target_status = "no_signal"
-            else:
-                target_status = "quarantined" if low_fidelity_reasons else "enriched"
-
-            await pool.execute(
-                """
-                UPDATE b2b_reviews
-                SET enrichment = $1,
-                    enrichment_status = $8,
-                    enrichment_attempts = enrichment_attempts + 1,
-                    enriched_at = $2,
-                    enrichment_model = $4,
-                    sentiment_direction = $5,
-                    sentiment_tenure = $6,
-                    sentiment_turning_point = $7,
-                    low_fidelity = $9,
-                    low_fidelity_reasons = $10::jsonb,
-                    low_fidelity_detected_at = $11
-                WHERE id = $3
-                """,
-                json.dumps(result),
-                detected_at,
-                review_id,
-                model_id,
-                st_direction,
-                st_tenure,
-                st_turning if st_turning and st_turning != "null" else None,
-                target_status,
-                bool(low_fidelity_reasons),
-                json.dumps(low_fidelity_reasons),
-                detected_at if low_fidelity_reasons else None,
-            )
-
-            # Fire ntfy notification for high-urgency signals (must never
-            # break enrichment -- wrapped in its own try/except)
-            try:
-                urgency = result.get("urgency_score", 0)
-                threshold = settings.b2b_churn.high_churn_urgency_threshold
-                if urgency >= threshold:
-                    signals = result.get("churn_signals", {})
-                    await _notify_high_urgency(
-                        vendor_name=row["vendor_name"],
-                        reviewer_company=row.get("reviewer_company") or "",
-                        urgency=urgency,
-                        pain_category=result.get("pain_category", ""),
-                        intent_to_leave=bool(signals.get("intent_to_leave")),
-                    )
-            except Exception:
-                logger.warning("ntfy notification failed for review %s, enrichment preserved", review_id)
-
-            # Backfill reviewer_company from LLM extraction when parser left it empty
-            try:
-                _ctx = result.get("reviewer_context") or {}
-                _extracted_company = (_ctx.get("company_name") or "").strip()
-                if _extracted_company and not (row.get("reviewer_company") or "").strip():
-                    _extracted_company_norm = normalize_company_name(_extracted_company) or None
-                    await pool.execute(
-                        "UPDATE b2b_reviews SET reviewer_company = $1, reviewer_company_norm = $2 WHERE id = $3",
-                        _extracted_company,
-                        _extracted_company_norm,
-                        review_id,
-                    )
-            except Exception:
-                logger.debug("Company name backfill failed for %s (non-fatal)", review_id)
-
-            if target_status == "quarantined":
-                return "quarantined"
-            return True
-        else:
-            await _increment_attempts(pool, review_id, row["enrichment_attempts"], max_attempts)
-            return False
+        )
 
     except Exception:
         logger.exception("Failed to enrich B2B review %s", review_id)
@@ -1530,7 +3786,7 @@ async def _enrich_single(pool, row, max_attempts: int, local_only: bool,
             )
         except Exception:
             pass
-        return False
+        return _finish(False)
 
 
 def _smart_truncate(text: str, max_len: int = 3000) -> str:
@@ -1556,7 +3812,7 @@ def _build_classify_payload(row, truncate_length: int = 3000) -> dict[str, Any]:
         except (json.JSONDecodeError, TypeError):
             raw_meta = {}
 
-    return {
+    payload: dict[str, Any] = {
         "vendor_name": row["vendor_name"],
         "product_name": row["product_name"] or "",
         "product_category": row["product_category"] or "",
@@ -1568,13 +3824,28 @@ def _build_classify_payload(row, truncate_length: int = 3000) -> dict[str, Any]:
         "rating_max": int(row["rating_max"]),
         "summary": row["summary"] or "",
         "review_text": review_text,
-        "pros": row["pros"] or "",
-        "cons": row["cons"] or "",
-        "reviewer_title": row["reviewer_title"] or "",
-        "reviewer_company": row["reviewer_company"] or "",
-        "company_size_raw": row["company_size_raw"] or "",
-        "reviewer_industry": row["reviewer_industry"] or "",
     }
+    for key, value in (
+        ("pros", row["pros"]),
+        ("cons", row["cons"]),
+        ("reviewer_title", row["reviewer_title"]),
+        ("reviewer_company", row["reviewer_company"]),
+        ("company_size_raw", row["company_size_raw"]),
+        ("reviewer_industry", row["reviewer_industry"]),
+    ):
+        if isinstance(value, str) and value.strip():
+            payload[key] = value
+    if not payload["product_name"]:
+        payload.pop("product_name", None)
+    if not payload["product_category"]:
+        payload.pop("product_category", None)
+    if payload.get("rating") is None:
+        payload.pop("rating", None)
+    if not payload["summary"]:
+        payload.pop("summary", None)
+    if not payload["review_text"]:
+        payload.pop("review_text", None)
+    return payload
 
 
 _LOW_FIDELITY_TOKEN_STOPWORDS = {
@@ -1751,13 +4022,31 @@ def _detect_low_fidelity_reasons(row: dict[str, Any], result: dict[str, Any]) ->
 
 _KNOWN_PAIN_CATEGORIES = {
     "pricing", "features", "reliability", "support", "integration",
-    "performance", "security", "ux", "onboarding", "other",
+    "performance", "security", "ux", "onboarding", "overall_dissatisfaction",
     "technical_debt", "contract_lock_in", "data_migration", "api_limitations",
+    "outcome_gap", "admin_burden", "ai_hallucination", "integration_debt",
 }
+
+_LEGACY_GENERIC_PAIN_CATEGORIES = {"other", "general_dissatisfaction"}
+
+
+def _normalize_pain_category(category: Any) -> str:
+    raw = str(category or "").strip().lower()
+    if not raw:
+        return "overall_dissatisfaction"
+    if raw in _LEGACY_GENERIC_PAIN_CATEGORIES:
+        return "overall_dissatisfaction"
+    if raw in _KNOWN_PAIN_CATEGORIES:
+        return raw
+    return "overall_dissatisfaction"
 
 
 def _coerce_bool(value: Any) -> bool | None:
-    """Coerce a value to bool. Returns None if unrecognizable."""
+    """Coerce a value to bool. Returns None if unrecognizable.
+    None/null is treated as False (absence of signal).
+    """
+    if value is None:
+        return False
     if isinstance(value, bool):
         return value
     if isinstance(value, (int, float)):
@@ -1765,7 +4054,7 @@ def _coerce_bool(value: Any) -> bool | None:
     if isinstance(value, str):
         if value.lower() in ("true", "yes", "1"):
             return True
-        if value.lower() in ("false", "no", "0"):
+        if value.lower() in ("false", "no", "0", "null", "none"):
             return False
     return None
 
@@ -1786,6 +4075,18 @@ _KNOWN_ROLE_LEVELS = {"executive", "director", "manager", "ic", "unknown"}
 _KNOWN_BUYING_STAGES = {"active_purchase", "evaluation", "renewal_decision", "post_purchase", "unknown"}
 _KNOWN_DECISION_TIMELINES = {"immediate", "within_quarter", "within_year", "unknown"}
 _KNOWN_CONTRACT_VALUE_SIGNALS = {"enterprise_high", "enterprise_mid", "mid_market", "smb", "unknown"}
+_KNOWN_REPLACEMENT_MODES = {
+    "competitor_switch", "bundled_suite_consolidation", "workflow_substitution",
+    "internal_tool", "none",
+}
+_KNOWN_OPERATING_MODEL_SHIFTS = {
+    "sync_to_async", "chat_to_docs", "chat_to_ticketing", "consolidation", "none",
+}
+_KNOWN_PRODUCTIVITY_DELTA_CLAIMS = {"more_productive", "less_productive", "no_change", "unknown"}
+_KNOWN_ORG_PRESSURE_TYPES = {
+    "procurement_mandate", "standardization_mandate", "bundle_pressure",
+    "budget_freeze", "none",
+}
 
 # Insider signal validation sets (migration 133)
 _KNOWN_CONTENT_TYPES = {"review", "community_discussion", "comment", "insider_account"}
@@ -1818,20 +4119,85 @@ _ROLE_TYPE_ALIASES = {
     "unknown": "unknown",
 }
 
-_NOISY_REVIEWER_TITLE_PATTERNS = (
-    re.compile(r"^repeat churn signal", re.I),
-    re.compile(r"score:\s*\d", re.I),
-)
+_ROLE_LEVEL_ALIASES = {
+    "executive": "executive",
+    "exec": "executive",
+    "csuite": "executive",
+    "cxo": "executive",
+    "ceo": "executive",
+    "cto": "executive",
+    "cfo": "executive",
+    "cio": "executive",
+    "cmo": "executive",
+    "coo": "executive",
+    "cro": "executive",
+    "president": "executive",
+    "founder": "executive",
+    "owner": "executive",
+    "executivedirector": "executive",
+    "presidentfounder": "executive",
+    "ownermanagingmember": "executive",
+    "ed": "executive",
+    "director": "director",
+    "vp": "director",
+    "vicepresident": "director",
+    "head": "director",
+    "directeur": "director",
+    "managingdirector": "director",
+    "headofcustomerexperience": "director",
+    "manager": "manager",
+    "lead": "manager",
+    "teamlead": "manager",
+    "supervisor": "manager",
+    "coordinator": "manager",
+    "projectmanager": "manager",
+    "programmanager": "manager",
+    "productmanager": "manager",
+    "marketingmanager": "manager",
+    "digitalmarketingmanager": "manager",
+    "salesmanager": "manager",
+    "operationsmanager": "manager",
+    "itmanager": "manager",
+    "businessdevelopmentmanager": "manager",
+    "clientservicemanager": "manager",
+    "customersuccessmanager": "manager",
+    "pmo": "manager",
+    "bdm": "manager",
+    "leadconsultant": "manager",
+    "projectmanagement": "manager",
+    "ic": "ic",
+    "individualcontributor": "ic",
+    "individual": "ic",
+    "user": "ic",
+    "product": "ic",
+    "marketing": "ic",
+    "digitalmarketing": "ic",
+    "consultant": "ic",
+    "customersupport": "ic",
+    "customersuccess": "ic",
+    "humanresources": "ic",
+    "softwaredevelopment": "ic",
+    "it": "ic",
+    "devops": "ic",
+    "swe": "ic",
+    "fse": "ic",
+    "cybersecurityanalyst": "ic",
+    "chemicalengineer": "ic",
+    "industrialengineer": "ic",
+    "customersatisfactionandqa": "ic",
+    "marketingteam": "ic",
+}
+
 _EXEC_REVIEWER_TITLE_PATTERN = re.compile(
-    r"\b(vp\b|vice president|director|head of|chief|cfo|ceo|coo|cio|cto|cro|cmo|founder|owner|president)\b",
+    r"\b(vp\b|vice president|director|head of|chief|cfo|ceo|coo|cio|cto|cro|cmo|founder|owner|president|executive director|managing member)\b",
     re.I,
 )
 _CHAMPION_REVIEWER_TITLE_PATTERN = re.compile(
-    r"\b(manager|lead|supervisor|coordinator)\b",
+    r"\b(manager|lead|team lead|supervisor|coordinator|pmo|project management|bdm)\b",
     re.I,
 )
 _EVALUATOR_REVIEWER_TITLE_PATTERN = re.compile(
-    r"\b(analyst|architect|engineer|developer|administrator|admin|consultant|specialist)\b",
+    r"\b(analyst|architect|engineer|developer|administrator|admin|consultant|specialist|devops|qa|customer support|customer success|human resources|marketing|product|software development|cybersecurity|it\b|swe\b|fse\b)\b",
     re.I,
 )
 _EXEC_ROLE_TEXT_PATTERN = re.compile(
@@ -1887,6 +4253,14 @@ _END_USER_TEXT_PATTERNS = (
     re.compile(r"\bdaily use\b", re.I),
     re.compile(r"\buse it for\b", re.I),
 )
+_MANAGER_DECISION_TITLE_PATTERN = re.compile(
+    r"\b(operations manager|it manager|project manager|program manager|product manager|marketing manager|sales manager|business development manager|client service manager|customer success manager|team lead|lead consultant|pmo|bdm|security manager|risk management)\b",
+    re.I,
+)
+_COMMERCIAL_DECISION_TEXT_PATTERN = re.compile(
+    r"\b(renewal|quote|quoted|pricing|price increase|budget|contract|procurement|vendor selection|selected|chose|approved|sign(?:ed)? off|purchase|buying committee|rfp|rfq|evaluate|evaluation|migration)\b",
+    re.I,
+)
 
 
 def _canonical_role_type(value: Any) -> str:
@@ -1896,27 +4270,22 @@ def _canonical_role_type(value: Any) -> str:
     return _ROLE_TYPE_ALIASES.get(raw, "unknown")
 
 
+def _normalize_role_title_key(value: Any) -> str:
+    text = unicodedata.normalize("NFKD", str(value or ""))
+    text = text.encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"[^a-z0-9]+", "", text.strip().lower())
+
+
 def _clean_reviewer_title_for_role_inference(value: Any) -> str:
-    title = str(value or "").strip()
+    title = sanitize_reviewer_title(value) or ""
     if not title or len(title) > 120:
-        return ""
-    lowered = title.lower()
-    if any(pattern.search(lowered) for pattern in _NOISY_REVIEWER_TITLE_PATTERNS):
         return ""
     return title
 
 
 def _canonical_role_level(value: Any) -> str:
-    raw = re.sub(r"[^a-z0-9]+", "", str(value or "").strip().lower())
-    if raw in {"executive", "exec", "csuite", "cxo"}:
-        return "executive"
-    if raw in {"director", "vp", "vicepresident", "head"}:
-        return "director"
-    if raw in {"manager", "lead", "teamlead", "supervisor", "coordinator"}:
-        return "manager"
-    if raw in {"ic", "individualcontributor", "individual", "user"}:
-        return "ic"
-    return "unknown"
+    raw = _normalize_role_title_key(value)
+    return _ROLE_LEVEL_ALIASES.get(raw, "unknown")
 
 
 def _combined_source_text(source_row: dict[str, Any] | None) -> str:
@@ -1934,6 +4303,9 @@ def _combined_source_text(source_row: dict[str, Any] | None) -> str:
 def _infer_role_level_from_text(reviewer_title: Any, source_row: dict[str, Any] | None) -> str:
     title = _clean_reviewer_title_for_role_inference(reviewer_title)
     if title:
+        canonical = _canonical_role_level(title)
+        if canonical != "unknown":
+            return canonical
         if re.search(r"\b(cfo|ceo|coo|cio|cto|cro|cmo|chief|founder|owner|president)\b", title, re.I):
             return "executive"
         if re.search(r"\b(vp\b|vice president|svp|evp|director|head of)\b", title, re.I):
@@ -1954,6 +4326,53 @@ def _infer_role_level_from_text(reviewer_title: Any, source_row: dict[str, Any] 
     if _IC_ROLE_TEXT_PATTERN.search(source_text):
         return "ic"
     return "unknown"
+
+
+def _has_manager_level_decision_context(result: dict[str, Any], source_row: dict[str, Any] | None) -> bool:
+    buyer_authority = _coerce_json_dict(result.get("buyer_authority"))
+    if _coerce_bool(buyer_authority.get("has_budget_authority")) is True:
+        return True
+
+    budget = _coerce_json_dict(result.get("budget_signals"))
+    if any(
+        budget.get(field)
+        for field in ("annual_spend_estimate", "price_per_seat", "price_increase_detail")
+    ):
+        return True
+    if _coerce_bool(budget.get("price_increase_mentioned")) is True:
+        return True
+
+    timeline = _coerce_json_dict(result.get("timeline"))
+    if timeline.get("contract_end") or timeline.get("evaluation_deadline"):
+        return True
+
+    churn = _coerce_json_dict(result.get("churn_signals"))
+    if any(
+        _coerce_bool(churn.get(field)) is True
+        for field in ("actively_evaluating", "migration_in_progress", "contract_renewal_mentioned")
+    ):
+        return True
+
+    return bool(_COMMERCIAL_DECISION_TEXT_PATTERN.search(_combined_source_text(source_row)))
+
+
+def _infer_decision_maker(result: dict[str, Any], source_row: dict[str, Any] | None) -> bool:
+    reviewer_context = _coerce_json_dict(result.get("reviewer_context"))
+    buyer_authority = _coerce_json_dict(result.get("buyer_authority"))
+    role_level = _canonical_role_level(reviewer_context.get("role_level"))
+    if role_level in {"executive", "director"}:
+        return True
+    if _coerce_bool(buyer_authority.get("has_budget_authority")) is True:
+        return True
+    if _canonical_role_type(buyer_authority.get("role_type")) == "economic_buyer":
+        return True
+
+    title = _clean_reviewer_title_for_role_inference((source_row or {}).get("reviewer_title"))
+    if title and _EXEC_REVIEWER_TITLE_PATTERN.search(title):
+        return True
+    if title and _MANAGER_DECISION_TITLE_PATTERN.search(title):
+        return _has_manager_level_decision_context(result, source_row)
+    return False
 
 
 def _infer_buyer_role_type_from_text(
@@ -2038,7 +4457,7 @@ _REPAIR_NEGATIVE_PATTERNS = (
 )
 _REPAIR_COMPETITOR_PATTERNS = (
     "switched to", "moved to", "replaced with", "evaluating", "looking at",
-    "considering", "alternative to", " vs ",
+    "considering", "shortlisting", "shortlisted", "poc with", "proof of concept with",
 )
 _REPAIR_PRICING_PATTERNS = (
     "billing", "invoice", "invoiced", "charged", "refund", "renewal",
@@ -2053,13 +4472,43 @@ _REPAIR_FEATURE_GAP_PATTERNS = (
     "missing", "lacks", "lacking", "wish it had", "wish they had",
     "need better", "needs better", "needs more", "could use", "limited",
 )
+_REPAIR_TIMELINE_PATTERNS = (
+    "renewal", "contract end", "contract expires", "deadline", "next quarter",
+    "q1", "q2", "q3", "q4", "30 days", "60 days", "90 days",
+)
+_REPAIR_CATEGORY_SHIFT_PATTERNS = (
+    "async", "docs", "documentation", "notion", "confluence", "bundle",
+    "workspace", "microsoft 365", "google workspace", "internal tool",
+    "homegrown", "home-grown", "custom tool",
+)
+_REPAIR_CURRENCY_RE = re.compile(r"\$\s?\d[\d,]*(?:\.\d+)?", re.I)
 
 
 def _trusted_repair_sources() -> set[str]:
+    return set(
+        filter_deprecated_sources(
+            _config_allowlist(getattr(settings.b2b_churn, "enrichment_priority_sources", ""), ""),
+            getattr(
+                settings.b2b_churn,
+                "deprecated_review_sources",
+                "capterra,software_advice,trustpilot,trustradius",
+            )
+            if isinstance(getattr(settings.b2b_churn, "deprecated_review_sources", ""), str)
+            else "capterra,software_advice,trustpilot,trustradius",
+        )
+    )
+
+
+def _effective_enrichment_skip_sources() -> set[str]:
+    configured = _config_allowlist(getattr(settings.b2b_churn, "enrichment_skip_sources", ""), "")
+    deprecated = _config_allowlist(
+        getattr(settings.b2b_churn, "deprecated_review_sources", ""),
+        "capterra,software_advice,trustpilot,trustradius",
+    )
     return {
-        source.strip().lower()
-        for source in str(settings.b2b_churn.enrichment_priority_sources or "").split(",")
-        if source.strip()
+        source
+        for source in [*configured, *deprecated]
+        if source
     }
 
 
@@ -2086,14 +4535,26 @@ def _repair_target_fields(result: dict[str, Any], source_row: dict[str, Any]) ->
     feature_gaps = _normalize_text_list(result.get("feature_gaps"))
     event_mentions = result.get("event_mentions") or []
     competitors = result.get("competitors_mentioned") or []
+    salience_flags = {
+        str(flag or "").strip().lower()
+        for flag in result.get("salience_flags") or []
+        if str(flag or "").strip()
+    }
+    timeline = _coerce_json_dict(result.get("timeline"))
 
-    if str(result.get("pain_category") or "").strip().lower() == "other" and _contains_any(review_blob, _REPAIR_NEGATIVE_PATTERNS):
+    if _normalize_pain_category(result.get("pain_category")) == "overall_dissatisfaction" and _contains_any(review_blob, _REPAIR_NEGATIVE_PATTERNS):
         for field in ("specific_complaints", "pricing_phrases", "recommendation_language"):
             _add_target(field)
     if not competitors and _contains_any(review_blob, _REPAIR_COMPETITOR_PATTERNS):
         _add_target("competitors_mentioned")
     if not pricing_phrases and _contains_any(review_blob, _REPAIR_PRICING_PATTERNS):
         _add_target("pricing_phrases")
+    if (
+        str(result.get("pain_category") or "").strip().lower() not in {"pricing", "contract_lock_in"}
+        and (_REPAIR_CURRENCY_RE.search(review_blob) or "explicit_dollar" in salience_flags)
+    ):
+        for field in ("specific_complaints", "pricing_phrases"):
+            _add_target(field)
     if not complaints and _contains_any(review_blob, _REPAIR_NEGATIVE_PATTERNS):
         _add_target("specific_complaints")
     if not recommendation_language and _contains_any(review_blob, _REPAIR_RECOMMEND_PATTERNS):
@@ -2102,6 +4563,19 @@ def _repair_target_fields(result: dict[str, Any], source_row: dict[str, Any]) ->
         _add_target("feature_gaps")
     if not event_mentions and _contains_any(review_blob, ("renewal", "migration", "switched", "price increase", "invoice")):
         _add_target("event_mentions")
+    if (
+        _contains_any(review_blob, _REPAIR_TIMELINE_PATTERNS)
+        and _is_unknownish(timeline.get("decision_timeline"))
+        and not event_mentions
+    ):
+        _add_target("event_mentions")
+    if competitors and all(
+        not str(comp.get("reason_category") or "").strip()
+        for comp in competitors if isinstance(comp, dict)
+    ):
+        _add_target("specific_complaints")
+    if _contains_any(review_blob, _REPAIR_CATEGORY_SHIFT_PATTERNS) and not feature_gaps and not complaints:
+        _add_target("specific_complaints")
     if status == "no_signal" and source in _trusted_repair_sources() and _contains_any(
         review_blob, _REPAIR_NEGATIVE_PATTERNS + _REPAIR_COMPETITOR_PATTERNS
     ):
@@ -2405,11 +4879,13 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
         logger.warning("feature_gaps is not a list: %s", type(fg).__name__)
         result["feature_gaps"] = []
 
-    # Coerce unknown pain_category to "other"
+    # Coerce unknown / legacy generic pain_category to the canonical fallback
     pain = result.get("pain_category")
-    if pain and pain not in _KNOWN_PAIN_CATEGORIES:
-        logger.warning("Unknown pain_category: %r -- coercing to 'other'", pain)
-        result["pain_category"] = "other"
+    if pain is not None:
+        normalized_pain = _normalize_pain_category(pain)
+        if normalized_pain != str(pain).strip().lower():
+            logger.warning("Normalizing pain_category %r -> %r", pain, normalized_pain)
+        result["pain_category"] = normalized_pain
 
     # --- New expanded field validation (permissive: coerce, never reject) ---
 
@@ -2423,9 +4899,7 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
             for item in pc:
                 if not isinstance(item, dict):
                     continue
-                cat = item.get("category", "other")
-                if cat not in _KNOWN_PAIN_CATEGORIES:
-                    cat = "other"
+                cat = _normalize_pain_category(item.get("category", "overall_dissatisfaction"))
                 sev = item.get("severity", "minor")
                 if sev not in _KNOWN_SEVERITY_LEVELS:
                     sev = "minor"
@@ -2438,6 +4912,10 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
         if not isinstance(bs, dict):
             result["budget_signals"] = {}
         else:
+            for field in ("annual_spend_estimate", "price_per_seat"):
+                if field in bs and bs[field] is not None and not isinstance(bs[field], (int, float)):
+                    text = _normalize_budget_value_text(bs[field])
+                    bs[field] = text if text else None
             if "seat_count" in bs and bs["seat_count"] is not None:
                 try:
                     seat = int(bs["seat_count"])
@@ -2447,6 +4925,11 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
             if "price_increase_mentioned" in bs:
                 coerced = _coerce_bool(bs["price_increase_mentioned"])
                 bs["price_increase_mentioned"] = coerced if coerced is not None else False
+            if "price_increase_detail" in bs and bs["price_increase_detail"] is not None:
+                detail = _normalize_budget_detail_text(bs["price_increase_detail"])
+                bs["price_increase_detail"] = detail if detail else None
+                if bs["price_increase_detail"] and not _coerce_bool(bs.get("price_increase_mentioned")):
+                    bs["price_increase_mentioned"] = True
 
     # use_case: dict with lists and lock_in_level
     uc = result.get("use_case")
@@ -2475,9 +4958,19 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
         )
     reviewer_ctx["role_level"] = role_level
     decision_maker = _coerce_bool(reviewer_ctx.get("decision_maker"))
+    derived_decision_maker = _infer_decision_maker(result, source_row)
     if decision_maker is None:
-        decision_maker = role_level in {"executive", "director"}
+        decision_maker = derived_decision_maker
+    else:
+        decision_maker = bool(decision_maker or derived_decision_maker)
     reviewer_ctx["decision_maker"] = decision_maker
+    company_name = str(reviewer_ctx.get("company_name") or "").strip()
+    if company_name:
+        reviewer_ctx["company_name"] = company_name
+    else:
+        trusted_company = _trusted_reviewer_company_name(source_row)
+        if trusted_company:
+            reviewer_ctx["company_name"] = trusted_company
 
     # sentiment_trajectory: dict with direction
     st = result.get("sentiment_trajectory")
@@ -2508,15 +5001,18 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
         if bstage and bstage not in _KNOWN_BUYING_STAGES:
             ba["buying_stage"] = "unknown"
         canonical_rt = _canonical_role_type(ba.get("role_type"))
+        derived_role_type = _infer_buyer_role_type(
+            ba,
+            reviewer_ctx,
+            (source_row or {}).get("reviewer_title"),
+            source_row,
+        )
         if canonical_rt == "unknown":
-            ba["role_type"] = _infer_buyer_role_type(
-                ba,
-                reviewer_ctx,
-                (source_row or {}).get("reviewer_title"),
-                source_row,
-            )
+            ba["role_type"] = derived_role_type
         else:
             ba["role_type"] = canonical_rt
+        if derived_role_type == "economic_buyer":
+            ba["role_type"] = "economic_buyer"
         if ba["role_type"] == "economic_buyer":
             reviewer_ctx["decision_maker"] = True
 
@@ -2544,6 +5040,101 @@ def _validate_enrichment(result: dict, source_row: dict[str, Any] | None = None)
     cc_val = result.get("content_classification")
     if cc_val and cc_val not in _KNOWN_CONTENT_TYPES:
         result["content_classification"] = "review"
+
+    if _schema_version(result) >= 3:
+        missing_fields = _missing_witness_primitives(result)
+        if missing_fields:
+            if source_row is None:
+                logger.warning(
+                    "schema v3 enrichment missing witness primitives without source row: %s",
+                    ", ".join(missing_fields),
+                )
+                return False
+            try:
+                recomputed = _compute_derived_fields(
+                    json.loads(json.dumps(result)),
+                    source_row,
+                )
+            except Exception:
+                logger.warning(
+                    "schema v3 witness primitive recompute failed for %s",
+                    source_row.get("id"),
+                    exc_info=True,
+                )
+                return False
+            result.clear()
+            result.update(recomputed)
+
+    # witness-oriented deterministic evidence fields
+    replacement_mode = str(result.get("replacement_mode") or "").strip()
+    if replacement_mode not in _KNOWN_REPLACEMENT_MODES:
+        result["replacement_mode"] = "none"
+    operating_model_shift = str(result.get("operating_model_shift") or "").strip()
+    if operating_model_shift not in _KNOWN_OPERATING_MODEL_SHIFTS:
+        result["operating_model_shift"] = "none"
+    productivity_delta_claim = str(result.get("productivity_delta_claim") or "").strip()
+    if productivity_delta_claim not in _KNOWN_PRODUCTIVITY_DELTA_CLAIMS:
+        result["productivity_delta_claim"] = "unknown"
+    org_pressure_type = str(result.get("org_pressure_type") or "").strip()
+    if org_pressure_type not in _KNOWN_ORG_PRESSURE_TYPES:
+        result["org_pressure_type"] = "none"
+
+    salience_flags = result.get("salience_flags")
+    if salience_flags is not None:
+        if not isinstance(salience_flags, list):
+            result["salience_flags"] = []
+        else:
+            result["salience_flags"] = [
+                str(flag).strip() for flag in salience_flags if str(flag or "").strip()
+            ]
+
+    evidence_spans = result.get("evidence_spans")
+    if evidence_spans is not None:
+        if not isinstance(evidence_spans, list):
+            result["evidence_spans"] = []
+        else:
+            cleaned_spans: list[dict[str, Any]] = []
+            for idx, span in enumerate(evidence_spans):
+                if not isinstance(span, dict):
+                    continue
+                text = str(span.get("text") or "").strip()
+                if not text:
+                    continue
+                pain_category = str(span.get("pain_category") or "").strip()
+                replacement = str(span.get("replacement_mode") or "").strip()
+                operating_shift = str(span.get("operating_model_shift") or "").strip()
+                productivity = str(span.get("productivity_delta_claim") or "").strip()
+                cleaned_spans.append({
+                    "span_id": str(span.get("span_id") or f"derived:{idx}"),
+                    "_sid": str(span.get("_sid") or span.get("span_id") or f"derived:{idx}"),
+                    "text": text,
+                    "start_char": span.get("start_char"),
+                    "end_char": span.get("end_char"),
+                    "signal_type": str(span.get("signal_type") or "review_context"),
+                    "pain_category": pain_category if pain_category in _KNOWN_PAIN_CATEGORIES else None,
+                    "competitor": str(span.get("competitor") or "").strip() or None,
+                    "company_name": str(span.get("company_name") or "").strip() or None,
+                    "reviewer_title": str(span.get("reviewer_title") or "").strip() or None,
+                    "time_anchor": str(span.get("time_anchor") or "").strip() or None,
+                    "numeric_literals": span.get("numeric_literals") if isinstance(span.get("numeric_literals"), dict) else {},
+                    "flags": [
+                        str(flag).strip() for flag in (span.get("flags") or [])
+                        if str(flag or "").strip()
+                    ],
+                    "replacement_mode": replacement if replacement in _KNOWN_REPLACEMENT_MODES else result.get("replacement_mode"),
+                    "operating_model_shift": operating_shift if operating_shift in _KNOWN_OPERATING_MODEL_SHIFTS else result.get("operating_model_shift"),
+                    "productivity_delta_claim": productivity if productivity in _KNOWN_PRODUCTIVITY_DELTA_CLAIMS else result.get("productivity_delta_claim"),
+                })
+            result["evidence_spans"] = cleaned_spans
+
+    if _schema_version(result) >= 3:
+        remaining_missing = _missing_witness_primitives(result)
+        if remaining_missing:
+            logger.warning(
+                "schema v3 enrichment still missing witness primitives after normalization: %s",
+                ", ".join(remaining_missing),
+            )
+            return False
 
     # insider_signals: validate structure if present
     insider = result.get("insider_signals")

--- a/atlas_brain/autonomous/tasks/b2b_scrape_intake.py
+++ b/atlas_brain/autonomous/tasks/b2b_scrape_intake.py
@@ -19,6 +19,16 @@ from typing import Any
 from urllib.parse import urlparse
 
 from ...config import settings
+from ...autonomous.visibility import record_dedup
+from ...services.b2b.review_dedup import (
+    choose_cross_source_duplicate_survivor,
+    load_cross_source_review_candidates,
+    make_cross_source_identity_key,
+    make_review_text_payload,
+    normalize_review_date_key,
+    normalize_reviewer_stem_key,
+)
+from ...services.b2b.reviewer_identity import sanitize_reviewer_title
 from ...services.company_normalization import normalize_company_name
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
@@ -58,6 +68,36 @@ _TWITTER_MARKETING_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b(?:now\s+available|product\s+update|release\s+notes|hiring)\b", re.I),
 )
 _CAPTERRA_AGGREGATE_METHOD = "jsonld_aggregate"
+_DEFAULT_SOURCE_QUALITY_GATE_SOURCES = frozenset({"quora", "twitter", "capterra"})
+
+
+def _coerce_config_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        if text in {"0", "false", "no", "off", ""}:
+            return False
+    return default
+
+
+def _normalize_source_quality_gate_sources(raw: Any) -> set[str]:
+    if isinstance(raw, str):
+        values = raw.split(",")
+    elif isinstance(raw, (list, tuple, set, frozenset)):
+        values = list(raw)
+    else:
+        values = []
+    sources = {
+        str(part).strip().lower()
+        for part in values
+        if str(part).strip()
+    }
+    return sources or set(_DEFAULT_SOURCE_QUALITY_GATE_SOURCES)
 
 
 def _parse_date(raw: Any) -> datetime | None:
@@ -168,6 +208,15 @@ def _make_review_content_hash(
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def _review_text_payload_from_row(review: dict[str, Any]) -> str:
+    return make_review_text_payload(
+        review.get("summary"),
+        review.get("review_text"),
+        review.get("pros"),
+        review.get("cons"),
+    )
+
+
 def _tokenize_vendor_name(vendor_name: str) -> list[str]:
     """Create robust vendor tokens for social-text checks."""
     tokens = [t for t in re.findall(r"[a-z0-9]+", str(vendor_name or "").lower()) if len(t) >= 4]
@@ -233,7 +282,10 @@ def _quality_gate_skip_reason(review: dict[str, Any], cfg) -> str | None:
             return "quora_non_question_url"
         return None
 
-    if source == "capterra" and cfg.source_quality_drop_capterra_aggregates:
+    if source == "capterra" and _coerce_config_bool(
+        getattr(cfg, "source_quality_drop_capterra_aggregates", True),
+        True,
+    ):
         meta = review.get("raw_metadata") or {}
         if str(meta.get("extraction_method") or "").strip().lower() == _CAPTERRA_AGGREGATE_METHOD:
             return "capterra_aggregate_page"
@@ -246,11 +298,14 @@ def _quality_gate_skip_reason(review: dict[str, Any], cfg) -> str | None:
             if str(value or "").strip()
         )
         intent = _review_has_twitter_intent(text)
-        if cfg.source_quality_twitter_require_intent and not intent:
+        if _coerce_config_bool(getattr(cfg, "source_quality_twitter_require_intent", True), True) and not intent:
             return "twitter_no_intent"
         if _review_looks_like_twitter_marketing(text) and not intent:
             return "twitter_marketing_post"
-        if cfg.source_quality_twitter_drop_vendor_self_posts and _is_vendor_self_tweet(
+        if _coerce_config_bool(
+            getattr(cfg, "source_quality_twitter_drop_vendor_self_posts", True),
+            True,
+        ) and _is_vendor_self_tweet(
             review, str(review.get("vendor_name") or "")
         ):
             return "twitter_vendor_self_post"
@@ -261,13 +316,11 @@ def _quality_gate_skip_reason(review: dict[str, Any], cfg) -> str | None:
 
 def _should_apply_source_quality_gate(source: str, cfg) -> bool:
     """Return True when source-specific quality gates should run."""
-    if not cfg.source_quality_gate_enabled:
+    if not _coerce_config_bool(getattr(cfg, "source_quality_gate_enabled", True), True):
         return False
-    gated_sources = {
-        part.strip().lower()
-        for part in str(cfg.source_quality_gate_sources or "").split(",")
-        if part.strip()
-    }
+    gated_sources = _normalize_source_quality_gate_sources(
+        getattr(cfg, "source_quality_gate_sources", _DEFAULT_SOURCE_QUALITY_GATE_SOURCES)
+    )
     return str(source or "").strip().lower() in gated_sources
 
 
@@ -322,6 +375,35 @@ async def _load_existing_review_identity_sets(
         source,
     )
     return known_keys, known_identities
+
+
+async def _load_vendor_cross_source_candidates(
+    pool,
+    *,
+    vendor_name: str,
+    content_hash: str | None,
+    identity_key: str | None,
+    reviewer_name: Any = None,
+    reviewed_at: Any = None,
+    rating: Any = None,
+) -> list[dict[str, Any]]:
+    cfg = settings.b2b_scrape
+    return await load_cross_source_review_candidates(
+        pool,
+        vendor_name=vendor_name,
+        content_hash=content_hash,
+        identity_key=identity_key,
+        reviewer_stem=normalize_reviewer_stem_key(
+            reviewer_name,
+            stem_length=cfg.cross_source_dedup_reviewer_stem_length,
+        ),
+        reviewed_date=normalize_review_date_key(reviewed_at),
+        rating=rating,
+        max_candidates=cfg.cross_source_dedup_max_candidates,
+        reviewer_stem_length=cfg.cross_source_dedup_reviewer_stem_length,
+        review_date_tolerance_days=cfg.cross_source_dedup_review_date_tolerance_days,
+        rating_tolerance=cfg.cross_source_dedup_rating_tolerance,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -552,14 +634,19 @@ INSERT INTO b2b_reviews (
     relevance_score, author_churn_score, source_weight,
     reddit_subreddit, reddit_trending, reddit_flair,
     reddit_is_edited, reddit_is_crosspost, reddit_num_comments,
-    reddit_score, reddit_comment_thread_count, reddit_crosspost_subreddits
+    reddit_score, reddit_comment_thread_count, reddit_crosspost_subreddits,
+    cross_source_content_hash, cross_source_identity_key,
+    duplicate_of_review_id, duplicate_reason, deduped_at,
+    enrichment_status, id
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23,
     $24, $25, $26,
     $27, $28, $29,
     $30, $31, $32, $33, $34, $35,
-    $36, $37, $38::jsonb
+    $36, $37, $38::jsonb,
+    $39, $40, $41::uuid, $42, $43,
+    $44, $45::uuid
 )
 ON CONFLICT (dedup_key) DO NOTHING
 """
@@ -916,11 +1003,21 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
     """Autonomous task handler: scrape B2B review sites per configured targets."""
     cfg = settings.b2b_scrape
     if not cfg.enabled:
-        return {"_skip_synthesis": True, "skipped": "b2b_scrape disabled"}
+        return {
+            "_skip_synthesis": True,
+            "skipped": "b2b_scrape disabled",
+            "skip_reason": "B2B scrape intake disabled",
+            "trigger_reason": "B2B scrape intake disabled",
+        }
 
     pool = get_db_pool()
     if not pool.is_initialized:
-        return {"_skip_synthesis": True, "skipped": "db not ready"}
+        return {
+            "_skip_synthesis": True,
+            "skipped": "db not ready",
+            "skip_reason": "B2B scrape intake skipped -- database not ready",
+            "trigger_reason": "B2B scrape intake skipped -- database not ready",
+        }
 
     # Import here to avoid circular imports and lazy-load curl_cffi
     from ...services.scraping.client import get_scrape_client
@@ -977,6 +1074,8 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
             "targets_due": 0,
             "targets_skipped_source_fit": len(source_fit_skipped),
             "skipped_targets": source_fit_skipped[:20],
+            "skip_reason": "No scrape targets due",
+            "trigger_reason": "No scrape targets due",
         }
 
     total_reviews = 0
@@ -1300,6 +1399,12 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
         ),
         "skipped_targets": source_fit_skipped[:20],
         "results": results_summary,
+        "skip_reason": "B2B scrape intake completed",
+        "trigger_reason": (
+            "B2B scrape intake completed -- new reviews inserted"
+            if total_inserted > 0
+            else "B2B scrape intake completed -- no new reviews inserted"
+        ),
     }
 
 
@@ -1339,6 +1444,7 @@ async def _insert_reviews(
 ) -> dict[str, int]:
     """Insert reviews into b2b_reviews with dedup and return batch stats."""
     rows = []
+    dedup_audit_events: list[tuple[str, str, str, dict[str, Any]]] = []
     cfg = settings.b2b_scrape
     _known = set(known_keys or set())
     _known_identities = set(known_identities or set())
@@ -1346,11 +1452,14 @@ async def _insert_reviews(
     _existing_keys = set(_known)
     _existing_identities = set(_known_identities)
     _existing_content_hashes = set(_known_content_hashes)
+    _batch_canonical_by_content_hash: dict[str, dict[str, Any]] = {}
+    _batch_canonical_by_identity_key: dict[str, dict[str, Any]] = {}
     skipped_short = 0
     skipped_quality_gate = 0
     duplicate_or_existing = 0
     duplicate_same_batch = 0
     duplicate_existing = 0
+    cross_source_duplicates = 0
     repaired_existing = 0
     repair_candidates: list[tuple[str, str | None, str | None, str | None, str | None, str | None, str | None]] = []
     for r in reviews:
@@ -1378,6 +1487,13 @@ async def _insert_reviews(
 
         reviewed_at_ts = _parse_date(r.get("reviewed_at"))
         content_hash = _make_review_content_hash(review_text, pros, cons)
+        review_payload = _review_text_payload_from_row(r)
+        cross_source_identity_key = make_cross_source_identity_key(
+            canonical_vendor,
+            r.get("reviewer_name"),
+            reviewed_at_ts or r.get("reviewed_at"),
+            r.get("rating"),
+        )
 
         dedup_key = _make_dedup_key(
             r["source"], canonical_vendor,
@@ -1393,6 +1509,7 @@ async def _insert_reviews(
             reviewed_at_ts or r.get("reviewed_at"),
         )
         reviewer_company = r.get("reviewer_company")
+        reviewer_title = sanitize_reviewer_title(r.get("reviewer_title"))
         reviewer_company_norm = normalize_company_name(reviewer_company or "") or None
 
         # Skip reviews already known in DB or already seen in this batch.
@@ -1409,12 +1526,17 @@ async def _insert_reviews(
             ):
                 duplicate_existing += 1
                 if any(
-                    r.get(field)
-                    for field in ("reviewer_title", "reviewer_company", "company_size_raw", "reviewer_industry")
+                    value
+                    for value in (
+                        reviewer_title,
+                        reviewer_company,
+                        r.get("company_size_raw"),
+                        r.get("reviewer_industry"),
+                    )
                 ):
                     repair_candidates.append((
                         dedup_key,
-                        r.get("reviewer_title"),
+                        reviewer_title,
                         reviewer_company,
                         reviewer_company_norm,
                         r.get("company_size_raw"),
@@ -1429,9 +1551,70 @@ async def _insert_reviews(
         if content_hash is not None:
             _known_content_hashes.add(content_hash)
 
+        review_uuid = _uuid.uuid4()
+        duplicate_of_review_id: _uuid.UUID | None = None
+        duplicate_reason: str | None = None
+        deduped_at: datetime | None = None
+        enrichment_status = "pending"
+        duplicate_detail: dict[str, Any] | None = None
+
+        if cfg.cross_source_dedup_enabled:
+            candidate_rows: list[dict[str, Any]] = []
+            if content_hash is not None and content_hash in _batch_canonical_by_content_hash:
+                candidate_rows.append(_batch_canonical_by_content_hash[content_hash])
+            if (
+                cross_source_identity_key is not None
+                and cross_source_identity_key in _batch_canonical_by_identity_key
+            ):
+                candidate = _batch_canonical_by_identity_key[cross_source_identity_key]
+                if candidate not in candidate_rows:
+                    candidate_rows.append(candidate)
+            if content_hash is not None or cross_source_identity_key is not None:
+                existing_candidates = await _load_vendor_cross_source_candidates(
+                    pool,
+                    vendor_name=canonical_vendor,
+                    content_hash=content_hash,
+                    identity_key=cross_source_identity_key,
+                    reviewer_name=r.get("reviewer_name"),
+                    reviewed_at=reviewed_at_ts or r.get("reviewed_at"),
+                    rating=r.get("rating"),
+                )
+                candidate_rows.extend(existing_candidates)
+            survivor, duplicate_reason, duplicate_detail = choose_cross_source_duplicate_survivor(
+                candidates=candidate_rows,
+                incoming_source=r["source"],
+                incoming_content_hash=content_hash,
+                incoming_identity_key=cross_source_identity_key,
+                incoming_payload=review_payload,
+                similarity_threshold=cfg.cross_source_dedup_similarity_threshold,
+                incoming_reviewer_name=r.get("reviewer_name"),
+                incoming_reviewed_at=reviewed_at_ts or r.get("reviewed_at"),
+                incoming_rating=r.get("rating"),
+                loose_similarity_threshold=cfg.cross_source_dedup_loose_similarity_threshold,
+                reviewer_stem_length=cfg.cross_source_dedup_reviewer_stem_length,
+                review_date_tolerance_days=cfg.cross_source_dedup_review_date_tolerance_days,
+                rating_tolerance=cfg.cross_source_dedup_rating_tolerance,
+            )
+            if survivor is not None:
+                survivor_id = survivor.get("id")
+                if survivor_id:
+                    duplicate_of_review_id = (
+                        survivor_id if isinstance(survivor_id, _uuid.UUID)
+                        else _uuid.UUID(str(survivor_id))
+                    )
+                    duplicate_reason = duplicate_reason or "cross_source_duplicate"
+                    deduped_at = datetime.now(timezone.utc)
+                    enrichment_status = "duplicate"
+                    cross_source_duplicates += 1
+
         raw_metadata = _merge_scrape_raw_metadata(r.get("raw_metadata", {}), target_context)
         if content_hash is not None:
             raw_metadata["review_content_hash"] = content_hash
+        if duplicate_of_review_id is not None:
+            raw_metadata["duplicate_of_review_id"] = str(duplicate_of_review_id)
+            raw_metadata["duplicate_reason"] = duplicate_reason
+            if duplicate_detail:
+                raw_metadata["duplicate_detail"] = duplicate_detail
 
         rows.append((
             dedup_key,
@@ -1448,7 +1631,7 @@ async def _insert_reviews(
             r.get("pros"),
             r.get("cons"),
             r.get("reviewer_name"),
-            r.get("reviewer_title"),
+            reviewer_title,
             reviewer_company,
             reviewer_company_norm,
             r.get("company_size_raw"),
@@ -1479,7 +1662,39 @@ async def _insert_reviews(
             json.dumps(raw_metadata.get("crosspost_subreddits"))
             if raw_metadata.get("crosspost_subreddits") is not None
             else None,
+            content_hash,
+            cross_source_identity_key,
+            duplicate_of_review_id,
+            duplicate_reason,
+            deduped_at,
+            enrichment_status,
+            review_uuid,
         ))
+        if duplicate_of_review_id is None:
+            canonical_row = {
+                "id": review_uuid,
+                "source": r["source"],
+                "cross_source_content_hash": content_hash,
+                "cross_source_identity_key": cross_source_identity_key,
+                "summary": r.get("summary"),
+                "review_text": r.get("review_text"),
+                "pros": r.get("pros"),
+                "cons": r.get("cons"),
+                "enrichment_status": enrichment_status,
+                "source_weight": raw_metadata.get("source_weight"),
+                "imported_at": datetime.now(timezone.utc).isoformat(),
+            }
+            if content_hash is not None:
+                _batch_canonical_by_content_hash[content_hash] = canonical_row
+            if cross_source_identity_key is not None:
+                _batch_canonical_by_identity_key[cross_source_identity_key] = canonical_row
+        else:
+            dedup_audit_events.append((
+                str(review_uuid),
+                str(duplicate_of_review_id),
+                duplicate_reason or "cross_source_duplicate",
+                duplicate_detail or {},
+            ))
 
     if skipped_short:
         logger.info("Skipped %d reviews with text < %d chars", skipped_short, _MIN_ENRICHABLE_TEXT_LEN)
@@ -1501,6 +1716,7 @@ async def _insert_reviews(
             "duplicate_same_batch": duplicate_same_batch,
             "duplicate_existing": duplicate_existing,
             "duplicate_db_conflict": 0,
+            "cross_source_duplicates": cross_source_duplicates,
             "repaired_existing": repaired_existing,
             "named_company_reviews": 0,
             "eligible_rows": 0,
@@ -1519,6 +1735,7 @@ async def _insert_reviews(
             "duplicate_same_batch": duplicate_same_batch,
             "duplicate_existing": duplicate_existing,
             "duplicate_db_conflict": len(rows),
+            "cross_source_duplicates": cross_source_duplicates,
             "repaired_existing": repaired_existing,
             "named_company_reviews": 0,
             "eligible_rows": len(rows),
@@ -1547,6 +1764,16 @@ async def _insert_reviews(
     inserted = int(count_row["cnt"] or 0) if count_row else 0
     named_company_reviews = int(count_row["named_company_reviews"] or 0) if count_row else 0
     duplicate_db_conflict = max(len(rows) - inserted, 0)
+    for entity_id, survivor_id, reason_code, detail in dedup_audit_events:
+        await record_dedup(
+            pool,
+            stage="review_ingest",
+            entity_type="review",
+            entity_id=entity_id,
+            survivor_entity_id=survivor_id,
+            reason=f"Suppressed cross-source duplicate review ({reason_code})",
+            detail=detail,
+        )
     return {
         "inserted": inserted,
         "skipped_short": skipped_short,
@@ -1555,6 +1782,7 @@ async def _insert_reviews(
         "duplicate_same_batch": duplicate_same_batch,
         "duplicate_existing": duplicate_existing,
         "duplicate_db_conflict": duplicate_db_conflict,
+        "cross_source_duplicates": cross_source_duplicates,
         "repaired_existing": repaired_existing,
         "named_company_reviews": named_company_reviews,
         "eligible_rows": len(rows),

--- a/atlas_brain/autonomous/visibility.py
+++ b/atlas_brain/autonomous/visibility.py
@@ -1,0 +1,344 @@
+"""Pipeline visibility: emit events, record artifact attempts, quarantines.
+
+Thin helpers that pipeline stages call to record operational outcomes.
+All writes are best-effort (never raise, never block the pipeline).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+logger = logging.getLogger("atlas.visibility")
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint computation
+# ---------------------------------------------------------------------------
+
+def _fingerprint(
+    stage: str,
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    reason_code: str | None = None,
+    rule_code: str | None = None,
+) -> str:
+    """Deterministic fingerprint for grouping repeated issues."""
+    parts = [stage, event_type, entity_type, entity_id]
+    if reason_code:
+        parts.append(reason_code)
+    if rule_code:
+        parts.append(rule_code)
+    raw = "|".join(str(p) for p in parts)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Event emitter
+# ---------------------------------------------------------------------------
+
+async def emit_event(
+    pool,
+    *,
+    stage: str,
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    summary: str,
+    severity: str = "info",
+    actionable: bool = False,
+    artifact_type: str | None = None,
+    reason_code: str | None = None,
+    rule_code: str | None = None,
+    decision: str | None = None,
+    run_id: str | None = None,
+    detail: dict[str, Any] | None = None,
+    source_table: str | None = None,
+    source_id: str | None = None,
+    update_review_state: bool = True,
+) -> str | None:
+    """Emit an immutable visibility event. Returns event ID or None on failure."""
+    fp = _fingerprint(stage, event_type, entity_type, entity_id, reason_code, rule_code)
+    event_id = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO pipeline_visibility_events
+                (id, occurred_at, run_id, stage, event_type, severity, actionable,
+                 entity_type, entity_id, artifact_type, reason_code, rule_code,
+                 decision, summary, detail, fingerprint, source_table, source_id)
+            VALUES ($1, NOW(), $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                    $14::jsonb, $15, $16, $17)
+            """,
+            event_id, run_id, stage, event_type, severity, actionable,
+            entity_type, entity_id, artifact_type, reason_code, rule_code,
+            decision, summary,
+            json.dumps(detail or {}, default=str),
+            fp, source_table, source_id,
+        )
+        if update_review_state:
+            await pool.execute(
+                """
+                INSERT INTO pipeline_visibility_reviews
+                    (fingerprint, status, latest_event_id, occurrence_count,
+                     first_seen_at, last_seen_at)
+                VALUES ($1, 'open', $2, 1, NOW(), NOW())
+                ON CONFLICT (fingerprint) DO UPDATE SET
+                    latest_event_id = EXCLUDED.latest_event_id,
+                    occurrence_count = pipeline_visibility_reviews.occurrence_count + 1,
+                    last_seen_at = NOW(),
+                    updated_at = NOW(),
+                    status = CASE
+                        WHEN pipeline_visibility_reviews.status IN ('resolved', 'ignored')
+                        THEN 'open'
+                        ELSE pipeline_visibility_reviews.status
+                    END
+                """,
+                fp, event_id,
+            )
+        return event_id
+    except Exception:
+        logger.debug("Failed to emit visibility event: %s/%s", stage, event_type, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Artifact attempt recorder
+# ---------------------------------------------------------------------------
+
+async def record_attempt(
+    pool,
+    *,
+    artifact_type: str,
+    artifact_id: str | None = None,
+    run_id: str | None = None,
+    attempt_no: int = 1,
+    stage: str,
+    status: str,
+    score: int | None = None,
+    threshold: int | None = None,
+    blocker_count: int = 0,
+    warning_count: int = 0,
+    blocking_issues: list[str] | None = None,
+    warnings: list[str] | None = None,
+    feedback_summary: str | None = None,
+    failure_step: str | None = None,
+    error_message: str | None = None,
+) -> str | None:
+    """Record an artifact generation attempt. Returns attempt ID or None."""
+    attempt_id = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO artifact_attempts
+                (id, artifact_type, artifact_id, run_id, attempt_no, stage, status,
+                 score, threshold, blocker_count, warning_count,
+                 blocking_issues, warnings,
+                 feedback_summary, failure_step, error_message,
+                 completed_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                    $12::jsonb, $13::jsonb, $14, $15, $16,
+                    CASE WHEN $7 != 'pending' THEN NOW() ELSE NULL END)
+            """,
+            attempt_id, artifact_type, artifact_id, run_id, attempt_no,
+            stage, status, score, threshold, blocker_count, warning_count,
+            json.dumps(blocking_issues or [], default=str),
+            json.dumps(warnings or [], default=str),
+            feedback_summary, failure_step, error_message,
+        )
+        return attempt_id
+    except Exception:
+        logger.debug("Failed to record artifact attempt: %s/%s", artifact_type, stage, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Enrichment quarantine recorder
+# ---------------------------------------------------------------------------
+
+async def record_quarantine(
+    pool,
+    *,
+    review_id: str | None = None,
+    vendor_name: str | None = None,
+    source: str | None = None,
+    reason_code: str,
+    severity: str = "warning",
+    actionable: bool = False,
+    summary: str | None = None,
+    evidence: dict[str, Any] | None = None,
+    run_id: str | None = None,
+) -> str | None:
+    """Record an enrichment quarantine decision. Returns quarantine ID or None."""
+    qid = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO enrichment_quarantines
+                (id, review_id, vendor_name, source, reason_code, severity,
+                 actionable, summary, evidence, run_id)
+            VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
+            """,
+            qid, review_id, vendor_name, source, reason_code, severity,
+            actionable, summary or reason_code,
+            json.dumps(evidence or {}, default=str),
+            run_id,
+        )
+        await emit_event(
+            pool,
+            stage="enrichment",
+            event_type="quarantine_recorded",
+            entity_type="review",
+            entity_id=str(review_id or vendor_name or qid),
+            summary=summary or reason_code,
+            severity="warning" if severity == "warning" else severity,
+            actionable=actionable,
+            artifact_type="enrichment",
+            reason_code=reason_code,
+            run_id=run_id,
+            detail=evidence or {},
+            source_table="enrichment_quarantines",
+            source_id=qid,
+        )
+        return qid
+    except Exception:
+        logger.debug("Failed to record quarantine: %s/%s", vendor_name, reason_code, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dedup decision recorder
+# ---------------------------------------------------------------------------
+
+async def record_dedup(
+    pool,
+    *,
+    stage: str,
+    entity_type: str,
+    entity_id: str,
+    reason: str,
+    survivor_entity_id: str | None = None,
+    run_id: str | None = None,
+    detail: dict[str, Any] | None = None,
+) -> str | None:
+    """Record a dedup/discard decision as a visibility event."""
+    try:
+        await pool.execute(
+            """
+            INSERT INTO dedup_decisions
+                (run_id, stage, entity_type, survivor_entity_id,
+                 discarded_entity_id, reason_code, comparison_metrics)
+            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+            """,
+            run_id,
+            stage,
+            entity_type,
+            survivor_entity_id,
+            entity_id,
+            "dedup_discard",
+            json.dumps(detail or {}, default=str),
+        )
+    except Exception:
+        logger.debug("Failed to record dedup row: %s/%s", stage, entity_id, exc_info=True)
+    return await emit_event(
+        pool,
+        stage=stage,
+        event_type="dedup_discard",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        summary=reason,
+        severity="info",
+        run_id=run_id,
+        reason_code="dedup_discard",
+        decision="discarded",
+        detail=detail,
+    )
+
+
+async def record_synthesis_validation_results(
+    pool,
+    *,
+    vendor_name: str,
+    as_of_date,
+    analysis_window_days: int,
+    schema_version: str,
+    run_id: str | None,
+    attempt_no: int,
+    results: list[dict[str, Any]],
+) -> None:
+    """Persist one row per synthesis validation rule result."""
+    if not results:
+        return
+    try:
+        await pool.executemany(
+            """
+            INSERT INTO synthesis_validation_results
+                (vendor_name, as_of_date, analysis_window_days, schema_version,
+                 run_id, attempt_no, rule_code, severity, passed, summary,
+                 field_path, detail)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)
+            """,
+            [
+                (
+                    vendor_name,
+                    as_of_date,
+                    analysis_window_days,
+                    schema_version,
+                    run_id,
+                    attempt_no,
+                    str(item.get("rule_code") or ""),
+                    str(item.get("severity") or "warning"),
+                    bool(item.get("passed")),
+                    str(item.get("summary") or ""),
+                    item.get("field_path"),
+                    json.dumps(item.get("detail") or {}, default=str),
+                )
+                for item in results
+                if item.get("rule_code")
+            ],
+        )
+    except Exception:
+        logger.debug("Failed to record synthesis validation rows: %s", vendor_name, exc_info=True)
+
+
+async def record_review_action(
+    pool,
+    *,
+    review_id: str,
+    fingerprint: str,
+    target_entity_type: str,
+    target_entity_id: str,
+    action: str,
+    note: str | None = None,
+    actor_id: str | None = None,
+    actor_type: str = "human",
+) -> str | None:
+    """Persist an immutable operator review action."""
+    action_id = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO pipeline_review_actions
+                (id, review_id, fingerprint, target_entity_type, target_entity_id,
+                 action, note, actor_id, actor_type)
+            VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            action_id,
+            review_id,
+            fingerprint,
+            target_entity_type,
+            target_entity_id,
+            action,
+            note,
+            actor_id,
+            actor_type,
+        )
+        return action_id
+    except Exception:
+        logger.debug("Failed to record review action: %s/%s", review_id, action, exc_info=True)
+        return None

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -24,6 +24,30 @@ class SaaSAuthConfig(BaseSettings):
     jwt_expiry_hours: int = Field(default=24, description="Access token expiry in hours")
     jwt_refresh_expiry_days: int = Field(default=30, description="Refresh token expiry in days")
     trial_days: int = Field(default=14, description="Trial period length in days")
+    frontend_base_url: str = Field(
+        default="http://localhost:5173",
+        description="Frontend base URL used in SaaS auth emails",
+    )
+    email_product_name: str = Field(
+        default="Churn Signals",
+        description="Display product name used in SaaS auth emails",
+    )
+    email_company_name: str = Field(
+        default="Atlas Intelligence",
+        description="Display company name used in SaaS auth emails",
+    )
+    b2b_welcome_product_name: str = Field(
+        default="Atlas B2B Intelligence",
+        description="Display product name used in B2B welcome email subjects",
+    )
+    b2b_welcome_heading: str = Field(
+        default="B2B Churn Intelligence",
+        description="Heading used in B2B welcome emails",
+    )
+    consumer_welcome_product_name: str = Field(
+        default="Amazon Seller Intelligence",
+        description="Display product name used in consumer welcome emails",
+    )
 
     # CORS -- extra origins to allow (comma-separated), e.g. "https://my-app.vercel.app"
     cors_origins: str = Field(default="", description="Extra CORS origins (comma-separated)")
@@ -1617,8 +1641,12 @@ class ModelPricingConfig(BaseModel):
     # Anthropic (per 1M tokens)
     anthropic_sonnet_input: float = 3.00
     anthropic_sonnet_output: float = 15.00
+    anthropic_sonnet_cache_read_input: float = 0.30
+    anthropic_sonnet_cache_write_input: float = 3.75
     anthropic_haiku_input: float = 0.25
     anthropic_haiku_output: float = 1.25
+    anthropic_haiku_cache_read_input: float = 0.03
+    anthropic_haiku_cache_write_input: float = 0.30
 
     # Groq (per 1M tokens -- hosted inference)
     groq_llama70b_input: float = 0.59
@@ -1636,16 +1664,43 @@ class ModelPricingConfig(BaseModel):
     local_input: float = 0.0
     local_output: float = 0.0
 
-    def cost_usd(self, provider: str, model: str, input_tokens: int, output_tokens: int) -> float:
+    def cost_usd(
+        self,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        *,
+        cached_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        billable_input_tokens: int | None = None,
+    ) -> float:
         """Calculate cost in USD for a given call."""
         p = (provider or "").lower()
         m = (model or "").lower()
+        cache_read = max(int(cached_tokens or 0), 0)
+        cache_write = max(int(cache_write_tokens or 0), 0)
+        base_input = (
+            max(int(billable_input_tokens), 0)
+            if billable_input_tokens is not None
+            else max(int(input_tokens or 0), 0)
+        )
         if p in ("ollama", "vllm", "transformers-flash", "llama-cpp") or "local" in p:
             return 0.0
         if p == "anthropic" or "claude" in m:
             if "haiku" in m:
-                return (input_tokens * self.anthropic_haiku_input + output_tokens * self.anthropic_haiku_output) / 1_000_000
-            return (input_tokens * self.anthropic_sonnet_input + output_tokens * self.anthropic_sonnet_output) / 1_000_000
+                return (
+                    base_input * self.anthropic_haiku_input
+                    + cache_read * self.anthropic_haiku_cache_read_input
+                    + cache_write * self.anthropic_haiku_cache_write_input
+                    + output_tokens * self.anthropic_haiku_output
+                ) / 1_000_000
+            return (
+                base_input * self.anthropic_sonnet_input
+                + cache_read * self.anthropic_sonnet_cache_read_input
+                + cache_write * self.anthropic_sonnet_cache_write_input
+                + output_tokens * self.anthropic_sonnet_output
+            ) / 1_000_000
         if p == "groq":
             return (input_tokens * self.groq_llama70b_input + output_tokens * self.groq_llama70b_output) / 1_000_000
         if p == "openrouter":
@@ -2030,6 +2085,9 @@ class InvoicingConfig(BaseSettings):
     auto_invoice_enabled: bool = Field(default=True, description="Monthly auto-invoice generation")
     auto_invoice_send_email: bool = Field(default=True, description="Auto-send invoices via email")
     auto_invoice_due_days: int = Field(default=30, ge=1, le=365, description="Payment terms for auto-invoices")
+    auto_invoice_calendar_id: str = Field(default="", description="Google Calendar ID for commercial cleaning events")
+    auto_invoice_review_mode: bool = Field(default=True, description="Hold invoices as draft for review instead of auto-sending")
+    auto_invoice_save_path: str = Field(default="~/Desktop/Atlas-Invoices", description="Base path for saving invoice PDFs")
 
 
 class ExternalDataConfig(BaseSettings):
@@ -2233,17 +2291,16 @@ class B2BChurnConfig(BaseSettings):
     enrichment_max_tokens: int = Field(default=2048, description="Max LLM output tokens")
     enrichment_local_only: bool = Field(default=False, description="Force local LLM only")
     enrichment_openrouter_model: str = Field(
-        default="",
+        default="anthropic/claude-haiku-4-5",
         description=(
-            "OpenRouter model for B2B enrichment (structured extraction). "
-            "Empty = inherit ATLAS_LLM__OPENROUTER_REASONING_MODEL."
+            "OpenRouter model for B2B enrichment (structured extraction)."
         ),
     )
 
     # Hybrid two-pass enrichment (Tier 1 local + Tier 2 local)
     enrichment_schema_version: int = Field(
         default=3,
-        description="Current enrichment schema version (1 = original LLM inference, 2 = extract plus Tier 2 LLM, 3 = single-pass extract plus deterministic compute)",
+        description="Current enrichment schema version (1 = original LLM inference, 2 = extract plus Tier 2 LLM, 3 = Tier 1 extract plus conditional Tier 2 plus deterministic compute)",
     )
     evidence_map_path: str = Field(
         default="",
@@ -2273,17 +2330,49 @@ class B2BChurnConfig(BaseSettings):
     )
     enrichment_tier2_model: str = Field(
         default="",
-        description="Model for Tier 2 extraction (empty = reuse Tier 1 model)",
+        description="Model for Tier 2 vLLM extraction (empty = reuse Tier 1 model)",
+    )
+    enrichment_tier2_openrouter_model: str = Field(
+        default="",
+        description="OpenRouter model for Tier 2 extraction (empty = reuse enrichment_openrouter_model)",
     )
     enrichment_tier2_max_tokens: int = Field(
         default=1536,
-        description="Max output tokens for Tier 2 vLLM extraction",
+        description="Max output tokens for Tier 2 extraction",
+    )
+    enrichment_tier2_strict_sources: str = Field(
+        default="gartner,peerspot",
+        description=(
+            "Comma-separated sources that require stronger Tier 1 evidence before Tier 2 classification fires"
+        ),
+    )
+    enrichment_tier2_strict_min_complaints: int = Field(
+        default=2,
+        ge=1,
+        le=20,
+        description="Minimum Tier 1 complaint count that qualifies strict sources for Tier 2",
+    )
+    enrichment_tier2_strict_min_quotes: int = Field(
+        default=2,
+        ge=1,
+        le=20,
+        description="Minimum Tier 1 quote count that helps qualify strict sources for Tier 2",
     )
     enrichment_tier2_timeout_seconds: float = Field(
         default=60.0,
         ge=5.0,
         le=600.0,
-        description="HTTP timeout for Tier 2 vLLM extraction requests",
+        description="HTTP timeout for Tier 2 extraction requests",
+    )
+    enrichment_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow B2B enrichment extraction to use Anthropic Message Batches when available",
+    )
+    enrichment_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum number of enrichment rows required before using Anthropic batching",
     )
     enrichment_tier1_connect_timeout_seconds: float = Field(
         default=10.0,
@@ -2293,27 +2382,63 @@ class B2BChurnConfig(BaseSettings):
     )
     # Account resolution
     account_resolution_batch_size: int = Field(
-        default=100,
+        default=1000,
         ge=1,
-        le=1000,
+        le=5000,
         description="Max reviews to resolve per batch in account resolution task",
     )
     account_resolution_backfill_min_confidence: str = Field(
         default="medium",
         description="Minimum confidence label to backfill reviewer_company (high/medium/low)",
     )
+    account_resolution_eligible_statuses: list[str] = Field(
+        default=["enriched", "no_signal", "quarantined"],
+        description=(
+            "Review enrichment statuses eligible for deterministic account resolution"
+        ),
+    )
+    account_resolution_source_priority: list[str] = Field(
+        default=["g2", "gartner", "capterra", "software_advice", "trustpilot"],
+        description=(
+            "Preferred source order when draining deterministic account-resolution candidates"
+        ),
+    )
+    account_resolution_excluded_sources: list[str] = Field(
+        default=["capterra", "software_advice", "trustpilot", "trustradius"],
+        description=(
+            "Sources excluded from deterministic account resolution because they lack reliable identity signals"
+        ),
+    )
     account_resolution_interval_seconds: int = Field(
         default=600,
         description="Account resolution task polling interval (seconds)",
     )
+    account_resolution_max_profile_fetches: int = Field(
+        default=50,
+        ge=1,
+        le=200,
+        description="Max profile fetches per batch (HN + GitHub combined). GitHub free tier allows 60 req/hr.",
+    )
+    account_resolution_profile_fetch_concurrency: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Max concurrent HN/GitHub profile fetches. 10 concurrent x 5s timeout ~= 25s for 50 profiles.",
+    )
+    account_resolution_profile_fetch_timeout: float = Field(
+        default=5.0,
+        ge=0.5,
+        le=30.0,
+        description="Per-request timeout (seconds) for HN and GitHub profile fetches.",
+    )
 
     enrichment_repair_enabled: bool = Field(
         default=False,
-        description="Enable structural repair pass for already-enriched B2B reviews",
+        description="Enable strategic adjudication pass for already-enriched B2B reviews",
     )
     enrichment_repair_interval_seconds: int = Field(
         default=900,
-        description="Repair polling interval for structurally weak enriched reviews",
+        description="Polling interval for weak or high-salience enriched reviews",
     )
     enrichment_repair_max_per_batch: int = Field(
         default=25,
@@ -2333,11 +2458,11 @@ class B2BChurnConfig(BaseSettings):
     )
     enrichment_repair_max_attempts: int = Field(
         default=2,
-        description="Max structural repair attempts per enriched review",
+        description="Max adjudication attempts per enriched review",
     )
     enrichment_repair_model: str = Field(
         default="",
-        description="Local vLLM model for structural repair pass",
+        description="Local vLLM model for strategic adjudication pass",
     )
     enrichment_repair_max_tokens: int = Field(
         default=512,
@@ -2345,11 +2470,59 @@ class B2BChurnConfig(BaseSettings):
         le=4096,
         description="Max completion tokens for the narrow field-repair extraction pass",
     )
+    enrichment_repair_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow B2B enrichment repair extraction to use Anthropic Message Batches when available",
+    )
+    enrichment_repair_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum number of repair rows required before using Anthropic batching",
+    )
+    enrichment_repair_strict_discussion_sources: str = Field(
+        default="reddit",
+        description=(
+            "Comma-separated community discussion sources that require stronger commercial signal before repair"
+        ),
+    )
+    enrichment_repair_strict_discussion_content_types: list[str] = Field(
+        default=["community_discussion", "insider_account", "comment"],
+        description=(
+            "Content types subject to strict discussion-source repair gating"
+        ),
+    )
+    enrichment_repair_strict_discussion_skip_limit: int = Field(
+        default=500,
+        ge=1,
+        le=5000,
+        description=(
+            "Max low-signal strict-discussion reviews to terminally skip per repair run"
+        ),
+    )
     enrichment_repair_min_urgency: int = Field(
         default=3,
         ge=0,
         le=10,
         description="Minimum urgency score for repair unless leave/eval pressure is already present",
+    )
+    enrichment_repair_orphan_timeout_minutes: int = Field(
+        default=30,
+        ge=5,
+        le=120,
+        description="Minutes before a row stuck in repairing status is recovered as orphaned",
+    )
+    enrichment_repair_failure_rate_threshold: float = Field(
+        default=0.5,
+        ge=0.1,
+        le=1.0,
+        description="Fraction of failed rows in a single round that triggers the circuit breaker",
+    )
+    enrichment_repair_no_progress_max_rounds: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description="Consecutive rounds with zero promotions before circuit breaker trips",
     )
     enrichment_low_fidelity_enabled: bool = Field(
         default=True,
@@ -2402,6 +2575,10 @@ class B2BChurnConfig(BaseSettings):
         default="g2,capterra,trustradius,gartner,peerspot",
         description="High-signal sources for executive-facing outputs (weekly_churn_feed, displacement, timeline)",
     )
+    deprecated_review_sources: str = Field(
+        default="capterra,software_advice,trustpilot,trustradius",
+        description="Sources deprecated from churn intelligence, blogs, and related downstream B2B review selection",
+    )
     intelligence_llm_backend: str = Field(
         default="vllm",
         description=(
@@ -2427,9 +2604,9 @@ class B2BChurnConfig(BaseSettings):
         default=18,
         description="Max vendor score rows to include in exploratory_overview payload",
     )
-    stratified_reasoning_vendor_limit: int = Field(
+    temporal_analysis_vendor_limit: int = Field(
         default=100,
-        description="Max vendors for temporal analysis + stratified reasoning per intel run (independent of LLM payload trimming)",
+        description="Max vendors for temporal analysis per intelligence run (independent of LLM payload trimming)",
     )
     intelligence_exploratory_high_intent_limit: int = Field(
         default=8,
@@ -2510,6 +2687,20 @@ class B2BChurnConfig(BaseSettings):
         default="openai/gpt-oss-120b",
         description="OpenRouter model for product profile synthesis",
     )
+    product_profile_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow B2B product profile synthesis to use Anthropic Message Batches when available",
+    )
+    product_profile_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum number of vendor profiles required before using Anthropic batching",
+    )
+    product_profile_cache_trace_enabled: bool = Field(
+        default=False,
+        description="Emit info-level exact-cache fingerprint logs for product profile synthesis debugging",
+    )
 
     # Blog post generation
     blog_post_enabled: bool = Field(default=False, description="Enable B2B blog post generation")
@@ -2520,6 +2711,64 @@ class B2BChurnConfig(BaseSettings):
     blog_post_ui_path: str = Field(default="", description="Path to atlas-churn-ui blog content dir")
     blog_base_url: str = Field(default="https://churnsignals.co", description="Base URL for B2B blog (full URLs in campaign emails)")
     blog_post_openrouter_model: str = Field(default="openai/gpt-oss-120b", description="OpenRouter model for blog generation")
+    blog_post_temperature: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=1.0,
+        description="Sampling temperature for B2B blog post generation",
+    )
+    blog_post_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow first-pass B2B blog generation to use Anthropic Message Batches when Anthropic is available",
+    )
+    blog_post_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum number of blog posts required before using Anthropic batching for first-pass generation",
+    )
+    blog_quality_pass_score: int = Field(
+        default=70,
+        ge=0,
+        le=100,
+        description="Minimum blog quality score required to pass the deterministic quality gate",
+    )
+    blog_specificity_require_anchor_support: bool = Field(
+        default=True,
+        description="Require blog drafts to use witness-backed anchors when concrete reasoning anchors are available",
+    )
+    blog_specificity_min_anchor_hits: int = Field(
+        default=1,
+        ge=1,
+        le=5,
+        description="Minimum number of witness-backed specificity signal groups a blog draft must hit when anchors are available",
+    )
+    blog_specificity_require_timing_or_numeric_when_available: bool = Field(
+        default=True,
+        description="Require blog drafts to mention a timing or numeric anchor when one is available in the reasoning packet",
+    )
+    blog_evidence_anchor_low_signal_labels: list[str] = Field(
+        default_factory=lambda: [
+            "ux",
+            "ui",
+            "review_context",
+            "named_org",
+            "positive_anchor",
+            "complaint",
+            "overall_dissatisfaction",
+        ],
+        description="Low-signal witness labels that should not appear as customer-facing blog evidence anchors",
+    )
+    blog_publish_revalidate_enabled: bool = Field(
+        default=True,
+        description="Re-run the deterministic blog quality and specificity gate before admin publish",
+    )
+    blog_quality_backfill_days: int = Field(
+        default=30,
+        ge=1,
+        le=365,
+        description="Default lookback window in days for recent blog quality backfills",
+    )
     # Blog auto-deploy (git push + Vercel deploy hook)
     blog_auto_deploy_enabled: bool = Field(default=False, description="Auto git-push + Vercel deploy after B2B blog publish")
     blog_auto_deploy_branch: str = Field(default="main", description="Git branch to push B2B blog commits to")
@@ -2534,6 +2783,93 @@ class B2BChurnConfig(BaseSettings):
     )
     # Regeneration mode -- re-process existing drafts through fixed pipeline
     blog_post_regenerate_mode: bool = Field(default=False, description="When True, regenerate existing draft posts instead of selecting new topics")
+    blog_post_min_words_default: int = Field(
+        default=1800,
+        ge=500,
+        le=5000,
+        description="Default minimum word count required for a blog draft to pass the deterministic quality gate",
+    )
+    blog_post_target_words_default: int = Field(
+        default=2300,
+        ge=500,
+        le=5000,
+        description="Default SEO target word count used as a warning threshold for blog drafts",
+    )
+    blog_post_min_words_by_topic: dict[str, int] = Field(
+        default_factory=lambda: {
+            "vendor_showdown": 2000,
+            "market_landscape": 1900,
+            "best_fit_guide": 1900,
+            "vendor_deep_dive": 1800,
+            "vendor_alternative": 1700,
+            "churn_report": 1700,
+            "pain_point_roundup": 1700,
+            "pricing_reality_check": 1600,
+            "migration_guide": 1500,
+            "switching_story": 1500,
+        },
+        description="Per-topic minimum word counts for the blog quality gate",
+    )
+    blog_post_target_words_by_topic: dict[str, int] = Field(
+        default_factory=lambda: {
+            "vendor_showdown": 2600,
+            "market_landscape": 2600,
+            "best_fit_guide": 2500,
+            "vendor_deep_dive": 2400,
+            "vendor_alternative": 2300,
+            "churn_report": 2300,
+            "pain_point_roundup": 2300,
+            "pricing_reality_check": 2200,
+            "migration_guide": 2100,
+            "switching_story": 2100,
+        },
+        description="Per-topic SEO target word counts used as warning thresholds for blog drafts",
+    )
+    blog_post_max_rejection_retries: int = Field(
+        default=1,
+        ge=0,
+        le=10,
+        description="Max rejected reruns allowed after an initial rejection before permanent block",
+    )
+    blog_post_rejection_cooldown_hours: int = Field(
+        default=24,
+        ge=0,
+        le=720,
+        description="Minimum hours before an autonomously rejected blog slug can be attempted again",
+    )
+    blog_post_borderline_shortfall_max_words: int = Field(
+        default=60,
+        ge=0,
+        le=500,
+        description="Maximum word-count shortfall eligible for deterministic coverage-snapshot repair during blog quality cleanup",
+    )
+    blog_min_quotes_by_topic: dict[str, int] = Field(
+        default_factory=lambda: {
+            "vendor_showdown": 4,
+            "vendor_deep_dive": 3,
+            "market_landscape": 4,
+            "best_fit_guide": 4,
+            "migration_guide": 3,
+        },
+        description="Per-topic minimum quotable-review counts required before blog generation is allowed",
+    )
+    blog_min_vendor_profiles_by_topic: dict[str, int] = Field(
+        default_factory=lambda: {
+            "market_landscape": 4,
+            "best_fit_guide": 4,
+        },
+        description="Per-topic minimum vendor-profile breadth required before multi-vendor blog generation is allowed",
+    )
+    blog_min_sections_by_topic: dict[str, int] = Field(
+        default_factory=lambda: {
+            "vendor_showdown": 6,
+            "vendor_deep_dive": 6,
+            "market_landscape": 7,
+            "best_fit_guide": 7,
+            "migration_guide": 5,
+        },
+        description="Per-topic minimum blueprint section counts required before blog generation is allowed",
+    )
 
     # Historical snapshots
     snapshot_enabled: bool = Field(default=True, description="Enable daily vendor health snapshots")
@@ -2584,14 +2920,71 @@ class B2BChurnConfig(BaseSettings):
         le=8192,
         description="Max output tokens for vendor scorecard narratives when the synthesis model is DeepSeek",
     )
+    llm_exact_cache_enabled: bool = Field(
+        default=False,
+        description="Enable exact-match Postgres caching for B2B/reporting LLM calls",
+    )
+    anthropic_batch_enabled: bool = Field(
+        default=False,
+        description="Enable Anthropic Message Batches for eligible B2B workloads",
+    )
+    anthropic_batch_poll_interval_seconds: float = Field(
+        default=5.0,
+        ge=1.0,
+        le=60.0,
+        description="Polling interval for Anthropic Message Batch reconciliation",
+    )
+    anthropic_batch_timeout_seconds: float = Field(
+        default=900.0,
+        ge=30.0,
+        le=86400.0,
+        description="Max time to wait for an Anthropic Message Batch before falling back",
+    )
+    scorecard_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow vendor scorecard narratives to use Anthropic Message Batches when available",
+    )
+    scorecard_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum uncached scorecard narratives required before using Anthropic batching",
+    )
+    reasoning_synthesis_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow vendor reasoning synthesis to use Anthropic Message Batches when available",
+    )
+    reasoning_synthesis_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum vendor reasoning items required before using Anthropic batching",
+    )
+    cross_vendor_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow cross-vendor reasoning synthesis to use Anthropic Message Batches when available",
+    )
+    cross_vendor_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum cross-vendor reasoning items required before using Anthropic batching",
+    )
+    tenant_report_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow tenant report synthesis chunks to use Anthropic Message Batches when available",
+    )
+    tenant_report_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum tenant report synthesis chunks required before using Anthropic batching",
+    )
 
     # Briefing gate (email capture for full report)
     vendor_briefing_gate_base_url: str = Field(default="https://churnsignals.co/report", description="Base URL for briefing gate landing page")
     vendor_briefing_gate_expiry_days: int = Field(default=7, description="Gate token expiry in days")
 
-    # Stratified reasoning integration (global intelligence run)
-    stratified_reasoning_enabled: bool = Field(default=False, description="Route vendors through stratified reasoner during global intelligence run")
-    stratified_reasoning_concurrency: int = Field(default=5, description="Max concurrent vendor reasoning tasks")
     reasoning_synthesis_attempts: int = Field(
         default=2,
         ge=1,
@@ -2604,30 +2997,237 @@ class B2BChurnConfig(BaseSettings):
         le=30.0,
         description="Delay between vendor reasoning synthesis retry attempts",
     )
+    reasoning_synthesis_timeout_seconds: float = Field(
+        default=180.0,
+        ge=1.0,
+        le=3600.0,
+        description="Timeout for each vendor or cross-vendor reasoning LLM call",
+    )
+    reasoning_synthesis_max_stale_days: int = Field(
+        default=3,
+        ge=0,
+        le=90,
+        description="Classify unchanged vendor reasoning rows newer than this as fresh reuse and older rows as stale reuse",
+    )
+    reasoning_synthesis_max_input_tokens: int = Field(
+        default=20000,
+        ge=512,
+        le=50000,
+        description="Approximate max input tokens allowed for a single vendor reasoning synthesis prompt before lean fallback or rejection",
+    )
+    reasoning_synthesis_max_items_per_pool: int = Field(
+        default=8,
+        ge=1,
+        le=20,
+        description="Max scored items per pool in the default vendor reasoning payload",
+    )
+    reasoning_synthesis_max_tokens: int = Field(
+        default=4096,
+        ge=256,
+        le=16384,
+        description="Max completion tokens for vendor or cross-vendor reasoning synthesis calls",
+    )
+    reasoning_synthesis_model: str = Field(
+        default="",
+        description=(
+            "OpenRouter model override for vendor reasoning synthesis. "
+            "Empty = prefer settings.llm.openrouter_reasoning_model before "
+            "falling back to the legacy reasoning-model defaults."
+        ),
+    )
+    reasoning_synthesis_temperature: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Temperature for vendor and cross-vendor reasoning synthesis calls",
+    )
     reasoning_synthesis_feedback_limit: int = Field(
         default=5,
         ge=1,
         le=10,
         description="Max validator issues to feed back into synthesis repair retries",
     )
-    stratified_reasoning_vendor_cap: int = Field(default=60, description="Max vendors to send through stratified reasoning (top N by urgency)")
-    intelligence_focus_categories: str = Field(
-        default="all",
+    reasoning_retry_escalation_window_hours: int = Field(
+        default=24,
+        ge=1,
+        le=168,
+        description="Rolling window for escalating repeated recovered synthesis validation retries",
+    )
+    reasoning_retry_repeat_rule_threshold: int = Field(
+        default=3,
+        ge=2,
+        le=20,
+        description="Escalate when the same vendor and validation rule hit this many recovered retries within the escalation window",
+    )
+    reasoning_retry_cost_min_retries: int = Field(
+        default=2,
+        ge=1,
+        le=20,
+        description="Minimum recovered retry count before token-cost escalation can trigger",
+    )
+    reasoning_retry_cost_tokens_threshold: int = Field(
+        default=80000,
+        ge=1000,
+        le=1000000,
+        description="Escalate recovered retry churn when retry-token spend crosses this threshold within the escalation window",
+    )
+    reasoning_witness_max_witnesses: int = Field(
+        default=12,
+        ge=1,
+        le=50,
+        description="Max witnesses included in each vendor reasoning packet",
+    )
+    reasoning_synthesis_lean_max_items_per_pool: int = Field(
+        default=4,
+        ge=1,
+        le=20,
+        description="Max scored items per pool when vendor reasoning falls back to lean prompt mode",
+    )
+    reasoning_synthesis_lean_max_witnesses: int = Field(
+        default=6,
+        ge=1,
+        le=20,
+        description="Max witnesses included when vendor reasoning falls back to lean prompt mode",
+    )
+    reasoning_synthesis_segment_candidate_limit: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Max segment shortlist candidates included in witness-first section packets",
+    )
+    reasoning_synthesis_temporal_candidate_limit: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Max temporal trigger candidates included in witness-first section packets",
+    )
+    reasoning_synthesis_displacement_candidate_limit: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Max displacement destination candidates included in witness-first section packets",
+    )
+    reasoning_synthesis_account_candidate_limit: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Max account shortlist candidates included in witness-first section packets",
+    )
+    reasoning_synthesis_category_candidate_limit: int = Field(
+        default=2,
+        ge=1,
+        le=10,
+        description="Max category regime candidates included in witness-first section packets",
+    )
+    reasoning_synthesis_retention_candidate_limit: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Max retention strength candidates included in witness-first section packets",
+    )
+    reasoning_synthesis_rerun_if_missing_packet_artifacts: bool = Field(
+        default=True,
+        description="Rerun vendor reasoning when the latest unchanged row is missing packet artifacts",
+    )
+    reasoning_synthesis_rerun_if_missing_reference_ids: bool = Field(
+        default=True,
+        description="Rerun vendor reasoning when the latest unchanged row is missing canonical reference ids",
+    )
+    reasoning_witness_highlight_limit: int = Field(
+        default=4,
+        ge=1,
+        le=20,
+        description="Max witness highlights surfaced to downstream render consumers",
+    )
+    witness_specificity_min_score: float = Field(
+        default=2.0,
+        ge=0.0,
+        le=10.0,
+        description="Minimum deterministic specificity score required before a witness can enter the normal witness pack",
+    )
+    witness_specificity_fallback_min_witnesses: int = Field(
+        default=4,
+        ge=0,
+        le=20,
+        description="Minimum witness count to recover with generic fallback when the specific witness pool is too thin",
+    )
+    witness_specificity_generic_patterns: list[str] = Field(
+        default_factory=lambda: [
+            "great tool",
+            "great platform",
+            "good tool",
+            "good platform",
+            "easy to use",
+            "easy-to-use",
+            "works well",
+            "working well",
+            "very helpful",
+            "super helpful",
+        ],
+        description="Boilerplate phrases that reduce witness specificity",
+    )
+    witness_specificity_concrete_patterns: list[str] = Field(
+        default_factory=lambda: [
+            "pricing",
+            "renewal",
+            "seat",
+            "integration",
+            "workflow",
+            "contract",
+            "budget",
+            "support",
+            "security",
+            "migration",
+            "implementation",
+            "downtime",
+            "latency",
+        ],
+        description="Concrete pain or workflow anchors that increase witness specificity",
+    )
+    witness_specificity_short_excerpt_chars: int = Field(
+        default=55,
+        ge=1,
+        le=500,
+        description="Excerpt length below which anchor-free witnesses incur a specificity penalty",
+    )
+    witness_specificity_long_excerpt_chars: int = Field(
+        default=80,
+        ge=1,
+        le=1000,
+        description="Excerpt length above which a witness receives a small specificity bonus",
+    )
+    witness_specificity_weights: dict[str, float] = Field(
+        default_factory=lambda: {
+            "currency": 2.0,
+            "number": 1.0,
+            "timing": 1.0,
+            "competitor": 1.0,
+            "reviewer_company": 1.0,
+            "pain_category": 0.75,
+            "replacement_mode": 0.75,
+            "operating_model_shift": 0.75,
+            "productivity_delta_claim": 0.75,
+            "signal_type": 0.5,
+            "long_excerpt": 0.5,
+            "concrete_pattern": 0.5,
+            "generic_phrase_penalty": 2.5,
+            "short_excerpt_penalty": 1.5,
+        },
+        description="Deterministic witness specificity scoring weights and penalties",
+    )
+    reasoning_synthesis_enabled: bool = Field(
+        default=True,
         description=(
-            "Comma-separated product categories to include in reasoning phase. "
-            "'all' = no filter (default). Only affects stratified reasoning and "
-            "cross-vendor analysis. Signals, vaults, and segments still build "
-            "for all vendors."
+            "Enable vendor reasoning synthesis as the canonical post-core reasoning pass. "
+            "When true, legacy stratified vendor reasoning inside b2b_churn_intelligence "
+            "is skipped to avoid duplicate LLM spend."
         ),
     )
     executive_summary_llm_enabled: bool = Field(default=False, description="Use LLM-synthesized executive summaries instead of deterministic templates")
 
-    # Cross-vendor reasoning (battles, category councils, asymmetry)
-    cross_vendor_reasoning_enabled: bool = Field(default=False, description="Enable cross-vendor LLM reasoning (battles, category councils, asymmetry)")
     cross_vendor_max_battles: int = Field(default=5, ge=0, le=20, description="Max pairwise battle reasoning calls per run")
     cross_vendor_max_categories: int = Field(default=3, ge=0, le=10, description="Max category council reasoning calls per run")
     cross_vendor_max_asymmetry: int = Field(default=3, ge=0, le=10, description="Max resource-asymmetry reasoning calls per run")
-    cross_vendor_concurrency: int = Field(default=3, ge=1, le=10, description="Max concurrent cross-vendor LLM calls")
     cross_vendor_battle_min_context_score: float = Field(default=2.0, ge=0.0, le=10.0, description="Min deterministic overlap score before a displacement pair gets battle reasoning")
     cross_vendor_category_min_vendors: int = Field(default=3, ge=1, le=20, description="Min reasoned vendors in a category before council reasoning")
     cross_vendor_category_min_context_vendors: int = Field(default=2, ge=1, le=20, description="Min context-rich vendors in a category before council reasoning")
@@ -2638,10 +3238,84 @@ class B2BChurnConfig(BaseSettings):
     cross_vendor_asymmetry_min_divergence_score: float = Field(default=2.0, ge=0.0, le=50.0, description="Min divergence score before asymmetry reasoning")
     cross_vendor_asymmetry_min_context_score: float = Field(default=2.0, ge=0.0, le=10.0, description="Min deterministic overlap score before asymmetry reasoning")
 
+    # Cross-vendor synthesis (runs in b2b_reasoning_synthesis after vendor synthesis)
+    cross_vendor_synthesis_enabled: bool = Field(default=True, description="Enable cross-vendor synthesis (battles, councils, asymmetry) in the reasoning synthesis task")
+    cross_vendor_synthesis_concurrency: int = Field(default=3, ge=1, le=10, description="Max concurrent cross-vendor synthesis LLM calls")
+    cross_vendor_synthesis_attempts: int = Field(default=2, ge=1, le=5, description="Max generation attempts per cross-vendor packet")
+    cross_vendor_synthesis_feedback_limit: int = Field(default=5, ge=1, le=10, description="Max validator issues to feed back per retry")
+    cross_vendor_llm_max_input_tokens: int = Field(
+        default=12000,
+        ge=512,
+        le=50000,
+        description="Approximate max input tokens allowed for a single cross-vendor synthesis prompt before the run is rejected to control spend",
+    )
+    cross_vendor_category_vendor_summary_limit: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description="Max vendor summaries included in a category-council packet",
+    )
+    cross_vendor_category_flow_limit: int = Field(
+        default=3,
+        ge=0,
+        le=50,
+        description="Max displacement flows included in a category-council packet",
+    )
+    competitive_set_max_competitors: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Max competitors allowed in one scoped competitive set",
+    )
+    competitive_set_refresh_interval_seconds: int = Field(
+        default=3600,
+        ge=300,
+        le=86400,
+        description="How often the scheduled competitive-set refresher scans for due scoped synthesis runs",
+    )
+    competitive_set_refresh_batch_size: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description="Max competitive sets processed in one scheduled synthesis scanner run",
+    )
+    competitive_set_preview_lookback_days: int = Field(
+        default=14,
+        ge=1,
+        le=90,
+        description="Lookback window for competitive-set run cost previews based on recent synthesis history",
+    )
+    competitive_set_changed_vendors_only_default: bool = Field(
+        default=True,
+        description=(
+            "Default changed-vendors-only policy for scoped competitive-set runs "
+            "when the caller does not explicitly choose full refresh behavior"
+        ),
+    )
+    reasoning_synthesis_scheduled_scope_strategy: str = Field(
+        default="competitive_sets",
+        description=(
+            "Runtime strategy for scheduled b2b_reasoning_synthesis runs: "
+            "'competitive_sets' scans due scoped sets, 'full_universe' keeps the legacy global run path"
+        ),
+    )
+
+    scorecard_narrative_concurrency: int = Field(default=6, description="Max concurrent LLM calls during scorecard narrative generation")
+
     battle_card_llm_concurrency: int = Field(default=3, description="Max concurrent battle card sales copy LLM calls")
     battle_card_llm_attempts: int = Field(default=2, ge=1, le=5, description="Max generation attempts per battle card, including repair retries")
     battle_card_llm_retry_delay_seconds: float = Field(default=1.0, ge=0.0, le=30.0, description="Delay between battle card LLM attempts")
     battle_card_llm_feedback_limit: int = Field(default=5, ge=1, le=10, description="Max validator issues to feed back into battle card repair attempts")
+    battle_card_anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow battle-card sales copy to use Anthropic Message Batches when the battle-card backend is set to anthropic",
+    )
+    battle_card_anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum battle-card sales-copy items required before using Anthropic batching",
+    )
     battle_card_llm_backend: str = Field(
         default="auto",
         description=(
@@ -2659,6 +3333,66 @@ class B2BChurnConfig(BaseSettings):
         ),
     )
     battle_card_llm_max_tokens: int = Field(default=16384, ge=256, le=32768, description="Max output tokens for battle card sales copy (reasoning models need extra budget)")
+    battle_card_llm_max_input_tokens: int = Field(
+        default=25000,
+        ge=512,
+        le=50000,
+        description="Approximate max input tokens allowed for a single battle-card sales-copy prompt before the LLM step falls back deterministically",
+    )
+    battle_card_render_anchor_examples_per_bucket: int = Field(
+        default=1,
+        ge=0,
+        le=5,
+        description="Max witness-backed anchor examples to surface per anchor bucket in battle-card sales-copy prompts",
+    )
+    battle_card_render_witness_highlights_limit: int = Field(
+        default=4,
+        ge=0,
+        le=12,
+        description="Max witness highlights to include in battle-card sales-copy prompts",
+    )
+    battle_card_render_reference_ids_limit: int = Field(
+        default=12,
+        ge=0,
+        le=40,
+        description="Max metric or witness reference ids to include per list in battle-card sales-copy prompts",
+    )
+    battle_card_render_cross_vendor_battles_limit: int = Field(
+        default=2,
+        ge=0,
+        le=5,
+        description="Max cross-vendor battle summaries to include in battle-card sales-copy prompts",
+    )
+    battle_card_render_high_intent_companies_limit: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description="Max high-intent accounts to include in battle-card sales-copy prompts",
+    )
+    battle_card_render_reframes_limit: int = Field(
+        default=3,
+        ge=0,
+        le=8,
+        description="Max competitive reframes to include in compact displacement reasoning for battle-card sales-copy prompts",
+    )
+    battle_card_render_priority_segments_limit: int = Field(
+        default=3,
+        ge=0,
+        le=8,
+        description="Max priority segments to include in compact vendor reasoning for battle-card sales-copy prompts",
+    )
+    battle_card_render_strengths_limit: int = Field(
+        default=3,
+        ge=0,
+        le=8,
+        description="Max incumbent strengths to include in compact battle-card retention context",
+    )
+    battle_card_render_data_gaps_limit: int = Field(
+        default=4,
+        ge=0,
+        le=12,
+        description="Max data gaps or confidence-limit notes to include per compact battle-card reasoning section",
+    )
     battle_card_llm_temperature: float = Field(default=0.5, ge=0.0, le=1.5, description="Sampling temperature for battle card sales copy generation")
     battle_card_llm_timeout_seconds: float = Field(default=90.0, ge=5.0, le=300.0, description="Timeout for a single battle card LLM generation attempt")
     battle_card_cache_confidence: float = Field(default=0.95, ge=0.0, le=1.0, description="Confidence assigned to validated battle card sales copy cache entries")
@@ -2666,7 +3400,7 @@ class B2BChurnConfig(BaseSettings):
     battle_card_high_priority_urgency_min: float = Field(default=5.0, ge=0.0, le=10.0, description="Min average urgency required before battle-card copy can use high-priority language")
     battle_card_feature_gap_headline_min_mentions: int = Field(default=5, ge=1, le=100, description="Min feature-gap mention count before a battle-card headline can elevate that gap directly")
     battle_card_quality_max_stale_days: int = Field(
-        default=1,
+        default=2,
         ge=0,
         le=30,
         description="Max allowed staleness (days) before battle-card quality gate hard-blocks publishing",
@@ -2705,6 +3439,12 @@ class B2BChurnConfig(BaseSettings):
     )
     synthesis_reference_confidence_min: float = Field(default=0.6, ge=0.0, le=1.0, description="Min reasoning or cross-vendor confidence before synthesis may reference a structured conclusion directly")
     synthesis_expert_take_max_words: int = Field(default=80, ge=20, le=200, description="Max word count for synthesized scorecard expert_take narratives")
+    vendor_scorecard_limit: int = Field(
+        default=15,
+        ge=1,
+        le=500,
+        description="Default max vendors included in the unscoped vendor_scorecard report artifact",
+    )
     battle_card_leaving_patterns: list[str] = Field(
         default=[
             "customers are leaving",
@@ -2718,9 +3458,30 @@ class B2BChurnConfig(BaseSettings):
     )
 
     # Accounts in motion
+    company_signal_skip_deprecated_sources: bool = Field(
+        default=True,
+        description="Exclude globally deprecated review sources from canonical company-signal and named-account products",
+    )
+    company_signal_low_trust_sources: list[str] = Field(
+        default=["reddit"],
+        description="Low-trust sources that require a higher confidence threshold before becoming canonical named-account signals",
+    )
+    company_signal_low_trust_min_confidence: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        description="Minimum unit-confidence required for low-trust company signals to enter canonical named-account products",
+    )
+    high_intent_require_signal_evidence: bool = Field(
+        default=True,
+        description="Require explicit churn/evaluation/renewal signal evidence before reviewer-company rows enter named-account high-intent products",
+    )
     accounts_in_motion_cron: str = Field(default="35 21 * * *", description="Cron for accounts-in-motion prospecting lists")
     accounts_in_motion_max_per_vendor: int = Field(default=25, ge=1, le=100, description="Max accounts per vendor in accounts_in_motion report")
+    accounts_in_motion_feed_max_total: int = Field(default=100, ge=1, le=200, description="Max total tenant feed rows returned by the aggregated accounts_in_motion endpoint")
     accounts_in_motion_min_urgency: float = Field(default=5.0, ge=0, le=10, description="Min urgency to include an account in motion")
+    accounts_in_motion_signal_metadata_min_confidence: float = Field(default=6.0, ge=0, le=10, description="Minimum normalized confidence required for company-signal metadata fallback rows to seed accounts_in_motion")
+    accounts_in_motion_reddit_insider_min_confidence: float = Field(default=6.0, ge=0, le=10, description="Minimum normalized confidence required for reddit insider_account company signals to seed accounts_in_motion")
     accounts_in_motion_repeat_evidence_bonus: int = Field(default=3, ge=0, le=20, description="Bonus points added per extra supporting review for an account in motion")
     accounts_in_motion_repeat_evidence_bonus_max: int = Field(default=6, ge=0, le=30, description="Max total repeat-evidence bonus for an account in motion")
     accounts_in_motion_low_confidence_threshold: float = Field(default=6.0, ge=0, le=10, description="Confidence below this threshold incurs a quality penalty in accounts_in_motion scoring")
@@ -2754,10 +3515,90 @@ class B2BAlertConfig(BaseSettings):
     )
 
     enabled: bool = Field(default=False, description="Enable churn signal spike alerts")
+    email_enabled: bool = Field(default=True, description="Send churn alerts to tenant owners via email when configured")
+    sender_name: str = Field(default="Atlas Intelligence", description="Display name for churn alert emails")
+    dashboard_base_url: str = Field(default="", description="Optional dashboard URL included in churn alert emails")
     signal_count_threshold: int = Field(default=3, description="New signals to trigger alert")
     urgency_spike_threshold: float = Field(default=1.5, description="Avg urgency increase to trigger alert")
+    min_reviews_for_urgency: int = Field(default=10, ge=1, le=100, description="Min reviews in 7-day window before avg_urgency can trigger alerts")
     cooldown_hours: int = Field(default=24, description="Min hours between alerts for same vendor")
     interval_seconds: int = Field(default=3600, description="Alert check interval (1 hour)")
+
+
+class B2BWatchlistDeliveryConfig(BaseSettings):
+    """Recurring email delivery for saved-view watchlist alerts."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_B2B_WATCHLIST_DELIVERY_", env_file=ENV_FILES, extra="ignore"
+    )
+
+    enabled: bool = Field(default=False, description="Enable recurring saved-view watchlist alert delivery")
+    interval_seconds: int = Field(default=3600, ge=60, le=86400, description="How often to check for due watchlist alert deliveries")
+    max_views_per_run: int = Field(default=25, ge=1, le=250, description="Max saved views processed in a single watchlist alert delivery run")
+    stale_claim_seconds: int = Field(default=900, ge=60, le=86400, description="How long a scheduled watchlist delivery claim can remain processing before another worker may reclaim it")
+    failed_retry_seconds: int = Field(default=3600, ge=60, le=86400 * 7, description="Delay before retrying a failed scheduled watchlist delivery")
+
+
+class B2BReportDeliveryConfig(BaseSettings):
+    """Recurring report-subscription delivery configuration."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_B2B_REPORT_DELIVERY_", env_file=ENV_FILES, extra="ignore"
+    )
+
+    enabled: bool = Field(default=False, description="Enable recurring report-subscription delivery")
+    sender_name: str = Field(default="Atlas Intelligence", description="Display name for recurring report emails")
+    dashboard_base_url: str = Field(default="", description="Optional frontend base URL used in report-delivery links")
+    interval_seconds: int = Field(default=3600, ge=60, le=86400, description="How often to check for due report subscriptions")
+    max_subscriptions_per_run: int = Field(default=25, ge=1, le=250, description="Max due subscriptions processed in a single task run")
+    max_reports_per_delivery: int = Field(default=6, ge=1, le=20, description="Max persisted artifacts included in one recurring library delivery")
+    stale_claim_seconds: int = Field(default=900, ge=60, le=86400, description="How long an in-flight delivery claim can sit before another worker may reclaim it")
+    fresh_hours: int = Field(default=72, ge=1, le=24 * 30, description="Artifacts newer than this are treated as fresh for delivery-policy checks")
+    monitor_hours: int = Field(default=24 * 7, ge=1, le=24 * 90, description="Artifacts newer than this but older than fresh_hours are treated as monitor state")
+    require_sales_ready_for_competitive: bool = Field(
+        default=True,
+        description="Require sales_ready quality status for battle-card style deliverables when quality metadata exists",
+    )
+    max_blocker_count: int = Field(
+        default=0,
+        ge=0,
+        le=50,
+        description="Maximum blocker_count allowed for a deliverable to remain eligible",
+    )
+    max_open_review_count: int = Field(
+        default=0,
+        ge=0,
+        le=50,
+        description="Maximum unresolved operator-review count allowed for a deliverable to remain eligible",
+    )
+    report_scope_overrides_library: bool = Field(
+        default=True,
+        description="Exclude artifacts from library deliveries when an enabled report-scoped subscription exists for the same artifact",
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Resolve due subscriptions and record delivery outcomes without sending email or advancing schedules",
+    )
+    canary_account_ids: str = Field(
+        default="",
+        description="Comma-separated or JSON list of account IDs allowed for live recurring delivery sends",
+    )
+    suppress_unchanged_deliveries: bool = Field(
+        default=True,
+        description="Skip recurring sends when the eligible artifact package has not materially changed since the last completed delivery",
+    )
+    max_send_attempts_per_recipient: int = Field(
+        default=2,
+        ge=1,
+        le=5,
+        description="Maximum send attempts per recipient before the delivery is marked partial or failed",
+    )
+    retry_backoff_seconds: int = Field(
+        default=3,
+        ge=0,
+        le=300,
+        description="Delay between recipient send retries",
+    )
 
 
 class B2BWebhookConfig(BaseSettings):
@@ -2838,6 +3679,10 @@ class B2BScrapeConfig(BaseSettings):
             "getapp,software_advice,trustpilot,reddit,hackernews,github,stackoverflow,slashdot"
         ),
         description="Sources allowed for automated scrape intake (comma-separated)",
+    )
+    deprecated_sources: str = Field(
+        default="capterra,software_advice,trustpilot,trustradius",
+        description="Sources deprecated from automated scrape intake and target planning",
     )
     source_fit_filter_enabled: bool = Field(
         default=True,
@@ -3009,6 +3854,46 @@ class B2BScrapeConfig(BaseSettings):
         default=True,
         description="Drop Capterra JSON-LD aggregate pages that are not real reviews",
     )
+    cross_source_dedup_enabled: bool = Field(
+        default=True,
+        description="Detect and suppress duplicate B2B reviews syndicated across multiple sources",
+    )
+    cross_source_dedup_similarity_threshold: float = Field(
+        default=0.82,
+        ge=0.5,
+        le=1.0,
+        description="Minimum normalized text similarity for reviewer/date cross-source duplicate matches",
+    )
+    cross_source_dedup_max_candidates: int = Field(
+        default=20,
+        ge=1,
+        le=500,
+        description="Max existing vendor review candidates to compare when checking cross-source duplicates",
+    )
+    cross_source_dedup_loose_similarity_threshold: float = Field(
+        default=0.9,
+        ge=0.5,
+        le=1.0,
+        description="Minimum normalized text similarity for reviewer-prefix/date-tolerant duplicate matches",
+    )
+    cross_source_dedup_review_date_tolerance_days: int = Field(
+        default=1,
+        ge=0,
+        le=7,
+        description="Allowed review-date drift when matching syndicated duplicates across sources",
+    )
+    cross_source_dedup_rating_tolerance: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=5.0,
+        description="Allowed rating delta when matching syndicated duplicates across sources",
+    )
+    cross_source_dedup_reviewer_stem_length: int = Field(
+        default=5,
+        ge=2,
+        le=12,
+        description="Reviewer-name prefix length used for loose cross-source duplicate candidate matching",
+    )
 
     # Exhaustive scrape mode
     exhaustive_lookback_days: int = Field(default=365, description="Date cutoff for exhaustive mode (days)")
@@ -3074,7 +3959,57 @@ class B2BCampaignConfig(BaseSettings):
     schedule_cron: str = Field(default="0 22 * * *", description="Campaign generation schedule (daily 10 PM)")
     dedup_days: int = Field(default=7, ge=1, description="Days before re-targeting same company")
     retention_days: int = Field(default=90, ge=1, description="Days to retain expired/sent campaigns before cleanup")
+    concurrency: int = Field(default=8, description="Max concurrent LLM calls during campaign generation")
     max_tokens: int = Field(default=2048, description="Max tokens per LLM generation call")
+    llm_timeout_seconds: float = Field(
+        default=120.0,
+        ge=5.0,
+        le=300.0,
+        description="Timeout for a single campaign LLM generation call",
+    )
+    anthropic_batch_enabled: bool = Field(
+        default=True,
+        description="Allow campaign generation to use Anthropic Message Batches when eligible",
+    )
+    anthropic_batch_detached_enabled: bool = Field(
+        default=False,
+        description="Submit campaign batches for later reconciliation instead of waiting inline for completion",
+    )
+    anthropic_batch_stale_minutes: int = Field(
+        default=30,
+        ge=5,
+        le=1440,
+        description="Minutes before a detached campaign batch job or claim is considered stale",
+    )
+    anthropic_batch_min_items: int = Field(
+        default=2,
+        ge=1,
+        le=10000,
+        description="Minimum uncached campaign items required before using Anthropic batching",
+    )
+    word_limits: dict[str, dict[str, list[int]]] = Field(
+        default_factory=lambda: {
+            "default": {
+                "email_cold": [50, 150],
+                "email_followup": [75, 150],
+                "linkedin": [0, 100],
+            },
+            "vendor_retention": {
+                "email_cold": [50, 125],
+                "email_followup": [75, 150],
+            },
+            "challenger_intel": {
+                "email_cold": [50, 125],
+                "email_followup": [75, 150],
+            },
+            "churning_company": {
+                "email_cold": [75, 150],
+                "email_followup": [75, 125],
+                "linkedin": [0, 100],
+            },
+        },
+        description="Per-target-mode campaign word limits by channel as [min_words, max_words]",
+    )
     temperature: float = Field(default=0.7, description="LLM sampling temperature")
     default_sender_name: str = Field(default="", description="Sender name for outreach")
     default_sender_title: str = Field(default="", description="Sender title for outreach")
@@ -3113,6 +4048,38 @@ class B2BCampaignConfig(BaseSettings):
         default=["executive", "technical", "operations", "evaluator", "champion"],
         description="Persona types to generate campaigns for (buying committee coverage)",
     )
+    specificity_require_anchor_support: bool = Field(
+        default=True,
+        description="Require campaign drafts to use witness-backed anchors when briefing-backed concrete anchors are available",
+    )
+    specificity_min_anchor_hits: int = Field(
+        default=1,
+        ge=1,
+        le=5,
+        description="Minimum number of witness-backed specificity signal groups a campaign draft must hit when anchors are available",
+    )
+    specificity_require_timing_or_numeric_when_available: bool = Field(
+        default=True,
+        description="Require campaign drafts to mention a timing or numeric anchor when one is available in briefing-backed witnesses",
+    )
+    specificity_revision_term_limit: int = Field(
+        default=3,
+        ge=1,
+        le=8,
+        description="Max exact witness-backed proof terms to surface in campaign prompt retries",
+    )
+    revalidate_before_manual_approval: bool = Field(
+        default=True,
+        description="Re-run deterministic witness-backed specificity checks before manual campaign approval",
+    )
+    revalidate_before_queue_send: bool = Field(
+        default=True,
+        description="Re-run deterministic witness-backed specificity checks before queueing a campaign for send",
+    )
+    revalidate_before_send: bool = Field(
+        default=True,
+        description="Re-run deterministic witness-backed specificity checks immediately before campaign auto-send",
+    )
 
 
 class CampaignSequenceConfig(BaseSettings):
@@ -3124,6 +4091,26 @@ class CampaignSequenceConfig(BaseSettings):
 
     enabled: bool = Field(default=False, description="Enable stateful campaign sequences")
     max_steps: int = Field(default=4, ge=2, le=8, description="Max emails per sequence")
+    progression_batch_limit: int = Field(
+        default=10, ge=1, le=250,
+        description="Max due sequences to progress in one task run",
+    )
+    onboarding_max_steps: int = Field(
+        default=4, ge=1, le=8,
+        description="Max emails in the onboarding sequence",
+    )
+    onboarding_sender_name: str = Field(
+        default="Atlas Intel",
+        description="Sender name used in onboarding sequences",
+    )
+    onboarding_sender_company: str = Field(
+        default="Atlas Intelligence",
+        description="Sender company used in onboarding sequences",
+    )
+    onboarding_product_name: str = Field(
+        default="Atlas Intel",
+        description="Display product name used in onboarding sequence prompts",
+    )
     step_delay_days: list[int] = Field(
         default=[3, 5, 7],
         description="Days between steps 1->2, 2->3, 3->4",
@@ -3136,6 +4123,26 @@ class CampaignSequenceConfig(BaseSettings):
     )
     check_interval_seconds: int = Field(
         default=3600, ge=600, description="How often to check for due sequence steps"
+    )
+    prompt_max_tokens: int = Field(
+        default=512, ge=128, le=2048,
+        description="Max completion tokens for next-step sequence generation",
+    )
+    prompt_list_limit: int = Field(
+        default=5, ge=1, le=20,
+        description="Max list items to keep when compacting sequence context for storage and prompts",
+    )
+    prompt_quote_limit: int = Field(
+        default=3, ge=1, le=10,
+        description="Max quotes or short signal items to keep in compact sequence context",
+    )
+    prompt_blog_post_limit: int = Field(
+        default=3, ge=1, le=10,
+        description="Max blog posts to keep in compact sequence selling context",
+    )
+    prompt_email_body_preview_chars: int = Field(
+        default=220, ge=80, le=1000,
+        description="Max plain-text characters to keep per previous-email preview in sequence prompts",
     )
     resend_api_key: str = Field(default="", description="Resend ESP API key")
     resend_from_email: str = Field(default="", description="Resend sender email address")
@@ -3669,6 +4676,65 @@ class NewsIntelligenceConfig(BaseSettings):
     )
 
 
+class ProviderCostConfig(BaseSettings):
+    """Provider billing sync configuration for cost reconciliation."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_PROVIDER_COST_", env_file=ENV_FILES, extra="ignore"
+    )
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable periodic sync of provider billing totals for reconciliation",
+    )
+    interval_seconds: int = Field(
+        default=3600,
+        ge=300,
+        le=86400,
+        description="How often to sync provider billing totals",
+    )
+    sync_timeout_seconds: int = Field(
+        default=20,
+        ge=5,
+        le=300,
+        description="HTTP timeout for provider billing sync requests",
+    )
+    snapshot_retention_days: int = Field(
+        default=90,
+        ge=7,
+        le=730,
+        description="Days to retain cumulative provider usage snapshots",
+    )
+    daily_retention_days: int = Field(
+        default=365,
+        ge=30,
+        le=1825,
+        description="Days to retain imported provider daily cost rows",
+    )
+    openrouter_enabled: bool = Field(
+        default=True,
+        description="Sync OpenRouter cumulative usage snapshots when a management key is available",
+    )
+    openrouter_api_key: str = Field(
+        default="",
+        description="Optional OpenRouter management key override for credits snapshots",
+    )
+    anthropic_enabled: bool = Field(
+        default=False,
+        description="Sync Anthropic admin daily cost reports when an admin key is available",
+    )
+    anthropic_admin_api_key: str = Field(
+        default="",
+        description="Anthropic Admin API key for usage and cost reporting",
+    )
+    anthropic_lookback_days: int = Field(
+        default=7,
+        ge=1,
+        le=31,
+        description="Lookback window for Anthropic daily cost report sync",
+    )
+
+
 class Settings(BaseSettings):
     """Application-wide settings."""
 
@@ -3745,6 +4811,8 @@ class Settings(BaseSettings):
     external_data: ExternalDataConfig = Field(default_factory=ExternalDataConfig)
     b2b_churn: B2BChurnConfig = Field(default_factory=B2BChurnConfig)
     b2b_alert: B2BAlertConfig = Field(default_factory=B2BAlertConfig)
+    b2b_watchlist_delivery: B2BWatchlistDeliveryConfig = Field(default_factory=B2BWatchlistDeliveryConfig)
+    b2b_report_delivery: B2BReportDeliveryConfig = Field(default_factory=B2BReportDeliveryConfig)
     b2b_webhook: B2BWebhookConfig = Field(default_factory=B2BWebhookConfig)
     crm_event: CRMEventConfig = Field(default_factory=CRMEventConfig)
     b2b_scrape: B2BScrapeConfig = Field(default_factory=B2BScrapeConfig)
@@ -3760,6 +4828,7 @@ class Settings(BaseSettings):
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     alert_monitor: AlertMonitorConfig = Field(default_factory=AlertMonitorConfig)
     news_intel: NewsIntelligenceConfig = Field(default_factory=NewsIntelligenceConfig)
+    provider_cost: ProviderCostConfig = Field(default_factory=ProviderCostConfig)
     saas_auth: SaaSAuthConfig = Field(default_factory=SaaSAuthConfig)
 
     # Reasoning agent (cross-domain event-driven intelligence)

--- a/atlas_brain/reasoning/evidence_engine.py
+++ b/atlas_brain/reasoning/evidence_engine.py
@@ -65,6 +65,11 @@ class EvidenceEngine:
             re.compile(p, re.IGNORECASE)
             for p in rec.get("negative_patterns", [])
         ]
+        price = self._enrichment.get("price_complaint_derivation", {})
+        self._price_positive = [
+            re.compile(p, re.IGNORECASE)
+            for p in price.get("positive_patterns", [])
+        ]
 
     # ------------------------------------------------------------------
     # Per-review: enrichment-time compute
@@ -121,10 +126,14 @@ class EvidenceEngine:
         feature_gaps: list[str] | None = None,
         recommendation_language: list[str] | None = None,
     ) -> str:
-        """Override 'other' pain_category using keyword scan."""
+        """Override generic pain_category using keyword scan."""
         cfg = self._enrichment.get("pain_override", {})
         trigger = cfg.get("trigger", {})
-        if pain_category != trigger.get("eq", "other"):
+        trigger_values = trigger.get("in")
+        if isinstance(trigger_values, list):
+            if pain_category not in {str(v).strip().lower() for v in trigger_values if str(v).strip()}:
+                return pain_category
+        elif pain_category != trigger.get("eq", "other"):
             return pain_category
 
         keyword_map: dict[str, list[str]] = cfg.get("keyword_map", {})
@@ -143,18 +152,23 @@ class EvidenceEngine:
             texts.extend(recommendation_language or [])
 
         if not texts:
-            return cfg.get("fallback", "other")
+            return cfg.get("fallback", "overall_dissatisfaction")
 
         combined = " ".join(texts).lower()
+
+        def _keyword_hits(keyword: str) -> bool:
+            pattern = rf"(?<!\w){re.escape(str(keyword or '').lower())}(?!\w)"
+            return bool(re.search(pattern, combined))
+
         scores: dict[str, int] = {}
         for category, keywords in keyword_map.items():
-            count = sum(1 for kw in keywords if kw in combined)
+            count = sum(1 for kw in keywords if _keyword_hits(str(kw)))
             if count > 0:
                 scores[category] = count
 
         if scores:
             return max(scores, key=scores.get)
-        return cfg.get("fallback", "other")
+        return cfg.get("fallback", "overall_dissatisfaction")
 
     def derive_recommend(
         self,
@@ -210,7 +224,22 @@ class EvidenceEngine:
     ) -> bool:
         """Derive price_complaint from Tier 1 flags + extracted phrases."""
         cfg = self._enrichment.get("price_complaint_derivation", {})
+        pricing_phrases = [
+            str(phrase or "").strip()
+            for phrase in enrichment.get("pricing_phrases") or []
+            if str(phrase or "").strip()
+        ]
+        all_pricing_phrases_positive = bool(pricing_phrases) and all(
+            any(pattern.search(phrase) for pattern in self._price_positive)
+            for phrase in pricing_phrases
+        )
         for rule in cfg.get("true_if_any", []):
+            if (
+                rule.get("field") == "pricing_phrases"
+                and "min_count" in rule
+                and all_pricing_phrases_positive
+            ):
+                continue
             if self._check_derivation_rule(rule, enrichment):
                 return True
         return False

--- a/atlas_brain/reasoning/evidence_map.yaml
+++ b/atlas_brain/reasoning/evidence_map.yaml
@@ -47,24 +47,28 @@ enrichment:
     clamp: [0, 10]
 
   pain_override:
-    description: "Override 'other' pain_category using keyword scan"
-    trigger: {field: pain_category, eq: other}
+    description: "Override generic pain_category using keyword scan"
+    trigger: {field: pain_category, in: [other, general_dissatisfaction, overall_dissatisfaction]}
     keyword_map:
-      pricing: [expensive, cost, price, pricing, budget, overpriced, overcharge, costly, fee, fees, subscription, invoice, invoiced, billing, billed, charged, charge, refund, cost increase, price increase, pay for every, paying for, paid for, invested, overpay, nickel and dime, hidden cost, hidden fee, sticker shock, renewal cost, renewal price, per seat, per user, add-on cost, upsell, price hike, price jump, not worth the price, too much money, waste of money, money pit]
-      support: [support, response time, ticket, customer service, helpdesk, wait time, unresponsive]
+      pricing: [expensive, cost, price, pricing, budget, overpriced, overcharge, costly, fee, fees, subscription, invoice, invoiced, billing, billed, charged, charge, refund, cost increase, price increase, pay for every, paying for, paid for, invested, overpay, nickel and dime, hidden cost, hidden fee, sticker shock, renewal cost, renewal price, per seat, per user, add-on cost, upsell, price hike, price jump, not worth the price, too much money, waste of money, money pit, rates, rate increase, not transparent about, deceptive pricing, bait and switch]
+      support: [support, response time, ticket, customer service, helpdesk, wait time, unresponsive, no help, unhelpful, ignored, no response, ghosted, runaround, passed around, escalation, complaint, complaints team]
       reliability: [downtime, outage, crash, bug, unstable, unreliable, broken, error]
       ux: [clunky, unintuitive, confusing, ui, ux, user interface, learning curve, ugly, dated, clumsy]
       performance: [slow, latency, performance, speed, loading, lag, timeout]
       integration: [integration, connector, webhook, incompatible, sync, interop]
       security: [security, breach, vulnerability, compliance, gdpr, soc2, encryption, audit]
       onboarding: [onboarding, setup, implementation, getting started, documentation, tutorial]
-      features: [feature, missing, roadmap, functionality, capability, wishlist, lacking]
+      features: [feature, missing, roadmap, functionality, capability, wishlist, lacking, calendar, scheduling, customization, workflow, template, automation, notification, dashboard, reporting, analytics, export]
       technical_debt: [technical debt, legacy, outdated codebase, deprecated, spaghetti, refactor, tech debt]
-      contract_lock_in: [lock-in, locked in, exit cost, switching cost, vendor lock, contract trap, penalty, cancel, cancellation, terminate, termination, auto renew, automatic renewal, renewed without notice, notice period, contract term, billing dispute, runaround]
+      contract_lock_in: [lock-in, locked in, exit cost, switching cost, vendor lock, contract trap, penalty, cancel, cancellation, terminate, termination, auto renew, automatic renewal, renewed without notice, notice period, contract term, billing dispute, runaround, unsubscribe, delete my account, close my account, deactivate, cannot cancel, won't let me cancel, impossible to cancel, trying to cancel]
       data_migration: [data migration, export, portability, data export, migrate data, data transfer, import]
       api_limitations: [api limit, rate limit, api limitation, missing endpoint, api documentation, throttle, api quota]
+      outcome_gap: [out of the box, only does, partial fit, does 60, does 70, does 80, not enough for our use case, had to work around, had to supplement, needed another tool, does not cover our process, poor fit for our workflow, missing business process support]
+      admin_burden: [dedicated admin, dedicated administrator, salesforce admin, consultant, consultants, consulting, requires consultants, apex, apex development, flow builder, workflow maintenance, maintain workflows, cumbersome setup, too much setup, too much configuration, admin overhead, maintenance overhead, hard to administer, needs constant maintenance, steep learning curve for admins, training investment]
+      ai_hallucination: [hallucination, hallucinates, made up answer, fabricated answer, wrong answer from ai, unsafe ai response, ai gave incorrect, ai summary was wrong, generated false]
+      integration_debt: [app exchange, appexchange, connector broke, integration broke, brittle integration, brittle connector, sync breaks, sync broke, integration maintenance, integration drift, middleware dependency, custom integration, patch integration after updates, update broke integration, after updates, constant maintenance, breaking after updates]
     scan_fields: [specific_complaints, quotable_phrases, pricing_phrases, feature_gaps, recommendation_language]
-    fallback: other
+    fallback: overall_dissatisfaction
 
   recommend_derivation:
     description: "Derive would_recommend from extracted language + rating"
@@ -93,6 +97,15 @@ enrichment:
 
   price_complaint_derivation:
     description: "Derive price_complaint from Tier 1 flags + extracted phrases"
+    positive_patterns:
+      - "\\bpricing (?:is )?reasonable\\b"
+      - "\\bprice(?:s|d)? (?:is|are|was|were)? reasonable\\b"
+      - "\\b(?:cost|pricing) (?:is|was|were|seems)? fair\\b"
+      - "\\baffordable\\b"
+      - "\\bgood value\\b"
+      - "\\bworth (?:the|its) price\\b"
+      - "\\bpricing (?:works|worked) for us\\b"
+      - "\\bmet all (?:of )?our expectations\\b"
     true_if_any:
       - {field: "budget_signals.price_increase_mentioned", eq: true}
       - {field: "pricing_phrases", min_count: 1}

--- a/atlas_brain/services/b2b/anthropic_batch.py
+++ b/atlas_brain/services/b2b/anthropic_batch.py
@@ -1,0 +1,1449 @@
+"""Shared Anthropic Message Batch helpers for B2B content workloads."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+from ...config import settings
+from ...pipelines.llm import trace_llm_call
+from ..llm.anthropic import AnthropicLLM
+from ..protocols import Message
+
+logger = logging.getLogger("atlas.services.b2b.anthropic_batch")
+
+_BATCH_ENDPOINT = "https://api.anthropic.com/v1/messages/batches"
+_BATCH_DISCOUNT_FACTOR = 0.5
+
+
+@dataclass(frozen=True)
+class AnthropicBatchItem:
+    custom_id: str
+    artifact_type: str
+    artifact_id: str
+    messages: Sequence[Message | dict[str, Any]]
+    max_tokens: int
+    temperature: float
+    vendor_name: str | None = None
+    trace_span_name: str = ""
+    trace_metadata: dict[str, Any] = field(default_factory=dict)
+    request_metadata: dict[str, Any] = field(default_factory=dict)
+    cached_response_text: str | None = None
+    cached_usage: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AnthropicBatchItemResult:
+    custom_id: str
+    artifact_type: str
+    artifact_id: str
+    vendor_name: str | None
+    response_text: str | None = None
+    usage: dict[str, Any] = field(default_factory=dict)
+    cached: bool = False
+    success: bool = False
+    fallback_required: bool = False
+    error_text: str | None = None
+    provider_request_id: str | None = None
+    item_status: str = ""
+
+
+@dataclass
+class AnthropicBatchExecution:
+    local_batch_id: str
+    provider_batch_id: str | None
+    stage_id: str
+    task_name: str
+    status: str
+    results_by_custom_id: dict[str, AnthropicBatchItemResult]
+    submitted_items: int
+    cache_prefiltered_items: int
+    fallback_single_call_items: int
+    completed_items: int
+    failed_items: int
+
+
+def _persisted_request_metadata(item: AnthropicBatchItem) -> dict[str, Any]:
+    metadata = dict(item.request_metadata or {})
+    metadata.setdefault("_trace_span_name", item.trace_span_name)
+    metadata.setdefault("_trace_metadata", dict(item.trace_metadata or {}))
+    metadata.setdefault(
+        "_messages",
+        [
+            {
+                "role": _message_from_value(message).role,
+                "content": _message_from_value(message).content,
+            }
+            for message in item.messages
+        ],
+    )
+    metadata.setdefault("_max_tokens", int(item.max_tokens))
+    metadata.setdefault("_temperature", float(item.temperature))
+    return metadata
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _message_from_value(value: Message | dict[str, Any]) -> Message:
+    if isinstance(value, Message):
+        return value
+    if isinstance(value, dict):
+        return Message(
+            role=str(value.get("role") or ""),
+            content=str(value.get("content") or ""),
+            tool_calls=value.get("tool_calls"),
+            tool_call_id=value.get("tool_call_id"),
+        )
+    raise TypeError(f"Unsupported Anthropic batch message type: {type(value)!r}")
+
+
+def _resolve_pool(pool: Any | None) -> Any | None:
+    if pool is not None:
+        return pool
+    from ...storage.database import get_db_pool
+
+    db_pool = get_db_pool()
+    if not db_pool.is_initialized:
+        return None
+    return db_pool
+
+
+async def _safe_execute(pool: Any | None, query: str, *args: Any) -> None:
+    if pool is None:
+        return
+    try:
+        await pool.execute(query, *args)
+    except Exception:
+        logger.exception("anthropic_batch.db_execute_failed")
+
+
+def _standard_cost_usd(
+    *,
+    provider: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cached_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    billable_input_tokens: int | None = None,
+) -> float:
+    return float(
+        settings.ftl_tracing.pricing.cost_usd(
+            provider,
+            model,
+            input_tokens,
+            output_tokens,
+            cached_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+            billable_input_tokens=billable_input_tokens,
+        )
+    )
+
+
+def _batch_cost_usd(**kwargs: Any) -> float:
+    return round(_standard_cost_usd(**kwargs) * _BATCH_DISCOUNT_FACTOR, 6)
+
+
+def _extract_message_text_and_usage(message: Any) -> tuple[str, dict[str, Any], str | None]:
+    text_parts: list[str] = []
+    for block in getattr(message, "content", []) or []:
+        if getattr(block, "type", None) == "text":
+            text = getattr(block, "text", "")
+            if text:
+                text_parts.append(str(text))
+    usage = getattr(message, "usage", None)
+    cache_read = getattr(usage, "cache_read_input_tokens", None) if usage is not None else None
+    cache_write = (
+        getattr(usage, "cache_creation_input_tokens", None)
+        if usage is not None
+        else None
+    )
+    input_tokens = int(getattr(usage, "input_tokens", 0) or 0) if usage is not None else 0
+    output_tokens = int(getattr(usage, "output_tokens", 0) or 0) if usage is not None else 0
+    usage_payload = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "billable_input_tokens": input_tokens,
+        "cached_tokens": int(cache_read or 0),
+        "cache_write_tokens": int(cache_write or 0),
+    }
+    provider_request_id = getattr(message, "id", None)
+    return "\n".join(text_parts).strip() or None, usage_payload, str(provider_request_id or "") or None
+
+
+def _trace_batched_item(
+    *,
+    item: AnthropicBatchItem,
+    llm: AnthropicLLM,
+    usage: dict[str, Any],
+    response_text: str,
+    provider_request_id: str | None,
+    duration_ms: float,
+    provider_batch_id: str,
+) -> None:
+    metadata = dict(item.trace_metadata)
+    metadata.setdefault("execution_strategy", "anthropic_batch")
+    metadata.setdefault("stage_id", "")
+    metadata["provider_batch_id"] = provider_batch_id
+    if item.vendor_name and not metadata.get("vendor_name"):
+        metadata["vendor_name"] = item.vendor_name
+
+    batch_cost = _batch_cost_usd(
+        provider=str(getattr(llm, "name", "") or ""),
+        model=str(getattr(llm, "model", "") or ""),
+        input_tokens=int(usage.get("input_tokens") or 0),
+        output_tokens=int(usage.get("output_tokens") or 0),
+        cached_tokens=int(usage.get("cached_tokens") or 0),
+        cache_write_tokens=int(usage.get("cache_write_tokens") or 0),
+        billable_input_tokens=(
+            int(usage["billable_input_tokens"])
+            if usage.get("billable_input_tokens") is not None
+            else None
+        ),
+    )
+
+    trace_llm_call(
+        span_name=item.trace_span_name,
+        input_tokens=int(usage.get("input_tokens") or 0),
+        output_tokens=int(usage.get("output_tokens") or 0),
+        cached_tokens=int(usage.get("cached_tokens") or 0),
+        cache_write_tokens=int(usage.get("cache_write_tokens") or 0),
+        billable_input_tokens=(
+            int(usage["billable_input_tokens"])
+            if usage.get("billable_input_tokens") is not None
+            else None
+        ),
+        model=str(getattr(llm, "model", "") or ""),
+        provider=str(getattr(llm, "name", "") or ""),
+        duration_ms=duration_ms,
+        metadata=metadata,
+        input_data={
+            "messages": [
+                {
+                    "role": _message_from_value(msg).role,
+                    "content": _message_from_value(msg).content[:500],
+                }
+                for msg in item.messages
+            ]
+        },
+        output_data={"response": response_text[:2000]} if response_text else None,
+        api_endpoint=_BATCH_ENDPOINT,
+        provider_request_id=provider_request_id,
+        cost_usd_override=batch_cost,
+    )
+
+
+async def _insert_batch_job(
+    *,
+    pool: Any | None,
+    local_batch_id: str,
+    stage_id: str,
+    task_name: str,
+    run_id: str | None,
+    total_items: int,
+    cache_prefiltered_items: int,
+    metadata: dict[str, Any] | None,
+) -> None:
+    await _safe_execute(
+        pool,
+        """
+        INSERT INTO anthropic_message_batches (
+            id, stage_id, task_name, run_id, status, total_items,
+            cache_prefiltered_items, metadata
+        ) VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::jsonb)
+        ON CONFLICT (id) DO NOTHING
+        """,
+        local_batch_id,
+        stage_id,
+        task_name,
+        run_id,
+        "preparing",
+        total_items,
+        cache_prefiltered_items,
+        json.dumps(metadata or {}, default=str),
+    )
+
+
+async def _insert_batch_item(
+    *,
+    pool: Any | None,
+    local_batch_id: str,
+    stage_id: str,
+    item: AnthropicBatchItem,
+    status: str,
+    cache_prefiltered: bool,
+    fallback_single_call: bool,
+    response_text: str | None = None,
+    usage: dict[str, Any] | None = None,
+    provider_request_id: str | None = None,
+    error_text: str | None = None,
+) -> None:
+    usage_payload = dict(usage or {})
+    cost_usd = 0.0
+    if response_text and usage_payload:
+        cost_usd = _batch_cost_usd(
+            provider="anthropic",
+            model=str(item.trace_metadata.get("model") or ""),
+            input_tokens=int(usage_payload.get("input_tokens") or 0),
+            output_tokens=int(usage_payload.get("output_tokens") or 0),
+            cached_tokens=int(usage_payload.get("cached_tokens") or 0),
+            cache_write_tokens=int(usage_payload.get("cache_write_tokens") or 0),
+            billable_input_tokens=(
+                int(usage_payload["billable_input_tokens"])
+                if usage_payload.get("billable_input_tokens") is not None
+                else None
+            ),
+        )
+    await _safe_execute(
+        pool,
+        """
+        INSERT INTO anthropic_message_batch_items (
+            id, batch_id, custom_id, stage_id, artifact_type, artifact_id,
+            vendor_name, status, cache_prefiltered, fallback_single_call,
+            response_text, input_tokens, billable_input_tokens, cached_tokens,
+            cache_write_tokens, output_tokens, cost_usd, provider_request_id,
+            error_text, request_metadata, completed_at
+        ) VALUES (
+            gen_random_uuid(), $1::uuid, $2, $3, $4, $5,
+            $6, $7, $8, $9,
+            $10, $11, $12, $13,
+            $14, $15, $16, $17,
+            $18, $19::jsonb,
+            CASE WHEN $7 IN ('cache_hit', 'batch_succeeded', 'fallback_succeeded', 'fallback_failed', 'batch_errored', 'batch_expired', 'batch_canceled') THEN NOW() ELSE NULL END
+        )
+        ON CONFLICT (batch_id, custom_id) DO UPDATE
+        SET status = EXCLUDED.status,
+            cache_prefiltered = EXCLUDED.cache_prefiltered,
+            fallback_single_call = EXCLUDED.fallback_single_call,
+            response_text = EXCLUDED.response_text,
+            input_tokens = EXCLUDED.input_tokens,
+            billable_input_tokens = EXCLUDED.billable_input_tokens,
+            cached_tokens = EXCLUDED.cached_tokens,
+            cache_write_tokens = EXCLUDED.cache_write_tokens,
+            output_tokens = EXCLUDED.output_tokens,
+            cost_usd = EXCLUDED.cost_usd,
+            provider_request_id = EXCLUDED.provider_request_id,
+            error_text = EXCLUDED.error_text,
+            request_metadata = EXCLUDED.request_metadata,
+            completed_at = EXCLUDED.completed_at
+        """,
+        local_batch_id,
+        item.custom_id,
+        stage_id,
+        item.artifact_type,
+        item.artifact_id,
+        item.vendor_name,
+        status,
+        cache_prefiltered,
+        fallback_single_call,
+        response_text,
+        int(usage_payload.get("input_tokens") or 0),
+        int(usage_payload.get("billable_input_tokens") or 0),
+        int(usage_payload.get("cached_tokens") or 0),
+        int(usage_payload.get("cache_write_tokens") or 0),
+        int(usage_payload.get("output_tokens") or 0),
+        cost_usd,
+        provider_request_id,
+        error_text,
+        json.dumps(_persisted_request_metadata(item), default=str),
+    )
+
+
+async def _update_batch_job(
+    *,
+    pool: Any | None,
+    local_batch_id: str,
+    status: str,
+    provider_batch_id: str | None = None,
+    submitted_items: int | None = None,
+    fallback_single_call_items: int | None = None,
+    completed_items: int | None = None,
+    failed_items: int | None = None,
+    estimated_sequential_cost_usd: float | None = None,
+    estimated_batch_cost_usd: float | None = None,
+    provider_error: str | None = None,
+    completed_at: datetime | None = None,
+) -> None:
+    await _safe_execute(
+        pool,
+        """
+        UPDATE anthropic_message_batches
+        SET status = $2,
+            provider_batch_id = COALESCE($3, provider_batch_id),
+            submitted_items = COALESCE($4, submitted_items),
+            fallback_single_call_items = COALESCE($5, fallback_single_call_items),
+            completed_items = COALESCE($6, completed_items),
+            failed_items = COALESCE($7, failed_items),
+            estimated_sequential_cost_usd = COALESCE($8, estimated_sequential_cost_usd),
+            estimated_batch_cost_usd = COALESCE($9, estimated_batch_cost_usd),
+            provider_error = COALESCE($10, provider_error),
+            submitted_at = CASE WHEN $3 IS NOT NULL THEN COALESCE(submitted_at, NOW()) ELSE submitted_at END,
+            completed_at = COALESCE($11, completed_at),
+            updated_at = NOW()
+        WHERE id = $1::uuid
+        """,
+        local_batch_id,
+        status,
+        provider_batch_id,
+        submitted_items,
+        fallback_single_call_items,
+        completed_items,
+        failed_items,
+        estimated_sequential_cost_usd,
+        estimated_batch_cost_usd,
+        provider_error,
+        completed_at,
+    )
+
+
+def _build_request_params(llm: AnthropicLLM, item: AnthropicBatchItem) -> dict[str, Any]:
+    messages = [_message_from_value(message) for message in item.messages]
+    system_prompt, api_messages = llm._convert_messages(messages)  # type: ignore[attr-defined]
+    params: dict[str, Any] = {
+        "model": llm.model,
+        "messages": api_messages,
+        "max_tokens": int(item.max_tokens),
+        "temperature": float(item.temperature),
+    }
+    if system_prompt:
+        params["system"] = system_prompt
+    return params
+
+
+def _rebuild_item_from_row(row: Any) -> AnthropicBatchItem:
+    metadata = row.get("request_metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except Exception:
+            metadata = {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    raw_messages = metadata.get("_messages") or []
+    messages = [
+        Message(
+            role=str((message or {}).get("role") or ""),
+            content=str((message or {}).get("content") or ""),
+        )
+        for message in raw_messages
+        if isinstance(message, dict)
+    ]
+    trace_metadata = metadata.get("_trace_metadata")
+    if not isinstance(trace_metadata, dict):
+        trace_metadata = {}
+    public_request_metadata = {
+        key: value for key, value in metadata.items() if not str(key).startswith("_")
+    }
+    return AnthropicBatchItem(
+        custom_id=str(row.get("custom_id") or ""),
+        artifact_type=str(row.get("artifact_type") or ""),
+        artifact_id=str(row.get("artifact_id") or ""),
+        vendor_name=str(row.get("vendor_name") or "") or None,
+        messages=messages,
+        max_tokens=int(metadata.get("_max_tokens") or 0 or 256),
+        temperature=float(metadata.get("_temperature") or 0.0),
+        trace_span_name=str(metadata.get("_trace_span_name") or ""),
+        trace_metadata=trace_metadata,
+        request_metadata=public_request_metadata,
+    )
+
+
+async def submit_anthropic_message_batch(
+    *,
+    llm: Any,
+    stage_id: str,
+    task_name: str,
+    items: Sequence[AnthropicBatchItem],
+    run_id: str | None = None,
+    min_batch_size: int = 2,
+    batch_metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> AnthropicBatchExecution:
+    """Submit a batch and persist durable item state without waiting for results."""
+    local_batch_id = str(uuid.uuid4())
+    db_pool = _resolve_pool(pool)
+    results: dict[str, AnthropicBatchItemResult] = {}
+    cache_prefiltered_items = 0
+    pending_items: list[AnthropicBatchItem] = []
+
+    await _insert_batch_job(
+        pool=db_pool,
+        local_batch_id=local_batch_id,
+        stage_id=stage_id,
+        task_name=task_name,
+        run_id=run_id,
+        total_items=len(items),
+        cache_prefiltered_items=sum(1 for item in items if item.cached_response_text is not None),
+        metadata=batch_metadata,
+    )
+
+    for item in items:
+        if item.cached_response_text is not None:
+            cache_prefiltered_items += 1
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                response_text=item.cached_response_text,
+                usage=dict(item.cached_usage),
+                cached=True,
+                success=True,
+                item_status="cache_hit",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="cache_hit",
+                cache_prefiltered=True,
+                fallback_single_call=False,
+                response_text=item.cached_response_text,
+                usage=item.cached_usage,
+            )
+        else:
+            pending_items.append(item)
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="pending",
+                cache_prefiltered=False,
+                fallback_single_call=False,
+            )
+
+    if not pending_items:
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="prefiltered_only",
+            submitted_items=0,
+            completed_items=0,
+            failed_items=0,
+            fallback_single_call_items=0,
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=None,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="prefiltered_only",
+            results_by_custom_id=results,
+            submitted_items=0,
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=0,
+            completed_items=0,
+            failed_items=0,
+        )
+
+    if not isinstance(llm, AnthropicLLM) or getattr(llm, "_async_client", None) is None:
+        for item in pending_items:
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text="anthropic_batch_unavailable",
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text="anthropic_batch_unavailable",
+            )
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="fallback_only",
+            submitted_items=0,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+            provider_error="anthropic_batch_unavailable",
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=None,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="fallback_only",
+            results_by_custom_id=results,
+            submitted_items=0,
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+        )
+
+    if len(pending_items) < int(min_batch_size):
+        for item in pending_items:
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text="batch_min_items_not_met",
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text="batch_min_items_not_met",
+            )
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="fallback_only",
+            submitted_items=0,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+            provider_error="batch_min_items_not_met",
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=None,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="fallback_only",
+            results_by_custom_id=results,
+            submitted_items=0,
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+        )
+
+    request_items = [
+        {"custom_id": item.custom_id, "params": _build_request_params(llm, item)}
+        for item in pending_items
+    ]
+    client = llm._async_client
+    batch = await client.messages.batches.create(requests=request_items)
+    provider_batch_id = str(batch.id)
+    await _update_batch_job(
+        pool=db_pool,
+        local_batch_id=local_batch_id,
+        status=str(batch.processing_status),
+        provider_batch_id=provider_batch_id,
+        submitted_items=len(pending_items),
+    )
+    return AnthropicBatchExecution(
+        local_batch_id=local_batch_id,
+        provider_batch_id=provider_batch_id,
+        stage_id=stage_id,
+        task_name=task_name,
+        status=str(batch.processing_status),
+        results_by_custom_id=results,
+        submitted_items=len(pending_items),
+        cache_prefiltered_items=cache_prefiltered_items,
+        fallback_single_call_items=0,
+        completed_items=0,
+        failed_items=0,
+    )
+
+
+async def reconcile_anthropic_message_batch(
+    *,
+    llm: Any,
+    local_batch_id: str,
+    pool: Any | None = None,
+    timeout_seconds: float | None = None,
+) -> AnthropicBatchExecution:
+    """Reconcile one submitted batch by polling provider status and ingesting results."""
+    db_pool = _resolve_pool(pool)
+    row = await db_pool.fetchrow(
+        """
+        SELECT id, stage_id, task_name, run_id, status, provider_batch_id
+        FROM anthropic_message_batches
+        WHERE id = $1::uuid
+        """,
+        local_batch_id,
+    ) if db_pool is not None else None
+    if not row:
+        raise ValueError(f"Unknown Anthropic batch id: {local_batch_id}")
+
+    item_rows = await db_pool.fetch(
+        """
+        SELECT *
+        FROM anthropic_message_batch_items
+        WHERE batch_id = $1::uuid
+        ORDER BY created_at ASC
+        """,
+        local_batch_id,
+    ) if db_pool is not None else []
+
+    results: dict[str, AnthropicBatchItemResult] = {}
+    for item_row in item_rows:
+        status = str(item_row.get("status") or "")
+        response_text = item_row.get("response_text")
+        usage = {
+            "input_tokens": int(item_row.get("input_tokens") or 0),
+            "billable_input_tokens": int(item_row.get("billable_input_tokens") or 0),
+            "cached_tokens": int(item_row.get("cached_tokens") or 0),
+            "cache_write_tokens": int(item_row.get("cache_write_tokens") or 0),
+            "output_tokens": int(item_row.get("output_tokens") or 0),
+        }
+        if status in {
+            "cache_hit",
+            "batch_succeeded",
+            "fallback_succeeded",
+            "fallback_failed",
+            "batch_errored",
+            "batch_expired",
+            "batch_canceled",
+        }:
+            results[str(item_row["custom_id"])] = AnthropicBatchItemResult(
+                custom_id=str(item_row["custom_id"]),
+                artifact_type=str(item_row["artifact_type"]),
+                artifact_id=str(item_row["artifact_id"]),
+                vendor_name=str(item_row.get("vendor_name") or "") or None,
+                response_text=str(response_text) if response_text else None,
+                usage=usage,
+                cached=status == "cache_hit",
+                success=status in {"cache_hit", "batch_succeeded", "fallback_succeeded"},
+                fallback_required=status == "fallback_pending",
+                error_text=str(item_row.get("error_text") or "") or None,
+                provider_request_id=str(item_row.get("provider_request_id") or "") or None,
+                item_status=status,
+            )
+
+    pending_rows = [row for row in item_rows if str(row.get("status") or "") == "pending"]
+    cache_prefiltered_items = sum(1 for item_row in item_rows if bool(item_row.get("cache_prefiltered")))
+    fallback_items = sum(1 for item_row in item_rows if bool(item_row.get("fallback_single_call")))
+
+    if not pending_rows or not row.get("provider_batch_id") or not isinstance(llm, AnthropicLLM) or getattr(llm, "_async_client", None) is None:
+        completed_items = sum(1 for item_row in item_rows if str(item_row.get("status") or "") in {"cache_hit", "batch_succeeded", "fallback_succeeded"})
+        failed_items = sum(1 for item_row in item_rows if str(item_row.get("status") or "") in {"fallback_failed", "batch_errored", "batch_expired", "batch_canceled"})
+        return AnthropicBatchExecution(
+            local_batch_id=str(row["id"]),
+            provider_batch_id=str(row.get("provider_batch_id") or "") or None,
+            stage_id=str(row.get("stage_id") or ""),
+            task_name=str(row.get("task_name") or ""),
+            status=str(row.get("status") or ""),
+            results_by_custom_id=results,
+            submitted_items=len(pending_rows),
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=fallback_items,
+            completed_items=completed_items,
+            failed_items=failed_items,
+        )
+
+    timeout = float(
+        timeout_seconds
+        if timeout_seconds is not None
+        else settings.b2b_churn.anthropic_batch_timeout_seconds
+    )
+    client = llm._async_client
+    provider_batch_id = str(row["provider_batch_id"])
+    batch = await client.messages.batches.retrieve(provider_batch_id, timeout=timeout)
+    await _update_batch_job(
+        pool=db_pool,
+        local_batch_id=str(row["id"]),
+        status=str(batch.processing_status),
+        provider_batch_id=provider_batch_id,
+        submitted_items=len(pending_rows),
+    )
+    if str(batch.processing_status) != "ended":
+        completed_items = sum(1 for item_row in item_rows if str(item_row.get("status") or "") in {"cache_hit", "batch_succeeded", "fallback_succeeded"})
+        failed_items = sum(1 for item_row in item_rows if str(item_row.get("status") or "") in {"fallback_failed", "batch_errored", "batch_expired", "batch_canceled"})
+        return AnthropicBatchExecution(
+            local_batch_id=str(row["id"]),
+            provider_batch_id=provider_batch_id,
+            stage_id=str(row.get("stage_id") or ""),
+            task_name=str(row.get("task_name") or ""),
+            status=str(batch.processing_status),
+            results_by_custom_id=results,
+            submitted_items=len(pending_rows),
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=fallback_items,
+            completed_items=completed_items,
+            failed_items=failed_items,
+        )
+
+    result_stream = await client.messages.batches.results(provider_batch_id, timeout=timeout)
+    result_map: dict[str, Any] = {}
+    async for result_row in result_stream:
+        result_map[str(result_row.custom_id)] = result_row.result
+
+    completed_items = 0
+    failed_items = 0
+    fallback_items = 0
+    sequential_cost_usd = 0.0
+    batch_cost_usd = 0.0
+    for item_row in pending_rows:
+        item = _rebuild_item_from_row(item_row)
+        raw_result = result_map.get(item.custom_id)
+        if raw_result is None:
+            failed_items += 1
+            fallback_items += 1
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text="missing_batch_result",
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=str(row["id"]),
+                stage_id=str(row["stage_id"]),
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text="missing_batch_result",
+            )
+            continue
+
+        result_type = str(getattr(raw_result, "type", "") or "")
+        if result_type == "succeeded":
+            response_text, usage, provider_request_id = _extract_message_text_and_usage(raw_result.message)
+            if response_text:
+                completed_items += 1
+                standard_cost = _standard_cost_usd(
+                    provider=str(getattr(llm, "name", "") or ""),
+                    model=str(getattr(llm, "model", "") or ""),
+                    input_tokens=int(usage.get("input_tokens") or 0),
+                    output_tokens=int(usage.get("output_tokens") or 0),
+                    cached_tokens=int(usage.get("cached_tokens") or 0),
+                    cache_write_tokens=int(usage.get("cache_write_tokens") or 0),
+                    billable_input_tokens=(
+                        int(usage["billable_input_tokens"])
+                        if usage.get("billable_input_tokens") is not None
+                        else None
+                    ),
+                )
+                sequential_cost_usd += standard_cost
+                batch_cost_usd += round(standard_cost * _BATCH_DISCOUNT_FACTOR, 6)
+                _trace_batched_item(
+                    item=item,
+                    llm=llm,
+                    usage=usage,
+                    response_text=response_text,
+                    provider_request_id=provider_request_id,
+                    duration_ms=0.0,
+                    provider_batch_id=provider_batch_id,
+                )
+                results[item.custom_id] = AnthropicBatchItemResult(
+                    custom_id=item.custom_id,
+                    artifact_type=item.artifact_type,
+                    artifact_id=item.artifact_id,
+                    vendor_name=item.vendor_name,
+                    response_text=response_text,
+                    usage=usage,
+                    success=True,
+                    provider_request_id=provider_request_id,
+                    item_status="batch_succeeded",
+                )
+                await _insert_batch_item(
+                    pool=db_pool,
+                    local_batch_id=str(row["id"]),
+                    stage_id=str(row["stage_id"]),
+                    item=item,
+                    status="batch_succeeded",
+                    cache_prefiltered=False,
+                    fallback_single_call=False,
+                    response_text=response_text,
+                    usage=usage,
+                    provider_request_id=provider_request_id,
+                )
+                continue
+
+        failed_items += 1
+        fallback_items += 1
+        if result_type == "errored":
+            error = getattr(raw_result, "error", None)
+            error_text = str(getattr(error, "message", "") or getattr(error, "type", "") or "batch_errored")
+            item_status = "batch_errored"
+        elif result_type == "expired":
+            error_text = "batch_expired"
+            item_status = "batch_expired"
+        else:
+            error_text = "batch_canceled"
+            item_status = "batch_canceled"
+        results[item.custom_id] = AnthropicBatchItemResult(
+            custom_id=item.custom_id,
+            artifact_type=item.artifact_type,
+            artifact_id=item.artifact_id,
+            vendor_name=item.vendor_name,
+            fallback_required=True,
+            error_text=error_text,
+            item_status="fallback_pending",
+        )
+        await _insert_batch_item(
+            pool=db_pool,
+            local_batch_id=str(row["id"]),
+            stage_id=str(row["stage_id"]),
+            item=item,
+            status=item_status,
+            cache_prefiltered=False,
+            fallback_single_call=True,
+            error_text=error_text,
+        )
+
+    await _update_batch_job(
+        pool=db_pool,
+        local_batch_id=str(row["id"]),
+        status="ended",
+        provider_batch_id=provider_batch_id,
+        submitted_items=len(pending_rows),
+        fallback_single_call_items=fallback_items,
+        completed_items=completed_items,
+        failed_items=failed_items,
+        estimated_sequential_cost_usd=round(sequential_cost_usd, 6),
+        estimated_batch_cost_usd=round(batch_cost_usd, 6),
+        completed_at=_utcnow(),
+    )
+    return AnthropicBatchExecution(
+        local_batch_id=str(row["id"]),
+        provider_batch_id=provider_batch_id,
+        stage_id=str(row.get("stage_id") or ""),
+        task_name=str(row.get("task_name") or ""),
+        status="ended",
+        results_by_custom_id=results,
+        submitted_items=len(pending_rows),
+        cache_prefiltered_items=cache_prefiltered_items,
+        fallback_single_call_items=fallback_items,
+        completed_items=completed_items,
+        failed_items=failed_items,
+    )
+
+
+async def run_anthropic_message_batch(
+    *,
+    llm: Any,
+    stage_id: str,
+    task_name: str,
+    items: Sequence[AnthropicBatchItem],
+    run_id: str | None = None,
+    min_batch_size: int = 2,
+    poll_interval_seconds: float | None = None,
+    timeout_seconds: float | None = None,
+    batch_metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> AnthropicBatchExecution:
+    """Submit and reconcile one Anthropic Message Batch with safe fallback flags."""
+    local_batch_id = str(uuid.uuid4())
+    db_pool = _resolve_pool(pool)
+    results: dict[str, AnthropicBatchItemResult] = {}
+    cache_prefiltered_items = 0
+    pending_items: list[AnthropicBatchItem] = []
+
+    await _insert_batch_job(
+        pool=db_pool,
+        local_batch_id=local_batch_id,
+        stage_id=stage_id,
+        task_name=task_name,
+        run_id=run_id,
+        total_items=len(items),
+        cache_prefiltered_items=sum(1 for item in items if item.cached_response_text is not None),
+        metadata=batch_metadata,
+    )
+
+    for item in items:
+        if item.cached_response_text is not None:
+            cache_prefiltered_items += 1
+            result = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                response_text=item.cached_response_text,
+                usage=dict(item.cached_usage),
+                cached=True,
+                success=True,
+                item_status="cache_hit",
+            )
+            results[item.custom_id] = result
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="cache_hit",
+                cache_prefiltered=True,
+                fallback_single_call=False,
+                response_text=item.cached_response_text,
+                usage=item.cached_usage,
+            )
+        else:
+            pending_items.append(item)
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="pending",
+                cache_prefiltered=False,
+                fallback_single_call=False,
+            )
+
+    if not pending_items:
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="prefiltered_only",
+            submitted_items=0,
+            completed_items=0,
+            failed_items=0,
+            fallback_single_call_items=0,
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=None,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="prefiltered_only",
+            results_by_custom_id=results,
+            submitted_items=0,
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=0,
+            completed_items=0,
+            failed_items=0,
+        )
+
+    if not isinstance(llm, AnthropicLLM) or getattr(llm, "_async_client", None) is None:
+        for item in pending_items:
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text="anthropic_batch_unavailable",
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text="anthropic_batch_unavailable",
+            )
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="fallback_only",
+            submitted_items=0,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+            provider_error="anthropic_batch_unavailable",
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=None,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="fallback_only",
+            results_by_custom_id=results,
+            submitted_items=0,
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+        )
+
+    if len(pending_items) < int(min_batch_size):
+        for item in pending_items:
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text="batch_min_items_not_met",
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text="batch_min_items_not_met",
+            )
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="fallback_only",
+            submitted_items=0,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+            provider_error="batch_min_items_not_met",
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=None,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="fallback_only",
+            results_by_custom_id=results,
+            submitted_items=0,
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+        )
+
+    request_items = [
+        {
+            "custom_id": item.custom_id,
+            "params": _build_request_params(llm, item),
+        }
+        for item in pending_items
+    ]
+
+    poll_seconds = float(
+        poll_interval_seconds
+        if poll_interval_seconds is not None
+        else settings.b2b_churn.anthropic_batch_poll_interval_seconds
+    )
+    timeout = float(
+        timeout_seconds
+        if timeout_seconds is not None
+        else settings.b2b_churn.anthropic_batch_timeout_seconds
+    )
+    client = llm._async_client
+    provider_batch_id: str | None = None
+    started = time.monotonic()
+
+    try:
+        batch = await client.messages.batches.create(requests=request_items, timeout=timeout)
+        provider_batch_id = str(batch.id)
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status=str(batch.processing_status),
+            provider_batch_id=provider_batch_id,
+            submitted_items=len(pending_items),
+        )
+
+        while str(batch.processing_status) != "ended":
+            if time.monotonic() - started >= timeout:
+                raise TimeoutError("anthropic_batch_timeout")
+            await asyncio.sleep(poll_seconds)
+            batch = await client.messages.batches.retrieve(provider_batch_id, timeout=timeout)
+            await _update_batch_job(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                status=str(batch.processing_status),
+                provider_batch_id=provider_batch_id,
+                submitted_items=len(pending_items),
+            )
+
+        result_stream = await client.messages.batches.results(provider_batch_id, timeout=timeout)
+        result_map: dict[str, Any] = {}
+        async for row in result_stream:
+            result_map[str(row.custom_id)] = row.result
+    except Exception as exc:
+        error_text = str(exc) or type(exc).__name__
+        for item in pending_items:
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text=error_text,
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text=error_text,
+            )
+        await _update_batch_job(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            status="timed_out" if "timeout" in error_text.lower() else "failed",
+            provider_batch_id=provider_batch_id,
+            submitted_items=len(pending_items),
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+            provider_error=error_text[:500],
+            completed_at=_utcnow(),
+        )
+        return AnthropicBatchExecution(
+            local_batch_id=local_batch_id,
+            provider_batch_id=provider_batch_id,
+            stage_id=stage_id,
+            task_name=task_name,
+            status="timed_out" if "timeout" in error_text.lower() else "failed",
+            results_by_custom_id=results,
+            submitted_items=len(pending_items),
+            cache_prefiltered_items=cache_prefiltered_items,
+            fallback_single_call_items=len(pending_items),
+            completed_items=0,
+            failed_items=len(pending_items),
+        )
+
+    completed_items = 0
+    failed_items = 0
+    fallback_items = 0
+    sequential_cost_usd = 0.0
+    batch_cost_usd = 0.0
+
+    for item in pending_items:
+        raw_result = result_map.get(item.custom_id)
+        if raw_result is None:
+            failed_items += 1
+            fallback_items += 1
+            results[item.custom_id] = AnthropicBatchItemResult(
+                custom_id=item.custom_id,
+                artifact_type=item.artifact_type,
+                artifact_id=item.artifact_id,
+                vendor_name=item.vendor_name,
+                fallback_required=True,
+                error_text="missing_batch_result",
+                item_status="fallback_pending",
+            )
+            await _insert_batch_item(
+                pool=db_pool,
+                local_batch_id=local_batch_id,
+                stage_id=stage_id,
+                item=item,
+                status="fallback_pending",
+                cache_prefiltered=False,
+                fallback_single_call=True,
+                error_text="missing_batch_result",
+            )
+            continue
+
+        result_type = str(getattr(raw_result, "type", "") or "")
+        if result_type == "succeeded":
+            response_text, usage, provider_request_id = _extract_message_text_and_usage(raw_result.message)
+            if response_text:
+                completed_items += 1
+                standard_cost = _standard_cost_usd(
+                    provider=str(getattr(llm, "name", "") or ""),
+                    model=str(getattr(llm, "model", "") or ""),
+                    input_tokens=int(usage.get("input_tokens") or 0),
+                    output_tokens=int(usage.get("output_tokens") or 0),
+                    cached_tokens=int(usage.get("cached_tokens") or 0),
+                    cache_write_tokens=int(usage.get("cache_write_tokens") or 0),
+                    billable_input_tokens=(
+                        int(usage["billable_input_tokens"])
+                        if usage.get("billable_input_tokens") is not None
+                        else None
+                    ),
+                )
+                sequential_cost_usd += standard_cost
+                batch_cost_usd += round(standard_cost * _BATCH_DISCOUNT_FACTOR, 6)
+                _trace_batched_item(
+                    item=item,
+                    llm=llm,
+                    usage=usage,
+                    response_text=response_text,
+                    provider_request_id=provider_request_id,
+                    duration_ms=(time.monotonic() - started) * 1000,
+                    provider_batch_id=provider_batch_id or "",
+                )
+                results[item.custom_id] = AnthropicBatchItemResult(
+                    custom_id=item.custom_id,
+                    artifact_type=item.artifact_type,
+                    artifact_id=item.artifact_id,
+                    vendor_name=item.vendor_name,
+                    response_text=response_text,
+                    usage=usage,
+                    success=True,
+                    provider_request_id=provider_request_id,
+                    item_status="batch_succeeded",
+                )
+                await _insert_batch_item(
+                    pool=db_pool,
+                    local_batch_id=local_batch_id,
+                    stage_id=stage_id,
+                    item=item,
+                    status="batch_succeeded",
+                    cache_prefiltered=False,
+                    fallback_single_call=False,
+                    response_text=response_text,
+                    usage=usage,
+                    provider_request_id=provider_request_id,
+                )
+                continue
+
+        failed_items += 1
+        fallback_items += 1
+        error_text = ""
+        if result_type == "errored":
+            error = getattr(raw_result, "error", None)
+            error_text = str(getattr(error, "message", "") or getattr(error, "type", "") or "batch_errored")
+            item_status = "batch_errored"
+        elif result_type == "expired":
+            error_text = "batch_expired"
+            item_status = "batch_expired"
+        else:
+            error_text = "batch_canceled"
+            item_status = "batch_canceled"
+        results[item.custom_id] = AnthropicBatchItemResult(
+            custom_id=item.custom_id,
+            artifact_type=item.artifact_type,
+            artifact_id=item.artifact_id,
+            vendor_name=item.vendor_name,
+            fallback_required=True,
+            error_text=error_text,
+            item_status="fallback_pending",
+        )
+        await _insert_batch_item(
+            pool=db_pool,
+            local_batch_id=local_batch_id,
+            stage_id=stage_id,
+            item=item,
+            status=item_status,
+            cache_prefiltered=False,
+            fallback_single_call=True,
+            error_text=error_text,
+        )
+
+    await _update_batch_job(
+        pool=db_pool,
+        local_batch_id=local_batch_id,
+        status="ended",
+        provider_batch_id=provider_batch_id,
+        submitted_items=len(pending_items),
+        fallback_single_call_items=fallback_items,
+        completed_items=completed_items,
+        failed_items=failed_items,
+        estimated_sequential_cost_usd=round(sequential_cost_usd, 6),
+        estimated_batch_cost_usd=round(batch_cost_usd, 6),
+        completed_at=_utcnow(),
+    )
+    return AnthropicBatchExecution(
+        local_batch_id=local_batch_id,
+        provider_batch_id=provider_batch_id,
+        stage_id=stage_id,
+        task_name=task_name,
+        status="ended",
+        results_by_custom_id=results,
+        submitted_items=len(pending_items),
+        cache_prefiltered_items=cache_prefiltered_items,
+        fallback_single_call_items=fallback_items,
+        completed_items=completed_items,
+        failed_items=failed_items,
+    )
+
+
+async def mark_batch_fallback_result(
+    *,
+    batch_id: str,
+    custom_id: str,
+    succeeded: bool,
+    pool: Any | None = None,
+    error_text: str | None = None,
+    response_text: str | None = None,
+    usage: dict[str, Any] | None = None,
+    provider_request_id: str | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> None:
+    """Finalize a fallback item after the caller runs the single-call path."""
+    db_pool = _resolve_pool(pool)
+    usage_payload = dict(usage or {})
+    resolved_provider = str(provider or usage_payload.get("provider") or "").strip()
+    resolved_model = str(model or usage_payload.get("model") or "").strip()
+    resolved_provider_request_id = (
+        str(provider_request_id or usage_payload.get("provider_request_id") or "").strip() or None
+    )
+
+    input_tokens: int | None = None
+    billable_input_tokens: int | None = None
+    cached_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    if usage_payload:
+        input_tokens = int(usage_payload.get("input_tokens") or 0)
+        cached_tokens = int(usage_payload.get("cached_tokens") or 0)
+        cache_write_tokens = int(usage_payload.get("cache_write_tokens") or 0)
+        output_tokens = int(usage_payload.get("output_tokens") or 0)
+        if usage_payload.get("billable_input_tokens") is not None:
+            billable_input_tokens = int(usage_payload["billable_input_tokens"])
+        else:
+            billable_input_tokens = input_tokens
+        if resolved_provider and resolved_model:
+            cost_usd = _standard_cost_usd(
+                provider=resolved_provider,
+                model=resolved_model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_tokens=cached_tokens,
+                cache_write_tokens=cache_write_tokens,
+                billable_input_tokens=billable_input_tokens,
+            )
+    await _safe_execute(
+        db_pool,
+        """
+        UPDATE anthropic_message_batch_items
+        SET status = $3,
+            error_text = COALESCE($4, error_text),
+            response_text = COALESCE($5, response_text),
+            input_tokens = input_tokens + COALESCE($6, 0),
+            billable_input_tokens = billable_input_tokens + COALESCE($7, 0),
+            cached_tokens = cached_tokens + COALESCE($8, 0),
+            cache_write_tokens = cache_write_tokens + COALESCE($9, 0),
+            output_tokens = output_tokens + COALESCE($10, 0),
+            cost_usd = cost_usd + COALESCE($11, 0),
+            provider_request_id = COALESCE($12, provider_request_id),
+            fallback_single_call = TRUE,
+            completed_at = NOW()
+        WHERE batch_id = $1::uuid
+          AND custom_id = $2
+        """,
+        batch_id,
+        custom_id,
+        "fallback_succeeded" if succeeded else "fallback_failed",
+        error_text,
+        response_text,
+        input_tokens,
+        billable_input_tokens,
+        cached_tokens,
+        cache_write_tokens,
+        output_tokens,
+        cost_usd,
+        resolved_provider_request_id,
+    )

--- a/atlas_brain/services/b2b/cache_runner.py
+++ b/atlas_brain/services/b2b/cache_runner.py
@@ -1,0 +1,279 @@
+"""Shared cache-aware helpers for B2B exact-match LLM stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Generic, TypeVar
+
+from .cache_strategy import require_b2b_cache_strategy
+from . import llm_exact_cache
+
+ParsedT = TypeVar("ParsedT")
+
+
+@dataclass(frozen=True)
+class ExactStageRequest:
+    stage_id: str
+    namespace: str
+    provider: str
+    model: str
+    request_envelope: dict[str, Any]
+
+
+@dataclass
+class ExactStageRunResult(Generic[ParsedT]):
+    request: ExactStageRequest
+    text: str | None
+    parsed: ParsedT | None
+    cached: bool
+    usage: dict[str, Any]
+
+
+def _resolve_provider_model(
+    *,
+    llm: Any | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> tuple[str, str]:
+    resolved_provider = str(provider or "")
+    resolved_model = str(model or "")
+    if llm is not None and (not resolved_provider or not resolved_model):
+        llm_provider, llm_model = llm_exact_cache.llm_identity(llm)
+        if not resolved_provider:
+            resolved_provider = llm_provider
+        if not resolved_model:
+            resolved_model = llm_model
+    return resolved_provider, resolved_model
+
+
+def prepare_b2b_exact_stage_request(
+    stage_id: str,
+    *,
+    llm: Any | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    messages: Any,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> ExactStageRequest:
+    """Build the normalized exact-cache request for a declared B2B stage."""
+    strategy = require_b2b_cache_strategy(stage_id, expected_mode="exact")
+    if not strategy.namespace:
+        raise ValueError(f"Stage '{stage_id}' is missing an exact-cache namespace")
+    resolved_provider, resolved_model = _resolve_provider_model(
+        llm=llm,
+        provider=provider,
+        model=model,
+    )
+    request_envelope = llm_exact_cache.build_request_envelope(
+        provider=resolved_provider,
+        model=resolved_model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        guided_json=guided_json,
+        extra=extra,
+    )
+    return ExactStageRequest(
+        stage_id=stage_id,
+        namespace=str(strategy.namespace),
+        provider=resolved_provider,
+        model=resolved_model,
+        request_envelope=request_envelope,
+    )
+
+
+def bind_b2b_exact_stage_request(
+    stage_id: str,
+    *,
+    provider: str,
+    model: str,
+    request_envelope: dict[str, Any],
+) -> ExactStageRequest:
+    """Bind an existing request envelope to a declared exact-cache stage."""
+    strategy = require_b2b_cache_strategy(stage_id, expected_mode="exact")
+    if not strategy.namespace:
+        raise ValueError(f"Stage '{stage_id}' is missing an exact-cache namespace")
+    return ExactStageRequest(
+        stage_id=stage_id,
+        namespace=str(strategy.namespace),
+        provider=str(provider or ""),
+        model=str(model or ""),
+        request_envelope=request_envelope,
+    )
+
+
+def prepare_b2b_exact_skill_stage_request(
+    stage_id: str,
+    *,
+    skill_name: str,
+    payload: Any,
+    llm: Any | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> tuple[ExactStageRequest, list[dict[str, str]]]:
+    """Build the exact-cache request for a skill-driven B2B stage."""
+    strategy = require_b2b_cache_strategy(stage_id, expected_mode="exact")
+    if not strategy.namespace:
+        raise ValueError(f"Stage '{stage_id}' is missing an exact-cache namespace")
+    resolved_provider, resolved_model = _resolve_provider_model(
+        llm=llm,
+        provider=provider,
+        model=model,
+    )
+    _, request_envelope, messages = llm_exact_cache.build_skill_request_envelope(
+        namespace=str(strategy.namespace),
+        skill_name=skill_name,
+        payload=payload,
+        provider=resolved_provider,
+        model=resolved_model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        guided_json=guided_json,
+        extra=extra,
+    )
+    return (
+        ExactStageRequest(
+            stage_id=stage_id,
+            namespace=str(strategy.namespace),
+            provider=resolved_provider,
+            model=resolved_model,
+            request_envelope=request_envelope,
+        ),
+        messages,
+    )
+
+
+async def lookup_b2b_exact_stage_text(
+    request: ExactStageRequest,
+    *,
+    pool: Any | None = None,
+) -> llm_exact_cache.B2BLLMExactCacheHit | None:
+    """Lookup a declared B2B exact-cache stage."""
+    return await llm_exact_cache.lookup_cached_text(
+        request.namespace,
+        request.request_envelope,
+        pool=pool,
+    )
+
+
+async def store_b2b_exact_stage_text(
+    request: ExactStageRequest,
+    *,
+    response_text: str,
+    usage: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> bool:
+    """Store a validated response for a declared B2B exact-cache stage."""
+    return await llm_exact_cache.store_cached_text(
+        request.namespace,
+        request.request_envelope,
+        provider=request.provider,
+        model=request.model,
+        response_text=response_text,
+        usage=usage,
+        metadata=metadata,
+        pool=pool,
+    )
+
+
+def _default_extract_text_and_usage(result: Any) -> tuple[str | None, dict[str, Any]]:
+    if result is None:
+        return None, {}
+    if isinstance(result, str):
+        return result, {}
+    if isinstance(result, dict):
+        text = str(result.get("response") or result.get("content") or "").strip()
+        usage = result.get("usage", {})
+        return text or None, usage if isinstance(usage, dict) else {}
+    return str(result).strip() or None, {}
+
+
+async def run_b2b_exact_stage(
+    stage_id: str,
+    *,
+    messages: Any,
+    invoke: Callable[[], Awaitable[Any]],
+    llm: Any | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    parse_response: Callable[[str], ParsedT] | None = None,
+    normalize_parsed: Callable[[ParsedT], ParsedT] | None = None,
+    serialize_parsed: Callable[[ParsedT], str] | None = None,
+    should_store_parsed: Callable[[ParsedT], bool] | None = None,
+    extract_text_and_usage: Callable[[Any], tuple[str | None, dict[str, Any]]] | None = None,
+) -> ExactStageRunResult[ParsedT]:
+    """Run a declared B2B exact-cache stage, storing on successful miss."""
+    request = prepare_b2b_exact_stage_request(
+        stage_id,
+        llm=llm,
+        provider=provider,
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        guided_json=guided_json,
+        extra=extra,
+    )
+    cached = await lookup_b2b_exact_stage_text(request)
+    if cached is not None:
+        text = str(cached["response_text"] or "")
+        parsed: ParsedT | None = parse_response(text) if parse_response is not None else None
+        if parsed is not None and normalize_parsed is not None:
+            parsed = normalize_parsed(parsed)
+            if serialize_parsed is not None:
+                text = serialize_parsed(parsed)
+        return ExactStageRunResult(
+            request=request,
+            text=text,
+            parsed=parsed,
+            cached=True,
+            usage=dict(cached.get("usage") or {}),
+        )
+
+    result = await invoke()
+    text, usage = (extract_text_and_usage or _default_extract_text_and_usage)(result)
+    parsed: ParsedT | None = None
+    text_to_store = text
+    if text and parse_response is not None:
+        parsed = parse_response(text)
+        if parsed is not None and normalize_parsed is not None:
+            parsed = normalize_parsed(parsed)
+        if parsed is not None and serialize_parsed is not None:
+            text_to_store = serialize_parsed(parsed)
+
+    should_store = bool(text_to_store and str(text_to_store).strip())
+    if parsed is not None and should_store_parsed is not None:
+        should_store = bool(should_store_parsed(parsed))
+    if should_store and text_to_store is not None:
+        await store_b2b_exact_stage_text(
+            request,
+            response_text=str(text_to_store),
+            usage=usage,
+            metadata=metadata,
+        )
+    return ExactStageRunResult(
+        request=request,
+        text=text_to_store,
+        parsed=parsed,
+        cached=False,
+        usage=usage,
+    )

--- a/atlas_brain/services/b2b/cache_strategy.py
+++ b/atlas_brain/services/b2b/cache_strategy.py
@@ -1,0 +1,154 @@
+"""Declared cache strategies for core B2B churn/report/blog LLM stages.
+
+This registry is intentionally explicit. New product/report/blog stages should
+add an entry here so cache coverage remains a deliberate design choice rather
+than an accident.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+CacheMode = Literal["exact", "semantic", "evidence_hash"]
+
+
+@dataclass(frozen=True)
+class CacheStrategy:
+    stage_id: str
+    file_path: str
+    mode: CacheMode
+    namespace: str | None = None
+    rationale: str = ""
+
+
+CORE_B2B_CACHE_STRATEGIES: tuple[CacheStrategy, ...] = (
+    CacheStrategy(
+        stage_id="b2b_enrichment.tier1",
+        file_path="atlas_brain/autonomous/tasks/b2b_enrichment.py",
+        mode="exact",
+        namespace="b2b_enrichment.tier1",
+        rationale="Single-review extraction is a stable exact-repeat workload.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_enrichment.tier2",
+        file_path="atlas_brain/autonomous/tasks/b2b_enrichment.py",
+        mode="exact",
+        namespace="b2b_enrichment.tier2",
+        rationale="Tier-2 enrichment is payload-deterministic and cheap to reuse exactly.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_enrichment_repair.extraction",
+        file_path="atlas_brain/autonomous/tasks/b2b_enrichment_repair.py",
+        mode="exact",
+        namespace="b2b_enrichment_repair.extraction",
+        rationale="Repair prompts should reuse identical review payloads exactly.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_churn_reports.scorecard_narrative",
+        file_path="atlas_brain/autonomous/tasks/b2b_churn_reports.py",
+        mode="exact",
+        namespace="b2b_churn_reports.scorecard_narrative",
+        rationale="Scorecard narratives are exact-repeat renders over deterministic packets.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_tenant_report.synthesis_chunk",
+        file_path="atlas_brain/autonomous/tasks/b2b_tenant_report.py",
+        mode="exact",
+        namespace="b2b_tenant_report.synthesis_chunk",
+        rationale="Tenant chunks are exact-repeat synthesis passes over fixed packet slices.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_vendor_briefing.analyst_summary",
+        file_path="atlas_brain/autonomous/tasks/b2b_vendor_briefing.py",
+        mode="exact",
+        namespace="b2b_vendor_briefing.analyst_summary",
+        rationale="Analyst summaries are deterministic renders over persisted briefing context.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_vendor_briefing.account_card",
+        file_path="atlas_brain/autonomous/tasks/b2b_vendor_briefing.py",
+        mode="exact",
+        namespace="b2b_vendor_briefing.account_card",
+        rationale="Account-card synthesis is exact-repeat on stable account payloads.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_campaign_generation.content",
+        file_path="atlas_brain/autonomous/tasks/b2b_campaign_generation.py",
+        mode="exact",
+        namespace="b2b_campaign_generation.content",
+        rationale="Campaign copy generation repeats exactly for unchanged payloads.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_blog_post_generation.content",
+        file_path="atlas_brain/autonomous/tasks/b2b_blog_post_generation.py",
+        mode="exact",
+        namespace="b2b_blog_post_generation.content",
+        rationale="Blog drafts reuse exact payloads keyed by slug/topic packet.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_product_profiles.synthesis",
+        file_path="atlas_brain/autonomous/tasks/b2b_product_profiles.py",
+        mode="exact",
+        namespace="b2b_product_profiles.synthesis",
+        rationale="Profile synthesis is exact-repeat over stable product profile packets.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_battle_cards.sales_copy",
+        file_path="atlas_brain/autonomous/tasks/b2b_battle_cards.py",
+        mode="semantic",
+        rationale="Battle-card render reuses semantically similar evidence bundles.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_reasoning_synthesis.vendor",
+        file_path="atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py",
+        mode="evidence_hash",
+        rationale="Vendor reasoning should rerun only when packet evidence changes.",
+    ),
+    CacheStrategy(
+        stage_id="b2b_reasoning_synthesis.cross_vendor",
+        file_path="atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py",
+        mode="evidence_hash",
+        rationale="Cross-vendor synthesis should rerun only when comparison evidence changes.",
+    ),
+)
+
+
+def iter_core_b2b_cache_strategies() -> tuple[CacheStrategy, ...]:
+    """Return the declared cache strategies for current B2B product stages."""
+    return CORE_B2B_CACHE_STRATEGIES
+
+
+def get_b2b_cache_strategy(stage_id: str) -> CacheStrategy | None:
+    """Return the declared cache strategy for a stage, if any."""
+    for strategy in CORE_B2B_CACHE_STRATEGIES:
+        if strategy.stage_id == stage_id:
+            return strategy
+    return None
+
+
+def require_b2b_cache_strategy(
+    stage_id: str,
+    *,
+    expected_mode: CacheMode | None = None,
+) -> CacheStrategy:
+    """Return the declared cache strategy or raise for missing/mismatched config."""
+    strategy = get_b2b_cache_strategy(stage_id)
+    if strategy is None:
+        raise KeyError(f"Missing B2B cache strategy for stage '{stage_id}'")
+    if expected_mode is not None and strategy.mode != expected_mode:
+        raise ValueError(
+            f"Stage '{stage_id}' declares cache mode '{strategy.mode}',"
+            f" expected '{expected_mode}'"
+        )
+    return strategy
+
+
+def exact_cache_namespaces() -> tuple[str, ...]:
+    """Return declared exact-cache namespaces for B2B product stages."""
+    return tuple(
+        strategy.namespace
+        for strategy in CORE_B2B_CACHE_STRATEGIES
+        if strategy.mode == "exact" and strategy.namespace
+    )

--- a/atlas_brain/services/b2b/enrichment_repair_policy.py
+++ b/atlas_brain/services/b2b/enrichment_repair_policy.py
@@ -1,0 +1,143 @@
+"""Shared policy helpers for enrichment repair gating and analytics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+STRICT_DISCUSSION_SKIP_MARKER = "repair_skipped_low_signal_discussion"
+
+REPAIR_STRUCTURED_CHURN_SQL = """
+(
+  COALESCE((enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+  OR COALESCE((enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+  OR COALESCE((enrichment->'churn_signals'->>'migration_in_progress')::boolean, false)
+  OR COALESCE((enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+)
+"""
+REPAIR_IDENTITY_SIGNAL_SQL = """
+(
+  COALESCE(
+    CASE
+      WHEN LOWER(COALESCE(reviewer_title, '')) LIKE 'repeat churn signal%' THEN NULL
+      ELSE NULLIF(reviewer_title, '')
+    END,
+    NULLIF(reviewer_company, ''),
+    NULLIF(enrichment->'reviewer_context'->>'company_name', '')
+  ) IS NOT NULL
+)
+"""
+STRONG_VALID_COMPETITOR_OBJECT_SQL = """
+EXISTS (
+  SELECT 1
+  FROM jsonb_array_elements(COALESCE(enrichment->'competitors_mentioned', '[]'::jsonb)) comp
+  WHERE NULLIF(BTRIM(comp->>'name'), '') IS NOT NULL
+    AND LOWER(BTRIM(comp->>'name')) <> LOWER(COALESCE(vendor_name, ''))
+    AND LOWER(BTRIM(comp->>'name')) <> LOWER(COALESCE(product_name, ''))
+    AND LOWER(BTRIM(comp->>'name')) !~ '(integration|app builder|template|cert(?:ification)?|course|academy|private app|custom-built|custom built|our own |api )'
+    AND (
+      COALESCE(comp->>'evidence_type', '') IN ('explicit_switch', 'active_evaluation')
+      OR COALESCE(comp->>'displacement_confidence', '') IN ('high', 'medium')
+      OR NULLIF(comp->>'reason', '') IS NOT NULL
+      OR NULLIF(comp->>'reason_category', '') IS NOT NULL
+      OR NULLIF(comp->>'reason_detail', '') IS NOT NULL
+    )
+)
+"""
+REPAIR_VENDOR_LITERAL_SQL = """
+(
+  review_text ILIKE ('%' || vendor_name || '%')
+  OR (
+    COALESCE(product_name, '') <> ''
+    AND lower(COALESCE(product_name, '')) <> lower(COALESCE(vendor_name, ''))
+    AND review_text ILIKE ('%' || product_name || '%')
+  )
+)
+"""
+REPAIR_CONTENT_EVIDENCE_SQL = """
+(
+  COALESCE(jsonb_array_length(enrichment->'pricing_phrases'), 0) > 0
+  OR COALESCE(jsonb_array_length(enrichment->'specific_complaints'), 0) > 0
+  OR COALESCE(jsonb_array_length(enrichment->'feature_gaps'), 0) > 0
+)
+"""
+ACTIVE_REPAIR_POOL_SQL_TEMPLATE = """
+(
+  enrichment_status IN ('enriched', 'no_signal')
+  AND COALESCE(low_fidelity, false) = false
+  AND enrichment IS NOT NULL
+  AND enrichment_repair_attempts < {max_attempts}
+  AND (
+    enrichment_repair_status IS NULL
+    OR enrichment_repair_status = 'failed'
+    OR enrichment_repair_status = 'promoted'
+    OR (
+      enrichment_repair_status = 'shadowed'
+      AND enrichment_status = 'quarantined'
+      AND jsonb_path_exists(
+        COALESCE(enrichment_repair_applied_fields, '[]'::jsonb),
+        '$[*] ? (@ like_regex "^adjudication:")'
+      )
+    )
+  )
+)
+"""
+
+
+def strict_discussion_keep_sql() -> str:
+    return f"""
+    (
+      {REPAIR_STRUCTURED_CHURN_SQL}
+      OR {REPAIR_IDENTITY_SIGNAL_SQL}
+      OR ({STRONG_VALID_COMPETITOR_OBJECT_SQL})
+      OR (
+        {REPAIR_VENDOR_LITERAL_SQL}
+        AND {REPAIR_CONTENT_EVIDENCE_SQL}
+      )
+    )
+    """
+
+
+def strict_discussion_gate_sql(source_param: int, content_type_param: int) -> str:
+    return f"""
+    (
+      cardinality(${source_param}::text[]) = 0
+      OR lower(source) <> ALL(${source_param}::text[])
+      OR cardinality(${content_type_param}::text[]) = 0
+      OR lower(COALESCE(content_type, '')) <> ALL(${content_type_param}::text[])
+      OR {strict_discussion_keep_sql()}
+    )
+    """
+
+
+def _parse_source_allowlist(raw: Any) -> set[str]:
+    if raw is None:
+        return set()
+    if isinstance(raw, str):
+        values = [part.strip().lower() for part in raw.split(",")]
+        return {value for value in values if value}
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        return {
+            str(value or "").strip().lower()
+            for value in raw
+            if str(value or "").strip()
+        }
+    value = str(raw).strip().lower()
+    return {value} if value else set()
+
+
+def strict_discussion_lists(cfg: Any) -> tuple[list[str], list[str]]:
+    raw_sources = getattr(cfg, "enrichment_repair_strict_discussion_sources", None)
+    if not isinstance(raw_sources, (str, list, tuple, set, frozenset)):
+        raw_sources = "reddit"
+    sources = sorted(_parse_source_allowlist(raw_sources))
+    raw_content_types = getattr(cfg, "enrichment_repair_strict_discussion_content_types", None)
+    if not isinstance(raw_content_types, (list, tuple, set, frozenset)):
+        raw_content_types = ["community_discussion", "insider_account", "comment"]
+    content_types = sorted(
+        {
+            str(value or "").strip().lower()
+            for value in (raw_content_types or [])
+            if str(value or "").strip()
+        }
+    )
+    return sources, content_types

--- a/atlas_brain/services/b2b/llm_exact_cache.py
+++ b/atlas_brain/services/b2b/llm_exact_cache.py
@@ -1,0 +1,378 @@
+"""Exact-match Postgres cache for B2B/reporting LLM responses."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import math
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger("atlas.services.b2b.llm_exact_cache")
+
+CACHE_VERSION = "b2b-llm-exact-v1"
+
+
+class CacheUnavailable(RuntimeError):
+    """Raised when a cache request depends on a missing skill."""
+
+
+class B2BLLMExactCacheHit(dict):
+    """Simple dict wrapper for cached response metadata."""
+
+
+def is_b2b_llm_exact_cache_enabled() -> bool:
+    """Return whether the feature-flagged exact cache is enabled."""
+    from ...config import settings
+
+    return bool(getattr(settings.b2b_churn, "llm_exact_cache_enabled", False))
+
+
+def _normalize_maybe_json_string(value: str) -> Any:
+    stripped = value.strip()
+    if stripped and stripped[0] in "{[":
+        try:
+            return _normalize_value(json.loads(stripped))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return value
+    return value
+
+
+def _normalize_message(value: Any) -> dict[str, Any] | None:
+    role = getattr(value, "role", None)
+    content = getattr(value, "content", None)
+    if role is None and content is None:
+        return None
+
+    payload: dict[str, Any] = {
+        "role": str(role or ""),
+        "content": _normalize_value(content or ""),
+    }
+    tool_calls = getattr(value, "tool_calls", None)
+    if tool_calls:
+        payload["tool_calls"] = _normalize_value(tool_calls)
+    tool_call_id = getattr(value, "tool_call_id", None)
+    if tool_call_id:
+        payload["tool_call_id"] = str(tool_call_id)
+    return payload
+
+
+def _normalize_value(value: Any) -> Any:
+    if is_dataclass(value):
+        value = asdict(value)
+
+    msg_payload = _normalize_message(value)
+    if msg_payload is not None:
+        return msg_payload
+
+    if isinstance(value, str):
+        return _normalize_maybe_json_string(value)
+
+    if value is None or isinstance(value, (bool, int)):
+        return value
+
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+
+    if isinstance(value, set):
+        normalized = [_normalize_value(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"), default=str),
+        )
+
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [_normalize_value(item) for item in value]
+
+    return str(value)
+
+
+def canonicalize_for_cache(value: Any) -> str:
+    """Return deterministic JSON for hashing exact cache requests."""
+    normalized = _normalize_value(value)
+    return json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+
+
+def build_request_envelope(
+    *,
+    provider: str,
+    model: str,
+    messages: Any,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the normalized request envelope that drives the cache key."""
+    envelope: dict[str, Any] = {
+        "provider": str(provider or ""),
+        "model": str(model or ""),
+        "messages": _normalize_value(messages),
+        "max_tokens": int(max_tokens) if max_tokens is not None else None,
+        "temperature": float(temperature) if temperature is not None else None,
+    }
+    if response_format is not None:
+        envelope["response_format"] = _normalize_value(response_format)
+    if guided_json is not None:
+        envelope["guided_json"] = _normalize_value(guided_json)
+    if extra:
+        envelope["extra"] = _normalize_value(extra)
+    return envelope
+
+
+def llm_identity(llm: Any) -> tuple[str, str]:
+    """Return provider/model identifiers for a resolved LLM instance."""
+    if llm is None:
+        return "", ""
+    provider = str(getattr(llm, "name", "") or "")
+    model = str(
+        getattr(llm, "model", "")
+        or getattr(llm, "model_id", "")
+        or getattr(llm, "model_name", "")
+        or ""
+    )
+    return provider, model
+
+
+def compute_cache_key(namespace: str, request_envelope: dict[str, Any]) -> str:
+    """Hash cache version + namespace + canonical request envelope."""
+    raw = f"{CACHE_VERSION}:{namespace}:{canonicalize_for_cache(request_envelope)}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_skill_messages(skill_name: str, payload: Any) -> list[dict[str, str]]:
+    """Build the exact message envelope used by call_llm_with_skill()."""
+    from ...skills import get_skill_registry
+
+    skill = get_skill_registry().get(skill_name)
+    if skill is None:
+        raise CacheUnavailable(f"Skill '{skill_name}' not found")
+
+    return [
+        {"role": "system", "content": skill.content},
+        {
+            "role": "user",
+            "content": json.dumps(payload, separators=(",", ":"), default=str),
+        },
+    ]
+
+
+def build_skill_request_envelope(
+    *,
+    namespace: str,
+    skill_name: str,
+    payload: Any,
+    provider: str,
+    model: str,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any], list[dict[str, str]]]:
+    """Return cache key + normalized envelope + exact skill messages."""
+    messages = build_skill_messages(skill_name, payload)
+    request_envelope = build_request_envelope(
+        provider=provider,
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        guided_json=guided_json,
+        extra={"skill_name": skill_name, **(extra or {})},
+    )
+    return compute_cache_key(namespace, request_envelope), request_envelope, messages
+
+
+def _resolve_pool(pool: Any | None) -> Any | None:
+    if pool is not None:
+        return pool
+    from ...storage.database import get_db_pool
+
+    db_pool = get_db_pool()
+    if not db_pool.is_initialized:
+        return None
+    return db_pool
+
+
+def _json_field_to_mapping(value: Any) -> dict[str, Any]:
+    """Normalize JSON/JSONB driver return values into a plain mapping."""
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+    return {}
+
+
+async def lookup_cached_text(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    pool: Any | None = None,
+) -> B2BLLMExactCacheHit | None:
+    """Return the cached text for an exact request envelope."""
+    if not namespace or not is_b2b_llm_exact_cache_enabled():
+        return None
+
+    db_pool = _resolve_pool(pool)
+    if db_pool is None:
+        return None
+
+    cache_key = compute_cache_key(namespace, request_envelope)
+    row = await db_pool.fetchrow(
+        """
+        WITH hit AS (
+            UPDATE b2b_llm_exact_cache
+            SET last_hit_at = NOW(),
+                hit_count = hit_count + 1
+            WHERE cache_key = $1
+            RETURNING cache_key, namespace, provider, model,
+                      response_text, usage_json, metadata,
+                      created_at, last_hit_at, hit_count
+        )
+        SELECT * FROM hit
+        """,
+        cache_key,
+    )
+    if row is None:
+        return None
+
+    logger.info("Exact LLM cache hit: %s", namespace)
+    return B2BLLMExactCacheHit(
+        cache_key=row["cache_key"],
+        namespace=row["namespace"],
+        provider=row["provider"],
+        model=row["model"],
+        response_text=row["response_text"],
+        usage=_json_field_to_mapping(row["usage_json"]),
+        metadata=_json_field_to_mapping(row["metadata"]),
+        created_at=row["created_at"],
+        last_hit_at=row["last_hit_at"],
+        hit_count=row["hit_count"],
+    )
+
+
+async def store_cached_text(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    provider: str,
+    model: str,
+    response_text: str,
+    usage: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> bool:
+    """Store a successful exact-match response."""
+    if (
+        not namespace
+        or not response_text
+        or not str(response_text).strip()
+        or not is_b2b_llm_exact_cache_enabled()
+    ):
+        return False
+
+    db_pool = _resolve_pool(pool)
+    if db_pool is None:
+        return False
+
+    cache_key = compute_cache_key(namespace, request_envelope)
+    metadata_json = {
+        "cache_version": CACHE_VERSION,
+        **(_normalize_value(metadata or {}) or {}),
+    }
+    await db_pool.execute(
+        """
+        INSERT INTO b2b_llm_exact_cache (
+            cache_key, namespace, provider, model, response_text, usage_json, metadata
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6::jsonb, $7::jsonb
+        )
+        ON CONFLICT (cache_key) DO UPDATE SET
+            provider = EXCLUDED.provider,
+            model = EXCLUDED.model,
+            response_text = EXCLUDED.response_text,
+            usage_json = EXCLUDED.usage_json,
+            metadata = EXCLUDED.metadata
+        """,
+        cache_key,
+        namespace,
+        str(provider or ""),
+        str(model or ""),
+        str(response_text).strip(),
+        canonicalize_for_cache(usage or {}),
+        canonicalize_for_cache(metadata_json),
+    )
+    logger.info("Stored exact LLM cache entry: %s", namespace)
+    return True
+
+
+def _run_coro_sync(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError(
+        "Synchronous exact-cache helpers cannot run inside an active event loop"
+    )
+
+
+def lookup_cached_text_sync(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    pool: Any | None = None,
+) -> B2BLLMExactCacheHit | None:
+    """Sync wrapper for exact-cache lookup."""
+    return _run_coro_sync(
+        lookup_cached_text(namespace, request_envelope, pool=pool)
+    )
+
+
+def store_cached_text_sync(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    provider: str,
+    model: str,
+    response_text: str,
+    usage: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> bool:
+    """Sync wrapper for exact-cache store."""
+    return bool(
+        _run_coro_sync(
+            store_cached_text(
+                namespace,
+                request_envelope,
+                provider=provider,
+                model=model,
+                response_text=response_text,
+                usage=usage,
+                metadata=metadata,
+                pool=pool,
+            )
+        )
+    )

--- a/atlas_brain/services/b2b/review_dedup.py
+++ b/atlas_brain/services/b2b/review_dedup.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timezone
+from difflib import SequenceMatcher
+from typing import Any
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or value is None:
+        numeric = default
+    elif isinstance(value, int):
+        numeric = value
+    elif isinstance(value, float):
+        if value != value:
+            numeric = default
+        else:
+            numeric = int(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            numeric = default
+        else:
+            try:
+                numeric = int(text)
+            except ValueError:
+                try:
+                    numeric = int(float(text))
+                except ValueError:
+                    numeric = default
+    else:
+        numeric = default
+    if minimum is not None and numeric < minimum:
+        return minimum
+    return numeric
+
+
+def _coerce_float(value: Any, default: float, *, minimum: float | None = None) -> float:
+    if isinstance(value, bool) or value is None:
+        numeric = default
+    elif isinstance(value, (int, float)):
+        numeric = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            numeric = default
+        else:
+            try:
+                numeric = float(text)
+            except ValueError:
+                numeric = default
+    else:
+        numeric = default
+    if numeric != numeric:
+        numeric = default
+    if minimum is not None and numeric < minimum:
+        return minimum
+    return numeric
+
+
+def normalize_review_text_for_hash(value: Any) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    return text.lower()
+
+
+def make_review_text_payload(
+    summary: Any,
+    review_text: Any,
+    pros: Any = None,
+    cons: Any = None,
+) -> str:
+    parts = [
+        normalize_review_text_for_hash(summary),
+        normalize_review_text_for_hash(review_text),
+        normalize_review_text_for_hash(pros),
+        normalize_review_text_for_hash(cons),
+    ]
+    return "\n".join(part for part in parts if part)
+
+
+def normalize_review_date_key(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw.astimezone(timezone.utc).date().isoformat()
+    if isinstance(raw, date):
+        return raw.isoformat()
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).date().isoformat()
+    except ValueError:
+        pass
+    match = re.search(r"(\d{4})-(\d{2})-(\d{2})", text)
+    if match:
+        return f"{match.group(1)}-{match.group(2)}-{match.group(3)}"
+    return None
+
+
+def normalize_reviewer_key(value: Any) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]+", "", str(value or "").strip().lower())
+    return normalized or None
+
+
+def normalize_reviewer_stem_key(value: Any, *, stem_length: int) -> str | None:
+    reviewer_key = normalize_reviewer_key(value)
+    if not reviewer_key:
+        return None
+    return reviewer_key[: _coerce_int(stem_length, 5, minimum=1)]
+
+
+def normalize_rating_key(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return ""
+    if numeric != numeric:
+        return ""
+    return f"{numeric:.1f}"
+
+
+def make_cross_source_identity_key(
+    vendor_name: str,
+    reviewer_name: Any,
+    reviewed_at: Any,
+    rating: Any = None,
+) -> str | None:
+    reviewer_key = normalize_reviewer_key(reviewer_name)
+    reviewed_key = normalize_review_date_key(reviewed_at)
+    vendor_key = str(vendor_name or "").strip().lower()
+    if not vendor_key or not reviewer_key or not reviewed_key:
+        return None
+    rating_key = normalize_rating_key(rating)
+    return f"{vendor_key}|{reviewer_key}|{reviewed_key}|{rating_key}"
+
+
+def review_text_similarity(left_payload: str, right_payload: str) -> float:
+    if not left_payload or not right_payload:
+        return 0.0
+    return float(SequenceMatcher(None, left_payload, right_payload).ratio())
+
+
+def _normalize_imported_at_rank(raw: Any) -> float:
+    if raw is None:
+        return float("inf")
+    if isinstance(raw, datetime):
+        value = raw
+    else:
+        text = str(raw or "").strip()
+        if not text:
+            return float("inf")
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            value = datetime.fromisoformat(text)
+        except ValueError:
+            return float("inf")
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.timestamp()
+
+
+async def load_cross_source_review_candidates(
+    pool,
+    *,
+    vendor_name: str,
+    content_hash: str | None,
+    identity_key: str | None,
+    reviewer_stem: str | None,
+    reviewed_date: str | None,
+    rating: Any = None,
+    max_candidates: int,
+    reviewer_stem_length: int,
+    review_date_tolerance_days: int,
+    rating_tolerance: float,
+) -> list[dict[str, Any]]:
+    reviewer_stem_length = _coerce_int(reviewer_stem_length, 5, minimum=1)
+    review_date_tolerance_days = _coerce_int(review_date_tolerance_days, 1, minimum=0)
+    rating_tolerance = _coerce_float(rating_tolerance, 1.0, minimum=0.0)
+    max_candidates = _coerce_int(max_candidates, 20, minimum=1)
+    if not content_hash and not identity_key and not (reviewer_stem and reviewed_date):
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT id, source, source_review_id, reviewer_name, reviewed_at, rating,
+               imported_at, enrichment_status, source_weight,
+               cross_source_content_hash,
+               cross_source_identity_key,
+               summary, review_text, pros, cons
+        FROM b2b_reviews
+        WHERE vendor_name = $1
+          AND duplicate_of_review_id IS NULL
+          AND (
+                ($2::text IS NOT NULL AND cross_source_content_hash = $2)
+             OR ($3::text IS NOT NULL AND cross_source_identity_key = $3)
+             OR (
+                    $4::text IS NOT NULL
+                AND $5::date IS NOT NULL
+                AND reviewed_at IS NOT NULL
+                AND ABS((reviewed_at AT TIME ZONE 'UTC')::date - $5::date) <= $6
+                AND (
+                    $7::numeric IS NULL
+                    OR rating IS NULL
+                    OR ABS(COALESCE(rating, 0)::numeric - $7::numeric) <= $8
+                )
+                AND LEFT(
+                    regexp_replace(lower(COALESCE(reviewer_name, '')), '[^a-z0-9]+', '', 'g'),
+                    $9
+                ) = $4
+             )
+          )
+        ORDER BY imported_at ASC, id ASC
+        LIMIT $10
+        """,
+        vendor_name,
+        content_hash,
+        identity_key,
+        reviewer_stem,
+        reviewed_date,
+        review_date_tolerance_days,
+        rating,
+        rating_tolerance,
+        reviewer_stem_length,
+        max_candidates,
+    )
+    return [dict(row) for row in rows]
+
+
+def choose_cross_source_duplicate_survivor(
+    *,
+    candidates: list[dict[str, Any]],
+    incoming_source: str,
+    incoming_content_hash: str | None,
+    incoming_identity_key: str | None,
+    incoming_payload: str,
+    similarity_threshold: float,
+    incoming_reviewer_name: Any = None,
+    incoming_reviewed_at: Any = None,
+    incoming_rating: Any = None,
+    loose_similarity_threshold: float = 0.9,
+    reviewer_stem_length: int = 5,
+    review_date_tolerance_days: int = 1,
+    rating_tolerance: float = 1.0,
+    require_source_difference: bool = True,
+) -> tuple[dict[str, Any] | None, str | None, dict[str, Any] | None]:
+    similarity_threshold = _coerce_float(similarity_threshold, 0.82, minimum=0.0)
+    loose_similarity_threshold = _coerce_float(loose_similarity_threshold, 0.9, minimum=0.0)
+    reviewer_stem_length = _coerce_int(reviewer_stem_length, 5, minimum=1)
+    review_date_tolerance_days = _coerce_int(review_date_tolerance_days, 1, minimum=0)
+    rating_tolerance = _coerce_float(rating_tolerance, 1.0, minimum=0.0)
+    ranked: list[tuple[tuple[int, int, float, str], dict[str, Any], str, dict[str, Any]]] = []
+    for candidate in candidates:
+        candidate_source = str(candidate.get("source") or "").strip().lower()
+        if require_source_difference and candidate_source == str(incoming_source or "").strip().lower():
+            continue
+        candidate_hash = str(candidate.get("cross_source_content_hash") or "").strip() or None
+        candidate_identity = str(candidate.get("cross_source_identity_key") or "").strip() or None
+        candidate_payload = make_review_text_payload(
+            candidate.get("summary"),
+            candidate.get("review_text"),
+            candidate.get("pros"),
+            candidate.get("cons"),
+        )
+        exact_hash = bool(
+            incoming_content_hash
+            and candidate_hash
+            and incoming_content_hash == candidate_hash
+        )
+        similarity = review_text_similarity(incoming_payload, candidate_payload)
+        identity_match = bool(
+            incoming_identity_key
+            and candidate_identity
+            and incoming_identity_key == candidate_identity
+        )
+        loose_reviewer_match = reviewer_keys_overlap(
+            incoming_reviewer_name,
+            candidate.get("reviewer_name"),
+            stem_length=reviewer_stem_length,
+        )
+        loose_date_match = review_dates_within_tolerance(
+            incoming_reviewed_at,
+            candidate.get("reviewed_at"),
+            tolerance_days=review_date_tolerance_days,
+        )
+        loose_rating_match = rating_values_within_tolerance(
+            incoming_rating,
+            candidate.get("rating"),
+            tolerance=rating_tolerance,
+        )
+        if exact_hash:
+            reason = "cross_source_exact_content"
+        elif identity_match and similarity >= similarity_threshold:
+            reason = "cross_source_identity_similarity"
+        elif (
+            loose_reviewer_match
+            and loose_date_match
+            and loose_rating_match
+            and similarity >= loose_similarity_threshold
+        ):
+            reason = "cross_source_reviewer_date_similarity"
+        else:
+            continue
+        status = str(candidate.get("enrichment_status") or "").strip().lower()
+        status_rank = 1 if status == "enriched" else 0
+        source_weight = float(candidate.get("source_weight") or 0.0)
+        imported_at_rank = _normalize_imported_at_rank(candidate.get("imported_at"))
+        detail = {
+            "survivor_review_id": str(candidate.get("id") or ""),
+            "survivor_source": candidate_source,
+            "reason_code": reason,
+            "content_hash_match": exact_hash,
+            "identity_key_match": identity_match,
+            "reviewer_overlap_match": loose_reviewer_match,
+            "review_date_tolerance_match": loose_date_match,
+            "rating_tolerance_match": loose_rating_match,
+            "text_similarity": round(similarity, 4),
+        }
+        rank = (
+            1 if exact_hash else 0,
+            status_rank,
+            source_weight,
+            -imported_at_rank,
+        )
+        ranked.append((rank, candidate, reason, detail))
+    if not ranked:
+        return None, None, None
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    _, candidate, reason, detail = ranked[0]
+    return candidate, reason, detail
+
+
+def _row_source_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _rating_value(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric != numeric:
+        return None
+    return numeric
+
+
+def review_dates_within_tolerance(left: Any, right: Any, *, tolerance_days: int) -> bool:
+    tolerance_days = _coerce_int(tolerance_days, 1, minimum=0)
+    left_key = normalize_review_date_key(left)
+    right_key = normalize_review_date_key(right)
+    if not left_key or not right_key:
+        return False
+    try:
+        left_day = date.fromisoformat(left_key)
+        right_day = date.fromisoformat(right_key)
+    except ValueError:
+        return False
+    return abs((left_day - right_day).days) <= tolerance_days
+
+
+def rating_values_within_tolerance(left: Any, right: Any, *, tolerance: float) -> bool:
+    tolerance = _coerce_float(tolerance, 1.0, minimum=0.0)
+    left_value = _rating_value(left)
+    right_value = _rating_value(right)
+    if left_value is None or right_value is None:
+        return True
+    return abs(left_value - right_value) <= tolerance
+
+
+def reviewer_keys_overlap(left: Any, right: Any, *, stem_length: int) -> bool:
+    left_key = normalize_reviewer_key(left)
+    right_key = normalize_reviewer_key(right)
+    if not left_key or not right_key:
+        return False
+    if left_key == right_key:
+        return True
+    left_stem = normalize_reviewer_stem_key(left_key, stem_length=stem_length)
+    right_stem = normalize_reviewer_stem_key(right_key, stem_length=stem_length)
+    if not left_stem or not right_stem:
+        return False
+    return left_key.startswith(right_stem) or right_key.startswith(left_stem)
+
+
+def _row_status_rank(value: Any) -> int:
+    status = str(value or "").strip().lower()
+    if status == "enriched":
+        return 3
+    if status == "no_signal":
+        return 2
+    if status == "quarantined":
+        return 1
+    return 0
+
+
+def _row_source_weight(value: Any) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if numeric != numeric:
+        return 0.0
+    return numeric
+
+
+def canonical_review_sort_key(row: dict[str, Any]) -> tuple[int, float, float, str]:
+    return (
+        _row_status_rank(row.get("enrichment_status")),
+        _row_source_weight(row.get("source_weight")),
+        -_normalize_imported_at_rank(row.get("imported_at")),
+        str(row.get("id") or ""),
+    )
+
+
+def choose_canonical_review_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=canonical_review_sort_key)
+
+
+def cluster_cross_source_duplicates(
+    rows: list[dict[str, Any]],
+    *,
+    similarity_threshold: float,
+    loose_similarity_threshold: float = 0.9,
+    reviewer_stem_length: int = 5,
+    review_date_tolerance_days: int = 1,
+    rating_tolerance: float = 1.0,
+) -> dict[str, dict[str, Any]]:
+    """Return duplicate decisions for rows belonging to one vendor.
+
+    The returned mapping is keyed by discarded review id and contains:
+    - survivor_review_id
+    - duplicate_reason
+    - duplicate_detail
+    """
+    decisions: dict[str, dict[str, Any]] = {}
+    if not rows:
+        return decisions
+
+    by_content_hash: dict[str, list[dict[str, Any]]] = {}
+    by_identity_key: dict[str, list[dict[str, Any]]] = {}
+    payload_by_id: dict[str, str] = {}
+
+    for row in rows:
+        row_id = str(row.get("id") or "").strip()
+        if not row_id:
+            continue
+        payload_by_id[row_id] = make_review_text_payload(
+            row.get("summary"),
+            row.get("review_text"),
+            row.get("pros"),
+            row.get("cons"),
+        )
+        content_hash = str(row.get("cross_source_content_hash") or "").strip()
+        identity_key = str(row.get("cross_source_identity_key") or "").strip()
+        if content_hash:
+            by_content_hash.setdefault(content_hash, []).append(row)
+        if identity_key:
+            by_identity_key.setdefault(identity_key, []).append(row)
+
+    for content_hash, group in by_content_hash.items():
+        distinct_sources = {_row_source_key(row.get("source")) for row in group if _row_source_key(row.get("source"))}
+        if len(group) < 2 or len(distinct_sources) < 2:
+            continue
+        survivor = choose_canonical_review_row(group)
+        if survivor is None:
+            continue
+        survivor_id = str(survivor.get("id") or "")
+        survivor_source = _row_source_key(survivor.get("source"))
+        for row in group:
+            row_id = str(row.get("id") or "")
+            if not row_id or row_id == survivor_id:
+                continue
+            decisions[row_id] = {
+                "survivor_review_id": survivor_id,
+                "duplicate_reason": "cross_source_exact_content",
+                "duplicate_detail": {
+                    "survivor_review_id": survivor_id,
+                    "survivor_source": survivor_source,
+                    "reason_code": "cross_source_exact_content",
+                    "content_hash_match": True,
+                    "identity_key_match": (
+                        str(row.get("cross_source_identity_key") or "").strip()
+                        and str(row.get("cross_source_identity_key") or "").strip()
+                        == str(survivor.get("cross_source_identity_key") or "").strip()
+                    ),
+                    "text_similarity": 1.0,
+                    "backfill_scope": "cross_source_review_dedup",
+                    "content_hash": content_hash,
+                },
+            }
+
+    for identity_key, group in by_identity_key.items():
+        distinct_sources = {_row_source_key(row.get("source")) for row in group if _row_source_key(row.get("source"))}
+        if len(group) < 2 or len(distinct_sources) < 2:
+            continue
+        candidates = [row for row in group if str(row.get("id") or "") not in decisions]
+        if len(candidates) < 2:
+            continue
+        survivor = choose_canonical_review_row(candidates)
+        if survivor is None:
+            continue
+        survivor_id = str(survivor.get("id") or "")
+        survivor_source = _row_source_key(survivor.get("source"))
+        survivor_payload = payload_by_id.get(survivor_id, "")
+        for row in candidates:
+            row_id = str(row.get("id") or "")
+            if not row_id or row_id == survivor_id or row_id in decisions:
+                continue
+            similarity = review_text_similarity(
+                payload_by_id.get(row_id, ""),
+                survivor_payload,
+            )
+            if similarity < similarity_threshold:
+                continue
+            decisions[row_id] = {
+                "survivor_review_id": survivor_id,
+                "duplicate_reason": "cross_source_identity_similarity",
+                "duplicate_detail": {
+                    "survivor_review_id": survivor_id,
+                    "survivor_source": survivor_source,
+                    "reason_code": "cross_source_identity_similarity",
+                    "content_hash_match": False,
+                    "identity_key_match": True,
+                    "text_similarity": round(similarity, 4),
+                    "backfill_scope": "cross_source_review_dedup",
+                    "identity_key": identity_key,
+                },
+            }
+
+    by_reviewer_stem: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        row_id = str(row.get("id") or "").strip()
+        if not row_id or row_id in decisions:
+            continue
+        reviewer_stem = normalize_reviewer_stem_key(
+            row.get("reviewer_name"),
+            stem_length=reviewer_stem_length,
+        )
+        if reviewer_stem:
+            by_reviewer_stem.setdefault(reviewer_stem, []).append(row)
+
+    for reviewer_stem, group in by_reviewer_stem.items():
+        distinct_sources = {_row_source_key(row.get("source")) for row in group if _row_source_key(row.get("source"))}
+        if len(group) < 2 or len(distinct_sources) < 2:
+            continue
+        candidates = [row for row in group if str(row.get("id") or "") not in decisions]
+        if len(candidates) < 2:
+            continue
+        survivor = choose_canonical_review_row(candidates)
+        if survivor is None:
+            continue
+        survivor_id = str(survivor.get("id") or "")
+        survivor_source = _row_source_key(survivor.get("source"))
+        survivor_payload = payload_by_id.get(survivor_id, "")
+        for row in candidates:
+            row_id = str(row.get("id") or "")
+            if not row_id or row_id == survivor_id or row_id in decisions:
+                continue
+            similarity = review_text_similarity(
+                payload_by_id.get(row_id, ""),
+                survivor_payload,
+            )
+            if similarity < loose_similarity_threshold:
+                continue
+            if not review_dates_within_tolerance(
+                row.get("reviewed_at"),
+                survivor.get("reviewed_at"),
+                tolerance_days=review_date_tolerance_days,
+            ):
+                continue
+            if not rating_values_within_tolerance(
+                row.get("rating"),
+                survivor.get("rating"),
+                tolerance=rating_tolerance,
+            ):
+                continue
+            decisions[row_id] = {
+                "survivor_review_id": survivor_id,
+                "duplicate_reason": "cross_source_reviewer_date_similarity",
+                "duplicate_detail": {
+                    "survivor_review_id": survivor_id,
+                    "survivor_source": survivor_source,
+                    "reason_code": "cross_source_reviewer_date_similarity",
+                    "content_hash_match": False,
+                    "identity_key_match": False,
+                    "reviewer_overlap_match": True,
+                    "review_date_tolerance_match": True,
+                    "rating_tolerance_match": True,
+                    "text_similarity": round(similarity, 4),
+                    "backfill_scope": "cross_source_review_dedup",
+                    "reviewer_stem": reviewer_stem,
+                },
+            }
+
+    return decisions

--- a/atlas_brain/services/b2b/reviewer_identity.py
+++ b/atlas_brain/services/b2b/reviewer_identity.py
@@ -1,0 +1,26 @@
+"""Shared reviewer-identity normalization helpers for B2B review ingestion."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_SYNTHETIC_REVIEWER_TITLE_PATTERNS = (
+    re.compile(r"^repeat churn signal", re.I),
+    re.compile(r"score:\s*\d", re.I),
+)
+
+
+def is_synthetic_reviewer_title(value: Any) -> bool:
+    title = str(value or "").strip()
+    if not title:
+        return False
+    lowered = title.lower()
+    return any(pattern.search(lowered) for pattern in _SYNTHETIC_REVIEWER_TITLE_PATTERNS)
+
+
+def sanitize_reviewer_title(value: Any) -> str | None:
+    title = str(value or "").strip()
+    if not title or is_synthetic_reviewer_title(title):
+        return None
+    return title

--- a/atlas_brain/services/scraping/sources.py
+++ b/atlas_brain/services/scraping/sources.py
@@ -10,6 +10,7 @@ Because ``ReviewSource`` extends ``str``, existing string comparisons
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from enum import Enum
 
 
@@ -159,6 +160,30 @@ DEFAULT_ALLOWLIST_SOURCES: frozenset[ReviewSource] = frozenset({
 def parse_source_allowlist(raw: str) -> list[str]:
     """Return a normalized source allowlist from a comma-separated string."""
     return [part.strip().lower() for part in raw.split(",") if part.strip()]
+
+
+def filter_deprecated_sources(
+    sources: Iterable[str],
+    deprecated: str | Iterable[str] | None,
+) -> list[str]:
+    """Remove deprecated sources from an allowlist while preserving order."""
+    if isinstance(deprecated, str):
+        deprecated_set = set(parse_source_allowlist(deprecated))
+    else:
+        deprecated_set = {
+            str(source).strip().lower()
+            for source in (deprecated or [])
+            if str(source).strip()
+        }
+    filtered: list[str] = []
+    seen: set[str] = set()
+    for source in sources:
+        normalized = str(source).strip().lower()
+        if not normalized or normalized in deprecated_set or normalized in seen:
+            continue
+        filtered.append(normalized)
+        seen.add(normalized)
+    return filtered
 
 
 def is_source_allowed(source: str, allowlist_raw: str) -> bool:

--- a/tests/test_b2b_batch_utils.py
+++ b/tests/test_b2b_batch_utils.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+
+
+def test_anthropic_batch_requested_prefers_task_metadata_when_global_default_is_off():
+    from atlas_brain.autonomous.tasks._b2b_batch_utils import anthropic_batch_requested
+
+    task = SimpleNamespace(
+        metadata={
+            "anthropic_batch_enabled": True,
+            "tenant_report_anthropic_batch_enabled": True,
+        }
+    )
+
+    enabled = anthropic_batch_requested(
+        task,
+        global_default=False,
+        task_default=False,
+        task_keys=("tenant_report_anthropic_batch_enabled",),
+    )
+
+    assert enabled is True
+
+
+def test_resolve_anthropic_batch_llm_preserves_matching_claude_model(monkeypatch):
+    from atlas_brain.autonomous.tasks._b2b_batch_utils import resolve_anthropic_batch_llm
+
+    class FakeAnthropicLLM:
+        def __init__(self, model: str = ""):
+            self.model = model
+            self.name = "anthropic"
+
+    active_llm = FakeAnthropicLLM("claude-sonnet-4-5")
+    activation = {}
+
+    monkeypatch.setattr(
+        "atlas_brain.services.llm.anthropic.AnthropicLLM",
+        FakeAnthropicLLM,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.pipelines.llm.get_pipeline_llm",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.config.settings.llm.anthropic_api_key",
+        "test-key",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.llm_registry.get_slot",
+        lambda slot_name: activation.update({"slot_name": slot_name}) or None,
+    )
+    def _activate_slot(slot_name, provider, **kwargs):
+        activation.update(
+            {"provider": provider, "model": kwargs.get("model"), "slot_name": slot_name}
+        )
+        return active_llm
+
+    monkeypatch.setattr(
+        "atlas_brain.services.llm_registry.activate_slot",
+        _activate_slot,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.llm_registry.activate",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("global activate should not run for Anthropic batch LLM resolution")
+        ),
+    )
+
+    resolved = resolve_anthropic_batch_llm(
+        current_llm=SimpleNamespace(
+            name="openrouter",
+            model="anthropic/claude-sonnet-4-5",
+        ),
+    )
+
+    assert activation == {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-5",
+        "slot_name": "b2b_batch_anthropic::claude-sonnet-4-5",
+    }
+    assert resolved is active_llm
+
+
+def test_resolve_anthropic_batch_llm_reuses_matching_slot_without_global_activation(monkeypatch):
+    from atlas_brain.autonomous.tasks._b2b_batch_utils import resolve_anthropic_batch_llm
+
+    class FakeAnthropicLLM:
+        def __init__(self, model: str = ""):
+            self.model = model
+            self.name = "anthropic"
+
+    slot_llm = FakeAnthropicLLM("claude-sonnet-4-5")
+
+    monkeypatch.setattr(
+        "atlas_brain.services.llm.anthropic.AnthropicLLM",
+        FakeAnthropicLLM,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.pipelines.llm.get_pipeline_llm",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.config.settings.llm.anthropic_api_key",
+        "test-key",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.llm_registry.get_slot",
+        lambda slot_name: slot_llm if slot_name == "b2b_batch_anthropic::claude-sonnet-4-5" else None,
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.llm_registry.activate_slot",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("activate_slot should not run when matching slot already exists")
+        ),
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.llm_registry.activate",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("global activate should not run for Anthropic batch LLM resolution")
+        ),
+    )
+
+    resolved = resolve_anthropic_batch_llm(
+        current_llm=SimpleNamespace(
+            name="openrouter",
+            model="anthropic/claude-sonnet-4-5",
+        ),
+    )
+
+    assert resolved is slot_llm

--- a/tests/test_b2b_enrichment.py
+++ b/tests/test_b2b_enrichment.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -6,6 +7,8 @@ from uuid import uuid4
 import pytest
 
 from atlas_brain.autonomous.tasks import b2b_enrichment
+from atlas_brain.autonomous.tasks._b2b_batch_utils import exact_stage_request_fingerprint, reconcile_existing_batch_artifacts
+from atlas_brain.reasoning import evidence_engine
 from atlas_brain.storage.models import ScheduledTask
 
 
@@ -27,6 +30,309 @@ class _Pool:
         self.fetch = AsyncMock(side_effect=batches)
         self.fetchval = AsyncMock(return_value=0)
         self.execute = AsyncMock(return_value="UPDATE 0")
+
+
+def test_normalize_pain_category_maps_legacy_other_to_overall_dissatisfaction():
+    assert b2b_enrichment._normalize_pain_category("other") == "overall_dissatisfaction"
+    assert b2b_enrichment._normalize_pain_category("general_dissatisfaction") == "overall_dissatisfaction"
+
+
+def test_normalize_pain_category_accepts_new_specific_buckets():
+    assert b2b_enrichment._normalize_pain_category("admin_burden") == "admin_burden"
+    assert b2b_enrichment._normalize_pain_category("integration_debt") == "integration_debt"
+
+
+def test_enrichment_batch_custom_id_is_anthropic_safe():
+    assert b2b_enrichment._enrichment_batch_custom_id("tier1", "1234-5678") == "tier1_1234-5678"
+
+
+def test_derive_competitor_annotations_prunes_generic_provider_labels():
+    row = {
+        "vendor_name": "Amazon Web Services",
+        "summary": "AWS Failed Me",
+        "review_text": "We may need a competing provider after this outage.",
+        "pros": "",
+        "cons": "",
+    }
+    result = {
+        "churn_signals": {"intent_to_leave": True, "actively_evaluating": False},
+        "competitors_mentioned": [{"name": "competing provider"}],
+    }
+
+    derived = b2b_enrichment._derive_competitor_annotations(result, row)
+
+    assert derived == []
+
+
+def test_derive_competitor_annotations_prunes_weak_neutral_mentions_without_named_context():
+    row = {
+        "vendor_name": "ActiveCampaign",
+        "summary": "Pricing and support issues",
+        "review_text": "Their pricing is outrageous and support is nonexistent. We need a better answer fast.",
+        "pros": "",
+        "cons": "",
+    }
+    result = {
+        "churn_signals": {"intent_to_leave": True, "actively_evaluating": False},
+        "competitors_mentioned": [{"name": "HubSpot"}],
+    }
+
+    derived = b2b_enrichment._derive_competitor_annotations(result, row)
+
+    assert derived == []
+
+
+def test_repair_target_fields_skips_roundup_style_competitor_repair_without_named_displacement():
+    row = {
+        "source": "reddit",
+        "enrichment_status": "enriched",
+        "summary": "I went through hundreds of user reviews of project management tools, here's what actually matters.",
+        "review_text": (
+            "Asana is strong for structured teams and workflows. Monday.com has great UI. "
+            "Notion is loved for docs plus project hybrid use. Trello falls short for growing teams."
+        ),
+        "pros": "",
+        "cons": "",
+    }
+    result = {
+        "pain_category": "overall_dissatisfaction",
+        "salience_flags": [],
+        "competitors_mentioned": [],
+        "specific_complaints": ["limited customization compared to others"],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "feature_gaps": ["limited customization compared to others"],
+        "event_mentions": [],
+        "timeline": {"decision_timeline": "unknown"},
+    }
+
+    targets = b2b_enrichment._repair_target_fields(result, row)
+
+    assert "competitors_mentioned" not in targets
+
+
+def test_effective_enrichment_skip_sources_includes_deprecated_sources(monkeypatch):
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_skip_sources",
+        "stackoverflow,github",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "deprecated_review_sources",
+        "capterra,software_advice,trustpilot,trustradius",
+        raising=False,
+    )
+
+    assert b2b_enrichment._effective_enrichment_skip_sources() == {
+        "stackoverflow",
+        "github",
+        "capterra",
+        "software_advice",
+        "trustpilot",
+        "trustradius",
+    }
+
+
+def test_trusted_repair_sources_filters_deprecated_sources(monkeypatch):
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_priority_sources",
+        "g2,trustradius,capterra,software_advice,gartner,trustpilot,peerspot",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "deprecated_review_sources",
+        "capterra,software_advice,trustpilot,trustradius",
+        raising=False,
+    )
+
+    assert b2b_enrichment._trusted_repair_sources() == {"g2", "gartner", "peerspot"}
+
+
+def test_tier2_system_prompt_trims_insider_section_for_non_insider_content():
+    prompt = (
+        "## Intro\n"
+        "Keep output grounded.\n\n"
+        "### insider_signals -- CLASSIFY + EXTRACT (only for insider_account)\n"
+        "Insider-only instructions.\n\n"
+        "## Output\n"
+        "Return JSON."
+    )
+
+    trimmed = b2b_enrichment._tier2_system_prompt_for_content_type(prompt, "review")
+
+    assert "Insider-only instructions." not in trimmed
+    assert "### insider_signals -- CLASSIFY + EXTRACT (only for insider_account)" not in trimmed
+    assert trimmed == "## Intro\nKeep output grounded.\n\n## Output\nReturn JSON."
+
+
+def test_tier2_system_prompt_keeps_insider_section_for_insider_accounts():
+    prompt = (
+        "## Intro\n"
+        "Keep output grounded.\n\n"
+        "### insider_signals -- CLASSIFY + EXTRACT (only for insider_account)\n"
+        "Insider-only instructions.\n\n"
+        "## Output\n"
+        "Return JSON."
+    )
+
+    preserved = b2b_enrichment._tier2_system_prompt_for_content_type(prompt, "insider_account")
+
+    assert preserved == prompt
+
+
+def test_build_classify_payload_omits_empty_optional_fields():
+    payload = b2b_enrichment._build_classify_payload(
+        {
+            "vendor_name": "Zendesk",
+            "product_name": "",
+            "product_category": "",
+            "source": "g2",
+            "raw_metadata": {},
+            "content_type": "review",
+            "rating": None,
+            "rating_max": 5,
+            "summary": "",
+            "review_text": "",
+            "pros": "",
+            "cons": "",
+            "reviewer_title": " ",
+            "reviewer_company": None,
+            "company_size_raw": "",
+            "reviewer_industry": "",
+        }
+    )
+
+    assert payload["vendor_name"] == "Zendesk"
+    assert payload["content_type"] == "review"
+    assert payload["rating_max"] == 5
+    assert "product_name" not in payload
+    assert "product_category" not in payload
+    assert "rating" not in payload
+    assert "summary" not in payload
+    assert "review_text" not in payload
+    assert "pros" not in payload
+    assert "cons" not in payload
+    assert "reviewer_title" not in payload
+    assert "reviewer_company" not in payload
+    assert "company_size_raw" not in payload
+    assert "reviewer_industry" not in payload
+
+
+def test_tier1_has_extraction_gaps_keeps_default_behavior_for_non_strict_sources(monkeypatch):
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_tier2_strict_sources",
+        "gartner,peerspot",
+        raising=False,
+    )
+    tier1 = {
+        "specific_complaints": [],
+        "quotable_phrases": ["Users keep mentioning admin overhead."],
+        "competitors_mentioned": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "churn_signals": {},
+    }
+
+    assert b2b_enrichment._tier1_has_extraction_gaps(tier1, source="g2") is True
+
+
+def test_tier1_has_extraction_gaps_is_stricter_for_gartner_and_peerspot(monkeypatch):
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_tier2_strict_sources",
+        "gartner,peerspot",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_tier2_strict_min_complaints",
+        2,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_tier2_strict_min_quotes",
+        2,
+        raising=False,
+    )
+    weak_tier1 = {
+        "specific_complaints": [],
+        "quotable_phrases": ["One generic quote"],
+        "competitors_mentioned": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "churn_signals": {},
+    }
+    strong_tier1 = {
+        "specific_complaints": ["Billing was confusing", "Renewal price jumped unexpectedly"],
+        "quotable_phrases": ["Two useful quotes", "Another useful quote"],
+        "competitors_mentioned": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "churn_signals": {},
+    }
+
+    assert b2b_enrichment._tier1_has_extraction_gaps(weak_tier1, source="gartner") is False
+    assert b2b_enrichment._tier1_has_extraction_gaps(weak_tier1, source="peerspot") is False
+    assert b2b_enrichment._tier1_has_extraction_gaps(strong_tier1, source="gartner") is True
+
+
+def test_tier1_has_extraction_gaps_still_allows_strict_sources_with_churn_or_competitor(monkeypatch):
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_tier2_strict_sources",
+        "gartner,peerspot",
+        raising=False,
+    )
+    churn_tier1 = {
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "competitors_mentioned": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "churn_signals": {"intent_to_leave": True},
+    }
+    competitor_tier1 = {
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "competitors_mentioned": [{"name": "HubSpot"}],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "churn_signals": {},
+    }
+
+    assert b2b_enrichment._tier1_has_extraction_gaps(churn_tier1, source="gartner") is True
+    assert b2b_enrichment._tier1_has_extraction_gaps(competitor_tier1, source="peerspot") is True
+
+
+def test_is_no_signal_result_accepts_empty_community_discussion_without_rating():
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "migration_in_progress": False,
+            "support_escalation": False,
+            "contract_renewal_mentioned": False,
+        },
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "event_mentions": [],
+        "feature_gaps": [],
+    }
+    row = {
+        "content_type": "community_discussion",
+        "rating": None,
+    }
+
+    assert b2b_enrichment._is_no_signal_result(result, row) is True
 
 
 @pytest.mark.asyncio
@@ -116,6 +422,7 @@ async def test_run_applies_manual_metadata_overrides(monkeypatch):
     assert max_batch == 25
     assert priority_sources == ["stackoverflow", "github"]
     assert enrich_rows.await_args.kwargs["concurrency_override"] == 17
+    assert enrich_rows.await_args.kwargs["task"] is task
 
 
 @pytest.mark.asyncio
@@ -163,6 +470,297 @@ async def test_enrich_rows_uses_configured_concurrency(monkeypatch):
     assert max_seen == 2
 
 
+@pytest.mark.asyncio
+async def test_enrich_rows_uses_anthropic_batch_when_enabled(monkeypatch):
+    class FakeAnthropicLLM:
+        def __init__(self, model: str = "claude-haiku-4-5"):
+            self.model = model
+            self.name = "anthropic"
+
+    row_id = uuid4()
+    rows = [{
+        "id": row_id,
+        "vendor_name": "Zendesk",
+        "product_name": "Zendesk",
+        "product_category": "Help Desk",
+        "source": "reddit",
+        "summary": "Pricing is getting rough",
+        "review_text": (
+            "Pricing is getting rough and support is slower now. "
+            "Renewal discussions are already getting tense and the team is actively reviewing options."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "",
+        "reviewer_company": "",
+        "company_size_raw": "",
+        "reviewer_industry": "",
+        "content_type": "review",
+        "raw_metadata": {},
+        "rating": None,
+        "rating_max": 5,
+        "enrichment_attempts": 0,
+    }]
+    cfg = SimpleNamespace(
+        enrichment_max_attempts=3,
+        enrichment_concurrency=2,
+        enrichment_local_only=False,
+        enrichment_max_tokens=2048,
+        review_truncate_length=3000,
+        openrouter_api_key="test-key",
+        enrichment_openrouter_model="anthropic/claude-haiku-4-5",
+        enrichment_tier1_max_tokens=512,
+        enrichment_tier2_max_tokens=512,
+        enrichment_tier2_openrouter_model="",
+        anthropic_batch_enabled=True,
+        enrichment_anthropic_batch_enabled=True,
+    )
+    task = _task()
+    task.metadata["anthropic_batch_enabled"] = True
+    task.metadata["enrichment_anthropic_batch_enabled"] = True
+    pool = SimpleNamespace(fetch=AsyncMock(return_value=[{"enrichment_status": "enriched", "ct": 1}]))
+    persist = AsyncMock(return_value=True)
+
+    monkeypatch.setattr("atlas_brain.services.llm.anthropic.AnthropicLLM", FakeAnthropicLLM)
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_batch_utils.resolve_anthropic_batch_llm",
+        lambda **_kwargs: FakeAnthropicLLM(),
+    )
+    monkeypatch.setattr(
+        "atlas_brain.skills.get_skill_registry",
+        lambda: SimpleNamespace(
+            get=lambda name: SimpleNamespace(content=f"{name} prompt")
+            if name in {"digest/b2b_churn_extraction_tier1", "digest/b2b_churn_extraction_tier2"}
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.b2b.cache_runner.prepare_b2b_exact_stage_request",
+        lambda *args, **_kwargs: SimpleNamespace(namespace="ns", request_envelope={}, provider="openrouter", model="anthropic/claude-haiku-4-5"),
+    )
+    monkeypatch.setattr("atlas_brain.services.b2b.cache_runner.lookup_b2b_exact_stage_text", AsyncMock(return_value=None))
+    monkeypatch.setattr("atlas_brain.services.b2b.cache_runner.store_b2b_exact_stage_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "atlas_brain.services.b2b.anthropic_batch.run_anthropic_message_batch",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                local_batch_id="batch-1",
+                provider_batch_id="provider-batch-1",
+                submitted_items=1,
+                cache_prefiltered_items=0,
+                fallback_single_call_items=0,
+                completed_items=1,
+                failed_items=0,
+                results_by_custom_id={
+                    b2b_enrichment._enrichment_batch_custom_id("tier1", row_id): SimpleNamespace(
+                        response_text=json.dumps({
+                            "specific_complaints": ["pricing pressure"],
+                            "quotable_phrases": [],
+                        }),
+                        cached=False,
+                        usage={},
+                        error_text=None,
+                    )
+                },
+            )
+        ),
+    )
+    monkeypatch.setattr(b2b_enrichment, "_persist_enrichment_result", persist)
+    monkeypatch.setattr(b2b_enrichment, "_tier1_has_extraction_gaps", lambda *_args, **_kwargs: False)
+
+    result = await b2b_enrichment._enrich_rows(rows, cfg, pool, run_id="run-1", task=task)
+
+    assert result["anthropic_batch_jobs"] == 1
+    assert result["anthropic_batch_items_submitted"] == 1
+    assert result["enriched"] == 1
+    assert persist.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_enrich_rows_reuses_existing_completed_tier1_batch_result(monkeypatch):
+    class FakeAnthropicLLM:
+        def __init__(self, model: str = "claude-haiku-4-5"):
+            self.model = model
+            self.name = "anthropic"
+
+    row_id = uuid4()
+    rows = [{
+        "id": row_id,
+        "vendor_name": "Zendesk",
+        "product_name": "Zendesk",
+        "product_category": "Help Desk",
+        "source": "reddit",
+        "summary": "Pricing is getting rough",
+        "review_text": (
+            "Pricing is getting rough and support is slower now. "
+            "Renewal discussions are already getting tense and the team is actively reviewing options."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "",
+        "reviewer_company": "",
+        "company_size_raw": "",
+        "reviewer_industry": "",
+        "content_type": "review",
+        "raw_metadata": {},
+        "rating": None,
+        "rating_max": 5,
+        "enrichment_attempts": 0,
+    }]
+    cfg = SimpleNamespace(
+        enrichment_max_attempts=3,
+        enrichment_concurrency=2,
+        enrichment_local_only=False,
+        enrichment_max_tokens=2048,
+        review_truncate_length=3000,
+        openrouter_api_key="test-key",
+        enrichment_openrouter_model="anthropic/claude-haiku-4-5",
+        enrichment_tier1_max_tokens=512,
+        enrichment_tier2_max_tokens=512,
+        enrichment_tier2_openrouter_model="",
+        anthropic_batch_enabled=True,
+        enrichment_anthropic_batch_enabled=True,
+    )
+    task = _task()
+    task.metadata["anthropic_batch_enabled"] = True
+    task.metadata["enrichment_anthropic_batch_enabled"] = True
+    pool = SimpleNamespace(fetch=AsyncMock(return_value=[{"enrichment_status": "enriched", "ct": 1}]))
+    persist = AsyncMock(return_value=True)
+
+    monkeypatch.setattr("atlas_brain.services.llm.anthropic.AnthropicLLM", FakeAnthropicLLM)
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_batch_utils.resolve_anthropic_batch_llm",
+        lambda **_kwargs: FakeAnthropicLLM(),
+    )
+    monkeypatch.setattr(
+        "atlas_brain.skills.get_skill_registry",
+        lambda: SimpleNamespace(
+            get=lambda name: SimpleNamespace(content=f"{name} prompt")
+            if name in {"digest/b2b_churn_extraction_tier1", "digest/b2b_churn_extraction_tier2"}
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "atlas_brain.services.b2b.cache_runner.prepare_b2b_exact_stage_request",
+        lambda *args, **_kwargs: SimpleNamespace(namespace="ns", request_envelope={}, provider="openrouter", model="anthropic/claude-haiku-4-5"),
+    )
+    monkeypatch.setattr("atlas_brain.services.b2b.cache_runner.lookup_b2b_exact_stage_text", AsyncMock(return_value=None))
+    monkeypatch.setattr("atlas_brain.services.b2b.cache_runner.store_b2b_exact_stage_text", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_batch_utils.reconcile_existing_batch_artifacts",
+        AsyncMock(
+            return_value={
+                str(row_id): {
+                    "state": "succeeded",
+                    "cached": False,
+                    "response_text": json.dumps({
+                        "specific_complaints": ["pricing pressure"],
+                        "quotable_phrases": [],
+                    }),
+                    "custom_id": b2b_enrichment._enrichment_batch_custom_id("tier1", row_id),
+                }
+            }
+        ),
+    )
+    run_batch = AsyncMock()
+    monkeypatch.setattr(
+        "atlas_brain.services.b2b.anthropic_batch.run_anthropic_message_batch",
+        run_batch,
+    )
+    monkeypatch.setattr(b2b_enrichment, "_persist_enrichment_result", persist)
+    monkeypatch.setattr(b2b_enrichment, "_tier1_has_extraction_gaps", lambda *_args, **_kwargs: False)
+
+    result = await b2b_enrichment._enrich_rows(rows, cfg, pool, run_id="run-1", task=task)
+
+    assert result["anthropic_batch_jobs"] == 0
+    assert result["anthropic_batch_reused_completed_items"] == 1
+    assert result["enriched"] == 1
+    assert persist.await_count == 1
+    run_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_requires_matching_request_fingerprint():
+    request = SimpleNamespace(
+        namespace="b2b_enrichment.tier1",
+        provider="openrouter",
+        model="anthropic/claude-haiku-4-5",
+        request_envelope={
+            "messages": [
+                {"role": "system", "content": "tier1 prompt"},
+                {"role": "user", "content": "payload"},
+            ],
+            "max_tokens": 4096,
+            "temperature": 0.0,
+            "response_format": {"type": "json_object"},
+        },
+    )
+    fingerprint = exact_stage_request_fingerprint(request)
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "review-1",
+                    "batch_id": "batch-1",
+                    "status": "batch_succeeded",
+                    "response_text": json.dumps({"specific_complaints": ["pricing"]}),
+                    "error_text": None,
+                    "custom_id": "tier1_review-1",
+                    "request_metadata": {"request_fingerprint": fingerprint},
+                    "batch_status": "completed",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="b2b_enrichment",
+        artifact_type="review_enrichment_tier1",
+        artifact_ids=["review-1"],
+        expected_request_fingerprints={"review-1": fingerprint},
+    )
+
+    assert result["review-1"]["state"] == "succeeded"
+    assert result["review-1"]["custom_id"] == "tier1_review-1"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_skips_mismatched_request_fingerprint():
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "review-1",
+                    "batch_id": "batch-1",
+                    "status": "batch_succeeded",
+                    "response_text": json.dumps({"specific_complaints": ["pricing"]}),
+                    "error_text": None,
+                    "custom_id": "tier1_review-1",
+                    "request_metadata": {"request_fingerprint": "stale-request"},
+                    "batch_status": "completed",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="b2b_enrichment",
+        artifact_type="review_enrichment_tier1",
+        artifact_ids=["review-1"],
+        expected_request_fingerprints={"review-1": "current-request"},
+    )
+
+    assert result == {}
+
+
 def test_get_base_enrichment_llm_uses_vllm_first(monkeypatch):
     calls = []
 
@@ -197,6 +795,151 @@ def test_get_base_enrichment_llm_respects_local_only(monkeypatch):
         "try_openrouter": False,
         "auto_activate_ollama": False,
     }]
+
+
+@pytest.mark.asyncio
+async def test_call_vllm_tier1_uses_exact_cache_hit(monkeypatch):
+    class _Registry:
+        def get(self, name):
+            if name == "digest/b2b_churn_extraction_tier1":
+                return SimpleNamespace(content="tier1")
+            return None
+
+    monkeypatch.setattr("atlas_brain.skills.get_skill_registry", lambda: _Registry())
+    monkeypatch.setattr(
+        b2b_enrichment,
+        "_lookup_cached_json_response",
+        AsyncMock(
+            return_value=(
+                {"specific_complaints": ["support delays"], "churn_signals": {"actively_evaluating": True}},
+                {"messages": [{"role": "user", "content": "cached"}]},
+            )
+        ),
+    )
+    client = SimpleNamespace(
+        post=AsyncMock(side_effect=AssertionError("tier1 HTTP should not run on exact-cache hit"))
+    )
+    cfg = SimpleNamespace(
+        enrichment_tier1_model="qwen3-30b",
+        enrichment_tier1_max_tokens=512,
+    )
+
+    parsed, model = await b2b_enrichment._call_vllm_tier1(
+        json.dumps({"vendor_name": "Zendesk"}),
+        cfg,
+        client,
+    )
+
+    assert parsed["specific_complaints"] == ["support delays"]
+    assert parsed["churn_signals"]["actively_evaluating"] is True
+    assert model == "qwen3-30b"
+    client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_call_openrouter_tier2_uses_exact_cache_hit(monkeypatch):
+    prompt = (
+        "## Intro\n"
+        "Base instructions.\n\n"
+        "### insider_signals -- CLASSIFY + EXTRACT (only for insider_account)\n"
+        "Insider-only instructions.\n\n"
+        "## Output\n"
+        "Return JSON."
+    )
+
+    class _Registry:
+        def get(self, name):
+            if name == "digest/b2b_churn_extraction_tier2":
+                return SimpleNamespace(content=prompt)
+            return None
+
+    cache_lookup = AsyncMock(
+        return_value=(
+            {"pain_categories": [{"category": "pricing", "severity": "primary"}]},
+            {"messages": [{"role": "user", "content": "cached"}]},
+        )
+    )
+    monkeypatch.setattr("atlas_brain.skills.get_skill_registry", lambda: _Registry())
+    monkeypatch.setattr(b2b_enrichment, "_lookup_cached_json_response", cache_lookup)
+    cfg = SimpleNamespace(
+        openrouter_api_key="test-key",
+        enrichment_tier2_openrouter_model="anthropic/claude-haiku-4-5",
+        enrichment_openrouter_model="openai/gpt-oss-120b",
+        enrichment_tier2_max_tokens=512,
+        enrichment_tier2_timeout_seconds=30.0,
+    )
+    row = {
+        "vendor_name": "Zendesk",
+        "product_name": "Zendesk",
+        "product_category": "Helpdesk",
+        "source": "g2",
+        "raw_metadata": {},
+        "content_type": "review",
+        "rating": 2.0,
+        "rating_max": 5,
+        "summary": "Pricing issues",
+        "review_text": "We are evaluating alternatives because pricing keeps rising.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "VP Support",
+        "reviewer_company": "Acme",
+        "company_size_raw": "201-500",
+        "reviewer_industry": "SaaS",
+    }
+    tier1_result = {
+        "specific_complaints": ["pricing keeps rising"],
+        "quotable_phrases": ["evaluating alternatives"],
+    }
+
+    parsed, model = await b2b_enrichment._call_openrouter_tier2(
+        tier1_result,
+        row,
+        cfg,
+        truncate_length=3000,
+    )
+
+    assert parsed["pain_categories"] == [{"category": "pricing", "severity": "primary"}]
+    assert model == "anthropic/claude-haiku-4-5"
+    assert cache_lookup.await_count == 1
+    assert (
+        cache_lookup.await_args.kwargs["system_prompt"]
+        == "## Intro\nBase instructions.\n\n## Output\nReturn JSON."
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_openrouter_tier1_defaults_to_claude_haiku_when_model_unset(monkeypatch):
+    prompt = "Return JSON."
+
+    class _Registry:
+        def get(self, name):
+            if name == "digest/b2b_churn_extraction_tier1":
+                return SimpleNamespace(content=prompt)
+            return None
+
+    cache_lookup = AsyncMock(
+        return_value=(
+            {"specific_complaints": ["support delays"], "churn_signals": {"actively_evaluating": True}},
+            {"messages": [{"role": "user", "content": "cached"}]},
+        )
+    )
+    monkeypatch.setattr("atlas_brain.skills.get_skill_registry", lambda: _Registry())
+    monkeypatch.setattr(b2b_enrichment, "_lookup_cached_json_response", cache_lookup)
+    cfg = SimpleNamespace(
+        openrouter_api_key="test-key",
+        enrichment_openrouter_model="",
+        enrichment_tier1_max_tokens=512,
+    )
+
+    parsed, model = await b2b_enrichment._call_openrouter_tier1(
+        json.dumps({"vendor_name": "Zendesk"}),
+        cfg,
+    )
+
+    assert parsed["specific_complaints"] == ["support delays"]
+    assert model == "anthropic/claude-haiku-4-5"
+    assert cache_lookup.await_count == 1
+    assert cache_lookup.await_args.kwargs["model"] == "anthropic/claude-haiku-4-5"
 
 
 @pytest.mark.asyncio
@@ -492,6 +1235,931 @@ def test_apply_structural_repair_promotes_only_unknown_fields():
     assert "contract_context.contract_value_signal" in applied
 
 
+def test_derive_decision_timeline_uses_raw_text_when_commercial_context_exists():
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": True,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": False,
+            "renewal_timing": None,
+        },
+        "timeline": {"contract_end": None, "evaluation_deadline": None},
+        "event_mentions": [],
+        "pricing_phrases": ["pricing pressure"],
+        "specific_complaints": ["We need to decide next quarter"],
+        "competitors_mentioned": [],
+    }
+    row = {
+        "summary": "Renewal decision coming soon",
+        "review_text": "Pricing pressure means we need to decide next quarter whether to switch.",
+        "pros": "",
+        "cons": "",
+    }
+
+    assert b2b_enrichment._derive_decision_timeline(result, row) == "within_quarter"
+
+
+def test_derive_decision_timeline_ignores_generic_deadline_without_commercial_context():
+    result = {
+        "churn_signals": {},
+        "timeline": {"contract_end": None, "evaluation_deadline": None},
+        "event_mentions": [],
+        "pricing_phrases": [],
+        "specific_complaints": [],
+        "competitors_mentioned": [],
+    }
+    row = {
+        "summary": "Helpful for daily work",
+        "review_text": "This helps me track tasks and deadlines every week for my team.",
+        "pros": "",
+        "cons": "",
+    }
+
+    assert b2b_enrichment._derive_decision_timeline(result, row) == "unknown"
+
+
+def test_derive_decision_timeline_ignores_soft_deadline_complaint_without_strong_commercial_signal():
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": False,
+            "renewal_timing": None,
+        },
+        "timeline": {"contract_end": None, "evaluation_deadline": None},
+        "event_mentions": [],
+        "pricing_phrases": [],
+        "specific_complaints": ["The reminders can get annoying."],
+        "competitors_mentioned": [],
+    }
+    row = {
+        "summary": "Helpful but noisy reminders",
+        "review_text": "It reminds us about deadlines and action items all the time, which can get annoying.",
+        "pros": "",
+        "cons": "",
+        "source": "software_advice",
+    }
+
+    assert b2b_enrichment._derive_decision_timeline(result, row) == "unknown"
+
+
+def test_derive_decision_timeline_ignores_ambiguous_noisy_source_without_vendor_context(monkeypatch):
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_low_fidelity_noisy_sources",
+        "reddit,quora,twitter",
+    )
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": False,
+            "renewal_timing": None,
+        },
+        "timeline": {"contract_end": None, "evaluation_deadline": None},
+        "event_mentions": [],
+        "pricing_phrases": [],
+        "specific_complaints": ["The zipper design is weak."],
+        "competitors_mentioned": [],
+    }
+    row = {
+        "vendor_name": "Copper",
+        "product_name": "Copper",
+        "summary": "Thinking about replacing my Copper Spur tent next quarter",
+        "review_text": "I am considering other tent options next quarter because the zipper design is weak.",
+        "pros": "",
+        "cons": "",
+        "source": "reddit",
+        "content_type": "community_discussion",
+    }
+
+    assert b2b_enrichment._derive_decision_timeline(result, row) == "unknown"
+
+
+def test_compute_derived_fields_promotes_contract_notice_into_evaluation_deadline(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 7.5
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return True
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "summary": "Cancel before renewal",
+        "review_text": (
+            "We need to give 30 days notice before renewal or they auto renew the contract. "
+            "Support refused to help us cancel."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "Operations Manager",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.8},
+        "content_type": "review",
+        "rating": 1.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": True,
+            "actively_evaluating": False,
+            "contract_renewal_mentioned": True,
+            "renewal_timing": None,
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {
+            "role_level": "manager",
+            "decision_maker": False,
+            "company_name": "Acme Corp",
+        },
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": ["Support refused to help us cancel."],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["timeline"]["contract_end"] == "renewal"
+    assert derived["timeline"]["evaluation_deadline"] == "30 days"
+    assert derived["timeline"]["decision_timeline"] == "within_quarter"
+    assert any(span["time_anchor"] == "30 days" for span in derived["evidence_spans"])
+
+
+def test_compute_derived_fields_promotes_event_timeframe_into_contract_end(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 7.1
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "summary": "Renewal planning",
+        "review_text": "We are evaluating alternatives ahead of renewal.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "",
+        "reviewer_company": "",
+        "raw_metadata": {"source_weight": 0.8},
+        "content_type": "review",
+        "rating": 2.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": True,
+            "contract_renewal_mentioned": True,
+            "renewal_timing": None,
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {},
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [{"event": "renewal", "timeframe": "next quarter"}],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["timeline"]["contract_end"] == "next quarter"
+    assert derived["timeline"]["decision_timeline"] == "within_quarter"
+
+
+def test_finalize_enrichment_for_persist_backfills_company_name_from_reviewer_company(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 4.1
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "HubSpot",
+        "summary": "Solid tool",
+        "review_text": "We use it daily for sales and support workflows.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "Operations Manager",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.8},
+        "content_type": "review",
+        "rating": 4.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": False,
+            "support_escalation": False,
+            "renewal_timing": None,
+        },
+        "reviewer_context": {"role_level": "manager", "decision_maker": False},
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    finalized, error = b2b_enrichment._finalize_enrichment_for_persist(result, row)
+
+    assert error is None
+    assert finalized is not None
+    assert finalized["reviewer_context"]["company_name"] == "Acme Corp"
+
+
+def test_finalize_enrichment_for_persist_does_not_copy_vendor_name_into_company_name(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 4.1
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "HubSpot",
+        "summary": "Solid tool",
+        "review_text": "We use it daily for sales and support workflows.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "Operations Manager",
+        "reviewer_company": "HubSpot",
+        "raw_metadata": {"source_weight": 0.8},
+        "content_type": "review",
+        "rating": 4.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": False,
+            "support_escalation": False,
+            "renewal_timing": None,
+        },
+        "reviewer_context": {"role_level": "manager", "decision_maker": False},
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    finalized, error = b2b_enrichment._finalize_enrichment_for_persist(result, row)
+
+    assert error is None
+    assert finalized is not None
+    assert finalized["reviewer_context"].get("company_name") in (None, "")
+
+
+def test_infer_role_level_from_generic_function_title_aliases():
+    row = {"summary": "", "review_text": "", "pros": "", "cons": ""}
+
+    assert b2b_enrichment._infer_role_level_from_text("PMO", row) == "manager"
+    assert b2b_enrichment._infer_role_level_from_text("Product", row) == "ic"
+    assert b2b_enrichment._infer_role_level_from_text("Owner/Managing Member", row) == "executive"
+
+
+def test_finalize_enrichment_for_persist_promotes_manager_with_commercial_context_to_decision_maker(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 7.0
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return True
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "Zendesk",
+        "summary": "Renewal decision forced budget review",
+        "review_text": (
+            "As operations manager, I owned the renewal review after they quoted us $48k/year "
+            "before the Q2 contract end."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "Operations Manager",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.9},
+        "content_type": "review",
+        "rating": 2.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": True,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": True,
+            "support_escalation": False,
+            "renewal_timing": None,
+        },
+        "reviewer_context": {"role_level": "manager", "decision_maker": False},
+        "budget_signals": {"annual_spend_estimate": "$48k/year"},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": ["quoted us $48k/year"],
+        "event_mentions": [],
+        "timeline": {"contract_end": "Q2 2026"},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    finalized, error = b2b_enrichment._finalize_enrichment_for_persist(result, row)
+
+    assert error is None
+    assert finalized is not None
+    assert finalized["reviewer_context"]["role_level"] == "manager"
+    assert finalized["reviewer_context"]["decision_maker"] is True
+    assert finalized["buyer_authority"]["role_type"] == "economic_buyer"
+
+
+def test_finalize_enrichment_for_persist_keeps_generic_manager_non_decision_maker_without_commercial_context(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 3.0
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "Klaviyo",
+        "summary": "Good ESP",
+        "review_text": "As marketing manager I use it every day for campaigns and segmentation.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "Marketing Manager",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.9},
+        "content_type": "review",
+        "rating": 4.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "migration_in_progress": False,
+            "contract_renewal_mentioned": False,
+            "support_escalation": False,
+            "renewal_timing": None,
+        },
+        "reviewer_context": {"role_level": "manager", "decision_maker": False},
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    finalized, error = b2b_enrichment._finalize_enrichment_for_persist(result, row)
+
+    assert error is None
+    assert finalized is not None
+    assert finalized["reviewer_context"]["decision_maker"] is False
+    assert finalized["buyer_authority"]["role_type"] == "champion"
+
+
+def test_compute_derived_fields_promotes_explicit_budget_anchors(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 8.2
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return True
+
+        def derive_price_complaint(self, result):
+            return True
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "summary": "Renewal quote forced a decision",
+        "review_text": (
+            "At renewal they quoted us $200k/year for 200 users, or $85/user/month. "
+            "It was a 30% price increase and we started evaluating alternatives."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "VP Operations",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.9},
+        "content_type": "review",
+        "rating": 2.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": True,
+            "contract_renewal_mentioned": True,
+            "renewal_timing": "next quarter",
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {
+            "role_level": "director",
+            "decision_maker": True,
+            "company_name": "Acme Corp",
+        },
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": ["The renewal quote forced us to reevaluate the tool."],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["budget_signals"]["annual_spend_estimate"] == "$200k/year"
+    assert derived["budget_signals"]["price_per_seat"] == "$85/user/month"
+    assert derived["budget_signals"]["seat_count"] == 200
+    assert derived["budget_signals"]["price_increase_mentioned"] is True
+    assert derived["budget_signals"]["price_increase_detail"] == "30% price increase"
+    assert derived["contract_context"]["contract_value_signal"] == "enterprise_high"
+
+
+def test_compute_derived_fields_ignores_salary_noise_for_budget_signals(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 1.5
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return None
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "Copper",
+        "product_name": "Copper",
+        "summary": "My intern salary this year",
+        "review_text": "I got a $140k salary offer as an intern this year and took the job.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "",
+        "reviewer_company": "",
+        "raw_metadata": {"source_weight": 0.2},
+        "content_type": "community_discussion",
+        "rating": None,
+        "rating_max": 5,
+        "source": "reddit",
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "contract_renewal_mentioned": False,
+            "renewal_timing": None,
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {"role_level": "unknown", "decision_maker": False},
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "community_discussion",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["budget_signals"] == {}
+
+
+def test_compute_derived_fields_ignores_ambiguous_noisy_source_budget_noise(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 2.0
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return None
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+    monkeypatch.setattr(
+        b2b_enrichment.settings.b2b_churn,
+        "enrichment_low_fidelity_noisy_sources",
+        "reddit,quora,twitter",
+    )
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "Close",
+        "product_name": "Close",
+        "summary": "Can't remove the charge? Well, I'll just use it then",
+        "review_text": (
+            "The apartment complex charged an upcharge of $25 a month for assigned parking. "
+            "The lease breaking fees and rent increase would have cost over a thousand dollars."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "",
+        "reviewer_company": "",
+        "raw_metadata": {"source_weight": 0.2},
+        "content_type": "community_discussion",
+        "rating": None,
+        "rating_max": 5,
+        "source": "reddit",
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "contract_renewal_mentioned": False,
+            "renewal_timing": None,
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {"role_level": "unknown", "decision_maker": False},
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "community_discussion",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": ["upcharge of $25 a month", "lease breaking fees", "over a thousand dollars"],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["budget_signals"] == {}
+
+
+def test_compute_derived_fields_derives_annual_spend_from_monthly_unit_price_and_seat_count(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 1.5
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return None
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "HubSpot",
+        "product_name": "HubSpot Sales Hub",
+        "summary": "Renewal pricing pushed us to reevaluate",
+        "review_text": "Our renewal quote came in at $85/user/month for 200 users.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "VP Operations",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.9},
+        "content_type": "review",
+        "rating": 2.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": True,
+            "contract_renewal_mentioned": True,
+            "renewal_timing": "next quarter",
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {
+            "role_level": "director",
+            "decision_maker": True,
+            "company_name": "Acme Corp",
+        },
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": ["The renewal quote forced us to reevaluate the tool."],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["budget_signals"]["price_per_seat"] == "$85/user/month"
+    assert derived["budget_signals"]["seat_count"] == 200
+    assert derived["budget_signals"]["annual_spend_estimate"] == "$204k/year"
+    assert derived["contract_context"]["contract_value_signal"] == "enterprise_high"
+
+
+def test_compute_derived_fields_skips_ambiguous_range_unit_price_for_annual_spend(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 1.5
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return None
+
+        def derive_budget_authority(self, result):
+            return False
+
+        def derive_price_complaint(self, result):
+            return False
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "vendor_name": "SentinelOne",
+        "product_name": "SentinelOne Singularity Complete",
+        "summary": "Pricing depends on volume",
+        "review_text": "The quote was $7 to $10 per agent per month for 6000 agents.",
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "Director of Security",
+        "reviewer_company": "Acme Corp",
+        "raw_metadata": {"source_weight": 0.9},
+        "content_type": "review",
+        "rating": 3.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": True,
+            "contract_renewal_mentioned": True,
+            "renewal_timing": "this quarter",
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {
+            "role_level": "director",
+            "decision_maker": True,
+            "company_name": "Acme Corp",
+        },
+        "budget_signals": {
+            "price_per_seat": "$7 to $10 per agent per month",
+            "seat_count": 6000,
+        },
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": ["The quote depends heavily on agent volume."],
+        "quotable_phrases": [],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": [],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["budget_signals"]["price_per_seat"] == "$7 to $10 per agent per month"
+    assert derived["budget_signals"]["seat_count"] == 6000
+    assert derived["budget_signals"].get("annual_spend_estimate") is None
+
+
+def test_extract_numeric_amount_supports_suffixes():
+    assert b2b_enrichment._extract_numeric_amount("$200k/year") == 200000
+    assert b2b_enrichment._extract_numeric_amount("USD 1.5m annual contract") == 1500000
+
+
+def test_normalize_budget_value_text_preserves_readable_time_markers():
+    assert b2b_enrichment._normalize_budget_value_text("$8,000 a year") == "$8,000 a year"
+    assert b2b_enrichment._normalize_budget_value_text("$8,000ayear") == "$8,000 a year"
+    assert b2b_enrichment._normalize_budget_value_text("$10k / year") == "$10k/year"
+    assert b2b_enrichment._normalize_budget_value_text("$4/ user/ month") == "$4/user/month"
+
+
 @pytest.mark.asyncio
 async def test_enrich_rows_counts_quarantined(monkeypatch):
     async def _fake_enrich_single(pool, row, max_attempts, local_only, max_tokens, truncate_length):
@@ -516,3 +2184,274 @@ async def test_enrich_rows_counts_quarantined(monkeypatch):
 
     assert result["enriched"] == 0
     assert result["quarantined"] == 3
+
+
+def test_compute_derived_fields_adds_witness_primitives(monkeypatch):
+    class _Engine:
+        map_hash = "test-hash"
+
+        def compute_urgency(self, indicators, rating, rating_max, content_type, source_weight):
+            return 8.4
+
+        def override_pain(self, primary_pain, complaints, quotable, pricing_phrases, feature_gaps, recommendation_language):
+            return primary_pain
+
+        def derive_recommend(self, rec_lang, rating, rating_max):
+            return False
+
+        def derive_budget_authority(self, result):
+            return True
+
+        def derive_price_complaint(self, result):
+            return True
+
+    monkeypatch.setattr(evidence_engine, "get_evidence_engine", lambda: _Engine())
+
+    row = {
+        "id": uuid4(),
+        "summary": "Renewal pricing pushed us toward async docs",
+        "review_text": (
+            "Slack wanted $200k/year at renewal. "
+            "We became more productive using docs and async updates instead."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "CTO",
+        "reviewer_company": "Hack Club",
+        "raw_metadata": {"source_weight": 0.9},
+        "content_type": "review",
+        "rating": 2.0,
+        "rating_max": 5,
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": True,
+            "actively_evaluating": False,
+            "contract_renewal_mentioned": True,
+            "renewal_timing": "next quarter",
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {
+            "role_level": "executive",
+            "decision_maker": True,
+            "company_name": "Hack Club",
+        },
+        "budget_signals": {
+            "annual_spend_estimate": 200000,
+            "price_per_seat": None,
+            "seat_count": None,
+            "price_increase_mentioned": True,
+        },
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": ["Slack wanted $200k/year at renewal"],
+        "quotable_phrases": ["We became more productive using docs and async updates instead"],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": ["I would not recommend this"],
+        "pricing_phrases": ["$200k/year at renewal"],
+        "event_mentions": [{"event": "renewal", "timeframe": "next quarter"}],
+        "timeline": {"contract_end": "next quarter", "evaluation_deadline": None},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["replacement_mode"] == "workflow_substitution"
+    assert derived["operating_model_shift"] == "sync_to_async"
+    assert derived["productivity_delta_claim"] == "more_productive"
+    assert derived["org_pressure_type"] == "none"
+    assert {"explicit_dollar", "named_account", "decision_maker"}.issubset(set(derived["salience_flags"]))
+    assert derived["evidence_spans"]
+    assert any(span["signal_type"] == "pricing_backlash" for span in derived["evidence_spans"])
+    assert any(span["productivity_delta_claim"] == "more_productive" for span in derived["evidence_spans"])
+
+
+def test_compute_derived_fields_positive_pricing_context_does_not_emit_pricing_backlash():
+    row = {
+        "id": uuid4(),
+        "summary": "Pricing fit",
+        "review_text": (
+            "Trello met all our expectations for sprint management. "
+            "I find the pricing reasonable."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": None,
+        "reviewer_company": "Infohob",
+        "raw_metadata": {"source_weight": 0.8},
+        "content_type": "review",
+        "rating": 4.5,
+        "rating_max": 5,
+        "source": "peerspot",
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": False,
+            "actively_evaluating": False,
+            "contract_renewal_mentioned": False,
+            "renewal_timing": None,
+            "migration_in_progress": False,
+            "support_escalation": False,
+        },
+        "reviewer_context": {
+            "role_level": "executive",
+            "decision_maker": True,
+            "company_name": "Infohob",
+        },
+        "budget_signals": {},
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": [],
+        "quotable_phrases": ["I find the pricing reasonable."],
+        "positive_aspects": ["Trello met all our expectations for sprint management."],
+        "feature_gaps": [],
+        "recommendation_language": [],
+        "pricing_phrases": ["I find the pricing reasonable."],
+        "event_mentions": [],
+        "timeline": {},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+
+    assert derived["contract_context"]["price_complaint"] is False
+    assert derived["contract_context"]["price_context"] == "I find the pricing reasonable."
+    assert derived["urgency_indicators"]["price_pressure_language"] is False
+    assert not any(span["signal_type"] == "pricing_backlash" for span in derived["evidence_spans"])
+
+
+def test_repair_target_fields_flags_semantic_pricing_and_timeline_gaps():
+    row = {
+        "summary": "Renewal confusion",
+        "review_text": "We got a $50k renewal quote and need to decide next quarter.",
+        "pros": "",
+        "cons": "",
+        "source": "reddit",
+        "enrichment_status": "enriched",
+    }
+    result = {
+        "pain_category": "ux",
+        "specific_complaints": [],
+        "pricing_phrases": [],
+        "recommendation_language": [],
+        "feature_gaps": [],
+        "event_mentions": [],
+        "competitors_mentioned": [],
+        "salience_flags": ["explicit_dollar"],
+        "timeline": {"decision_timeline": "unknown"},
+    }
+
+    targets = b2b_enrichment._repair_target_fields(result, row)
+
+    assert "specific_complaints" in targets
+    assert "pricing_phrases" in targets
+    assert "event_mentions" in targets
+
+
+def _witness_ready_row_and_result():
+    row = {
+        "id": "review-1",
+        "vendor_name": "Slack",
+        "source": "g2",
+        "content_type": "review",
+        "summary": "Renewal pushed us away from Slack",
+        "review_text": (
+            "Slack wanted $200k/year at renewal. We became more productive using docs "
+            "and async updates instead."
+        ),
+        "pros": "",
+        "cons": "",
+        "reviewer_title": "VP Operations",
+        "reviewer_company": "Hack Club",
+        "rating": 2,
+        "rating_max": 5,
+        "raw_metadata": {"source_weight": 0.9},
+    }
+    result = {
+        "churn_signals": {
+            "intent_to_leave": True,
+            "actively_evaluating": True,
+            "migration_in_progress": False,
+            "support_escalation": False,
+            "contract_renewal_mentioned": True,
+        },
+        "reviewer_context": {
+            "role_level": "executive",
+            "decision_maker": True,
+            "company_name": "Hack Club",
+        },
+        "budget_signals": {
+            "annual_spend_estimate": 200000,
+            "price_per_seat": None,
+            "seat_count": None,
+            "price_increase_mentioned": True,
+        },
+        "use_case": {"modules_mentioned": [], "integration_stack": [], "lock_in_level": "low"},
+        "content_classification": "review",
+        "competitors_mentioned": [],
+        "specific_complaints": ["Slack wanted $200k/year at renewal"],
+        "quotable_phrases": ["We became more productive using docs and async updates instead"],
+        "positive_aspects": [],
+        "feature_gaps": [],
+        "recommendation_language": ["I would not recommend this"],
+        "pricing_phrases": ["$200k/year at renewal"],
+        "event_mentions": [{"event": "renewal", "timeframe": "next quarter"}],
+        "timeline": {"contract_end": "next quarter", "evaluation_deadline": None},
+        "contract_context": {},
+        "buyer_authority": {},
+        "sentiment_trajectory": {},
+    }
+    return row, result
+
+
+def test_finalize_enrichment_for_persist_populates_witness_primitives():
+    row, result = _witness_ready_row_and_result()
+
+    finalized, error = b2b_enrichment._finalize_enrichment_for_persist(result, row)
+
+    assert error is None
+    assert finalized is not None
+    assert finalized["replacement_mode"] == "workflow_substitution"
+    assert finalized["operating_model_shift"] == "sync_to_async"
+    assert finalized["productivity_delta_claim"] == "more_productive"
+    assert finalized["org_pressure_type"] == "none"
+    assert finalized["salience_flags"]
+    assert finalized["evidence_spans"]
+    assert finalized["evidence_map_hash"]
+
+
+def test_validate_enrichment_schema_v3_recomputes_missing_witness_primitives():
+    row, result = _witness_ready_row_and_result()
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+    for key in (
+        "replacement_mode",
+        "operating_model_shift",
+        "productivity_delta_claim",
+        "org_pressure_type",
+        "salience_flags",
+        "evidence_spans",
+        "evidence_map_hash",
+    ):
+        derived.pop(key, None)
+
+    assert b2b_enrichment._validate_enrichment(derived, row)
+    assert derived["replacement_mode"] == "workflow_substitution"
+    assert derived["evidence_spans"]
+    assert derived["evidence_map_hash"]
+
+
+def test_validate_enrichment_schema_v3_rejects_missing_witness_primitives_without_source_row():
+    row, result = _witness_ready_row_and_result()
+    derived = b2b_enrichment._compute_derived_fields(result, row)
+    derived.pop("evidence_spans", None)
+    derived.pop("evidence_map_hash", None)
+
+    assert not b2b_enrichment._validate_enrichment(derived)


### PR DESCRIPTION
## What changed
- bring the validated B2B enrichment batch infrastructure onto `main`
- add the shared Anthropic batch helper, exact-cache runner, witness primitives, reviewer identity helpers, review dedup helpers, and visibility support used by the current enrichment task
- update `b2b_enrichment.py`, `config.py`, and the paired reasoning map/engine to the validated batch-aware implementation
- add the matching enrichment-focused tests for batch utils and enrichment behavior

## Why
PR #26 is the scoped repair/reuse fix, but it depends on newer enrichment pipeline infrastructure that is not on remote `main` yet. This PR isolates those prerequisites so the repair PR can stack cleanly on top.

## Validation
```bash
~/Desktop/Atlas/.venv/bin/pytest -q tests/test_b2b_batch_utils.py tests/test_b2b_enrichment.py
```

Result: `66 passed`

## Follow-up
After this lands, PR #26 should be based on this branch or rebased onto `main` once this PR merges.
