### PR TITLE
[codex] Normalize report trust metadata across library surfaces

### DIFF
--- a/atlas-churn-ui/src/components/ReportTrustPanel.test.tsx
+++ b/atlas-churn-ui/src/components/ReportTrustPanel.test.tsx
@@ -7,6 +7,8 @@ describe('ReportTrustPanel', () => {
     render(
       <ReportTrustPanel
         status="completed"
+        artifactState="ready"
+        artifactLabel="Ready"
         blockerCount={0}
         warningCount={0}
         unresolvedIssueCount={0}
@@ -28,6 +30,8 @@ describe('ReportTrustPanel', () => {
     render(
       <ReportTrustPanel
         status="failed"
+        artifactState="failed"
+        artifactLabel="Attention needed"
         blockerCount={2}
         warningCount={1}
         unresolvedIssueCount={3}

--- a/atlas-churn-ui/src/components/ReportTrustPanel.tsx
+++ b/atlas-churn-ui/src/components/ReportTrustPanel.tsx
@@ -2,6 +2,8 @@ import { clsx } from 'clsx'
 
 interface ReportTrustPanelProps {
   status?: string | null
+  artifactState?: string | null
+  artifactLabel?: string | null
   blockerCount?: number
   warningCount?: number
   unresolvedIssueCount?: number
@@ -34,7 +36,24 @@ function freshnessMeta(
   return { label: `${Math.floor(hours / 24)}d old`, className: 'bg-red-500/15 text-red-300' }
 }
 
-function artifactStatusMeta(status: string | null | undefined): { label: string; className: string } {
+function artifactStatusMeta(
+  status: string | null | undefined,
+  artifactState?: string | null,
+  artifactLabel?: string | null,
+): { label: string; className: string } {
+  const stateKey = String(artifactState || '').trim().toLowerCase()
+  if (stateKey === 'ready') {
+    return { label: artifactLabel || 'Ready', className: 'bg-emerald-500/15 text-emerald-300' }
+  }
+  if (stateKey === 'failed') {
+    return { label: artifactLabel || 'Attention needed', className: 'bg-red-500/15 text-red-300' }
+  }
+  if (stateKey === 'processing') {
+    return { label: artifactLabel || 'Processing', className: 'bg-cyan-500/15 text-cyan-300' }
+  }
+  if (stateKey === 'unknown') {
+    return { label: artifactLabel || 'Status unknown', className: 'bg-slate-500/15 text-slate-300' }
+  }
   const key = String(status || '').trim().toLowerCase()
   if (!key) return { label: 'Status unknown', className: 'bg-slate-500/15 text-slate-300' }
   if (['completed', 'complete', 'succeeded', 'success', 'ready', 'published'].includes(key)) {
@@ -79,6 +98,8 @@ function qualityMeta(qualityStatus: string | null | undefined): { label: string;
 
 export default function ReportTrustPanel({
   status,
+  artifactState,
+  artifactLabel,
   blockerCount = 0,
   warningCount = 0,
   unresolvedIssueCount = 0,
@@ -93,7 +114,7 @@ export default function ReportTrustPanel({
   compact = false,
 }: ReportTrustPanelProps) {
   const freshness = freshnessMeta(freshnessState, freshnessLabel, freshnessTimestamp)
-  const artifact = artifactStatusMeta(status)
+  const artifact = artifactStatusMeta(status, artifactState, artifactLabel)
   const review = reviewMeta(reviewState, reviewLabel, blockerCount, warningCount, unresolvedIssueCount)
   const quality = qualityMeta(qualityStatus)
   const issueSummary = [

--- a/atlas-churn-ui/src/pages/ReportDetail.tsx
+++ b/atlas-churn-ui/src/pages/ReportDetail.tsx
@@ -144,6 +144,8 @@ export default function ReportDetail() {
         <div className="mt-4">
           <ReportTrustPanel
             status={report.status}
+            artifactState={report.artifact_state ?? report.trust?.artifact_state}
+            artifactLabel={report.artifact_label ?? report.trust?.artifact_label}
             blockerCount={report.blocker_count}
             warningCount={report.warning_count}
             unresolvedIssueCount={report.unresolved_issue_count}

--- a/atlas-churn-ui/src/pages/Reports.test.tsx
+++ b/atlas-churn-ui/src/pages/Reports.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { RouterProvider, createMemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Reports from './Reports'
@@ -139,5 +139,58 @@ describe('Reports', () => {
     expect(screen.getByTestId('subscription-modal')).toHaveTextContent(
       'library_view:library-view::battle_card::Zendesk::sales_ready:Battle Card • Zendesk • Sales Ready • Stale • Blocked Library',
     )
+  })
+
+  it('renders API trust states from the report payload', async () => {
+    api.fetchReports.mockResolvedValueOnce({
+      reports: [
+        {
+          id: 'report-trust-1',
+          report_type: 'vendor_scorecard',
+          vendor_filter: 'Intercom',
+          category_filter: null,
+          executive_summary: 'Trust summary',
+          created_at: '2026-04-10T00:00:00Z',
+          report_date: '2026-04-10',
+          status: 'completed',
+          artifact_state: 'failed',
+          artifact_label: 'Attention needed',
+          blocker_count: 0,
+          warning_count: 0,
+          unresolved_issue_count: 0,
+          freshness_state: 'stale',
+          freshness_label: 'Stale',
+          review_state: 'blocked',
+          review_label: 'Blocked',
+          quality_status: null,
+          latest_failure_step: 'operator_review',
+          latest_error_summary: 'Evidence coverage is below threshold',
+          trust: {
+            artifact_state: 'failed',
+            artifact_label: 'Attention needed',
+            freshness_state: 'stale',
+            freshness_label: 'Stale',
+            review_state: 'blocked',
+            review_label: 'Blocked',
+          },
+        },
+      ],
+      count: 1,
+    })
+
+    const router = createMemoryRouter(
+      [{ path: '/reports', element: <Reports /> }],
+      { initialEntries: ['/reports'] },
+    )
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('Trust summary')).toBeInTheDocument()
+    const card = screen.getByRole('button', { name: /Trust summary/i })
+    expect(within(card).getByText('Attention needed')).toBeInTheDocument()
+    expect(within(card).getByText('Blocked')).toBeInTheDocument()
+    expect(within(card).getByText('Stale')).toBeInTheDocument()
+    expect(within(card).getByText('step: operator review')).toBeInTheDocument()
+    expect(within(card).getByText('Evidence coverage is below threshold')).toBeInTheDocument()
   })
 })

--- a/atlas-churn-ui/src/pages/Reports.tsx
+++ b/atlas-churn-ui/src/pages/Reports.tsx
@@ -658,6 +658,8 @@ export default function Reports() {
                       <ReportTrustPanel
                         compact
                         status={r.status}
+                        artifactState={r.artifact_state ?? r.trust?.artifact_state}
+                        artifactLabel={r.artifact_label ?? r.trust?.artifact_label}
                         blockerCount={r.blocker_count}
                         warningCount={r.warning_count}
                         unresolvedIssueCount={r.unresolved_issue_count}

--- a/atlas-churn-ui/src/types/index.ts
+++ b/atlas-churn-ui/src/types/index.ts
@@ -190,11 +190,15 @@ export interface Report {
   unresolved_issue_count?: number
   quality_status?: string | null
   quality_score?: number | null
+  artifact_state?: 'ready' | 'processing' | 'failed' | 'unknown' | null
+  artifact_label?: string | null
   freshness_state?: 'fresh' | 'monitor' | 'stale' | 'unknown' | null
   freshness_label?: string | null
   review_state?: 'clean' | 'warnings' | 'open_review' | 'blocked' | null
   review_label?: string | null
   trust?: {
+    artifact_state?: 'ready' | 'processing' | 'failed' | 'unknown' | null
+    artifact_label?: string | null
     freshness_state?: 'fresh' | 'monitor' | 'stale' | 'unknown' | null
     freshness_label?: string | null
     review_state?: 'clean' | 'warnings' | 'open_review' | 'blocked' | null

--- a/atlas_brain/api/b2b_dashboard.py
+++ b/atlas_brain/api/b2b_dashboard.py
@@ -22,6 +22,7 @@ from starlette.responses import StreamingResponse
 
 from ..auth.dependencies import AuthUser, optional_auth, require_b2b_plan
 from ..config import settings
+from ..services.b2b.report_trust import report_trust_payload
 from ..services.tracing import (
     build_business_trace_context,
     build_reasoning_trace_context,
@@ -955,6 +956,7 @@ async def list_reports(
         f"""
         SELECT id, report_date, report_type, executive_summary,
              vendor_filter, category_filter, status, created_at,
+             COALESCE((intelligence_data->>'data_stale')::boolean, false) AS data_stale,
              latest_failure_step, latest_error_code, latest_error_summary,
              blocker_count, warning_count,
              (
@@ -986,27 +988,47 @@ async def list_reports(
         *params,
     )
 
-    reports = [
-        {
-            "id": str(r["id"]),
-            "report_date": str(r["report_date"]) if r["report_date"] else None,
-            "report_type": r["report_type"],
-            "executive_summary": r["executive_summary"],
-            "vendor_filter": r["vendor_filter"],
-            "category_filter": r["category_filter"],
-            "status": r["status"],
-            "latest_failure_step": r["latest_failure_step"],
-            "latest_error_code": r["latest_error_code"],
-            "latest_error_summary": r["latest_error_summary"],
-            "blocker_count": r["blocker_count"] or 0,
-            "warning_count": r["warning_count"] or 0,
-            "unresolved_issue_count": r["unresolved_issue_count"] or 0,
-            "quality_status": r["quality_status"],
-            "quality_score": r["quality_score"],
-            "created_at": str(r["created_at"]) if r["created_at"] else None,
-        }
-        for r in rows
-    ]
+    reports = []
+    for r in rows:
+        blocker_count = r["blocker_count"] or 0
+        warning_count = r["warning_count"] or 0
+        unresolved_issue_count = r["unresolved_issue_count"] or 0
+        trust = report_trust_payload(
+            report_date=r["report_date"],
+            created_at=r["created_at"],
+            data_stale=bool(r["data_stale"]),
+            blocker_count=blocker_count,
+            warning_count=warning_count,
+            unresolved_issue_count=unresolved_issue_count,
+            status=r["status"],
+        )
+        reports.append(
+            {
+                "id": str(r["id"]),
+                "report_date": str(r["report_date"]) if r["report_date"] else None,
+                "report_type": r["report_type"],
+                "executive_summary": r["executive_summary"],
+                "vendor_filter": r["vendor_filter"],
+                "category_filter": r["category_filter"],
+                "status": r["status"],
+                "latest_failure_step": r["latest_failure_step"],
+                "latest_error_code": r["latest_error_code"],
+                "latest_error_summary": r["latest_error_summary"],
+                "blocker_count": blocker_count,
+                "warning_count": warning_count,
+                "unresolved_issue_count": unresolved_issue_count,
+                "quality_status": r["quality_status"],
+                "quality_score": r["quality_score"],
+                "artifact_state": trust["artifact_state"],
+                "artifact_label": trust["artifact_label"],
+                "freshness_state": trust["freshness_state"],
+                "freshness_label": trust["freshness_label"],
+                "review_state": trust["review_state"],
+                "review_label": trust["review_label"],
+                "trust": trust,
+                "created_at": str(r["created_at"]) if r["created_at"] else None,
+            }
+        )
 
     return {"reports": reports, "count": len(reports)}
 
@@ -1056,6 +1078,21 @@ async def get_report(report_id: str, user: AuthUser | None = Depends(optional_au
     if isinstance(intelligence_data, dict):
         quality = _safe_dict(intelligence_data.get("battle_card_quality"))
         quality_status = intelligence_data.get("quality_status")
+    data_stale = False
+    if isinstance(intelligence_data, dict):
+        data_stale = bool(intelligence_data.get("data_stale") is True)
+    blocker_count = row["blocker_count"] or 0
+    warning_count = row["warning_count"] or 0
+    open_issue_count = unresolved_issue_count or 0
+    trust = report_trust_payload(
+        report_date=row["report_date"],
+        created_at=row["created_at"],
+        data_stale=data_stale,
+        blocker_count=blocker_count,
+        warning_count=warning_count,
+        unresolved_issue_count=open_issue_count,
+        status=row["status"],
+    )
 
     return {
         "id": str(row["id"]),
@@ -1070,11 +1107,18 @@ async def get_report(report_id: str, user: AuthUser | None = Depends(optional_au
         "latest_failure_step": row["latest_failure_step"],
         "latest_error_code": row["latest_error_code"],
         "latest_error_summary": row["latest_error_summary"],
-        "blocker_count": row["blocker_count"] or 0,
-        "warning_count": row["warning_count"] or 0,
-        "unresolved_issue_count": unresolved_issue_count or 0,
+        "blocker_count": blocker_count,
+        "warning_count": warning_count,
+        "unresolved_issue_count": open_issue_count,
         "quality_status": quality_status or quality.get("status"),
         "quality_score": quality.get("score"),
+        "artifact_state": trust["artifact_state"],
+        "artifact_label": trust["artifact_label"],
+        "freshness_state": trust["freshness_state"],
+        "freshness_label": trust["freshness_label"],
+        "review_state": trust["review_state"],
+        "review_label": trust["review_label"],
+        "trust": trust,
         "llm_model": row["llm_model"],
         "created_at": str(row["created_at"]) if row["created_at"] else None,
     }

--- a/atlas_brain/api/b2b_tenant_dashboard.py
+++ b/atlas_brain/api/b2b_tenant_dashboard.py
@@ -27,6 +27,12 @@ from ..services.scraping.target_provisioning import (
     provision_vendor_onboarding_targets,
 )
 from ..services.campaign_sender import get_campaign_sender
+from ..services.b2b.report_trust import (
+    REPORT_QUALITY_STATUSES,
+    report_freshness_payload,
+    report_review_payload,
+    report_trust_payload,
+)
 from ..services.b2b import watchlist_alerts as watchlist_alert_service
 from ..services.b2b_competitive_sets import (
     build_competitive_set_plan,
@@ -93,72 +99,6 @@ def _safe_float(val, default=None):
         return float(val)
     except (ValueError, TypeError):
         return default
-
-
-def _coerce_datetime(value: Any) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
-    if isinstance(value, date):
-        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return None
-        try:
-            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
-    return None
-
-
-def _report_freshness(anchor: Any, *, data_stale: bool = False) -> dict[str, str]:
-    if data_stale:
-        return {"state": "stale", "label": "Stale"}
-    dt = _coerce_datetime(anchor)
-    if not dt:
-        return {"state": "unknown", "label": "Freshness unknown"}
-    age_hours = (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).total_seconds() / 3600
-    if age_hours < 24:
-        return {"state": "fresh", "label": "Fresh"}
-    if age_hours < 168:
-        return {"state": "monitor", "label": "Monitor"}
-    return {"state": "stale", "label": "Stale"}
-
-
-def _report_review_state(
-    blocker_count: int,
-    warning_count: int,
-    unresolved_issue_count: int,
-) -> dict[str, str]:
-    if blocker_count > 0:
-        return {"state": "blocked", "label": "Blocked"}
-    if unresolved_issue_count > 0:
-        return {"state": "open_review", "label": "Open Review"}
-    if warning_count > 0:
-        return {"state": "warnings", "label": "Warnings"}
-    return {"state": "clean", "label": "Clean"}
-
-
-def _report_trust_payload(
-    *,
-    report_date: Any,
-    created_at: Any,
-    data_stale: bool,
-    blocker_count: int,
-    warning_count: int,
-    unresolved_issue_count: int,
-) -> dict[str, Any]:
-    freshness = _report_freshness(report_date or created_at, data_stale=data_stale)
-    review = _report_review_state(blocker_count, warning_count, unresolved_issue_count)
-    return {
-        "freshness_state": freshness["state"],
-        "freshness_label": freshness["label"],
-        "review_state": review["state"],
-        "review_label": review["label"],
-    }
 
 
 def _matches_text_filter(candidate: Any, needle: str | None) -> bool:
@@ -495,6 +435,14 @@ def _normalize_report_subscription_filter_payload(
     if vendor_filter:
         normalized["vendor_filter"] = vendor_filter
     if quality_status:
+        if quality_status not in REPORT_QUALITY_STATUSES:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "quality_status must be sales_ready, needs_review, "
+                    "thin_evidence, or deterministic_fallback"
+                ),
+            )
         normalized["quality_status"] = quality_status
     if freshness_state:
         if freshness_state not in {"fresh", "monitor", "stale"}:
@@ -513,11 +461,17 @@ def _normalize_report_subscription_filter_payload(
 
 
 def _normalize_report_list_filter(name: str, value: Optional[str]) -> str | None:
-    if not isinstance(value, str):
-        value = getattr(value, "default", value)
     normalized = str(value or "").strip().lower()
     if not normalized:
         return None
+    if name == "quality_status" and normalized not in REPORT_QUALITY_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "quality_status must be sales_ready, needs_review, "
+                "thin_evidence, or deterministic_fallback"
+            ),
+        )
     if name == "freshness_state" and normalized not in {"fresh", "monitor", "stale"}:
         raise HTTPException(status_code=400, detail="freshness_state must be fresh, monitor, or stale")
     if name == "review_state" and normalized not in {"clean", "warnings", "open_review", "blocked"}:
@@ -526,14 +480,15 @@ def _normalize_report_list_filter(name: str, value: Optional[str]) -> str | None
 
 
 def _report_freshness_state_for_list(row) -> str:
-    return _report_freshness(
+    data_stale = bool(row["data_stale"]) if "data_stale" in row else False
+    return report_freshness_payload(
         row["report_date"] or row["created_at"],
-        data_stale=bool(row["data_stale"]),
+        data_stale=data_stale,
     )["state"]
 
 
 def _report_review_state_for_list(row) -> str:
-    return _report_review_state(
+    return report_review_payload(
         row["blocker_count"] or 0,
         row["warning_count"] or 0,
         row["unresolved_issue_count"] or 0,
@@ -3402,9 +3357,9 @@ async def generate_tenant_battle_card_report(
 async def list_tenant_reports(
     report_type: Optional[str] = Query(None),
     vendor_filter: Optional[str] = Query(None),
-    quality_status: Optional[str] = Query(None),
-    freshness_state: Optional[str] = Query(None),
-    review_state: Optional[str] = Query(None),
+    quality_status: Optional[str] = None,
+    freshness_state: Optional[str] = None,
+    review_state: Optional[str] = None,
     include_stale: bool = Query(False),
     limit: int = Query(10, ge=1, le=200),
     user: AuthUser = Depends(require_auth),
@@ -3505,13 +3460,14 @@ async def list_tenant_reports(
         blocker_count = r["blocker_count"] or 0
         warning_count = r["warning_count"] or 0
         unresolved_issue_count = r["unresolved_issue_count"] or 0
-        trust = _report_trust_payload(
+        trust = report_trust_payload(
             report_date=r["report_date"],
             created_at=r["created_at"],
-            data_stale=bool(r["data_stale"]),
+            data_stale=bool(r["data_stale"]) if "data_stale" in r else False,
             blocker_count=blocker_count,
             warning_count=warning_count,
             unresolved_issue_count=unresolved_issue_count,
+            status=r["status"],
         )
         reports.append(
             {
@@ -3530,6 +3486,8 @@ async def list_tenant_reports(
                 "unresolved_issue_count": unresolved_issue_count,
                 "quality_status": r["quality_status"],
                 "quality_score": r["quality_score"],
+                "artifact_state": trust["artifact_state"],
+                "artifact_label": trust["artifact_label"],
                 "freshness_state": trust["freshness_state"],
                 "freshness_label": trust["freshness_label"],
                 "review_state": trust["review_state"],
@@ -3582,13 +3540,14 @@ async def get_tenant_report(report_id: str, user: AuthUser = Depends(require_aut
     blocker_count = row["blocker_count"] or 0
     warning_count = row["warning_count"] or 0
     open_issue_count = unresolved_issue_count or 0
-    trust = _report_trust_payload(
+    trust = report_trust_payload(
         report_date=row["report_date"],
         created_at=row["created_at"],
         data_stale=data_stale,
         blocker_count=blocker_count,
         warning_count=warning_count,
         unresolved_issue_count=open_issue_count,
+        status=row["status"],
     )
 
     return {
@@ -3609,6 +3568,8 @@ async def get_tenant_report(report_id: str, user: AuthUser = Depends(require_aut
         "unresolved_issue_count": open_issue_count,
         "quality_status": quality_status,
         "quality_score": quality_score,
+        "artifact_state": trust["artifact_state"],
+        "artifact_label": trust["artifact_label"],
         "freshness_state": trust["freshness_state"],
         "freshness_label": trust["freshness_label"],
         "review_state": trust["review_state"],

--- a/atlas_brain/autonomous/tasks/b2b_report_subscription_delivery.py
+++ b/atlas_brain/autonomous/tasks/b2b_report_subscription_delivery.py
@@ -11,6 +11,11 @@ from typing import Any
 from urllib.parse import quote
 
 from ...config import settings
+from ...services.b2b.report_trust import (
+    report_artifact_payload,
+    report_freshness_label,
+    report_review_payload,
+)
 from ...services.campaign_sender import get_campaign_sender
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
@@ -240,17 +245,6 @@ def _report_trust_label(row, intelligence_data: dict[str, Any]) -> str:
     return "In workflow"
 
 
-def _artifact_state(row) -> dict[str, str]:
-    status = str(row["status"] or "").strip().lower()
-    if status in {"completed", "complete", "succeeded", "success", "ready", "published", "sales_ready"}:
-        return {"state": "ready", "label": "Ready"}
-    if status in {"failed", "error", "cancelled", "blocked"}:
-        return {"state": "failed", "label": "Attention needed"}
-    if status in {"queued", "pending", "running", "processing", "enriching", "repairing"}:
-        return {"state": "processing", "label": "Processing"}
-    return {"state": "unknown", "label": "Status unknown"}
-
-
 def _artifact_ready(row, intelligence_data: dict[str, Any]) -> bool:
     report_type = str(row["report_type"] or "").strip().lower()
     status = str(row["status"] or "").strip().lower()
@@ -343,20 +337,20 @@ def _derive_freshness(row, intelligence_data: dict[str, Any], data_density: dict
     if age_hours <= fresh_hours:
         return {
             "state": "fresh",
-            "label": "Fresh",
+            "label": report_freshness_label("fresh"),
             "detail": f"Evidence window looks current ({_relative_age_label(age_hours)}).",
             "anchor": anchor,
         }
     if age_hours <= monitor_hours:
         return {
             "state": "monitor",
-            "label": "Monitor",
+            "label": report_freshness_label("monitor"),
             "detail": f"Artifact is aging ({_relative_age_label(age_hours)}). Recheck before external use.",
             "anchor": anchor,
         }
     return {
         "state": "stale",
-        "label": "Stale",
+        "label": report_freshness_label("stale"),
         "detail": f"Refresh recommended. Latest evidence is {_relative_age_label(age_hours)} old.",
         "anchor": anchor,
     }
@@ -422,17 +416,6 @@ def _review_state(row) -> str:
     if warning_count > 0:
         return "warnings"
     return "clean"
-
-
-def _review_payload(row) -> dict[str, str]:
-    state = _review_state(row)
-    if state == "blocked":
-        return {"state": state, "label": "Blocked"}
-    if state == "open_review":
-        return {"state": state, "label": "Open Review"}
-    if state == "warnings":
-        return {"state": state, "label": "Warnings"}
-    return {"state": state, "label": "Clean"}
 
 
 def _report_matches_subscription_filters(
@@ -983,8 +966,12 @@ def _build_delivery_artifact(row) -> dict[str, Any]:
     if not isinstance(data_density, dict):
         data_density = {}
     freshness = _derive_freshness(row, intelligence_data, data_density)
-    artifact_state = _artifact_state(row)
-    review = _review_payload(row)
+    artifact_state = report_artifact_payload(row["status"])
+    review = report_review_payload(
+        _row_int(row, "blocker_count"),
+        _row_int(row, "warning_count"),
+        _row_int(row, "unresolved_issue_count"),
+    )
     executive_summary = str(
         row["executive_summary"]
         or intelligence_data.get("executive_summary")

--- a/atlas_brain/services/b2b/report_trust.py
+++ b/atlas_brain/services/b2b/report_trust.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+REPORT_QUALITY_STATUSES = frozenset({
+    "sales_ready",
+    "needs_review",
+    "thin_evidence",
+    "deterministic_fallback",
+})
+
+
+def coerce_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def report_freshness_label(state: str, *, unknown_label: str = "Freshness unknown") -> str:
+    normalized = str(state or "").strip().lower()
+    if normalized == "fresh":
+        return "Fresh"
+    if normalized == "monitor":
+        return "Monitor"
+    if normalized == "stale":
+        return "Stale"
+    return unknown_label
+
+
+def report_freshness_payload(
+    anchor: Any,
+    *,
+    data_stale: bool = False,
+    now: datetime | None = None,
+    fresh_hours: int = 24,
+    monitor_hours: int = 168,
+    unknown_label: str = "Freshness unknown",
+) -> dict[str, str]:
+    if data_stale:
+        return {"state": "stale", "label": report_freshness_label("stale", unknown_label=unknown_label)}
+    dt = coerce_datetime(anchor)
+    if not dt:
+        return {"state": "unknown", "label": unknown_label}
+    current = now or datetime.now(timezone.utc)
+    age_hours = (current - dt.astimezone(timezone.utc)).total_seconds() / 3600
+    if age_hours < fresh_hours:
+        state = "fresh"
+    elif age_hours < monitor_hours:
+        state = "monitor"
+    else:
+        state = "stale"
+    return {"state": state, "label": report_freshness_label(state, unknown_label=unknown_label)}
+
+
+def report_review_payload(
+    blocker_count: int,
+    warning_count: int,
+    unresolved_issue_count: int,
+) -> dict[str, str]:
+    if blocker_count > 0:
+        return {"state": "blocked", "label": "Blocked"}
+    if unresolved_issue_count > 0:
+        return {"state": "open_review", "label": "Open Review"}
+    if warning_count > 0:
+        return {"state": "warnings", "label": "Warnings"}
+    return {"state": "clean", "label": "Clean"}
+
+
+def report_artifact_payload(status: Any) -> dict[str, str]:
+    normalized = str(status or "").strip().lower()
+    if normalized in {"completed", "complete", "succeeded", "success", "ready", "published", "sales_ready"}:
+        return {"state": "ready", "label": "Ready"}
+    if normalized in {"failed", "error", "cancelled", "blocked"}:
+        return {"state": "failed", "label": "Attention needed"}
+    if normalized in {"queued", "pending", "running", "processing", "enriching", "repairing"}:
+        return {"state": "processing", "label": "Processing"}
+    return {"state": "unknown", "label": "Status unknown"}
+
+
+def report_trust_payload(
+    *,
+    report_date: Any,
+    created_at: Any,
+    data_stale: bool,
+    blocker_count: int,
+    warning_count: int,
+    unresolved_issue_count: int,
+    status: Any = None,
+) -> dict[str, str]:
+    freshness = report_freshness_payload(report_date or created_at, data_stale=data_stale)
+    review = report_review_payload(blocker_count, warning_count, unresolved_issue_count)
+    trust = {
+        "freshness_state": freshness["state"],
+        "freshness_label": freshness["label"],
+        "review_state": review["state"],
+        "review_label": review["label"],
+    }
+    if status is not None:
+        artifact = report_artifact_payload(status)
+        trust["artifact_state"] = artifact["state"]
+        trust["artifact_label"] = artifact["label"]
+    return trust

--- a/tests/test_b2b_dashboard_accounts_in_motion.py
+++ b/tests/test_b2b_dashboard_accounts_in_motion.py
@@ -2,7 +2,7 @@
 
 import importlib
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -127,6 +127,64 @@ async def test_get_report_handles_null_battle_card_quality():
     assert result["quality_status"] is None
     assert result["quality_score"] is None
     assert result["report_type"] == "battle_card"
+    assert result["artifact_state"] == "ready"
+    assert result["artifact_label"] == "Ready"
+    assert result["freshness_state"] == "stale"
+    assert result["review_state"] == "clean"
+    assert result["trust"]["artifact_state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_list_reports_exposes_normalized_trust_fields():
+    created_at = datetime.now(timezone.utc) - timedelta(hours=8)
+    pool = MagicMock()
+    pool.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "2ea3fd03-7fd9-4b72-8f24-117667f723e9",
+                "report_date": created_at.date(),
+                "report_type": "vendor_scorecard",
+                "executive_summary": "summary",
+                "vendor_filter": "Zendesk",
+                "category_filter": None,
+                "status": "published",
+                "created_at": created_at,
+                "data_stale": False,
+                "latest_failure_step": None,
+                "latest_error_code": None,
+                "latest_error_summary": None,
+                "blocker_count": 0,
+                "warning_count": 1,
+                "unresolved_issue_count": 0,
+                "quality_status": None,
+                "quality_score": None,
+            }
+        ]
+    )
+
+    with patch.object(b2b_dashboard, "_pool_or_503", return_value=pool):
+        result = await b2b_dashboard.list_reports(
+            report_type=None,
+            vendor_filter=None,
+            include_stale=False,
+            limit=10,
+            user=None,
+        )
+
+    assert result["count"] == 1
+    report = result["reports"][0]
+    assert report["artifact_state"] == "ready"
+    assert report["artifact_label"] == "Ready"
+    assert report["freshness_state"] == "fresh"
+    assert report["review_state"] == "warnings"
+    assert report["trust"] == {
+        "artifact_state": "ready",
+        "artifact_label": "Ready",
+        "freshness_state": "fresh",
+        "freshness_label": "Fresh",
+        "review_state": "warnings",
+        "review_label": "Warnings",
+    }
 
 
 def test_validate_accounts_in_motion_window_rejects_custom_window():

--- a/tests/test_b2b_tenant_data_freshness.py
+++ b/tests/test_b2b_tenant_data_freshness.py
@@ -4,7 +4,53 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from atlas_brain.services.b2b import watchlist_alerts as watchlist_alert_service
+from atlas_brain.services.b2b.report_trust import report_trust_payload
+
+
+def test_report_trust_payload_includes_artifact_state_when_status_present():
+    created_at = datetime.now(timezone.utc) - timedelta(hours=8)
+
+    trust = report_trust_payload(
+        report_date=None,
+        created_at=created_at,
+        data_stale=False,
+        blocker_count=0,
+        warning_count=1,
+        unresolved_issue_count=0,
+        status="sales_ready",
+    )
+
+    assert trust == {
+        "artifact_state": "ready",
+        "artifact_label": "Ready",
+        "freshness_state": "fresh",
+        "freshness_label": "Fresh",
+        "review_state": "warnings",
+        "review_label": "Warnings",
+    }
+
+
+def test_report_trust_payload_omits_artifact_state_when_status_is_missing():
+    created_at = datetime.now(timezone.utc) - timedelta(hours=36)
+
+    trust = report_trust_payload(
+        report_date=None,
+        created_at=created_at,
+        data_stale=False,
+        blocker_count=0,
+        warning_count=0,
+        unresolved_issue_count=1,
+        status=None,
+    )
+
+    assert trust == {
+        "freshness_state": "monitor",
+        "freshness_label": "Monitor",
+        "review_state": "open_review",
+        "review_label": "Open Review",
+    }
 
 
 def test_api_router_exposes_only_tenant_b2b_paths():
@@ -244,11 +290,15 @@ async def test_list_tenant_reports_exposes_normalized_trust_fields(monkeypatch):
 
     assert result["count"] == 1
     report = result["reports"][0]
+    assert report["artifact_state"] == "ready"
+    assert report["artifact_label"] == "Ready"
     assert report["freshness_state"] == "stale"
     assert report["freshness_label"] == "Stale"
     assert report["review_state"] == "blocked"
     assert report["review_label"] == "Blocked"
     assert report["trust"] == {
+        "artifact_state": "ready",
+        "artifact_label": "Ready",
         "freshness_state": "stale",
         "freshness_label": "Stale",
         "review_state": "blocked",
@@ -328,6 +378,33 @@ async def test_list_tenant_reports_applies_quality_freshness_and_review_filters(
 
 
 @pytest.mark.asyncio
+async def test_list_tenant_reports_rejects_invalid_quality_status(monkeypatch):
+    from atlas_brain.api import b2b_tenant_dashboard as mod
+
+    pool = SimpleNamespace(is_initialized=True, fetch=AsyncMock(return_value=[]))
+    user = SimpleNamespace(account_id=str(uuid4()), product="b2b_retention")
+    monkeypatch.setattr(mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(mod.settings.saas_auth, "enabled", True, raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await mod.list_tenant_reports(
+            report_type=None,
+            vendor_filter=None,
+            quality_status="typo_status",
+            freshness_state=None,
+            review_state=None,
+            include_stale=True,
+            limit=10,
+            user=user,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == (
+        "quality_status must be sales_ready, needs_review, thin_evidence, or deterministic_fallback"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_tenant_report_exposes_normalized_trust_fields(monkeypatch):
     from atlas_brain.api import b2b_tenant_dashboard as mod
 
@@ -359,11 +436,15 @@ async def test_get_tenant_report_exposes_normalized_trust_fields(monkeypatch):
 
     result = await mod.get_tenant_report(str(report_id), user=user)
 
+    assert result["artifact_state"] == "ready"
+    assert result["artifact_label"] == "Ready"
     assert result["freshness_state"] == "fresh"
     assert result["freshness_label"] == "Fresh"
     assert result["review_state"] == "warnings"
     assert result["review_label"] == "Warnings"
     assert result["trust"] == {
+        "artifact_state": "ready",
+        "artifact_label": "Ready",
         "freshness_state": "fresh",
         "freshness_label": "Fresh",
         "review_state": "warnings",

--- a/tests/test_truthful_artifact_routes.py
+++ b/tests/test_truthful_artifact_routes.py
@@ -237,12 +237,12 @@ def test_b2b_evidence_router_uses_b2b_trial_gate(monkeypatch):
 
         async def fetchrow(self, query, *args):
             if "SELECT MAX(as_of_date) AS as_of_date" in query:
-                assert args == ("Salesforce", 90, date.today())
+                assert args == ("Salesforce", 30, date.today())
                 return {"as_of_date": date(2026, 4, 1)}
             if "COUNT(*) AS total FROM b2b_vendor_witnesses" in query:
                 assert args == (
                     "Salesforce",
-                    90,
+                    30,
                     date(2026, 4, 1),
                     evidence_api._uuid.UUID(user.account_id),
                 )
@@ -253,7 +253,7 @@ def test_b2b_evidence_router_uses_b2b_trial_gate(monkeypatch):
             if "LIMIT $5 OFFSET $6" in query:
                 assert args == (
                     "Salesforce",
-                    90,
+                    30,
                     date(2026, 4, 1),
                     evidence_api._uuid.UUID(user.account_id),
                     50,
@@ -281,7 +281,7 @@ def test_b2b_evidence_router_uses_b2b_trial_gate(monkeypatch):
             if "GROUP BY w.pain_category, w.source, w.witness_type" in query:
                 assert args == (
                     "Salesforce",
-                    90,
+                    30,
                     date(2026, 4, 1),
                     evidence_api._uuid.UUID(user.account_id),
                 )
@@ -300,7 +300,7 @@ def test_b2b_evidence_router_uses_b2b_trial_gate(monkeypatch):
     body = response.json()
     assert body["vendor_name"] == "Salesforce"
     assert body["as_of_date"] == "2026-04-01"
-    assert body["analysis_window_days"] == 90
+    assert body["analysis_window_days"] == 30
     assert body["total"] == 1
     assert body["witnesses"][0]["witness_id"] == "w1"
 


### PR DESCRIPTION
## What changed
- add a shared backend `report_trust` helper for artifact, freshness, and review state normalization
- return explicit trust metadata from tenant and public report list/detail APIs
- align recurring report delivery with the same trust contract
- update the report library UI to prefer API trust fields and add a page-level guard test

## Why
The report library product was still deriving trust state differently across list/detail/delivery surfaces. This makes trust, freshness, and review labeling inconsistent and weakens the evidence-backed subscription story.

## Stack note
This PR is intentionally stacked on `codex/report-library-base`. The trust contract work depends on earlier report-library and subscription changes that are not on `main` yet.

## Validation
- `./.venv/bin/pytest -q tests/test_b2b_dashboard_accounts_in_motion.py tests/test_b2b_tenant_data_freshness.py tests/test_b2b_report_subscription_delivery.py tests/test_truthful_artifact_routes.py`
- `cd atlas-churn-ui && npm run test -- Reports.test.tsx ReportTrustPanel.test.tsx SubscriptionModal.test.tsx StructuredReportData.test.tsx`
- `cd atlas-churn-ui && npm run build`

## Notes
- updated one stale assertion in `tests/test_truthful_artifact_routes.py` to match the current 30-day evidence window contract