### PR TITLE
Sanitize percent parameters, fix volume pattern captures, and make TimeSkill formatting platform-independent

### DIFF
--- a/atlas_edge/intent/actions.py
+++ b/atlas_edge/intent/actions.py
@@ -31,6 +31,18 @@ class ActionIntent:
     raw_query: str = ""
     source: str = "pattern"  # "pattern", "classifier", "brain"
 
+    @staticmethod
+    def _clamp_percent(value: Any, default: int, *, absolute: bool = False) -> int:
+        """Coerce value to int percent in [0, 100], fallback to default."""
+        try:
+            numeric_float = float(value)
+            if absolute:
+                numeric_float = abs(numeric_float)
+            numeric = int(round(numeric_float))
+        except (TypeError, ValueError):
+            numeric = default
+        return min(100, max(0, numeric))
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -132,22 +144,36 @@ class ActionIntent:
 
         # Add action-specific parameters
         if self.action == "set_brightness":
-            brightness = self.parameters.get("brightness", 100)
-            data["brightness_pct"] = min(100, max(0, brightness))
+            brightness = self._clamp_percent(
+                self.parameters.get("brightness", 100),
+                default=100,
+            )
+            data["brightness_pct"] = brightness
 
         elif self.action == "brighten":
             # Relative brightness increase
-            amount = self.parameters.get("amount", 10)
+            amount = self._clamp_percent(
+                self.parameters.get("amount", 10),
+                default=10,
+                absolute=True,
+            )
             data["brightness_step_pct"] = amount
 
         elif self.action == "dim":
             # Relative brightness decrease
-            amount = self.parameters.get("amount", 10)
+            amount = self._clamp_percent(
+                self.parameters.get("amount", 10),
+                default=10,
+                absolute=True,
+            )
             data["brightness_step_pct"] = -amount
 
         elif self.action == "set_volume":
-            volume = self.parameters.get("volume", 50)
-            data["volume_level"] = min(1.0, max(0.0, volume / 100.0))
+            volume = self._clamp_percent(
+                self.parameters.get("volume", 50),
+                default=50,
+            )
+            data["volume_level"] = volume / 100.0
 
         elif self.action in ("mute", "unmute"):
             data["is_volume_muted"] = self.action == "mute"

--- a/atlas_edge/intent/patterns.py
+++ b/atlas_edge/intent/patterns.py
@@ -187,12 +187,12 @@ DEVICE_PATTERNS = [
     ),
     (
         re.compile(
-            r"(turn\s+)?(volume\s+)?(up|down)(?:\s+(?:on|for)\s+(?:the\s+)?(.+))?$",
+            r"(?:turn\s+)?volume\s+(up|down)(?:\s+(?:on|for)\s+(?:the\s+)?(.+))?$",
             re.IGNORECASE,
         ),
-        lambda m: ("volume_up" if m.group(3).lower() == "up" else "volume_down"),
+        lambda m: ("volume_up" if m.group(1).lower() == "up" else "volume_down"),
         "media_player",
-        lambda m: {"target_name": m.group(4).strip() if m.group(4) else None},
+        lambda m: {"target_name": m.group(2).strip() if m.group(2) else None},
     ),
     # Generic "turn on/off the X" pattern (fallback)
     (

--- a/atlas_edge/skills/time_skill.py
+++ b/atlas_edge/skills/time_skill.py
@@ -31,16 +31,27 @@ class TimeSkill:
         except Exception:
             return datetime.now()
 
+    @staticmethod
+    def _format_date(now: datetime) -> str:
+        """Format a date string without platform-specific strftime directives."""
+        return f"Today is {now.strftime('%A')}, {now.strftime('%B')} {now.day}, {now.year}."
+
+    @staticmethod
+    def _format_time(now: datetime) -> str:
+        """Format a 12-hour time string without platform-specific strftime directives."""
+        hour_12 = now.hour % 12 or 12
+        return f"It's {hour_12}:{now.minute:02d} {now.strftime('%p')}."
+
     async def execute(self, query: str, match: re.Match) -> SkillResult:
         now = self._now()
         query_lower = query.lower()
 
         if "date" in query_lower:
-            text = now.strftime("Today is %A, %B %-d, %Y.")
+            text = self._format_date(now)
         elif "day" in query_lower and "time" not in query_lower:
-            text = now.strftime("Today is %A, %B %-d.")
+            text = f"Today is {now.strftime('%A')}, {now.strftime('%B')} {now.day}."
         else:
-            text = now.strftime("It's %-I:%M %p.")
+            text = self._format_time(now)
 
         return SkillResult(
             success=True,

--- a/tests/atlas_edge/test_actions.py
+++ b/tests/atlas_edge/test_actions.py
@@ -263,6 +263,16 @@ class TestActionIntent:
         data = intent.get_service_data()
         assert data["brightness_step_pct"] == -15
 
+    def test_service_data_brighten_negative_amount_is_sanitized(self):
+        """Test brighten amount is absolute and clamped."""
+        intent = ActionIntent(
+            action="brighten",
+            target_type="light",
+            parameters={"amount": -250},
+        )
+        data = intent.get_service_data()
+        assert data["brightness_step_pct"] == 100
+
     def test_service_data_volume(self):
         """Test service data for set_volume."""
         intent = ActionIntent(
@@ -282,6 +292,16 @@ class TestActionIntent:
         )
         data = intent.get_service_data()
         assert data["volume_level"] == 1.0
+
+    def test_service_data_volume_invalid_input_uses_default(self):
+        """Test invalid volume values gracefully fall back to default."""
+        intent = ActionIntent(
+            action="set_volume",
+            target_type="media_player",
+            parameters={"volume": "loud"},
+        )
+        data = intent.get_service_data()
+        assert data["volume_level"] == 0.5
 
     def test_service_data_mute(self):
         """Test service data for mute."""

--- a/tests/atlas_edge/test_patterns.py
+++ b/tests/atlas_edge/test_patterns.py
@@ -247,6 +247,13 @@ class TestDevicePatternParser:
         assert result is not None
         assert result.action == "volume_down"
 
+    def test_volume_down_with_target(self, parser):
+        """Test volume down command with explicit target."""
+        result = parser.parse("volume down on the office speaker")
+        assert result is not None
+        assert result.action == "volume_down"
+        assert result.target_name == "office speaker"
+
     # --- Fallback generic pattern ---
 
     def test_generic_turn_on(self, parser):
@@ -277,6 +284,11 @@ class TestDevicePatternParser:
     def test_partial_match_fails(self, parser):
         """Test partial command doesn't match."""
         result = parser.parse("turn the light")  # missing on/off
+        assert result is None
+
+    def test_direction_only_does_not_match_volume(self, parser):
+        """Test plain direction words do not trigger media volume intent."""
+        result = parser.parse("up")
         assert result is None
 
     # --- can_parse method ---

--- a/tests/atlas_edge/test_time_skill.py
+++ b/tests/atlas_edge/test_time_skill.py
@@ -1,0 +1,23 @@
+"""
+Tests for edge TimeSkill formatting behavior.
+"""
+
+from datetime import datetime
+
+from atlas_edge.skills.time_skill import TimeSkill
+
+
+class TestTimeSkillFormatting:
+    """Validate platform-independent formatting helpers."""
+
+    def test_format_date_avoids_platform_specific_directives(self):
+        now = datetime(2026, 4, 5, 9, 7)
+        assert TimeSkill._format_date(now) == "Today is Sunday, April 5, 2026."
+
+    def test_format_time_midnight(self):
+        now = datetime(2026, 4, 5, 0, 7)
+        assert TimeSkill._format_time(now) == "It's 12:07 AM."
+
+    def test_format_time_afternoon(self):
+        now = datetime(2026, 4, 5, 15, 45)
+        assert TimeSkill._format_time(now) == "It's 3:45 PM."


### PR DESCRIPTION
### Motivation
- Ensure numeric percentage-like parameters (brightness, volume, brighten/dim amounts) are robustly coerced, clamped to valid ranges, and handle invalid or negative inputs safely.
- Fix pattern matching for media volume up/down commands so the correct regex capture groups are used and targets are resolved reliably.
- Remove platform-dependent `strftime` directives from time/date formatting to avoid inconsistent behavior across platforms.

### Description
- Added a static helper `ActionIntent._clamp_percent` to coerce inputs to integer percentages in the `0-100` range and used it for `set_brightness`, `brighten`, `dim`, and `set_volume` handling in `ActionIntent.get_service_data` so values are clamped, negative relative amounts are made absolute when appropriate, and invalid inputs fall back to defaults.
- Updated the media volume regex in `DEVICE_PATTERNS` to `r"(?:turn\s+)?volume\s+(up|down)..."` and adjusted the associated lambdas to use the correct capture groups so `volume up/down` and `volume ... on the X` resolve target names properly.
- Replaced platform-specific `strftime` directives in `TimeSkill` with two helpers `TimeSkill._format_date` and `TimeSkill._format_time` that build strings without `%-d`/`%-I`, and used these in `execute` to produce consistent date/time strings.
- Added and updated unit tests to cover the new sanitization and parsing behavior and to validate the time formatting helpers.

### Testing
- Ran the unit test suite with `pytest`, including `tests/atlas_edge/test_actions.py`, `tests/atlas_edge/test_patterns.py`, and the new `tests/atlas_edge/test_time_skill.py`; all tests passed.
- New tests include `test_service_data_brighten_negative_amount_is_sanitized` and `test_service_data_volume_invalid_input_uses_default` which verify parameter sanitization and defaults, and `test_volume_down_with_target` and `test_direction_only_does_not_match_volume` which validate the corrected volume pattern behavior.
- Time formatting is covered by `tests/atlas_edge/test_time_skill.py` which asserts deterministic date and 12-hour time string outputs across platforms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec327d7a30832ea07c26337f5c5e1a)