### PR TITLE
Sanitize percent/volume inputs, fix volume pattern groups, add platform-independent time formatting, and correct escalation flag

### DIFF
--- a/atlas_edge/intent/actions.py
+++ b/atlas_edge/intent/actions.py
@@ -31,6 +31,18 @@ class ActionIntent:
     raw_query: str = ""
     source: str = "pattern"  # "pattern", "classifier", "brain"
 
+    @staticmethod
+    def _clamp_percent(value: Any, default: int, *, absolute: bool = False) -> int:
+        """Coerce value to int percent in [0, 100], fallback to default."""
+        try:
+            numeric_float = float(value)
+            if absolute:
+                numeric_float = abs(numeric_float)
+            numeric = int(round(numeric_float))
+        except (TypeError, ValueError):
+            numeric = default
+        return min(100, max(0, numeric))
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -132,22 +144,36 @@ class ActionIntent:
 
         # Add action-specific parameters
         if self.action == "set_brightness":
-            brightness = self.parameters.get("brightness", 100)
-            data["brightness_pct"] = min(100, max(0, brightness))
+            brightness = self._clamp_percent(
+                self.parameters.get("brightness", 100),
+                default=100,
+            )
+            data["brightness_pct"] = brightness
 
         elif self.action == "brighten":
             # Relative brightness increase
-            amount = self.parameters.get("amount", 10)
+            amount = self._clamp_percent(
+                self.parameters.get("amount", 10),
+                default=10,
+                absolute=True,
+            )
             data["brightness_step_pct"] = amount
 
         elif self.action == "dim":
             # Relative brightness decrease
-            amount = self.parameters.get("amount", 10)
+            amount = self._clamp_percent(
+                self.parameters.get("amount", 10),
+                default=10,
+                absolute=True,
+            )
             data["brightness_step_pct"] = -amount
 
         elif self.action == "set_volume":
-            volume = self.parameters.get("volume", 50)
-            data["volume_level"] = min(1.0, max(0.0, volume / 100.0))
+            volume = self._clamp_percent(
+                self.parameters.get("volume", 50),
+                default=50,
+            )
+            data["volume_level"] = volume / 100.0
 
         elif self.action in ("mute", "unmute"):
             data["is_volume_muted"] = self.action == "mute"

--- a/atlas_edge/intent/patterns.py
+++ b/atlas_edge/intent/patterns.py
@@ -187,12 +187,12 @@ DEVICE_PATTERNS = [
     ),
     (
         re.compile(
-            r"(turn\s+)?(volume\s+)?(up|down)(?:\s+(?:on|for)\s+(?:the\s+)?(.+))?$",
+            r"(?:turn\s+)?volume\s+(up|down)(?:\s+(?:on|for)\s+(?:the\s+)?(.+))?$",
             re.IGNORECASE,
         ),
-        lambda m: ("volume_up" if m.group(3).lower() == "up" else "volume_down"),
+        lambda m: ("volume_up" if m.group(1).lower() == "up" else "volume_down"),
         "media_player",
-        lambda m: {"target_name": m.group(4).strip() if m.group(4) else None},
+        lambda m: {"target_name": m.group(2).strip() if m.group(2) else None},
     ),
     # Generic "turn on/off the X" pattern (fallback)
     (

--- a/atlas_edge/pipeline/voice_pipeline.py
+++ b/atlas_edge/pipeline/voice_pipeline.py
@@ -304,6 +304,7 @@ class EdgeVoicePipeline:
             if skill_result and skill_result.success:
                 result.response_text = skill_result.response_text
                 result.action_type = skill_result.action_type
+                result.escalated = False
                 result.handled_locally = True
                 result.success = True
                 return result

--- a/atlas_edge/skills/time_skill.py
+++ b/atlas_edge/skills/time_skill.py
@@ -31,16 +31,27 @@ class TimeSkill:
         except Exception:
             return datetime.now()
 
+    @staticmethod
+    def _format_date(now: datetime) -> str:
+        """Format a date string without platform-specific strftime directives."""
+        return f"Today is {now.strftime('%A')}, {now.strftime('%B')} {now.day}, {now.year}."
+
+    @staticmethod
+    def _format_time(now: datetime) -> str:
+        """Format a 12-hour time string without platform-specific strftime directives."""
+        hour_12 = now.hour % 12 or 12
+        return f"It's {hour_12}:{now.minute:02d} {now.strftime('%p')}."
+
     async def execute(self, query: str, match: re.Match) -> SkillResult:
         now = self._now()
         query_lower = query.lower()
 
         if "date" in query_lower:
-            text = now.strftime("Today is %A, %B %-d, %Y.")
+            text = self._format_date(now)
         elif "day" in query_lower and "time" not in query_lower:
-            text = now.strftime("Today is %A, %B %-d.")
+            text = f"Today is {now.strftime('%A')}, {now.strftime('%B')} {now.day}."
         else:
-            text = now.strftime("It's %-I:%M %p.")
+            text = self._format_time(now)
 
         return SkillResult(
             success=True,

--- a/tests/atlas_edge/test_actions.py
+++ b/tests/atlas_edge/test_actions.py
@@ -263,6 +263,16 @@ class TestActionIntent:
         data = intent.get_service_data()
         assert data["brightness_step_pct"] == -15
 
+    def test_service_data_brighten_negative_amount_is_sanitized(self):
+        """Test brighten amount is absolute and clamped."""
+        intent = ActionIntent(
+            action="brighten",
+            target_type="light",
+            parameters={"amount": -250},
+        )
+        data = intent.get_service_data()
+        assert data["brightness_step_pct"] == 100
+
     def test_service_data_volume(self):
         """Test service data for set_volume."""
         intent = ActionIntent(
@@ -282,6 +292,16 @@ class TestActionIntent:
         )
         data = intent.get_service_data()
         assert data["volume_level"] == 1.0
+
+    def test_service_data_volume_invalid_input_uses_default(self):
+        """Test invalid volume values gracefully fall back to default."""
+        intent = ActionIntent(
+            action="set_volume",
+            target_type="media_player",
+            parameters={"volume": "loud"},
+        )
+        data = intent.get_service_data()
+        assert data["volume_level"] == 0.5
 
     def test_service_data_mute(self):
         """Test service data for mute."""

--- a/tests/atlas_edge/test_patterns.py
+++ b/tests/atlas_edge/test_patterns.py
@@ -247,6 +247,13 @@ class TestDevicePatternParser:
         assert result is not None
         assert result.action == "volume_down"
 
+    def test_volume_down_with_target(self, parser):
+        """Test volume down command with explicit target."""
+        result = parser.parse("volume down on the office speaker")
+        assert result is not None
+        assert result.action == "volume_down"
+        assert result.target_name == "office speaker"
+
     # --- Fallback generic pattern ---
 
     def test_generic_turn_on(self, parser):
@@ -277,6 +284,11 @@ class TestDevicePatternParser:
     def test_partial_match_fails(self, parser):
         """Test partial command doesn't match."""
         result = parser.parse("turn the light")  # missing on/off
+        assert result is None
+
+    def test_direction_only_does_not_match_volume(self, parser):
+        """Test plain direction words do not trigger media volume intent."""
+        result = parser.parse("up")
         assert result is None
 
     # --- can_parse method ---

--- a/tests/atlas_edge/test_time_skill.py
+++ b/tests/atlas_edge/test_time_skill.py
@@ -1,0 +1,23 @@
+"""
+Tests for edge TimeSkill formatting behavior.
+"""
+
+from datetime import datetime
+
+from atlas_edge.skills.time_skill import TimeSkill
+
+
+class TestTimeSkillFormatting:
+    """Validate platform-independent formatting helpers."""
+
+    def test_format_date_avoids_platform_specific_directives(self):
+        now = datetime(2026, 4, 5, 9, 7)
+        assert TimeSkill._format_date(now) == "Today is Sunday, April 5, 2026."
+
+    def test_format_time_midnight(self):
+        now = datetime(2026, 4, 5, 0, 7)
+        assert TimeSkill._format_time(now) == "It's 12:07 AM."
+
+    def test_format_time_afternoon(self):
+        now = datetime(2026, 4, 5, 15, 45)
+        assert TimeSkill._format_time(now) == "It's 3:45 PM."

--- a/tests/atlas_edge/test_voice_pipeline.py
+++ b/tests/atlas_edge/test_voice_pipeline.py
@@ -1,0 +1,70 @@
+"""
+Tests for edge voice pipeline escalation behavior.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from atlas_edge.pipeline.voice_pipeline import EdgeVoicePipeline, PipelineResult
+
+
+def test_offline_escalation_fallback_to_skill_clears_escalated_flag():
+    """If offline escalation falls back to a local skill, result should not remain escalated."""
+    pipeline = EdgeVoicePipeline()
+
+    class MockEscalation:
+        async def escalate(self, query, session_id=None, speaker_id=None):
+            return SimpleNamespace(
+                response_text="Brain is offline.",
+                action_type="fallback",
+                success=False,
+                was_offline=True,
+            )
+
+    async def fake_try_skill(_query: str):
+        return SimpleNamespace(
+            success=True,
+            response_text="Local skill response.",
+            action_type="skill",
+        )
+
+    pipeline._escalation = MockEscalation()
+    pipeline._try_skill = fake_try_skill
+
+    result = asyncio.run(
+        pipeline._escalate_to_brain("status", None, None, PipelineResult(success=False))
+    )
+
+    assert result.handled_locally is True
+    assert result.success is True
+    assert result.action_type == "skill"
+    assert result.escalated is False
+
+
+def test_offline_escalation_without_skill_stays_escalated():
+    """If offline escalation has no local skill fallback, it should stay escalated."""
+    pipeline = EdgeVoicePipeline()
+
+    class MockEscalation:
+        async def escalate(self, query, session_id=None, speaker_id=None):
+            return SimpleNamespace(
+                response_text="Brain is offline.",
+                action_type="fallback",
+                success=False,
+                was_offline=True,
+            )
+
+    async def fake_try_skill(_query: str):
+        return None
+
+    pipeline._escalation = MockEscalation()
+    pipeline._try_skill = fake_try_skill
+
+    result = asyncio.run(
+        pipeline._escalate_to_brain("status", None, None, PipelineResult(success=False))
+    )
+
+    assert result.handled_locally is False
+    assert result.success is False
+    assert result.action_type == "fallback"
+    assert result.escalated is True


### PR DESCRIPTION
### Motivation
- Normalize and sanitize numeric percentage inputs for brightness and volume to prevent out-of-range or invalid values from reaching Home Assistant services.
- Fix pattern matching for media volume up/down commands to correctly extract the direction and optional target name.
- Avoid platform-specific `strftime` directives in time/date formatting to ensure consistent behavior across OSes.
- Ensure the pipeline escalation result reflects when an offline brain fallback is actually handled locally.

### Description
- Added `ActionIntent._clamp_percent` to coerce and clamp percent-like parameters and used it for `set_brightness`, `brighten`, `dim`, and `set_volume` so values are validated, negative relative amounts are made absolute, and invalid inputs fall back to defaults.
- Adjusted `get_service_data` to convert clamped volume percent to a `volume_level` float in `[0.0, 1.0]` and to use `brightness_step_pct` sign for `dim`.
- Updated `DEVICE_PATTERNS` regex and match-group references for volume up/down so the correct capture group is used and unnecessary groups are removed.
- Replaced platform-dependent `strftime` uses in `TimeSkill` with `_format_date` and `_format_time` helpers to produce OS-independent date/time strings.
- Set `result.escalated = False` when an offline escalation is handled by a local skill in `EdgeVoicePipeline._escalate_to_brain` so the result correctly reflects local handling.
- Added and updated unit tests covering percent clamping and sanitization, volume pattern parsing with targets, platform-independent time formatting, and escalation fallback behavior.

### Testing
- Ran unit tests with `pytest` for the `atlas_edge` test suite, including `tests/atlas_edge/test_actions.py`, `tests/atlas_edge/test_patterns.py`, `tests/atlas_edge/test_time_skill.py`, and `tests/atlas_edge/test_voice_pipeline.py`, and all tests passed.
- New tests verify that invalid and out-of-range numeric inputs are sanitized and that volume/date/time/pipeline behaviors work as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec327d7a30832ea07c26337f5c5e1a)