### PR TITLE
Add extracted_content_pipeline scaffold with B2B reasoning modules and CI checks

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -1,0 +1,36 @@
+name: Extracted Pipeline Checks
+
+on:
+  pull_request:
+    paths:
+      - "extracted_content_pipeline/**"
+      - "scripts/sync_extracted_content_pipeline.sh"
+      - "scripts/validate_extracted_content_pipeline.sh"
+      - "scripts/check_ascii_python.sh"
+      - "scripts/check_extracted_imports.py"
+      - "scripts/smoke_extracted_pipeline_imports.py"
+      - "scripts/run_extracted_pipeline_checks.sh"
+  push:
+    paths:
+      - "extracted_content_pipeline/**"
+      - "scripts/sync_extracted_content_pipeline.sh"
+      - "scripts/validate_extracted_content_pipeline.sh"
+      - "scripts/check_ascii_python.sh"
+      - "scripts/check_extracted_imports.py"
+      - "scripts/smoke_extracted_pipeline_imports.py"
+      - "scripts/run_extracted_pipeline_checks.sh"
+
+jobs:
+  extracted-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run extracted pipeline checks
+        run: bash scripts/run_extracted_pipeline_checks.sh

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -115,3 +115,7 @@ In standalone mode, `extracted_content_pipeline/services/blog_quality.py` provid
 ## Standalone normalization shims
 
 In standalone mode, `extracted_content_pipeline/services/company_normalization.py` provides a local `normalize_company_name` fallback used by extracted B2B helpers.
+
+## Standalone vendor registry shims
+
+In standalone mode, `extracted_content_pipeline/services/vendor_registry.py` provides a local `resolve_vendor_name_cached` fallback used by extracted B2B helpers.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -111,3 +111,7 @@ In standalone mode, `extracted_content_pipeline/reasoning/wedge_registry.py` pro
 ## Standalone quality shims
 
 In standalone mode, `extracted_content_pipeline/services/blog_quality.py` provides local fallback quality helpers (`blog_quality_summary`, `blog_quality_revalidation`, and `merge_blog_first_pass_quality_data_context`) for B2B blog pipeline paths.
+
+## Standalone normalization shims
+
+In standalone mode, `extracted_content_pipeline/services/company_normalization.py` provides a local `normalize_company_name` fallback used by extracted B2B helpers.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -1,0 +1,109 @@
+# Extracted Content Pipeline (Staging Copy)
+
+This directory is an additive extraction scaffold copied from `atlas_brain`.
+It is intentionally kept side-by-side with Atlas so pipeline logic can be
+carved out safely without removing or changing production code.
+
+## Current contents
+
+- `autonomous/tasks/`: copied task implementations
+- `skills/digest/`: copied prompt skill contracts
+- `storage/migrations/`: copied blog persistence migrations
+
+## Sync command
+
+To refresh this scaffold from Atlas source of truth:
+
+```bash
+bash scripts/sync_extracted_content_pipeline.sh
+```
+
+## Manifest
+
+Mirror mappings are declared in `extracted_content_pipeline/manifest.json` so sync and validation use one source of truth.
+
+## Scope
+
+This scaffold preserves code exactly as copied so behavior and signatures remain
+unchanged while extraction work continues.
+
+
+## Validation command
+
+```bash
+bash scripts/validate_extracted_content_pipeline.sh
+```
+
+## ASCII compliance check
+
+```bash
+bash scripts/check_ascii_python.sh
+```
+
+## Import debt check
+
+```bash
+python scripts/check_extracted_imports.py
+```
+
+Known unresolved relative imports are tracked in `extracted_content_pipeline/import_debt_allowlist.txt`.
+
+## One-shot checks
+
+```bash
+bash scripts/run_extracted_pipeline_checks.sh
+```
+
+## Compatibility shims
+
+To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`) that delegate to `atlas_brain` implementations.
+
+B2B helper siblings required by `b2b_blog_post_generation.py` are also copied into `extracted_content_pipeline/autonomous/tasks/`.
+
+## Import smoke test
+
+```bash
+python scripts/smoke_extracted_pipeline_imports.py
+```
+
+## Status tracker
+
+Current extraction status is tracked in `extracted_content_pipeline/STATUS.md`.
+
+## CI workflow
+
+GitHub Actions workflow: `.github/workflows/extracted_pipeline_checks.yml` runs `bash scripts/run_extracted_pipeline_checks.sh` when extracted scaffold files change.
+
+## File inventory
+
+```bash
+bash scripts/list_extracted_pipeline_files.sh
+```
+
+## Standalone mode toggle
+
+Set `EXTRACTED_PIPELINE_STANDALONE=1` to use `extracted_content_pipeline/settings.py` instead of delegating config to `atlas_brain.config`.
+
+## Standalone pipeline shims
+
+In standalone mode (`EXTRACTED_PIPELINE_STANDALONE=1`), `extracted_content_pipeline/pipelines/llm.py` and `extracted_content_pipeline/pipelines/notify.py` provide local fallback behavior (no-op notifier and safe JSON/cleaning helpers) so task modules can execute without Atlas pipeline services.
+
+## Standalone storage shims
+
+In standalone mode, `extracted_content_pipeline/storage/database.py` and `extracted_content_pipeline/storage/models.py` provide minimal local fallbacks (`get_db_pool`, `ScheduledTask`) so task entrypoints can execute without Atlas storage imports.
+
+## Standalone skill registry
+
+In standalone mode, `extracted_content_pipeline/skills/registry.py` uses local markdown files under `extracted_content_pipeline/skills/` for `get_skill_registry()` lookups.
+
+## Standalone service shims
+
+In standalone mode, `extracted_content_pipeline/services/__init__.py` and `extracted_content_pipeline/services/protocols.py` provide minimal local fallbacks (`llm_registry.get_active()`, `Message`) so task imports do not require Atlas service modules.
+
+## Standalone source shims
+
+In standalone mode, `extracted_content_pipeline/services/scraping/sources.py` provides local `ReviewSource` enums and allowlist helpers used by B2B tasks without requiring Atlas source modules.
+
+## Standalone reasoning shims
+
+In standalone mode, `extracted_content_pipeline/reasoning/wedge_registry.py` provides local `Wedge`, `get_wedge_meta`, and `validate_wedge` fallbacks used by B2B extracted modules.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -107,3 +107,7 @@ In standalone mode, `extracted_content_pipeline/services/scraping/sources.py` pr
 ## Standalone reasoning shims
 
 In standalone mode, `extracted_content_pipeline/reasoning/wedge_registry.py` provides local `Wedge`, `get_wedge_meta`, and `validate_wedge` fallbacks used by B2B extracted modules.
+
+## Standalone quality shims
+
+In standalone mode, `extracted_content_pipeline/services/blog_quality.py` provides local fallback quality helpers (`blog_quality_summary`, `blog_quality_revalidation`, and `merge_blog_first_pass_quality_data_context`) for B2B blog pipeline paths.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -119,3 +119,7 @@ In standalone mode, `extracted_content_pipeline/services/company_normalization.p
 ## Standalone vendor registry shims
 
 In standalone mode, `extracted_content_pipeline/services/vendor_registry.py` provides a local `resolve_vendor_name_cached` fallback used by extracted B2B helpers.
+
+## Standalone tracing shims
+
+In standalone mode, `extracted_content_pipeline/services/tracing.py` provides a local `build_business_trace_context` fallback used by extracted B2B helpers.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -1,0 +1,33 @@
+# Extracted Content Pipeline Status
+
+## Current state
+
+- Scaffold root exists at `extracted_content_pipeline/`.
+- Primary task modules are copied and import-smokeable:
+  - `blog_post_generation.py`
+  - `b2b_blog_post_generation.py`
+  - `complaint_content_generation.py`
+  - `complaint_enrichment.py`
+  - `article_enrichment.py`
+- B2B helper siblings required by copied blog/campaign flows are present.
+- Compatibility bridge modules map extracted package imports back to `atlas_brain` for side-by-side operation.
+
+## Validation gates in repo
+
+- `scripts/sync_extracted_content_pipeline.sh`
+- `scripts/validate_extracted_content_pipeline.sh`
+- `scripts/check_ascii_python.sh`
+- `scripts/check_extracted_imports.py`
+- `scripts/smoke_extracted_pipeline_imports.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+
+## Remaining extraction work
+
+1. Replace bridge-module delegation (`from atlas_brain...`) with native extracted implementations package by package.
+2. Trim copied helper surface to only the modules required by target sellable workflows.
+3. Introduce standalone config and runtime wiring for DB/LLM/skills/notify.
+4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).
+
+## Operational note
+
+Until bridge-module delegation is removed, this scaffold remains an in-repo extraction staging area (not yet a fully detached standalone runtime).

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py
@@ -1,0 +1,378 @@
+"""Shared helpers for B2B Anthropic batch enablement."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("atlas.autonomous.tasks._b2b_batch_utils")
+
+_ANTHROPIC_BATCH_SUCCESS_STATUSES = {
+    "cache_hit",
+    "batch_succeeded",
+    "fallback_succeeded",
+}
+
+
+def exact_stage_request_fingerprint(request: Any) -> str:
+    payload = {
+        "namespace": str(getattr(request, "namespace", "") or ""),
+        "provider": str(getattr(request, "provider", "") or ""),
+        "model": str(getattr(request, "model", "") or ""),
+        "request_envelope": getattr(request, "request_envelope", None) or {},
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stored_request_fingerprint(row: Any) -> str | None:
+    metadata = row.get("request_metadata") if hasattr(row, "get") else None
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("request_fingerprint")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def task_metadata(task: Any) -> dict[str, Any]:
+    metadata = getattr(task, "metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def metadata_bool(metadata: dict[str, Any], keys: tuple[str, ...], default: bool) -> bool:
+    for key in keys:
+        if key not in metadata:
+            continue
+        value = metadata.get(key)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off"}:
+                return False
+        if isinstance(value, (int, float)):
+            return bool(value)
+        logger.warning("Ignoring invalid %s=%r on task metadata", key, value)
+    return bool(default)
+
+
+def metadata_int(
+    metadata: dict[str, Any],
+    keys: tuple[str, ...],
+    default: int,
+    *,
+    min_value: int = 1,
+) -> int:
+    for key in keys:
+        if key not in metadata:
+            continue
+        value = metadata.get(key)
+        try:
+            if value is not None:
+                return max(min_value, int(value))
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid %s=%r on task metadata", key, value)
+    return max(min_value, int(default))
+
+
+def anthropic_batch_requested(
+    task: Any,
+    *,
+    global_default: bool,
+    task_default: bool,
+    global_keys: tuple[str, ...] = ("anthropic_batch_enabled",),
+    task_keys: tuple[str, ...] = (),
+) -> bool:
+    metadata = task_metadata(task)
+    global_enabled = metadata_bool(metadata, global_keys, global_default)
+    task_enabled = metadata_bool(metadata, task_keys, task_default)
+    return bool(global_enabled and task_enabled)
+
+
+def anthropic_batch_min_items(
+    task: Any,
+    *,
+    default: int,
+    keys: tuple[str, ...],
+    min_value: int = 1,
+) -> int:
+    return metadata_int(task_metadata(task), keys, default, min_value=min_value)
+
+
+def anthropic_model_name(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.startswith("anthropic/"):
+        text = text.split("/", 1)[1].strip()
+    if text.startswith("claude"):
+        return text
+    return None
+
+
+def is_anthropic_llm(value: Any) -> bool:
+    provider = str(getattr(value, "name", "") or "").strip().lower()
+    if provider == "anthropic":
+        return True
+    if provider:
+        return False
+    model = getattr(value, "model", "") or getattr(value, "model_id", "")
+    if anthropic_model_name(model) is not None:
+        return True
+    class_name = type(value).__name__.strip().lower()
+    module_name = str(getattr(type(value), "__module__", "") or "").strip().lower()
+    return "anthropic" in class_name or module_name.endswith(".anthropic") or ".anthropic." in module_name
+
+
+def anthropic_model_candidates(*values: Any, current_llm: Any | None = None) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(value: Any) -> None:
+        model = anthropic_model_name(value)
+        if model and model not in seen:
+            seen.add(model)
+            candidates.append(model)
+
+    if current_llm is not None:
+        provider = str(getattr(current_llm, "name", "") or "").strip().lower()
+        model = str(getattr(current_llm, "model", "") or "").strip()
+        if provider in {"anthropic", "openrouter"}:
+            _add(model)
+    for value in values:
+        _add(value)
+    return candidates
+
+
+def resolve_anthropic_batch_llm(
+    *,
+    current_llm: Any | None = None,
+    target_model_candidates: tuple[Any, ...] = (),
+):
+    from ...config import settings
+    from ...pipelines.llm import get_pipeline_llm
+    from ...services import llm_registry
+
+    candidates = anthropic_model_candidates(*target_model_candidates, current_llm=current_llm)
+
+    if is_anthropic_llm(current_llm):
+        current_model = anthropic_model_name(getattr(current_llm, "model", ""))
+        if not candidates or current_model in candidates:
+            return current_llm
+
+    batch_llm = get_pipeline_llm(workload="anthropic")
+    if is_anthropic_llm(batch_llm):
+        current_model = anthropic_model_name(getattr(batch_llm, "model", ""))
+        if not candidates or current_model in candidates:
+            return batch_llm
+
+    target_model = candidates[0] if candidates else None
+    if not target_model:
+        return batch_llm if is_anthropic_llm(batch_llm) else None
+
+    api_key = (
+        settings.llm.anthropic_api_key
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("ATLAS_LLM_ANTHROPIC_API_KEY", "")
+    )
+    if not api_key:
+        logger.warning(
+            "Anthropic batch requested for %s but no Anthropic API key is configured",
+            target_model,
+        )
+        return batch_llm if is_anthropic_llm(batch_llm) else None
+
+    slot_name = f"b2b_batch_anthropic::{target_model}"
+    existing_slot = llm_registry.get_slot(slot_name)
+    if is_anthropic_llm(existing_slot):
+        existing_model = anthropic_model_name(getattr(existing_slot, "model", ""))
+        if existing_model == target_model:
+            return existing_slot
+
+    try:
+        return llm_registry.activate_slot(
+            slot_name,
+            "anthropic",
+            model=target_model,
+            api_key=api_key,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to activate Anthropic batch slot %s for model %s: %s",
+            slot_name,
+            target_model,
+            exc,
+        )
+    return batch_llm if is_anthropic_llm(batch_llm) else None
+
+
+async def reconcile_existing_batch_artifacts(
+    *,
+    pool: Any,
+    llm: Any | None,
+    task_name: str,
+    artifact_type: str,
+    artifact_ids: list[str],
+    expected_request_fingerprints: dict[str, str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Reconcile matching Anthropic batch rows and return the best-known item state.
+
+    This lets a rerun reuse already-completed provider work and avoid duplicating
+    requests that are still in flight after a process restart.
+    """
+    if (
+        not artifact_ids
+        or pool is None
+        or not getattr(pool, "is_initialized", False)
+        or not hasattr(pool, "fetch")
+    ):
+        return {}
+
+    artifact_ids = [str(value) for value in artifact_ids if str(value or "").strip()]
+    if not artifact_ids:
+        return {}
+
+    fingerprint_map = None
+    if expected_request_fingerprints is not None:
+        fingerprint_map = {
+            str(key): str(value).strip()
+            for key, value in expected_request_fingerprints.items()
+            if str(value or "").strip()
+        }
+
+    rows = await pool.fetch(
+        """
+        SELECT
+            i.*,
+            b.status AS batch_status,
+            b.provider_batch_id,
+            b.created_at AS batch_created_at
+        FROM anthropic_message_batch_items i
+        JOIN anthropic_message_batches b ON b.id = i.batch_id
+        WHERE b.task_name = $1
+          AND i.artifact_type = $2
+          AND i.artifact_id = ANY($3::text[])
+        ORDER BY i.artifact_id ASC, b.created_at DESC, i.created_at DESC
+        """,
+        task_name,
+        artifact_type,
+        artifact_ids,
+    )
+    if not rows:
+        return {}
+
+    batch_ids_to_reconcile = {
+        str(row["batch_id"])
+        for row in rows
+        if str(row.get("batch_status") or "") == "in_progress"
+        and str(row.get("provider_batch_id") or "").strip()
+    }
+    if batch_ids_to_reconcile and llm is not None:
+        from ...services.b2b.anthropic_batch import reconcile_anthropic_message_batch
+
+        for batch_id in sorted(batch_ids_to_reconcile):
+            try:
+                await reconcile_anthropic_message_batch(
+                    llm=llm,
+                    local_batch_id=batch_id,
+                    pool=pool,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed reconciling existing Anthropic batch %s for %s/%s",
+                    batch_id,
+                    task_name,
+                    artifact_type,
+                )
+        rows = await pool.fetch(
+            """
+            SELECT
+                i.*,
+                b.status AS batch_status,
+                b.provider_batch_id,
+                b.created_at AS batch_created_at
+            FROM anthropic_message_batch_items i
+            JOIN anthropic_message_batches b ON b.id = i.batch_id
+            WHERE b.task_name = $1
+              AND i.artifact_type = $2
+              AND i.artifact_id = ANY($3::text[])
+            ORDER BY i.artifact_id ASC, b.created_at DESC, i.created_at DESC
+            """,
+            task_name,
+            artifact_type,
+            artifact_ids,
+        )
+
+    grouped: dict[str, list[Any]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["artifact_id"]), []).append(row)
+
+    selected: dict[str, dict[str, Any]] = {}
+    for artifact_id, artifact_rows in grouped.items():
+        if fingerprint_map is not None:
+            expected_fingerprint = fingerprint_map.get(artifact_id)
+            if not expected_fingerprint:
+                continue
+            artifact_rows = [
+                row for row in artifact_rows
+                if _stored_request_fingerprint(row) == expected_fingerprint
+            ]
+            if not artifact_rows:
+                continue
+
+        success_row = next(
+            (
+                row
+                for row in artifact_rows
+                if str(row.get("status") or "") in _ANTHROPIC_BATCH_SUCCESS_STATUSES
+                and str(row.get("response_text") or "").strip()
+            ),
+            None,
+        )
+        if success_row is not None:
+            status = str(success_row.get("status") or "")
+            selected[artifact_id] = {
+                "state": "succeeded",
+                "status": status,
+                "cached": status == "cache_hit",
+                "response_text": str(success_row.get("response_text") or ""),
+                "error_text": str(success_row.get("error_text") or "") or None,
+                "batch_id": str(success_row["batch_id"]),
+                "custom_id": str(success_row["custom_id"]),
+            }
+            continue
+
+        pending_row = next(
+            (
+                row
+                for row in artifact_rows
+                if str(row.get("status") or "") == "pending"
+                and str(row.get("provider_batch_id") or "").strip()
+            ),
+            None,
+        )
+        if pending_row is not None:
+            selected[artifact_id] = {
+                "state": "pending",
+                "status": str(pending_row.get("status") or ""),
+                "cached": False,
+                "response_text": None,
+                "error_text": str(pending_row.get("error_text") or "") or None,
+                "batch_id": str(pending_row["batch_id"]),
+                "custom_id": str(pending_row["custom_id"]),
+            }
+
+    return selected

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_cross_vendor_synthesis.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_cross_vendor_synthesis.py
@@ -1,0 +1,1063 @@
+"""Cross-vendor synthesis packet builders and persistence helpers.
+
+Builds deterministic evidence packets for pairwise battles, category
+councils, and resource asymmetry analyses.  Each packet is a plain dict
+suitable for JSON serialization and LLM prompting.
+
+The ``to_legacy_cross_vendor_conclusion`` converter mirrors synthesis
+output into the persisted ``b2b_cross_vendor_conclusions`` shape used by
+downstream deterministic/reporting consumers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import date
+from typing import Any
+
+logger = logging.getLogger("atlas.autonomous.tasks._b2b_cross_vendor_synthesis")
+
+
+# ---------------------------------------------------------------------------
+# Vendor name helpers
+# ---------------------------------------------------------------------------
+
+def _canon(name: str) -> str:
+    return (name or "").strip().lower()
+
+
+def _sorted_vendors(*names: str | None) -> list[str]:
+    return sorted(set(
+        s for n in names
+        if isinstance(n, str) and (s := n.strip())
+    ))
+
+
+def _slug(value: str | None) -> str:
+    text = (value or "").strip().lower()
+    if not text:
+        return "unknown"
+    chars = []
+    for ch in text:
+        chars.append(ch if ch.isalnum() else "_")
+    slug = "".join(chars).strip("_")
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug or "unknown"
+
+
+def empty_cross_vendor_lookup() -> dict[str, dict]:
+    """Return the normalized empty cross-vendor lookup shape."""
+    return {"battles": {}, "councils": {}, "asymmetries": {}}
+
+
+# ---------------------------------------------------------------------------
+# Evidence hashing
+# ---------------------------------------------------------------------------
+
+def compute_cross_vendor_evidence_hash(packet: dict[str, Any]) -> str:
+    """Deterministic SHA-256 prefix from packet content."""
+    raw = json.dumps(packet, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Pool summary extraction
+# ---------------------------------------------------------------------------
+
+def _vendor_pool_summary(
+    vendor_name: str,
+    pool_layers: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Extract a compact vendor summary from pool layers."""
+    layers = pool_layers.get(vendor_name) or pool_layers.get(_canon(vendor_name)) or {}
+    if not layers:
+        # Try fuzzy match
+        for k, v in pool_layers.items():
+            if _canon(k) == _canon(vendor_name):
+                layers = v
+                break
+
+    core = layers.get("core") or layers.get("churn_signal") or {}
+    pain = layers.get("pain_distribution") or []
+    budget = layers.get("budget_pressure") or {}
+    segment = layers.get("segment") or layers.get("affected_roles") or []
+    temporal = layers.get("temporal") or {}
+    displacement = layers.get("displacement") or layers.get("competitive_flows") or []
+    segment_rows = (
+        (segment.get("affected_roles") or [])
+        if isinstance(segment, dict)
+        else (segment if isinstance(segment, list) else [])
+    )
+
+    compact_pain: list[dict[str, Any]] = []
+    for item in (pain or [])[:3]:
+        if not isinstance(item, dict):
+            continue
+        compact_pain.append({
+            "category": item.get("category") or item.get("label") or item.get("theme"),
+            "count": item.get("count") or item.get("review_count") or item.get("mention_count"),
+            "churn_rate": item.get("churn_rate"),
+        })
+
+    compact_targets: list[dict[str, Any]] = []
+    for item in (displacement or [])[:3]:
+        if not isinstance(item, dict):
+            continue
+        flow_summary = item.get("flow_summary") or {}
+        primary_driver = item.get("primary_driver")
+        if not primary_driver:
+            switch_reasons = item.get("switch_reasons") or []
+            if switch_reasons and isinstance(switch_reasons[0], dict):
+                primary_driver = (
+                    switch_reasons[0].get("reason")
+                    or switch_reasons[0].get("reason_category")
+                    or switch_reasons[0].get("switch_reason")
+                )
+        compact_targets.append({
+            "to_vendor": item.get("to_vendor") or item.get("competitor"),
+            "mention_count": flow_summary.get("total_flow_mentions") or flow_summary.get("mention_count"),
+            "explicit_switch_count": flow_summary.get("explicit_switch_count"),
+            "active_evaluation_count": flow_summary.get("active_evaluation_count"),
+            "primary_driver": primary_driver,
+        })
+
+    compact_segments: list[dict[str, Any]] = []
+    for item in segment_rows[:3]:
+        if not isinstance(item, dict):
+            continue
+        compact_segments.append({
+            "role_type": item.get("role_type") or item.get("department") or item.get("segment"),
+            "review_count": item.get("review_count") or item.get("count"),
+            "churn_rate": item.get("churn_rate"),
+            "top_pain": item.get("top_pain"),
+        })
+
+    compact_competitors: list[dict[str, Any]] = []
+    for item in (core.get("top_competitors") or [])[:3]:
+        if isinstance(item, dict):
+            compact_competitors.append({
+                "name": item.get("name") or item.get("competitor") or item.get("vendor"),
+                "mention_count": item.get("mention_count") or item.get("count"),
+            })
+        elif str(item or "").strip():
+            compact_competitors.append({"name": str(item).strip()})
+
+    return {
+        "vendor": vendor_name,
+        "total_reviews": core.get("total_reviews") or core.get("review_count") or 0,
+        "avg_urgency": core.get("avg_urgency_score") or core.get("avg_urgency") or 0,
+        "churn_density": core.get("churn_signal_density") or 0,
+        "price_complaint_rate": core.get("price_complaint_rate") or budget.get("price_complaint_rate") or 0,
+        "price_increase_rate": budget.get("price_increase_rate") or 0,
+        "avg_seat_count": budget.get("avg_seat_count") or 0,
+        "recommend_ratio": core.get("recommend_ratio"),
+        "nps_proxy": core.get("nps_proxy"),
+        "pain_distribution": compact_pain,
+        "top_competitors": compact_competitors,
+        "displacement_targets": compact_targets,
+        "segment_summary": compact_segments,
+        "sentiment_direction": (temporal.get("sentiment_trajectory") or {}).get("direction"),
+    }
+
+
+def _vendor_profile_summary(
+    vendor_name: str,
+    product_profiles: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Extract a compact profile summary."""
+    profile = product_profiles.get(vendor_name) or {}
+    if not profile:
+        for k, v in product_profiles.items():
+            if _canon(k) == _canon(vendor_name):
+                profile = v
+                break
+    return {
+        "category": profile.get("product_category") or "",
+        "strengths": (profile.get("strengths") or [])[:3],
+        "weaknesses": (profile.get("weaknesses") or [])[:3],
+        "use_cases": (profile.get("primary_use_cases") or [])[:3],
+        "typical_company_size": profile.get("typical_company_size"),
+    }
+
+
+def _copy_reference_ids(refs: dict[str, Any] | None) -> dict[str, list[str]]:
+    refs = refs or {}
+    metric_ids = [
+        str(item).strip()
+        for item in (refs.get("metric_ids") or [])
+        if str(item).strip()
+    ]
+    witness_ids = [
+        str(item).strip()
+        for item in (refs.get("witness_ids") or [])
+        if str(item).strip()
+    ]
+    return {
+        "metric_ids": list(dict.fromkeys(metric_ids)),
+        "witness_ids": list(dict.fromkeys(witness_ids)),
+    }
+
+
+def _merge_reference_ids(*refs_groups: dict[str, Any] | None) -> dict[str, list[str]]:
+    metric_ids: list[str] = []
+    witness_ids: list[str] = []
+    for refs in refs_groups:
+        copied = _copy_reference_ids(refs)
+        metric_ids.extend(copied["metric_ids"])
+        witness_ids.extend(copied["witness_ids"])
+    return {
+        "metric_ids": list(dict.fromkeys(metric_ids)),
+        "witness_ids": list(dict.fromkeys(witness_ids)),
+    }
+
+
+async def _fetch_pairwise_reference_fallbacks(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[tuple[str, ...], dict[str, list[str]]]:
+    """Build pairwise witness refs from persisted displacement-edge provenance."""
+    fallbacks: dict[tuple[str, ...], dict[str, list[str]]] = {}
+    rows = await pool.fetch(
+        """
+        SELECT from_vendor, to_vendor, sample_review_ids,
+               computed_date, created_at
+        FROM b2b_displacement_edges
+        WHERE computed_date <= $1
+          AND computed_date > $1::date - make_interval(days => $2)
+        ORDER BY from_vendor, to_vendor, computed_date DESC, created_at DESC
+        """,
+        as_of,
+        analysis_window_days,
+    )
+    for row in rows:
+        key = tuple(_sorted_vendors(row.get("from_vendor"), row.get("to_vendor")))
+        if len(key) < 2 or key in fallbacks:
+            continue
+        witness_ids = [
+            str(review_id).strip()
+            for review_id in (row.get("sample_review_ids") or [])
+            if str(review_id).strip()
+        ]
+        if witness_ids:
+            fallbacks[key] = {"witness_ids": list(dict.fromkeys(witness_ids))}
+    return fallbacks
+
+
+def _append_citation_entry(
+    registry: list[dict[str, Any]],
+    *,
+    sid: str,
+    label: str,
+    refs: dict[str, Any] | None = None,
+) -> None:
+    if not sid or not label:
+        return
+    registry.append({
+        "_sid": sid,
+        "label": label,
+        "reference_ids": _copy_reference_ids(refs),
+    })
+
+
+def _normalize_citation_text(value: str) -> str:
+    text = (value or "").strip().lower()
+    if not text:
+        return ""
+    text = text.replace("\u2192", "->")
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return " ".join(text.split())
+
+
+def _best_registry_sid_for_citation(
+    citation: str,
+    registry_map: dict[str, dict[str, Any]],
+) -> str | None:
+    citation_norm = _normalize_citation_text(citation)
+    if not citation_norm:
+        return None
+    if citation in registry_map:
+        return citation
+
+    best_sid: str | None = None
+    best_score = 0.0
+    citation_tokens = set(citation_norm.split())
+    for sid, item in registry_map.items():
+        label = str(item.get("label") or "")
+        label_norm = _normalize_citation_text(label)
+        if not label_norm:
+            continue
+        if citation_norm == label_norm:
+            return sid
+        label_tokens = set(label_norm.split())
+        overlap = citation_tokens.intersection(label_tokens)
+        if not overlap:
+            continue
+        score = len(overlap) / max(1, len(citation_tokens.union(label_tokens)))
+        if citation_norm in label_norm or label_norm in citation_norm:
+            score += 0.35
+        if score > best_score:
+            best_score = score
+            best_sid = sid
+    if best_score >= 0.45:
+        return best_sid
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Packet builders
+# ---------------------------------------------------------------------------
+
+def build_pairwise_battle_packet(
+    vendor_a: str,
+    vendor_b: str,
+    edge: dict[str, Any],
+    pool_layers: dict[str, dict[str, Any]],
+    product_profiles: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a deterministic evidence packet for a pairwise battle.
+
+    The ``locked_direction`` field tells the LLM which vendor is gaining
+    (winner) and which is losing (loser) based on displacement evidence.
+    """
+    from_vendor = edge.get("from_vendor") or vendor_a
+    to_vendor = edge.get("to_vendor") or vendor_b
+
+    return {
+        "analysis_type": "pairwise_battle",
+        "locked_direction": {
+            "winner": to_vendor,
+            "loser": from_vendor,
+        },
+        "displacement_edge": {
+            "from_vendor": from_vendor,
+            "to_vendor": to_vendor,
+            "mention_count": edge.get("mention_count") or 0,
+            "signal_strength": edge.get("signal_strength") or "emerging",
+            "primary_driver": edge.get("primary_driver") or "",
+            "evidence_breakdown": edge.get("evidence_breakdown") or {},
+            "velocity_7d": edge.get("velocity_7d") or 0,
+        },
+        "vendor_a_pool": _vendor_pool_summary(vendor_a, pool_layers),
+        "vendor_b_pool": _vendor_pool_summary(vendor_b, pool_layers),
+        "vendor_a_profile": _vendor_profile_summary(vendor_a, product_profiles),
+        "vendor_b_profile": _vendor_profile_summary(vendor_b, product_profiles),
+    }
+
+
+def build_category_council_packet(
+    category: str,
+    ecosystem_evidence: dict[str, Any],
+    pool_layers: dict[str, dict[str, Any]],
+    product_profiles: dict[str, dict[str, Any]],
+    displacement_edges: list[dict[str, Any]] | None = None,
+    *,
+    vendor_summary_limit: int = 10,
+    flow_limit: int = 15,
+) -> dict[str, Any]:
+    """Build a deterministic evidence packet for a category council."""
+    # Find vendors in this category from profiles
+    category_vendors: list[str] = []
+    for vname, profile in product_profiles.items():
+        if _canon(profile.get("product_category") or "") == _canon(category):
+            category_vendors.append(vname)
+
+    vendor_summaries = [
+        _vendor_pool_summary(v, pool_layers)
+        for v in sorted(category_vendors)[: max(1, int(vendor_summary_limit))]
+    ]
+
+    # Filter displacement edges to this category's vendors
+    cat_vendor_set = {_canon(v) for v in category_vendors}
+    cat_edges = []
+    for edge in (displacement_edges or []):
+        if (_canon(edge.get("from_vendor") or "") in cat_vendor_set
+                or _canon(edge.get("to_vendor") or "") in cat_vendor_set):
+            cat_edges.append({
+                "from_vendor": edge.get("from_vendor"),
+                "to_vendor": edge.get("to_vendor"),
+                "mention_count": edge.get("mention_count") or 0,
+                "primary_driver": edge.get("primary_driver") or "",
+            })
+
+    return {
+        "analysis_type": "category_council",
+        "category": category,
+        "vendor_count": len(category_vendors),
+        "ecosystem_evidence": {
+            "hhi": ecosystem_evidence.get("hhi"),
+            "market_structure": ecosystem_evidence.get("market_structure"),
+            "displacement_intensity": ecosystem_evidence.get("displacement_intensity"),
+            "dominant_archetype": ecosystem_evidence.get("dominant_archetype"),
+            "archetype_distribution": ecosystem_evidence.get("archetype_distribution") or {},
+        },
+        "vendor_summaries": vendor_summaries,
+        "displacement_flows": cat_edges[: max(0, int(flow_limit))],
+    }
+
+
+def build_resource_asymmetry_packet(
+    vendor_a: str,
+    vendor_b: str,
+    pool_layers: dict[str, dict[str, Any]],
+    product_profiles: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a deterministic evidence packet for resource asymmetry analysis."""
+    summary_a = _vendor_pool_summary(vendor_a, pool_layers)
+    summary_b = _vendor_pool_summary(vendor_b, pool_layers)
+
+    # Determine favored/disadvantaged by review count (proxy for installed base)
+    reviews_a = summary_a.get("total_reviews") or 0
+    reviews_b = summary_b.get("total_reviews") or 0
+
+    return {
+        "analysis_type": "resource_asymmetry",
+        "vendor_a": vendor_a,
+        "vendor_b": vendor_b,
+        "pressure_scores": {
+            "vendor_a_urgency": summary_a.get("avg_urgency") or 0,
+            "vendor_b_urgency": summary_b.get("avg_urgency") or 0,
+        },
+        "resource_indicators": {
+            "vendor_a_reviews": reviews_a,
+            "vendor_b_reviews": reviews_b,
+            "vendor_a_seat_count": summary_a.get("avg_seat_count") or 0,
+            "vendor_b_seat_count": summary_b.get("avg_seat_count") or 0,
+            "vendor_a_recommend_ratio": summary_a.get("recommend_ratio"),
+            "vendor_b_recommend_ratio": summary_b.get("recommend_ratio"),
+        },
+        "divergence_score": abs(reviews_a - reviews_b) / max(reviews_a, reviews_b, 1),
+        "vendor_a_pool": summary_a,
+        "vendor_b_pool": summary_b,
+        "vendor_a_profile": _vendor_profile_summary(vendor_a, product_profiles),
+        "vendor_b_profile": _vendor_profile_summary(vendor_b, product_profiles),
+    }
+
+
+def attach_cross_vendor_citation_registry(
+    packet: dict[str, Any],
+    *,
+    analysis_type: str,
+    vendors: list[str],
+    category: str | None,
+    vendor_reference_lookup: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Attach packet-level citation ids that map to underlying vendor refs."""
+    vendor_reference_lookup = vendor_reference_lookup or {}
+    sorted_vendors = _sorted_vendors(*vendors)
+    combined_refs = _merge_reference_ids(
+        *(vendor_reference_lookup.get(vendor) for vendor in sorted_vendors)
+    )
+    registry: list[dict[str, Any]] = []
+
+    if analysis_type == "pairwise_battle":
+        winner = ((packet.get("locked_direction") or {}).get("winner") or "").strip()
+        loser = ((packet.get("locked_direction") or {}).get("loser") or "").strip()
+        edge = packet.get("displacement_edge") or {}
+        edge_sid = (
+            f"xv:pairwise:edge:{_slug(loser)}_to_{_slug(winner)}"
+            if winner and loser else
+            f"xv:pairwise:edge:{_slug(sorted_vendors[0] if sorted_vendors else '')}"
+        )
+        _append_citation_entry(
+            registry,
+            sid=edge_sid,
+            label=(
+                f"{loser}->{winner} displacement edge: mention_count={edge.get('mention_count') or 0}, "
+                f"signal_strength={edge.get('signal_strength') or 'unknown'}, "
+                f"primary_driver={edge.get('primary_driver') or 'unknown'}, "
+                f"velocity_7d={edge.get('velocity_7d') or 0}"
+            ),
+            refs=combined_refs,
+        )
+    elif analysis_type == "category_council":
+        ecosystem = packet.get("ecosystem_evidence") or {}
+        _append_citation_entry(
+            registry,
+            sid=f"xv:category:{_slug(category)}:ecosystem",
+            label=(
+                f"{category} ecosystem: displacement_intensity={ecosystem.get('displacement_intensity')}, "
+                f"market_structure={ecosystem.get('market_structure') or 'unknown'}, "
+                f"dominant_archetype={ecosystem.get('dominant_archetype') or 'unknown'}"
+            ),
+            refs=combined_refs,
+        )
+    elif analysis_type == "resource_asymmetry":
+        pressure = packet.get("pressure_scores") or {}
+        resources = packet.get("resource_indicators") or {}
+        _append_citation_entry(
+            registry,
+            sid=f"xv:asymmetry:{_slug(sorted_vendors[0] if sorted_vendors else '')}_{_slug(sorted_vendors[1] if len(sorted_vendors) > 1 else '')}:summary",
+            label=(
+                f"resource asymmetry summary: vendor_a_urgency={pressure.get('vendor_a_urgency') or 0}, "
+                f"vendor_b_urgency={pressure.get('vendor_b_urgency') or 0}, "
+                f"vendor_a_reviews={resources.get('vendor_a_reviews') or 0}, "
+                f"vendor_b_reviews={resources.get('vendor_b_reviews') or 0}, "
+                f"divergence_score={packet.get('divergence_score') or 0}"
+            ),
+            refs=combined_refs,
+        )
+        for field in ("pressure_scores", "resource_indicators"):
+            item = packet.get(field) or {}
+            if not isinstance(item, dict):
+                continue
+            label_bits = ", ".join(
+                f"{key}={value}"
+                for key, value in item.items()
+                if value is not None and value != ""
+            )
+            _append_citation_entry(
+                registry,
+                sid=f"xv:asymmetry:{_slug(sorted_vendors[0] if sorted_vendors else '')}_{_slug(sorted_vendors[1] if len(sorted_vendors) > 1 else '')}:{field}",
+                label=f"{field}: {label_bits}",
+                refs=combined_refs,
+            )
+
+    for vendor_key in ("vendor_a_pool", "vendor_b_pool", "vendor_a_profile", "vendor_b_profile"):
+        item = packet.get(vendor_key) or {}
+        vendor = str(item.get("vendor") or "").strip()
+        if not vendor:
+            if vendor_key.startswith("vendor_a"):
+                vendor = sorted_vendors[0] if sorted_vendors else ""
+            elif len(sorted_vendors) > 1:
+                vendor = sorted_vendors[1]
+        refs = vendor_reference_lookup.get(vendor) or {}
+        if vendor_key.endswith("_pool"):
+            _append_citation_entry(
+                registry,
+                sid=f"xv:vendor:{_slug(vendor)}:pool",
+                label=(
+                    f"{vendor} pool summary: total_reviews={item.get('total_reviews') or 0}, "
+                    f"avg_urgency={item.get('avg_urgency') or 0}, "
+                    f"churn_density={item.get('churn_density') or 0}, "
+                    f"price_complaint_rate={item.get('price_complaint_rate') or 0}"
+                ),
+                refs=refs,
+            )
+            for idx, target in enumerate(item.get("displacement_targets") or []):
+                competitor = str(
+                    target.get("to_vendor") or target.get("name") or ""
+                ).strip()
+                flow_summary = target.get("flow_summary") or {}
+                edge_metrics = target.get("edge_metrics") or {}
+                switch_reasons = target.get("switch_reasons") or []
+                reason_text = ""
+                if switch_reasons and isinstance(switch_reasons[0], dict):
+                    reason_text = str(
+                        switch_reasons[0].get("reason")
+                        or switch_reasons[0].get("reason_category")
+                        or switch_reasons[0].get("switch_reason")
+                        or ""
+                    ).strip()
+                _append_citation_entry(
+                    registry,
+                    sid=f"xv:vendor:{_slug(vendor)}:flow:{idx}:{_slug(competitor)}",
+                    label=(
+                        f"{vendor} displacement target: {vendor}->{competitor}, "
+                        f"total_flow_mentions={flow_summary.get('total_flow_mentions') or edge_metrics.get('mention_count') or 0}, "
+                        f"explicit_switch_count={flow_summary.get('explicit_switch_count') or 0}, "
+                        f"active_evaluation_count={flow_summary.get('active_evaluation_count') or 0}, "
+                        f"switch_reason={reason_text or 'unknown'}"
+                    ),
+                    refs=refs,
+                )
+        else:
+            _append_citation_entry(
+                registry,
+                sid=f"xv:vendor:{_slug(vendor)}:profile",
+                label=(
+                    f"{vendor} profile: category={item.get('category') or 'unknown'}, "
+                    f"typical_company_size={item.get('typical_company_size') or 'unknown'}"
+                ),
+                refs=refs,
+            )
+
+    for idx, summary in enumerate(packet.get("vendor_summaries") or []):
+        vendor = str(summary.get("vendor") or "").strip()
+        refs = vendor_reference_lookup.get(vendor) or {}
+        _append_citation_entry(
+            registry,
+            sid=f"xv:category:{_slug(category)}:vendor_summary:{idx}:{_slug(vendor)}",
+            label=(
+                f"{vendor} vendor summary: total_reviews={summary.get('total_reviews') or 0}, "
+                f"avg_urgency={summary.get('avg_urgency') or 0}, "
+                f"churn_density={summary.get('churn_density') or 0}, "
+                f"price_complaint_rate={summary.get('price_complaint_rate') or 0}"
+            ),
+            refs=refs,
+        )
+
+    for idx, flow in enumerate(packet.get("displacement_flows") or []):
+        from_vendor = str(flow.get("from_vendor") or "").strip()
+        to_vendor = str(flow.get("to_vendor") or "").strip()
+        refs = _merge_reference_ids(
+            vendor_reference_lookup.get(from_vendor),
+            vendor_reference_lookup.get(to_vendor),
+        )
+        _append_citation_entry(
+            registry,
+            sid=f"xv:flow:{idx}:{_slug(from_vendor)}_to_{_slug(to_vendor)}",
+            label=(
+                f"displacement_flows: {from_vendor}->{to_vendor}, "
+                f"mention_count={flow.get('mention_count') or 0}, "
+                f"primary_driver={flow.get('primary_driver') or 'unknown'}"
+            ),
+            refs=refs,
+        )
+
+    packet["citation_registry"] = registry
+    return packet
+
+
+def prompt_compact_cross_vendor_packet(packet: dict[str, Any]) -> dict[str, Any]:
+    """Return a prompt-safe packet with citation ids but without heavy ref arrays."""
+    compact = dict(packet)
+    registry = []
+    for item in packet.get("citation_registry") or []:
+        if not isinstance(item, dict):
+            continue
+        sid = str(item.get("_sid") or "").strip()
+        label = str(item.get("label") or "").strip()
+        if not sid or not label:
+            continue
+        registry.append({
+            "_sid": sid,
+            "label": label,
+        })
+    if registry:
+        compact["citation_registry"] = registry
+    else:
+        compact.pop("citation_registry", None)
+    return compact
+
+
+def materialize_cross_vendor_reference_ids(
+    synthesis: dict[str, Any],
+    packet: dict[str, Any],
+) -> dict[str, Any]:
+    """Map cited packet ids to underlying metric/witness reference ids."""
+    registry = packet.get("citation_registry") or []
+    registry_map: dict[str, dict[str, Any]] = {}
+    for item in registry:
+        if not isinstance(item, dict):
+            continue
+        sid = str(item.get("_sid") or "").strip()
+        if sid:
+            registry_map[sid] = item
+
+    citations = synthesis.get("citations") or []
+    if not isinstance(citations, list):
+        citations = []
+    normalized_citations = []
+    metric_ids: list[str] = []
+    witness_ids: list[str] = []
+    for sid in citations:
+        sid_text = str(sid).strip()
+        resolved_sid = _best_registry_sid_for_citation(sid_text, registry_map)
+        if not resolved_sid:
+            continue
+        normalized_citations.append(resolved_sid)
+        refs = _copy_reference_ids(registry_map[resolved_sid].get("reference_ids"))
+        metric_ids.extend(refs["metric_ids"])
+        witness_ids.extend(refs["witness_ids"])
+
+    synthesis["citations"] = list(dict.fromkeys(normalized_citations))
+    synthesis["reference_ids"] = {
+        "metric_ids": sorted(set(metric_ids)),
+        "witness_ids": sorted(set(witness_ids)),
+    }
+    return synthesis
+
+
+# ---------------------------------------------------------------------------
+# Contract normalization
+# ---------------------------------------------------------------------------
+
+def normalize_cross_vendor_contract(
+    raw: dict[str, Any],
+    analysis_type: str,
+) -> dict[str, Any]:
+    """Ensure a parsed LLM response has the expected contract fields."""
+    if analysis_type == "pairwise_battle":
+        return {
+            "winner": raw.get("winner") or "",
+            "loser": raw.get("loser") or "",
+            "conclusion": raw.get("conclusion") or "",
+            "confidence": _clamp_confidence(raw.get("confidence")),
+            "durability_assessment": raw.get("durability_assessment") or "uncertain",
+            "key_insights": _ensure_insight_list(raw.get("key_insights")),
+            "falsification_conditions": raw.get("falsification_conditions") or [],
+            "citations": raw.get("citations") or [],
+            "meta": raw.get("meta") or {"analysis_type": analysis_type, "schema_version": "synthesis_v1"},
+        }
+    elif analysis_type == "category_council":
+        return {
+            "market_regime": raw.get("market_regime") or "uncertain",
+            "conclusion": raw.get("conclusion") or "",
+            "winner": raw.get("winner"),
+            "loser": raw.get("loser"),
+            "confidence": _clamp_confidence(raw.get("confidence")),
+            "durability_assessment": raw.get("durability_assessment") or "uncertain",
+            "key_insights": _ensure_insight_list(raw.get("key_insights")),
+            "citations": raw.get("citations") or [],
+            "meta": raw.get("meta") or {"analysis_type": analysis_type, "schema_version": "synthesis_v1"},
+        }
+    elif analysis_type == "resource_asymmetry":
+        return {
+            "favored_vendor": raw.get("favored_vendor") or "",
+            "disadvantaged_vendor": raw.get("disadvantaged_vendor") or "",
+            "conclusion": raw.get("conclusion") or "",
+            "pressure_delta": float(raw.get("pressure_delta") or 0),
+            "confidence": _clamp_confidence(raw.get("confidence")),
+            "key_insights": _ensure_insight_list(raw.get("key_insights")),
+            "citations": raw.get("citations") or [],
+            "meta": raw.get("meta") or {"analysis_type": analysis_type, "schema_version": "synthesis_v1"},
+        }
+    return raw
+
+
+def _clamp_confidence(val: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(val)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _ensure_insight_list(val: Any) -> list[dict[str, str]]:
+    if not isinstance(val, list):
+        return []
+    result = []
+    for item in val:
+        if isinstance(item, dict):
+            result.append({
+                "insight": str(item.get("insight") or ""),
+                "evidence": str(item.get("evidence") or ""),
+            })
+        elif isinstance(item, str):
+            result.append({"insight": item, "evidence": ""})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Legacy compatibility mirror
+# ---------------------------------------------------------------------------
+
+def to_legacy_cross_vendor_conclusion(
+    synthesis: dict[str, Any],
+    analysis_type: str,
+    vendors: list[str],
+    category: str | None = None,
+    evidence_hash: str = "",
+    tokens_used: int = 0,
+) -> dict[str, Any]:
+    """Convert a synthesis contract into a legacy b2b_cross_vendor_conclusions row.
+
+    Returns a dict with keys matching the legacy table columns.
+    """
+    conclusion: dict[str, Any]
+    confidence: float
+
+    if analysis_type == "pairwise_battle":
+        conclusion = {
+            "winner": synthesis.get("winner") or "",
+            "loser": synthesis.get("loser") or "",
+            "conclusion": synthesis.get("conclusion") or "",
+            "market_regime": synthesis.get("meta", {}).get("market_regime"),
+            "durability_assessment": synthesis.get("durability_assessment") or "uncertain",
+            "key_insights": synthesis.get("key_insights") or [],
+        }
+        confidence = _clamp_confidence(synthesis.get("confidence"))
+    elif analysis_type == "category_council":
+        conclusion = {
+            "winner": synthesis.get("winner"),
+            "loser": synthesis.get("loser"),
+            "conclusion": synthesis.get("conclusion") or "",
+            "market_regime": synthesis.get("market_regime") or "",
+            "durability_assessment": synthesis.get("durability_assessment") or "uncertain",
+            "key_insights": synthesis.get("key_insights") or [],
+        }
+        confidence = _clamp_confidence(synthesis.get("confidence"))
+    elif analysis_type == "resource_asymmetry":
+        conclusion = {
+            "favored_vendor": synthesis.get("favored_vendor") or "",
+            "disadvantaged_vendor": synthesis.get("disadvantaged_vendor") or "",
+            "conclusion": synthesis.get("conclusion") or "",
+            "resource_advantage": synthesis.get("favored_vendor") or "",
+            "pressure_delta": synthesis.get("pressure_delta") or 0,
+        }
+        confidence = _clamp_confidence(synthesis.get("confidence"))
+    else:
+        conclusion = dict(synthesis)
+        confidence = _clamp_confidence(synthesis.get("confidence"))
+
+    return {
+        "analysis_type": analysis_type,
+        "vendors": sorted(vendors),
+        "category": category,
+        "conclusion": conclusion,
+        "confidence": confidence,
+        "evidence_hash": evidence_hash,
+        "tokens_used": tokens_used,
+        "cached": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-vendor synthesis reader
+# ---------------------------------------------------------------------------
+
+
+async def load_cross_vendor_synthesis_lookup(
+    pool,
+    *,
+    as_of: date | None = None,
+    analysis_window_days: int = 90,
+) -> dict[str, dict]:
+    """Read cross-vendor synthesis from the canonical table.
+
+    Returns the shared cross-vendor lookup shape used by downstream
+    consumers:
+
+        {"battles": {...}, "councils": {...}, "asymmetries": {...}}
+
+    Each value uses sorted vendor tuples (battles/asymmetries) or category
+    names (councils) as keys.
+    """
+    if as_of is None:
+        as_of = date.today()
+
+    try:
+        pairwise_reference_fallbacks = await _fetch_pairwise_reference_fallbacks(
+            pool,
+            as_of=as_of,
+            analysis_window_days=analysis_window_days,
+        )
+    except Exception:
+        pairwise_reference_fallbacks = {}
+        logger.debug("Pairwise reference fallback load failed", exc_info=True)
+
+    rows = await pool.fetch(
+        """
+        SELECT analysis_type, vendors, category, synthesis,
+               as_of_date, created_at
+        FROM b2b_cross_vendor_reasoning_synthesis
+        WHERE as_of_date <= $1
+          AND analysis_window_days = $2
+        ORDER BY analysis_type, vendors, category,
+                 as_of_date DESC, created_at DESC
+        """,
+        as_of,
+        analysis_window_days,
+    )
+
+    battles: dict[tuple[str, ...], dict] = {}
+    councils: dict[str, dict] = {}
+    asymmetries: dict[tuple[str, ...], dict] = {}
+
+    def _prefer_candidate(existing: dict[str, Any] | None, candidate: dict[str, Any]) -> bool:
+        if existing is None:
+            return True
+        existing_refs = bool(existing.get("reference_ids"))
+        candidate_refs = bool(candidate.get("reference_ids"))
+        if not existing_refs and candidate_refs:
+            return True
+        if existing_refs and not candidate_refs:
+            return False
+        existing_date = existing.get("computed_date")
+        candidate_date = candidate.get("computed_date")
+        if existing_date != candidate_date:
+            return candidate_date is not None and (
+                existing_date is None or candidate_date > existing_date
+            )
+        existing_created = str(existing.get("created_at") or "")
+        candidate_created = str(candidate.get("created_at") or "")
+        return candidate_created > existing_created
+
+    for r in rows:
+        atype = r["analysis_type"]
+        vendors = list(r["vendors"]) if r["vendors"] else []
+        category = r["category"] or ""
+        raw = r["synthesis"]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        if not isinstance(raw, dict):
+            continue
+
+        # The synthesis column stores either:
+        # 1. a normalized top-level contract with winner/loser/conclusion keys
+        # 2. a wrapper object with a nested "conclusion" dict
+        nested_conclusion = raw.get("conclusion")
+        if isinstance(nested_conclusion, dict):
+            conclusion = nested_conclusion
+        else:
+            conclusion = raw
+        confidence = float(
+            conclusion.get("confidence") or raw.get("confidence") or 0,
+        )
+
+        entry = {
+            "conclusion": conclusion,
+            "confidence": confidence,
+            "vendors": vendors,
+            "category": category,
+            "computed_date": r["as_of_date"],
+            "created_at": r["created_at"],
+            "source": "synthesis",
+        }
+        reference_ids = raw.get("reference_ids")
+        if isinstance(reference_ids, dict) and reference_ids:
+            entry["reference_ids"] = _copy_reference_ids(reference_ids)
+        elif atype == "pairwise_battle" and len(vendors) >= 2:
+            fallback_refs = pairwise_reference_fallbacks.get(tuple(sorted(vendors)))
+            if fallback_refs:
+                entry["reference_ids"] = _copy_reference_ids(fallback_refs)
+
+        if atype == "pairwise_battle" and len(vendors) >= 2:
+            key = tuple(sorted(vendors))
+            if _prefer_candidate(battles.get(key), entry):
+                battles[key] = entry
+        elif atype == "category_council" and category:
+            if _prefer_candidate(councils.get(category), entry):
+                councils[category] = entry
+        elif atype == "resource_asymmetry" and len(vendors) >= 2:
+            key = tuple(sorted(vendors))
+            if _prefer_candidate(asymmetries.get(key), entry):
+                asymmetries[key] = entry
+
+    return {"battles": battles, "councils": councils, "asymmetries": asymmetries}
+
+
+async def load_best_cross_vendor_lookup(
+    pool,
+    *,
+    as_of: date | None = None,
+    analysis_window_days: int = 90,
+) -> dict[str, dict]:
+    """Load canonical cross-vendor synthesis."""
+    try:
+        synthesis_lookup = await load_cross_vendor_synthesis_lookup(
+            pool,
+            as_of=as_of,
+            analysis_window_days=analysis_window_days,
+        )
+    except Exception:
+        logger.debug("Cross-vendor synthesis lookup failed", exc_info=True)
+        synthesis_lookup = empty_cross_vendor_lookup()
+
+    try:
+        pairwise_reference_fallbacks = await _fetch_pairwise_reference_fallbacks(
+            pool,
+            as_of=as_of or date.today(),
+            analysis_window_days=analysis_window_days,
+        )
+    except Exception:
+        pairwise_reference_fallbacks = {}
+        logger.debug("Merged pairwise reference fallback load failed", exc_info=True)
+    if pairwise_reference_fallbacks:
+        for key, entry in (synthesis_lookup.get("battles") or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            if isinstance(entry.get("reference_ids"), dict) and entry.get("reference_ids"):
+                continue
+            fallback_refs = pairwise_reference_fallbacks.get(tuple(sorted(key)))
+            if fallback_refs:
+                entry["reference_ids"] = _copy_reference_ids(fallback_refs)
+    return synthesis_lookup
+
+
+def build_cross_vendor_conclusions_for_vendor(
+    vendor_name: str,
+    *,
+    category: str | None = None,
+    xv_lookup: dict[str, dict] | None = None,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Materialize vendor-facing cross-vendor conclusions from a merged lookup."""
+    vendor = str(vendor_name or "").strip()
+    if not vendor:
+        return []
+    category_name = str(category or "").strip()
+    lookup = xv_lookup or empty_cross_vendor_lookup()
+    results: list[dict[str, Any]] = []
+
+    def _append_entry(
+        *,
+        analysis_type: str,
+        entry: dict[str, Any],
+        vendors: list[str],
+        category_value: str | None = None,
+    ) -> None:
+        conclusion = entry.get("conclusion") or {}
+        if not isinstance(conclusion, dict):
+            return
+        summary = (
+            conclusion.get("conclusion")
+            or conclusion.get("summary")
+            or ""
+        )
+        if not summary:
+            return
+        item: dict[str, Any] = {
+            "analysis_type": analysis_type,
+            "vendors": list(vendors),
+            "confidence": float(entry.get("confidence") or 0),
+            "summary": summary,
+            "source": entry.get("source") or "",
+        }
+        if category_value:
+            item["category"] = category_value
+        computed_date = entry.get("computed_date")
+        if computed_date is not None and hasattr(computed_date, "isoformat"):
+            item["computed_date"] = computed_date.isoformat()
+        reference_ids = entry.get("reference_ids")
+        if isinstance(reference_ids, dict) and reference_ids:
+            item["reference_ids"] = _copy_reference_ids(reference_ids)
+        results.append(item)
+
+    vendor_lower = vendor.lower()
+    for pair_key, entry in (lookup.get("battles") or {}).items():
+        members = [str(value or "").strip() for value in pair_key]
+        if any(member.lower() == vendor_lower for member in members):
+            _append_entry(
+                analysis_type="pairwise_battle",
+                entry=entry,
+                vendors=members,
+            )
+
+    for pair_key, entry in (lookup.get("asymmetries") or {}).items():
+        members = [str(value or "").strip() for value in pair_key]
+        if any(member.lower() == vendor_lower for member in members):
+            _append_entry(
+                analysis_type="resource_asymmetry",
+                entry=entry,
+                vendors=members,
+            )
+
+    if category_name:
+        council = (lookup.get("councils") or {}).get(category_name)
+        if isinstance(council, dict):
+            _append_entry(
+                analysis_type="category_council",
+                entry=council,
+                vendors=list(council.get("vendors") or []),
+                category_value=category_name,
+            )
+
+    results.sort(
+        key=lambda item: (
+            0 if item.get("analysis_type") == "pairwise_battle" else 1,
+            -float(item.get("confidence") or 0),
+            str(item.get("computed_date") or ""),
+        ),
+    )
+    if limit > 0:
+        return results[:limit]
+    return results

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_pool_compression.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_pool_compression.py
@@ -1,0 +1,2319 @@
+"""Scored pool compression with source traceability for reasoning synthesis v2.
+
+Replaces the inline ``_compress_layers()`` in the synthesis task with:
+- Per-item relevance scoring (recency 0.3, signal_strength 0.5, uniqueness 0.2)
+- Deterministic source IDs (``pool:kind:key``) on every item
+- Pre-computed aggregates with ``{value, _sid}`` wrappers
+- A ``CompressedPacket`` that serializes to an LLM-ready payload
+
+Review UUIDs are carried through in ``SourceRef.review_ids`` where the pool
+provides them (vault weakness/strength, company signals, provenance).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from ._b2b_shared import _canonicalize_competitor, _segment_role_multiplier
+from ._b2b_witnesses import build_vendor_witness_artifacts
+
+# ---------------------------------------------------------------------------
+# Scoring coefficients (weights must sum to 1.0)
+# ---------------------------------------------------------------------------
+W_RECENCY = 0.3
+W_SIGNAL = 0.5
+W_UNIQUENESS = 0.2
+
+# Recency defaults when no timestamp is available
+RECENCY_HIGH = 1.0       # recent / time-sensitive items (spikes, deadlines)
+RECENCY_DEFAULT = 0.8    # items with no explicit recency signal
+RECENCY_LOW = 0.7        # segment/category items (less time-sensitive)
+
+# Uniqueness penalty thresholds (Jaccard word overlap)
+OVERLAP_HIGH = 0.7       # above this -> heavy penalty (0.3)
+OVERLAP_MEDIUM = 0.5     # above this -> moderate penalty (0.6)
+PENALTY_HIGH = 0.3
+PENALTY_MEDIUM = 0.6
+
+# Temporal spike magnitude normalization divisor
+SPIKE_MAGNITUDE_MAX = 5.0
+
+# Decision-maker intent boost
+DM_INTENT_BOOST = 0.2
+ACTIVE_EVAL_ACCOUNT_BOOST = 0.1
+
+# Evidence window depth threshold (days)
+MIN_EVIDENCE_WINDOW_DAYS = 14
+
+# Do not surface tiny segments to sales-facing synthesis.
+MIN_SEGMENT_SAMPLE_SIZE = 5
+
+_REASONING_CORE_AGGREGATE_LABELS = frozenset({
+    "total_reviews",
+    "churn_density",
+    "avg_urgency",
+    "recommend_ratio",
+    "negative_review_pct",
+    "price_complaint_rate",
+    "dm_churn_rate",
+    "displacement_mention_count",
+    "total_explicit_switches",
+    "total_active_evaluations",
+    "total_flow_mentions",
+    "regime_confidence",
+    "regime_avg_churn_velocity",
+    "regime_avg_price_pressure",
+    "keyword_spike_count",
+    "spike_count",
+    "evaluation_deadline_signals",
+    "contract_end_signals",
+    "renewal_signals",
+    "budget_cycle_signals",
+    "declining_pct",
+    "price_increase_rate",
+    "total_accounts",
+    "decision_maker_count",
+    "high_intent_count",
+    "active_eval_signal_count",
+    "enrichment_window_start",
+    "enrichment_window_end",
+})
+
+def _approx_payload_tokens(value: Any) -> int:
+    """Approximate token count for a compact JSON payload fragment."""
+    serialized = json.dumps(
+        value,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+    if not serialized:
+        return 0
+    return max(1, (len(serialized) + 3) // 4)
+
+
+def _reasoning_section_candidate_limit(section: str, default: int) -> int:
+    """Resolve section-packet shortlist limits from config."""
+    from ...config import settings
+
+    cfg = settings.b2b_churn
+    attr = f"reasoning_synthesis_{section}_candidate_limit"
+    try:
+        value = int(getattr(cfg, attr, default))
+    except (TypeError, ValueError):
+        value = default
+    return max(1, value)
+
+
+_REASONING_PROMPT_WITNESS_OMIT_FIELDS = frozenset({
+    "vendor_name",
+    "review_id",
+    "source_span_id",
+    "selection_reason",
+    "salience_score",
+    "candidate_types",
+    "specificity_score",
+    "witness_hash",
+    "witness_id",
+    "generic_reason",
+})
+
+
+def _compact_reasoning_witness_entry(witness: dict[str, Any]) -> dict[str, Any]:
+    """Drop prompt-irrelevant witness selection metadata from the LLM payload."""
+    return {
+        key: value
+        for key, value in witness.items()
+        if key not in _REASONING_PROMPT_WITNESS_OMIT_FIELDS
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source reference
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    """Deterministic source identifier for a pool item."""
+
+    pool: str            # e.g. "vault", "segment", "temporal"
+    kind: str            # e.g. "weakness", "strength", "flow"
+    key: str             # e.g. "pricing", "enterprise_ops_team"
+    review_ids: tuple[str, ...] = ()
+
+    @property
+    def source_id(self) -> str:
+        return f"{self.pool}:{self.kind}:{self.key}"
+
+
+# ---------------------------------------------------------------------------
+# Scored item + tracked aggregate
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class ScoredItem:
+    """A pool item with its relevance score and source reference."""
+
+    data: dict[str, Any]
+    score: float
+    source_ref: SourceRef
+
+
+@dataclass(frozen=True, slots=True)
+class TrackedAggregate:
+    """A pre-computed number the LLM must reference, with source provenance."""
+
+    label: str
+    value: Any
+    source_id: str
+
+
+def _retain_kind_coverage(
+    items: list[ScoredItem],
+    *,
+    max_items: int,
+    required_kinds: tuple[str, ...],
+) -> list[ScoredItem]:
+    """Keep at least one item for each required kind when a pool is crowded."""
+    ranked = sorted(items, key=lambda x: x.score, reverse=True)
+    if len(ranked) <= max_items:
+        return ranked[:max_items]
+
+    selected: list[ScoredItem] = []
+    used_ids: set[int] = set()
+    for kind in required_kinds:
+        for idx, item in enumerate(ranked):
+            if idx in used_ids:
+                continue
+            if item.source_ref.kind != kind:
+                continue
+            selected.append(item)
+            used_ids.add(idx)
+            break
+
+    for idx, item in enumerate(ranked):
+        if idx in used_ids:
+            continue
+        selected.append(item)
+        used_ids.add(idx)
+        if len(selected) >= max_items:
+            break
+
+    selected.sort(key=lambda x: x.score, reverse=True)
+    return selected[:max_items]
+
+
+# ---------------------------------------------------------------------------
+# Compressed packet
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class CompressedPacket:
+    """Full compressed input for one vendor's reasoning synthesis."""
+
+    vendor_name: str
+    pools: dict[str, list[ScoredItem]]
+    aggregates: list[TrackedAggregate]
+    source_registry: dict[str, SourceRef] = field(default_factory=dict)
+    # Governance / tension signals (Phase 2)
+    metric_ledger: list[dict[str, Any]] = field(default_factory=list)
+    contradiction_rows: list[dict[str, Any]] = field(default_factory=list)
+    minority_signals: list[dict[str, Any]] = field(default_factory=list)
+    coverage_gaps: list[dict[str, Any]] = field(default_factory=list)
+    retention_proof: list[dict[str, Any]] = field(default_factory=list)
+    witness_pack: list[dict[str, Any]] = field(default_factory=list)
+    section_packets: dict[str, Any] = field(default_factory=dict)
+
+    def source_ids(self) -> frozenset[str]:
+        """All valid source IDs in this packet."""
+        ids: set[str] = set()
+        for items in self.pools.values():
+            for item in items:
+                ids.add(item.source_ref.source_id)
+        for agg in self.aggregates:
+            ids.add(agg.source_id)
+        # Include governance source IDs
+        for entry in self.metric_ledger:
+            sid = entry.get("_sid")
+            if sid:
+                ids.add(sid)
+        for entry in self.contradiction_rows:
+            sid = entry.get("_sid")
+            if sid:
+                ids.add(sid)
+        for entry in self.minority_signals:
+            sid = entry.get("_sid")
+            if sid:
+                ids.add(sid)
+        for entry in self.coverage_gaps:
+            sid = entry.get("_sid")
+            if sid:
+                ids.add(sid)
+        for entry in self.retention_proof:
+            sid = entry.get("_sid")
+            if sid:
+                ids.add(sid)
+        for witness in self.witness_pack:
+            sid = witness.get("_sid") or witness.get("witness_id")
+            if sid:
+                ids.add(str(sid))
+        return frozenset(ids)
+
+    def prompt_validation_view(
+        self,
+        *,
+        compact_aggregates: bool = False,
+        include_contradiction_rows: bool = True,
+        include_minority_signals: bool = True,
+        include_section_packets: bool = True,
+    ) -> "CompressedPacket":
+        """Return a packet view aligned to the structures shown in the prompt."""
+        aggregates = self.aggregates
+        metric_ledger = self.metric_ledger
+        if compact_aggregates:
+            allowed_aggregate_ids = self._reasoning_aggregate_source_ids()
+            aggregates = [
+                agg for agg in self.aggregates
+                if agg.source_id in allowed_aggregate_ids
+            ]
+            metric_ledger = [
+                entry for entry in self.metric_ledger
+                if str(entry.get("_sid") or "") in allowed_aggregate_ids
+            ]
+        deduped_aggregates: dict[str, TrackedAggregate] = {}
+        for aggregate in aggregates:
+            deduped_aggregates[aggregate.label] = aggregate
+        aggregates = list(deduped_aggregates.values())
+        aggregate_labels_unique = len(aggregates) == len(self.aggregates)
+        if (
+            not compact_aggregates
+            and aggregate_labels_unique
+            and
+            include_contradiction_rows
+            and include_minority_signals
+            and include_section_packets
+        ):
+            return self
+        return replace(
+            self,
+            aggregates=aggregates,
+            metric_ledger=metric_ledger,
+            contradiction_rows=(
+                self.contradiction_rows if include_contradiction_rows else []
+            ),
+            minority_signals=(
+                self.minority_signals if include_minority_signals else []
+            ),
+            section_packets=self.section_packets if include_section_packets else {},
+        )
+
+    def _reasoning_aggregate_source_ids(self) -> set[str]:
+        """Aggregate IDs worth sending to the reasoning model."""
+        retained_prefixes = {
+            item.source_ref.source_id
+            for items in self.pools.values()
+            for item in items
+        }
+        allowed: set[str] = set()
+        for agg in self.aggregates:
+            sid = agg.source_id
+            if agg.label in _REASONING_CORE_AGGREGATE_LABELS:
+                allowed.add(sid)
+                continue
+            for prefix in retained_prefixes:
+                if sid == prefix or sid.startswith(f"{prefix}:"):
+                    allowed.add(sid)
+                    break
+        return allowed
+
+    def to_llm_payload(
+        self,
+        *,
+        compact_metric_ledger: bool = False,
+        compact_aggregates: bool = False,
+        include_contradiction_rows: bool = True,
+        include_minority_signals: bool = True,
+        include_section_packets: bool = True,
+    ) -> dict[str, Any]:
+        """Serialize to JSON-ready dict with ``_sid`` on every item."""
+        payload: dict[str, Any] = {}
+        for pool_name, items in self.pools.items():
+            pool_out: list[dict[str, Any]] = []
+            for si in items:
+                entry = dict(si.data)
+                entry["_sid"] = si.source_ref.source_id
+                pool_out.append(entry)
+            payload[pool_name] = pool_out
+
+        allowed_aggregate_ids = (
+            self._reasoning_aggregate_source_ids()
+            if compact_aggregates
+            else None
+        )
+        agg_out: dict[str, dict[str, Any]] = {}
+        for agg in self.aggregates:
+            if allowed_aggregate_ids is not None and agg.source_id not in allowed_aggregate_ids:
+                continue
+            agg_out[agg.label] = {"value": agg.value, "_sid": agg.source_id}
+        payload["precomputed_aggregates"] = agg_out
+
+        # Governance / tension signals
+        if self.metric_ledger:
+            metric_ledger = self.metric_ledger
+            if allowed_aggregate_ids is not None:
+                metric_ledger = [
+                    entry for entry in self.metric_ledger
+                    if str(entry.get("_sid") or "") in allowed_aggregate_ids
+                ]
+            if compact_metric_ledger:
+                payload["metric_ledger"] = [
+                    {
+                        "label": entry.get("label"),
+                        "_sid": entry.get("_sid"),
+                    }
+                    for entry in metric_ledger
+                ]
+            else:
+                payload["metric_ledger"] = metric_ledger
+        if include_contradiction_rows and self.contradiction_rows:
+            payload["contradiction_rows"] = self.contradiction_rows
+        if include_minority_signals and self.minority_signals:
+            payload["minority_signals"] = self.minority_signals
+        if self.coverage_gaps:
+            payload["coverage_gaps"] = self.coverage_gaps
+        if self.retention_proof:
+            payload["retention_proof"] = self.retention_proof
+        if self.witness_pack:
+            payload["witness_pack"] = self.witness_pack
+        if include_section_packets and self.section_packets:
+            payload["section_packets"] = self.section_packets
+
+        return payload
+
+    def to_reasoning_payload(
+        self,
+        *,
+        compact_metric_ledger: bool = True,
+        compact_aggregates: bool = True,
+        include_contradiction_rows: bool = True,
+        include_minority_signals: bool = True,
+        include_section_packets: bool = True,
+    ) -> dict[str, Any]:
+        """Serialize to a witness-first synthesis payload.
+
+        The reasoning model receives witness excerpts, section-scoped
+        witness packets, and light governance signals. Deterministic
+        aggregates still remain on the packet object for validation and
+        contract expansion, but they are not emitted as global prompt
+        blocks.
+        """
+        payload: dict[str, Any] = {}
+        if include_contradiction_rows and self.contradiction_rows:
+            payload["contradiction_rows"] = self.contradiction_rows
+        if include_minority_signals and self.minority_signals:
+            payload["minority_signals"] = self.minority_signals
+        if self.coverage_gaps:
+            payload["coverage_gaps"] = self.coverage_gaps
+        if self.retention_proof:
+            payload["retention_proof"] = self.retention_proof
+        if self.witness_pack:
+            payload["witness_pack"] = [
+                _compact_reasoning_witness_entry(witness)
+                for witness in self.witness_pack
+                if isinstance(witness, dict)
+            ]
+        if include_section_packets and self.section_packets:
+            payload["section_packets"] = self._reasoning_section_packets()
+
+        payload["payload_profile"] = "witness_first_v2"
+        return payload
+
+    def _reasoning_section_packets(self) -> dict[str, Any]:
+        packets = json.loads(json.dumps(self.section_packets, default=str))
+        packets.pop("_witness_governance", None)
+        packets.setdefault("segment_packet", {})
+        packets.setdefault("timing_packet", {})
+        packets.setdefault("displacement_packet", {})
+        packets.setdefault("account_packet", {})
+        packets.setdefault("category_packet", {})
+        packets.setdefault("retention_packet", {})
+
+        packets["segment_packet"]["priority_segment_candidates"] = self._segment_candidates()
+        packets["timing_packet"]["numeric_support"] = {
+            "active_eval_signals": self._aggregate_wrapper("active_eval_signal_count"),
+        }
+        packets["timing_packet"]["trigger_candidates"] = self._temporal_candidates()
+        packets["displacement_packet"]["numeric_support"] = {
+            "switch_volume": self._aggregate_wrapper("total_explicit_switches"),
+            "active_evaluation_volume": self._aggregate_wrapper("total_active_evaluations"),
+            "displacement_mention_volume": self._aggregate_wrapper("displacement_mention_count"),
+        }
+        packets["displacement_packet"]["destination_candidates"] = self._displacement_candidates()
+        packets["account_packet"]["numeric_support"] = {
+            "total_accounts": self._aggregate_wrapper("total_accounts"),
+            "high_intent_count": self._aggregate_wrapper("high_intent_count"),
+            "active_eval_count": self._aggregate_wrapper("active_eval_signal_count"),
+        }
+        packets["account_packet"]["top_accounts"] = self._account_candidates()
+        packets["category_packet"]["regime_candidates"] = self._category_candidates()
+        packets["retention_packet"]["strength_candidates"] = self._retention_candidates()
+        return packets
+
+    def _aggregate_wrapper(self, label: str) -> dict[str, Any] | None:
+        for agg in self.aggregates:
+            if agg.label == label:
+                return {"value": agg.value, "source_id": agg.source_id}
+        return None
+
+    def _segment_candidates(self) -> list[dict[str, Any]]:
+        limit = _reasoning_section_candidate_limit("segment", 3)
+        candidates: list[dict[str, Any]] = []
+        for item in self.pools.get("segment") or []:
+            entry = _compact_reasoning_context_entry("segment", item)
+            if not entry:
+                continue
+            label = (
+                entry.get("role_type")
+                or entry.get("department")
+                or entry.get("use_case")
+                or entry.get("segment")
+                or entry.get("duration")
+            )
+            if not label:
+                continue
+            candidates.append({
+                "_sid": entry.get("_sid"),
+                "kind": entry.get("kind"),
+                "label": label,
+                "churn_rate": entry.get("churn_rate"),
+                "review_count": entry.get("review_count") or entry.get("count"),
+            })
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    def _temporal_candidates(self) -> list[dict[str, Any]]:
+        limit = _reasoning_section_candidate_limit("temporal", 3)
+        candidates: list[dict[str, Any]] = []
+        for item in self.pools.get("temporal") or []:
+            entry = _compact_reasoning_context_entry("temporal", item)
+            if not entry:
+                continue
+            candidates.append(entry)
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    def _displacement_candidates(self) -> list[dict[str, Any]]:
+        limit = _reasoning_section_candidate_limit("displacement", 3)
+        candidates: list[dict[str, Any]] = []
+        for item in self.pools.get("displacement") or []:
+            entry = _compact_reasoning_context_entry("displacement", item)
+            if not entry:
+                continue
+            candidates.append({
+                "_sid": entry.get("_sid"),
+                "to_vendor": entry.get("to_vendor"),
+                "mention_count": entry.get("mention_count"),
+                "explicit_switch_count": entry.get("explicit_switch_count"),
+                "active_evaluation_count": entry.get("active_evaluation_count"),
+                "primary_driver": entry.get("primary_driver"),
+            })
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    def _account_candidates(self) -> list[dict[str, Any]]:
+        limit = _reasoning_section_candidate_limit("account", 3)
+        candidates: list[dict[str, Any]] = []
+        for item in self.pools.get("accounts") or []:
+            entry = _compact_reasoning_context_entry("accounts", item)
+            if not entry:
+                continue
+            candidates.append({
+                "name": entry.get("name"),
+                "intent_score": entry.get("intent_score"),
+                "source_id": entry.get("_sid"),
+                "buying_stage": entry.get("buying_stage"),
+                "decision_maker": entry.get("decision_maker"),
+            })
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    def _category_candidates(self) -> list[dict[str, Any]]:
+        limit = _reasoning_section_candidate_limit("category", 2)
+        candidates: list[dict[str, Any]] = []
+        for item in self.pools.get("category") or []:
+            entry = _compact_reasoning_context_entry("category", item)
+            if not entry:
+                continue
+            candidates.append(entry)
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    def _retention_candidates(self) -> list[dict[str, Any]]:
+        limit = _reasoning_section_candidate_limit("retention", 3)
+        candidates: list[dict[str, Any]] = []
+        for entry in self.retention_proof or []:
+            candidates.append({
+                "_sid": entry.get("_sid"),
+                "area": entry.get("area"),
+                "evidence": entry.get("evidence"),
+            })
+            if len(candidates) >= limit:
+                break
+        return candidates
+
+    def reasoning_payload_component_tokens(
+        self,
+        *,
+        compact_metric_ledger: bool = True,
+        compact_aggregates: bool = True,
+        include_contradiction_rows: bool = True,
+        include_minority_signals: bool = True,
+        include_section_packets: bool = True,
+    ) -> dict[str, int]:
+        """Approximate per-component token contribution for the reasoning payload."""
+        payload = self.to_reasoning_payload(
+            compact_metric_ledger=compact_metric_ledger,
+            compact_aggregates=compact_aggregates,
+            include_contradiction_rows=include_contradiction_rows,
+            include_minority_signals=include_minority_signals,
+            include_section_packets=include_section_packets,
+        )
+        estimates: dict[str, int] = {}
+        for key, value in payload.items():
+            estimates[key] = _approx_payload_tokens({key: value})
+        return estimates
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+def _slug(text: str) -> str:
+    """Create a URL-safe slug from text for use in source IDs."""
+    return (
+        text.lower()
+        .replace(" ", "_")
+        .replace("/", "_")
+        .replace("-", "_")
+        .replace(".", "")
+        .replace(",", "")
+        .replace("(", "")
+        .replace(")", "")
+    )[:60]
+
+
+def _compact_reasoning_context_entry(
+    pool_name: str,
+    item: ScoredItem,
+) -> dict[str, Any] | None:
+    """Project a scored pool item into a compact synthesis context row."""
+    data = item.data if isinstance(item.data, dict) else {}
+    sid = item.source_ref.source_id
+    kind = item.source_ref.kind
+
+    if pool_name == "segment":
+        if kind == "role":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "role_type": data.get("role_type"),
+                "review_count": data.get("review_count"),
+                "churn_rate": data.get("churn_rate"),
+            }
+        if kind == "department":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "department": data.get("department"),
+                "review_count": data.get("review_count"),
+                "churn_rate": data.get("churn_rate"),
+            }
+        if kind == "use_case":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "use_case": data.get("use_case") or data.get("name"),
+                "mention_count": data.get("mention_count"),
+                "confidence_score": data.get("confidence_score"),
+            }
+        if kind == "size":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "segment": data.get("segment"),
+                "review_count": data.get("review_count"),
+                "churn_rate": data.get("churn_rate"),
+            }
+        if kind == "contract":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "segment": data.get("segment"),
+                "count": data.get("count"),
+                "churn_rate": data.get("churn_rate"),
+            }
+        if kind == "duration":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "duration": data.get("duration"),
+                "count": data.get("count"),
+                "churn_rate": data.get("churn_rate"),
+            }
+        return None
+
+    if pool_name == "temporal":
+        if kind == "spike":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "keyword": data.get("keyword") or data.get("term"),
+                "magnitude": data.get("magnitude") or data.get("spike_ratio"),
+                "change_pct": data.get("change_pct"),
+            }
+        if kind == "sentiment":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "direction": data.get("direction"),
+                "count": data.get("count"),
+                "pct": data.get("pct"),
+            }
+        return {
+            "_sid": sid,
+            "kind": kind,
+            "type": data.get("type") or data.get("trigger_type"),
+            "trigger": (
+                data.get("label")
+                or data.get("trigger")
+                or data.get("deadline")
+                or data.get("evaluation_deadline")
+                or data.get("contract_end")
+                or data.get("decision_timeline")
+                or data.get("date")
+                or data.get("company")
+            ),
+            "urgency": data.get("urgency"),
+            "date": data.get("date") or data.get("deadline"),
+        }
+
+    if pool_name == "displacement":
+        flow_summary = data.get("flow_summary") or {}
+        primary_driver = data.get("primary_driver")
+        if not primary_driver:
+            switch_reasons = data.get("switch_reasons") or []
+            if switch_reasons and isinstance(switch_reasons[0], dict):
+                primary_driver = (
+                    switch_reasons[0].get("reason")
+                    or switch_reasons[0].get("reason_category")
+                    or switch_reasons[0].get("switch_reason")
+                )
+        return {
+            "_sid": sid,
+            "kind": kind,
+            "to_vendor": data.get("to_vendor") or data.get("competitor"),
+            "mention_count": flow_summary.get("total_flow_mentions") or flow_summary.get("mention_count"),
+            "explicit_switch_count": flow_summary.get("explicit_switch_count"),
+            "active_evaluation_count": flow_summary.get("active_evaluation_count"),
+            "primary_driver": primary_driver,
+        }
+
+    if pool_name == "category":
+        if kind == "regime":
+            return {
+                "_sid": sid,
+                "kind": kind,
+                "regime_type": data.get("regime_type"),
+                "confidence": data.get("confidence"),
+                "avg_churn_velocity": data.get("avg_churn_velocity"),
+                "avg_price_pressure": data.get("avg_price_pressure"),
+            }
+        return {
+            "_sid": sid,
+            "kind": kind,
+            "confidence": data.get("confidence"),
+            "winner": data.get("winner"),
+            "loser": data.get("loser"),
+        }
+
+    if pool_name == "accounts":
+        return {
+            "_sid": sid,
+            "kind": kind,
+            "name": data.get("company_name") or data.get("company") or data.get("name"),
+            "intent_score": _normalize_account_intent_score(
+                data.get("urgency_score")
+                or data.get("intent_score")
+                or data.get("confidence_score")
+            ),
+            "buying_stage": data.get("buying_stage"),
+            "decision_maker": bool(data.get("decision_maker") or data.get("is_decision_maker")),
+        }
+
+    return None
+
+
+def _safe_float(val: Any, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(val: Any, default: int = 0) -> int:
+    try:
+        return int(float(val))
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_account_intent_score(val: Any) -> float:
+    score = _safe_float(val, 0.0)
+    if score <= 0:
+        return 0.0
+    if score > 1.0:
+        score = score / 10.0
+    return max(0.0, min(score, 1.0))
+
+
+def _is_active_eval_stage(stage: Any) -> bool:
+    text = str(stage or "").strip().lower()
+    if not text:
+        return False
+    if text in {"evaluation", "active_purchase", "consideration", "trial", "poc"}:
+        return True
+    return "evaluat" in text or "consider" in text
+
+
+def _looks_like_displacement_tool_label(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    generic_modifiers = ("custom", "homegrown", "home-grown", "in-house", "internal")
+    generic_artifacts = (
+        "integration", "utility", "workflow", "tool", "stack",
+        "system", "automation", "bot",
+    )
+    return any(token in text for token in generic_modifiers) and any(
+        token in text for token in generic_artifacts
+    )
+
+
+def _displacement_flow_counts(flow: dict[str, Any]) -> tuple[float, int, int]:
+    summary = flow.get("flow_summary") or {}
+    edge_metrics = flow.get("edge_metrics") or {}
+    mentions = _safe_float(
+        summary.get("mention_count")
+        or summary.get("total_flow_mentions")
+        or edge_metrics.get("mention_count"),
+        0.0,
+    )
+    switches = _safe_int(summary.get("explicit_switch_count"), 0)
+    evals = _safe_int(summary.get("active_evaluation_count"), 0)
+    return mentions, switches, evals
+
+
+def _merge_displacement_flow_rows(flows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for flow in flows or []:
+        if not isinstance(flow, dict):
+            continue
+        raw_to_vendor = str(flow.get("to_vendor") or flow.get("competitor") or "").strip()
+        canonical_to_vendor = _canonicalize_competitor(raw_to_vendor) or raw_to_vendor
+        if not canonical_to_vendor or _looks_like_displacement_tool_label(canonical_to_vendor):
+            continue
+        from_vendor = str(flow.get("from_vendor") or "").strip()
+        if from_vendor and canonical_to_vendor.lower() == from_vendor.lower():
+            continue
+
+        key = canonical_to_vendor.lower()
+        current = merged.get(key)
+        if current is None:
+            current = dict(flow)
+            current["to_vendor"] = canonical_to_vendor
+            current["flow_summary"] = dict(flow.get("flow_summary") or {})
+            current["edge_metrics"] = dict(flow.get("edge_metrics") or {})
+            current["switch_reasons"] = list(flow.get("switch_reasons") or [])
+            current["evidence_breakdown"] = list(flow.get("evidence_breakdown") or [])
+            merged[key] = current
+            continue
+
+        existing_mentions, existing_switches, existing_evals = _displacement_flow_counts(current)
+        new_mentions, new_switches, new_evals = _displacement_flow_counts(flow)
+
+        current_summary = dict(current.get("flow_summary") or {})
+        current_summary["total_flow_mentions"] = existing_mentions + new_mentions
+        current_summary["mention_count"] = existing_mentions + new_mentions
+        current_summary["explicit_switch_count"] = existing_switches + new_switches
+        current_summary["active_evaluation_count"] = existing_evals + new_evals
+        current["flow_summary"] = current_summary
+
+        current_edge = dict(current.get("edge_metrics") or {})
+        new_edge = dict(flow.get("edge_metrics") or {})
+        if new_mentions > existing_mentions:
+            if new_edge.get("key_quote"):
+                current_edge["key_quote"] = new_edge.get("key_quote")
+            if new_edge.get("primary_driver"):
+                current_edge["primary_driver"] = new_edge.get("primary_driver")
+            if new_edge.get("signal_strength"):
+                current_edge["signal_strength"] = new_edge.get("signal_strength")
+        current_edge["mention_count"] = existing_mentions + new_mentions
+        current_edge["velocity_7d"] = _safe_float(current_edge.get("velocity_7d"), 0.0) + _safe_float(new_edge.get("velocity_7d"), 0.0)
+        current_edge["velocity_30d"] = _safe_float(current_edge.get("velocity_30d"), 0.0) + _safe_float(new_edge.get("velocity_30d"), 0.0)
+        current_edge["confidence_score"] = max(
+            _safe_float(current_edge.get("confidence_score"), 0.0),
+            _safe_float(new_edge.get("confidence_score"), 0.0),
+        )
+        current["edge_metrics"] = current_edge
+
+        current["switch_reasons"] = list(current.get("switch_reasons") or []) + list(flow.get("switch_reasons") or [])
+        current["evidence_breakdown"] = list(current.get("evidence_breakdown") or []) + list(flow.get("evidence_breakdown") or [])
+
+    return list(merged.values())
+
+
+def _uniqueness_penalty(
+    item: dict[str, Any],
+    higher_ranked: list[dict[str, Any]],
+) -> float:
+    """Penalize items that are textually similar to higher-ranked ones.
+
+    Simple overlap check on the string representation.  Returns 1.0 for
+    unique, lower for duplicates.
+    """
+    if not higher_ranked:
+        return 1.0
+    item_str = str(item).lower()
+    for prev in higher_ranked:
+        prev_str = str(prev).lower()
+        # Jaccard-ish overlap on word sets
+        iw = set(item_str.split())
+        pw = set(prev_str.split())
+        if not iw or not pw:
+            continue
+        overlap = len(iw & pw) / max(len(iw | pw), 1)
+        if overlap > OVERLAP_HIGH:
+            return PENALTY_HIGH
+        if overlap > OVERLAP_MEDIUM:
+            return PENALTY_MEDIUM
+    return 1.0
+
+
+def _vault_item_recency_score(item: dict[str, Any]) -> float:
+    """Derive a recency score from recent-count and trend metadata."""
+    total = _safe_float(
+        item.get("mention_count_total", item.get("mention_count", 0)),
+        0.0,
+    )
+    recent = _safe_float(item.get("mention_count_recent"), 0.0)
+    recency = RECENCY_DEFAULT
+    if total > 0 and recent > 0:
+        ratio = min(max(recent / total, 0.0), 1.0)
+        recency = max(recency, 0.7 + 0.3 * ratio)
+
+    trend = item.get("trend") if isinstance(item.get("trend"), dict) else {}
+    direction = str(trend.get("direction") or "").strip().lower()
+    if direction in {"accelerating", "new"}:
+        recency = min(1.0, recency + 0.15)
+    elif direction == "declining":
+        recency = max(RECENCY_LOW, recency - 0.15)
+    return recency
+
+
+# ---------------------------------------------------------------------------
+# Per-pool scorers
+# ---------------------------------------------------------------------------
+
+def _score_evidence_vault(
+    ev: dict[str, Any], max_items: int,
+) -> tuple[list[ScoredItem], list[TrackedAggregate]]:
+    """Score evidence vault weakness and strength items."""
+    items: list[ScoredItem] = []
+    aggregates: list[TrackedAggregate] = []
+
+    ms = ev.get("metric_snapshot") or {}
+    prov = ev.get("provenance") or {}
+
+    # Aggregates from metric snapshot
+    for metric_key in (
+        "total_reviews",
+        "reviews_in_analysis_window",
+        "reviews_in_recent_window",
+        "churn_density",
+        "avg_urgency",
+        "recommend_yes",
+        "recommend_no",
+        "recommend_ratio",
+        "price_complaint_rate",
+        "dm_churn_rate",
+        "positive_review_pct",
+        "displacement_mention_count",
+        "keyword_spike_count",
+        "avg_rating",
+        "negative_review_pct",
+    ):
+        val = ms.get(metric_key)
+        if val is not None:
+            aggregates.append(TrackedAggregate(
+                label=metric_key,
+                value=val,
+                source_id=f"vault:metric:{metric_key}",
+            ))
+
+    # Evidence window from provenance
+    for prov_key in ("enrichment_window_start", "enrichment_window_end"):
+        val = prov.get(prov_key)
+        if val is not None:
+            aggregates.append(TrackedAggregate(
+                label=prov_key,
+                value=str(val),
+                source_id=f"vault:provenance:{prov_key}",
+            ))
+
+    company_signals = ev.get("company_signals") or []
+    if company_signals:
+        high_urgency_count = 0
+        evaluation_count = 0
+        active_purchase_count = 0
+        decision_maker_count = 0
+        for signal in company_signals:
+            if not isinstance(signal, dict):
+                continue
+            urgency = _safe_float(signal.get("urgency_score"), 0.0)
+            stage = str(signal.get("buying_stage") or "").strip().lower()
+            if urgency >= 8.0:
+                high_urgency_count += 1
+            if "evaluat" in stage:
+                evaluation_count += 1
+            elif stage == "active_purchase":
+                active_purchase_count += 1
+            if signal.get("decision_maker") is True:
+                decision_maker_count += 1
+
+        for label, value, sid in (
+            ("company_signal_count", len(company_signals), "vault:company_signals:count"),
+            ("company_signal_high_urgency_count", high_urgency_count, "vault:company_signals:high_urgency_count"),
+            ("company_signal_evaluation_count", evaluation_count, "vault:company_signals:evaluation_count"),
+            ("company_signal_active_purchase_count", active_purchase_count, "vault:company_signals:active_purchase_count"),
+            ("company_signal_decision_maker_count", decision_maker_count, "vault:company_signals:decision_maker_count"),
+        ):
+            aggregates.append(TrackedAggregate(
+                label=label,
+                value=value,
+                source_id=sid,
+            ))
+
+        higher_ranked_companies: list[dict[str, Any]] = []
+        for signal in company_signals:
+            if not isinstance(signal, dict):
+                continue
+            name = str(signal.get("company_name") or signal.get("company") or "").strip()
+            if not name:
+                continue
+            intent = _normalize_account_intent_score(
+                signal.get("urgency_score") or signal.get("intent_score") or signal.get("confidence_score", 0),
+            )
+            is_dm = bool(signal.get("decision_maker") or signal.get("is_decision_maker"))
+            is_active_eval = _is_active_eval_stage(signal.get("buying_stage"))
+            signal_strength = intent
+            if is_dm:
+                signal_strength = min(signal_strength + DM_INTENT_BOOST, 1.0)
+            if is_active_eval:
+                signal_strength = min(signal_strength + ACTIVE_EVAL_ACCOUNT_BOOST, 1.0)
+            uniq = _uniqueness_penalty(signal, higher_ranked_companies)
+            score = W_RECENCY * RECENCY_DEFAULT + W_SIGNAL * signal_strength + W_UNIQUENESS * uniq
+            review_id = str(signal.get("review_id") or "").strip()
+            review_ids = (review_id,) if review_id else ()
+            items.append(ScoredItem(
+                data=signal,
+                score=score,
+                source_ref=SourceRef(
+                    pool="vault",
+                    kind="company",
+                    key=_slug(name),
+                    review_ids=review_ids,
+                ),
+            ))
+            higher_ranked_companies.append(signal)
+
+    # Score weakness evidence
+    weaknesses = ev.get("weakness_evidence") or []
+    w_max_mc = (
+        max(
+            (
+                _safe_float(
+                    x.get("mention_count_total", x.get("mention_count", 0)),
+                )
+                for x in weaknesses
+            ),
+            default=1.0,
+        )
+        if weaknesses else 1.0
+    )
+    higher_ranked: list[dict[str, Any]] = []
+    for w in weaknesses:
+        cat = (
+            w.get("key")
+            or w.get("label")
+            or w.get("category")
+            or w.get("theme")
+            or "unknown"
+        )
+        slug = _slug(cat)
+        mc = _safe_float(w.get("mention_count_total", w.get("mention_count", 0)))
+        mc_recent = int(_safe_float(w.get("mention_count_recent"))) if w.get("mention_count_recent") is not None else None
+        signal = mc / max(w_max_mc, 1.0) if w_max_mc > 0 else 0.0
+        uniq = _uniqueness_penalty(w, higher_ranked)
+        recency = _vault_item_recency_score(w)
+        score = W_RECENCY * recency + W_SIGNAL * signal + W_UNIQUENESS * uniq
+
+        aggregates.append(TrackedAggregate(
+            label=f"vault_weakness_{slug}_mention_count_total",
+            value=int(mc),
+            source_id=f"vault:weakness:{slug}:mention_count_total",
+        ))
+        if mc_recent is not None:
+            aggregates.append(TrackedAggregate(
+                label=f"vault_weakness_{slug}_mention_count_recent",
+                value=mc_recent,
+                source_id=f"vault:weakness:{slug}:mention_count_recent",
+            ))
+
+        rids = tuple(w.get("supporting_review_ids") or w.get("review_ids") or [])
+        items.append(ScoredItem(
+            data=w,
+            score=score,
+            source_ref=SourceRef(
+                pool="vault", kind="weakness", key=slug,
+                review_ids=rids,
+            ),
+        ))
+        higher_ranked.append(w)
+
+    # Score strength evidence
+    strengths = ev.get("strength_evidence") or []
+    s_max_mc = (
+        max(
+            (
+                _safe_float(
+                    x.get("mention_count_total", x.get("mention_count", 0)),
+                )
+                for x in strengths
+            ),
+            default=1.0,
+        )
+        if strengths else 1.0
+    )
+    higher_ranked = []
+    for s in strengths:
+        cat = (
+            s.get("key")
+            or s.get("label")
+            or s.get("category")
+            or s.get("theme")
+            or "unknown"
+        )
+        slug = _slug(cat)
+        mc = _safe_float(s.get("mention_count_total", s.get("mention_count", 0)))
+        mc_recent = int(_safe_float(s.get("mention_count_recent"))) if s.get("mention_count_recent") is not None else None
+        signal = mc / max(s_max_mc, 1.0) if s_max_mc > 0 else 0.0
+        uniq = _uniqueness_penalty(s, higher_ranked)
+        recency = _vault_item_recency_score(s)
+        score = W_RECENCY * recency + W_SIGNAL * signal + W_UNIQUENESS * uniq
+
+        aggregates.append(TrackedAggregate(
+            label=f"vault_strength_{slug}_mention_count_total",
+            value=int(mc),
+            source_id=f"vault:strength:{slug}:mention_count_total",
+        ))
+        if mc_recent is not None:
+            aggregates.append(TrackedAggregate(
+                label=f"vault_strength_{slug}_mention_count_recent",
+                value=mc_recent,
+                source_id=f"vault:strength:{slug}:mention_count_recent",
+            ))
+
+        rids = tuple(s.get("supporting_review_ids") or s.get("review_ids") or [])
+        items.append(ScoredItem(
+            data=s,
+            score=score,
+            source_ref=SourceRef(
+                pool="vault", kind="strength", key=slug,
+                review_ids=rids,
+            ),
+        ))
+        higher_ranked.append(s)
+
+    items.sort(key=lambda x: x.score, reverse=True)
+    return items[:max_items * 2], aggregates  # 2x: weaknesses + strengths
+
+
+def _score_segment(
+    seg: dict[str, Any], max_items: int,
+) -> tuple[list[ScoredItem], list[TrackedAggregate]]:
+    """Score segment intelligence items.
+
+    Real structure: affected_roles, affected_departments,
+    contract_segments, affected_company_sizes, usage_duration_segments,
+    budget_pressure, buying_stage_distribution, top_use_cases_under_pressure.
+    """
+    items: list[ScoredItem] = []
+    aggregates: list[TrackedAggregate] = []
+
+    def _append_reach_aggregate(kind: str, name: str, sample_size: int) -> None:
+        if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+            return
+        slug = _slug(name or "unknown")
+        aggregates.append(TrackedAggregate(
+            label=f"segment_reach_{kind}_{slug}",
+            value=sample_size,
+            source_id=f"segment:reach:{kind}:{slug}",
+        ))
+
+    # Affected departments (list of dicts with department, churn_rate, review_count)
+    departments = seg.get("affected_departments") or []
+    for d in departments:
+        if not isinstance(d, dict):
+            continue
+        sample_size = _safe_int(d.get("review_count", 0))
+        if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+            continue
+        name = d.get("department") or "unknown"
+        churn = _safe_float(d.get("churn_rate", 0))
+        score = W_RECENCY * RECENCY_LOW + W_SIGNAL * churn + W_UNIQUENESS * 1.0
+        items.append(ScoredItem(
+            data=d,
+            score=score,
+            source_ref=SourceRef(
+                pool="segment", kind="department", key=_slug(name),
+            ),
+        ))
+        _append_reach_aggregate("department", name, sample_size)
+
+    # Affected roles (list of dicts with role_type, review_count, churn_rate)
+    roles = seg.get("affected_roles") or []
+    for r in roles:
+        if not isinstance(r, dict):
+            continue
+        sample_size = _safe_int(r.get("review_count", 0))
+        if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+            continue
+        name = r.get("role_type") or "unknown"
+        churn = _safe_float(r.get("churn_rate", 0))
+        priority_score = _safe_float(r.get("priority_score"), default=-1.0)
+        if priority_score < 0:
+            priority_score = sample_size * _segment_role_multiplier(name)
+        role_bonus = priority_score / 100.0
+        score = (
+            W_RECENCY * RECENCY_LOW
+            + W_SIGNAL * churn
+            + W_UNIQUENESS * 1.0
+            + role_bonus
+        )
+        items.append(ScoredItem(
+            data=r,
+            score=score,
+            source_ref=SourceRef(
+                pool="segment", kind="role", key=_slug(name),
+            ),
+        ))
+        _append_reach_aggregate("role", name, sample_size)
+
+    # Contract segments (list of dicts with segment, count, churn_rate)
+    contracts = seg.get("contract_segments") or []
+    for c in contracts:
+        if not isinstance(c, dict):
+            continue
+        sample_size = _safe_int(c.get("count", 0))
+        if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+            continue
+        name = c.get("segment") or "unknown"
+        churn = _safe_float(c.get("churn_rate", 0))
+        score = W_RECENCY * RECENCY_LOW + W_SIGNAL * churn + W_UNIQUENESS * 1.0
+        items.append(ScoredItem(
+            data=c,
+            score=score,
+            source_ref=SourceRef(
+                pool="segment", kind="contract", key=_slug(name),
+            ),
+        ))
+        _append_reach_aggregate("contract", name, sample_size)
+
+    # Usage duration segments (list of dicts with duration, count, churn_rate)
+    durations = seg.get("usage_duration_segments") or []
+    for d in durations:
+        if not isinstance(d, dict):
+            continue
+        sample_size = _safe_int(d.get("count", 0))
+        if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+            continue
+        name = d.get("duration") or "unknown"
+        churn = _safe_float(d.get("churn_rate", 0))
+        score = W_RECENCY * RECENCY_LOW + W_SIGNAL * churn + W_UNIQUENESS * 1.0
+        items.append(ScoredItem(
+            data=d,
+            score=score,
+            source_ref=SourceRef(
+                pool="segment", kind="duration", key=_slug(name),
+            ),
+        ))
+        _append_reach_aggregate("duration", name, sample_size)
+
+    # Use cases under pressure (list of dicts with use_case, mention_count)
+    use_cases = seg.get("top_use_cases_under_pressure") or []
+    max_mentions = max(
+        (_safe_float(u.get("mention_count", 0)) for u in use_cases if isinstance(u, dict)),
+        default=1.0,
+    )
+    higher_ranked_use_cases: list[dict[str, Any]] = []
+    for u in use_cases:
+        if not isinstance(u, dict):
+            continue
+        sample_size = _safe_int(u.get("mention_count", 0))
+        if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+            continue
+        name = u.get("use_case") or "unknown"
+        confidence = _safe_float(u.get("confidence_score", 0))
+        signal = max(sample_size / max(max_mentions, 1.0), confidence)
+        uniq = _uniqueness_penalty(u, higher_ranked_use_cases)
+        score = W_RECENCY * RECENCY_LOW + W_SIGNAL * signal + W_UNIQUENESS * uniq
+        items.append(ScoredItem(
+            data=u,
+            score=score,
+            source_ref=SourceRef(
+                pool="segment", kind="use_case", key=_slug(name),
+            ),
+        ))
+        _append_reach_aggregate("use_case", name, sample_size)
+        higher_ranked_use_cases.append(u)
+
+    # Budget pressure (dict with dm_churn_rate, price_increase_rate, etc.)
+    bp = seg.get("budget_pressure")
+    if isinstance(bp, dict):
+        dm_churn = bp.get("dm_churn_rate")
+        if dm_churn is not None:
+            aggregates.append(TrackedAggregate(
+                label="dm_churn_rate",
+                value=dm_churn,
+                source_id="segment:budget:dm_churn_rate",
+            ))
+        pi_rate = bp.get("price_increase_rate")
+        if pi_rate is not None:
+            aggregates.append(TrackedAggregate(
+                label="price_increase_rate",
+                value=pi_rate,
+                source_id="segment:budget:price_increase_rate",
+            ))
+        pi_count = bp.get("price_increase_count")
+        if pi_count is not None:
+            aggregates.append(TrackedAggregate(
+                label="price_increase_count",
+                value=pi_count,
+                source_id="segment:budget:price_increase_count",
+            ))
+        annual_spend_signals = bp.get("annual_spend_signals") or []
+        if annual_spend_signals:
+            aggregates.append(TrackedAggregate(
+                label="annual_spend_signal_count",
+                value=len(annual_spend_signals),
+                source_id="segment:budget:annual_spend_signal_count",
+            ))
+        price_per_seat_signals = bp.get("price_per_seat_signals") or []
+        if price_per_seat_signals:
+            aggregates.append(TrackedAggregate(
+                label="price_per_seat_signal_count",
+                value=len(price_per_seat_signals),
+                source_id="segment:budget:price_per_seat_signal_count",
+            ))
+
+    # Company size signals (dict with avg/median/max seat counts)
+    company_sizes = seg.get("affected_company_sizes")
+    if isinstance(company_sizes, dict):
+        for field in ("avg_seat_count", "median_seat_count", "max_seat_count"):
+            value = company_sizes.get(field)
+            if value is None:
+                continue
+            aggregates.append(TrackedAggregate(
+                label=f"segment_{field}",
+                value=value,
+                source_id=f"segment:size:{field}",
+            ))
+        for entry in company_sizes.get("size_distribution") or []:
+            if not isinstance(entry, dict):
+                continue
+            sample_size = _safe_int(entry.get("review_count", 0))
+            if sample_size < MIN_SEGMENT_SAMPLE_SIZE:
+                continue
+            name = entry.get("segment") or "unknown"
+            churn = _safe_float(entry.get("churn_rate", 0))
+            score = W_RECENCY * RECENCY_LOW + W_SIGNAL * churn + W_UNIQUENESS * 1.0
+            items.append(ScoredItem(
+                data=entry,
+                score=score,
+                source_ref=SourceRef(
+                    pool="segment", kind="size", key=_slug(name),
+                ),
+            ))
+            _append_reach_aggregate("size", name, sample_size)
+
+    # Buying-stage distribution can carry real evaluation pressure even when
+    # named account extraction is sparse or aggressively sanitized.
+    def _is_active_eval_stage(stage: Any) -> bool:
+        text = str(stage or "").strip().lower()
+        if not text:
+            return False
+        if text in {
+            "evaluation", "active_purchase", "consideration", "trial", "poc",
+        }:
+            return True
+        return "evaluat" in text or "consider" in text
+
+    active_eval_count = 0
+    for row in seg.get("buying_stage_distribution") or []:
+        if not isinstance(row, dict):
+            continue
+        if not _is_active_eval_stage(row.get("stage")):
+            continue
+        active_eval_count += _safe_int(row.get("count", 0))
+
+    if active_eval_count:
+        aggregates.append(TrackedAggregate(
+            label="segment_active_eval_signal_count",
+            value=active_eval_count,
+            source_id="segment:aggregate:active_eval_signal_count",
+        ))
+
+    return _retain_kind_coverage(
+        items,
+        max_items=max_items,
+        required_kinds=(
+            "role",
+            "department",
+            "contract",
+            "duration",
+            "size",
+            "use_case",
+        ),
+    ), aggregates
+
+
+def _score_temporal(
+    temp: dict[str, Any], max_items: int,
+) -> tuple[list[ScoredItem], list[TrackedAggregate]]:
+    """Score temporal intelligence items."""
+    items: list[ScoredItem] = []
+    aggregates: list[TrackedAggregate] = []
+
+    ts = temp.get("timeline_signal_summary") or {}
+    for sig_key in (
+        "evaluation_deadline_signals", "contract_end_signals",
+        "renewal_signals", "budget_cycle_signals",
+    ):
+        val = ts.get(sig_key)
+        if val is not None:
+            aggregates.append(TrackedAggregate(
+                label=sig_key,
+                value=val,
+                source_id=f"temporal:signal:{sig_key}",
+            ))
+
+    # Keyword spikes - structure is {spike_count, spike_keywords, keyword_details}
+    ks_raw = temp.get("keyword_spikes") or {}
+    if isinstance(ks_raw, dict):
+        spike_count = ks_raw.get("spike_count", 0)
+        if spike_count:
+            aggregates.append(TrackedAggregate(
+                label="spike_count",
+                value=spike_count,
+                source_id="temporal:spike:spike_count",
+            ))
+        # keyword_details has the structured items
+        spikes = ks_raw.get("keyword_details") or []
+    elif isinstance(ks_raw, list):
+        spikes = ks_raw
+    else:
+        spikes = []
+
+    def _spike_signal_strength(spike: dict[str, Any]) -> float:
+        magnitude = _safe_float(
+            spike.get("magnitude") or spike.get("spike_ratio"),
+            0.0,
+        )
+        base = min(magnitude / SPIKE_MAGNITUDE_MAX, 1.0) if magnitude > 0 else 0.0
+        change_pct = abs(_safe_float(spike.get("change_pct"), 0.0))
+        if change_pct > 1.0:
+            change_pct = change_pct / 100.0
+        volume = _safe_float(spike.get("volume"), 0.0)
+        volume_signal = min(volume / 10.0, 1.0) if volume > 0 else 0.0
+        if spike.get("is_spike"):
+            base = max(base, 0.5)
+        return min(max(base, change_pct, volume_signal * 0.5), 1.0)
+
+    for sp in spikes:
+        if isinstance(sp, str):
+            # Plain keyword string, no magnitude info
+            items.append(ScoredItem(
+                data={"keyword": sp},
+                score=W_RECENCY * RECENCY_HIGH + W_SIGNAL * 0.5 + W_UNIQUENESS * 1.0,
+                source_ref=SourceRef(
+                    pool="temporal", kind="spike", key=_slug(sp),
+                ),
+            ))
+            continue
+        if not isinstance(sp, dict):
+            continue
+        kw = sp.get("keyword") or sp.get("term") or "unknown"
+        signal_strength = _spike_signal_strength(sp)
+        score = W_RECENCY * RECENCY_HIGH + W_SIGNAL * signal_strength + W_UNIQUENESS * 1.0
+        items.append(ScoredItem(
+            data=sp,
+            score=score,
+            source_ref=SourceRef(
+                pool="temporal", kind="spike", key=_slug(kw),
+            ),
+        ))
+
+    sent = temp.get("sentiment_trajectory") or {}
+    if isinstance(sent, dict):
+        for key in ("declining", "stable", "improving", "total"):
+            val = sent.get(key)
+            if val is not None:
+                aggregates.append(TrackedAggregate(
+                    label=f"sentiment_{key}",
+                    value=val,
+                    source_id=f"temporal:sentiment:{key}_count",
+                ))
+        for key in ("declining_pct", "improving_pct"):
+            val = sent.get(key)
+            if val is not None:
+                aggregates.append(TrackedAggregate(
+                    label=key,
+                    value=val,
+                    source_id=f"temporal:sentiment:{key}",
+                ))
+        for direction in ("declining", "improving", "stable"):
+            count = _safe_int(sent.get(direction))
+            total = max(_safe_int(sent.get("total")), 1)
+            if count <= 0:
+                continue
+            pct = _safe_float(sent.get(f"{direction}_pct"), count / total)
+            items.append(ScoredItem(
+                data={
+                    "direction": direction,
+                    "count": count,
+                    "pct": pct,
+                },
+                score=W_RECENCY * RECENCY_DEFAULT + W_SIGNAL * min(pct, 1.0) + W_UNIQUENESS * 1.0,
+                source_ref=SourceRef(
+                    pool="temporal", kind="sentiment", key=_slug(direction),
+                ),
+            ))
+
+    trigger_entries = temp.get("immediate_triggers") or []
+    deadline_entries = temp.get("evaluation_deadlines") or []
+    seen_triggers: set[tuple[str, str]] = set()
+
+    def _append_trigger_item(entry: dict[str, Any]) -> None:
+        trigger_type = str(
+            entry.get("trigger_type")
+            or entry.get("type")
+            or "signal"
+        ).strip().lower()
+        if not trigger_type:
+            trigger_type = "signal"
+        label = (
+            entry.get("label")
+            or entry.get("trigger")
+            or entry.get("deadline")
+            or entry.get("evaluation_deadline")
+            or entry.get("contract_end")
+            or entry.get("decision_timeline")
+            or entry.get("date")
+            or entry.get("company")
+            or trigger_type
+        )
+        key = _slug(str(label))
+        dedupe = (trigger_type, key)
+        if dedupe in seen_triggers:
+            return
+        seen_triggers.add(dedupe)
+        urgency = _safe_float(entry.get("urgency"), 0.0)
+        recency = RECENCY_HIGH if trigger_type in {"deadline", "contract_end", "spike"} else RECENCY_DEFAULT
+        signal_strength = min(max(urgency / 10.0, 0.4 if trigger_type in {"timeline_signal", "signal"} else 0.0), 1.0)
+        item = dict(entry)
+        item.setdefault("type", trigger_type)
+        item.setdefault("trigger_type", trigger_type)
+        items.append(ScoredItem(
+            data=item,
+            score=W_RECENCY * recency + W_SIGNAL * signal_strength + W_UNIQUENESS * 1.0,
+            source_ref=SourceRef(
+                pool="temporal", kind=trigger_type, key=key,
+            ),
+        ))
+
+    for trigger in trigger_entries:
+        if isinstance(trigger, dict):
+            _append_trigger_item(trigger)
+    for dl in deadline_entries:
+        if isinstance(dl, dict):
+            _append_trigger_item(dl)
+
+    turning_points = temp.get("turning_points") or []
+    max_turning_mentions = max(
+        (_safe_float(item.get("mentions", 0)) for item in turning_points if isinstance(item, dict)),
+        default=1.0,
+    )
+    for tp in turning_points:
+        if not isinstance(tp, dict):
+            continue
+        trigger = tp.get("trigger") or "unknown"
+        mentions = _safe_float(tp.get("mentions", 0))
+        score = (
+            W_RECENCY * RECENCY_DEFAULT
+            + W_SIGNAL * (mentions / max(max_turning_mentions, 1.0))
+            + W_UNIQUENESS * 1.0
+        )
+        items.append(ScoredItem(
+            data=tp,
+            score=score,
+            source_ref=SourceRef(
+                pool="temporal", kind="turning_point", key=_slug(str(trigger)),
+            ),
+        ))
+
+    sentiment_tenure = temp.get("sentiment_tenure") or []
+    max_tenure_count = max(
+        (_safe_float(item.get("count", 0)) for item in sentiment_tenure if isinstance(item, dict)),
+        default=1.0,
+    )
+    for tenure in sentiment_tenure:
+        if not isinstance(tenure, dict):
+            continue
+        label = tenure.get("tenure") or "unknown"
+        count = _safe_float(tenure.get("count", 0))
+        score = (
+            W_RECENCY * RECENCY_LOW
+            + W_SIGNAL * (count / max(max_tenure_count, 1.0))
+            + W_UNIQUENESS * 1.0
+        )
+        items.append(ScoredItem(
+            data=tenure,
+            score=score,
+            source_ref=SourceRef(
+                pool="temporal", kind="tenure", key=_slug(str(label)),
+            ),
+        ))
+
+    items.sort(key=lambda x: x.score, reverse=True)
+    return items[:max_items], aggregates
+
+
+def _score_displacement(
+    disp: list[dict[str, Any]], max_items: int,
+) -> tuple[list[ScoredItem], list[TrackedAggregate]]:
+    """Score displacement flow items."""
+    items: list[ScoredItem] = []
+    aggregates: list[TrackedAggregate] = []
+
+    disp = _merge_displacement_flow_rows(disp)
+    total_switches = 0
+    total_evals = 0
+    total_mentions = 0
+    d_max_mc = (
+        max(
+            (_displacement_flow_counts(x)[0] for x in disp),
+            default=1.0,
+        )
+        if disp else 1.0
+    )
+    d_max_switches = (
+        max((_displacement_flow_counts(x)[1] for x in disp), default=1)
+        if disp else 1
+    )
+    d_max_evals = (
+        max((_displacement_flow_counts(x)[2] for x in disp), default=1)
+        if disp else 1
+    )
+
+    for d in disp:
+        to_vendor = d.get("to_vendor") or d.get("competitor") or "unknown"
+        mc, switches, evals = _displacement_flow_counts(d)
+        fs = dict(d.get("flow_summary") or {})
+        fs["mention_count"] = mc
+        fs["total_flow_mentions"] = mc
+        fs["explicit_switch_count"] = switches
+        fs["active_evaluation_count"] = evals
+        d["flow_summary"] = fs
+        total_switches += switches
+        total_evals += evals
+        total_mentions += int(mc)
+
+        mention_signal = mc / max(d_max_mc, 1.0) if d_max_mc > 0 else 0.0
+        switch_signal = switches / max(d_max_switches, 1.0) if d_max_switches > 0 else 0.0
+        eval_signal = evals / max(d_max_evals, 1.0) if d_max_evals > 0 else 0.0
+        signal = 0.55 * switch_signal + 0.3 * eval_signal + 0.15 * mention_signal
+        score = W_RECENCY * RECENCY_DEFAULT + W_SIGNAL * signal + W_UNIQUENESS * 1.0
+
+        items.append(ScoredItem(
+            data=d,
+            score=score,
+            source_ref=SourceRef(
+                pool="displacement", kind="flow",
+                key=_slug(to_vendor),
+            ),
+        ))
+
+    aggregates.append(TrackedAggregate(
+        label="total_explicit_switches",
+        value=total_switches,
+        source_id="displacement:aggregate:total_explicit_switches",
+    ))
+    aggregates.append(TrackedAggregate(
+        label="total_active_evaluations",
+        value=total_evals,
+        source_id="displacement:aggregate:total_active_evaluations",
+    ))
+    aggregates.append(TrackedAggregate(
+        label="total_flow_mentions",
+        value=total_mentions,
+        source_id="displacement:aggregate:total_flow_mentions",
+    ))
+
+    items.sort(key=lambda x: x.score, reverse=True)
+    return items[:max_items], aggregates
+
+
+def _score_category(
+    cat: dict[str, Any], max_items: int,
+) -> tuple[list[ScoredItem], list[TrackedAggregate]]:
+    """Score category dynamics items.
+
+    Real structure: category, vendor_count, market_regime,
+    displacement_flow_count, council_summary, cross_category_comparison.
+    """
+    items: list[ScoredItem] = []
+    aggregates: list[TrackedAggregate] = []
+
+    # Category-level aggregates
+    for agg_key in ("vendor_count", "displacement_flow_count"):
+        val = cat.get(agg_key)
+        if val is not None:
+            aggregates.append(TrackedAggregate(
+                label=agg_key,
+                value=val,
+                source_id=f"category:aggregate:{agg_key}",
+            ))
+
+    # Market regime as a scored item
+    regime = cat.get("market_regime")
+    if isinstance(regime, dict):
+        for field in ("confidence", "avg_churn_velocity", "avg_price_pressure"):
+            value = regime.get(field)
+            if value is None:
+                continue
+            aggregates.append(TrackedAggregate(
+                label=f"regime_{field}",
+                value=value,
+                source_id=f"category:regime:{field}",
+            ))
+        regime_type = regime.get("regime_type") or "unknown"
+        confidence = _safe_float(regime.get("confidence", 0))
+        score = W_RECENCY * RECENCY_DEFAULT + W_SIGNAL * confidence + W_UNIQUENESS * 1.0
+        items.append(ScoredItem(
+            data=regime,
+            score=score,
+            source_ref=SourceRef(
+                pool="category", kind="regime", key=_slug(regime_type),
+            ),
+        ))
+
+    # Council summary if present
+    council = cat.get("council_summary")
+    if isinstance(council, dict):
+        council_confidence = _safe_float(council.get("confidence", 0.0))
+        items.append(ScoredItem(
+            data=council,
+            score=W_RECENCY * RECENCY_LOW + W_SIGNAL * max(council_confidence, 0.5) + W_UNIQUENESS * 1.0,
+            source_ref=SourceRef(
+                pool="category", kind="council", key="summary",
+            ),
+        ))
+
+    items.sort(key=lambda x: x.score, reverse=True)
+    return items[:max_items], aggregates
+
+
+def _score_accounts(
+    accts: dict[str, Any], max_items: int,
+) -> tuple[list[ScoredItem], list[TrackedAggregate]]:
+    """Score account intelligence items."""
+    items: list[ScoredItem] = []
+    aggregates: list[TrackedAggregate] = []
+
+    summary = dict(accts.get("summary") or {})
+    account_list = accts.get("accounts") or []
+
+    if "total_accounts" not in summary:
+        summary["total_accounts"] = len(account_list)
+
+    if "high_intent_count" not in summary:
+        from ...config import settings
+
+        threshold = float(
+            getattr(settings.b2b_churn, "high_churn_urgency_threshold", 7.0),
+        )
+        summary["high_intent_count"] = sum(
+            1
+            for a in account_list
+            if _safe_float(a.get("urgency_score") or a.get("intent_score"), 0.0)
+            >= threshold
+        )
+
+    if "active_eval_signal_count" not in summary:
+        summary["active_eval_signal_count"] = sum(
+            1
+            for a in account_list
+            if _is_active_eval_stage(a.get("buying_stage"))
+        )
+
+    for agg_key in (
+        "total_accounts",
+        "decision_maker_count",
+        "high_intent_count",
+        "active_eval_signal_count",
+    ):
+        val = summary.get(agg_key)
+        if val is not None:
+            aggregates.append(TrackedAggregate(
+                label=agg_key,
+                value=val,
+                source_id=f"accounts:summary:{agg_key}",
+            ))
+
+    for a in account_list:
+        if not isinstance(a, dict):
+            continue
+        name = a.get("company_name") or a.get("company") or a.get("name") or "unknown"
+        intent = _normalize_account_intent_score(
+            a.get("urgency_score") or a.get("intent_score") or a.get("confidence_score", 0),
+        )
+        is_dm = bool(a.get("decision_maker") or a.get("is_decision_maker"))
+        is_active_eval = _is_active_eval_stage(a.get("buying_stage"))
+        signal = intent
+        if is_dm:
+            signal = min(signal + DM_INTENT_BOOST, 1.0)
+        if is_active_eval:
+            signal = min(signal + ACTIVE_EVAL_ACCOUNT_BOOST, 1.0)
+        score = W_RECENCY * RECENCY_DEFAULT + W_SIGNAL * signal + W_UNIQUENESS * 1.0
+
+        rids = tuple(a.get("review_ids") or [])
+        items.append(ScoredItem(
+            data=a,
+            score=score,
+            source_ref=SourceRef(
+                pool="accounts", kind="company", key=_slug(name),
+                review_ids=rids,
+            ),
+        ))
+
+    items.sort(key=lambda x: x.score, reverse=True)
+    return items[:max_items], aggregates
+
+
+# ---------------------------------------------------------------------------
+# Governance / tension signal extractors (Phase 2 packet widening)
+# ---------------------------------------------------------------------------
+
+# Dimensions that can carry contradictions across segments.
+_CONTRADICTION_DIMENSIONS = (
+    "support", "pricing", "usability", "integrations", "performance",
+    "reliability", "onboarding", "documentation", "security",
+)
+
+# Segment kinds used for contradiction detection.
+_SEGMENT_KINDS_FOR_CONTRADICTIONS = (
+    "role", "department", "size", "duration", "contract",
+)
+
+
+def _build_metric_ledger(
+    aggregates: list[TrackedAggregate],
+    *,
+    analysis_window_days: int = 90,
+) -> list[dict[str, Any]]:
+    """Build a scoped metric ledger from pre-computed aggregates.
+
+    Every numeric claim the LLM might cite must come from this ledger so
+    downstream validators can reject unsupported numbers.
+    """
+    # Metrics that are safe for all surfaces
+    _ALL_SURFACES = ["report", "battle_card", "blog", "campaign"]
+    # Metrics only appropriate for internal analysis
+    _INTERNAL = ["report", "battle_card"]
+
+    # (label, scope_category, surfaces)
+    _METRIC_REGISTRY: dict[str, tuple[str, list[str]]] = {
+        # Volume / density
+        "total_reviews": ("review_volume", _ALL_SURFACES),
+        "reviews_in_analysis_window": ("review_volume", _ALL_SURFACES),
+        "reviews_in_recent_window": ("review_volume", _ALL_SURFACES),
+        "churn_density": ("churn_intensity", _ALL_SURFACES),
+        "avg_urgency": ("churn_intensity", _ALL_SURFACES),
+        # Sentiment
+        "recommend_ratio": ("sentiment", _ALL_SURFACES),
+        "recommend_yes": ("sentiment", _ALL_SURFACES),
+        "recommend_no": ("sentiment", _ALL_SURFACES),
+        "avg_rating": ("sentiment", _ALL_SURFACES),
+        "negative_review_pct": ("sentiment", _ALL_SURFACES),
+        "positive_review_pct": ("sentiment", _ALL_SURFACES),
+        # Pricing pressure
+        "price_complaint_rate": ("pricing_pressure", _ALL_SURFACES),
+        # Decision-maker signals
+        "dm_churn_rate": ("decision_maker_signals", _INTERNAL),
+        "company_signal_decision_maker_count": ("decision_maker_signals", _INTERNAL),
+        # Displacement
+        "displacement_mention_count": ("displacement", _ALL_SURFACES),
+        "total_explicit_switches": ("displacement", _ALL_SURFACES),
+        "total_active_evaluations": ("displacement", _ALL_SURFACES),
+        "total_flow_mentions": ("displacement", _INTERNAL),
+        # Category
+        "vendor_count": ("category_dynamics", _INTERNAL),
+        "displacement_flow_count": ("category_dynamics", _INTERNAL),
+        "regime_confidence": ("category_dynamics", _INTERNAL),
+        "regime_avg_churn_velocity": ("category_dynamics", _INTERNAL),
+        "regime_avg_price_pressure": ("category_dynamics", _INTERNAL),
+        # Temporal signals
+        "keyword_spike_count": ("temporal_spikes", _INTERNAL),
+        "spike_count": ("temporal_spikes", _INTERNAL),
+        "evaluation_deadline_signals": ("temporal_signals", _INTERNAL),
+        "contract_end_signals": ("temporal_signals", _INTERNAL),
+        "renewal_signals": ("temporal_signals", _INTERNAL),
+        "budget_cycle_signals": ("temporal_signals", _INTERNAL),
+        # Temporal sentiment
+        "sentiment_declining": ("temporal_sentiment", _INTERNAL),
+        "sentiment_stable": ("temporal_sentiment", _INTERNAL),
+        "sentiment_improving": ("temporal_sentiment", _INTERNAL),
+        "sentiment_total": ("temporal_sentiment", _INTERNAL),
+        "declining_pct": ("temporal_sentiment", _INTERNAL),
+        "improving_pct": ("temporal_sentiment", _INTERNAL),
+        # Segment budget
+        "price_increase_rate": ("segment_budget", _INTERNAL),
+        "price_increase_count": ("segment_budget", _INTERNAL),
+        "annual_spend_signal_count": ("segment_budget", _INTERNAL),
+        "price_per_seat_signal_count": ("segment_budget", _INTERNAL),
+        # Account signals
+        "company_signal_count": ("account_signals", _ALL_SURFACES),
+        "company_signal_high_urgency_count": ("account_signals", _INTERNAL),
+        "company_signal_evaluation_count": ("account_signals", _INTERNAL),
+        "company_signal_active_purchase_count": ("account_signals", _INTERNAL),
+        "segment_active_eval_signal_count": ("account_signals", _INTERNAL),
+        # Account summary
+        "total_accounts": ("account_signals", _ALL_SURFACES),
+        "decision_maker_count": ("account_signals", _INTERNAL),
+        "high_intent_count": ("account_signals", _INTERNAL),
+        "active_eval_signal_count": ("account_signals", _INTERNAL),
+    }
+
+    ledger: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for agg in aggregates:
+        dedupe_key = (agg.label, agg.source_id)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        reg = _METRIC_REGISTRY.get(agg.label)
+        if reg is not None:
+            scope_category, surfaces = reg
+        elif agg.label.startswith("vault_weakness_"):
+            scope_category, surfaces = "weakness_mentions", _INTERNAL
+        elif agg.label.startswith("vault_strength_"):
+            scope_category, surfaces = "strength_mentions", _INTERNAL
+        elif agg.label.startswith("segment_reach_"):
+            scope_category, surfaces = "segment_reach", _INTERNAL
+        elif agg.label.startswith("segment_"):
+            scope_category, surfaces = "segment_metrics", _INTERNAL
+        else:
+            continue
+        ledger.append({
+            "label": agg.label,
+            "value": agg.value,
+            "scope": scope_category,
+            "time_window_days": analysis_window_days,
+            "allowed_surfaces": surfaces,
+            "_sid": agg.source_id,
+        })
+    return ledger
+
+
+def _build_contradiction_rows(
+    pools: dict[str, list[ScoredItem]],
+) -> list[dict[str, Any]]:
+    """Detect segment-level contradictions across dimensions.
+
+    A contradiction exists when two segments within the same dimension
+    (e.g., support) have opposing sentiment signals -- one positive, one
+    negative. This forces the LLM to hedge rather than generalise.
+    """
+    segment_items = pools.get("segment", [])
+
+    # Group items by weakness/strength dimension mentioned in the data
+    # Key: (dimension, segment_kind) -> list of (segment_label, sentiment)
+    signals_by_dim: dict[str, list[tuple[str, str, str]]] = {}
+
+    for si in segment_items:
+        kind = si.source_ref.kind
+        if kind not in _SEGMENT_KINDS_FOR_CONTRADICTIONS:
+            continue
+        seg_label = si.source_ref.key
+        churn_rate = _safe_float(si.data.get("churn_rate", 0))
+        # Infer sentiment from churn rate
+        if churn_rate >= 0.4:
+            sentiment = "negative"
+        elif churn_rate <= 0.15:
+            sentiment = "positive"
+        else:
+            continue  # ambiguous, skip
+        signals_by_dim.setdefault(kind, []).append((seg_label, sentiment, kind))
+
+    # Also look at weakness/strength evidence vault items for dimension signals
+    vault_items = pools.get("evidence_vault", [])
+    weakness_dims: set[str] = set()
+    strength_dims: set[str] = set()
+    for si in vault_items:
+        dim = si.source_ref.key
+        if si.source_ref.kind == "weakness":
+            weakness_dims.add(dim)
+        elif si.source_ref.kind == "strength":
+            strength_dims.add(dim)
+
+    rows: list[dict[str, Any]] = []
+
+    # Contradiction type 1: same segment kind has both high-churn and low-churn segments
+    for kind, entries in signals_by_dim.items():
+        positives = [e for e in entries if e[1] == "positive"]
+        negatives = [e for e in entries if e[1] == "negative"]
+        if positives and negatives:
+            rows.append({
+                "dimension": kind,
+                "segment_a": negatives[0][0],
+                "segment_b": positives[0][0],
+                "statement_a": "negative",
+                "statement_b": "positive",
+                "_sid": f"segment:contradiction:{kind}",
+            })
+
+    # Contradiction type 2: dimension appears in both weakness AND strength evidence
+    overlap_dims = weakness_dims & strength_dims
+    for dim in sorted(overlap_dims):
+        rows.append({
+            "dimension": dim,
+            "segment_a": "weakness_evidence",
+            "segment_b": "strength_evidence",
+            "statement_a": "negative",
+            "statement_b": "positive",
+            "_sid": f"vault:contradiction:{dim}",
+        })
+
+    return rows
+
+
+def _build_minority_signals(
+    pools: dict[str, list[ScoredItem]],
+    aggregates: list[TrackedAggregate],
+) -> list[dict[str, Any]]:
+    """Extract rare-but-severe signals that scored compression might drop.
+
+    A minority signal is one with high urgency but low mention count --
+    the kind of thing that gets silently dropped by top-N truncation
+    but could be a critical blocker for specific segments.
+    """
+    signals: list[dict[str, Any]] = []
+
+    vault_items = pools.get("evidence_vault", [])
+    for si in vault_items:
+        if si.source_ref.kind != "weakness":
+            continue
+        mc = _safe_float(
+            si.data.get("mention_count_total", si.data.get("mention_count", 0)),
+        )
+        urgency = _safe_float(si.data.get("avg_urgency", si.data.get("urgency", 0)))
+        # Minority: low count but high urgency
+        if mc <= 5 and urgency >= 7.0:
+            label = si.source_ref.key
+            signals.append({
+                "label": label,
+                "urgency": round(urgency, 1),
+                "count": int(mc),
+                "reason": "rare_but_severe",
+                "_sid": f"vault:minority:{label}",
+            })
+
+    # Also check account signals for isolated high-urgency DM signals
+    account_items = pools.get("accounts", [])
+    for si in account_items:
+        urgency = _safe_float(
+            si.data.get("urgency_score", si.data.get("intent_score", 0)),
+        )
+        is_dm = bool(si.data.get("decision_maker") or si.data.get("is_decision_maker"))
+        if is_dm and urgency >= 9.0:
+            name = si.source_ref.key
+            signals.append({
+                "label": f"dm_alert_{name}",
+                "urgency": round(urgency, 1),
+                "count": 1,
+                "reason": "decision_maker_extreme_urgency",
+                "_sid": f"accounts:minority:{name}",
+            })
+
+    return signals
+
+
+def _build_coverage_gaps(
+    pools: dict[str, list[ScoredItem]],
+    aggregates: list[TrackedAggregate],
+) -> list[dict[str, Any]]:
+    """Detect areas where evidence is thin and conclusions should be hedged.
+
+    Coverage gaps are NOT missing data -- they are areas where data exists
+    but is too sparse to support confident claims.
+    """
+    gaps: list[dict[str, Any]] = []
+
+    # Gap type 1: thin segment samples (segment items that were retained
+    # despite being near the MIN_SEGMENT_SAMPLE_SIZE threshold)
+    segment_items = pools.get("segment", [])
+    for si in segment_items:
+        sample_size = _safe_int(
+            si.data.get("review_count", si.data.get("count", 0)),
+        )
+        if 0 < sample_size < MIN_SEGMENT_SAMPLE_SIZE * 2:
+            area = f"{si.source_ref.kind}_{si.source_ref.key}"
+            gaps.append({
+                "type": "thin_segment_sample",
+                "area": area,
+                "sample_size": sample_size,
+                "_sid": f"gap:thin_segment:{area}",
+            })
+
+    # Gap type 2: no displacement evidence
+    disp_items = pools.get("displacement", [])
+    if not disp_items:
+        gaps.append({
+            "type": "missing_pool",
+            "area": "displacement",
+            "sample_size": 0,
+            "_sid": "gap:missing_pool:displacement",
+        })
+
+    # Gap type 3: very few account signals
+    account_items = pools.get("accounts", [])
+    if len(account_items) < 3:
+        gaps.append({
+            "type": "thin_account_signals",
+            "area": "accounts",
+            "sample_size": len(account_items),
+            "_sid": "gap:thin_accounts:accounts",
+        })
+
+    # Gap type 4: shallow evidence window
+    window_start = None
+    window_end = None
+    for agg in aggregates:
+        if agg.label == "enrichment_window_start":
+            window_start = agg.value
+        elif agg.label == "enrichment_window_end":
+            window_end = agg.value
+    if window_start and window_end:
+        try:
+            from datetime import date as _date
+            start = _date.fromisoformat(str(window_start)[:10])
+            end = _date.fromisoformat(str(window_end)[:10])
+            window_days = (end - start).days
+            if window_days < MIN_EVIDENCE_WINDOW_DAYS:
+                gaps.append({
+                    "type": "shallow_evidence_window",
+                    "area": "temporal_depth",
+                    "sample_size": window_days,
+                    "_sid": "gap:shallow_window:temporal_depth",
+                })
+        except (ValueError, TypeError):
+            pass
+
+    return gaps
+
+
+def _build_retention_proof(
+    pools: dict[str, list[ScoredItem]],
+) -> list[dict[str, Any]]:
+    """Extract strength evidence that explains why customers stay despite frustration.
+
+    Retention proof is the counter-signal to churn pressure. Without it,
+    the LLM over-indexes on churn signals and produces unrealistically
+    aggressive positioning.
+    """
+    proofs: list[dict[str, Any]] = []
+
+    vault_items = pools.get("evidence_vault", [])
+    for si in vault_items:
+        if si.source_ref.kind != "strength":
+            continue
+        area = si.source_ref.key
+        mc = _safe_float(
+            si.data.get("mention_count_total", si.data.get("mention_count", 0)),
+        )
+        # Only include strengths with meaningful evidence
+        if mc < 3:
+            continue
+        # Build a strength summary from available data
+        summary_parts: list[str] = []
+        for field in ("summary", "description", "key", "label", "category", "theme"):
+            val = si.data.get(field)
+            if val and isinstance(val, str) and len(val) > 5:
+                summary_parts.append(val)
+                break
+        strength_text = summary_parts[0] if summary_parts else area.replace("_", " ")
+        proofs.append({
+            "area": area,
+            "strength": strength_text,
+            "mention_count": int(mc),
+            "_sid": f"vault:strength:{area}",
+        })
+
+    return proofs
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def compress_vendor_pools(
+    vendor_name: str,
+    layers: dict[str, Any],
+    *,
+    max_items_per_pool: int = 8,
+    max_witnesses: int | None = None,
+) -> CompressedPacket:
+    """Compress and score all pool layers for one vendor.
+
+    Returns a ``CompressedPacket`` with scored items and pre-computed
+    aggregates ready for LLM serialization.
+    """
+    all_pools: dict[str, list[ScoredItem]] = {}
+    all_aggregates: list[TrackedAggregate] = []
+    source_reg: dict[str, SourceRef] = {}
+
+    # Evidence vault
+    ev = layers.get("evidence_vault") or {}
+    if ev:
+        items, aggs = _score_evidence_vault(ev, max_items_per_pool)
+        all_pools["evidence_vault"] = items
+        all_aggregates.extend(aggs)
+
+    # Segment
+    seg = layers.get("segment") or {}
+    if seg:
+        items, aggs = _score_segment(seg, max_items_per_pool)
+        all_pools["segment"] = items
+        all_aggregates.extend(aggs)
+
+    # Temporal
+    temp = layers.get("temporal") or {}
+    if temp:
+        items, aggs = _score_temporal(temp, max_items_per_pool)
+        all_pools["temporal"] = items
+        all_aggregates.extend(aggs)
+
+    # Displacement
+    disp = layers.get("displacement")
+    if layers:
+        items, aggs = _score_displacement(disp or [], max_items_per_pool)
+        if items:
+            all_pools["displacement"] = items
+        all_aggregates.extend(aggs)
+
+    # Category
+    cat = layers.get("category") or {}
+    if cat:
+        items, aggs = _score_category(cat, max_items_per_pool)
+        all_pools["category"] = items
+        all_aggregates.extend(aggs)
+
+    # Accounts
+    accts = layers.get("accounts") or {}
+    if accts:
+        items, aggs = _score_accounts(accts, max_items_per_pool)
+        all_pools["accounts"] = items
+        all_aggregates.extend(aggs)
+
+    # Build source registry
+    for pool_items in all_pools.values():
+        for si in pool_items:
+            source_reg[si.source_ref.source_id] = si.source_ref
+    for agg in all_aggregates:
+        # Create a synthetic SourceRef for aggregates
+        parts = agg.source_id.split(":", 2)
+        if len(parts) == 3:
+            source_reg[agg.source_id] = SourceRef(
+                pool=parts[0], kind=parts[1], key=parts[2],
+            )
+
+    # Build governance / tension signals
+    from ...config import settings
+
+    cfg = settings.b2b_churn
+    metric_ledger = _build_metric_ledger(all_aggregates)
+    contradiction_rows = _build_contradiction_rows(all_pools)
+    minority_signals = _build_minority_signals(all_pools, all_aggregates)
+    coverage_gaps = _build_coverage_gaps(all_pools, all_aggregates)
+    retention_proof = _build_retention_proof(all_pools)
+    witness_pack, section_packets = build_vendor_witness_artifacts(
+        vendor_name,
+        layers.get("reviews") or [],
+        max_witnesses=(
+            int(max_witnesses)
+            if max_witnesses is not None
+            else int(getattr(cfg, "reasoning_witness_max_witnesses", 12))
+        ),
+        min_specificity_score=float(
+            getattr(cfg, "witness_specificity_min_score", 2.0),
+        ),
+        fallback_min_witnesses=int(
+            getattr(cfg, "witness_specificity_fallback_min_witnesses", 4),
+        ),
+        generic_patterns=list(
+            getattr(cfg, "witness_specificity_generic_patterns", []) or [],
+        ),
+        concrete_patterns=list(
+            getattr(cfg, "witness_specificity_concrete_patterns", []) or [],
+        ),
+        short_excerpt_chars=int(
+            getattr(cfg, "witness_specificity_short_excerpt_chars", 55),
+        ),
+        long_excerpt_chars=int(
+            getattr(cfg, "witness_specificity_long_excerpt_chars", 80),
+        ),
+        specificity_weights=dict(
+            getattr(cfg, "witness_specificity_weights", {}) or {},
+        ),
+    )
+
+    return CompressedPacket(
+        vendor_name=vendor_name,
+        pools=all_pools,
+        aggregates=all_aggregates,
+        source_registry=source_reg,
+        metric_ledger=metric_ledger,
+        contradiction_rows=contradiction_rows,
+        minority_signals=minority_signals,
+        coverage_gaps=coverage_gaps,
+        retention_proof=retention_proof,
+        witness_pack=witness_pack,
+        section_packets=section_packets,
+    )

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_reasoning_contracts.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_reasoning_contracts.py
@@ -1,0 +1,1773 @@
+"""Deterministic contract decomposition for reasoning synthesis output.
+
+The current synthesis task still produces a battle-card-shaped response.
+This module decomposes that response into reusable reasoning contracts so
+downstream products can migrate to shared vendor, displacement, and category
+objects without depending on one report-specific schema forever.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ...reasoning.wedge_registry import validate_wedge
+from ...services.company_normalization import normalize_company_name
+
+
+def _copy_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _copy_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _titleize_wedge(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return text.replace("_", " ").replace("-", " ").title()
+
+
+_PLACEHOLDER_NAMED_EXAMPLE_PATTERNS = (
+    re.compile(r"^unknown\b", re.I),
+    re.compile(r"^anonymous\b", re.I),
+    re.compile(r"^redacted\b", re.I),
+    re.compile(r"\b(customer|prospect|company|account|buyer|reviewer|user|team|organization|organisation|business|department)\b", re.I),
+    re.compile(r"\b(smb|mid[\s_-]?market|enterprise)\b", re.I),
+)
+
+_SEGMENT_ROLE_LABELS: dict[str, str] = {
+    "decision maker": "decision-makers",
+    "decision makers": "decision-makers",
+    "economic buyer": "economic buyers",
+    "economic buyers": "economic buyers",
+    "champion": "internal champions",
+    "champions": "internal champions",
+    "internal champion": "internal champions",
+    "internal champions": "internal champions",
+    "evaluator": "evaluators",
+    "evaluators": "evaluators",
+    "end user": "end users",
+    "end users": "end users",
+}
+
+_SEGMENT_OPENING_ANGLE_LOWERCASE_WORDS = frozenset((
+    "address",
+    "benchmark",
+    "demonstrate",
+    "emphasize",
+    "highlight",
+    "lead",
+    "offer",
+    "pitch",
+    "position",
+    "show",
+))
+
+_SEGMENT_TEAM_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("project management", "Project Management teams"),
+    ("customer support", "Customer Support teams"),
+    ("data & analytics", "Data & Analytics teams"),
+    ("data and analytics", "Data & Analytics teams"),
+    ("marketing", "Marketing teams"),
+    ("sales", "Sales teams"),
+    ("operations", "Operations teams"),
+    ("support", "Support teams"),
+    ("engineering", "Engineering teams"),
+    ("finance", "Finance teams"),
+    ("security", "Security teams"),
+    ("product", "Product teams"),
+    ("analytics", "Analytics teams"),
+    ("data", "Data teams"),
+    ("hr", "HR teams"),
+    ("it", "IT teams"),
+)
+
+
+def _looks_like_tool_label(value: str) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    generic_modifiers = ("custom", "homegrown", "home-grown", "in-house", "internal")
+    generic_artifacts = (
+        "integration", "utility", "workflow", "tool", "stack",
+        "system", "automation", "bot",
+    )
+    return any(token in text for token in generic_modifiers) and any(
+        token in text for token in generic_artifacts
+    )
+
+
+def _contract_block(synthesis: dict[str, Any], name: str) -> dict[str, Any]:
+    contracts = synthesis.get("reasoning_contracts")
+    if isinstance(contracts, dict):
+        block = contracts.get(name)
+        if isinstance(block, dict) and block:
+            return dict(block)
+    return {}
+
+
+def _aggregate_wrapper(packet: Any, source_id: str) -> dict[str, Any] | None:
+    for agg in getattr(packet, "aggregates", []) or []:
+        if getattr(agg, "source_id", "") == source_id:
+            return {
+                "value": getattr(agg, "value", None),
+                "source_id": source_id,
+            }
+    return None
+
+
+def _wrapper_numeric_value(wrapper: Any) -> float | None:
+    if not isinstance(wrapper, dict):
+        return None
+    try:
+        value = wrapper.get("value")
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_wrapper_value(wrapper: Any) -> Any:
+    if not isinstance(wrapper, dict):
+        return wrapper
+    value = wrapper.get("value")
+    if not isinstance(value, str):
+        return wrapper
+    text = value.strip()
+    if not text:
+        return wrapper
+    try:
+        numeric = float(text)
+    except ValueError:
+        return wrapper
+    normalized = dict(wrapper)
+    normalized["value"] = int(numeric) if numeric.is_integer() else numeric
+    return normalized
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_contract_text(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    for codepoint in (0x2010, 0x2011, 0x2012, 0x2013, 0x2014, 0x2212):
+        text = text.replace(chr(codepoint), "-")
+    text = text.replace(chr(0x202f), " ").replace(chr(0x00a0), " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _normalize_account_intent_score(value: Any) -> float:
+    score = _safe_float(value, 0.0)
+    if score <= 0:
+        return 0.0
+    if score > 1.0:
+        score = score / 10.0
+    return max(0.0, min(score, 1.0))
+
+
+def _normalize_migration_semantics(migration_proof: dict[str, Any]) -> dict[str, Any]:
+    """Make migration-proof evidence semantics deterministic from the wrappers."""
+    switch_volume = _wrapper_numeric_value(migration_proof.get("switch_volume"))
+    active_eval_volume = _wrapper_numeric_value(
+        migration_proof.get("active_evaluation_volume"),
+    )
+    confidence = str(migration_proof.get("confidence") or "").strip().lower()
+
+    has_switches = (switch_volume or 0.0) > 0.0
+    has_active_eval = (active_eval_volume or 0.0) > 0.0
+
+    migration_proof["switching_is_real"] = has_switches
+    if has_switches:
+        migration_proof["evidence_type"] = "explicit_switch"
+    elif has_active_eval:
+        migration_proof["evidence_type"] = "active_evaluation"
+        if confidence in {"", "high"}:
+            migration_proof["confidence"] = "medium"
+    else:
+        migration_proof["evidence_type"] = "insufficient_data"
+        if confidence in {"", "high", "medium"}:
+            migration_proof["confidence"] = "low"
+    return migration_proof
+
+
+def _ensure_migration_citations(migration_proof: dict[str, Any]) -> dict[str, Any]:
+    """Backfill migration-proof citations from its deterministic wrappers."""
+    citations = _copy_list(migration_proof.get("citations"))
+    for key in (
+        "switch_volume",
+        "active_evaluation_volume",
+        "displacement_mention_volume",
+        "top_destination",
+        "primary_switch_driver",
+    ):
+        wrapper = migration_proof.get(key)
+        if not isinstance(wrapper, dict):
+            continue
+        sid = wrapper.get("source_id")
+        if isinstance(sid, str) and sid and sid not in citations:
+            citations.append(sid)
+    migration_proof["citations"] = citations
+    return migration_proof
+
+
+def _collect_source_ids(value: Any, sink: set[str]) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"source_id", "_sid"} and isinstance(item, str) and item.strip():
+                sink.add(item.strip())
+            elif key == "citations" and isinstance(item, list):
+                for citation in item:
+                    if isinstance(citation, str) and citation.strip():
+                        sink.add(citation.strip())
+            else:
+                _collect_source_ids(item, sink)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_source_ids(item, sink)
+
+
+def _canonicalize_trigger_type(value: Any) -> str:
+    """Normalize temporal trigger type aliases to the validator contract."""
+    raw = str(value or "").strip().lower()
+    if raw in {"timeline", "timeline_signal", "turning_point"}:
+        return "signal"
+    if raw == "contract_end":
+        return "deadline"
+    return raw
+
+
+def _segment_scale_label(text: str) -> str:
+    lowered = text.lower()
+    if any(token in lowered for token in ("small business", "smb", "sme")):
+        return "SMB"
+    if "mid market" in lowered or "mid-market" in lowered:
+        return "mid-market"
+    if "enterprise" in lowered:
+        return "enterprise"
+    if "startup" in lowered:
+        return "startup"
+    return ""
+
+
+_SEGMENT_NAME_PRESERVATIONS: dict[str, str] = {
+    "small business": "Small Business",
+    "mid market": "Mid-Market",
+    "mid-market": "Mid-Market",
+}
+
+
+def _normalize_priority_segment_label(value: Any) -> str:
+    text = _normalize_contract_text(value)
+    if not text:
+        return ""
+    lowered = text.lower()
+    lowered = re.sub(r"\(\s*role\s*:\s*([^)]+)\)", r" \1 ", lowered)
+    lowered = re.sub(r"\brole:\s*", "", lowered)
+    lowered = re.sub(r"\([^)]*\b(use case|role|segment|department|size|contract)\b[^)]*\)", " ", lowered)
+    # Strip parenthetical numeric ranges like "(1-10 employees)" or "(51-200)"
+    lowered = re.sub(r"\([^)]*\d[^)]*\)", " ", lowered)
+    lowered = re.sub(r"\s+", " ", lowered).strip(" -")
+
+    for key, label in _SEGMENT_ROLE_LABELS.items():
+        if key in lowered or key.replace(" ", "_") in lowered:
+            return label
+    for key, label in _SEGMENT_TEAM_KEYWORDS:
+        if key in lowered:
+            return label
+    # Preserve human-readable segment tier names before scale normalization
+    preservation = _SEGMENT_NAME_PRESERVATIONS.get(lowered)
+    if preservation:
+        return preservation
+    scale = _segment_scale_label(lowered)
+    if scale:
+        if "contract" in lowered:
+            return f"{scale} contracts"
+        return f"{scale} accounts"
+    cleaned = re.sub(r"\b(role|segment|department|size|contract)\b", " ", lowered)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip(" -")
+    if not cleaned:
+        return ""
+    if cleaned == "mid market":
+        return "mid-market"
+    if cleaned == "smb":
+        return "SMB"
+    return cleaned[:1].upper() + cleaned[1:]
+
+
+def _normalize_opening_angle_phrase(value: Any) -> str:
+    text = _normalize_contract_text(value)
+    if not text:
+        return ""
+    first = text.split(" ", 1)[0].lower()
+    if first in _SEGMENT_OPENING_ANGLE_LOWERCASE_WORDS:
+        return text[:1].lower() + text[1:]
+    return text
+
+
+def _normalize_best_timing_window(value: Any) -> str:
+    text = _normalize_contract_text(value)
+    if not text:
+        return ""
+    text = re.sub(r"\(\s*timeline[_ ]signal\s*:\s*[^)]+\)", "", text, flags=re.I)
+    text = re.sub(r"\btimeline[_ ]signal\s*:\s*\w+\b", "", text, flags=re.I)
+    replacements = (
+        (r"\bactive[- ]evaluation signals? are present across multiple flows\b", "buyers are actively evaluating alternatives across multiple flows"),
+        (r"\bactive[- ]evaluation signals? are present across all tracked accounts\b", "buyers are actively evaluating alternatives across tracked accounts"),
+        (r"\bactive[- ]evaluation signals? are already present\b", "buyers are already evaluating alternatives"),
+        (r"\ban active[- ]evaluation signal exists\b", "buyers are already evaluating alternatives"),
+        (r"\bactive[- ]evaluation signal detected this week\b", "buyers are actively evaluating alternatives this week"),
+        (r"\bsegment[- ]level active[- ]evaluation signals?\b", "buyer evaluation activity in this segment"),
+    )
+    for pattern, replacement in replacements:
+        text = re.sub(pattern, replacement, text, flags=re.I)
+    text = re.sub(r"\s+", " ", text).strip(" -")
+    return text[:1].upper() + text[1:] if text else ""
+
+
+def _canonicalize_timing_intelligence(timing_intelligence: dict[str, Any]) -> dict[str, Any]:
+    """Normalize immediate trigger types onto the persisted contract enum."""
+    best_window = _normalize_best_timing_window(
+        timing_intelligence.get("best_timing_window"),
+    )
+    if best_window:
+        timing_intelligence["best_timing_window"] = best_window
+    else:
+        timing_intelligence.pop("best_timing_window", None)
+    triggers = timing_intelligence.get("immediate_triggers")
+    if not isinstance(triggers, list):
+        return timing_intelligence
+    normalized: list[Any] = []
+    for trigger in triggers:
+        if not isinstance(trigger, dict):
+            normalized.append(trigger)
+            continue
+        item = dict(trigger)
+        canonical = _canonicalize_trigger_type(
+            item.get("type") or item.get("trigger_type"),
+        )
+        if canonical:
+            item["type"] = canonical
+            if "trigger_type" in item:
+                item["trigger_type"] = canonical
+        normalized.append(item)
+    timing_intelligence["immediate_triggers"] = normalized
+    return timing_intelligence
+
+
+def _canonicalize_segment_playbook(segment_playbook: dict[str, Any]) -> dict[str, Any]:
+    segments = segment_playbook.get("priority_segments")
+    if not isinstance(segments, list):
+        return segment_playbook
+    normalized: list[Any] = []
+    for segment in segments:
+        if not isinstance(segment, dict):
+            normalized.append(segment)
+            continue
+        item = dict(segment)
+        label = _normalize_priority_segment_label(item.get("segment"))
+        if label:
+            item["segment"] = label
+        else:
+            item.pop("segment", None)
+        opening = _normalize_opening_angle_phrase(item.get("best_opening_angle"))
+        if opening:
+            item["best_opening_angle"] = opening
+        else:
+            item.pop("best_opening_angle", None)
+        normalized.append(item)
+    segment_playbook["priority_segments"] = normalized
+    return segment_playbook
+
+
+def _preferred_active_eval_wrapper(
+    packet: Any,
+    current: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Prefer the strongest available active-evaluation signal wrapper."""
+    candidates = [
+        _normalize_wrapper_value(current) if isinstance(current, dict) else None,
+        _aggregate_wrapper(packet, "accounts:summary:active_eval_signal_count"),
+        _aggregate_wrapper(packet, "segment:aggregate:active_eval_signal_count"),
+        _aggregate_wrapper(packet, "temporal:signal:evaluation_deadline_signals"),
+    ]
+
+    best: dict[str, Any] | None = None
+    best_value = float("-inf")
+    for wrapper in candidates:
+        numeric = _wrapper_numeric_value(wrapper)
+        if numeric is None:
+            continue
+        if numeric > best_value:
+            best = wrapper
+            best_value = numeric
+    return best or current
+
+
+def _preferred_migration_eval_wrapper(
+    packet: Any,
+    current: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Prefer the strongest migration-relevant evaluation signal wrapper."""
+    candidates = [
+        _normalize_wrapper_value(current) if isinstance(current, dict) else None,
+        _aggregate_wrapper(packet, "displacement:aggregate:total_active_evaluations"),
+        _aggregate_wrapper(packet, "accounts:summary:active_eval_signal_count"),
+        _aggregate_wrapper(packet, "segment:aggregate:active_eval_signal_count"),
+        _aggregate_wrapper(packet, "temporal:signal:evaluation_deadline_signals"),
+    ]
+
+    best: dict[str, Any] | None = None
+    best_value = float("-inf")
+    for wrapper in candidates:
+        numeric = _wrapper_numeric_value(wrapper)
+        if numeric is None:
+            continue
+        if numeric > best_value:
+            best = wrapper
+            best_value = numeric
+    return best or current
+
+
+def _preferred_migration_switch_wrapper(
+    packet: Any,
+    current: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Use the canonical explicit-switch aggregate when it exists."""
+    if isinstance(current, dict):
+        normalized_current = _normalize_wrapper_value(current)
+        if (_wrapper_numeric_value(normalized_current) or 0.0) <= 0.0:
+            return normalized_current
+    aggregate = _aggregate_wrapper(
+        packet,
+        "displacement:aggregate:total_explicit_switches",
+    )
+    if aggregate is not None and aggregate.get("value") is not None:
+        return aggregate
+    if isinstance(current, dict):
+        return _normalize_wrapper_value(current)
+    return current
+
+
+def _preferred_displacement_mention_wrapper(
+    packet: Any,
+    current: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Prefer the broadest non-switch mention/intensity wrapper."""
+    candidates = [
+        _normalize_wrapper_value(current) if isinstance(current, dict) else None,
+        _aggregate_wrapper(packet, "vault:metric:displacement_mention_count"),
+        _aggregate_wrapper(packet, "category:aggregate:displacement_flow_count"),
+    ]
+
+    best: dict[str, Any] | None = None
+    best_value = float("-inf")
+    for wrapper in candidates:
+        numeric = _wrapper_numeric_value(wrapper)
+        if numeric is None:
+            continue
+        if numeric > best_value:
+            best = wrapper
+            best_value = numeric
+    return best or current
+
+
+def _pool_items(packet: Any, pool_name: str) -> list[Any]:
+    pools = getattr(packet, "pools", {}) or {}
+    return list(pools.get(pool_name, []) or [])
+
+
+def _segment_items_by_kind(
+    packet: Any,
+    kind: str,
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in _pool_items(packet, "segment"):
+        source_ref = getattr(item, "source_ref", None)
+        if getattr(source_ref, "kind", "") != kind:
+            continue
+        data = _copy_dict(getattr(item, "data", None))
+        if not data:
+            continue
+        source_id = getattr(source_ref, "source_id", "")
+        if source_id:
+            data["source_id"] = source_id
+        rows.append(data)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _timing_items_by_kind(
+    packet: Any,
+    kinds: str | tuple[str, ...],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    allowed = {kinds} if isinstance(kinds, str) else set(kinds)
+    for item in _pool_items(packet, "temporal"):
+        source_ref = getattr(item, "source_ref", None)
+        if getattr(source_ref, "kind", "") not in allowed:
+            continue
+        data = _copy_dict(getattr(item, "data", None))
+        if not data:
+            continue
+        canonical = _canonicalize_trigger_type(
+            data.get("type") or data.get("trigger_type"),
+        )
+        if canonical:
+            data["type"] = canonical
+            data["trigger_type"] = canonical
+        source_id = getattr(source_ref, "source_id", "")
+        if source_id:
+            data["source_id"] = source_id
+        rows.append(data)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _timing_signal_item_from_trigger(trigger: dict[str, Any]) -> dict[str, Any]:
+    item = _copy_dict(trigger)
+    canonical = _canonicalize_trigger_type(
+        item.get("type") or item.get("trigger_type"),
+    )
+    if canonical:
+        item["type"] = canonical
+        item["trigger_type"] = canonical
+    source = item.get("source")
+    source_id = str(item.get("source_id") or "").strip()
+    if not source_id and isinstance(source, dict):
+        source_id = str(source.get("source_id") or "").strip()
+    if source_id:
+        item["source_id"] = source_id
+    return item
+
+
+def _timing_signal_fallback_rows(
+    timing_intelligence: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for trigger in timing_intelligence.get("immediate_triggers") or []:
+        if not isinstance(trigger, dict):
+            continue
+        item = _timing_signal_item_from_trigger(trigger)
+        label = str(item.get("trigger") or item.get("label") or item.get("date") or "").strip()
+        key = (str(item.get("type") or item.get("trigger_type") or "").strip(), label)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(item)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _timing_signal_summary_rows(
+    supporting_evidence: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    timeline = supporting_evidence.get("timeline_signal_summary")
+    if not isinstance(timeline, dict):
+        return rows
+    field_map = (
+        ("contract_end_signals", "deadline", "Contract end signals detected"),
+        ("evaluation_deadline_signals", "deadline", "Evaluation deadline signals detected"),
+        ("renewal_signals", "deadline", "Renewal signals detected"),
+        ("budget_cycle_signals", "signal", "Budget cycle signals detected"),
+    )
+    for field, signal_type, trigger in field_map:
+        wrapper = timeline.get(field)
+        count = _safe_int((wrapper or {}).get("value") if isinstance(wrapper, dict) else None, 0)
+        if count <= 0:
+            continue
+        rows.append({
+            "type": signal_type,
+            "trigger_type": signal_type,
+            "trigger": trigger,
+            "count": count,
+            "source_id": str(wrapper.get("source_id") or "").strip() if isinstance(wrapper, dict) else "",
+        })
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _merge_timing_signal_rows(
+    primary: list[dict[str, Any]],
+    fallback: list[dict[str, Any]],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for row in list(primary) + list(fallback):
+        if not isinstance(row, dict):
+            continue
+        key = (
+            str(row.get("type") or row.get("trigger_type") or "").strip(),
+            str(row.get("trigger") or row.get("label") or "").strip(),
+            str(row.get("source_id") or "").strip(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(row)
+        if len(merged) >= limit:
+            break
+    return merged
+
+
+_SEGMENT_STRATEGIC_ROLE_SCORES: dict[str, float] = {
+    "decision_maker": 20.0,
+    "economic_buyer": 15.0,
+    "champion": 15.0,
+    "evaluator": 10.0,
+}
+
+
+def _segment_role_sort_key(item: dict[str, Any]) -> tuple[float, float, float, str]:
+    role_type = str(item.get("role_type") or "").strip() or "unknown"
+    return (
+        _safe_float(item.get("priority_score"), 0.0),
+        _safe_float(item.get("review_count"), 0.0),
+        _SEGMENT_STRATEGIC_ROLE_SCORES.get(role_type, 0.0),
+        role_type,
+    )
+
+
+def _segment_strategic_roles(packet: Any, *, limit: int = 3) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in _pool_items(packet, "segment"):
+        source_ref = getattr(item, "source_ref", None)
+        if getattr(source_ref, "kind", "") != "role":
+            continue
+        data = _copy_dict(getattr(item, "data", None))
+        role_type = str(data.get("role_type") or "").strip() or "unknown"
+        if role_type not in _SEGMENT_STRATEGIC_ROLE_SCORES:
+            continue
+        source_id = getattr(source_ref, "source_id", "")
+        if source_id:
+            data["source_id"] = source_id
+        rows.append(data)
+    rows.sort(key=_segment_role_sort_key, reverse=True)
+    return rows[:limit]
+
+
+def _segment_supporting_evidence(packet: Any) -> dict[str, Any]:
+    supporting: dict[str, Any] = {}
+
+    list_fields = (
+        ("role", "top_roles"),
+        ("department", "top_departments"),
+        ("size", "top_company_sizes"),
+        ("contract", "top_contract_segments"),
+        ("duration", "top_usage_durations"),
+        ("use_case", "top_use_cases"),
+    )
+    for kind, output_key in list_fields:
+        rows = _segment_items_by_kind(packet, kind)
+        if rows:
+            supporting[output_key] = rows
+    strategic_roles = _segment_strategic_roles(packet)
+    if strategic_roles:
+        supporting["top_strategic_roles"] = strategic_roles
+
+    company_size: dict[str, Any] = {}
+    for field in ("avg_seat_count", "median_seat_count", "max_seat_count"):
+        wrapper = _aggregate_wrapper(packet, f"segment:size:{field}")
+        if wrapper is not None and wrapper.get("value") is not None:
+            company_size[field] = wrapper
+    if company_size:
+        supporting["company_size_context"] = company_size
+
+    budget_context: dict[str, Any] = {}
+    budget_fields = (
+        "dm_churn_rate",
+        "price_increase_rate",
+        "price_increase_count",
+        "annual_spend_signal_count",
+        "price_per_seat_signal_count",
+    )
+    for field in budget_fields:
+        wrapper = _aggregate_wrapper(packet, f"segment:budget:{field}")
+        if wrapper is not None and wrapper.get("value") is not None:
+            budget_context[field] = wrapper
+    if budget_context:
+        supporting["budget_context"] = budget_context
+
+    active_eval = _aggregate_wrapper(packet, "segment:aggregate:active_eval_signal_count")
+    if active_eval is not None and active_eval.get("value") is not None:
+        supporting["active_eval_signals"] = active_eval
+
+    return supporting
+
+
+def _timing_supporting_evidence(packet: Any) -> dict[str, Any]:
+    supporting: dict[str, Any] = {}
+
+    list_fields = (
+        (
+            ("deadline", "contract_end", "signal", "timeline_signal", "spike"),
+            "top_timing_signals",
+        ),
+        ("spike", "top_keyword_spikes"),
+        ("turning_point", "top_turning_points"),
+        ("tenure", "top_sentiment_tenure"),
+    )
+    for kinds, output_key in list_fields:
+        rows = _timing_items_by_kind(packet, kinds)
+        if rows:
+            supporting[output_key] = rows
+
+    timeline_summary: dict[str, Any] = {}
+    for field in (
+        "evaluation_deadline_signals",
+        "contract_end_signals",
+        "renewal_signals",
+        "budget_cycle_signals",
+    ):
+        wrapper = _aggregate_wrapper(packet, f"temporal:signal:{field}")
+        if wrapper is not None and wrapper.get("value") is not None:
+            timeline_summary[field] = wrapper
+    if timeline_summary:
+        supporting["timeline_signal_summary"] = timeline_summary
+
+    sentiment_snapshot: dict[str, Any] = {}
+    for field in (
+        "declining_count",
+        "stable_count",
+        "improving_count",
+        "total_count",
+        "declining_pct",
+        "improving_pct",
+    ):
+        wrapper = _aggregate_wrapper(packet, f"temporal:sentiment:{field}")
+        if wrapper is not None and wrapper.get("value") is not None:
+            sentiment_snapshot[field] = wrapper
+    if sentiment_snapshot:
+        supporting["sentiment_snapshot"] = sentiment_snapshot
+
+    spike_count = _aggregate_wrapper(packet, "temporal:spike:spike_count")
+    if spike_count is not None and spike_count.get("value") is not None:
+        supporting["spike_count"] = spike_count
+
+    return supporting
+
+
+def _timing_sentiment_direction(
+    timing_intelligence: dict[str, Any],
+    packet: Any,
+) -> str:
+    confidence = str(timing_intelligence.get("confidence") or "").strip().lower()
+    if confidence in {"low", "insufficient"}:
+        return "insufficient_data"
+
+    counts = {
+        "declining": _safe_int((_aggregate_wrapper(packet, "temporal:sentiment:declining_count") or {}).get("value"), 0),
+        "stable": _safe_int((_aggregate_wrapper(packet, "temporal:sentiment:stable_count") or {}).get("value"), 0),
+        "improving": _safe_int((_aggregate_wrapper(packet, "temporal:sentiment:improving_count") or {}).get("value"), 0),
+    }
+    total = _safe_int((_aggregate_wrapper(packet, "temporal:sentiment:total_count") or {}).get("value"), 0)
+    if total <= 0:
+        return ""
+
+    top_direction = max(counts, key=counts.get)
+    top_count = counts[top_direction]
+    if top_count <= 0:
+        return ""
+    if sum(1 for value in counts.values() if value == top_count) > 1:
+        return "stable"
+    if top_direction != "stable" and top_count * 2 < total:
+        return "stable"
+    if top_direction:
+        return top_direction
+
+    existing = str(timing_intelligence.get("sentiment_direction") or "").strip().lower()
+    if existing in {"declining", "stable", "improving", "insufficient_data"}:
+        return existing
+    return ""
+
+
+def _segment_sample_size_from_reach(wrapper: Any) -> int | None:
+    if not isinstance(wrapper, dict):
+        return None
+    source_id = str(wrapper.get("source_id") or "").strip()
+    if not source_id.startswith("segment:reach:"):
+        return None
+    sample_size = _safe_int(wrapper.get("value"), 0)
+    return sample_size if sample_size > 0 else None
+
+
+def _attach_segment_sample_sizes(segment_playbook: dict[str, Any]) -> dict[str, Any]:
+    segments = segment_playbook.get("priority_segments")
+    if not isinstance(segments, list):
+        return segment_playbook
+    for segment in segments:
+        if not isinstance(segment, dict):
+            continue
+        sample_size = _segment_sample_size_from_reach(segment.get("estimated_reach"))
+        if sample_size is not None:
+            segment["sample_size"] = sample_size
+            continue
+        existing = _safe_int(segment.get("sample_size"), 0)
+        if existing > 0:
+            segment["sample_size"] = existing
+        else:
+            segment.pop("sample_size", None)
+    return segment_playbook
+
+
+def _top_displacement_flows(packet: Any, limit: int = 3) -> list[dict[str, Any]]:
+    flows: list[dict[str, Any]] = []
+    for item in _pool_items(packet, "displacement")[:limit]:
+        data = getattr(item, "data", {}) or {}
+        if not isinstance(data, dict):
+            continue
+        edge_metrics = data.get("edge_metrics") or {}
+        switch_reasons = data.get("switch_reasons") or []
+        evidence_breakdown = data.get("evidence_breakdown") or []
+        summary = data.get("flow_summary") or {}
+        primary_driver = (
+            edge_metrics.get("primary_driver")
+            or _infer_flow_driver(switch_reasons, evidence_breakdown)
+        )
+        flows.append({
+            "to_vendor": data.get("to_vendor") or data.get("competitor") or "",
+            "mention_count": (
+                summary.get("mention_count")
+                or summary.get("total_flow_mentions")
+                or edge_metrics.get("mention_count")
+            ),
+            "explicit_switch_count": summary.get("explicit_switch_count"),
+            "active_evaluation_count": summary.get("active_evaluation_count"),
+            "primary_driver": primary_driver,
+            "source_id": getattr(getattr(item, "source_ref", None), "source_id", ""),
+        })
+    return flows
+
+
+def _infer_flow_driver(
+    switch_reasons: list[dict[str, Any]],
+    evidence_breakdown: list[dict[str, Any]],
+) -> str | None:
+    counts: dict[str, int] = {}
+    for item in switch_reasons or []:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("reason_category") or item.get("reason") or "").strip().lower()
+        if not key:
+            continue
+        counts[key] = counts.get(key, 0) + max(int(item.get("mention_count") or 0), 1)
+    for item in evidence_breakdown or []:
+        if not isinstance(item, dict):
+            continue
+        for key, count in (item.get("reason_categories") or {}).items():
+            label = str(key or "").strip().lower()
+            if not label:
+                continue
+            counts[label] = counts.get(label, 0) + int(count or 0)
+    if not counts:
+        return None
+    return max(counts.items(), key=lambda kv: kv[1])[0]
+
+
+def _flow_counts(data: dict[str, Any]) -> tuple[int, int, int]:
+    summary = data.get("flow_summary") or {}
+    edge_metrics = data.get("edge_metrics") or {}
+    switches = int(_wrapper_numeric_value({"value": summary.get("explicit_switch_count")}) or 0)
+    evals = int(_wrapper_numeric_value({"value": summary.get("active_evaluation_count")}) or 0)
+    mentions = int(
+        _wrapper_numeric_value(
+            {
+                "value": (
+                    summary.get("mention_count")
+                    or summary.get("total_flow_mentions")
+                    or edge_metrics.get("mention_count")
+                ),
+            }
+        ) or 0
+    )
+    return switches, evals, mentions
+
+
+def _best_displacement_flow(packet: Any) -> dict[str, Any] | None:
+    best: dict[str, Any] | None = None
+    best_score: tuple[int, int, int] | None = None
+    for item in _pool_items(packet, "displacement"):
+        data = getattr(item, "data", {}) or {}
+        if not isinstance(data, dict):
+            continue
+        to_vendor = str(data.get("to_vendor") or data.get("competitor") or "").strip()
+        if not to_vendor:
+            continue
+        switches, evals, mentions = _flow_counts(data)
+        if max(switches, evals, mentions) <= 0:
+            continue
+        score = (switches, evals, mentions)
+        if best_score is None or score > best_score:
+            edge_metrics = data.get("edge_metrics") or {}
+            switch_reasons = data.get("switch_reasons") or []
+            evidence_breakdown = data.get("evidence_breakdown") or []
+            best = {
+                "to_vendor": to_vendor,
+                "primary_driver": (
+                    edge_metrics.get("primary_driver")
+                    or _infer_flow_driver(switch_reasons, evidence_breakdown)
+                ),
+                "source_id": getattr(getattr(item, "source_ref", None), "source_id", ""),
+                "switches": switches,
+                "evals": evals,
+                "mentions": mentions,
+            }
+            best_score = score
+    return best
+
+
+def _account_summary(packet: Any) -> dict[str, Any]:
+    top_accounts: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+
+    def _append_account_item(item: Any) -> None:
+        data = getattr(item, "data", {}) or {}
+        if not isinstance(data, dict):
+            return
+        name = data.get("company_name") or data.get("company") or data.get("name") or "unknown"
+        normalized_name = normalize_company_name(name)
+        dedupe_key = (normalized_name or str(name or "").strip()).lower()
+        if not dedupe_key or dedupe_key in seen_names:
+            return
+        intent = _normalize_account_intent_score(
+            data.get("urgency_score") or data.get("intent_score") or data.get("confidence_score", 0),
+        )
+        top_accounts.append({
+            "name": name,
+            "intent_score": intent,
+            "source_id": getattr(getattr(item, "source_ref", None), "source_id", ""),
+        })
+        seen_names.add(dedupe_key)
+
+    for item in _pool_items(packet, "accounts"):
+        _append_account_item(item)
+
+    if not top_accounts:
+        for item in _pool_items(packet, "evidence_vault"):
+            source_ref = getattr(item, "source_ref", None)
+            if getattr(source_ref, "kind", "") != "company":
+                continue
+            _append_account_item(item)
+            if len(top_accounts) >= 5:
+                break
+
+    return {
+        "schema_version": "v1",
+        "total_accounts": _aggregate_wrapper(packet, "accounts:summary:total_accounts"),
+        "high_intent_count": _aggregate_wrapper(packet, "accounts:summary:high_intent_count"),
+        "active_eval_count": _aggregate_wrapper(packet, "accounts:summary:active_eval_signal_count"),
+        "top_accounts": top_accounts[:5],
+    }
+
+
+def _category_summary(packet: Any) -> dict[str, Any]:
+    regime_item = None
+    council_item = None
+    for item in _pool_items(packet, "category"):
+        source_ref = getattr(item, "source_ref", None)
+        kind = getattr(source_ref, "kind", "")
+        if kind == "regime" and regime_item is None:
+            regime_item = item
+        elif kind == "council" and council_item is None:
+            council_item = item
+    regime_data = getattr(regime_item, "data", {}) or {}
+    regime_source_id = getattr(getattr(regime_item, "source_ref", None), "source_id", "")
+    council_data = getattr(council_item, "data", {}) or {}
+    council_source_id = getattr(getattr(council_item, "source_ref", None), "source_id", "")
+
+    citations: list[str] = []
+    if regime_source_id:
+        citations.append(regime_source_id)
+    if council_source_id and council_source_id not in citations:
+        citations.append(council_source_id)
+
+    result: dict[str, Any] = {
+        "schema_version": "v1",
+        "market_regime": (
+            council_data.get("market_regime")
+            or regime_data.get("regime_type")
+            or ""
+        ),
+        "narrative": (
+            council_data.get("conclusion")
+            or regime_data.get("narrative")
+            or ""
+        ),
+        "confidence_score": (
+            council_data.get("confidence")
+            if council_data.get("confidence") is not None
+            else regime_data.get("confidence")
+        ),
+        "vendor_count": _aggregate_wrapper(packet, "category:aggregate:vendor_count"),
+        "displacement_flow_count": _aggregate_wrapper(
+            packet,
+            "category:aggregate:displacement_flow_count",
+        ),
+        "winner": council_data.get("winner") or None,
+        "loser": council_data.get("loser") or None,
+        "top_differentiator": council_data.get("top_differentiator") or None,
+        "top_vulnerability": council_data.get("top_vulnerability") or None,
+        "key_insights": council_data.get("key_insights") or [],
+        "durability": council_data.get("durability_assessment") or None,
+        "avg_churn_velocity": regime_data.get("avg_churn_velocity"),
+        "avg_price_pressure": regime_data.get("avg_price_pressure"),
+        "outlier_vendors": regime_data.get("outlier_vendors") or [],
+        "segment_dynamics": council_data.get("segment_dynamics") or None,
+        "category_default": council_data.get("category_default") or None,
+        "citations": citations,
+    }
+    return result
+
+
+def _is_placeholder_named_example_company(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return True
+    normalized = normalize_company_name(text)
+    if not normalized:
+        return True
+    if _looks_like_tool_label(text):
+        return True
+    return any(pattern.search(text) for pattern in _PLACEHOLDER_NAMED_EXAMPLE_PATTERNS)
+
+
+def _sanitize_named_examples(
+    migration_proof: dict[str, Any],
+) -> dict[str, Any]:
+    examples = _copy_list(migration_proof.get("named_examples"))
+    if not examples:
+        return migration_proof
+
+    cleaned: list[dict[str, Any]] = []
+    dropped = False
+    for item in examples:
+        if not isinstance(item, dict):
+            dropped = True
+            continue
+        if _is_placeholder_named_example_company(item.get("company")):
+            dropped = True
+            continue
+        cleaned.append(item)
+
+    migration_proof["named_examples"] = cleaned
+    if dropped:
+        data_gaps = _copy_list(migration_proof.get("data_gaps"))
+        message = "No credible named migration examples"
+        if message not in data_gaps:
+            data_gaps.append(message)
+        migration_proof["data_gaps"] = data_gaps
+    return migration_proof
+
+
+def _sanitize_text_wrapper(
+    wrapper: Any,
+) -> dict[str, Any]:
+    if not isinstance(wrapper, dict):
+        return {"value": None, "source_id": None}
+    value = wrapper.get("value")
+    source_id = wrapper.get("source_id")
+    if not isinstance(value, str):
+        return {"value": None, "source_id": None}
+    text = value.strip()
+    if not text or text.lower() in {"0", "none", "null", "unknown", "n/a", "na", "n.a."}:
+        return {"value": None, "source_id": None}
+    return {
+        "value": text,
+        "source_id": source_id if isinstance(source_id, str) and source_id.strip() else None,
+    }
+
+
+def _filter_valid_citations(value: Any, valid_source_ids: set[str]) -> Any:
+    """Drop citations that do not exist in the current packet."""
+    if isinstance(value, dict):
+        citations = value.get("citations")
+        if isinstance(citations, list):
+            filtered: list[str] = []
+            for sid in citations:
+                if isinstance(sid, str) and sid in valid_source_ids and sid not in filtered:
+                    filtered.append(sid)
+            if filtered:
+                value["citations"] = filtered
+            else:
+                value.pop("citations", None)
+        for child in value.values():
+            _filter_valid_citations(child, valid_source_ids)
+    elif isinstance(value, list):
+        for item in value:
+            _filter_valid_citations(item, valid_source_ids)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 contract builders
+# ---------------------------------------------------------------------------
+
+def _build_why_they_stay(packet: Any) -> dict[str, Any] | None:
+    """Build a why_they_stay block from packet retention_proof.
+
+    Explains why customers remain despite churn pressure -- the counter-
+    signal that prevents over-aggressive positioning.
+    """
+    retention_proof = getattr(packet, "retention_proof", None) or []
+    if not retention_proof:
+        return None
+    strengths: list[dict[str, Any]] = []
+    for proof in retention_proof:
+        if not isinstance(proof, dict):
+            continue
+        area = proof.get("area", "")
+        strength_text = proof.get("strength", "")
+        if not area:
+            continue
+        entry: dict[str, Any] = {"area": area}
+        if strength_text:
+            entry["evidence"] = strength_text
+        sid = proof.get("_sid")
+        if sid:
+            entry["_sid"] = sid
+        mc = proof.get("mention_count")
+        if mc is not None:
+            entry["mention_count"] = mc
+        strengths.append(entry)
+    if not strengths:
+        return None
+    # Build summary from top strengths
+    top_areas = [s["area"].replace("_", " ") for s in strengths[:3]]
+    summary = (
+        f"Retention anchored by {', '.join(top_areas)}"
+        if top_areas else ""
+    )
+    return {
+        "summary": summary,
+        "strengths": strengths,
+    }
+
+
+def _build_confidence_posture(
+    packet: Any,
+    causal_narrative: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Build a confidence_posture block from coverage gaps and section confidence.
+
+    Surfaces the explicit limits on what the reasoning can claim, so
+    downstream consumers can hedge appropriately.
+    """
+    coverage_gaps = getattr(packet, "coverage_gaps", None) or []
+    section_confidence = causal_narrative.get("confidence", "medium")
+
+    limits: list[str] = []
+    for gap in coverage_gaps:
+        if not isinstance(gap, dict):
+            continue
+        gap_type = gap.get("type", "")
+        area = gap.get("area", "")
+        sample = gap.get("sample_size", 0)
+        if gap_type == "thin_segment_sample":
+            limits.append(f"thin {area.replace('_', ' ')} sample (n={sample})")
+        elif gap_type == "missing_pool":
+            limits.append(f"no {area} evidence")
+        elif gap_type == "thin_account_signals":
+            limits.append(f"weak account signal density (n={sample})")
+        elif gap_type == "shallow_evidence_window":
+            limits.append(f"shallow evidence window ({sample} days)")
+
+    contradictions = getattr(packet, "contradiction_rows", None) or []
+    contradiction_dims = sorted(
+        {
+            str(item.get("dimension") or "").strip().lower()
+            for item in contradictions
+            if isinstance(item, dict) and str(item.get("dimension") or "").strip()
+        },
+    )
+    if contradiction_dims:
+        limits.append(
+            f"contradictions on {', '.join(contradiction_dims)} "
+            "require cautious interpretation"
+        )
+
+    if not limits and section_confidence in ("high", "medium"):
+        return None
+
+    overall_score = causal_narrative.get("confidence_score")
+    try:
+        overall_score = float(overall_score)
+    except (TypeError, ValueError):
+        overall_score = None
+    if overall_score is not None and not (0.0 <= overall_score <= 1.0):
+        overall_score = None
+
+    posture = {
+        "overall": section_confidence,
+        "limits": limits,
+    }
+    if overall_score is not None:
+        posture["overall_score"] = overall_score
+    return posture
+
+
+def _apply_contradiction_hedging(
+    packet: Any,
+    causal_narrative: dict[str, Any],
+) -> dict[str, Any]:
+    """Backfill contradiction-aware caveats before validation/retry decisions."""
+    if not isinstance(causal_narrative, dict) or not causal_narrative:
+        return causal_narrative
+
+    contradictions = getattr(packet, "contradiction_rows", None) or []
+    contradiction_dims = sorted(
+        {
+            str(item.get("dimension") or "").strip().lower()
+            for item in contradictions
+            if isinstance(item, dict) and str(item.get("dimension") or "").strip()
+        },
+    )
+    if not contradiction_dims:
+        return causal_narrative
+
+    if str(causal_narrative.get("confidence") or "").strip().lower() == "high":
+        causal_narrative["confidence"] = "medium"
+    try:
+        confidence_score = float(causal_narrative.get("confidence_score"))
+    except (TypeError, ValueError):
+        confidence_score = None
+    if confidence_score is not None and confidence_score >= 0.75:
+        causal_narrative["confidence_score"] = 0.69
+
+    data_gaps = _copy_list(causal_narrative.get("data_gaps"))
+    gap_text = " ".join(str(item) for item in data_gaps).lower()
+    missing_dims = [dim for dim in contradiction_dims if dim not in gap_text]
+    if missing_dims:
+        data_gaps.append(
+            f"Contradictory evidence on {', '.join(missing_dims)} requires caution"
+        )
+        causal_narrative["data_gaps"] = data_gaps
+    return causal_narrative
+
+
+def _build_switch_triggers(
+    timing_intelligence: dict[str, Any],
+    packet: Any,
+) -> list[dict[str, Any]]:
+    """Extract switch triggers from timing intelligence and displacement data.
+
+    Switch triggers are the specific events or conditions that push a
+    customer from 'frustrated but staying' to 'actively switching'.
+    """
+    triggers: list[dict[str, Any]] = []
+    seen_labels: set[str] = set()
+
+    # Source 1: immediate_triggers from timing intelligence
+    immediate = timing_intelligence.get("immediate_triggers") or []
+    for t in immediate:
+        if not isinstance(t, dict):
+            continue
+        trigger_type = t.get("type") or t.get("trigger_type") or ""
+        description = t.get("description") or t.get("signal") or ""
+        label = trigger_type or description[:40]
+        if not label or label in seen_labels:
+            continue
+        seen_labels.add(label)
+        entry: dict[str, Any] = {"type": trigger_type}
+        if description:
+            entry["description"] = description
+        sid = t.get("_sid") or t.get("source_id")
+        if sid:
+            entry["_sid"] = sid
+        triggers.append(entry)
+
+    # Source 2: high-urgency temporal spikes from packet
+    temporal_items = getattr(packet, "pools", {}).get("temporal", [])
+    for si in temporal_items:
+        data = getattr(si, "data", {})
+        if not isinstance(data, dict):
+            continue
+        spike_type = data.get("spike_type") or data.get("type") or ""
+        magnitude = data.get("magnitude") or data.get("spike_magnitude") or 0
+        try:
+            mag_val = float(magnitude)
+        except (TypeError, ValueError):
+            mag_val = 0.0
+        if mag_val < 2.0:
+            continue
+        label = spike_type or "temporal_spike"
+        if label in seen_labels:
+            continue
+        seen_labels.add(label)
+        entry = {"type": "spike", "description": spike_type}
+        ref = getattr(si, "source_ref", None)
+        if ref:
+            entry["_sid"] = ref.source_id
+        triggers.append(entry)
+
+    return triggers
+
+
+def _build_evidence_governance(packet: Any) -> dict[str, Any] | None:
+    """Build evidence_governance block from packet governance signals.
+
+    Passthrough of metric_ledger, contradictions, and coverage_gaps so
+    downstream consumers can read uncertainty/governance directly.
+    """
+    metric_ledger = getattr(packet, "metric_ledger", None) or []
+    contradictions = getattr(packet, "contradiction_rows", None) or []
+    coverage_gaps = getattr(packet, "coverage_gaps", None) or []
+    minority_signals = getattr(packet, "minority_signals", None) or []
+
+    if not any([metric_ledger, contradictions, coverage_gaps, minority_signals]):
+        return None
+
+    gov: dict[str, Any] = {}
+    if metric_ledger:
+        gov["metric_ledger"] = metric_ledger
+    if contradictions:
+        gov["contradictions"] = contradictions
+    if coverage_gaps:
+        gov["coverage_gaps"] = coverage_gaps
+    if minority_signals:
+        gov["minority_signals"] = minority_signals
+    return gov
+
+
+def build_reasoning_contracts(
+    synthesis: dict[str, Any],
+    packet: Any,
+) -> dict[str, Any]:
+    """Build reusable reasoning contracts from battle-card synthesis output."""
+    explicit_contracts = synthesis.get("reasoning_contracts")
+    has_explicit_contracts = (
+        isinstance(explicit_contracts, dict) and bool(explicit_contracts)
+    )
+    valid_source_ids = set(packet.source_ids())
+    explicit_vendor_core = _contract_block(synthesis, "vendor_core_reasoning")
+    explicit_displacement = _contract_block(synthesis, "displacement_reasoning")
+    explicit_category = _contract_block(synthesis, "category_reasoning")
+    explicit_account = _contract_block(synthesis, "account_reasoning")
+
+    causal_narrative = _copy_dict(
+        explicit_vendor_core.get("causal_narrative")
+        or ({} if has_explicit_contracts else synthesis.get("causal_narrative")),
+    )
+    segment_playbook = _copy_dict(
+        explicit_vendor_core.get("segment_playbook")
+        or ({} if has_explicit_contracts else synthesis.get("segment_playbook")),
+    )
+    if segment_playbook:
+        segment_playbook = _attach_segment_sample_sizes(segment_playbook)
+        segment_playbook = _canonicalize_segment_playbook(segment_playbook)
+        supporting_evidence = _segment_supporting_evidence(packet)
+        existing_support = _copy_dict(segment_playbook.get("supporting_evidence"))
+        for key, value in existing_support.items():
+            if key not in supporting_evidence:
+                supporting_evidence[key] = value
+        if supporting_evidence:
+            segment_playbook["supporting_evidence"] = supporting_evidence
+        else:
+            segment_playbook.pop("supporting_evidence", None)
+    timing_intelligence = _copy_dict(
+        explicit_vendor_core.get("timing_intelligence")
+        or ({} if has_explicit_contracts else synthesis.get("timing_intelligence")),
+    )
+    if timing_intelligence or not has_explicit_contracts:
+        preferred_active_eval = _preferred_active_eval_wrapper(
+            packet,
+            timing_intelligence.get("active_eval_signals"),
+        )
+        if preferred_active_eval is not None:
+            timing_intelligence["active_eval_signals"] = preferred_active_eval
+        supporting_evidence = _timing_supporting_evidence(packet)
+        timing_rows = list(supporting_evidence.get("top_timing_signals") or [])
+        timing_rows = _merge_timing_signal_rows(
+            timing_rows,
+            _timing_signal_fallback_rows(timing_intelligence),
+        )
+        timing_rows = _merge_timing_signal_rows(
+            timing_rows,
+            _timing_signal_summary_rows(supporting_evidence),
+        )
+        if timing_rows:
+            supporting_evidence["top_timing_signals"] = timing_rows
+        existing_support = _copy_dict(timing_intelligence.get("supporting_evidence"))
+        for key, value in existing_support.items():
+            if key not in supporting_evidence:
+                supporting_evidence[key] = value
+        if supporting_evidence:
+            timing_intelligence["supporting_evidence"] = supporting_evidence
+        else:
+            timing_intelligence.pop("supporting_evidence", None)
+        sentiment_direction = _timing_sentiment_direction(timing_intelligence, packet)
+        if sentiment_direction:
+            timing_intelligence["sentiment_direction"] = sentiment_direction
+        else:
+            timing_intelligence.pop("sentiment_direction", None)
+        timing_intelligence = _canonicalize_timing_intelligence(timing_intelligence)
+    migration_proof = _copy_dict(
+        explicit_displacement.get("migration_proof")
+        or ({} if has_explicit_contracts else synthesis.get("migration_proof")),
+    )
+    migration_proof = _sanitize_named_examples(migration_proof)
+    best_flow = _best_displacement_flow(packet)
+    if migration_proof:
+        fallback_destination = (
+            {
+                "value": best_flow.get("to_vendor"),
+                "source_id": best_flow.get("source_id"),
+            }
+            if best_flow and best_flow.get("to_vendor")
+            else None
+        )
+        fallback_driver = (
+            {
+                "value": best_flow.get("primary_driver"),
+                "source_id": best_flow.get("source_id"),
+            }
+            if best_flow and best_flow.get("primary_driver")
+            else None
+        )
+        migration_proof["top_destination"] = (
+            fallback_destination
+            or _sanitize_text_wrapper(migration_proof.get("top_destination"))
+        )
+        migration_proof["primary_switch_driver"] = (
+            fallback_driver
+            or _sanitize_text_wrapper(migration_proof.get("primary_switch_driver"))
+        )
+    if migration_proof or not has_explicit_contracts:
+        preferred_switch_volume = _preferred_migration_switch_wrapper(
+            packet,
+            migration_proof.get("switch_volume"),
+        )
+        if preferred_switch_volume is not None:
+            migration_proof["switch_volume"] = preferred_switch_volume
+        preferred_migration_eval = _preferred_migration_eval_wrapper(
+            packet,
+            migration_proof.get("active_evaluation_volume"),
+        )
+        if preferred_migration_eval is not None:
+            migration_proof["active_evaluation_volume"] = preferred_migration_eval
+        preferred_mention_volume = _preferred_displacement_mention_wrapper(
+            packet,
+            migration_proof.get("displacement_mention_volume"),
+        )
+        if preferred_mention_volume is not None:
+            migration_proof["displacement_mention_volume"] = preferred_mention_volume
+        migration_proof = _normalize_migration_semantics(migration_proof)
+        migration_proof = _ensure_migration_citations(migration_proof)
+    competitive_reframes = _copy_dict(
+        explicit_displacement.get("competitive_reframes")
+        or ({} if has_explicit_contracts else synthesis.get("competitive_reframes")),
+    )
+    for section in (
+        causal_narrative,
+        segment_playbook,
+        timing_intelligence,
+        migration_proof,
+        competitive_reframes,
+    ):
+        _filter_valid_citations(section, valid_source_ids)
+
+    vendor_core_citations: list[str] = []
+    for section in (causal_narrative, segment_playbook, timing_intelligence):
+        vendor_core_citations.extend(_copy_list(section.get("citations")))
+    deduped_vendor_core_citations = list(dict.fromkeys(vendor_core_citations))
+
+    displacement_citations = _copy_list(migration_proof.get("citations"))
+    top_flows = _top_displacement_flows(packet)
+    for flow in top_flows:
+        sid = flow.get("source_id")
+        if sid and sid not in displacement_citations:
+            displacement_citations.append(sid)
+
+    causal_narrative = _apply_contradiction_hedging(packet, causal_narrative)
+
+    vendor_core: dict[str, Any] = {}
+    if explicit_vendor_core or not has_explicit_contracts:
+        vendor_core = {
+            **explicit_vendor_core,
+            "schema_version": str(explicit_vendor_core.get("schema_version") or "v1"),
+        }
+        if causal_narrative:
+            vendor_core["causal_narrative"] = causal_narrative
+        if segment_playbook:
+            vendor_core["segment_playbook"] = segment_playbook
+        if timing_intelligence:
+            vendor_core["timing_intelligence"] = timing_intelligence
+        citations = deduped_vendor_core_citations or _copy_list(explicit_vendor_core.get("citations"))
+        if citations:
+            vendor_core["citations"] = citations
+
+    displacement: dict[str, Any] = {}
+    if explicit_displacement or not has_explicit_contracts:
+        displacement = {
+            **explicit_displacement,
+            "schema_version": str(explicit_displacement.get("schema_version") or "v1"),
+            "top_flows": _copy_list(explicit_displacement.get("top_flows")) or top_flows,
+            "confirmed_switch_count": explicit_displacement.get("confirmed_switch_count") or _aggregate_wrapper(
+                packet,
+                "displacement:aggregate:total_explicit_switches",
+            ),
+            "active_evaluation_count": explicit_displacement.get("active_evaluation_count") or _aggregate_wrapper(
+                packet,
+                "displacement:aggregate:total_active_evaluations",
+            ),
+            "displacement_mention_volume": explicit_displacement.get("displacement_mention_volume") or _aggregate_wrapper(
+                packet,
+                "vault:metric:displacement_mention_count",
+            ),
+        }
+        if migration_proof:
+            displacement["migration_proof"] = migration_proof
+        if competitive_reframes:
+            displacement["competitive_reframes"] = competitive_reframes
+        citations = displacement_citations or _copy_list(explicit_displacement.get("citations"))
+        if citations:
+            displacement["citations"] = citations
+
+    account_summary = _account_summary(packet)
+    flat_account = (
+        _copy_dict(synthesis.get("account_reasoning"))
+        if not has_explicit_contracts
+        else {}
+    )
+    account = {
+        **flat_account,
+        **explicit_account,
+        **account_summary,
+        "schema_version": str(explicit_account.get("schema_version") or "v1"),
+        "market_summary": (
+            explicit_account.get("market_summary")
+            or flat_account.get("market_summary")
+            or ""
+        ),
+        "confidence": (
+            explicit_account.get("confidence")
+            or flat_account.get("confidence")
+        ),
+        "data_gaps": (
+            explicit_account.get("data_gaps")
+            if explicit_account.get("data_gaps") is not None
+            else flat_account.get("data_gaps", [])
+        ),
+        "confidence_score": (
+            explicit_account.get("confidence_score")
+            if explicit_account.get("confidence_score") is not None
+            else account_summary.get("confidence_score")
+        ),
+    }
+    citations = list(dict.fromkeys(
+        _copy_list(explicit_account.get("citations"))
+        + _copy_list(account_summary.get("citations"))
+    ))
+    if citations:
+        account["citations"] = citations
+    _filter_valid_citations(account, valid_source_ids)
+
+    category_summary = _category_summary(packet)
+    flat_category = (
+        _copy_dict(synthesis.get("category_reasoning"))
+        if not has_explicit_contracts
+        else {}
+    )
+    category = {
+        **category_summary,
+        **flat_category,
+        **explicit_category,
+        "schema_version": str(explicit_category.get("schema_version") or "v1"),
+        "market_regime": explicit_category.get("market_regime") or flat_category.get("market_regime") or category_summary.get("market_regime") or "",
+        "narrative": explicit_category.get("narrative") or flat_category.get("narrative") or category_summary.get("narrative") or "",
+        "confidence": (
+            explicit_category.get("confidence")
+            or flat_category.get("confidence")
+        ),
+        "data_gaps": (
+            explicit_category.get("data_gaps")
+            if explicit_category.get("data_gaps") is not None
+            else flat_category.get("data_gaps", [])
+        ),
+        "confidence_score": (
+            explicit_category.get("confidence_score")
+            if explicit_category.get("confidence_score") is not None
+            else category_summary.get("confidence_score")
+        ),
+        "vendor_count": explicit_category.get("vendor_count") or category_summary.get("vendor_count"),
+        "displacement_flow_count": explicit_category.get("displacement_flow_count") or category_summary.get("displacement_flow_count"),
+    }
+    citations = list(dict.fromkeys(
+        _copy_list(explicit_category.get("citations"))
+        + _copy_list(category_summary.get("citations"))
+    ))
+    if citations:
+        category["citations"] = citations
+    _filter_valid_citations(category, valid_source_ids)
+
+    # --- Phase 3: why_they_stay from retention_proof -----------------------
+    # Merge: deterministic builder fills gaps, model-provided content preserved
+    deterministic_wts = _build_why_they_stay(packet)
+    if vendor_core:
+        existing_wts = vendor_core.get("why_they_stay")
+        if isinstance(existing_wts, dict) and existing_wts:
+            # Model provided content -- merge deterministic strengths in
+            if deterministic_wts:
+                existing_strengths = existing_wts.get("strengths") or []
+                existing_areas = {s.get("area") for s in existing_strengths if isinstance(s, dict)}
+                for s in deterministic_wts.get("strengths") or []:
+                    if isinstance(s, dict) and s.get("area") not in existing_areas:
+                        existing_strengths.append(s)
+                existing_wts["strengths"] = existing_strengths
+            vendor_core["why_they_stay"] = existing_wts
+        elif deterministic_wts:
+            vendor_core["why_they_stay"] = deterministic_wts
+
+    # --- Phase 3: confidence_posture from coverage_gaps -------------------
+    deterministic_cp = _build_confidence_posture(packet, causal_narrative)
+    if vendor_core:
+        existing_cp = vendor_core.get("confidence_posture")
+        if isinstance(existing_cp, dict) and existing_cp:
+            # Model provided content -- merge deterministic limits in
+            if deterministic_cp:
+                existing_limits = list(existing_cp.get("limits") or [])
+                existing_set = set(existing_limits)
+                for lim in deterministic_cp.get("limits") or []:
+                    if lim not in existing_set:
+                        existing_limits.append(lim)
+                existing_cp["limits"] = existing_limits
+                if (
+                    existing_cp.get("overall_score") in (None, "")
+                    and deterministic_cp.get("overall_score") not in (None, "")
+                ):
+                    existing_cp["overall_score"] = deterministic_cp.get("overall_score")
+            vendor_core["confidence_posture"] = existing_cp
+        elif deterministic_cp:
+            vendor_core["confidence_posture"] = deterministic_cp
+
+    # --- Phase 3: switch_triggers from timing/displacement ----------------
+    deterministic_st = _build_switch_triggers(timing_intelligence, packet)
+    if displacement:
+        existing_st = displacement.get("switch_triggers")
+        if isinstance(existing_st, list) and existing_st:
+            # Model provided triggers -- merge deterministic ones in
+            existing_types = {t.get("type") for t in existing_st if isinstance(t, dict)}
+            for t in deterministic_st:
+                if isinstance(t, dict) and t.get("type") not in existing_types:
+                    existing_st.append(t)
+            displacement["switch_triggers"] = existing_st
+        elif deterministic_st:
+            displacement["switch_triggers"] = deterministic_st
+
+    # --- Phase 3: evidence_governance passthrough from packet -------------
+    evidence_governance = _build_evidence_governance(packet)
+
+    contracts = {"schema_version": "v1"}
+    if vendor_core:
+        contracts["vendor_core_reasoning"] = vendor_core
+    if displacement:
+        contracts["displacement_reasoning"] = displacement
+    if category:
+        contracts["category_reasoning"] = category
+    if account:
+        contracts["account_reasoning"] = account
+    if evidence_governance:
+        contracts["evidence_governance"] = evidence_governance
+    return contracts
+
+
+def build_persistable_synthesis(
+    synthesis: dict[str, Any],
+    packet: Any,
+) -> dict[str, Any]:
+    """Build the canonical persisted synthesis payload.
+
+    Persist contracts as the source of truth. Flat battle-card-shaped sections are
+    treated as transient prompt/validation intermediates and are not stored at the
+    top level anymore.
+    """
+    from ._b2b_reasoning_atoms import (
+        build_reasoning_atoms,
+        build_scope_manifest,
+    )
+
+    contracts = build_reasoning_contracts(synthesis, packet)
+    raw_schema = str(synthesis.get("schema_version") or "2.1")
+    meta = _copy_dict(synthesis.get("meta"))
+    warnings = _copy_list(synthesis.get("_validation_warnings"))
+
+    persisted: dict[str, Any] = {
+        "schema_version": raw_schema,
+        "reasoning_shape": "contracts_first_v1",
+        "reasoning_contracts": contracts,
+    }
+    if meta:
+        persisted["meta"] = meta
+    if warnings:
+        persisted["_validation_warnings"] = warnings
+
+    referenced_ids: set[str] = set()
+    _collect_source_ids(contracts, referenced_ids)
+    metric_source_ids = {
+        str(agg.source_id)
+        for agg in getattr(packet, "aggregates", []) or []
+        if getattr(agg, "source_id", None)
+    }
+    metric_source_ids.update(
+        str(entry.get("_sid"))
+        for entry in getattr(packet, "metric_ledger", []) or []
+        if isinstance(entry, dict) and str(entry.get("_sid") or "").strip()
+    )
+    witness_source_ids = {
+        str(witness.get("_sid") or witness.get("witness_id"))
+        for witness in getattr(packet, "witness_pack", []) or []
+        if isinstance(witness, dict) and str(witness.get("_sid") or witness.get("witness_id") or "").strip()
+    }
+    persisted["reference_ids"] = {
+        "metric_ids": sorted(referenced_ids.intersection(metric_source_ids)),
+        "witness_ids": sorted(referenced_ids.intersection(witness_source_ids)),
+    }
+    if getattr(packet, "witness_pack", None) or getattr(packet, "section_packets", None):
+        persisted["packet_artifacts"] = {
+            "witness_pack": list(getattr(packet, "witness_pack", []) or []),
+            "section_packets": dict(getattr(packet, "section_packets", {}) or {}),
+        }
+    persisted["scope_manifest"] = build_scope_manifest(packet)
+    persisted["reasoning_atoms"] = build_reasoning_atoms(contracts, packet)
+
+    vendor_core = contracts.get("vendor_core_reasoning") or {}
+    causal = vendor_core.get("causal_narrative") or {}
+    wedge = str(causal.get("primary_wedge") or "").strip()
+    valid_wedge = validate_wedge(wedge)
+    if valid_wedge is not None:
+        persisted["synthesis_wedge"] = valid_wedge.value
+        persisted["synthesis_wedge_label"] = _titleize_wedge(valid_wedge.value)
+
+    return persisted

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_shared.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_shared.py
@@ -1,0 +1,19875 @@
+"""Shared fetch helpers, lookup builders, and deterministic report builders.
+
+Extracted from b2b_churn_intelligence.py to enable follow-up tasks
+(reports, battle cards, article correlation) to re-use these without
+importing the monolith.
+"""
+
+import ast
+import asyncio
+import json
+import logging
+import math
+import re
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping
+
+from ...config import settings
+from ...services.apollo_company_overrides import fetch_company_override_map
+from ...services.b2b.corrections import suppress_predicate
+from ...services.b2b.enrichment_contract import (
+    pain_category_for_bucket,
+    quote_grade_phrases,
+    resolve_pain_confidence,
+)
+from ...services.company_normalization import normalize_company_name
+from ...services.scraping.sources import (
+    REQUIRED_ACTIONABLE_SOURCES,
+    parse_source_allowlist,
+    filter_blocked_sources,
+    filter_deprecated_sources,
+    with_required_sources,
+    display_name as _source_display_name,
+    VERIFIED_SOURCES,
+)
+from ...services.tracing import build_business_trace_context
+from ...services.vendor_registry import resolve_vendor_name_cached
+
+logger = logging.getLogger("atlas.autonomous.tasks.b2b_shared")
+
+_INTELLIGENCE_ELIGIBLE_STATUSES: tuple[str, ...] = (
+    "enriched",
+    "no_signal",
+    "quarantined",
+)
+
+
+def _reasoning_int(value: Any) -> int | None:
+    """Unwrap a traced numeric contract field into an integer."""
+    raw = value.get("value") if isinstance(value, dict) else value
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        try:
+            return int(float(raw))
+        except (TypeError, ValueError):
+            return None
+
+
+async def has_complete_core_run_marker(pool, report_date: date) -> bool:
+    """Return whether the core churn materialization finished for ``report_date``."""
+    marker = await pool.fetchval(
+        """
+        SELECT 1
+        FROM b2b_intelligence
+        WHERE report_type = 'core_run_complete'
+          AND report_date = $1
+          AND status = 'published'
+          AND COALESCE(
+                (intelligence_data->>'materialization_complete')::boolean,
+                TRUE
+              ) = TRUE
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        report_date,
+    )
+    return bool(marker)
+
+
+async def latest_complete_core_report_date(pool) -> date | None:
+    """Return the newest report_date with a complete published core-run marker."""
+    return await pool.fetchval(
+        """
+        SELECT report_date
+        FROM b2b_intelligence
+        WHERE report_type = 'core_run_complete'
+          AND status = 'published'
+          AND COALESCE(
+                (intelligence_data->>'materialization_complete')::boolean,
+                TRUE
+              ) = TRUE
+        ORDER BY report_date DESC, created_at DESC
+        LIMIT 1
+        """
+    )
+
+
+async def describe_core_run_gap(pool, report_date: date) -> str:
+    """Explain why the canonical core-run marker is unavailable for ``report_date``."""
+    row = await pool.fetchrow(
+        """
+        SELECT status, intelligence_data
+        FROM b2b_intelligence
+        WHERE report_type = 'core_run_complete'
+          AND report_date = $1
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        report_date,
+    )
+    if not row:
+        return "Core signals are not available for today"
+
+    intelligence_data = row.get("intelligence_data") or {}
+    if not isinstance(intelligence_data, dict):
+        intelligence_data = {}
+    materialization_status = intelligence_data.get("materialization_status") or {}
+    if not isinstance(materialization_status, dict):
+        materialization_status = {}
+
+    failed_phases = [
+        str(item).strip()
+        for item in (materialization_status.get("failed_phases") or [])
+        if str(item).strip()
+    ]
+    partial_phases = [
+        str(item).strip()
+        for item in (materialization_status.get("partial_phases") or [])
+        if str(item).strip()
+    ]
+
+    details: list[str] = []
+    if failed_phases:
+        details.append(f"failed: {', '.join(failed_phases)}")
+    if partial_phases:
+        details.append(f"partial: {', '.join(partial_phases)}")
+
+    reason = "Core churn materialization is incomplete for today"
+    if details:
+        return f"{reason} ({'; '.join(details)})"
+    return reason
+
+
+
+def filter_vendors_by_focus_categories(
+    vendor_scores: list[dict],
+    focus_categories_raw: str,
+) -> list[dict]:
+    """Filter vendor_scores to only include vendors in focus categories.
+
+    Returns the full list unchanged when focus is 'all' or empty.
+    Category matching is case-insensitive.
+    """
+    raw = (focus_categories_raw or "").strip().lower()
+    if not raw or raw == "all":
+        return vendor_scores
+    focus = {c.strip() for c in raw.split(",") if c.strip()}
+    if not focus:
+        return vendor_scores
+    return [
+        vs for vs in vendor_scores
+        if (vs.get("product_category") or "").strip().lower() in focus
+    ]
+
+
+_EXPLORATORY_OVERVIEW_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "exploratory_summary": {"type": "string"},
+        "timeline_hot_list": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "company": {"type": "string"},
+                    "vendor": {"type": "string"},
+                    "contract_end": {"type": ["string", "null"]},
+                    "urgency": {"type": "number"},
+                    "action": {"type": "string"},
+                    "buyer_role": {"type": "string"},
+                    "budget_authority": {"type": "boolean"},
+                },
+                "required": [
+                    "company", "vendor", "contract_end", "urgency",
+                    "action", "buyer_role", "budget_authority",
+                ],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["exploratory_summary", "timeline_hot_list"],
+    "additionalProperties": False,
+}
+
+
+def _battle_card_high_priority_score_min() -> float:
+    """Return the configured score threshold for high-priority language."""
+    return float(settings.b2b_churn.battle_card_high_priority_score_min)
+
+
+def _battle_card_high_priority_urgency_min() -> float:
+    """Return the configured urgency threshold for high-priority language."""
+    return float(settings.b2b_churn.battle_card_high_priority_urgency_min)
+
+
+def _battle_card_feature_gap_headline_min_mentions() -> int:
+    """Return the configured feature-gap mention threshold for headlines."""
+    return int(settings.b2b_churn.battle_card_feature_gap_headline_min_mentions)
+
+
+def _battle_card_leaving_patterns() -> tuple[str, ...]:
+    """Return configured phrases that imply unsupported switching claims."""
+    patterns = settings.b2b_churn.battle_card_leaving_patterns or []
+    return tuple(str(item).strip().lower() for item in patterns if str(item).strip())
+
+
+def _synthesis_reference_confidence_min() -> float:
+    """Return the configured confidence floor for synthesis references."""
+    return float(settings.b2b_churn.synthesis_reference_confidence_min)
+
+
+# Overreaching absolute phrases paired with evidence-calibrated replacements.
+# Checked in the validator (raises a warning) and in the sanitizer (auto-replaced).
+_BATTLE_CARD_OVERREACH_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    ("inability to execute", "execution risk is emerging"),
+    ("shows an inability to", "shows emerging risk of"),
+    ("inability to deliver", "delivery risk is present"),
+    ("strongest loser", "losing momentum in evaluated segments"),
+    ("biggest loser", "losing momentum in evaluated segments"),
+    ("clear loser", "losing ground in evaluated segments"),
+    ("failing across the board", "showing broad evaluation pressure"),
+    ("failing at scale", "facing scaling pressure"),
+    ("customers are fleeing", "buyers are actively evaluating alternatives"),
+    ("customers are abandoning", "buyers are evaluating alternatives"),
+    ("customers are leaving in droves", "buyers are evaluating alternatives at scale"),
+    ("is collapsing", "is under increasing pressure"),
+    ("is crumbling", "is showing structural weakness"),
+    ("cannot execute", "faces execution risk"),
+    ("has lost the market", "is losing momentum in evaluated segments"),
+)
+
+
+def _battle_card_overreach_violations(text: str) -> list[str]:
+    """Return banned overreach phrases found in text."""
+    lowered = text.lower()
+    return [phrase for phrase, _ in _BATTLE_CARD_OVERREACH_REPLACEMENTS if phrase in lowered]
+
+
+def _battle_card_replace_overreach(text: str) -> str:
+    """Replace overreaching phrases with evidence-calibrated language."""
+    result = text
+    for phrase, replacement in _BATTLE_CARD_OVERREACH_REPLACEMENTS:
+        lowered = result.lower()
+        if phrase not in lowered:
+            continue
+        idx = lowered.index(phrase)
+        # Preserve sentence casing: if phrase starts a sentence, capitalize replacement.
+        if idx == 0 or lowered[idx - 1] in ".!?\n":
+            replacement = replacement[0].upper() + replacement[1:]
+        result = result[:idx] + replacement + result[idx + len(phrase):]
+    return result
+
+
+def _synthesis_expert_take_max_words() -> int:
+    """Return the configured max word count for scorecard expert_take."""
+    return int(settings.b2b_churn.synthesis_expert_take_max_words)
+
+
+def _evidence_vault_supporting_review_limit() -> int:
+    """Return the max supporting-review IDs stored per evidence item."""
+    return int(settings.b2b_churn.intelligence_evidence_vault_supporting_review_limit)
+
+
+def _evidence_vault_segment_limit() -> int:
+    """Return the max affected segments stored per evidence item."""
+    return int(settings.b2b_churn.intelligence_evidence_vault_segment_limit)
+
+
+def _evidence_vault_role_limit() -> int:
+    """Return the max affected roles stored per evidence item."""
+    return int(settings.b2b_churn.intelligence_evidence_vault_role_limit)
+
+
+def _evidence_vault_trend_accelerating_ratio() -> float:
+    """Return the ratio needed to mark a trend as accelerating."""
+    return float(settings.b2b_churn.intelligence_evidence_vault_trend_accelerating_ratio)
+
+
+def _evidence_vault_trend_declining_ratio() -> float:
+    """Return the ratio at or below which a trend is declining."""
+    return float(settings.b2b_churn.intelligence_evidence_vault_trend_declining_ratio)
+
+
+def _evidence_vault_trend_new_min_recent() -> int:
+    """Return the minimum recent mentions needed to call a trend new."""
+    return int(settings.b2b_churn.intelligence_evidence_vault_trend_new_min_recent)
+
+
+def _trim_words(text: str, limit: int) -> str:
+    """Trim text to a max word count while preserving sentence punctuation."""
+    words = str(text or "").split()
+    if len(words) <= limit:
+        return str(text or "").strip()
+    return " ".join(words[:limit]).rstrip(" ,;") + "."
+
+
+# Default scoring weights for churn pressure score.
+_DEFAULT_WEIGHTS = {
+    "churn_density": 0.30,
+    "urgency": 0.25,
+    "dm_churn_rate": 0.20,
+    "displacement": 0.15,
+    "price_complaints": 0.10,
+}
+
+# Archetype-specific weight overrides. When vendor reasoning identifies
+# an archetype-style churn pattern, the corresponding weight set is used
+# instead of the default, biasing the score toward the most relevant signal.
+_ARCHETYPE_WEIGHT_OVERRIDES: dict[str, dict[str, float]] = {
+    "pricing_shock":        {"churn_density": 0.20, "urgency": 0.20, "dm_churn_rate": 0.15, "displacement": 0.10, "price_complaints": 0.35},
+    "feature_gap":          {"churn_density": 0.25, "urgency": 0.20, "dm_churn_rate": 0.15, "displacement": 0.30, "price_complaints": 0.10},
+    "support_collapse":     {"churn_density": 0.30, "urgency": 0.35, "dm_churn_rate": 0.15, "displacement": 0.10, "price_complaints": 0.10},
+    "acquisition_decay":    {"churn_density": 0.35, "urgency": 0.25, "dm_churn_rate": 0.20, "displacement": 0.15, "price_complaints": 0.05},
+    "category_disruption":  {"churn_density": 0.20, "urgency": 0.15, "dm_churn_rate": 0.15, "displacement": 0.40, "price_complaints": 0.10},
+    "integration_break":    {"churn_density": 0.30, "urgency": 0.30, "dm_churn_rate": 0.20, "displacement": 0.15, "price_complaints": 0.05},
+    "leadership_redesign":  {"churn_density": 0.30, "urgency": 0.25, "dm_churn_rate": 0.15, "displacement": 0.20, "price_complaints": 0.10},
+    "compliance_gap":       {"churn_density": 0.25, "urgency": 0.30, "dm_churn_rate": 0.25, "displacement": 0.10, "price_complaints": 0.10},
+}
+
+
+# ------------------------------------------------------------------
+# Layer 0: no internal dependencies
+# ------------------------------------------------------------------
+
+
+def _canonicalize_competitor(raw: str) -> str:
+    """Normalize competitor name via vendor registry, then title-case."""
+    return resolve_vendor_name_cached(raw)
+
+
+def _canonicalize_vendor(raw: str) -> str:
+    """Normalize vendor labels using the same alias handling as competitors."""
+    return resolve_vendor_name_cached(raw)
+
+
+async def _sync_vendor_firmographics(pool, *, as_of: date) -> int:
+    """Best-effort vendor -> org-cache sync for firmographic reasoning inputs."""
+    override_map = await fetch_company_override_map(pool)
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT vendor_name
+        FROM b2b_reviews
+        WHERE vendor_name IS NOT NULL AND vendor_name <> ''
+          AND duplicate_of_review_id IS NULL
+        ORDER BY vendor_name
+        """
+    )
+    synced = 0
+    for row in rows:
+        vendor_name = _canonicalize_vendor(row["vendor_name"] or "")
+        vendor_name_norm = normalize_company_name(vendor_name)
+        if not vendor_name or not vendor_name_norm:
+            continue
+        override = override_map.get(vendor_name_norm) or {}
+        candidate_names = [vendor_name_norm]
+        for alias in override.get("search_names", []) or []:
+            alias_norm = normalize_company_name(str(alias))
+            if alias_norm and alias_norm not in candidate_names:
+                candidate_names.append(alias_norm)
+        candidate_domains = []
+        for domain in override.get("domains", []) or []:
+            cleaned = str(domain).strip().lower().removeprefix("www.")
+            if cleaned and cleaned not in candidate_domains:
+                candidate_domains.append(cleaned)
+        org = await pool.fetchrow(
+            """
+            SELECT id, company_name_raw, company_name_norm, domain,
+                   industry, employee_count, annual_revenue_range
+            FROM prospect_org_cache
+            WHERE status = 'enriched'
+              AND (
+                company_name_norm = ANY($1::text[])
+                OR (
+                  domain IS NOT NULL
+                  AND domain <> ''
+                  AND LOWER(domain) = ANY($2::text[])
+                )
+              )
+            ORDER BY
+                CASE
+                    WHEN company_name_norm = $3 THEN 0
+                    WHEN company_name_norm = ANY($1::text[]) THEN 1
+                    ELSE 2
+                END,
+                employee_count DESC NULLS LAST,
+                updated_at DESC
+            LIMIT 1
+            """,
+            candidate_names,
+            candidate_domains,
+            vendor_name_norm,
+        )
+        if not org:
+            continue
+        await pool.execute(
+            """
+            INSERT INTO b2b_vendor_firmographics (
+                vendor_name, vendor_name_norm, company_name_raw, company_name_norm,
+                org_cache_id, domain, industry, employee_count,
+                annual_revenue_range, source, match_confidence, last_synced_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'prospect_org_cache', 1.0, NOW(), NOW())
+            ON CONFLICT (vendor_name_norm) DO UPDATE SET
+                vendor_name = EXCLUDED.vendor_name,
+                company_name_raw = EXCLUDED.company_name_raw,
+                company_name_norm = EXCLUDED.company_name_norm,
+                org_cache_id = EXCLUDED.org_cache_id,
+                domain = EXCLUDED.domain,
+                industry = EXCLUDED.industry,
+                employee_count = EXCLUDED.employee_count,
+                annual_revenue_range = EXCLUDED.annual_revenue_range,
+                last_synced_at = NOW(),
+                updated_at = NOW()
+            """,
+            vendor_name,
+            vendor_name_norm,
+            org["company_name_raw"],
+            org["company_name_norm"],
+            org["id"],
+            org["domain"],
+            org["industry"],
+            org["employee_count"],
+            org["annual_revenue_range"],
+        )
+        if org["employee_count"] is not None:
+            await pool.execute(
+                """
+                INSERT INTO b2b_vendor_firmographic_snapshots (
+                    vendor_name, vendor_name_norm, snapshot_date,
+                    employee_count, annual_revenue_range, industry, source
+                ) VALUES ($1, $2, $3, $4, $5, $6, 'prospect_org_cache')
+                ON CONFLICT (vendor_name_norm, snapshot_date) DO UPDATE SET
+                    vendor_name = EXCLUDED.vendor_name,
+                    employee_count = EXCLUDED.employee_count,
+                    annual_revenue_range = EXCLUDED.annual_revenue_range,
+                    industry = EXCLUDED.industry
+                """,
+                vendor_name,
+                vendor_name_norm,
+                as_of,
+                org["employee_count"],
+                org["annual_revenue_range"],
+                org["industry"],
+            )
+        synced += 1
+    return synced
+
+
+def _battle_card_quote_sort_key(raw_quote: Any) -> tuple[float, int, int]:
+    """Rank quotes for battle cards by urgency, specificity, and metadata richness."""
+    if not isinstance(raw_quote, dict):
+        text = str(raw_quote or "")
+        return (0.0, min(len(text), 240), 0)
+
+    text = str(raw_quote.get("quote") or raw_quote.get("text") or "")
+    urgency = float(raw_quote.get("urgency") or 0.0)
+    metadata_points = sum(
+        1 for key in ("company", "title", "company_size", "industry", "source_site")
+        if raw_quote.get(key)
+    )
+    # Longer, more concrete quotes usually perform better than generic one-liners.
+    specificity = min(len(text.strip()), 240)
+    return (urgency, specificity, metadata_points)
+
+
+_PAIN_SIGNAL_TERMS: frozenset[str] = frozenset([
+    "expensive", "pricey", "costly", "overpriced",
+    "difficult", "frustrating", "complicated", "confusing", "clunky",
+    "crashes", "crash", "bugs", "broken", "unreliable", "outage",
+    "poor", "terrible", "awful", "disappointing", "subpar",
+    "canceling", "cancelling", "switching to", "switched to",
+    "migrating to", "as a replacement", "looking to replace",
+    "looking for alternative", "considering switching",
+    "evaluating alternatives", "evaluating a replacement",
+    "unfortunately",
+    "not user-friendly", "not intuitive", "not great", "not good",
+    "unable to", "needs improvement",
+    "missing feature", "limited feature",
+    "price increase", "prices have", "pricing issues", "pricing concerns",
+    "issues with", "problems with",
+])
+
+_POSITIVE_ONLY_PHRASES: tuple[str, ...] = (
+    "perfect score",
+    "rate customer support a perfect",
+    "customer support is good",
+    "support is excellent",
+    "support is amazing",
+    "support is outstanding",
+    "very positive experience",
+    "highly recommend",
+    "no complaints",
+    "no issues",
+    "love everything about",
+    "could not be happier",
+    "best tool",
+    "best crm",
+)
+
+
+def _quote_has_pain_signal(
+    quote_text: str,
+    urgency: float = 0.0,
+    rating: float | None = None,
+    rating_max: float | None = None,
+) -> bool:
+    """Return True if the quote is appropriate for a pain/weakness section.
+
+    Rejects clearly-positive testimonials. High-urgency quotes (>= 6.5) are
+    kept even when ambiguous to avoid discarding thin evidence pools.
+    """
+    lowered = quote_text.lower().strip()
+    if not lowered:
+        return False
+    if rating is not None and rating_max and float(rating_max) > 0:
+        if float(rating) / float(rating_max) >= 0.80:
+            return False
+    for phrase in _POSITIVE_ONLY_PHRASES:
+        if phrase in lowered:
+            if not any(t in lowered for t in _PAIN_SIGNAL_TERMS):
+                return False
+    if any(t in lowered for t in _PAIN_SIGNAL_TERMS):
+        return True
+    return urgency >= 6.5
+
+
+def _build_llm_trace_metadata(
+    phase: str,
+    *,
+    report_type: str | None = None,
+    vendor_name: str | None = None,
+) -> dict[str, Any]:
+    """Build compact trace metadata for churn-intelligence LLM phases."""
+    metadata: dict[str, Any] = {
+        "workflow": "b2b_churn_intelligence",
+        "phase": phase,
+    }
+    if report_type:
+        metadata["report_type"] = report_type
+    if vendor_name:
+        metadata["vendor_name"] = vendor_name
+    business = build_business_trace_context(
+        workflow="b2b_churn_intelligence",
+        report_type=report_type,
+        vendor_name=vendor_name,
+    )
+    if business:
+        metadata["business"] = business
+    return metadata
+
+
+def _intelligence_source_allowlist() -> list[str]:
+    """Return the configured intelligence source allowlist for SQL ANY() binding."""
+    return filter_deprecated_sources(
+        with_required_sources(parse_source_allowlist(settings.b2b_churn.intelligence_source_allowlist)),
+        settings.b2b_churn.deprecated_review_sources,
+    )
+
+
+def _executive_source_list() -> list[str]:
+    """Return curated executive sources for headline-facing queries."""
+    sources = filter_deprecated_sources(
+        with_required_sources(parse_source_allowlist(settings.b2b_churn.intelligence_executive_sources)),
+        settings.b2b_churn.deprecated_review_sources,
+    )
+    return filter_blocked_sources(
+        sources,
+        getattr(settings.b2b_churn, "intelligence_infra_blocked_sources", ""),
+    )
+
+
+def _company_signal_skip_sources() -> set[str]:
+    """Return sources that should never seed canonical named-account artifacts."""
+    blocked: set[str] = set()
+    if settings.b2b_churn.company_signal_skip_deprecated_sources:
+        blocked.update(
+            set(parse_source_allowlist(settings.b2b_scrape.deprecated_sources))
+            - set(REQUIRED_ACTIONABLE_SOURCES)
+        )
+    return blocked
+
+
+def _company_signal_low_trust_sources() -> set[str]:
+    """Return configured low-trust sources for canonical company signals."""
+    return {
+        str(source).strip().lower()
+        for source in (settings.b2b_churn.company_signal_low_trust_sources or [])
+        if str(source).strip()
+    }
+
+
+def _configured_source_name_set(raw: Any) -> set[str]:
+    """Normalize list-like source config values into a lowercase set."""
+    values = raw if isinstance(raw, (list, tuple, set)) else [raw]
+    normalized: set[str] = set()
+    for value in values:
+        if isinstance(value, str):
+            for part in value.split(","):
+                source = str(part or "").strip().lower()
+                if source:
+                    normalized.add(source)
+        else:
+            source = str(value or "").strip().lower()
+            if source:
+                normalized.add(source)
+    return normalized
+
+
+def _company_signal_named_account_blocked_sources() -> set[str]:
+    """Return sources that should never seed named-account queues."""
+    return _configured_source_name_set(
+        getattr(settings.b2b_churn, "company_signal_named_account_blocked_sources", []),
+    )
+
+
+def _company_signal_verified_anchor_sources() -> set[str]:
+    """Return context-only sources that need a verified or direct company anchor."""
+    return _configured_source_name_set(
+        getattr(settings.b2b_churn, "company_signal_verified_anchor_sources", []),
+    )
+
+
+def _company_signal_high_identity_sources() -> set[str]:
+    """Return sources with strong named-company yield for account-level confidence biasing."""
+    return _configured_source_name_set(
+        getattr(settings.b2b_churn, "company_signal_high_identity_sources", []),
+    )
+
+
+def _company_signal_context_rich_sources() -> set[str]:
+    """Return sources with rich reviewer context but weaker named-company yield."""
+    return _configured_source_name_set(
+        getattr(settings.b2b_churn, "company_signal_context_rich_sources", []),
+    )
+
+
+_COMPANY_SIGNAL_SIZE_LABEL_RE = re.compile(
+    r"(?:\bsmall-business\b|\bmid-market\b|\benterprise\b|\b\d[\d,\- ]*\s*employees?\b|\bemp\.)",
+    re.I,
+)
+
+
+def _company_signal_looks_like_company_size_label(value: Any) -> bool:
+    return bool(_COMPANY_SIGNAL_SIZE_LABEL_RE.search(str(value or "").strip()))
+
+
+def _company_signal_source_identity_bonus(source: Any) -> float:
+    """Return the configured account-level confidence bonus for a source."""
+    normalized_source = str(source or "").strip().lower()
+    if not normalized_source:
+        return 0.0
+    if normalized_source in _company_signal_high_identity_sources():
+        return float(
+            getattr(settings.b2b_churn, "company_signal_high_identity_source_bonus", 0.18),
+        )
+    if normalized_source in _company_signal_context_rich_sources():
+        return float(
+            getattr(settings.b2b_churn, "company_signal_context_rich_source_bonus", 0.08),
+        )
+    return 0.0
+
+
+def _company_signal_has_direct_company_anchor(signal: Mapping[str, Any]) -> bool:
+    """Return whether a row carries a direct company-name anchor."""
+    for value in (
+        signal.get("company_name"),
+        signal.get("reviewer_company"),
+        signal.get("company_name_raw"),
+        signal.get("raw_reviewer_company"),
+    ):
+        text = str(value or "").strip()
+        if text and not _company_signal_looks_like_company_size_label(text):
+            return True
+    return False
+
+
+def _company_signal_has_verified_or_direct_anchor(signal: Mapping[str, Any]) -> bool:
+    """Return whether a row carries a trusted resolved identity or direct employer anchor."""
+    resolution_confidence = str(signal.get("resolution_confidence") or "").strip().lower()
+    trusted_resolution = resolution_confidence in {"high", "medium"}
+    return trusted_resolution or _company_signal_has_direct_company_anchor(signal)
+
+
+def _company_signal_effective_source_identity_bonus(signal: Mapping[str, Any]) -> float:
+    """Return the usable source bonus after source-specific identity gates are applied."""
+    normalized_source = str(signal.get("source") or "").strip().lower()
+    base_bonus = _company_signal_source_identity_bonus(normalized_source)
+    if not normalized_source or base_bonus <= 0:
+        return 0.0
+    if (
+        normalized_source in _company_signal_verified_anchor_sources()
+        and not _company_signal_has_verified_or_direct_anchor(signal)
+    ):
+        return 0.0
+    return base_bonus
+
+
+def _company_signal_source_actionability_tier(source: Any) -> str:
+    """Return the configured actionability tier for a review source."""
+    normalized_source = str(source or "").strip().lower()
+    if not normalized_source:
+        return "unknown"
+    if normalized_source in _company_signal_named_account_blocked_sources():
+        return "blocked_named_account"
+    if normalized_source in _company_signal_high_identity_sources():
+        return "high_identity"
+    if normalized_source in _company_signal_verified_anchor_sources():
+        return "context_only_requires_anchor"
+    if normalized_source in _company_signal_context_rich_sources():
+        return "context_rich"
+    if normalized_source in _company_signal_low_trust_sources():
+        return "low_trust"
+    return "standard"
+
+
+def _company_signal_identity_anchor_quality(signal: Mapping[str, Any]) -> str:
+    """Return the strongest identity anchor quality available on a signal row."""
+    resolution_confidence = str(signal.get("resolution_confidence") or "").strip().lower()
+    if resolution_confidence in {"high", "medium"}:
+        return "trusted_resolution"
+    if _company_signal_has_direct_company_anchor(signal):
+        return "direct_company_anchor"
+    if str(signal.get("company_domain") or "").strip():
+        return "domain_only"
+    return "context_only"
+
+
+def _company_signal_named_account_identity_field_count(signal: Mapping[str, Any]) -> int:
+    """Count reviewer identity/context fields that strengthen named-account trust."""
+    return sum(
+        1
+        for field in (
+            signal.get("reviewer_title") or signal.get("title"),
+            signal.get("company_size") or signal.get("company_size_raw"),
+            signal.get("industry"),
+            signal.get("company_domain"),
+        )
+        if str(field or "").strip()
+    )
+
+
+def _company_signal_named_account_identity_trusted(
+    signal: Mapping[str, Any],
+    *,
+    confidence_score: Any = None,
+) -> bool:
+    """Return whether a row is strong enough for named-account consumers.
+
+    Analyst-review queues can still surface weaker rows. This gate is for
+    canonical-ready and account-level outputs that should prefer sources with
+    durable employer identity.
+    """
+    normalized_source = str(signal.get("source") or "").strip().lower()
+    if not normalized_source:
+        return False
+    if normalized_source in _company_signal_named_account_blocked_sources():
+        return False
+
+    resolution_confidence = str(signal.get("resolution_confidence") or "").strip().lower()
+    trusted_resolution = resolution_confidence in {"high", "medium"}
+    has_company_domain = bool(str(signal.get("company_domain") or "").strip())
+    company_anchor = (
+        signal.get("company_name")
+        or signal.get("reviewer_company")
+        or signal.get("company_name_raw")
+        or signal.get("raw_reviewer_company")
+        or ""
+    )
+    has_company_name = bool(str(company_anchor).strip()) and not _company_signal_looks_like_company_size_label(
+        company_anchor,
+    )
+    identity_fields = _company_signal_named_account_identity_field_count(signal)
+    min_identity_fields = int(
+        getattr(settings.b2b_churn, "company_signal_named_account_min_identity_fields", 2),
+    )
+    has_identity_context = identity_fields >= max(0, min_identity_fields)
+
+    confidence = _normalize_company_signal_confidence(
+        confidence_score if confidence_score is not None else signal.get("confidence_score"),
+    )
+    has_confidence = confidence is not None
+    low_trust_min_confidence = _normalize_company_signal_confidence(
+        getattr(settings.b2b_churn, "company_signal_low_trust_min_confidence", 0.6),
+    )
+    if low_trust_min_confidence is None:
+        low_trust_min_confidence = 0.6
+
+    if not normalized_source:
+        return trusted_resolution or has_company_domain or has_company_name or has_identity_context
+
+    if normalized_source in _company_signal_verified_anchor_sources():
+        return trusted_resolution or has_company_name
+
+    if normalized_source in _company_signal_low_trust_sources():
+        return (
+            trusted_resolution
+            or has_company_domain
+            or has_company_name
+            or (
+                has_identity_context
+                and confidence is not None
+                and confidence >= low_trust_min_confidence
+            )
+        )
+
+    if normalized_source in _company_signal_high_identity_sources():
+        return trusted_resolution or has_company_domain or has_company_name or has_identity_context or has_confidence
+
+    if normalized_source in _company_signal_context_rich_sources():
+        if bool(
+            getattr(
+                settings.b2b_churn,
+                "company_signal_context_rich_requires_company_anchor",
+                True,
+            )
+        ):
+            return trusted_resolution or has_company_domain or has_company_name
+        return trusted_resolution or has_company_domain or has_company_name or has_identity_context or has_confidence
+
+    return trusted_resolution or has_company_domain
+
+
+def _company_signal_named_account_gap_reason(
+    signal: Mapping[str, Any],
+    *,
+    confidence_score: Any = None,
+) -> str | None:
+    """Return a stable gap reason when a row lacks durable named-account trust."""
+    normalized_source = str(signal.get("source") or "").strip().lower()
+    if normalized_source in _company_signal_named_account_blocked_sources():
+        return "non_actionable_named_account_source"
+    if _company_signal_named_account_identity_trusted(
+        signal,
+        confidence_score=confidence_score,
+    ):
+        return None
+    return "weak_identity_context"
+
+
+def _company_signal_low_trust_analyst_min_confidence() -> float:
+    """Return the minimum confidence for low-trust analyst-review queue admission."""
+    confidence = _normalize_company_signal_confidence(
+        getattr(
+            settings.b2b_churn,
+            "company_signal_low_trust_analyst_min_confidence",
+            0.35,
+        ),
+    )
+    if confidence is None:
+        return 0.35
+    return confidence
+
+
+def _company_signal_below_threshold_analyst_max_urgency_gap() -> float:
+    """Return the maximum urgency gap allowed for below-threshold analyst rows."""
+    try:
+        return float(
+            getattr(
+                settings.b2b_churn,
+                "company_signal_below_threshold_analyst_max_urgency_gap",
+                2.0,
+            )
+        )
+    except (TypeError, ValueError):
+        return 2.0
+
+
+def _company_signal_low_trust_source_membership_sql(expr: str) -> str:
+    """Return SQL that checks whether a source expression is in the configured low-trust set."""
+    sources = sorted(_company_signal_low_trust_sources())
+    if not sources:
+        return "FALSE"
+    literals = ", ".join("'" + source.replace("'", "''") + "'" for source in sources)
+    return f"LOWER({expr}) IN ({literals})"
+
+
+def _normalize_company_signal_confidence(value: Any) -> float | None:
+    """Normalize confidence values to a 0-1 unit interval."""
+    if value is None:
+        return None
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return None
+    if confidence > 1.0:
+        confidence /= 10.0
+    return round(min(1.0, max(0.0, confidence)), 3)
+
+
+def _company_signal_candidate_confidence_tier(value: Any) -> str:
+    """Bucket candidate confidence into operator-friendly tiers."""
+    confidence = _normalize_company_signal_confidence(value) or 0.0
+    medium_threshold = _normalize_company_signal_confidence(
+        getattr(settings.b2b_churn, "company_signal_candidate_medium_confidence", 0.3),
+    ) or 0.3
+    high_threshold = _normalize_company_signal_confidence(
+        getattr(settings.b2b_churn, "company_signal_candidate_high_confidence", 0.6),
+    ) or 0.6
+    if high_threshold < medium_threshold:
+        high_threshold = medium_threshold
+    if confidence >= high_threshold:
+        return "high"
+    if confidence >= medium_threshold:
+        return "medium"
+    return "low"
+
+
+def _company_signal_queue_sla_days() -> dict[str, float]:
+    """Return non-decreasing SLA targets for company-signal review priority bands."""
+    def _read(name: str, default: float) -> float:
+        try:
+            value = float(getattr(settings.b2b_churn, name, default))
+        except (TypeError, ValueError):
+            value = default
+        return max(0.0, value)
+
+    promote_now = _read("company_signal_queue_promote_now_sla_days", 1.0)
+    high = max(promote_now, _read("company_signal_queue_high_sla_days", 3.0))
+    medium = max(high, _read("company_signal_queue_medium_sla_days", 7.0))
+    low = max(medium, _read("company_signal_queue_low_sla_days", 14.0))
+    return {
+        "promote_now": round(promote_now, 3),
+        "high": round(high, 3),
+        "medium": round(medium, 3),
+        "low": round(low, 3),
+    }
+
+
+def _company_signal_queue_near_threshold_windows() -> dict[str, float]:
+    """Return tunable windows for blocked groups that are close to actionable thresholds."""
+
+    def _read(name: str, default: float, upper: float) -> float:
+        try:
+            value = float(getattr(settings.b2b_churn, name, default))
+        except (TypeError, ValueError):
+            value = default
+        return min(max(0.0, value), upper)
+
+    return {
+        "confidence_gap": round(_read("company_signal_queue_near_confidence_gap_max", 0.1, 1.0), 3),
+        "urgency_gap": round(_read("company_signal_queue_near_urgency_gap_max", 1.0, 10.0), 3),
+    }
+
+
+def _company_signal_candidate_group_pending_age_days_sql(alias: str = "") -> str:
+    """Return SQL for grouped candidate queue age in days."""
+    p = f"{alias}." if alias else ""
+    return (
+        f"EXTRACT(EPOCH FROM (NOW() - COALESCE({p}review_status_updated_at, {p}first_seen_at)))"
+        f" / 86400.0"
+    )
+
+
+def _eligible_review_timestamp_expr(*, alias: str = "") -> str:
+    """Stable review-occurrence timestamp for intelligence windows."""
+    p = f"{alias}." if alias else ""
+    return f"COALESCE({p}reviewed_at, {p}imported_at, {p}enriched_at)"
+
+
+def _eligible_review_filters(
+    *,
+    window_param: int | None = 1,
+    source_param: int = 2,
+    alias: str = "",
+    vendor_expr: str | None = None,
+) -> str:
+    """Build a reusable SQL predicate for eligible intelligence review rows.
+
+    When *alias* is set (e.g. ``"r"``), column references are prefixed
+    with the table alias so the predicate works inside JOINed queries.
+    """
+    p = f"{alias}." if alias else ""
+    time_expr = _eligible_review_timestamp_expr(alias=alias)
+    vendor_ref = vendor_expr or f"{p}vendor_name"
+    status_list = ", ".join(
+        f"'{status}'"
+        for status in _INTELLIGENCE_ELIGIBLE_STATUSES
+        if re.fullmatch(r"[a-z_]+", status)
+    )
+    parts = [f"{p}enrichment_status IN ({status_list})"]
+    parts.append(f"{p}duplicate_of_review_id IS NULL")
+    if window_param is not None:
+        parts.append(f"{time_expr} > NOW() - make_interval(days => ${window_param})")
+    parts.append(f"{p}source = ANY(${source_param}::text[])")
+    parts.append(f"COALESCE({p}raw_metadata->>'extraction_method', '') != 'jsonld_aggregate'")
+    parts.append(
+        f"NOT EXISTS (SELECT 1 FROM data_corrections dc"
+        f" WHERE dc.entity_type = 'review' AND dc.entity_id = {p}id"
+        f" AND dc.correction_type = 'suppress' AND dc.status = 'applied')"
+    )
+    # Exclude reviews from suppressed sources (global or vendor-scoped)
+    parts.append(
+        f"NOT EXISTS (SELECT 1 FROM data_corrections dc2"
+        f" WHERE dc2.entity_type = 'source'"
+        f" AND dc2.correction_type = 'suppress_source'"
+        f" AND dc2.status = 'applied'"
+        f" AND LOWER(dc2.metadata->>'source_name') = LOWER({p}source)"
+        f" AND (dc2.field_name IS NULL OR LOWER(dc2.field_name) = LOWER({vendor_ref}))"
+        f")"
+    )
+    return "\n          AND ".join(parts)
+
+
+def _review_vendor_match_join(
+    *,
+    review_alias: str = "r",
+    vendor_param: int | None = None,
+    scoped_param: int | None = None,
+    output_alias: str = "matched_vm",
+) -> str:
+    """Return a lateral join that resolves a review row to one matched vendor."""
+    conditions = [f"vm.review_id = {review_alias}.id"]
+    if vendor_param is None and scoped_param is None:
+        conditions.append("vm.is_primary = TRUE")
+    if vendor_param is not None:
+        conditions.append(f"vm.vendor_name ILIKE '%' || ${vendor_param} || '%'")
+    if scoped_param is not None:
+        conditions.append(f"vm.vendor_name = ANY(${scoped_param}::text[])")
+    where_sql = "\n              AND ".join(conditions)
+    return f"""
+        JOIN LATERAL (
+            SELECT vm.vendor_name
+            FROM b2b_review_vendor_mentions vm
+            WHERE {where_sql}
+            ORDER BY vm.is_primary DESC, vm.vendor_name ASC
+        ) {output_alias} ON TRUE
+    """
+
+
+def _review_vendor_association_join(
+    *,
+    review_alias: str = "r",
+    output_alias: str = "vm",
+    primary_only: bool = False,
+) -> str:
+    """Return a join that expands a review row to vendor associations."""
+    conditions = [f"{output_alias}.review_id = {review_alias}.id"]
+    if primary_only:
+        conditions.append(f"{output_alias}.is_primary = TRUE")
+    return (
+        f"JOIN b2b_review_vendor_mentions {output_alias}"
+        f" ON {' AND '.join(conditions)}"
+    )
+
+
+def _parse_task_result_payload(result_text: Any) -> dict[str, Any]:
+    """Safely parse scheduler result payloads stored as JSON or legacy literals."""
+    if isinstance(result_text, dict):
+        return result_text
+    if not isinstance(result_text, str):
+        return {}
+    try:
+        parsed = json.loads(result_text)
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+    if isinstance(parsed, dict):
+        return parsed
+    try:
+        legacy = ast.literal_eval(result_text)
+    except (SyntaxError, ValueError):
+        return {}
+    return legacy if isinstance(legacy, dict) else {}
+
+
+def _extract_scrape_intake_funnel_from_result(
+    payload: dict[str, Any],
+    *,
+    allowed_sources: set[str],
+) -> dict[str, int] | None:
+    """Extract source-filtered scrape funnel totals from one task result payload."""
+    def _count(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _company_signal_count(row: dict[str, Any]) -> int:
+        if "company_signal_eligible_reviews" in row:
+            return _count(row.get("company_signal_eligible_reviews"))
+        if "company_signal_reviews" in row:
+            return _count(row.get("company_signal_reviews"))
+        # Legacy scrape payloads only persisted named_company_reviews before the
+        # eligible-vs-raw_only split existed in task results.
+        return _count(row.get("named_company_reviews"))
+
+    rows = payload.get("results")
+    if not isinstance(rows, list):
+        return None
+    totals = {
+        "found": 0,
+        "filtered": 0,
+        "short_flagged": 0,
+        "quality_gated": 0,
+        "duplicate_or_existing": 0,
+        "retained_pending": 0,
+        "retained_raw_only": 0,
+        "inserted": 0,
+        "company_signal_eligible": 0,
+    }
+    matched = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("source") or "").strip().lower() not in allowed_sources:
+            continue
+        matched += 1
+        totals["found"] += _count(row.get("found"))
+        totals["filtered"] += _count(row.get("filtered"))
+        totals["short_flagged"] += _count(row.get("short_flagged"))
+        totals["quality_gated"] += _count(row.get("quality_gate_flagged"))
+        totals["duplicate_or_existing"] += _count(row.get("duplicate_or_existing"))
+        totals["retained_pending"] += _count(row.get("retained_pending"))
+        totals["retained_raw_only"] += _count(row.get("retained_raw_only"))
+        totals["inserted"] += _count(row.get("inserted"))
+        totals["company_signal_eligible"] += _company_signal_count(row)
+    return totals if matched else None
+
+
+async def _fetch_recent_scrape_intake_funnel(pool, window_days: int, sources: list[str]) -> dict[str, int]:
+    """Aggregate recent scrape-intake funnel counts from source-filtered task results."""
+    rows = await pool.fetch(
+        """
+        SELECT e.result_text
+        FROM task_executions e
+        JOIN scheduled_tasks t ON t.id = e.task_id
+        WHERE t.name = 'b2b_scrape_intake'
+          AND e.status = 'completed'
+          AND e.started_at > NOW() - make_interval(days => $1)
+        ORDER BY e.started_at DESC
+        """,
+        window_days,
+    )
+    totals: dict[str, int] = {
+        "runs": 0,
+        "found": 0,
+        "filtered": 0,
+        "short_flagged": 0,
+        "quality_gated": 0,
+        "duplicate_or_existing": 0,
+        "retained_pending": 0,
+        "retained_raw_only": 0,
+        "inserted": 0,
+        "company_signal_eligible": 0,
+    }
+    allowed_sources = {
+        str(source or "").strip().lower()
+        for source in sources
+        if str(source or "").strip()
+    }
+    if not allowed_sources:
+        return totals
+    for row in rows:
+        payload = _parse_task_result_payload(row.get("result_text"))
+        funnel = _extract_scrape_intake_funnel_from_result(
+            payload,
+            allowed_sources=allowed_sources,
+        )
+        if funnel is None:
+            continue
+        totals["runs"] += 1
+        for key in (
+            "found",
+            "filtered",
+            "short_flagged",
+            "quality_gated",
+            "duplicate_or_existing",
+            "retained_pending",
+            "retained_raw_only",
+            "inserted",
+            "company_signal_eligible",
+        ):
+            try:
+                totals[key] += int(funnel.get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+    return totals
+
+
+async def _fetch_review_funnel_audit(pool, window_days: int) -> dict[str, Any]:
+    """Return end-to-end review funnel counts for the active intelligence sources."""
+    sources = _intelligence_source_allowlist()
+    eligible_filters = _eligible_review_filters(window_param=1, source_param=2)
+    status_rows = await pool.fetch(
+        """
+        SELECT enrichment_status, count(*) AS ct
+        FROM b2b_reviews
+        WHERE duplicate_of_review_id IS NULL
+          AND source = ANY($1::text[])
+          AND COALESCE(reviewed_at, imported_at, enriched_at) > NOW() - make_interval(days => $2)
+        GROUP BY enrichment_status
+        """,
+        sources,
+        window_days,
+    )
+    status_counts = {
+        str(row["enrichment_status"] or ""): int(row["ct"] or 0)
+        for row in status_rows
+    }
+    eligible_row = await pool.fetchrow(
+        f"""
+        SELECT
+            count(*) AS intelligence_eligible_reviews,
+            count(*) FILTER (
+                WHERE reviewer_company_norm IS NOT NULL
+                  AND reviewer_company_norm <> ''
+            ) AS company_signal_eligible_reviews,
+            count(*) FILTER (
+                WHERE reviewer_company_norm IS NOT NULL
+                  AND reviewer_company_norm <> ''
+                  AND source <> ALL($3::text[])
+            ) AS trusted_named_account_reviews
+        FROM b2b_reviews
+        WHERE {eligible_filters}
+        """,
+        window_days,
+        sources,
+        list(_company_signal_low_trust_sources()),
+    )
+
+    def _row_count(key: str) -> int:
+        if not eligible_row:
+            return 0
+        return int((eligible_row[key] or 0))
+
+    intelligence_eligible_reviews = _row_count("intelligence_eligible_reviews")
+    company_signal_eligible_reviews = _row_count("company_signal_eligible_reviews")
+    trusted_named_account_reviews = _row_count("trusted_named_account_reviews")
+    scrape_intake = await _fetch_recent_scrape_intake_funnel(pool, window_days, sources)
+    return {
+        "found": sum(status_counts.values()),
+        "enriched": status_counts.get("enriched", 0),
+        "no_signal": status_counts.get("no_signal", 0),
+        "quarantined": status_counts.get("quarantined", 0),
+        "raw_only": status_counts.get("raw_only", 0),
+        "pending": status_counts.get("pending", 0),
+        "failed": status_counts.get("failed", 0),
+        "not_applicable": status_counts.get("not_applicable", 0),
+        "duplicate": status_counts.get("duplicate", 0),
+        "intelligence_eligible": intelligence_eligible_reviews,
+        "company_signal_eligible": company_signal_eligible_reviews,
+        "trusted_named_account": trusted_named_account_reviews,
+        "high_confidence_named_account": trusted_named_account_reviews,
+        "scrape_runs": scrape_intake["runs"],
+        "scrape_found": scrape_intake["found"],
+        "scrape_filtered": scrape_intake["filtered"],
+        "scrape_short_flagged": scrape_intake["short_flagged"],
+        "scrape_quality_gated": scrape_intake["quality_gated"],
+        "scrape_duplicate_or_existing": scrape_intake["duplicate_or_existing"],
+        "scrape_retained_pending": scrape_intake["retained_pending"],
+        "scrape_retained_raw_only": scrape_intake["retained_raw_only"],
+        "scrape_inserted": scrape_intake["inserted"],
+        "scrape_company_signal_eligible": scrape_intake["company_signal_eligible"],
+    }
+
+
+def _quote_text(q: Any) -> str | None:
+    """Extract plain quote text from a quote item (dict or string)."""
+    if isinstance(q, str):
+        return q
+    if isinstance(q, dict):
+        return q.get("quote")
+    return None
+
+
+def _strip_quote_ids(quotes: list) -> list[str]:
+    """Strip review_ids from quote dicts, returning plain strings for LLM payloads."""
+    return [t for q in quotes if (t := _quote_text(q))]
+
+
+def _safe_json(value: Any, default: Any = None) -> Any:
+    """Safely deserialize a JSON value, returning *default* on failure."""
+    if default is None:
+        default = []
+    if value is None:
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Malformed JSON in aggregation data: %.100r", value)
+            return default
+    return default
+
+
+def _parse_enrichment_dict(value: Any) -> dict[str, Any] | None:
+    """Parse a JSONB enrichment payload without turning missing data into {}."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _quote_grade_rows_from_enrichment(
+    enrichment: dict[str, Any] | None,
+    *,
+    urgency: float | None = None,
+    review_id: Any = None,
+    source: Any = None,
+    company: Any = None,
+    title: Any = None,
+    company_size: Any = None,
+    industry: Any = None,
+) -> list[dict[str, Any]]:
+    """Build quote rows that are safe for customer-facing quote rendering."""
+    rows: list[dict[str, Any]] = []
+    for phrase in quote_grade_phrases(enrichment):
+        text = str(phrase.get("text") or "").strip()
+        if not text:
+            continue
+        row: dict[str, Any] = {
+            "quote": text[:500],
+            "urgency": urgency,
+            "review_id": str(review_id) if review_id else None,
+            "source_site": source,
+            "phrase_verbatim": True,
+            "quote_origin": "review",
+            "field": phrase.get("field"),
+        }
+        if company:
+            row["company"] = company
+        if title:
+            row["title"] = title
+        if company_size:
+            row["company_size"] = company_size
+        if industry:
+            row["industry"] = industry
+        rows.append(row)
+    return rows
+
+
+def _battle_card_iter_text(value: Any, path: str = ""):
+    """Yield flattened string fields from nested battle-card payloads."""
+    if isinstance(value, str):
+        yield path, value
+        return
+    if isinstance(value, dict):
+        for key, inner in value.items():
+            next_path = f"{path}.{key}" if path else str(key)
+            yield from _battle_card_iter_text(inner, next_path)
+        return
+    if isinstance(value, list):
+        for idx, inner in enumerate(value):
+            next_path = f"{path}[{idx}]"
+            yield from _battle_card_iter_text(inner, next_path)
+
+
+def _battle_card_numeric_paths(path: str) -> bool:
+    """Return True when a path should contain only input-supported claims."""
+    return (
+        path == "executive_summary"
+        or ".evidence" in path
+        or ".proof_point" in path
+        or path.startswith("competitive_landscape.")
+        or path.startswith("recommended_plays[")
+        or path.startswith("talk_track.")
+    )
+
+
+def _battle_card_headline_paths(path: str) -> bool:
+    """Return True for top-line summary fields that should stay on strong evidence."""
+    return path == "executive_summary" or path.startswith("weakness_analysis[0].")
+
+
+def _battle_card_numeric_tokens(text: str) -> set[str]:
+    """Extract numeric tokens from narrative sections for validation."""
+    tokens: set[str] = set()
+    for match in re.finditer(r"\b\d[\d,]*(?:\.\d+)?%?", text or ""):
+        token = match.group(0)
+        start, end = match.span()
+        next_char = text[end] if end < len(text or "") else ""
+        next_next = text[end + 1] if end + 1 < len(text or "") else ""
+        normalized = token.replace(",", "").rstrip("%")
+        # Ignore UI-style singleton compounds like "1-click" that are not
+        # economic or corpus-level claims. Multi-digit timeline claims such as
+        # "12-month" still flow through validation.
+        if len(normalized) == 1 and next_char == "-" and next_next.isalpha():
+            continue
+        tokens.add(token)
+    return tokens
+
+
+def _battle_card_normalize_numeric_token(token: str) -> str:
+    """Canonicalize equivalent numeric strings like 27 and 27.0%."""
+    text = str(token or "").strip()
+    if not text:
+        return text
+    has_pct = text.endswith("%")
+    raw = text[:-1] if has_pct else text
+    raw = raw.replace(",", "")
+    try:
+        numeric = float(raw)
+    except ValueError:
+        return text
+    if numeric.is_integer():
+        base = str(int(numeric))
+    else:
+        base = f"{numeric:.1f}".rstrip("0").rstrip(".")
+    return f"{base}%" if has_pct else base
+
+
+def _battle_card_add_claim(claims: set[str], value: Any, *, pct: bool = False) -> None:
+    """Add an allowed numeric claim token derived from source data."""
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return
+    if pct:
+        num *= 100.0
+    rounded = round(num, 1)
+    if float(rounded).is_integer():
+        base = f"{int(round(rounded))}"
+    else:
+        base = f"{rounded:.1f}"
+    claims.add(base)
+    claims.add(f"{int(round(num)):,}" if not pct and num >= 1000 else base)
+    if pct:
+        claims.add(f"{base}%")
+        claims.add(f"{int(round(num))}%")
+    elif num >= 1000:
+        claims.add(f"{int(round(num))}")
+
+
+def _battle_card_add_wrapper_claim(claims: set[str], wrapper: Any) -> None:
+    """Add numeric tokens from a {value, source_id} wrapper when possible."""
+    if not isinstance(wrapper, dict):
+        return
+    _battle_card_add_claim(claims, wrapper.get("value"))
+
+
+def _battle_card_add_text_numeric_claims(claims: set[str], text: Any) -> None:
+    """Add normalized numeric tokens pulled from witness-backed text."""
+    excerpt = str(text or "")
+    if not excerpt:
+        return
+    for token in re.findall(r"\$?\d[\d,]*(?:\.\d+)?%?", excerpt):
+        normalized = _battle_card_normalize_numeric_token(token.lstrip("$"))
+        if normalized:
+            claims.add(normalized)
+
+
+def _battle_card_add_witness_numeric_claims(claims: set[str], witness_blob: Any) -> None:
+    """Import numeric claims from raw witness/anchor payloads."""
+    if isinstance(witness_blob, dict):
+        if "excerpt_text" in witness_blob or "quote" in witness_blob:
+            _battle_card_add_text_numeric_claims(claims, witness_blob.get("excerpt_text"))
+            _battle_card_add_text_numeric_claims(claims, witness_blob.get("quote"))
+            return
+        for value in witness_blob.values():
+            _battle_card_add_witness_numeric_claims(claims, value)
+        return
+    if isinstance(witness_blob, list):
+        for item in witness_blob:
+            _battle_card_add_witness_numeric_claims(claims, item)
+        return
+    return
+
+
+def _battle_card_allowed_claims(card: dict[str, Any]) -> set[str]:
+    """Build the set of numeric claims supported by deterministic card input."""
+    claims: set[str] = set()
+    _battle_card_add_claim(claims, card.get("total_reviews"))
+    _battle_card_add_claim(claims, card.get("churn_pressure_score"))
+    acct = card.get("account_pressure_metrics") or {}
+    for key in ("total_accounts", "active_eval_count", "high_intent_count"):
+        _battle_card_add_claim(claims, acct.get(key))
+    for item in card.get("high_intent_companies") or []:
+        if isinstance(item, dict):
+            _battle_card_add_claim(claims, item.get("urgency"))
+    data = card.get("objection_data") or {}
+    for key in ("price_complaint_rate", "dm_churn_rate"):
+        _battle_card_add_claim(claims, data.get(key), pct=True)
+    for key in ("churn_signal_density", "avg_urgency", "total_reviews"):
+        _battle_card_add_claim(claims, data.get(key))
+    for item in card.get("vendor_weaknesses") or []:
+        _battle_card_add_claim(claims, item.get("evidence_count") or item.get("count"))
+    for item in _battle_card_aggregated_competitors(card).values():
+        _battle_card_add_claim(claims, item.get("mentions"))
+        _battle_card_add_claim(claims, item.get("switch_count"))
+    for item in data.get("top_feature_gaps") or []:
+        _battle_card_add_claim(claims, item.get("mentions"))
+    for key in ("avg_seat_count", "max_seat_count", "median_seat_count", "price_increase_count"):
+        _battle_card_add_claim(claims, (data.get("budget_context") or {}).get(key))
+    _battle_card_add_claim(claims, (data.get("budget_context") or {}).get("price_increase_rate"), pct=True)
+    contracts = card.get("reasoning_contracts")
+    if isinstance(contracts, dict):
+        vendor_core = contracts.get("vendor_core_reasoning") or {}
+        if isinstance(vendor_core, dict):
+            timing = vendor_core.get("timing_intelligence") or {}
+            if isinstance(timing, dict):
+                _battle_card_add_wrapper_claim(claims, timing.get("active_eval_signals"))
+            segments = vendor_core.get("segment_playbook") or {}
+            if isinstance(segments, dict):
+                for segment in segments.get("priority_segments") or []:
+                    if not isinstance(segment, dict):
+                        continue
+                    _battle_card_add_wrapper_claim(claims, segment.get("estimated_reach"))
+                    _battle_card_add_claim(claims, segment.get("sample_size"))
+        account_reasoning = contracts.get("account_reasoning") or {}
+        if isinstance(account_reasoning, dict):
+            _battle_card_add_wrapper_claim(claims, account_reasoning.get("total_accounts"))
+            _battle_card_add_wrapper_claim(claims, account_reasoning.get("active_eval_count"))
+            _battle_card_add_wrapper_claim(claims, account_reasoning.get("high_intent_count"))
+        displacement = contracts.get("displacement_reasoning") or {}
+        if isinstance(displacement, dict):
+            migration = displacement.get("migration_proof") or {}
+            if isinstance(migration, dict):
+                _battle_card_add_wrapper_claim(claims, migration.get("switch_volume"))
+                _battle_card_add_wrapper_claim(claims, migration.get("active_evaluation_volume"))
+                _battle_card_add_wrapper_claim(claims, migration.get("displacement_mention_volume"))
+            reframes = displacement.get("competitive_reframes") or {}
+            if isinstance(reframes, dict):
+                for item in reframes.get("reframes") or []:
+                    if not isinstance(item, dict):
+                        continue
+                    proof = item.get("proof_point") or {}
+                    if isinstance(proof, dict):
+                        _battle_card_add_claim(claims, proof.get("value"))
+        category = contracts.get("category_reasoning") or {}
+        if isinstance(category, dict):
+            _battle_card_add_claim(claims, category.get("vendor_count"))
+            _battle_card_add_claim(claims, category.get("displacement_flow_count"))
+    _battle_card_add_witness_numeric_claims(claims, card.get("anchor_examples"))
+    _battle_card_add_witness_numeric_claims(claims, card.get("witness_highlights"))
+    return claims
+
+
+def _battle_card_contract(card: dict[str, Any], name: str) -> dict[str, Any]:
+    """Resolve a battle-card reasoning contract from canonical storage."""
+    contracts = card.get("reasoning_contracts")
+    if isinstance(contracts, dict):
+        contract = contracts.get(name)
+        if isinstance(contract, dict) and contract:
+            return contract
+        if contracts:
+            return {}
+    return {}
+
+
+def _battle_card_contract_section(
+    card: dict[str, Any],
+    contract_name: str,
+    section_name: str,
+    flat_name: str,
+) -> dict[str, Any]:
+    """Resolve a section from contracts first, then flat compatibility fields."""
+    contract = _battle_card_contract(card, contract_name)
+    if contract:
+        section = contract.get(section_name)
+        if isinstance(section, dict) and section:
+            return section
+    contracts = card.get("reasoning_contracts")
+    if isinstance(contracts, dict) and contracts:
+        return {}
+    flat = card.get(flat_name)
+    if isinstance(flat, dict) and flat:
+        return flat
+    return {}
+
+
+def _battle_card_validator_source(card: dict[str, Any]) -> dict[str, Any]:
+    """Return the contract-first source-of-truth view for validation.
+
+    The renderer now consumes a compact contract-first packet. Validation should
+    use the same authoritative view so stale flat mirrors do not expand the set
+    of accepted claims.
+    """
+    base_keys = (
+        "vendor",
+        "category",
+        "churn_pressure_score",
+        "risk_level",
+        "total_reviews",
+        "confidence",
+        "vendor_weaknesses",
+        "customer_pain_quotes",
+        "competitor_differentiators",
+        "weakness_analysis",
+        "competitive_landscape",
+        "archetype",
+        "synthesis_wedge",
+        "synthesis_wedge_label",
+        "archetype_risk_level",
+        "archetype_key_signals",
+        "evidence_depth_warning",
+        "objection_data",
+        "cross_vendor_battles",
+        "category_council",
+        "resource_asymmetry",
+        "ecosystem_context",
+        "high_intent_companies",
+        "integration_stack",
+        "buyer_authority",
+        "keyword_spikes",
+        "retention_signals",
+        "active_evaluation_deadlines",
+        "falsification_conditions",
+        "uncertainty_sources",
+        "evidence_window",
+        "evidence_window_days",
+        "reasoning_source",
+        "synthesis_schema_version",
+        "render_packet_version",
+    )
+    source = {
+        key: card[key]
+        for key in base_keys
+        if key in card
+    }
+    reasoning_contracts = card.get("reasoning_contracts")
+    if isinstance(reasoning_contracts, dict) and reasoning_contracts:
+        source["reasoning_contracts"] = reasoning_contracts
+
+    for contract_name, section_name, flat_name in (
+        ("vendor_core_reasoning", "causal_narrative", "causal_narrative"),
+        ("vendor_core_reasoning", "segment_playbook", "segment_playbook"),
+        ("vendor_core_reasoning", "timing_intelligence", "timing_intelligence"),
+        ("displacement_reasoning", "competitive_reframes", "competitive_reframes"),
+        ("displacement_reasoning", "migration_proof", "migration_proof"),
+    ):
+        section = _battle_card_contract_section(card, contract_name, section_name, flat_name)
+        if section:
+            source[flat_name] = section
+    return source
+
+
+def _battle_card_competitor_names(card: dict[str, Any], *, limit: int = 2) -> list[str]:
+    """Return top competitor names already present in deterministic card input."""
+    names: list[str] = []
+    for item in card.get("competitor_differentiators") or []:
+        competitor = str(item.get("competitor") or "").strip()
+        if competitor and competitor not in names:
+            names.append(competitor)
+        if len(names) >= limit:
+            break
+    return names
+
+
+def _join_summary_terms(items: list[str]) -> str:
+    """Join short label lists into readable executive-summary phrasing."""
+    cleaned = [str(item).strip() for item in items if str(item).strip()]
+    if not cleaned:
+        return ""
+    if len(cleaned) == 1:
+        return cleaned[0]
+    if len(cleaned) == 2:
+        return f"{cleaned[0]} and {cleaned[1]}"
+    return ", ".join(cleaned[:-1]) + f", and {cleaned[-1]}"
+
+
+def _battle_card_safe_summary(card: dict[str, Any]) -> str:
+    """Build a grounded executive summary when generated copy overclaims."""
+    vendor = str(card.get("vendor") or "This vendor").strip() or "This vendor"
+    weaknesses = [
+        str(item.get("area") or item.get("weakness") or "").strip().lower()
+        for item in card.get("vendor_weaknesses") or []
+        if str(item.get("area") or item.get("weakness") or "").strip()
+    ]
+    pain = weaknesses[0] if weaknesses else "customer fit"
+    competitors = _battle_card_competitor_names(card)
+    if competitors:
+        return (
+            f"{vendor} is showing churn pressure around {pain} while buyers "
+            f"re-evaluate fit against {_join_summary_terms(competitors)}."
+        )
+    return f"{vendor} is showing churn pressure around {pain} in recent buyer feedback."
+
+
+def _battle_card_segment_evidence_is_thin(card: dict[str, Any]) -> bool:
+    """Return True when segment targeting should stay explicitly tentative."""
+    if card.get("high_intent_companies"):
+        return False
+    segment_playbook = _battle_card_contract_section(
+        card,
+        "vendor_core_reasoning",
+        "segment_playbook",
+        "segment_playbook",
+    )
+    if not isinstance(segment_playbook, dict) or not segment_playbook:
+        return False
+    data_gaps = [
+        str(item).strip().lower()
+        for item in (segment_playbook.get("data_gaps") or [])
+        if str(item).strip()
+    ]
+    return any("no account-level intelligence" in gap for gap in data_gaps)
+
+
+def _battle_card_segment_playbook(card: dict[str, Any]) -> dict[str, Any]:
+    """Return the contract-first segment playbook section."""
+    return _battle_card_contract_section(
+        card,
+        "vendor_core_reasoning",
+        "segment_playbook",
+        "segment_playbook",
+    )
+
+
+_SEGMENT_STRATEGIC_ROLE_TYPES = frozenset((
+    "decision_maker",
+    "economic_buyer",
+    "champion",
+    "evaluator",
+))
+
+_SEGMENT_ROLE_LABELS: dict[str, str] = {
+    "decision_maker": "decision-makers",
+    "economic_buyer": "economic buyers",
+    "champion": "internal champions",
+    "evaluator": "evaluators",
+    "end_user": "end users",
+}
+
+_SEGMENT_DEPARTMENT_LABELS: dict[str, str] = {
+    "it": "IT",
+    "hr": "HR",
+    "qa": "QA",
+    "bi": "BI",
+}
+
+_SEGMENT_GENERIC_CONTRACTS = frozenset((
+    "smb",
+    "mid market",
+    "enterprise",
+    "enterprise mid",
+    "enterprise high",
+))
+
+_SEGMENT_SAFE_USE_CASE_ACRONYMS = frozenset((
+    "crm", "erp", "hr", "hris", "it", "bi", "qa", "seo", "sms",
+    "etl", "api", "csm", "plg", "okr", "kpi",
+))
+
+_SEGMENT_PRIORITY_LABEL_OVERRIDES: dict[str, str] = {
+    "small business": "Small Business",
+    "mid market": "Mid-Market",
+}
+
+_SEGMENT_OPENING_ANGLE_LOWERCASE_WORDS = frozenset((
+    "advanced",
+    "benchmark",
+    "compare",
+    "cost",
+    "demonstrate",
+    "emphasize",
+    "feature",
+    "focus",
+    "frame",
+    "highlight",
+    "lead",
+    "license",
+    "offer",
+    "open",
+    "position",
+    "reliable",
+    "show",
+    "simplified",
+    "target",
+    "use",
+))
+
+_TIMING_GENERIC_TRIGGER_PATTERNS = (
+    "active evaluation signal",
+    "active evaluation signals",
+    "signal detected",
+    "price increase signal",
+    "price increase count spike",
+    "timeline signal",
+    "contract renewal deadline",
+    "within quarter evaluation deadline",
+)
+
+
+def _clean_segment_label(value: Any) -> str:
+    text = re.sub(r"[_-]+", " ", str(value or "").strip())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _join_segment_labels(labels: list[str]) -> str:
+    items = [str(label).strip() for label in labels if str(label).strip()]
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def _segment_role_display_label(role_type: Any) -> str:
+    role_name = str(role_type or "").strip() or "unknown"
+    return _SEGMENT_ROLE_LABELS.get(role_name, _clean_segment_label(role_name) or "buyers")
+
+
+def _segment_priority_display_label(value: Any) -> str:
+    text = re.sub(r"\([^)]*\d[^)]*\)", "", _clean_segment_label(value)).strip(" -")
+    if not text:
+        return ""
+    lower = re.sub(r"\s+role$", "", text.lower()).strip()
+    role_key = lower.replace(" ", "_")
+    if role_key in _SEGMENT_ROLE_LABELS:
+        return _segment_role_display_label(role_key)
+    override = _SEGMENT_PRIORITY_LABEL_OVERRIDES.get(lower)
+    if override:
+        return override
+    return text
+
+
+def _segment_opening_angle_phrase(value: Any) -> str:
+    text = _clean_segment_label(value)
+    if not text:
+        return ""
+    first_word = text.split(" ", 1)[0].strip().lower()
+    if first_word in _SEGMENT_OPENING_ANGLE_LOWERCASE_WORDS:
+        return text[:1].lower() + text[1:]
+    return text
+
+
+def _segment_playbook_supporting_list(
+    segment_playbook: dict[str, Any],
+    key: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(segment_playbook, dict):
+        return []
+    supporting = segment_playbook.get("supporting_evidence") or {}
+    items = supporting.get(key) or []
+    return [dict(item) for item in items if isinstance(item, dict)]
+
+
+def _segment_role_sort_value(item: dict[str, Any]) -> tuple[float, float, float, str]:
+    role_type = str(item.get("role_type") or "").strip() or "unknown"
+    try:
+        priority = float(item.get("priority_score") or 0)
+    except (TypeError, ValueError):
+        priority = 0.0
+    try:
+        review_count = float(item.get("review_count") or 0)
+    except (TypeError, ValueError):
+        review_count = 0.0
+    return (priority, review_count, _SEGMENT_ROLE_SCORES.get(role_type, 0.0), role_type)
+
+
+def _segment_playbook_strategic_roles(
+    segment_playbook: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    roles = _segment_playbook_supporting_list(segment_playbook, "top_strategic_roles")
+    if not roles:
+        roles = [
+            item for item in _segment_playbook_supporting_list(segment_playbook, "top_roles")
+            if str(item.get("role_type") or "").strip() in _SEGMENT_STRATEGIC_ROLE_TYPES
+        ]
+    roles.sort(key=_segment_role_sort_value, reverse=True)
+    return roles[:limit]
+
+
+def _segment_playbook_context_label(
+    segment_playbook: dict[str, Any],
+    key: str,
+    field: str,
+) -> str:
+    items = _segment_playbook_supporting_list(segment_playbook, key)
+    if not items:
+        return ""
+    return _clean_segment_label(items[0].get(field))
+
+
+def _segment_department_label(value: Any) -> str:
+    text = _clean_segment_label(value).lower()
+    if not text:
+        return ""
+    return _SEGMENT_DEPARTMENT_LABELS.get(text, text.title())
+
+
+def _segment_context_key(value: Any) -> str:
+    text = _clean_segment_label(value).lower()
+    if not text:
+        return ""
+    return re.sub(r"[^a-z0-9]+", " ", text).strip()
+
+
+def _segment_contract_clause(segment_playbook: dict[str, Any]) -> tuple[int, str]:
+    text = _segment_playbook_context_label(segment_playbook, "top_contract_segments", "segment")
+    if not text:
+        return (0, "")
+    priority = 35 if text.lower() in _SEGMENT_GENERIC_CONTRACTS else 50
+    return (priority, f"{text} contracts")
+
+
+def _segment_safe_use_case_label(value: Any) -> str:
+    text = _clean_segment_label(value)
+    if not text:
+        return ""
+    raw_tokens = [tok for tok in re.split(r"\s+", text) if tok]
+    if not raw_tokens:
+        return ""
+    has_title_case = any(
+        any(ch.isupper() for ch in tok[1:]) or (tok[:1].isupper() and tok[1:].islower())
+        for tok in raw_tokens
+    )
+    if has_title_case:
+        return ""
+    normalized = text.lower()
+    compact = re.sub(r"[^a-z0-9/+-]", "", normalized)
+    if compact in _SEGMENT_SAFE_USE_CASE_ACRONYMS:
+        return text.upper()
+    words = [tok for tok in re.split(r"[^a-z0-9/+-]+", normalized) if tok]
+    if not words:
+        return ""
+    if len(words) == 1 and len(words[0]) > 12:
+        return ""
+    return text
+
+
+def _segment_context_clauses(
+    segment_playbook: dict[str, Any],
+    *,
+    limit: int = 2,
+) -> list[tuple[str, str]]:
+    candidates: list[tuple[int, str, str]] = []
+    department = _segment_department_label(
+        _segment_playbook_context_label(segment_playbook, "top_departments", "department"),
+    )
+    if department:
+        candidates.append((90, "in", f"{department} teams"))
+    size = _segment_playbook_context_label(segment_playbook, "top_company_sizes", "segment")
+    size_key = _segment_context_key(size)
+    if size:
+        candidates.append((80, "in", f"{size} accounts"))
+    safe_use_case = ""
+    for item in _segment_playbook_supporting_list(segment_playbook, "top_use_cases"):
+        safe_use_case = _segment_safe_use_case_label(item.get("use_case"))
+        if safe_use_case:
+            break
+    if safe_use_case:
+        candidates.append((65, "plain", f"for {safe_use_case} workflows"))
+    duration = _segment_playbook_context_label(segment_playbook, "top_usage_durations", "duration")
+    if duration:
+        candidates.append((55, "plain", f"after {duration} of usage"))
+    contract_priority, contract_clause = _segment_contract_clause(segment_playbook)
+    contract_key = _segment_context_key(
+        _segment_playbook_context_label(segment_playbook, "top_contract_segments", "segment"),
+    )
+    if contract_clause and contract_key != size_key:
+        candidates.append((contract_priority, "in", contract_clause))
+    candidates.sort(key=lambda item: (item[0], item[2]), reverse=True)
+    clauses: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for _, mode, clause in candidates:
+        norm = clause.lower()
+        if norm in seen:
+            continue
+        seen.add(norm)
+        clauses.append((mode, clause))
+        if len(clauses) >= limit:
+            break
+    return clauses
+
+
+def _segment_best_timing_sentence(timing_intelligence: dict[str, Any] | None) -> str:
+    if not isinstance(timing_intelligence, dict):
+        return ""
+    window = _clean_segment_label(timing_intelligence.get("best_timing_window"))
+    if not window:
+        return ""
+    lower = window[:1].lower() + window[1:] if window else ""
+    if re.match(r"^(during|before|after|when|within|immediately|at)\b", lower):
+        return f"Best tested {lower}."
+    return f"Best tested during {lower}."
+
+
+def _segment_targeting_summary(
+    segment_playbook: dict[str, Any],
+    timing_intelligence: dict[str, Any] | None = None,
+) -> str:
+    roles = _segment_playbook_strategic_roles(segment_playbook, limit=2)
+    if roles:
+        labels = [_segment_role_display_label(item.get("role_type")) for item in roles]
+        contexts = _segment_context_clauses(segment_playbook, limit=2)
+        summary = f"Strongest current pressure is surfacing with {_join_segment_labels(labels)}"
+        in_clauses = [text for mode, text in contexts if mode == "in"]
+        plain_clauses = [text for mode, text in contexts if mode == "plain"]
+        if in_clauses and plain_clauses:
+            sentence = (
+                f"{summary}, especially in {_join_segment_labels(in_clauses)}, "
+                f"and {_join_segment_labels(plain_clauses)}."
+            )
+        elif in_clauses:
+            sentence = f"{summary}, especially in {_join_segment_labels(in_clauses)}."
+        elif plain_clauses:
+            sentence = f"{summary}, especially {_join_segment_labels(plain_clauses)}."
+        else:
+            sentence = summary + "."
+        timing = _segment_best_timing_sentence(timing_intelligence)
+        context_texts = [text for _, text in contexts]
+        if timing and (not context_texts or all("contracts" in ctx.lower() for ctx in context_texts)):
+            return f"{sentence} {timing}"
+        return sentence
+    for segment in segment_playbook.get("priority_segments") or []:
+        if not isinstance(segment, dict):
+            continue
+        name = _segment_priority_display_label(segment.get("segment"))
+        angle = _segment_opening_angle_phrase(segment.get("best_opening_angle"))
+        if name and angle:
+            timing = _segment_best_timing_sentence(timing_intelligence)
+            sentence = f"Best current segment wedge is {name}, led with {angle}."
+            return f"{sentence} {timing}".strip() if timing else sentence
+        if name:
+            timing = _segment_best_timing_sentence(timing_intelligence)
+            sentence = f"Best current segment wedge is {name}."
+            return f"{sentence} {timing}".strip() if timing else sentence
+    return ""
+
+
+def _timing_wrapper_int(value: Any) -> int | None:
+    if isinstance(value, dict):
+        value = value.get("value")
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _timing_wrapper_float(value: Any) -> float | None:
+    if isinstance(value, dict):
+        value = value.get("value")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _summary_sentence(text: Any) -> str:
+    sentence = str(text or "").strip()
+    if not sentence:
+        return ""
+    sentence = sentence[0].upper() + sentence[1:]
+    if sentence[-1] not in ".!?":
+        sentence += "."
+    return sentence
+
+
+def _timing_window_conflicts_with_active_eval(
+    best_window: Any,
+    active_eval: int | None,
+) -> bool:
+    if active_eval is None or active_eval <= 0:
+        return False
+    text = str(best_window or "").strip().lower()
+    if not text:
+        return False
+    if text.startswith("no strong timing signal"):
+        return True
+    if "no active evaluation" in text:
+        return True
+    if text.startswith("none") and "no" in text:
+        return True
+    return False
+
+
+def _timing_summary_key(text: Any) -> str:
+    cleaned = str(text or "").strip().lower()
+    cleaned = re.sub(r"[_-]+", " ", cleaned)
+    cleaned = re.sub(r"[^a-z0-9% ]+", " ", cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _timing_window_is_generic(best_window: Any) -> bool:
+    text = _timing_summary_key(best_window)
+    if not text:
+        return False
+    if re.search(r"\b(after|before|following|during|when)\b", text):
+        return False
+    return text.startswith((
+        "immediate",
+        "immediately",
+        "within",
+        "next 30 days",
+        "current quarter",
+        "q4",
+        "this week",
+    ))
+
+
+def _timing_trigger_is_generic(label: Any) -> bool:
+    text = _timing_summary_key(label)
+    if not text:
+        return True
+    return any(pattern in text for pattern in _TIMING_GENERIC_TRIGGER_PATTERNS)
+
+
+def _timing_trigger_sentence(
+    best_window: Any,
+    trigger_labels: list[str],
+) -> str:
+    best_key = _timing_summary_key(best_window)
+    if not trigger_labels:
+        return ""
+    for label in trigger_labels:
+        text = str(label or "").strip()
+        key = _timing_summary_key(text)
+        if not key or _timing_trigger_is_generic(text):
+            continue
+        if best_key and (key in best_key or best_key in key):
+            continue
+        return f"Key trigger: {_summary_sentence(text).rstrip('.') }."
+    return ""
+
+
+def _timing_summary_payload(
+    timing_intelligence: dict[str, Any] | None,
+) -> tuple[str, dict[str, Any], list[str]]:
+    if not isinstance(timing_intelligence, dict) or not timing_intelligence:
+        return ("", {}, [])
+
+    metrics: dict[str, Any] = {}
+    triggers = timing_intelligence.get("immediate_triggers") or []
+    trigger_labels: list[str] = []
+    seen_triggers: set[str] = set()
+    for item in triggers:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("trigger") or item.get("label") or "").strip()
+        if not label:
+            continue
+        norm = label.casefold()
+        if norm in seen_triggers:
+            continue
+        seen_triggers.add(norm)
+        trigger_labels.append(label)
+        if len(trigger_labels) >= 3:
+            break
+    if triggers:
+        metrics["immediate_trigger_count"] = len(triggers)
+
+    active_eval = _timing_wrapper_int(timing_intelligence.get("active_eval_signals"))
+    if active_eval is not None:
+        metrics["active_eval_signals"] = active_eval
+
+    supporting = timing_intelligence.get("supporting_evidence") or {}
+    timeline = supporting.get("timeline_signal_summary") or {}
+    for field in (
+        "evaluation_deadline_signals",
+        "contract_end_signals",
+        "renewal_signals",
+        "budget_cycle_signals",
+    ):
+        value = _timing_wrapper_int(timeline.get(field))
+        if value is not None:
+            metrics[field] = value
+
+    sentiment_direction = str(
+        timing_intelligence.get("sentiment_direction") or ""
+    ).strip().lower()
+    if sentiment_direction:
+        metrics["sentiment_direction"] = sentiment_direction
+
+    sentiment = supporting.get("sentiment_snapshot") or {}
+    for field in ("declining_pct", "improving_pct"):
+        value = _timing_wrapper_float(sentiment.get(field))
+        if value is not None:
+            metrics[field] = round(value, 2)
+
+    best_window = str(timing_intelligence.get("best_timing_window") or "").strip()
+    summary_parts: list[str] = []
+    if best_window and not _timing_window_conflicts_with_active_eval(best_window, active_eval):
+        summary_parts.append(_summary_sentence(best_window))
+    trigger_sentence = ""
+    if not best_window or _timing_window_is_generic(best_window):
+        trigger_sentence = _timing_trigger_sentence(best_window, trigger_labels)
+    if trigger_sentence:
+        summary_parts.append(trigger_sentence)
+    if active_eval is not None and active_eval > 0:
+        summary_parts.append(
+            f"{active_eval} active evaluation signals are visible right now."
+        )
+    elif metrics.get("immediate_trigger_count"):
+        count = int(metrics["immediate_trigger_count"])
+        summary_parts.append(
+            f"{count} immediate timing triggers are currently open."
+        )
+
+    if sentiment_direction == "declining":
+        summary_parts.append("Review sentiment is skewing more negative.")
+    elif sentiment_direction == "improving":
+        summary_parts.append(
+            "Review sentiment is improving, so outreach should stay tied to concrete events."
+        )
+
+    return (" ".join(summary_parts).strip(), metrics, trigger_labels)
+
+
+def _battle_card_timing_intelligence(card: dict[str, Any]) -> dict[str, Any]:
+    """Return the contract-first timing intelligence section."""
+    return _battle_card_contract_section(
+        card,
+        "vendor_core_reasoning",
+        "timing_intelligence",
+        "timing_intelligence",
+    )
+
+
+def _battle_card_primary_weakness(card: dict[str, Any]) -> str:
+    """Return the strongest weakness label available for safe seller phrasing."""
+    weaknesses = card.get("vendor_weaknesses") or []
+    if weaknesses and isinstance(weaknesses[0], dict):
+        area = str(
+            weaknesses[0].get("area")
+            or weaknesses[0].get("weakness")
+            or ""
+        ).strip().lower()
+        if area:
+            return area
+    return "fit and value"
+
+
+def _battle_card_structured_proof_text(card: dict[str, Any]) -> str:
+    """Return the strongest supported proof-point sentence for seller copy."""
+    timing = _battle_card_contract_section(
+        card,
+        "vendor_core_reasoning",
+        "timing_intelligence",
+        "timing_intelligence",
+    )
+    active_eval = {}
+    if isinstance(timing, dict):
+        active_eval = timing.get("active_eval_signals") or {}
+    if isinstance(active_eval, dict):
+        value = active_eval.get("value")
+        try:
+            count = int(round(float(value)))
+        except (TypeError, ValueError):
+            count = 0
+        if count > 0:
+            weakness = _battle_card_primary_weakness(card)
+            if weakness:
+                return f"{count} active evaluation signals show recurring buyer pressure around {weakness}."
+            return f"{count} active evaluation signals show recurring buyer pressure."
+
+    weaknesses = card.get("vendor_weaknesses") or []
+    if weaknesses and isinstance(weaknesses[0], dict):
+        top = weaknesses[0]
+        area = str(top.get("area") or top.get("weakness") or "customer fit").strip().lower()
+        count = top.get("evidence_count") or top.get("count")
+        try:
+            count_int = int(round(float(count)))
+        except (TypeError, ValueError):
+            count_int = 0
+        if count_int > 0:
+            return f"{count_int} recurring complaints point to buyer friction around {area}."
+
+    return "The input shows recurring buyer friction and credible evaluation pressure."
+
+
+def _battle_card_safe_play_text(card: dict[str, Any], path: str) -> str:
+    """Return grounded fallback text for recommended plays and talk tracks."""
+    weakness = _battle_card_primary_weakness(card)
+    index_match = re.search(r"\[(\d+)\]", path)
+    index = int(index_match.group(1)) if index_match else 0
+    if path.endswith(".target_segment"):
+        if weakness == "pricing":
+            return "Support, finance, and operations teams already feeling pricing pressure."
+        if weakness == "support":
+            return "Support leaders already dealing with service friction and renewal pressure."
+        return "Teams already showing evaluation pressure around fit and value."
+    if path.endswith(".key_message"):
+        if weakness == "pricing":
+            variants = [
+                "Lead with pricing clarity, spend control, and fewer forced add-ons.",
+                "Lead with packaging clarity, budget predictability, and less renewal surprise.",
+                "Lead with tighter spend control, clearer packaging, and a cleaner renewal story.",
+            ]
+            return variants[index % len(variants)]
+        if weakness == "support":
+            variants = [
+                "Lead with more responsive support operations and clearer accountability.",
+                "Lead with faster escalations, cleaner ownership, and less day-to-day support friction.",
+                "Lead with stronger service responsiveness and clearer accountability at renewal.",
+            ]
+            return variants[index % len(variants)]
+        variants = [
+            "Lead with a simpler path to better fit, lower friction, and clearer value.",
+            "Lead with cleaner fit, less operational drag, and a clearer path to value.",
+            "Lead with lower friction, stronger day-to-day fit, and easier value validation.",
+        ]
+        return variants[index % len(variants)]
+    if path.endswith(".timing"):
+        timing_variants = [
+            "Best tested during active evaluation windows, renewal review, or planning cycles.",
+            "Best timed to renewal planning, budget review, or any fresh fit-and-value checkpoint.",
+            "Use this when buyers are reassessing fit, budgets, or switching timing ahead of the next renewal motion.",
+        ]
+        return timing_variants[index % len(timing_variants)]
+    if path.endswith(".play"):
+        prefix = "Best tested on" if _battle_card_segment_evidence_is_thin(card) else "Target"
+        if weakness == "pricing":
+            return f"{prefix} teams facing pricing pressure with a focused pricing and packaging benchmark."
+        if weakness == "support":
+            return f"{prefix} support teams with a support-operations benchmark against current escalation pain."
+        return f"{prefix} teams showing fit and renewal pressure with a focused benchmark."
+    if path.startswith("talk_track."):
+        if path.endswith(".opening"):
+            vendor = str(card.get("vendor") or "the incumbent").strip() or "the incumbent"
+            anchor_phrase = _battle_card_anchor_phrase_from_card(card)
+            opening = (
+                f"Buyers are actively pressure-testing {vendor} because {weakness} concerns keep resurfacing during evaluation."
+            )
+            if anchor_phrase:
+                opening = f"{opening} The clearest live signal is coming from {anchor_phrase}."
+            return opening
+        if path.endswith(".mid_call_pivot"):
+            return "Once pain is confirmed, pivot to the recurring friction and evaluation pressure visible in the current evidence."
+        if path.endswith(".closing"):
+            return "Close with a working session to benchmark current fit, costs, and switching timing before renewal."
+    return ""
+
+
+def _battle_card_normalize_recommended_play_segment(value: Any) -> str:
+    """Normalize a recommended-play target segment for duplicate detection."""
+    segment = str(value or "").strip().lower()
+    segment = re.sub(r"\s*\(sample n=\d+\)\s*$", "", segment)
+    return re.sub(r"\s+", " ", segment).strip()
+
+
+def _battle_card_normalize_recommended_play_text(value: Any) -> str:
+    """Normalize recommended-play text for duplicate detection."""
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[.]+$", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _repair_battle_card_recommended_play_duplicates(card: dict[str, Any], generated: dict[str, Any]) -> None:
+    """Deterministically diversify duplicate recommended-play rows before retry."""
+    plays = generated.get("recommended_plays")
+    if not isinstance(plays, list) or not plays:
+        return
+    fallback_candidates = _battle_card_fallback_recommended_plays(
+        card,
+        limit=max(len(plays) + 2, 2),
+    )
+    repaired: list[dict[str, Any]] = []
+    seen_segments: set[str] = set()
+    seen_plays: set[str] = set()
+    seen_messages: set[str] = set()
+
+    def _row_signals(row: dict[str, Any]) -> tuple[str, str, str]:
+        return (
+            _battle_card_normalize_recommended_play_segment(row.get("target_segment")),
+            _battle_card_normalize_recommended_play_text(row.get("play")),
+            _battle_card_normalize_recommended_play_text(row.get("key_message")),
+        )
+
+    def _next_fallback() -> dict[str, Any] | None:
+        for candidate in fallback_candidates:
+            if not isinstance(candidate, dict):
+                continue
+            segment_key, play_key, message_key = _row_signals(candidate)
+            if segment_key and segment_key in seen_segments:
+                continue
+            if play_key and play_key in seen_plays:
+                continue
+            if message_key and message_key in seen_messages:
+                continue
+            return dict(candidate)
+        return None
+
+    for idx, item in enumerate(plays):
+        row = dict(item) if isinstance(item, dict) else {}
+        if not row:
+            continue
+        segment_key, play_key, message_key = _row_signals(row)
+        if segment_key and segment_key in seen_segments:
+            replacement = _next_fallback()
+            if replacement is not None:
+                row = replacement
+                segment_key, play_key, message_key = _row_signals(row)
+        if play_key and play_key in seen_plays:
+            row["play"] = _battle_card_safe_play_text(card, f"recommended_plays[{idx}].play").rstrip(".") + "."
+            play_key = _battle_card_normalize_recommended_play_text(row.get("play"))
+        if message_key and message_key in seen_messages:
+            row["key_message"] = _battle_card_safe_play_text(card, f"recommended_plays[{idx}].key_message").rstrip(".") + "."
+            message_key = _battle_card_normalize_recommended_play_text(row.get("key_message"))
+        if (segment_key and segment_key in seen_segments) or (play_key and play_key in seen_plays) or (message_key and message_key in seen_messages):
+            replacement = _next_fallback()
+            if replacement is not None:
+                row = replacement
+                segment_key, play_key, message_key = _row_signals(row)
+        repaired.append(row)
+        if segment_key:
+            seen_segments.add(segment_key)
+        if play_key:
+            seen_plays.add(play_key)
+        if message_key:
+            seen_messages.add(message_key)
+    if repaired:
+        generated["recommended_plays"] = repaired
+
+
+def _battle_card_role_target_segment(
+    segment_playbook: dict[str, Any],
+    role: dict[str, Any],
+) -> str:
+    role_label = _segment_role_display_label(role.get("role_type"))
+    contexts = _segment_context_clauses(segment_playbook, limit=1)
+    if contexts:
+        mode, clause = contexts[0]
+        if mode == "plain":
+            return f"{role_label} {clause}"
+        return f"{role_label} in {clause}"
+    return role_label
+
+
+def _battle_card_role_opening_angle(card: dict[str, Any], role_type: str) -> str:
+    weakness = _battle_card_primary_weakness(card)
+    if role_type in {"decision_maker", "economic_buyer"} and weakness == "pricing":
+        return "a finance-ready pricing and renewal benchmark"
+    if role_type in {"decision_maker", "economic_buyer"}:
+        return "a decision-ready fit, risk, and renewal benchmark"
+    if role_type == "champion":
+        return "an adoption and internal-alignment review"
+    if role_type == "evaluator":
+        return "a side-by-side evaluation on fit and switching friction"
+    return "a focused benchmark on fit and value"
+
+
+def _battle_card_role_key_message(card: dict[str, Any], role_type: str) -> str:
+    weakness = _battle_card_primary_weakness(card)
+    if role_type in {"decision_maker", "economic_buyer"} and weakness == "pricing":
+        return "Lead with pricing predictability, spend control, and fewer surprise costs"
+    if role_type in {"decision_maker", "economic_buyer"}:
+        return "Lead with clearer vendor accountability, lower friction, and more predictable value"
+    if role_type == "champion":
+        return "Lead with smoother adoption, fewer workarounds, and less internal pushback"
+    if role_type == "evaluator":
+        return "Lead with faster evaluation clarity, cleaner validation, and fewer edge-case surprises"
+    return _battle_card_safe_play_text(card, "recommended_plays[0].key_message").rstrip(".")
+
+
+def _battle_card_account_stage_timing(stage: Any, default_timing: str) -> str:
+    normalized = _normalize_buying_stage(stage)
+    if normalized == "renewal_decision":
+        return "Before the next renewal decision checkpoint."
+    if normalized == "evaluation":
+        return "During active evaluation and renewal review."
+    if normalized == "consideration":
+        return "As the evaluation moves into shortlist review."
+    if normalized == "procurement":
+        return "Before procurement locks the renewal plan."
+    return default_timing.rstrip(".") + "."
+
+
+def _battle_card_safe_fallback_timing(value: Any) -> str:
+    text = str(value or "").strip()
+    default = "Best tested during active evaluation windows, renewal review, or planning cycles."
+    if not text:
+        return default
+    if len(text) > 140:
+        return default
+    if re.search(r"\b20\d{2}\b", text):
+        return default
+    if any(token in text.lower() for token in ("march ", "april ", "may ", "june ", "july ", "august ", "september ", "october ", "november ", "december ", "january ", "february ")):
+        return default
+    return text.rstrip(".") + "."
+
+
+def _battle_card_account_play_text(card: dict[str, Any], company: str) -> str:
+    weakness = _battle_card_primary_weakness(card)
+    if weakness == "pricing":
+        return f"Run a pricing benchmark workshop with {company} before renewal pressure hardens."
+    if weakness == "support":
+        return f"Run a support-risk review with {company} before the next renewal checkpoint."
+    return f"Run a fit-and-risk benchmark with {company} before the next evaluation checkpoint."
+
+
+def _battle_card_generic_fallback_roles(card: dict[str, Any]) -> list[dict[str, str]]:
+    weakness = _battle_card_primary_weakness(card)
+    if weakness == "pricing":
+        return [
+            {"role_type": "economic_buyer"},
+            {"role_type": "evaluator"},
+        ]
+    if weakness == "support":
+        return [
+            {"role_type": "champion"},
+            {"role_type": "economic_buyer"},
+        ]
+    return [
+        {"role_type": "evaluator"},
+        {"role_type": "economic_buyer"},
+    ]
+
+
+def _battle_card_fallback_recommended_plays(
+    card: dict[str, Any],
+    *,
+    limit: int = 2,
+) -> list[dict[str, str]]:
+    """Build deterministic recommended-play fallbacks from segment contracts."""
+    segment_playbook = _battle_card_segment_playbook(card)
+    timing = _battle_card_timing_intelligence(card)
+    best_timing_window = str(timing.get("best_timing_window") or "").strip()
+    default_timing = _battle_card_safe_fallback_timing(best_timing_window)
+    thin = _battle_card_segment_evidence_is_thin(card)
+    prefix = "Best tested on" if thin else "Target"
+    plays: list[dict[str, str]] = []
+    seen_segments: set[str] = set()
+    for segment in segment_playbook.get("priority_segments") or []:
+        if not isinstance(segment, dict):
+            continue
+        segment_name = str(segment.get("segment") or "").strip()
+        if not segment_name:
+            continue
+        display_segment = re.sub(r"\([^)]*\d[^)]*\)", "", segment_name).strip()
+        display_segment = re.sub(r"\s+", " ", display_segment).strip()
+        norm = re.sub(r"\s+", " ", display_segment.lower()).strip()
+        if not norm or norm in seen_segments:
+            continue
+        seen_segments.add(norm)
+        opening = str(segment.get("best_opening_angle") or "").strip()
+        sample_size = None
+        try:
+            sample_size = int(round(float(segment.get("sample_size"))))
+        except (TypeError, ValueError):
+            sample_size = None
+        segment_label = display_segment
+        if sample_size and sample_size > 0:
+            segment_label = f"{display_segment} (sample n={sample_size})"
+        play_text = f"{prefix} {display_segment} with {opening or 'a focused benchmark on fit and value'}"
+        target_text = segment_label
+        key_message = opening or _battle_card_safe_play_text(card, "recommended_plays[0].key_message")
+        timing_text = default_timing
+        plays.append({
+            "play": play_text.rstrip(".") + ".",
+            "target_segment": target_text,
+            "key_message": key_message.rstrip(".") + ".",
+            "timing": timing_text.rstrip(".") + ".",
+        })
+        if len(plays) >= limit:
+            break
+    for role in _segment_playbook_strategic_roles(segment_playbook, limit=limit):
+        if len(plays) >= limit:
+            break
+        role_type = str(role.get("role_type") or "").strip()
+        target_text = _battle_card_role_target_segment(segment_playbook, role)
+        norm = re.sub(r"\s+", " ", target_text.lower()).strip()
+        if not norm or norm in seen_segments:
+            continue
+        seen_segments.add(norm)
+        plays.append({
+            "play": f"{prefix} {target_text} with {_battle_card_role_opening_angle(card, role_type)}.",
+            "target_segment": target_text,
+            "key_message": _battle_card_role_key_message(card, role_type).rstrip(".") + ".",
+            "timing": default_timing.rstrip(".") + ".",
+        })
+    if len(plays) < limit:
+        for account in _rank_high_intent_companies(card.get("high_intent_companies") or []):
+            if len(plays) >= limit:
+                break
+            if not isinstance(account, dict):
+                continue
+            company = str(account.get("company") or account.get("company_name") or "").strip()
+            if not company:
+                continue
+            stage = account.get("buying_stage") or account.get("stage")
+            target_text = f"{company} renewal stakeholders"
+            norm = re.sub(r"\s+", " ", target_text.lower()).strip()
+            if not norm or norm in seen_segments:
+                continue
+            seen_segments.add(norm)
+            plays.append({
+                "play": _battle_card_account_play_text(card, company),
+                "target_segment": target_text,
+                "key_message": _battle_card_safe_play_text(card, "recommended_plays[0].key_message").rstrip(".") + ".",
+                "timing": _battle_card_account_stage_timing(stage, default_timing),
+            })
+    for role in _battle_card_generic_fallback_roles(card):
+        if len(plays) >= limit:
+            break
+        role_type = str(role.get("role_type") or "").strip()
+        if not role_type:
+            continue
+        target_text = _battle_card_role_target_segment(segment_playbook, role)
+        norm = re.sub(r"\s+", " ", target_text.lower()).strip()
+        if not norm or norm in seen_segments:
+            continue
+        seen_segments.add(norm)
+        plays.append({
+            "play": f"{prefix} {target_text} with {_battle_card_role_opening_angle(card, role_type)}.",
+            "target_segment": target_text,
+            "key_message": _battle_card_role_key_message(card, role_type).rstrip(".") + ".",
+            "timing": default_timing.rstrip(".") + ".",
+        })
+    return plays
+
+
+def _battle_card_has_duplicate_recommended_play_segments(generated: dict[str, Any]) -> bool:
+    """Return True when recommended plays collapse onto the same target segment."""
+    plays = generated.get("recommended_plays")
+    if not isinstance(plays, list):
+        return False
+    seen: set[str] = set()
+    for item in plays:
+        if not isinstance(item, dict):
+            continue
+        segment = str(item.get("target_segment") or "").strip().lower()
+        segment = re.sub(r"\s*\(sample n=\d+\)\s*$", "", segment)
+        segment = re.sub(r"\s+", " ", segment)
+        if not segment:
+            continue
+        if segment in seen:
+            return True
+        seen.add(segment)
+    return False
+
+
+def _battle_card_safe_text(card: dict[str, Any], path: str) -> str:
+    """Return grounded replacement text for numeric-sensitive paths."""
+    if path == "executive_summary":
+        return _battle_card_safe_summary(card)
+    if path.startswith("objection_handlers[") and path.endswith(".pivot"):
+        weakness = _battle_card_primary_weakness(card)
+        return (
+            f"The better question is whether {weakness} is creating enough drag to justify a cleaner alternative before renewal."
+        )
+    if path.startswith("why_they_stay.strengths["):
+        index_match = re.search(r"\[(\d+)\]", path)
+        index = int(index_match.group(1)) if index_match else 0
+        neutralize_variants = [
+            "Acknowledge the familiar setup, then redirect to the renewal risks already showing up in current evaluation motion.",
+            "Reframe the conversation around operational predictability, simpler administration, and less day-to-day friction.",
+            "Keep the focus on reducing switching risk, spend surprises, and the manual work buyers are already flagging.",
+        ]
+        evidence_variants = [
+            "Customers still cite familiar workflows as a reason to stay.",
+            "Some teams still value the incumbent because the current setup feels established and good enough.",
+            "Retention signals show the incumbent still gets credit for familiarity and continuity.",
+        ]
+        if path.endswith(".how_to_neutralize"):
+            return neutralize_variants[index % len(neutralize_variants)]
+        if path.endswith(".evidence"):
+            return evidence_variants[index % len(evidence_variants)]
+        if path.endswith(".summary"):
+            return "The incumbent still holds on where familiarity and continuity outweigh switching effort."
+    if path.endswith(".evidence"):
+        return "Supported by recurring customer complaints and churn-oriented review evidence."
+    if path.endswith(".proof_point"):
+        base = _battle_card_structured_proof_text(card).rstrip(".")
+        weakness = _battle_card_primary_weakness(card)
+        index_match = re.search(r"\[(\d+)\]", path)
+        index = int(index_match.group(1)) if index_match else 0
+        variants = [
+            f"{base}.",
+            f"{base}, which keeps reinforcing buyer scrutiny around {weakness}.",
+            f"{base}. That pattern is showing up again in current evaluation motion.",
+            f"{base}. It is one of the clearest signals behind current switching pressure.",
+        ]
+        return variants[index % len(variants)]
+    if path.startswith("recommended_plays[") or path.startswith("talk_track."):
+        return _battle_card_safe_play_text(card, path)
+    if path.startswith("competitive_landscape."):
+        competitors = _battle_card_competitor_names(card)
+        if "top_alternatives" in path and competitors:
+            return (
+                "Alternatives appearing most often in buyer evaluation sets include "
+                f"{_join_summary_terms(competitors)}."
+            )
+        return "Competitive pressure is present where buyers are re-evaluating fit and value."
+    return ""
+
+
+def _battle_card_anchor_phrase_from_card(card: dict[str, Any]) -> str:
+    """Return a seller-safe anchor phrase from raw anchor_examples."""
+    raw = card.get("anchor_examples")
+    if not isinstance(raw, dict):
+        return ""
+    for rows in raw.values():
+        if not isinstance(rows, list):
+            continue
+        for witness in rows:
+            if not isinstance(witness, dict):
+                continue
+            company = str(witness.get("reviewer_company") or "").strip()
+            competitor = str(witness.get("competitor") or "").strip()
+            time_anchor = _battle_card_specific_time_anchor(witness.get("time_anchor"))
+            parts: list[str] = []
+            if company:
+                parts.append(f"accounts like {company}")
+            if competitor:
+                parts.append(f"while evaluating {competitor}")
+            if time_anchor:
+                parts.append(f"during {time_anchor}")
+            excerpt = str(witness.get("excerpt_text") or "")
+            numeric_tokens = re.findall(r"\$\d[\d,]*(?:\.\d+)?|\d[\d,]*(?:\.\d+)?%", excerpt)
+            if numeric_tokens:
+                preview = ", ".join(numeric_tokens[:3])
+                if parts:
+                    parts.append(f"with pricing callouts like {preview}")
+                else:
+                    parts.append(f"pricing callouts like {preview} in current review evidence")
+            if parts:
+                return " ".join(parts)
+    return ""
+
+
+def _battle_card_anchor_terms_from_card(card: dict[str, Any]) -> set[str]:
+    """Collect non-numeric anchor terms from raw anchor_examples."""
+    raw = card.get("anchor_examples")
+    if not isinstance(raw, dict):
+        return set()
+    terms: set[str] = set()
+    for rows in raw.values():
+        if not isinstance(rows, list):
+            continue
+        for witness in rows:
+            if not isinstance(witness, dict):
+                continue
+            for value in (
+                witness.get("reviewer_company"),
+                witness.get("competitor"),
+                witness.get("time_anchor"),
+            ):
+                if value == witness.get("time_anchor"):
+                    term = _battle_card_specific_time_anchor(value).lower()
+                else:
+                    term = str(value or "").strip().lower()
+                if term:
+                    terms.add(term)
+            excerpt = str(witness.get("excerpt_text") or "")
+            for token in re.findall(r"\$\d[\d,]*(?:\.\d+)?|\d[\d,]*(?:\.\d+)?%", excerpt):
+                normalized = token.strip().lower()
+                if normalized:
+                    terms.add(normalized)
+    return terms
+
+
+def _battle_card_render_text_from_generated(generated: dict[str, Any]) -> str:
+    """Flatten generated seller copy into comparable lowercase text."""
+    return " ".join(text for _, text in _battle_card_iter_text(generated) if text).lower()
+
+
+def _battle_card_set_generated_path(generated: dict[str, Any], path: str, value: str) -> None:
+    """Set a nested generated path like talk_track.opening or objection_handlers[1].proof_point."""
+    current: Any = generated
+    tokens = re.findall(r"([^\.\[\]]+)|\[(\d+)\]", path)
+    if not tokens:
+        return
+    for idx, (key_token, index_token) in enumerate(tokens):
+        is_last = idx == len(tokens) - 1
+        if index_token:
+            if not isinstance(current, list):
+                return
+            index = int(index_token)
+            if index >= len(current):
+                return
+            if is_last:
+                current[index] = value
+                return
+            current = current[index]
+            continue
+        key = str(key_token)
+        if not isinstance(current, dict) or key not in current:
+            return
+        if is_last:
+            current[key] = value
+            return
+        current = current[key]
+
+
+def _repair_battle_card_duplicate_copy(card: dict[str, Any], generated: dict[str, Any]) -> None:
+    """Replace duplicate long-form sections with grounded fallback phrasing."""
+    long_strings: list[tuple[str, str]] = []
+    for path, text in _battle_card_iter_text(generated):
+        stripped = text.strip()
+        if len(stripped) >= 80:
+            long_strings.append((path, stripped))
+    seen_prefixes: dict[str, str] = {}
+    for path, text in long_strings:
+        prefix = text[:80].lower()
+        first_path = seen_prefixes.get(prefix)
+        if first_path and first_path != path:
+            replacement = _battle_card_safe_text(card, path)
+            if replacement and replacement.strip().lower() != text.lower():
+                _battle_card_set_generated_path(generated, path, replacement)
+        else:
+            seen_prefixes[prefix] = path
+
+
+def _repair_battle_card_missing_anchor(card: dict[str, Any], generated: dict[str, Any]) -> None:
+    """Inject a witness-backed anchor when seller copy stays too generic."""
+    anchor_phrase = _battle_card_anchor_phrase_from_card(card)
+    anchor_terms = _battle_card_anchor_terms_from_card(card)
+    if not anchor_phrase or not anchor_terms:
+        return
+    render_text = _battle_card_render_text_from_generated(generated)
+    raw = card.get("anchor_examples")
+    companies: set[str] = set()
+    competitor_terms: set[str] = set()
+    timing_terms: set[str] = set()
+    numeric_terms: set[str] = set()
+    if isinstance(raw, dict):
+        for rows in raw.values():
+            if not isinstance(rows, list):
+                continue
+            for witness in rows:
+                if not isinstance(witness, dict):
+                    continue
+                company = str(witness.get("reviewer_company") or "").strip().lower()
+                competitor = str(witness.get("competitor") or "").strip().lower()
+                time_anchor = _battle_card_specific_time_anchor(witness.get("time_anchor")).lower()
+                if company:
+                    companies.add(company)
+                if competitor:
+                    competitor_terms.add(competitor)
+                if time_anchor:
+                    timing_terms.add(time_anchor)
+                excerpt = str(witness.get("excerpt_text") or "")
+                for token in re.findall(r"\$\d[\d,]*(?:\.\d+)?|\d[\d,]*(?:\.\d+)?%", excerpt):
+                    normalized = token.strip().lower()
+                    if normalized:
+                        numeric_terms.add(normalized)
+    anchor_categories_missing = any((
+        companies and not any(term in render_text for term in companies),
+        competitor_terms and not any(term in render_text for term in competitor_terms),
+        timing_terms and not any(term in render_text for term in timing_terms),
+        numeric_terms and not any(term in render_text for term in numeric_terms),
+    ))
+    if not anchor_categories_missing and any(term in render_text for term in anchor_terms):
+        return
+    anchor_sentence = f"The clearest live signal is coming from {anchor_phrase}."
+    summary = str(generated.get("executive_summary") or "").strip()
+    if summary:
+        generated["executive_summary"] = f"{summary.rstrip('.')} {anchor_sentence}".strip()
+        return
+    talk_track = generated.get("talk_track")
+    if isinstance(talk_track, dict):
+        opening = str(talk_track.get("opening") or "").strip()
+        if opening:
+            talk_track["opening"] = f"{opening.rstrip('.')} {anchor_sentence}".strip()
+
+
+def _sanitize_battle_card_text(
+    card: dict[str, Any],
+    path: str,
+    text: str,
+    *,
+    allowed_claims: set[str],
+    source_text: str,
+    max_switch: int,
+    score: float,
+    urgency: float,
+    low_gap_terms: list[str],
+) -> str:
+    """Rewrite overclaiming battle-card strings into validator-safe text."""
+    cleaned = str(text or "")
+    normalized_allowed_claims = {
+        _battle_card_normalize_numeric_token(token) for token in (allowed_claims or set())
+    }
+    if path.startswith("recommended_plays[") and path.endswith(".timing"):
+        if _battle_card_numeric_tokens(cleaned):
+            cleaned = _battle_card_safe_text(card, path)
+    if _battle_card_numeric_paths(path):
+        bad = sorted(
+            tok
+            for tok in _battle_card_numeric_tokens(cleaned)
+            if _battle_card_normalize_numeric_token(tok) not in normalized_allowed_claims
+        )
+        if bad:
+            cleaned = _battle_card_safe_text(card, path)
+    years = [year for year in re.findall(r"\b20\d{2}\b", cleaned) if year not in source_text]
+    for year in years:
+        cleaned = re.sub(rf"\s*\b{re.escape(year)}\b", "", cleaned)
+    if max_switch == 0:
+        replacements = (
+            ("customers are leaving", "buyers are evaluating alternatives"),
+            ("customer are leaving", "buyers are evaluating alternatives"),
+            ("are leaving for", "are evaluating"),
+            ("capturing defectors", "winning evaluations"),
+            ("capture defectors", "win evaluations"),
+            ("defectors", "evaluators"),
+        )
+        lowered = cleaned.lower()
+        for src, dst in replacements:
+            if src in lowered:
+                cleaned = re.sub(re.escape(src), dst, cleaned, flags=re.IGNORECASE)
+                lowered = cleaned.lower()
+    if score < _battle_card_high_priority_score_min() or urgency < _battle_card_high_priority_urgency_min():
+        cleaned = re.sub(r"high[- ]priority target:?\s*", "Emerging vulnerability: ", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(
+            r"\b(a|an)\s+Emerging vulnerability:\s*",
+            "an emerging vulnerability for ",
+            cleaned,
+            flags=re.IGNORECASE,
+        )
+    if _battle_card_segment_evidence_is_thin(card) and path.endswith(".play"):
+        cleaned = re.sub(r"^\s*target\b", "Best tested on", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"^\s*engage\b", "Best tested on", cleaned, flags=re.IGNORECASE)
+    if _battle_card_headline_paths(path):
+        for term in low_gap_terms:
+            if term and term in cleaned.lower():
+                return _battle_card_safe_summary(card) if path == "executive_summary" else "Workflow friction is showing up in customer feedback."
+    if _battle_card_overreach_violations(cleaned):
+        cleaned = _battle_card_replace_overreach(cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _battle_card_allowed_quotes(card: dict[str, Any]) -> list[str]:
+    """Return exact customer pain quotes that synthesis may reuse."""
+    quotes: list[str] = []
+    for item in card.get("customer_pain_quotes") or []:
+        if isinstance(item, dict):
+            quote = str(item.get("quote") or "").strip()
+        else:
+            quote = str(item or "").strip()
+        if quote and quote not in quotes:
+            quotes.append(quote)
+    return quotes
+
+
+def _battle_card_quote_entries(card: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return unique quote entries with any attached metadata preserved."""
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in card.get("customer_pain_quotes") or []:
+        if isinstance(item, dict):
+            quote = str(item.get("quote") or "").strip()
+            urgency = float(item.get("urgency") or 0)
+            rating = item.get("rating")
+            rating_max = item.get("rating_max")
+        else:
+            quote = str(item or "").strip()
+            urgency = 0.0
+            rating = None
+            rating_max = None
+        if quote and quote not in seen:
+            seen.add(quote)
+            entries.append({
+                "quote": quote,
+                "urgency": urgency,
+                "rating": rating,
+                "rating_max": rating_max,
+            })
+    return entries
+
+
+def _battle_card_best_supported_quote(
+    card: dict[str, Any],
+    context: str = "",
+    *,
+    preferred_terms: list[str] | None = None,
+    excluded_quotes: set[str] | None = None,
+    require_preferred_match: bool = False,
+) -> str:
+    """Pick the most relevant exact quote from source data for a weakness context."""
+    entries = _battle_card_quote_entries(card)
+    if excluded_quotes:
+        entries = [entry for entry in entries if entry["quote"] not in excluded_quotes]
+    entries = [
+        e for e in entries
+        if _quote_has_pain_signal(
+            e["quote"],
+            urgency=float(e.get("urgency") or 0),
+            rating=e.get("rating"),
+            rating_max=e.get("rating_max"),
+        )
+    ]
+    if not entries:
+        return ""
+    context_tokens = {
+        token for token in re.findall(r"[a-z0-9]+", context.lower())
+        if len(token) >= 4
+    }
+    preferred = [term.lower() for term in (preferred_terms or []) if term]
+    ranked = sorted(
+        entries,
+        key=lambda entry: (
+            sum(1 for term in preferred if term in entry["quote"].lower()),
+            len(context_tokens & set(re.findall(r"[a-z0-9]+", entry["quote"].lower()))),
+            float(entry.get("urgency") or 0),
+            len(entry["quote"]),
+        ),
+        reverse=True,
+    )
+    if preferred and require_preferred_match:
+        best = ranked[0]
+        if not any(term in best["quote"].lower() for term in preferred):
+            return ""
+    return ranked[0]["quote"]
+
+
+def _battle_card_weakness_headline(area: str, *, source: str = "") -> str:
+    """Map a weakness area into a rep-facing battle-card wedge."""
+    lower = area.lower()
+    if any(token in lower for token in ("price", "pricing", "cost", "budget")):
+        return "Pricing pressure is creating renewal scrutiny"
+    if any(token in lower for token in ("support", "service", "response", "help")):
+        return "Support friction is undermining buyer confidence"
+    if any(token in lower for token in ("reliability", "uptime", "outage", "stability", "performance")):
+        return "Reliability issues are increasing switching risk"
+    if source == "feature_gap" or any(token in lower for token in ("feature", "workflow", "reporting", "automation")):
+        return "Feature gaps are pushing teams to evaluate alternatives"
+    if any(token in lower for token in ("integration", "plugin", "api", "stack")):
+        return "Integration complexity is adding operational drag"
+    return f"{area.title()} concerns keep resurfacing in buyer feedback"
+
+
+def _battle_card_winning_position(area: str, *, source: str = "") -> str:
+    """Return a vendor-agnostic capability emphasis for a weakness."""
+    lower = area.lower()
+    if any(token in lower for token in ("price", "pricing", "cost", "budget")):
+        return "Emphasize transparent pricing, packaging clarity, and spend controls."
+    if any(token in lower for token in ("support", "service", "response", "help")):
+        return "Emphasize responsive support operations and clearer accountability on escalations."
+    if any(token in lower for token in ("reliability", "uptime", "outage", "stability", "performance")):
+        return "Emphasize reliability, incident response discipline, and operational resilience."
+    if source == "feature_gap" or any(token in lower for token in ("feature", "workflow", "reporting", "automation")):
+        return "Emphasize broader native capability coverage and fewer workaround-heavy workflows."
+    if any(token in lower for token in ("integration", "plugin", "api", "stack")):
+        return "Emphasize native integrations, simpler administration, and less app sprawl."
+    return "Emphasize predictable operations, easier adoption, and lower day-to-day friction."
+
+
+def _battle_card_weakness_evidence(card: dict[str, Any], weakness: dict[str, Any]) -> str:
+    """Build a deterministic evidence line for a weakness entry."""
+    area = str(weakness.get("area") or weakness.get("weakness") or "").strip()
+    source = str(weakness.get("source") or "").strip()
+    count = int(weakness.get("evidence_count") or weakness.get("count") or 0)
+    data = card.get("objection_data") or {}
+    total_reviews = int(card.get("total_reviews") or data.get("total_reviews") or 0)
+    if any(token in area.lower() for token in ("price", "pricing", "cost", "budget")) and data.get("price_complaint_rate") is not None:
+        return f"{float(data['price_complaint_rate']):.1%} price complaint rate across {total_reviews:,} reviews"
+    for gap in data.get("top_feature_gaps") or []:
+        if str(gap.get("feature") or "").strip().lower() == area.lower():
+            mentions = int(gap.get("mentions") or 0)
+            return f"{mentions} feature-gap mentions tied to {area}"
+    if source == "product_profile" and weakness.get("score") is not None:
+        return f"Satisfaction score {float(weakness['score']):.1f} with {count} supporting reviews"
+    if count:
+        unit = "reviews" if source == "product_profile" else "mentions"
+        return f"{count} supporting {unit} tied to {area}"
+    return f"Recurring customer friction tied to {area}"
+
+
+def _battle_card_quote_terms(area: str, *, source: str = "") -> list[str]:
+    """Return quote-preference keywords for a weakness area."""
+    lower = area.lower()
+    if any(token in lower for token in ("price", "pricing", "cost", "budget")):
+        return ["cost", "costs", "price", "pricing", "budget", "spend"]
+    if any(token in lower for token in ("support", "service", "response", "help")):
+        return ["support", "service", "response", "escalation", "help"]
+    if any(token in lower for token in ("reliability", "uptime", "outage", "stability", "performance")):
+        return ["outage", "uptime", "reliability", "stability", "incident", "performance", "downtime", "down"]
+    if source == "feature_gap" or any(token in lower for token in ("feature", "workflow", "reporting", "automation")):
+        return ["feature", "workflow", "reporting", "automation", "capability"]
+    if any(token in lower for token in ("integration", "plugin", "api", "stack")):
+        return ["integration", "plugin", "api", "stack"]
+    return []
+
+
+def _battle_card_specific_time_anchor(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    lower = text.lower()
+    if re.search(r"\d", lower):
+        return text
+    if any(
+        term in lower
+        for term in (
+            "renewal",
+            "review",
+            "planning",
+            "quarter",
+            "month",
+            "week",
+            "deadline",
+            "window",
+            "cycle",
+            "decision",
+        )
+    ):
+        return text
+    return ""
+
+
+def _battle_card_competitor_bucket_key(raw_label: str, buckets: dict[str, dict[str, Any]]) -> tuple[str, str]:
+    """Return a stable dedupe key and display label for a competitor mention."""
+    label = _canonicalize_competitor(raw_label) or raw_label
+    norm = normalize_company_name(label)
+    if not norm:
+        return label, label
+    for existing_norm, bucket in buckets.items():
+        if existing_norm == norm:
+            return existing_norm, str(bucket.get("competitor") or label)
+        if existing_norm.endswith(f" {norm}") or norm.endswith(f" {existing_norm}"):
+            existing_label = str(bucket.get("competitor") or label)
+            display_label = label if len(label) > len(existing_label) else existing_label
+            return existing_norm, display_label
+    return norm, label
+
+
+def _battle_card_competitor_is_eligible(label: str) -> bool:
+    """Return True when a competitor label is seller-usable in battle cards."""
+    lower = str(label or "").strip().lower()
+    if not lower:
+        return False
+    blocked_terms = (
+        " integration",
+        "integrations",
+        "plugin",
+        "plug-in",
+        "add-on",
+        "addon",
+        "workflow",
+        "workaround",
+        "custom ",
+        "internal ",
+        "in-house",
+    )
+    return not any(term in lower for term in blocked_terms)
+
+
+def _battle_card_aggregated_competitors(card: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Aggregate seller-usable competitor counts for battle-card surfaces."""
+    aggregated_competitors: dict[str, dict[str, Any]] = {}
+    for item in card.get("competitor_differentiators") or []:
+        if not isinstance(item, dict):
+            continue
+        raw_label = str(item.get("competitor") or "").strip()
+        bucket_key, label = _battle_card_competitor_bucket_key(raw_label, aggregated_competitors)
+        if not label or not bucket_key or not _battle_card_competitor_is_eligible(label):
+            continue
+        bucket = aggregated_competitors.setdefault(
+            bucket_key,
+            {"competitor": label, "mentions": 0, "switch_count": 0, "driver_counts": Counter()},
+        )
+        if len(label) > len(str(bucket.get("competitor") or "")):
+            bucket["competitor"] = label
+        bucket["mentions"] += int(item.get("mentions") or 0)
+        bucket["switch_count"] += int(item.get("switch_count") or 0)
+        driver = str(item.get("primary_driver") or "buyer fit").strip()
+        if driver:
+            bucket["driver_counts"][driver] += max(int(item.get("mentions") or 0), 1)
+    return aggregated_competitors
+
+
+def _sanitize_battle_card_sales_copy(card: dict[str, Any], generated: dict[str, Any]) -> dict[str, Any]:
+    """Deterministically rewrite near-miss sales copy before final rejection."""
+    if not isinstance(generated, dict):
+        return {}
+    allowed = _battle_card_allowed_claims(card)
+    source_text = json.dumps(_battle_card_validator_source(card), default=str).lower()
+    max_switch = max(
+        (int(c.get("switch_count") or 0) for c in card.get("competitor_differentiators") or []),
+        default=0,
+    )
+    score = float(card.get("churn_pressure_score") or 0)
+    urgency = float(((card.get("objection_data") or {}).get("avg_urgency")) or 0)
+    low_gap_terms = [
+        str(g.get("feature") or "").strip().lower()
+        for g in ((card.get("objection_data") or {}).get("top_feature_gaps") or [])
+        if int(g.get("mentions") or 0) < _battle_card_feature_gap_headline_min_mentions()
+    ]
+
+    def _walk(value: Any, path: str = "") -> Any:
+        if isinstance(value, str):
+            return _sanitize_battle_card_text(
+                card,
+                path,
+                value,
+                allowed_claims=allowed,
+                source_text=source_text,
+                max_switch=max_switch,
+                score=score,
+                urgency=urgency,
+                low_gap_terms=low_gap_terms,
+            )
+        if isinstance(value, list):
+            return [_walk(item, f"{path}[{idx}]") for idx, item in enumerate(value)]
+        if isinstance(value, dict):
+            return {
+                key: _walk(inner, f"{path}.{key}" if path else str(key))
+                for key, inner in value.items()
+            }
+        return value
+
+    sanitized = _walk(generated)
+    if isinstance(sanitized, dict) and _battle_card_has_duplicate_recommended_play_segments(sanitized):
+        fallback_plays = _battle_card_fallback_recommended_plays(card)
+        if fallback_plays:
+            sanitized["recommended_plays"] = fallback_plays
+    if isinstance(sanitized, dict):
+        _repair_battle_card_recommended_play_duplicates(card, sanitized)
+        _repair_battle_card_duplicate_copy(card, sanitized)
+        _repair_battle_card_missing_anchor(card, sanitized)
+    allowed_quotes = _battle_card_allowed_quotes(card)
+    pain_quote_meta: dict[str, dict[str, Any]] = {}
+    for _pq in card.get("customer_pain_quotes") or []:
+        if isinstance(_pq, dict):
+            _qt = str(_pq.get("quote") or "").strip()
+            if _qt:
+                pain_quote_meta[_qt] = _pq
+    weaknesses = sanitized.get("weakness_analysis") if isinstance(sanitized, dict) else None
+    if allowed_quotes and isinstance(weaknesses, list):
+        for item in weaknesses:
+            if not isinstance(item, dict):
+                continue
+            customer_quote = str(item.get("customer_quote") or "").strip()
+            needs_replacement = bool(customer_quote and customer_quote not in allowed_quotes)
+            if not needs_replacement and customer_quote:
+                _meta = pain_quote_meta.get(customer_quote) or {}
+                if not _quote_has_pain_signal(
+                    customer_quote,
+                    urgency=float(_meta.get("urgency") or 0),
+                    rating=_meta.get("rating"),
+                    rating_max=_meta.get("rating_max"),
+                ):
+                    needs_replacement = True
+            if needs_replacement:
+                context = "%s %s" % (item.get("weakness") or "", item.get("evidence") or "")
+                excluded = {customer_quote} if customer_quote else None
+                item["customer_quote"] = _battle_card_best_supported_quote(
+                    card, context, excluded_quotes=excluded,
+                )
+    return sanitized
+
+
+def _build_deterministic_battle_card_weakness_analysis(
+    card: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> list[dict[str, str]]:
+    """Build battle-card weakness analysis from deterministic evidence only."""
+    items: list[dict[str, str]] = []
+    used_quotes: set[str] = set()
+    for weakness in (card.get("vendor_weaknesses") or [])[:limit]:
+        if not isinstance(weakness, dict):
+            continue
+        area = str(weakness.get("area") or weakness.get("weakness") or "").strip()
+        if not area:
+            continue
+        source = str(weakness.get("source") or "").strip()
+        evidence = _battle_card_weakness_evidence(card, weakness)
+        hint = area
+        lower = area.lower()
+        if any(token in lower for token in ("price", "pricing", "cost", "budget")):
+            hint += " pricing cost budget spend renewal"
+        elif any(token in lower for token in ("support", "service", "response", "help")):
+            hint += " support service response escalation"
+        elif any(token in lower for token in ("reliability", "uptime", "outage", "stability", "performance")):
+            hint += " outage uptime reliability stability incident"
+        elif source == "feature_gap" or any(token in lower for token in ("feature", "workflow", "reporting", "automation")):
+            hint += " feature workflow capability reporting automation"
+        elif any(token in lower for token in ("integration", "plugin", "api", "stack")):
+            hint += " integration plugin api stack"
+        quote_terms = _battle_card_quote_terms(area, source=source)
+        quote = _battle_card_best_supported_quote(
+            card,
+            f"{hint} {evidence}",
+            preferred_terms=quote_terms,
+            excluded_quotes=used_quotes,
+            require_preferred_match=bool(quote_terms),
+        )
+        if quote:
+            used_quotes.add(quote)
+        items.append({
+            "weakness": _battle_card_weakness_headline(area, source=source),
+            "evidence": evidence,
+            "customer_quote": quote,
+            "winning_position": _battle_card_winning_position(area, source=source),
+        })
+    return items
+
+
+def _build_deterministic_battle_card_competitive_landscape(
+    card: dict[str, Any],
+    *,
+    trigger_limit: int = 3,
+    alt_limit: int = 3,
+) -> dict[str, Any]:
+    """Build battle-card competitive landscape from deterministic inputs."""
+    data = card.get("objection_data") or {}
+    budget = data.get("budget_context") or {}
+    sentiment = str(data.get("sentiment_direction") or "").strip()
+    council = card.get("category_council") or {}
+    category_reasoning = {}
+    contracts = card.get("reasoning_contracts")
+    if isinstance(contracts, dict):
+        contract = contracts.get("category_reasoning")
+        if isinstance(contract, dict):
+            category_reasoning = contract
+    if not category_reasoning:
+        raw_category = card.get("category_reasoning")
+        if isinstance(raw_category, dict):
+            category_reasoning = raw_category
+    market_regime = (
+        str(council.get("market_regime") or "").strip()
+        or str(category_reasoning.get("market_regime") or "").strip()
+    )
+    aggregated_competitors = _battle_card_aggregated_competitors(card)
+    alternatives: list[str] = []
+    ranked_competitors = sorted(
+        aggregated_competitors.values(),
+        key=lambda item: (int(item["switch_count"]), int(item["mentions"]), item["competitor"]),
+        reverse=True,
+    )
+    for item in ranked_competitors[:alt_limit]:
+        label = str(item["competitor"]).strip()
+        switches = int(item["switch_count"] or 0)
+        mentions = int(item["mentions"] or 0)
+        if switches <= 0 and mentions <= 0:
+            continue
+        driver_counts = item.get("driver_counts") or Counter()
+        driver = driver_counts.most_common(1)[0][0] if driver_counts else "buyer fit"
+        if switches > 0:
+            alternatives.append(f"{label} ({switches} explicit switches; primary driver: {driver})")
+        else:
+            alternatives.append(f"{label} ({mentions} mentions in evaluation sets; primary driver: {driver})")
+    window_bits: list[str] = []
+    if sentiment == "declining":
+        window_bits.append("Buyer sentiment is declining")
+    if float(budget.get("price_increase_rate") or 0) > 0:
+        window_bits.append("recent price increases are creating renewal scrutiny")
+    if card.get("active_evaluation_deadlines"):
+        window_bits.append("near-term evaluation timing is visible in review signals")
+    if market_regime:
+        window_bits.append(f"the category backdrop is {market_regime}")
+    if not window_bits:
+        window_bits.append("buyers are actively re-evaluating fit and value")
+    triggers: list[str] = []
+    if float(budget.get("price_increase_rate") or 0) > 0:
+        triggers.append("Renewal cycles after recent price increases or packaging changes")
+    if card.get("active_evaluation_deadlines"):
+        triggers.append("Accounts showing explicit evaluation timelines or near-term decision windows")
+    if any("support" in str(item.get("area") or "").lower() for item in (card.get("vendor_weaknesses") or [])):
+        triggers.append("Support escalations or unresolved service issues")
+    if not triggers and alternatives:
+        triggers.append(f"Direct head-to-head evaluations against {alternatives[0].split(' (', 1)[0]}")
+    return {
+        "vulnerability_window": ". ".join(bit[:1].upper() + bit[1:] for bit in window_bits) + ".",
+        "top_alternatives": alternatives,
+        "displacement_triggers": triggers[:trigger_limit],
+    }
+
+
+def _best_cross_vendor_comparison(scorecard: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the highest-confidence cross-vendor comparison above the ref floor."""
+    floor = _synthesis_reference_confidence_min()
+    comparisons = [
+        comp for comp in (scorecard.get("cross_vendor_comparisons") or [])
+        if float(comp.get("confidence") or 0) >= floor
+    ]
+    if not comparisons:
+        return None
+    return max(
+        comparisons,
+        key=lambda comp: (
+            float(comp.get("confidence") or 0),
+            str(comp.get("opponent") or "").strip().lower(),
+        ),
+    )
+
+
+def _build_scorecard_locked_facts(scorecard: dict[str, Any]) -> dict[str, Any]:
+    """Build source-of-truth synthesis constraints for scorecard narratives."""
+    locked: dict[str, Any] = {
+        "vendor": str(scorecard.get("vendor") or ""),
+        "risk_level": str(scorecard.get("risk_level") or ""),
+    }
+    if float(scorecard.get("archetype_confidence") or 0) >= _synthesis_reference_confidence_min():
+        if scorecard.get("archetype"):
+            locked["archetype"] = scorecard["archetype"]
+    allowed_opponents = sorted({
+        str(comp.get("opponent") or "").strip()
+        for comp in (scorecard.get("cross_vendor_comparisons") or [])
+        if str(comp.get("opponent") or "").strip()
+        and float(comp.get("confidence") or 0) >= _synthesis_reference_confidence_min()
+    })
+    if allowed_opponents:
+        locked["allowed_opponents"] = allowed_opponents
+    best = _best_cross_vendor_comparison(scorecard)
+    if best:
+        locked["comparison"] = {
+            "opponent": best.get("opponent", ""),
+            "resource_advantage": best.get("resource_advantage", ""),
+        }
+    return {k: v for k, v in locked.items() if v not in ("", [], None)}
+
+
+def _build_metric_ledger(card: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build a scoped metric ledger so the LLM knows exactly what each number means.
+
+    Each entry: {label, value, scope, wording}
+    scope options: all_reviews, pricing_mentions, decision_makers,
+                   active_eval_accounts, segment_sample, budget_data
+    """
+    entries: list[dict[str, Any]] = []
+    data = card.get("objection_data") or {}
+    total_reviews = int(data.get("total_reviews") or card.get("total_reviews") or 0)
+    if total_reviews:
+        entries.append({
+            "label": "Reviews analyzed",
+            "value": total_reviews,
+            "scope": "all_reviews",
+            "wording": f"{total_reviews:,} reviews analyzed across sources",
+        })
+    price_rate = data.get("price_complaint_rate")
+    if price_rate is not None:
+        pct = round(float(price_rate) * 100, 1)
+        base = int(round(float(price_rate) * total_reviews)) if total_reviews else None
+        base_text = f" ({base:,} of {total_reviews:,} reviews)" if base else ""
+        entries.append({
+            "label": "Price complaint rate",
+            "value": f"{pct}%",
+            "scope": "pricing_mentions",
+            "wording": f"{pct}% of reviews mention pricing as a pain point{base_text}",
+        })
+    dm_rate = data.get("dm_churn_rate")
+    if dm_rate is not None:
+        pct = round(float(dm_rate) * 100, 1)
+        entries.append({
+            "label": "Decision-maker churn signal rate",
+            "value": f"{pct}%",
+            "scope": "decision_makers",
+            "wording": f"{pct}% of decision-maker reviews show churn signals",
+        })
+    density = data.get("churn_signal_density")
+    if density is not None:
+        entries.append({
+            "label": "Churn signal density",
+            "value": round(float(density), 1),
+            "scope": "all_reviews",
+            "wording": f"{round(float(density), 1)}% of all reviews contain a churn signal",
+        })
+    avg_urgency = data.get("avg_urgency")
+    if avg_urgency is not None:
+        entries.append({
+            "label": "Average urgency score",
+            "value": round(float(avg_urgency), 1),
+            "scope": "all_reviews",
+            "wording": (
+                f"average urgency {round(float(avg_urgency), 1)}/10 across all reviews"
+            ),
+        })
+    acct_metrics = card.get("account_pressure_metrics") or {}
+    eval_count = acct_metrics.get("active_eval_count")
+    if eval_count is not None:
+        entries.append({
+            "label": "Active evaluation accounts",
+            "value": int(eval_count),
+            "scope": "active_eval_accounts",
+            "wording": f"{int(eval_count)} accounts actively evaluating alternatives",
+        })
+    budget = data.get("budget_context") or {}
+    price_inc_count = budget.get("price_increase_count")
+    price_inc_rate = budget.get("price_increase_rate")
+    if price_inc_count and price_inc_rate is not None:
+        pct = round(float(price_inc_rate) * 100, 1)
+        entries.append({
+            "label": "Price increase mentions",
+            "value": int(price_inc_count),
+            "scope": "budget_data",
+            "wording": (
+                f"{int(price_inc_count)} reviews mention a price increase "
+                f"({pct}% of all reviews)"
+            ),
+        })
+    for seg in (card.get("segment_playbook") or {}).get("priority_segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        seg_name = str(seg.get("segment") or "").strip()
+        sample = seg.get("sample_size")
+        if seg_name and sample is not None:
+            entries.append({
+                "label": f"Segment sample: {seg_name}",
+                "value": int(sample),
+                "scope": "segment_sample",
+                "wording": (
+                    f"{int(sample)} reviews from {seg_name} accounts "
+                    f"(sample n={int(sample)})"
+                ),
+            })
+    return entries
+
+
+def _build_battle_card_locked_facts(card: dict[str, Any]) -> dict[str, Any]:
+    """Build source-of-truth synthesis constraints for battle-card copy."""
+    objection_data = card.get("objection_data") or {}
+    allowed_opponents: list[str] = []
+    for comp in _battle_card_aggregated_competitors(card).values():
+        name = str(comp.get("competitor") or "").strip()
+        if name and name not in allowed_opponents:
+            allowed_opponents.append(name)
+    for battle in card.get("cross_vendor_battles") or []:
+        name = str(battle.get("opponent") or "").strip()
+        if name and name not in allowed_opponents:
+            allowed_opponents.append(name)
+    asymmetry = card.get("resource_asymmetry") or {}
+    asym_opponent = str(asymmetry.get("opponent") or "").strip()
+    if asym_opponent and asym_opponent not in allowed_opponents:
+        allowed_opponents.append(asym_opponent)
+    locked: dict[str, Any] = {
+        "vendor": str(card.get("vendor") or ""),
+        "priority_language_allowed": (
+            float(card.get("churn_pressure_score") or 0) >= _battle_card_high_priority_score_min()
+            and float(objection_data.get("avg_urgency") or 0) >= _battle_card_high_priority_urgency_min()
+        ),
+    }
+    if card.get("archetype"):
+        locked["archetype"] = card["archetype"]
+    if card.get("archetype_risk_level"):
+        locked["archetype_risk_level"] = card["archetype_risk_level"]
+    if allowed_opponents:
+        locked["allowed_opponents"] = allowed_opponents
+    if asymmetry.get("resource_advantage"):
+        locked["resource_advantage"] = asymmetry.get("resource_advantage")
+    return locked
+
+
+def _fallback_scorecard_expert_take(scorecard: dict[str, Any]) -> str:
+    """Build a deterministic, buyer-facing scorecard narrative fallback."""
+    vendor = str(scorecard.get("vendor") or "this vendor").strip() or "this vendor"
+    reasoning = str(scorecard.get("reasoning_summary") or "").strip()
+    if reasoning:
+        base = reasoning
+    else:
+        top_pain = str(scorecard.get("top_pain") or "customer fit").strip().lower()
+        trend = str(scorecard.get("trend") or "stable").strip().lower() or "stable"
+        competitor_overlap = scorecard.get("competitor_overlap") or []
+        top_comp = ""
+        if competitor_overlap and isinstance(competitor_overlap[0], dict):
+            top_comp = str(competitor_overlap[0].get("competitor") or "").strip()
+        if top_comp:
+            base = (
+                f"Buyers considering {vendor} should pressure-test {top_pain} because "
+                f"recent feedback is {trend} and evaluation pressure is clustering around {top_comp}."
+            )
+        else:
+            base = (
+                f"Buyers considering {vendor} should pressure-test {top_pain} because "
+                f"recent buyer feedback shows a {trend} churn pattern."
+            )
+    # Cross-vendor comparison context is available in the separate
+    # cross_vendor_comparisons field on the scorecard.  Appending it to the
+    # expert_take prose leaked internal LLM labels (e.g. "Neither - Resource
+    # Parity") into buyer-facing copy, so we no longer interpolate it here.
+    return _trim_words(base, _synthesis_expert_take_max_words())
+
+
+def _validate_scorecard_expert_take(scorecard: dict[str, Any], expert_take: str) -> list[str]:
+    """Reject synthesized scorecard narratives that contradict locked facts."""
+    text = str(expert_take or "").strip()
+    if not text:
+        return ["expert_take is empty"]
+    warnings: list[str] = []
+    lower = text.lower()
+    if len(text.split()) > _synthesis_expert_take_max_words():
+        warnings.append("expert_take exceeds max word count")
+    locked = _build_scorecard_locked_facts(scorecard)
+    allowed_archetype = str(locked.get("archetype") or "").lower()
+    from ...reasoning.archetypes import ARCHETYPES
+    for archetype_name in ARCHETYPES:
+        if archetype_name in lower:
+            if not allowed_archetype:
+                warnings.append("expert_take references an archetype without sufficient reasoning confidence")
+            elif archetype_name != allowed_archetype:
+                warnings.append(f"expert_take references archetype '{archetype_name}' instead of '{allowed_archetype}'")
+            break
+    all_opponents = [
+        str(comp.get("opponent") or "").strip()
+        for comp in (scorecard.get("cross_vendor_comparisons") or [])
+        if str(comp.get("opponent") or "").strip()
+    ]
+    allowed_opponents = {str(name).lower() for name in (locked.get("allowed_opponents") or [])}
+    for opponent in all_opponents:
+        if opponent.lower() in lower and opponent.lower() not in allowed_opponents:
+            warnings.append(f"expert_take references opponent '{opponent}' without high-confidence comparison support")
+            break
+    return warnings
+
+
+def _normalize_scorecard_expert_take(expert_take: str) -> str:
+    """Clamp synthesized scorecard narratives to the configured word budget."""
+    text = str(expert_take or "").strip()
+    if not text:
+        return ""
+    return _trim_words(text, _synthesis_expert_take_max_words())
+
+
+def _build_buyer_action(vendor: str, pain: str | None, alternatives: list[str], archetype: str | None = None) -> str:
+    """Deterministic buyer-facing recommendation for weekly churn feed entries."""
+    alt_text = ", ".join(alternatives[:2]) if alternatives else "competing alternatives"
+    pain_l = (pain or "").lower()
+    if pain_l == "pricing":
+        return f"Teams on {vendor} should benchmark pricing against {alt_text} before renewal and model migration costs before signing any extension."
+    if pain_l == "reliability":
+        return f"Teams on {vendor} should demand incident reviews and SLA remedies immediately while validating {alt_text} as contingency options."
+    if pain_l == "features":
+        return f"Teams on {vendor} should map missing requirements against {alt_text} and require roadmap commitments before renewal."
+    if pain_l == "ux":
+        return f"Teams on {vendor} should compare admin burden and end-user adoption against {alt_text} before committing to another term."
+    if archetype == "acquisition_decay":
+        return f"Teams on {vendor} should assess post-acquisition roadmap stability against {alt_text} before committing to another term."
+    if archetype == "support_collapse":
+        return f"Teams on {vendor} should escalate support SLA concerns immediately and benchmark response times against {alt_text}."
+    if archetype == "integration_break":
+        return f"Teams on {vendor} should audit API/integration stability and evaluate migration paths to {alt_text} before renewal."
+    return f"Teams on {vendor} should compare current fit against {alt_text} and validate switching costs before the next renewal decision."
+
+
+def _classify_trend(
+    vendor: str,
+    churn_density: float,
+    avg_urgency: float,
+    prior_metrics: dict[str, float] | None,
+    temporal_lookup: dict[str, dict] | None = None,
+) -> str:
+    """Classify vendor trend using temporal z-scores when available, falling
+    back to hardcoded delta thresholds.
+
+    Returns one of: ``"new"``, ``"worsening"``, ``"improving"``, ``"stable"``.
+    """
+    if not prior_metrics:
+        return "new"
+
+    # Prefer temporal z-score anomalies when available
+    td = (temporal_lookup or {}).get(vendor, {})
+    anomalies = td.get("anomalies", [])
+    if anomalies:
+        anomalies_by_metric: dict[str, dict] = {}
+        for a in anomalies:
+            if isinstance(a, dict):
+                anomalies_by_metric[a.get("metric", "")] = a
+        cd_a = anomalies_by_metric.get("churn_density", {})
+        urg_a = anomalies_by_metric.get("avg_urgency", {})
+        if (cd_a.get("is_anomaly") and cd_a.get("z_score", 0) > 0) or \
+           (urg_a.get("is_anomaly") and urg_a.get("z_score", 0) > 0):
+            return "worsening"
+        if (cd_a.get("is_anomaly") and cd_a.get("z_score", 0) < 0) or \
+           (urg_a.get("is_anomaly") and urg_a.get("z_score", 0) < 0):
+            return "improving"
+
+    # Fallback: hardcoded delta thresholds
+    delta_density = churn_density - prior_metrics.get("churn_signal_density", 0)
+    delta_urgency = avg_urgency - prior_metrics.get("avg_urgency", 0)
+    if delta_density >= 5 or delta_urgency >= 1:
+        return "worsening"
+    if delta_density <= -5 or delta_urgency <= -1:
+        return "improving"
+    return "stable"
+
+
+def _infer_driver_from_reasons(reasons: list[str], fallback: str | None = None) -> str | None:
+    """Classify a driver label from competitor-reason text."""
+    for reason in reasons:
+        normalized = _normalize_displacement_driver_label(reason)
+        if normalized:
+            return normalized
+    text = " ".join(reasons).lower()
+    keyword_map = {
+        "pricing": ("price", "pricing", "cost", "cheaper", "affordable", "budget"),
+        "support": ("support", "service", "response", "help desk", "ticket"),
+        "reliability": ("outage", "uptime", "reliable", "stability", "incident"),
+        "ux": ("ui", "ux", "easy", "simpler", "interface", "adoption", "learning curve"),
+        "integration": ("integration", "api", "connector", "webhook", "plugin", "stack"),
+        "features": ("feature", "workflow", "automation", "reporting", "capability"),
+        "security": ("security", "privacy", "governance", "server", "encryption"),
+        "compliance": ("compliance", "gdpr", "hipaa", "soc2", "soc 2"),
+    }
+    for label, keywords in keyword_map.items():
+        if any(keyword in text for keyword in keywords):
+            return label
+    return fallback
+
+
+def _get_vendor_reasoning(
+    vendor: str,
+    *,
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+) -> dict[str, Any]:
+    """Get reasoning entry for a vendor, preferring SynthesisView.
+
+    Returns the same dict shape as reasoning_lookup entries: archetype,
+    confidence, executive_summary, key_signals, etc.  When a SynthesisView
+    is available, reads directly from it; otherwise falls back to the
+    pre-built reasoning_lookup shim.
+    """
+    if synthesis_views:
+        view = synthesis_views.get(vendor)
+        # Canonicalized fallback: try lowered/stripped key
+        if view is None and vendor:
+            canon = vendor.strip().lower()
+            for vn, v in synthesis_views.items():
+                if vn.strip().lower() == canon:
+                    view = v
+                    break
+        if view is not None:
+            from ._b2b_synthesis_reader import synthesis_view_to_reasoning_entry
+            return synthesis_view_to_reasoning_entry(view)
+    return (reasoning_lookup or {}).get(vendor, {})
+
+
+def _build_market_shift_signal(
+    category: str,
+    highest_vendor: str,
+    churn_density: float,
+    total_reviews: int,
+    emerging: str,
+    reasoning_lookup: dict[str, dict],
+    synthesis_views: dict[str, Any] | None = None,
+) -> str:
+    """Build market shift signal with archetype context when available."""
+    base = (
+        f"Based on {total_reviews} reviews, {highest_vendor} shows "
+        f"{churn_density}% churn-signal density in {category}."
+    )
+    _rc = _get_vendor_reasoning(highest_vendor, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup)
+    arch = _rc.get("archetype", "")
+    if arch:
+        base += f" Classified as {arch} pattern."
+    challenger_part = (
+        f" {emerging} is the most visible challenger flow in this category."
+        if emerging and "Insufficient" not in emerging
+        else ""
+    )
+    return base + challenger_part
+
+
+def _vendor_match(value: str, vendor_set: set[str]) -> bool:
+    """Case-insensitive ILIKE-style match: vendor_set entry is contained in value."""
+    vl = value.lower()
+    return any(name in vl for name in vendor_set)
+
+
+def _filter_by_vendors(data: list[dict], vendor_names: list[str]) -> list[dict]:
+    """Post-filter fetcher results to only include rows matching vendor_names.
+
+    Handles two structures:
+    - Flat dicts with a ``vendor`` / ``vendor_name`` key (most fetchers)
+    - Nested dicts like ``use_case_distribution`` with ``{"type": ..., "data": [...]}``
+      where vendor data lives inside ``data[*]["vendor_name"]``
+    """
+    lowered = {v.lower() for v in vendor_names}
+    filtered = []
+    for row in data:
+        vn = row.get("vendor") or row.get("vendor_name") or ""
+        if vn:
+            # Standard flat row
+            if _vendor_match(vn, lowered):
+                filtered.append(row)
+        elif "data" in row and isinstance(row["data"], list):
+            # Nested structure (use_case_distribution): filter inner data
+            inner = [r for r in row["data"] if _vendor_match(
+                r.get("vendor_name") or r.get("vendor") or "", lowered
+            )]
+            if inner:
+                filtered.append({**row, "data": inner})
+        # else: no vendor key at all, skip row
+    return filtered
+
+
+# ------------------------------------------------------------------
+# Layer 1: depends on Layer 0
+# ------------------------------------------------------------------
+
+
+def _validate_report(
+    parsed: dict[str, Any],
+    *,
+    source_high_intent: list[dict[str, Any]],
+    source_quotable: list[dict[str, Any]],
+    source_displacement: list[dict[str, Any]],
+    report_date: date,
+) -> list[str]:
+    """Post-LLM validation: drop fabricated quotes, unmatched displacements, stale dates.
+
+    Mutates *parsed* in place and returns a list of warning strings.
+    """
+    warnings: list[str] = []
+
+    # Build lookup of real quotes from source data (handles both str and dict quotes)
+    real_quotes: set[str] = set()
+    for h in source_high_intent:
+        for q in h.get("quotes", []):
+            text = _quote_text(q)
+            if text:
+                real_quotes.add(text)
+    for qe in source_quotable:
+        for q in qe.get("quotes", []):
+            text = _quote_text(q)
+            if text:
+                real_quotes.add(text)
+
+    # 1. Summary vendor check -- warn if exec summary names a vendor not in feed
+    exec_summary = parsed.get("executive_summary", "")
+    feed = parsed.get("weekly_churn_feed", [])
+    feed_vendors = {e.get("vendor", "") for e in feed if isinstance(e, dict)}
+    feed_vendors.discard("")
+    if isinstance(exec_summary, str) and feed_vendors:
+        # Collect all vendor names from source data (superset of feed)
+        all_known_vendors = {h.get("vendor", "") for h in source_high_intent}
+        all_known_vendors.discard("")
+        for vendor in all_known_vendors:
+            if vendor in exec_summary and vendor not in feed_vendors:
+                warnings.append(
+                    f"Executive summary mentions {vendor!r} which is not in weekly_churn_feed"
+                )
+
+    # 2. Quote verification -- weekly_churn_feed
+    if isinstance(feed, list):
+        for entry in feed:
+            kq = entry.get("key_quote")
+            if kq and kq not in real_quotes:
+                warnings.append(f"Fabricated key_quote in weekly_churn_feed for {entry.get('vendor') or entry.get('company')}: {kq[:80]}")
+                entry["key_quote"] = None
+
+    # 2b. Quote verification -- displacement_map
+    disp_map = parsed.get("displacement_map", [])
+    if isinstance(disp_map, list):
+        for entry in disp_map:
+            kq = entry.get("key_quote")
+            if kq and kq not in real_quotes:
+                warnings.append(f"Fabricated key_quote in displacement_map for {entry.get('from_vendor')}->{entry.get('to_vendor')}: {kq[:80]}")
+                entry["key_quote"] = None
+
+    # 3. Displacement pair verification (add both orderings for direction ambiguity)
+    source_pairs: set[tuple[str, str]] = set()
+    for d in source_displacement:
+        vendor_l = _canonicalize_vendor(d.get("vendor", "")).lower()
+        comp_l = _canonicalize_competitor(d.get("competitor", "")).lower()
+        source_pairs.add((vendor_l, comp_l))
+        source_pairs.add((comp_l, vendor_l))
+    if isinstance(disp_map, list):
+        valid_disp = []
+        for entry in disp_map:
+            pair = (
+                _canonicalize_vendor(entry.get("from_vendor") or "").lower(),
+                _canonicalize_competitor(entry.get("to_vendor") or "").lower(),
+            )
+            if pair in source_pairs:
+                valid_disp.append(entry)
+            else:
+                warnings.append(f"Unmatched displacement pair: {entry.get('from_vendor')}->{entry.get('to_vendor')}")
+        parsed["displacement_map"] = valid_disp
+
+    # 4. Stale date detection in timeline_hot_list
+    timeline = parsed.get("timeline_hot_list", [])
+    if isinstance(timeline, list):
+        valid_tl = []
+        for entry in timeline:
+            contract_end = entry.get("contract_end")
+            if contract_end:
+                try:
+                    from datetime import datetime
+                    end_date = datetime.strptime(str(contract_end)[:10], "%Y-%m-%d").date()
+                    if end_date < report_date:
+                        warnings.append(f"Stale contract_end {contract_end} for {entry.get('company')} (before report date {report_date})")
+                        continue
+                except (ValueError, TypeError):
+                    warnings.append(
+                        f"Unparseable contract_end {contract_end!r} for {entry.get('company')} -- kept in timeline"
+                    )
+            valid_tl.append(entry)
+        parsed["timeline_hot_list"] = valid_tl
+
+    return warnings
+
+
+def _validate_battle_card_sales_copy(
+    card: dict[str, Any],
+    generated: dict[str, Any],
+) -> list[str]:
+    """Reject battle-card copy that overclaims beyond deterministic evidence."""
+    if not isinstance(generated, dict):
+        return ["battle card sales copy is not a JSON object"]
+    warnings: list[str] = []
+    if _battle_card_has_duplicate_recommended_play_segments(generated):
+        warnings.append("recommended_plays repeat the same target segment")
+    allowed = _battle_card_allowed_claims(card)
+    source_text = json.dumps(_battle_card_validator_source(card), default=str).lower()
+    max_switch = max((int(c.get("switch_count") or 0) for c in card.get("competitor_differentiators") or []), default=0)
+    score = float(card.get("churn_pressure_score") or 0)
+    urgency = float(((card.get("objection_data") or {}).get("avg_urgency")) or 0)
+    low_gap_terms = [
+        str(g.get("feature") or "").strip().lower()
+        for g in ((card.get("objection_data") or {}).get("top_feature_gaps") or [])
+        if int(g.get("mentions") or 0) < _battle_card_feature_gap_headline_min_mentions()
+    ]
+    allowed_quotes = set(_battle_card_allowed_quotes(card))
+    for path, text in _battle_card_iter_text(generated):
+        lowered = text.lower()
+        if _battle_card_numeric_paths(path):
+            bad = sorted(
+                tok
+                for tok in _battle_card_numeric_tokens(text)
+                if _battle_card_normalize_numeric_token(tok) not in allowed
+            )
+            if bad:
+                warnings.append(f"{path} uses unsupported numeric claims: {', '.join(bad[:4])}")
+        years = re.findall(r"\b20\d{2}\b", text)
+        if any(year not in source_text for year in years):
+            warnings.append(f"{path} references a year not present in source data")
+        if max_switch == 0 and any(term in lowered for term in _battle_card_leaving_patterns()):
+            warnings.append(f"{path} implies switching despite zero switch_count evidence")
+        if score < _battle_card_high_priority_score_min() or urgency < _battle_card_high_priority_urgency_min():
+            if "high-priority target" in lowered or "high priority target" in lowered:
+                warnings.append(f"{path} overstates urgency for a moderate-priority card")
+        if _battle_card_segment_evidence_is_thin(card) and path.endswith(".play"):
+            if lowered.startswith("target ") or lowered.startswith("engage "):
+                warnings.append(f"{path} overstates segment certainty without account-level intelligence")
+        if _battle_card_headline_paths(path):
+            for term in low_gap_terms:
+                if term and term in lowered:
+                    warnings.append(f"{path} elevates low-evidence feature gap '{term}' to a headline")
+        overreach = _battle_card_overreach_violations(text)
+        if overreach:
+            warnings.append(
+                f"{path} uses overreaching language: {overreach[0]!r}"
+            )
+    pain_quote_meta: dict[str, dict[str, Any]] = {}
+    for _pq in card.get("customer_pain_quotes") or []:
+        if isinstance(_pq, dict):
+            _qt = str(_pq.get("quote") or "").strip()
+            if _qt:
+                pain_quote_meta[_qt] = _pq
+    weaknesses = generated.get("weakness_analysis")
+    if allowed_quotes and isinstance(weaknesses, list):
+        for idx, item in enumerate(weaknesses):
+            if not isinstance(item, dict):
+                continue
+            customer_quote = str(item.get("customer_quote") or "").strip()
+            if customer_quote and customer_quote not in allowed_quotes:
+                warnings.append(
+                    f"weakness_analysis[{idx}].customer_quote is not an exact source quote"
+                )
+            if customer_quote:
+                _meta = pain_quote_meta.get(customer_quote) or {}
+                if not _quote_has_pain_signal(
+                    customer_quote,
+                    urgency=float(_meta.get("urgency") or 0),
+                    rating=_meta.get("rating"),
+                    rating_max=_meta.get("rating_max"),
+                ):
+                    warnings.append(
+                        f"weakness_analysis[{idx}].customer_quote appears positive, not a pain signal"
+                    )
+    # Detect near-duplicate sections: collect all long string values and
+    # flag when the same substantial prefix appears in more than one field.
+    long_strings: list[tuple[str, str]] = []
+    for path, text in _battle_card_iter_text(generated):
+        if len(text.strip()) >= 80:
+            long_strings.append((path, text.strip()))
+    seen_prefixes: dict[str, str] = {}
+    for path, text in long_strings:
+        prefix = text[:80].lower()
+        if prefix in seen_prefixes and seen_prefixes[prefix] != path:
+            warnings.append(
+                f"{path} duplicates content already present in {seen_prefixes[prefix]}"
+            )
+        else:
+            seen_prefixes[prefix] = path
+    return warnings
+
+
+def _extract_alternative_names(alternatives: list[Any]) -> list[str]:
+    """Normalize alternative names from review enrichment objects."""
+    names: list[str] = []
+    for alt in alternatives or []:
+        if isinstance(alt, dict):
+            label = alt.get("name", "")
+        else:
+            label = str(alt) if alt is not None else ""
+        label = _canonicalize_competitor(label)
+        if label and label not in names:
+            names.append(label)
+    return names
+
+
+def _compute_churn_pressure_score(
+    *,
+    churn_density: float,
+    avg_urgency: float,
+    dm_churn_rate: float,
+    displacement_mention_count: int,
+    price_complaint_rate: float,
+    total_reviews: int,
+    archetype: str | None = None,
+    displacement_velocity: float | None = None,
+) -> float:
+    """Composite 0-100 score for ranking vendors by churn pressure.
+
+    Default weights: churn density 30%, urgency 25%, DM churn rate 20%,
+    displacement mentions 15%, price complaints 10%.
+
+    When *archetype* is provided from a reasoning layer, the weights
+    shift to emphasise the signal most relevant to that churn pattern --
+    e.g. ``pricing_shock`` boosts price_complaints to 35%.
+
+    Optional *displacement_velocity* adds a 0-5 point bonus for vendors
+    with accelerating competitive displacement (leading indicator).
+
+    Confidence multiplier: 1.0 (50+), 0.85 (20-49), 0.65 (<20).
+    """
+    w = _ARCHETYPE_WEIGHT_OVERRIDES.get(archetype or "", _DEFAULT_WEIGHTS)
+    raw = (
+        min(churn_density, 100.0) * w["churn_density"]
+        + min(avg_urgency, 10.0) * 10.0 * w["urgency"]
+        + min(dm_churn_rate, 1.0) * 100.0 * w["dm_churn_rate"]
+        + min(displacement_mention_count, 50) * 2.0 * w["displacement"]
+        + min(price_complaint_rate, 1.0) * 100.0 * w["price_complaints"]
+    )
+    # Displacement velocity bonus: 0-5 points on top of weighted score
+    if displacement_velocity is not None and displacement_velocity > 0:
+        raw += min(displacement_velocity / 5.0, 1.0) * 5.0
+    if total_reviews >= 50:
+        confidence = 1.0
+    elif total_reviews >= 20:
+        confidence = 0.85
+    else:
+        confidence = 0.65
+    return round(min(raw * confidence, 100.0), 1)
+
+
+def _compute_evidence_confidence(
+    mention_count: int,
+    source_distribution: dict[str, int],
+) -> float:
+    """Evidence-based confidence score for provenance-tracked entities.
+
+    Three equally-weighted signals (each 0-1, averaged):
+      - mention_weight:  log-scaled mention count (caps at 20)
+      - source_weight:   number of distinct sources (3+ = 1.0)
+      - quality_weight:  proportion from VERIFIED_SOURCES
+    """
+    _VERIFIED = {s.value for s in VERIFIED_SOURCES}
+
+    # Mention weight: log2(count)/log2(20), capped at 1.0
+    mention_weight = min(math.log2(max(mention_count, 1)) / math.log2(20), 1.0)
+
+    # Source diversity: n_sources / 3, capped at 1.0
+    n_sources = len(source_distribution)
+    source_weight = min(n_sources / 3.0, 1.0)
+
+    # Quality weight: fraction of mentions from verified sources
+    total = sum(source_distribution.values()) or 1
+    verified_total = sum(
+        cnt for src, cnt in source_distribution.items() if src in _VERIFIED
+    )
+    quality_weight = verified_total / total
+
+    score = (mention_weight + source_weight + quality_weight) / 3.0
+    return round(score, 2)
+
+
+def _pick_displacement_quote(
+    *,
+    vendor: str,
+    competitor: str,
+    reasons: list[str],
+    quote_lookup: dict[str, list],
+) -> str | None:
+    """Choose a quote matching the competitor or reason text when possible."""
+    quotes = quote_lookup.get(vendor, [])
+    competitor_l = competitor.lower()
+    for q in quotes:
+        text = _quote_text(q) or ""
+        if competitor_l in text.lower():
+            return text
+    for reason in reasons:
+        for token in reason.lower().split():
+            if len(token) >= 5:
+                for q in quotes:
+                    text = _quote_text(q) or ""
+                    if token in text.lower():
+                        return text
+    return _quote_text(quotes[0]) if quotes else None
+
+
+def _build_reason_lookup(competitor_reasons: list[dict[str, Any]]) -> dict[tuple[str, str], list[str]]:
+    """Map (vendor, competitor) to ordered reason strings.
+
+    Prefers structured ``reason_category`` when available; falls back to
+    free-text ``reason`` for legacy data.
+    """
+    lookup: dict[tuple[str, str], list[str]] = {}
+    for row in competitor_reasons:
+        vendor = _canonicalize_vendor(row.get("vendor", ""))
+        competitor = _canonicalize_competitor(row.get("competitor", ""))
+        reason = row.get("reason_category") or row.get("reason") or ""
+        if not vendor or not competitor or not reason:
+            continue
+        key = (vendor, competitor)
+        lookup.setdefault(key, [])
+        if reason not in lookup[key]:
+            lookup[key].append(reason)
+    return lookup
+
+
+def _normalize_generic_pain_label(label: Any) -> str:
+    raw = str(label or "").strip().lower()
+    if raw in {"other", "general_dissatisfaction", "overall_dissatisfaction"}:
+        return "overall_dissatisfaction"
+    return raw
+
+
+def _is_generic_pain_label(label: Any) -> bool:
+    return _normalize_generic_pain_label(label) == "overall_dissatisfaction"
+
+
+def _executive_summary_representative_quote(
+    feed: list[dict[str, Any]],
+    *,
+    limit: int = 5,
+) -> str | None:
+    """Pick a churn-aligned representative quote from the weekly feed."""
+    candidates: list[tuple[int, float, int, str]] = []
+    fallback_quotes: list[tuple[int, float, int, str]] = []
+    for idx, entry in enumerate(feed[: max(limit, 1)]):
+        if not isinstance(entry, dict):
+            continue
+        quote = str(entry.get("key_quote") or "").strip()
+        if not quote:
+            continue
+        try:
+            urgency = float(entry.get("avg_urgency") or 0.0)
+        except (TypeError, ValueError):
+            urgency = 0.0
+        ranked = (idx, urgency, len(quote), quote)
+        if _quote_has_pain_signal(quote, urgency=urgency):
+            candidates.append(ranked)
+        else:
+            fallback_quotes.append(ranked)
+    if candidates:
+        candidates.sort(key=lambda item: (-item[1], item[0], -item[2]))
+        return candidates[0][3]
+    if fallback_quotes:
+        fallback_quotes.sort(key=lambda item: (item[0], -item[1], -item[2]))
+        return fallback_quotes[0][3]
+    return None
+
+
+def _build_validated_executive_summary(
+    parsed: dict[str, Any],
+    *,
+    data_context: dict[str, Any],
+    executive_sources: list[str],
+    report_type: str = "weekly_churn_feed",
+) -> str:
+    """Build a concise deterministic executive summary from validated structured data.
+
+    Each *report_type* gets a tailored summary.  Shared helper ``_summary_preamble``
+    produces the opening sentence; the body varies per type.
+    """
+    feed = parsed.get("weekly_churn_feed", [])
+    if not isinstance(feed, list) or not feed:
+        return parsed.get("executive_summary", "")
+
+    period = data_context.get("enrichment_period") or {}
+    start = period.get("earliest")
+    end = period.get("latest")
+    window_label = f"Between {start} and {end}" if start and end else "In the current analysis window"
+
+    source_dist = data_context.get("source_distribution") or {}
+    total_review_count = sum(
+        int((source_dist.get(source) or {}).get("reviews") or 0)
+        for source in executive_sources
+    )
+    source_labels = [_source_display_name(source) for source in executive_sources]
+    source_label_text = ", ".join(source_labels)
+
+    # --- per-report-type summaries ------------------------------------
+
+    if report_type == "vendor_scorecard":
+        scorecards = parsed.get("vendor_scorecards", [])
+        n = len(scorecards)
+        if not scorecards:
+            return ""
+
+        # Risk distribution
+        risk_counts: dict[str, int] = {"high": 0, "medium": 0, "low": 0}
+        for s in scorecards:
+            rl = s.get("risk_level", "low")
+            if rl in risk_counts:
+                risk_counts[rl] += 1
+        risk_parts = []
+        for level in ("high", "medium", "low"):
+            if risk_counts[level]:
+                risk_parts.append(f"{risk_counts[level]} {level}-risk")
+
+        # Sentence 1: scale + risk distribution
+        lines = [
+            f"{window_label}, Atlas scored {n} vendors on churn pressure"
+            + (f" from {total_review_count:,} reviews across {source_label_text}"
+               if total_review_count else f" across {source_label_text}")
+            + f" -- {', '.join(risk_parts)}."
+        ]
+
+        # Sentence 2: top-pressure vendor, score, driver, DM rate
+        top = scorecards[0]  # sorted by urgency+density descending
+        top_vendor = top.get("vendor", "")
+        top_score = top.get("churn_pressure_score", 0)
+        top_density = top.get("churn_signal_density", 0)
+        top_pain = top.get("top_pain", "")
+        dm_rate = top.get("dm_churn_rate", 0)
+
+        s2 = f"{top_vendor} scored highest at {top_score:.1f}"
+        s2 += f" ({top_density}% churn density -- share of reviews containing explicit switching signals)"
+        if top_pain and not _is_generic_pain_label(top_pain) and top_pain.lower() != "unknown":
+            s2 += f", driven primarily by {top_pain} complaints"
+        if dm_rate and dm_rate >= 0.3:
+            s2 += f"; {dm_rate:.0%} of switching signals came from decision-makers"
+        s2 += "."
+        lines.append(s2)
+
+        # Sentence 3: trend direction (only when there's a clear skew)
+        trend_counts: dict[str, int] = {"worsening": 0, "improving": 0, "stable": 0, "new": 0}
+        for s in scorecards:
+            t = s.get("trend", "stable")
+            if t in trend_counts:
+                trend_counts[t] += 1
+        if trend_counts["worsening"] > trend_counts["improving"]:
+            lines.append(
+                f"{trend_counts['worsening']} vendors are trending worse than last period"
+                + (f", {trend_counts['improving']} improving." if trend_counts["improving"] else ".")
+            )
+        elif trend_counts["improving"] > trend_counts["worsening"]:
+            lines.append(
+                f"{trend_counts['improving']} vendors are improving"
+                + (f", {trend_counts['worsening']} worsening." if trend_counts["worsening"] else ".")
+            )
+
+        # Sentence 4: displacement direction for highest-risk vendor
+        top_threat = top.get("top_competitor_threat", "")
+        if top_threat and "Insufficient" not in top_threat:
+            lines.append(f"High-risk vendors are losing ground primarily to {top_threat}.")
+
+        return " ".join(lines)
+
+    if report_type == "displacement_report":
+        disp = parsed.get("displacement_map", [])
+        if not disp:
+            return ""
+        n_edges = len(disp)
+        from_vendors = {e.get("from_vendor") for e in disp if e.get("from_vendor")}
+        total_mentions = sum(e.get("mention_count", 0) for e in disp)
+
+        # Sentence 1: scale
+        lines = [
+            f"{window_label}, Atlas tracked {n_edges} competitive displacement flows"
+            f" across {len(from_vendors)} vendors"
+            + (f" from {total_review_count:,} reviews" if total_review_count else "")
+            + f", totaling {total_mentions:,} switching mentions."
+        ]
+
+        # Sentence 2: strongest flow
+        top = disp[0]  # sorted by mention_count descending
+        top_from = top.get("from_vendor", "")
+        top_to = top.get("to_vendor", "")
+        top_count = top.get("mention_count", 0)
+        top_driver = top.get("primary_driver", "")
+        s2 = f"The strongest flow is {top_from} -> {top_to} ({top_count} mentions)"
+        if top_driver and not _is_generic_pain_label(top_driver):
+            s2 += f", driven by {top_driver}"
+        s2 += "."
+        lines.append(s2)
+
+        # Sentence 3: driver distribution (weighted by mention count)
+        driver_counts: dict[str, int] = {}
+        for e in disp:
+            d = e.get("primary_driver") or None
+            if d and not _is_generic_pain_label(d):
+                driver_counts[d] = driver_counts.get(d, 0) + e.get("mention_count", 0)
+        if driver_counts and total_mentions:
+            ranked_drivers = sorted(driver_counts.items(), key=lambda x: -x[1])
+            top_d = ranked_drivers[0]
+            pct = round(top_d[1] * 100 / total_mentions)
+            parts = [f"{top_d[0]} drives {pct}% of all displacement flow"]
+            for d_name, d_count in ranked_drivers[1:3]:
+                parts.append(f"{d_name} ({round(d_count * 100 / total_mentions)}%)")
+            lines.append(", followed by ".join(parts) + "." if len(parts) > 1 else parts[0] + ".")
+
+        # Sentence 4: signal strength breakdown
+        strength_counts: dict[str, int] = {"strong": 0, "moderate": 0, "emerging": 0}
+        for e in disp:
+            ss = e.get("signal_strength", "emerging")
+            if ss in strength_counts:
+                strength_counts[ss] += 1
+        strength_parts = []
+        for level, label in [("strong", "strong signal (5+ mentions)"), ("moderate", "moderate"), ("emerging", "emerging")]:
+            if strength_counts[level]:
+                strength_parts.append(f"{strength_counts[level]} {label}")
+        if strength_parts:
+            lines.append(", ".join(strength_parts) + ".")
+
+        return " ".join(lines)
+
+    if report_type == "category_overview":
+        cats = parsed.get("category_insights", [])
+        if not cats:
+            return ""
+        n = len(cats)
+
+        # Count total unique vendors across all category rankings
+        all_cat_vendors: set[str] = set()
+        for cat in cats:
+            for vr in cat.get("vendor_rankings", []):
+                v = vr.get("vendor")
+                if v:
+                    all_cat_vendors.add(v)
+
+        # Sentence 1: scale
+        lines = [
+            f"{window_label}, Atlas analyzed churn trends across {n} product categories"
+            + (f" covering {len(all_cat_vendors)} vendors from {total_review_count:,} reviews."
+               if total_review_count and all_cat_vendors
+               else f" covering {len(all_cat_vendors)} vendors." if all_cat_vendors
+               else ".")
+        ]
+
+        # Sentence 2: hottest category (highest churn density)
+        hottest = None
+        hottest_density = 0.0
+        for cat in cats:
+            rankings = cat.get("vendor_rankings", [])
+            if rankings:
+                cd = rankings[0].get("churn_signal_density", 0)
+                if cd > hottest_density:
+                    hottest_density = cd
+                    hottest = cat
+        if hottest:
+            cat_name = hottest.get("category", "")
+            risk_vendor = hottest.get("highest_churn_risk", "")
+            pain = hottest.get("dominant_pain", "")
+            s2 = (
+                f"{cat_name} shows the highest pressure -- {risk_vendor}"
+                f" at {hottest_density}% churn density"
+                " (share of reviews with explicit switching signals)"
+            )
+            if pain and not _is_generic_pain_label(pain) and pain.lower() != "unknown":
+                s2 += f", driven by {pain}"
+            s2 += "."
+            lines.append(s2)
+
+        # Sentence 3: market movement -- categories with clear challengers
+        movements = []
+        for cat in cats:
+            challenger = cat.get("emerging_challenger", "")
+            incumbent = cat.get("highest_churn_risk", "")
+            cat_name = cat.get("category", "")
+            if challenger and incumbent and "Insufficient" not in challenger:
+                # Skip the hottest category (already covered in sentence 2)
+                if hottest and cat_name == hottest.get("category"):
+                    continue
+                movements.append(f"in {cat_name}, {challenger} is emerging as the primary alternative to {incumbent}")
+        if movements:
+            lines.append("; ".join(movements[:2]).capitalize() + ".")
+
+        # Sentence 4: cross-category pain pattern
+        pain_counts: dict[str, int] = {}
+        for cat in cats:
+            p = cat.get("dominant_pain", "")
+            if p and not _is_generic_pain_label(p) and p.lower() != "unknown":
+                pain_counts[p] = pain_counts.get(p, 0) + 1
+        if pain_counts:
+            top_pain_name, top_pain_ct = max(pain_counts.items(), key=lambda x: x[1])
+            if top_pain_ct >= 2:
+                lines.append(f"{top_pain_name.capitalize()} is the dominant churn driver in {top_pain_ct} of {n} categories.")
+
+        return " ".join(lines)
+
+    # --- default: weekly_churn_feed -----------------------------------
+
+    top_entries = feed[:3]
+    top_vendors: list[str] = []
+    top_pains: list[str] = []
+    top_alternatives: list[str] = []
+    quote = _executive_summary_representative_quote(top_entries)
+    churn_density_defined = False
+
+    for entry in top_entries:
+        vendor = entry.get("vendor")
+        churn_density = entry.get("churn_signal_density") or entry.get("churn_density")
+        total_reviews = entry.get("total_reviews")
+        if vendor:
+            parts = [str(vendor)]
+            if churn_density is not None:
+                if not churn_density_defined:
+                    parts[0] += f" ({churn_density}% churn density -- share of reviews containing explicit switching signals"
+                    churn_density_defined = True
+                else:
+                    parts[0] += f" ({churn_density}%"
+                if total_reviews:
+                    parts[0] += f", {total_reviews} reviews)"
+                else:
+                    parts[0] += ")"
+            top_vendors.append(parts[0])
+        # Extract pains from pain_breakdown or top_pain -- skip generic fallback labels
+        pain_breakdown = entry.get("pain_breakdown", [])
+        if pain_breakdown:
+            for pb in pain_breakdown[:2]:
+                p = pb.get("category", "")
+                if p and not _is_generic_pain_label(p) and p not in top_pains:
+                    top_pains.append(str(p))
+        elif entry.get("top_pain"):
+            p = str(entry["top_pain"])
+            if not _is_generic_pain_label(p) and p not in top_pains:
+                top_pains.append(p)
+        # Extract alternatives from displacement targets
+        for dt in entry.get("top_displacement_targets", []) or []:
+            comp = dt.get("competitor", "")
+            if comp and comp not in top_alternatives:
+                top_alternatives.append(comp)
+
+    lines = [
+        (
+            f"{window_label}, Atlas identified {len(feed)} vendors under elevated churn pressure "
+            f"from {total_review_count} reviews across {source_label_text}."
+            if total_review_count
+            else f"{window_label}, Atlas identified {len(feed)} vendors under elevated churn pressure across {source_label_text}."
+        )
+    ]
+
+    if top_vendors:
+        lines.append("Strongest vendor-level churn signals: " + "; ".join(top_vendors) + ".")
+    if top_pains or top_alternatives:
+        pain_text = _join_summary_terms(top_pains[:3]) if top_pains else "mixed issues"
+        alt_text = _join_summary_terms(top_alternatives[:4]) if top_alternatives else "multiple alternatives"
+        lines.append(
+            f"The dominant churn drivers are {pain_text}. The most visible active alternatives are {alt_text}."
+        )
+    if quote:
+        lines.append(f"Representative evidence: \"{quote}\"")
+
+    lines.append(
+        "Confidence is highest for vendors with 50+ reviews; smaller samples should be treated as directional."
+    )
+    return " ".join(lines)
+
+
+# ------------------------------------------------------------------
+# Layer 2: async fetch helpers
+# ------------------------------------------------------------------
+
+
+async def _fetch_data_context(pool, window_days: int) -> dict[str, Any]:
+    """Compute temporal metadata and source composition for the LLM."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(window_param=None, source_param=2)
+    funnel_audit = await _fetch_review_funnel_audit(pool, window_days)
+    row = await pool.fetchrow(
+        f"""
+        SELECT
+            count(*) AS total_enriched,
+            count(*) FILTER (WHERE enriched_at > NOW() - make_interval(days => $1)) AS in_window,
+            min(enriched_at) AS earliest_enriched,
+            max(enriched_at) AS latest_enriched,
+            count(DISTINCT vendor_name) AS vendor_count,
+            count(DISTINCT reviewer_company) FILTER (
+                WHERE reviewer_company IS NOT NULL AND reviewer_company != ''
+            ) AS company_count
+        FROM b2b_reviews
+        WHERE {filters}
+        """,
+        window_days,
+        sources,
+    )
+
+    # Source distribution so LLM knows the composition
+    source_rows = await pool.fetch(
+        f"""
+        SELECT source, count(*) AS cnt,
+            count(*) FILTER (
+                WHERE (enrichment->>'urgency_score')::numeric >= 7
+            ) AS high_urgency
+        FROM b2b_reviews
+        WHERE {filters}
+            AND enriched_at > NOW() - make_interval(days => $1)
+        GROUP BY source ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    source_dist = {
+        r["source"]: {"reviews": r["cnt"], "high_urgency": r["high_urgency"]}
+        for r in source_rows
+    }
+
+    return {
+        "total_enriched_reviews": row["total_enriched"],
+        "reviews_in_analysis_window": row["in_window"],
+        "analysis_window_days": window_days,
+        "enrichment_period": {
+            "earliest": str(row["earliest_enriched"].date()) if row["earliest_enriched"] else None,
+            "latest": str(row["latest_enriched"].date()) if row["latest_enriched"] else None,
+        },
+        "unique_vendors": row["vendor_count"],
+        "unique_companies": row["company_count"],
+        "source_distribution": source_dist,
+        "funnel_audit": funnel_audit,
+    }
+
+
+async def _fetch_vendor_provenance(pool, window_days: int) -> dict[str, dict]:
+    """Per-vendor provenance: source distribution, sample review IDs, and review window.
+
+    Returns {vendor_name: {"source_distribution": {...}, "sample_review_ids": [...],
+             "review_window_start": dt, "review_window_end": dt}}.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    time_expr = _eligible_review_timestamp_expr(alias="r")
+
+    # Source distribution per vendor
+    dist_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name, r.source, count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+        GROUP BY vm.vendor_name, r.source
+        """,
+        window_days,
+        sources,
+    )
+    dist: dict[str, dict[str, int]] = {}
+    for r in dist_rows:
+        dist.setdefault(r["vendor_name"], {})[r["source"]] = r["cnt"]
+
+    # Sample review IDs (top 50 by urgency) + window per vendor
+    sample_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            (ARRAY_AGG(r.id ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST))[1:50]
+                AS sample_ids,
+            MIN({time_expr}) AS window_start,
+            MAX({time_expr}) AS window_end
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+        GROUP BY vm.vendor_name
+        """,
+        window_days,
+        sources,
+    )
+
+    result: dict[str, dict] = {}
+    for r in sample_rows:
+        vendor = r["vendor_name"]
+        result[vendor] = {
+            "source_distribution": dist.get(vendor, {}),
+            "sample_review_ids": r["sample_ids"] or [],
+            "review_window_start": r["window_start"],
+            "review_window_end": r["window_end"],
+        }
+    # Fill in vendors that appear in dist but not in sample (shouldn't happen, but safe)
+    for vendor in dist:
+        if vendor not in result:
+            result[vendor] = {
+                "source_distribution": dist[vendor],
+                "sample_review_ids": [],
+                "review_window_start": None,
+                "review_window_end": None,
+            }
+    return result
+
+
+async def _fetch_vendor_churn_scores(pool, window_days: int, min_reviews: int) -> list[dict[str, Any]]:
+    """Per-vendor health metrics from enriched reviews."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=3,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        WITH review_scores AS (
+            SELECT vm.vendor_name AS vendor_name,
+                MODE() WITHIN GROUP (ORDER BY r.product_category) AS product_category,
+                count(*) AS total_reviews,
+                count(*) FILTER (
+                    WHERE COALESCE((r.enrichment->>'urgency_score')::numeric, 0) > 0
+                       OR (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+                       OR jsonb_array_length(COALESCE(r.enrichment->'competitors_mentioned', '[]'::jsonb)) > 0
+                ) AS signal_reviews,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+                ) AS churn_intent,
+                avg(
+                    (r.enrichment->>'urgency_score')::numeric
+                    * COALESCE(r.source_weight, 0.7)
+                    * (0.7 + 0.3 * COALESCE(r.relevance_score, 0.5))
+                ) / NULLIF(avg(
+                    COALESCE(r.source_weight, 0.7)
+                    * (0.7 + 0.3 * COALESCE(r.relevance_score, 0.5))
+                ), 0)
+                AS avg_urgency,
+                avg(r.author_churn_score) FILTER (WHERE r.author_churn_score IS NOT NULL)
+                AS avg_author_churn_score,
+                avg(r.rating / NULLIF(r.rating_max, 0)) AS avg_rating_normalized,
+                count(*) FILTER (
+                    WHERE (r.enrichment->>'would_recommend')::boolean = true
+                ) AS recommend_yes,
+                count(*) FILTER (
+                    WHERE (r.enrichment->>'would_recommend')::boolean = false
+                ) AS recommend_no,
+                count(*) FILTER (
+                    WHERE r.enrichment->>'would_recommend' IS NOT NULL
+                ) AS recommend_total,
+                ROUND(
+                    count(*) FILTER (
+                        WHERE r.rating IS NOT NULL AND r.rating_max > 0
+                          AND (r.rating / r.rating_max) >= 0.7
+                    ) * 100.0 / NULLIF(count(*) FILTER (
+                        WHERE r.rating IS NOT NULL AND r.rating_max > 0
+                    ), 0),
+                    1
+                ) AS positive_review_pct,
+                AVG(rating / NULLIF(rating_max, 0)) FILTER (
+                    WHERE r.review_text ILIKE '%support%' OR r.review_text ILIKE '%service%'
+                ) AS support_sentiment,
+                AVG(rating / NULLIF(rating_max, 0)) FILTER (
+                    WHERE r.review_text ILIKE '%legacy%' OR r.review_text ILIKE '%old version%' OR r.review_text ILIKE '%deprecated%'
+                ) AS legacy_support_score,
+                COUNT(*) FILTER (
+                    WHERE r.review_text ILIKE '%new feature%' OR r.review_text ILIKE '%update%' OR r.review_text ILIKE '%release%'
+                ) * 1.0 / NULLIF(count(*), 0) AS new_feature_velocity,
+                -- v2 urgency indicator counts (from three-layer extraction)
+                count(*) FILTER (
+                    WHERE (r.enrichment->'urgency_indicators'->>'explicit_cancel_language')::boolean = true
+                ) AS indicator_cancel_count,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'urgency_indicators'->>'active_migration_language')::boolean = true
+                ) AS indicator_migration_count,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'urgency_indicators'->>'active_evaluation_language')::boolean = true
+                ) AS indicator_evaluation_count,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'urgency_indicators'->>'completed_switch_language')::boolean = true
+                ) AS indicator_switch_count,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'urgency_indicators'->>'named_alternative_with_reason')::boolean = true
+                ) AS indicator_named_alt_count,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'urgency_indicators'->>'decision_maker_language')::boolean = true
+                ) AS indicator_dm_language_count,
+                -- v2 pricing phrase count
+                count(*) FILTER (
+                    WHERE jsonb_array_length(COALESCE(r.enrichment->'pricing_phrases', '[]'::jsonb)) > 0
+                ) AS has_pricing_phrases_count,
+                -- v2 recommendation language count
+                count(*) FILTER (
+                    WHERE jsonb_array_length(COALESCE(r.enrichment->'recommendation_language', '[]'::jsonb)) > 0
+                ) AS has_recommendation_language_count
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            WHERE {filters}
+            GROUP BY vm.vendor_name
+            HAVING count(*) >= $2
+        )
+        SELECT rs.*,
+               vf.employee_count,
+               vf.industry AS vendor_industry,
+               vf.annual_revenue_range,
+               CASE
+                   WHEN prev.employee_count IS NOT NULL
+                        AND prev.employee_count > 0
+                        AND vf.employee_count IS NOT NULL
+                   THEN (vf.employee_count - prev.employee_count)::numeric / prev.employee_count
+                   ELSE NULL
+               END AS employee_growth_rate
+        FROM review_scores rs
+        LEFT JOIN b2b_vendor_firmographics vf
+          ON LOWER(vf.vendor_name) = LOWER(rs.vendor_name)
+        LEFT JOIN LATERAL (
+            SELECT employee_count
+            FROM b2b_vendor_firmographic_snapshots snap
+            WHERE snap.vendor_name_norm = vf.vendor_name_norm
+              AND snap.snapshot_date < CURRENT_DATE
+              AND snap.employee_count IS NOT NULL
+            ORDER BY snap.snapshot_date DESC
+            LIMIT 1
+        ) prev ON TRUE
+        ORDER BY rs.avg_urgency DESC
+        """,
+        window_days,
+        min_reviews,
+        sources,
+    )
+    return [
+        {
+            "vendor_name": r["vendor_name"],
+            "product_category": r["product_category"],
+            "total_reviews": r["total_reviews"],
+            "signal_reviews": r["signal_reviews"],
+            "churn_intent": r["churn_intent"],
+            "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+            "avg_rating_normalized": float(r["avg_rating_normalized"]) if r["avg_rating_normalized"] else None,
+            "recommend_yes": r["recommend_yes"],
+            "recommend_no": r["recommend_no"],
+            "recommend_total": r["recommend_total"],
+            "positive_review_pct": float(r["positive_review_pct"]) if r["positive_review_pct"] is not None else None,
+            "avg_author_churn_score": float(r["avg_author_churn_score"]) if r["avg_author_churn_score"] is not None else None,
+            "support_sentiment": float(r["support_sentiment"]) if r["support_sentiment"] is not None else None,
+            "legacy_support_score": float(r["legacy_support_score"]) if r["legacy_support_score"] is not None else None,
+            "new_feature_velocity": float(r["new_feature_velocity"]) if r["new_feature_velocity"] is not None else None,
+            "employee_growth_rate": float(r["employee_growth_rate"]) if r["employee_growth_rate"] is not None else None,
+            "employee_count": r["employee_count"],
+            "vendor_industry": r["vendor_industry"],
+            "annual_revenue_range": r["annual_revenue_range"],
+        }
+        for r in rows
+    ]
+
+
+def _is_generic_vendor_score_category(category: str | None) -> bool:
+    """Return True for generic vendor-score categories we should down-rank."""
+    return str(category or "").strip().lower() in {"", "unknown", "b2b software"}
+
+
+def _canonicalize_vendor_name_filters(vendor_names: Iterable[Any] | None) -> list[str]:
+    """Normalize an optional vendor filter list for adapter-backed reads."""
+    return sorted(
+        {
+            canonical.lower()
+            for name in (vendor_names or [])
+            for canonical in [_canonicalize_vendor(name)]
+            if canonical
+        }
+    )
+
+
+def _normalize_materialization_run_id(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+async def read_vendor_scorecards(
+    pool,
+    *,
+    window_days: int,
+    min_reviews: int,
+    vendor_names: Iterable[Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Read derived vendor scorecards from ``b2b_churn_signals``.
+
+    This is the canonical adapter for vendor-level ranking and score reads.
+    Feature code should prefer this adapter instead of querying
+    ``b2b_churn_signals`` directly.
+    """
+    requested_vendors = _canonicalize_vendor_name_filters(vendor_names)
+    vendor_filter_clause = "AND LOWER(vendor_name) = ANY($3::text[])" if requested_vendors else ""
+    rows = await pool.fetch(
+        """
+        SELECT vendor_name,
+               product_category,
+               total_reviews,
+               signal_reviews,
+               churn_intent_count AS churn_intent,
+               avg_urgency_score AS avg_urgency,
+               materialization_run_id,
+               last_computed_at,
+               review_window_end
+        FROM b2b_churn_signals
+        WHERE total_reviews >= $2
+          AND COALESCE(review_window_end, last_computed_at::date) >= CURRENT_DATE - $1::int
+          """ + vendor_filter_clause + """
+        ORDER BY vendor_name, total_reviews DESC, last_computed_at DESC
+        """,
+        window_days,
+        min_reviews,
+        *([requested_vendors] if requested_vendors else []),
+    )
+    mapped = []
+    for row in rows:
+        if not row.get("vendor_name"):
+            continue
+        mapped_row = {
+            "vendor_name": row["vendor_name"],
+            "product_category": row["product_category"],
+            "total_reviews": int(row["total_reviews"] or 0),
+            "churn_intent": int(row["churn_intent"] or 0),
+            "avg_urgency": (
+                float(row["avg_urgency"])
+                if row["avg_urgency"] is not None
+                else 0.0
+            ),
+        }
+        materialization_run_id = _normalize_materialization_run_id(
+            row.get("materialization_run_id"),
+        )
+        if materialization_run_id is not None:
+            mapped_row["materialization_run_id"] = materialization_run_id
+        mapped.append(mapped_row)
+
+    categories_by_vendor: dict[str, set[str]] = {}
+    for row in mapped:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        categories_by_vendor.setdefault(vendor, set()).add(
+            str(row.get("product_category") or "").strip()
+        )
+
+    filtered: list[dict[str, Any]] = []
+    for row in mapped:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        category = str(row.get("product_category") or "").strip()
+        categories = categories_by_vendor.get(vendor) or set()
+        has_specific_category = any(
+            not _is_generic_vendor_score_category(value)
+            for value in categories
+        )
+        if has_specific_category and _is_generic_vendor_score_category(category):
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def _align_vendor_intelligence_records_to_scorecards(
+    vendor_scores: list[dict[str, Any]],
+    records: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Filter vault overlays to vendors whose current scorecard run still matches.
+
+    We only suppress a vault overlay when both sides carry explicit
+    ``materialization_run_id`` values and those values disagree. Legacy rows
+    without a run id are allowed through for backward compatibility.
+    """
+    scorecards_by_vendor: dict[str, dict[str, Any]] = {}
+    for row in vendor_scores:
+        vendor = _canonicalize_vendor(
+            row.get("vendor_name") or row.get("vendor") or "",
+        )
+        if vendor and vendor not in scorecards_by_vendor:
+            scorecards_by_vendor[vendor] = row
+
+    aligned_lookup: dict[str, dict[str, Any]] = {}
+    mismatched_vendors: list[str] = []
+    legacy_scorecard_vendors: list[str] = []
+    legacy_vault_vendors: list[str] = []
+
+    for record in records:
+        vendor = _canonicalize_vendor(record.get("vendor_name") or "")
+        if not vendor:
+            continue
+        scorecard = scorecards_by_vendor.get(vendor)
+        if scorecard is None:
+            continue
+        score_run_id = _normalize_materialization_run_id(
+            scorecard.get("materialization_run_id"),
+        )
+        vault_run_id = _normalize_materialization_run_id(
+            record.get("materialization_run_id"),
+        )
+        if score_run_id and vault_run_id and score_run_id != vault_run_id:
+            mismatched_vendors.append(vendor)
+            continue
+        if score_run_id is None:
+            legacy_scorecard_vendors.append(vendor)
+        if vault_run_id is None:
+            legacy_vault_vendors.append(vendor)
+        vault = record.get("vault")
+        aligned_lookup[vendor] = vault if isinstance(vault, dict) else {}
+
+    return aligned_lookup, {
+        "matched_vendor_count": len(aligned_lookup),
+        "mismatched_vendor_count": len(mismatched_vendors),
+        "mismatched_vendors": sorted(mismatched_vendors),
+        "legacy_scorecard_vendor_count": len(set(legacy_scorecard_vendors)),
+        "legacy_scorecard_vendors": sorted(set(legacy_scorecard_vendors)),
+        "legacy_vault_vendor_count": len(set(legacy_vault_vendors)),
+        "legacy_vault_vendors": sorted(set(legacy_vault_vendors)),
+    }
+
+
+def _align_vendor_intelligence_record_to_scorecard(
+    scorecard: dict[str, Any] | None,
+    record: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Align one vendor-intelligence record against one scorecard row."""
+    if not isinstance(record, dict):
+        return None, {
+            "matched_vendor_count": 0,
+            "mismatched_vendor_count": 0,
+            "mismatched_vendors": [],
+            "legacy_scorecard_vendor_count": 0,
+            "legacy_scorecard_vendors": [],
+            "legacy_vault_vendor_count": 0,
+            "legacy_vault_vendors": [],
+        }
+
+    aligned_lookup, alignment = _align_vendor_intelligence_records_to_scorecards(
+        [scorecard] if isinstance(scorecard, dict) else [],
+        [record],
+    )
+    vendor_name = _canonicalize_vendor(
+        record.get("vendor_name")
+        or (scorecard or {}).get("vendor_name")
+        or (scorecard or {}).get("vendor")
+        or "",
+    )
+    if not vendor_name:
+        return None, alignment
+    return aligned_lookup.get(vendor_name), alignment
+
+
+async def read_vendor_scorecard(
+    pool,
+    vendor_name: str,
+    *,
+    window_days: int,
+    min_reviews: int,
+) -> dict[str, Any] | None:
+    """Read the derived scorecard row for a single vendor."""
+    rows = await read_vendor_scorecards(
+        pool,
+        window_days=window_days,
+        min_reviews=min_reviews,
+        vendor_names=[vendor_name],
+    )
+    canonical = _canonicalize_vendor(vendor_name)
+    if not canonical:
+        return None
+    for row in rows:
+        if _canonicalize_vendor(row.get("vendor_name") or "") == canonical:
+            return row
+    return None
+
+
+async def read_vendor_scorecard_details(
+    pool,
+    *,
+    vendor_names: Iterable[Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Read detailed derived scorecard rows from ``b2b_churn_signals``.
+
+    This adapter is for vendor-level fallback consumers that need the richer
+    compatibility columns from the derived scorecard table.
+    """
+    requested_vendors = _canonicalize_vendor_name_filters(vendor_names)
+    vendor_filter_clause = "WHERE LOWER(vendor_name) = ANY($1::text[])" if requested_vendors else ""
+    rows = await pool.fetch(
+        """
+        SELECT vendor_name,
+               product_category,
+               total_reviews,
+               negative_reviews,
+               churn_intent_count,
+               avg_urgency_score,
+               top_pain_categories,
+               top_competitors,
+               top_feature_gaps,
+               price_complaint_rate,
+               decision_maker_churn_rate,
+               company_churn_list,
+               quotable_evidence,
+               materialization_run_id,
+               last_computed_at,
+               review_window_end
+        FROM b2b_churn_signals
+        """ + vendor_filter_clause + """
+        ORDER BY vendor_name, total_reviews DESC, last_computed_at DESC
+        """,
+        *([requested_vendors] if requested_vendors else []),
+    )
+    mapped = [dict(row) for row in rows if row.get("vendor_name")]
+
+    categories_by_vendor: dict[str, set[str]] = {}
+    for row in mapped:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        categories_by_vendor.setdefault(vendor, set()).add(
+            str(row.get("product_category") or "").strip()
+        )
+
+    filtered: list[dict[str, Any]] = []
+    for row in mapped:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        category = str(row.get("product_category") or "").strip()
+        categories = categories_by_vendor.get(vendor) or set()
+        has_specific_category = any(
+            not _is_generic_vendor_score_category(value)
+            for value in categories
+        )
+        if has_specific_category and _is_generic_vendor_score_category(category):
+            continue
+        filtered.append(row)
+    return filtered
+
+
+async def read_vendor_scorecard_detail(
+    pool,
+    vendor_name: str,
+) -> dict[str, Any] | None:
+    """Read the detailed derived scorecard row for a single vendor."""
+    rows = await read_vendor_scorecard_details(
+        pool,
+        vendor_names=[vendor_name],
+    )
+    canonical = _canonicalize_vendor(vendor_name)
+    if not canonical:
+        return None
+    for row in rows:
+        if _canonicalize_vendor(row.get("vendor_name") or "") == canonical:
+            return row
+    return None
+
+
+async def read_vendor_signal_detail(
+    pool,
+    *,
+    vendor_name_query: str,
+    product_category: str | None = None,
+    tracked_account_id: Any | None = None,
+    include_snapshot_metrics: bool = False,
+    exclude_suppressed: bool = False,
+) -> dict[str, Any] | None:
+    """Read one vendor signal detail row with optional scope and snapshot fields."""
+    normalized_query = str(vendor_name_query or "").strip()
+    if not normalized_query:
+        return None
+
+    conditions = ["sig.vendor_name ILIKE '%' || $1 || '%'"]
+    params: list[Any] = [normalized_query]
+    idx = 2
+
+    if product_category:
+        conditions.append(f"sig.product_category = ${idx}")
+        params.append(product_category)
+        idx += 1
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    snapshot_select = ""
+    snapshot_join = ""
+    if include_snapshot_metrics:
+        snapshot_select = """
+               , snap.support_sentiment AS support_sentiment
+               , snap.legacy_support_score AS legacy_support_score
+               , snap.new_feature_velocity AS new_feature_velocity
+               , snap.employee_growth_rate AS employee_growth_rate
+        """
+        snapshot_join = """
+        LEFT JOIN LATERAL (
+            SELECT support_sentiment,
+                   legacy_support_score,
+                   new_feature_velocity,
+                   employee_growth_rate
+            FROM b2b_vendor_snapshots snap
+            WHERE snap.vendor_name = sig.vendor_name
+            ORDER BY snap.snapshot_date DESC
+            LIMIT 1
+        ) snap ON TRUE
+        """
+
+    row = await pool.fetchrow(
+        """
+        SELECT sig.*
+               """
+        + snapshot_select
+        + """
+        FROM b2b_churn_signals sig
+        """
+        + snapshot_join
+        + """
+        WHERE """
+        + " AND ".join(conditions)
+        + """
+        ORDER BY sig.avg_urgency_score DESC
+        LIMIT 1
+        """,
+        *params,
+    )
+    return dict(row) if row else None
+
+
+async def read_vendor_signal_detail_exact(
+    pool,
+    *,
+    vendor_name: str,
+    product_category: str | None = None,
+    tracked_account_id: Any | None = None,
+    include_snapshot_metrics: bool = False,
+    exclude_suppressed: bool = False,
+) -> dict[str, Any] | None:
+    """Read one exact-match vendor signal detail row with optional scope."""
+    normalized_vendor = _canonicalize_vendor(vendor_name) or str(vendor_name or "").strip()
+    if not normalized_vendor:
+        return None
+
+    conditions = ["LOWER(sig.vendor_name) = LOWER($1)"]
+    params: list[Any] = [normalized_vendor]
+    idx = 2
+
+    if product_category:
+        conditions.append(f"sig.product_category = ${idx}")
+        params.append(product_category)
+        idx += 1
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    snapshot_select = ""
+    snapshot_join = ""
+    if include_snapshot_metrics:
+        snapshot_select = """
+               , snap.support_sentiment AS support_sentiment
+               , snap.legacy_support_score AS legacy_support_score
+               , snap.new_feature_velocity AS new_feature_velocity
+               , snap.employee_growth_rate AS employee_growth_rate
+        """
+        snapshot_join = """
+        LEFT JOIN LATERAL (
+            SELECT support_sentiment,
+                   legacy_support_score,
+                   new_feature_velocity,
+                   employee_growth_rate
+            FROM b2b_vendor_snapshots snap
+            WHERE snap.vendor_name = sig.vendor_name
+            ORDER BY snap.snapshot_date DESC
+            LIMIT 1
+        ) snap ON TRUE
+        """
+
+    row = await pool.fetchrow(
+        """
+        SELECT sig.*
+               """
+        + snapshot_select
+        + """
+        FROM b2b_churn_signals sig
+        """
+        + snapshot_join
+        + """
+        WHERE """
+        + " AND ".join(conditions)
+        + """
+        ORDER BY sig.last_computed_at DESC NULLS LAST,
+                 sig.total_reviews DESC NULLS LAST,
+                 sig.product_category ASC NULLS LAST
+        LIMIT 1
+        """,
+        *params,
+    )
+    return dict(row) if row else None
+
+
+def _normalize_vendor_name_list(vendor_names: Iterable[Any] | None) -> list[str]:
+    return _canonicalize_vendor_name_filters(vendor_names)
+
+
+async def read_vendor_signal_rows(
+    pool,
+    *,
+    vendor_name_query: str | None = None,
+    vendor_names: Iterable[Any] | None = None,
+    min_urgency: float = 0.0,
+    product_category: str | None = None,
+    tracked_account_id: Any | None = None,
+    include_snapshot_metrics: bool = False,
+    exclude_suppressed: bool = False,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Read vendor signal list rows with optional scope and snapshot fields."""
+    normalized_vendor_names = _normalize_vendor_name_list(vendor_names)
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if normalized_vendor_names:
+        conditions.append(f"LOWER(sig.vendor_name) = ANY(${idx}::text[])")
+        params.append(normalized_vendor_names)
+        idx += 1
+
+    normalized_query = str(vendor_name_query or "").strip()
+    if normalized_query:
+        conditions.append(f"sig.vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(normalized_query)
+        idx += 1
+
+    if min_urgency > 0:
+        conditions.append(f"sig.avg_urgency_score >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+
+    if product_category:
+        conditions.append(f"sig.product_category = ${idx}")
+        params.append(product_category)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    snapshot_select = ""
+    snapshot_join = ""
+    if include_snapshot_metrics:
+        snapshot_select = """
+               , snap.support_sentiment AS support_sentiment
+               , snap.legacy_support_score AS legacy_support_score
+               , snap.new_feature_velocity AS new_feature_velocity
+               , snap.employee_growth_rate AS employee_growth_rate
+        """
+        snapshot_join = """
+        LEFT JOIN LATERAL (
+            SELECT support_sentiment,
+                   legacy_support_score,
+                   new_feature_velocity,
+                   employee_growth_rate
+            FROM b2b_vendor_snapshots snap
+            WHERE snap.vendor_name = sig.vendor_name
+            ORDER BY snap.snapshot_date DESC
+            LIMIT 1
+        ) snap ON TRUE
+        """
+
+    where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
+    capped_limit = max(1, min(int(limit or 20), 10_000))
+    rows = await pool.fetch(
+        """
+        SELECT sig.vendor_name,
+               sig.product_category,
+               sig.total_reviews,
+               sig.churn_intent_count,
+               sig.avg_urgency_score,
+               sig.avg_rating_normalized,
+               sig.nps_proxy,
+               sig.price_complaint_rate,
+               sig.decision_maker_churn_rate,
+               sig.keyword_spike_count,
+               sig.insider_signal_count,
+               sig.last_computed_at
+               """
+        + snapshot_select
+        + """
+        FROM b2b_churn_signals sig
+        """
+        + snapshot_join
+        + """
+        """
+        + where_clause
+        + f"""
+        ORDER BY sig.avg_urgency_score DESC
+        LIMIT ${idx}
+        """,
+        *params,
+        capped_limit,
+    )
+    return [dict(row) for row in rows]
+
+
+async def read_best_vendor_signal_rows(
+    pool,
+    *,
+    vendor_name_query: str | None = None,
+    vendor_names: Iterable[Any] | None = None,
+    tracked_account_id: Any | None = None,
+    exclude_suppressed: bool = False,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Read one best-fit vendor signal row per vendor."""
+    normalized_vendor_names = _normalize_vendor_name_list(vendor_names)
+    if vendor_names is not None and not normalized_vendor_names:
+        return []
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if normalized_vendor_names:
+        conditions.append(f"LOWER(sig.vendor_name) = ANY(${idx}::text[])")
+        params.append(normalized_vendor_names)
+        idx += 1
+
+    normalized_query = str(vendor_name_query or "").strip()
+    if normalized_query:
+        conditions.append(f"sig.vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(normalized_query)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
+    capped_limit = max(1, min(int(limit or 20), 5000))
+    rows = await pool.fetch(
+        """
+        WITH ranked_signals AS (
+            SELECT sig.vendor_name,
+                   sig.product_category,
+                   sig.total_reviews,
+                   sig.churn_intent_count,
+                   sig.avg_urgency_score,
+                   sig.nps_proxy,
+                   sig.last_computed_at,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY sig.vendor_name
+                       ORDER BY sig.avg_urgency_score DESC,
+                                sig.total_reviews DESC,
+                                sig.last_computed_at DESC NULLS LAST,
+                                sig.product_category ASC NULLS LAST
+                   ) AS vendor_row_rank
+            FROM b2b_churn_signals sig
+        """
+        + where_clause
+        + """
+        )
+        SELECT vendor_name,
+               product_category,
+               total_reviews,
+               churn_intent_count,
+               avg_urgency_score,
+               nps_proxy,
+               last_computed_at
+        FROM ranked_signals
+        WHERE vendor_row_rank = 1
+        ORDER BY total_reviews DESC,
+                 avg_urgency_score DESC,
+                 last_computed_at DESC NULLS LAST,
+                 vendor_name ASC
+        LIMIT $"""
+        + str(idx),
+        *params,
+        capped_limit,
+    )
+    return [dict(row) for row in rows]
+
+
+async def read_vendor_signal_summary(
+    pool,
+    *,
+    vendor_name_query: str | None = None,
+    vendor_names: Iterable[Any] | None = None,
+    min_urgency: float = 0.0,
+    product_category: str | None = None,
+    tracked_account_id: Any | None = None,
+    exclude_suppressed: bool = False,
+) -> dict[str, Any]:
+    """Read aggregate summary stats for vendor signal list surfaces."""
+    normalized_vendor_names = _normalize_vendor_name_list(vendor_names)
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if normalized_vendor_names:
+        conditions.append(f"LOWER(sig.vendor_name) = ANY(${idx}::text[])")
+        params.append(normalized_vendor_names)
+        idx += 1
+
+    normalized_query = str(vendor_name_query or "").strip()
+    if normalized_query:
+        conditions.append(f"sig.vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(normalized_query)
+        idx += 1
+
+    if min_urgency > 0:
+        conditions.append(f"sig.avg_urgency_score >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+
+    if product_category:
+        conditions.append(f"sig.product_category = ${idx}")
+        params.append(product_category)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
+    row = await pool.fetchrow(
+        """
+        SELECT COUNT(DISTINCT sig.vendor_name) AS total_vendors,
+               COUNT(*) FILTER (WHERE sig.avg_urgency_score >= 7) AS high_urgency_count,
+               COALESCE(SUM(sig.total_reviews), 0) AS total_signal_reviews
+        FROM b2b_churn_signals sig
+        """
+        + where_clause,
+        *params,
+    )
+    return dict(row) if row else {
+        "total_vendors": 0,
+        "high_urgency_count": 0,
+        "total_signal_reviews": 0,
+    }
+
+
+async def read_vendor_signal_overview(
+    pool,
+    *,
+    vendor_name_query: str | None = None,
+    vendor_names: Iterable[Any] | None = None,
+    min_urgency: float = 0.0,
+    product_category: str | None = None,
+    tracked_account_id: Any | None = None,
+    exclude_suppressed: bool = False,
+) -> dict[str, Any]:
+    """Read overview rollups for vendor signal dashboard surfaces."""
+    normalized_vendor_names = _normalize_vendor_name_list(vendor_names)
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if normalized_vendor_names:
+        conditions.append(f"LOWER(sig.vendor_name) = ANY(${idx}::text[])")
+        params.append(normalized_vendor_names)
+        idx += 1
+
+    normalized_query = str(vendor_name_query or "").strip()
+    if normalized_query:
+        conditions.append(f"sig.vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(normalized_query)
+        idx += 1
+
+    if min_urgency > 0:
+        conditions.append(f"sig.avg_urgency_score >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+
+    if product_category:
+        conditions.append(f"sig.product_category = ${idx}")
+        params.append(product_category)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
+    row = await pool.fetchrow(
+        """
+        SELECT COALESCE(AVG(sig.avg_urgency_score), 0) AS avg_urgency,
+               COALESCE(SUM(sig.churn_intent_count), 0) AS total_churn_signals,
+               COALESCE(SUM(sig.total_reviews), 0) AS total_reviews
+        FROM b2b_churn_signals sig
+        """
+        + where_clause,
+        *params,
+    )
+    return dict(row) if row else {
+        "avg_urgency": 0,
+        "total_churn_signals": 0,
+        "total_reviews": 0,
+    }
+
+
+async def read_ranked_vendor_signal_rows(
+    pool,
+    *,
+    vendor_name_query: str | None = None,
+    vendor_names: Iterable[Any] | None = None,
+    product_category: str | None = None,
+    tracked_account_id: Any | None = None,
+    exclude_suppressed: bool = False,
+    require_snapshot_activity: bool = False,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Read one ranked vendor signal row per vendor for slow-burn/watchlist surfaces."""
+    normalized_vendor_names = _normalize_vendor_name_list(vendor_names)
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if require_snapshot_activity:
+        conditions.append(
+            "("
+            "snap.support_sentiment IS NOT NULL OR "
+            "snap.legacy_support_score IS NOT NULL OR "
+            "snap.new_feature_velocity IS NOT NULL OR "
+            "snap.employee_growth_rate IS NOT NULL"
+            ")"
+        )
+
+    if tracked_account_id is not None:
+        conditions.append(
+            f"sig.vendor_name IN (SELECT vendor_name FROM tracked_vendors WHERE account_id = ${idx}::uuid)"
+        )
+        params.append(tracked_account_id)
+        idx += 1
+
+    if normalized_vendor_names:
+        conditions.append(f"LOWER(sig.vendor_name) = ANY(${idx}::text[])")
+        params.append(normalized_vendor_names)
+        idx += 1
+
+    normalized_query = str(vendor_name_query or "").strip()
+    if normalized_query:
+        conditions.append(f"sig.vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(normalized_query)
+        idx += 1
+
+    if product_category:
+        conditions.append(f"sig.product_category = ${idx}")
+        params.append(product_category)
+        idx += 1
+
+    if exclude_suppressed:
+        conditions.append(
+            suppress_predicate(
+                "churn_signal",
+                id_expr="sig.id",
+                vendor_expr="sig.vendor_name",
+            )
+        )
+
+    where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
+    capped_limit = max(1, min(int(limit or 10), 100))
+    rows = await pool.fetch(
+        """
+        WITH ranked_signals AS (
+            SELECT sig.vendor_name,
+                   sig.product_category,
+                   sig.total_reviews,
+                   sig.churn_intent_count,
+                   sig.avg_urgency_score,
+                   sig.avg_rating_normalized,
+                   sig.nps_proxy,
+                   sig.price_complaint_rate,
+                   sig.decision_maker_churn_rate,
+                   sig.keyword_spike_count,
+                   sig.insider_signal_count,
+                   sig.last_computed_at,
+                   snap.support_sentiment AS support_sentiment,
+                   snap.legacy_support_score AS legacy_support_score,
+                   snap.new_feature_velocity AS new_feature_velocity,
+                   snap.employee_growth_rate AS employee_growth_rate,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY sig.vendor_name
+                       ORDER BY sig.avg_urgency_score DESC,
+                                sig.total_reviews DESC,
+                                sig.last_computed_at DESC NULLS LAST,
+                                sig.product_category ASC NULLS LAST
+                   ) AS vendor_row_rank
+            FROM b2b_churn_signals sig
+            LEFT JOIN LATERAL (
+                SELECT support_sentiment,
+                       legacy_support_score,
+                       new_feature_velocity,
+                       employee_growth_rate
+                FROM b2b_vendor_snapshots snap
+                WHERE snap.vendor_name = sig.vendor_name
+                ORDER BY snap.snapshot_date DESC
+                LIMIT 1
+            ) snap ON TRUE
+        """
+        + where_clause
+        + f"""
+        )
+        SELECT vendor_name,
+               product_category,
+               total_reviews,
+               churn_intent_count,
+               avg_urgency_score,
+               avg_rating_normalized,
+               nps_proxy,
+               price_complaint_rate,
+               decision_maker_churn_rate,
+               keyword_spike_count,
+               insider_signal_count,
+               last_computed_at,
+               support_sentiment,
+               legacy_support_score,
+               new_feature_velocity,
+               employee_growth_rate
+        FROM ranked_signals
+        WHERE vendor_row_rank = 1
+        ORDER BY employee_growth_rate DESC NULLS LAST,
+                 support_sentiment ASC NULLS LAST,
+                 legacy_support_score ASC NULLS LAST,
+                 new_feature_velocity DESC NULLS LAST,
+                 avg_urgency_score DESC,
+                 last_computed_at DESC NULLS LAST
+        LIMIT ${idx}
+        """,
+        *params,
+        capped_limit,
+    )
+    return [dict(row) for row in rows]
+
+
+async def read_vendor_top_competitor_map(
+    pool,
+    *,
+    vendor_names: Iterable[Any] | None = None,
+) -> dict[str, str]:
+    """Read the top named competitor per vendor from derived scorecard rows."""
+    rows = await read_vendor_scorecard_details(
+        pool,
+        vendor_names=vendor_names,
+    )
+    result: dict[str, str] = {}
+    for row in rows:
+        vendor = str(row.get("vendor_name") or "").strip()
+        if not vendor or vendor in result:
+            continue
+        flat_competitor = str(row.get("top_competitor") or "").strip()
+        if flat_competitor:
+            result[vendor] = flat_competitor
+            continue
+        competitors = _safe_json(row.get("top_competitors"), default=[])
+        if not isinstance(competitors, list) or not competitors:
+            continue
+        first = competitors[0]
+        if isinstance(first, dict):
+            competitor = str(first.get("name") or first.get("competitor") or "").strip()
+        else:
+            competitor = str(first or "").strip()
+        if competitor:
+            result[vendor] = competitor
+    return result
+
+
+async def read_company_churn_context(
+    pool,
+    *,
+    company_hint: str,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Read derived churn context rows matching a company hint."""
+    normalized_hint = str(company_hint or "").strip()
+    if not normalized_hint:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT vendor_name,
+               product_category,
+               avg_urgency_score,
+               top_pain_categories,
+               top_competitors,
+               decision_maker_churn_rate,
+               price_complaint_rate
+        FROM b2b_churn_signals
+        WHERE EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(company_churn_list) AS company_row
+            WHERE company_row->>'company' ILIKE '%' || $1 || '%'
+        )
+        ORDER BY avg_urgency_score DESC
+        LIMIT $2
+        """,
+        normalized_hint,
+        limit,
+    )
+    return [
+        {
+            "vendor_name": row["vendor_name"],
+            "product_category": row["product_category"],
+            "avg_urgency_score": float(row["avg_urgency_score"]) if row["avg_urgency_score"] else 0.0,
+            "top_pain_categories": _safe_json(row.get("top_pain_categories"), default=[]),
+            "top_competitors": _safe_json(row.get("top_competitors"), default=[]),
+            "decision_maker_churn_rate": (
+                float(row["decision_maker_churn_rate"])
+                if row["decision_maker_churn_rate"] is not None
+                else None
+            ),
+            "price_complaint_rate": (
+                float(row["price_complaint_rate"])
+                if row["price_complaint_rate"] is not None
+                else None
+            ),
+        }
+        for row in rows
+        if row.get("vendor_name")
+    ]
+
+
+async def read_signal_product_categories(
+    pool,
+) -> list[str]:
+    """Read distinct non-empty product categories from vendor scorecards."""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT product_category
+        FROM b2b_churn_signals
+        WHERE product_category IS NOT NULL
+          AND TRIM(product_category) != ''
+        ORDER BY product_category
+        """
+    )
+    categories: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        category = str(row.get("product_category") or "").strip()
+        if not category:
+            continue
+        key = category.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        categories.append(category)
+    return categories
+
+
+async def read_category_vendor_signal_rows(
+    pool,
+    *,
+    product_category: str,
+) -> list[dict[str, Any]]:
+    """Read one scorecard-backed vendor row per vendor within a category."""
+    normalized_category = str(product_category or "").strip()
+    if not normalized_category:
+        return []
+
+    rows = await pool.fetch(
+        """
+        WITH ranked_signals AS (
+            SELECT vendor_name,
+                   total_reviews,
+                   avg_urgency_score,
+                   confidence_score,
+                   last_computed_at,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY vendor_name
+                       ORDER BY total_reviews DESC,
+                                last_computed_at DESC NULLS LAST,
+                                product_category ASC NULLS LAST
+                   ) AS vendor_row_rank
+            FROM b2b_churn_signals
+            WHERE LOWER(product_category) = LOWER($1)
+        )
+        SELECT rs.vendor_name,
+               rs.total_reviews,
+               rs.avg_urgency_score AS avg_urgency,
+               rs.confidence_score,
+               snap.churn_density,
+               snap.positive_review_pct,
+               snap.displacement_edge_count,
+               COALESCE(d_out.cnt, 0) AS displacement_out,
+               COALESCE(d_in.cnt, 0) AS displacement_in
+        FROM ranked_signals rs
+        LEFT JOIN (
+            SELECT DISTINCT ON (vendor_name) *
+            FROM b2b_vendor_snapshots
+            ORDER BY vendor_name, snapshot_date DESC
+        ) snap ON LOWER(rs.vendor_name) = LOWER(snap.vendor_name)
+        LEFT JOIN (
+            SELECT from_vendor, SUM(mention_count) AS cnt
+            FROM b2b_displacement_edges
+            GROUP BY from_vendor
+        ) d_out ON LOWER(rs.vendor_name) = LOWER(d_out.from_vendor)
+        LEFT JOIN (
+            SELECT to_vendor, SUM(mention_count) AS cnt
+            FROM b2b_displacement_edges
+            GROUP BY to_vendor
+        ) d_in ON LOWER(rs.vendor_name) = LOWER(d_in.to_vendor)
+        WHERE rs.vendor_row_rank = 1
+        ORDER BY rs.total_reviews DESC, rs.vendor_name ASC
+        """,
+        normalized_category,
+    )
+    return [dict(row) for row in rows if row.get("vendor_name")]
+
+
+async def read_vendor_graph_sync_rows(
+    pool,
+) -> list[dict[str, Any]]:
+    """Read vendor rows for knowledge-graph sync from canonical scorecard state."""
+    rows = await pool.fetch(
+        """
+        WITH ranked_signals AS (
+            SELECT vendor_name,
+                   product_category,
+                   total_reviews,
+                   avg_urgency_score,
+                   confidence_score,
+                   last_computed_at,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY vendor_name
+                       ORDER BY total_reviews DESC,
+                                last_computed_at DESC NULLS LAST,
+                                product_category ASC NULLS LAST
+                   ) AS vendor_row_rank
+            FROM b2b_churn_signals
+        )
+        SELECT v.canonical_name,
+               v.aliases,
+               rs.product_category,
+               rs.total_reviews,
+               rs.avg_urgency_score AS avg_urgency,
+               rs.confidence_score,
+               snap.churn_density,
+               snap.positive_review_pct,
+               snap.recommend_ratio,
+               snap.pain_count,
+               snap.competitor_count
+        FROM b2b_vendors v
+        LEFT JOIN ranked_signals rs
+            ON LOWER(v.canonical_name) = LOWER(rs.vendor_name)
+           AND rs.vendor_row_rank = 1
+        LEFT JOIN (
+            SELECT DISTINCT ON (vendor_name) *
+            FROM b2b_vendor_snapshots
+            ORDER BY vendor_name, snapshot_date DESC
+        ) snap ON LOWER(v.canonical_name) = LOWER(snap.vendor_name)
+        ORDER BY v.canonical_name
+        """
+    )
+    return [dict(row) for row in rows if row.get("canonical_name")]
+
+
+async def read_vendor_scorecard_inventory_rows(
+    pool,
+) -> list[dict[str, Any]]:
+    """Read scorecard-derived inventory rows for scrape coverage planning."""
+    rows = await pool.fetch(
+        """
+        SELECT vendor_name,
+               COALESCE(NULLIF(TRIM(product_category), ''), 'Unknown') AS product_category,
+               MAX(total_reviews) AS total_reviews_analyzed,
+               0.0::double precision AS confidence_score,
+               NULL::timestamptz AS last_computed_at,
+               'b2b_churn_signals' AS inventory_source
+        FROM b2b_churn_signals
+        WHERE vendor_name IS NOT NULL
+          AND TRIM(vendor_name) != ''
+        GROUP BY vendor_name, COALESCE(NULLIF(TRIM(product_category), ''), 'Unknown')
+        """
+    )
+    return [dict(row) for row in rows]
+
+
+async def read_vendor_scorecard_metrics(
+    pool,
+    *,
+    vendor_name: str,
+) -> dict[str, Any] | None:
+    """Read the latest scorecard metrics row for one vendor."""
+    row = await pool.fetchrow(
+        """
+        SELECT price_complaint_rate,
+               decision_maker_churn_rate,
+               total_reviews,
+               signal_reviews,
+               churn_intent_count,
+               avg_urgency_score,
+               avg_rating_normalized,
+               top_competitors,
+               sentiment_distribution,
+               materialization_run_id
+        FROM b2b_churn_signals
+        WHERE LOWER(vendor_name) = LOWER($1)
+        ORDER BY last_computed_at DESC
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    return dict(row) if row else None
+
+
+async def read_vendor_scorecard_archetypes(
+    pool,
+    *,
+    vendor_names: Iterable[Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Read latest non-null vendor archetypes from the derived scorecard table."""
+    requested_vendors = _canonicalize_vendor_name_filters(vendor_names)
+    if not requested_vendors:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (vendor_name)
+               vendor_name,
+               archetype,
+               archetype_confidence
+        FROM b2b_churn_signals
+        WHERE LOWER(vendor_name) = ANY($1::text[])
+          AND archetype IS NOT NULL
+        ORDER BY vendor_name,
+                 last_computed_at DESC NULLS LAST,
+                 total_reviews DESC NULLS LAST
+        """,
+        requested_vendors,
+    )
+    return [
+        dict(row)
+        for row in rows
+        if row.get("vendor_name") and row.get("archetype")
+    ]
+
+
+async def read_vendor_intelligence_records_latest(
+    pool,
+    *,
+    vendor_names: Iterable[Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Read the latest canonical vendor intelligence row per vendor across all windows."""
+    requested_vendors = _canonicalize_vendor_name_filters(vendor_names)
+    if not requested_vendors:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (vendor_name)
+               vendor_name,
+               as_of_date,
+               analysis_window_days,
+               schema_version,
+               materialization_run_id,
+               vault,
+               created_at
+        FROM b2b_evidence_vault
+        WHERE LOWER(vendor_name) = ANY($1::text[])
+        ORDER BY vendor_name, as_of_date DESC, created_at DESC
+        """,
+        requested_vendors,
+    )
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        record = _normalize_vendor_intelligence_record(row)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+async def read_market_landscape_candidates(
+    pool,
+    *,
+    min_vendor_profiles: int,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Read category-level market landscape candidates from profile + scorecard joins."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            pp.product_category AS category,
+            COUNT(DISTINCT pp.vendor_name) AS vendor_count,
+            COALESCE(SUM(cs.total_reviews), 0) AS total_reviews,
+            ROUND(AVG(cs.avg_urgency_score)::numeric, 1) AS avg_urgency
+        FROM b2b_product_profiles pp
+        JOIN b2b_churn_signals cs
+          ON LOWER(cs.vendor_name) = LOWER(pp.vendor_name)
+         AND LOWER(COALESCE(cs.product_category, '')) = LOWER(COALESCE(pp.product_category, ''))
+        WHERE pp.product_category IS NOT NULL AND pp.product_category != ''
+        GROUP BY pp.product_category
+        HAVING COUNT(DISTINCT pp.vendor_name) >= $1
+        ORDER BY COUNT(DISTINCT pp.vendor_name) DESC, COALESCE(SUM(cs.total_reviews), 0) DESC
+        LIMIT $2
+        """,
+        min_vendor_profiles,
+        limit,
+    )
+    return [
+        {
+            "category": row["category"],
+            "vendor_count": row["vendor_count"],
+            "total_reviews": row["total_reviews"],
+            "avg_urgency": float(row["avg_urgency"]),
+        }
+        for row in rows
+    ]
+
+
+async def read_vendor_alternative_candidates(
+    pool,
+    *,
+    min_avg_urgency: float = 6.0,
+    min_total_reviews: int = 5,
+    limit: int = 15,
+) -> list[dict[str, Any]]:
+    """Read vendor-alternative blog candidates from churn scorecards."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            cs.vendor_name AS vendor,
+            cs.product_category AS category,
+            cs.avg_urgency_score AS urgency,
+            cs.total_reviews AS review_count,
+            ap.id AS affiliate_id,
+            ap.name AS affiliate_name,
+            ap.product_name AS affiliate_product,
+            ap.affiliate_url
+        FROM b2b_churn_signals cs
+        LEFT JOIN affiliate_partners ap
+            ON LOWER(ap.category) = LOWER(cs.product_category)
+            AND ap.enabled = true
+        WHERE cs.avg_urgency_score >= $1
+          AND cs.total_reviews >= $2
+        ORDER BY cs.avg_urgency_score * cs.total_reviews DESC
+        LIMIT $3
+        """,
+        min_avg_urgency,
+        min_total_reviews,
+        limit,
+    )
+    return [
+        {
+            "vendor": row["vendor"],
+            "category": row["category"],
+            "urgency": float(row["urgency"]),
+            "review_count": row["review_count"],
+            "has_affiliate": row["affiliate_id"] is not None,
+            "affiliate_id": str(row["affiliate_id"]) if row["affiliate_id"] else None,
+            "affiliate_name": row["affiliate_name"],
+            "affiliate_product": row["affiliate_product"],
+            "affiliate_url": row["affiliate_url"],
+        }
+        for row in rows
+    ]
+
+
+async def read_vendor_showdown_candidates(
+    pool,
+    *,
+    min_total_reviews: int = 10,
+    limit: int = 80,
+) -> list[dict[str, Any]]:
+    """Read vendor-showdown blog candidates from churn scorecards."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            a.vendor_name AS vendor_a, b.vendor_name AS vendor_b,
+            a.product_category AS category,
+            a.total_reviews AS reviews_a, b.total_reviews AS reviews_b,
+            (a.total_reviews + b.total_reviews) AS total_reviews,
+            a.avg_urgency_score AS urgency_a, b.avg_urgency_score AS urgency_b,
+            ABS(a.avg_urgency_score - b.avg_urgency_score) AS pain_diff
+        FROM b2b_churn_signals a
+        JOIN b2b_churn_signals b
+            ON a.product_category = b.product_category
+            AND a.vendor_name < b.vendor_name
+        WHERE a.total_reviews >= $1 AND b.total_reviews >= $1
+        ORDER BY (a.total_reviews + b.total_reviews) DESC
+        LIMIT $2
+        """,
+        min_total_reviews,
+        limit,
+    )
+    return [
+        {
+            "vendor_a": row["vendor_a"],
+            "vendor_b": row["vendor_b"],
+            "category": row["category"],
+            "reviews_a": row["reviews_a"],
+            "reviews_b": row["reviews_b"],
+            "total_reviews": row["total_reviews"],
+            "urgency_a": round(float(row["urgency_a"]), 1),
+            "urgency_b": round(float(row["urgency_b"]), 1),
+            "pain_diff": round(float(row["pain_diff"]), 1),
+        }
+        for row in rows
+    ]
+
+
+async def read_churn_report_candidates(
+    pool,
+    *,
+    min_negative_reviews: int = 8,
+    min_avg_urgency: float = 6.0,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Read churn-report blog candidates from churn scorecards."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            vendor_name AS vendor,
+            product_category AS category,
+            negative_reviews,
+            avg_urgency_score AS avg_urgency,
+            total_reviews
+        FROM b2b_churn_signals
+        WHERE negative_reviews >= $1
+          AND avg_urgency_score >= $2
+        ORDER BY negative_reviews * avg_urgency_score DESC
+        LIMIT $3
+        """,
+        min_negative_reviews,
+        min_avg_urgency,
+        limit,
+    )
+    return [
+        {
+            "vendor": row["vendor"],
+            "category": row["category"],
+            "negative_reviews": row["negative_reviews"],
+            "avg_urgency": round(float(row["avg_urgency"]), 1),
+            "total_reviews": row["total_reviews"],
+        }
+        for row in rows
+    ]
+
+
+async def read_category_vendor_rows(
+    pool,
+    *,
+    category_names: Iterable[Any],
+    limit: int | None = None,
+    require_scorecard_match: bool = False,
+) -> list[dict[str, Any]]:
+    """Read vendor rows for one or more product categories."""
+    normalized_categories = sorted(
+        {
+            str(value or "").strip().lower()
+            for value in category_names
+            if str(value or "").strip()
+        }
+    )
+    if not normalized_categories:
+        return []
+
+    limit_clause = " LIMIT $2" if limit is not None else ""
+    if require_scorecard_match:
+        query = (
+            """
+            SELECT DISTINCT pp.vendor_name, pp.product_category
+            FROM b2b_product_profiles pp
+            JOIN b2b_churn_signals cs
+              ON LOWER(cs.vendor_name) = LOWER(pp.vendor_name)
+             AND LOWER(COALESCE(cs.product_category, '')) = LOWER(COALESCE(pp.product_category, ''))
+            WHERE LOWER(pp.product_category) = ANY($1::text[])
+            ORDER BY pp.vendor_name
+            """
+            + limit_clause
+        )
+    else:
+        query = (
+            """
+            SELECT DISTINCT vendor_name, product_category
+            FROM b2b_product_profiles
+            WHERE LOWER(product_category) = ANY($1::text[])
+            ORDER BY vendor_name
+            """
+            + limit_clause
+        )
+    rows = await pool.fetch(
+        query,
+        normalized_categories,
+        *([limit] if limit is not None else []),
+    )
+    return [dict(row) for row in rows if row.get("vendor_name")]
+
+
+async def read_known_vendor_names(
+    pool,
+) -> list[str]:
+    """Read the canonical known-vendor list from churn scorecards."""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT vendor_name
+        FROM b2b_churn_signals
+        WHERE vendor_name IS NOT NULL AND TRIM(vendor_name) != ''
+        ORDER BY vendor_name
+        """
+    )
+    return [str(row["vendor_name"]) for row in rows if row.get("vendor_name")]
+
+
+async def _fetch_vendor_churn_scores_from_signals(
+    pool,
+    window_days: int,
+    min_reviews: int,
+) -> list[dict[str, Any]]:
+    """Deprecated wrapper. Use ``read_vendor_scorecards`` instead."""
+    return await read_vendor_scorecards(
+        pool,
+        window_days=window_days,
+        min_reviews=min_reviews,
+    )
+
+
+async def _fetch_high_intent_companies(
+    pool,
+    urgency_threshold: float,
+    window_days: int,
+    *,
+    vendor_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Companies showing high churn intent -- the money feed."""
+    sources = _intelligence_source_allowlist()
+    params: list = [urgency_threshold, window_days, sources]
+    signal_where = ""
+    if _high_intent_signal_evidence_enabled():
+        signal_where = """
+          AND (
+                COALESCE((r.enrichment->'churn_signals'->>'intent_to_leave')::boolean, false)
+             OR COALESCE((r.enrichment->'churn_signals'->>'actively_evaluating')::boolean, false)
+             OR COALESCE((r.enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean, false)
+             OR COALESCE((r.enrichment->'urgency_indicators'->>'explicit_cancel_language')::boolean, false)
+             OR COALESCE((r.enrichment->'urgency_indicators'->>'active_migration_language')::boolean, false)
+             OR COALESCE((r.enrichment->'urgency_indicators'->>'active_evaluation_language')::boolean, false)
+             OR COALESCE((r.enrichment->'urgency_indicators'->>'completed_switch_language')::boolean, false)
+          )
+        """
+    idx = 4
+    vendor_param = None
+    scoped_param = None
+    if vendor_name:
+        vendor_param = idx
+        params.append(vendor_name)
+        idx += 1
+    if scoped_vendors is not None:
+        if not scoped_vendors:
+            return []  # scoped user with no tracked vendors = zero results
+        scoped_param = idx
+        params.append(scoped_vendors)
+        idx += 1
+    filters = _eligible_review_filters(
+        window_param=2,
+        source_param=3,
+        alias="r",
+        vendor_expr="matched_vm.vendor_name",
+    )
+    vendor_join = _review_vendor_match_join(
+        review_alias="r",
+        vendor_param=vendor_param,
+        scoped_param=scoped_param,
+    )
+    limit_clause = ""
+    if limit is not None:
+        limit_clause = f"\n        LIMIT ${idx}"
+        params.append(limit)
+        idx += 1
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id AS review_id, r.source,
+            COALESCE(
+                CASE
+                    WHEN ar.confidence_label IN ('high', 'medium')
+                    THEN ar.resolved_company_name
+                    ELSE NULL
+                END,
+                r.reviewer_company
+            ) AS reviewer_company,
+            r.reviewer_company AS raw_reviewer_company,
+            ar.confidence_label AS resolution_confidence,
+            matched_vm.vendor_name AS vendor_name,
+            r.product_category,
+            r.reviewer_title,
+            r.company_size_raw,
+            COALESCE(poc.industry, r.reviewer_industry,
+                     r.enrichment->'reviewer_context'->>'industry') AS industry,
+            poc.employee_count AS verified_employee_count,
+            poc.country AS company_country,
+            poc.domain AS company_domain,
+            poc.annual_revenue_range AS revenue_range,
+            poc.founded_year,
+            poc.total_funding,
+            poc.latest_funding_stage,
+            poc.headcount_growth_6m,
+            poc.headcount_growth_12m,
+            poc.headcount_growth_24m,
+            poc.publicly_traded_exchange,
+            poc.publicly_traded_symbol,
+            poc.short_description AS company_description,
+            r.enrichment->'reviewer_context'->>'role_level' AS role_level,
+            (r.enrichment->'reviewer_context'->>'decision_maker')::boolean AS is_dm,
+            (r.enrichment->>'urgency_score')::numeric AS urgency,
+            r.enrichment->>'pain_category' AS pain,
+            r.enrichment AS enrichment_raw,
+            r.enrichment->'competitors_mentioned' AS alternatives,
+            r.enrichment->'contract_context'->>'contract_value_signal' AS value_signal,
+            r.enrichment->'budget_signals'->>'seat_count' AS seat_count,
+            r.enrichment->'use_case'->>'lock_in_level' AS lock_in_level,
+            r.enrichment->'timeline'->>'contract_end' AS contract_end,
+            r.enrichment->'buyer_authority'->>'buying_stage' AS buying_stage,
+            r.relevance_score,
+            r.author_churn_score,
+            (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean AS intent_to_leave,
+            (r.enrichment->'churn_signals'->>'actively_evaluating')::boolean AS actively_evaluating,
+            (r.enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean AS contract_renewal_mentioned,
+            -- v2 urgency indicators for richer account intelligence
+            (r.enrichment->'urgency_indicators'->>'explicit_cancel_language')::boolean AS indicator_cancel,
+            (r.enrichment->'urgency_indicators'->>'active_migration_language')::boolean AS indicator_migration,
+            (r.enrichment->'urgency_indicators'->>'active_evaluation_language')::boolean AS indicator_evaluation,
+            (r.enrichment->'urgency_indicators'->>'completed_switch_language')::boolean AS indicator_switch,
+            (r.enrichment->'urgency_indicators'->>'named_alternative_with_reason')::boolean AS indicator_named_alternative,
+            (r.enrichment->'urgency_indicators'->>'timeline_mentioned')::boolean AS indicator_timeline,
+            (r.enrichment->'urgency_indicators'->>'price_pressure_language')::boolean AS indicator_price_pressure,
+            (r.enrichment->'buyer_authority'->>'has_budget_authority')::boolean AS has_budget_authority
+        FROM b2b_reviews r
+        {vendor_join}
+        LEFT JOIN b2b_account_resolution ar
+            ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
+        LEFT JOIN prospect_org_cache poc
+            ON poc.company_name_norm = CASE
+                WHEN ar.confidence_label IN ('high', 'medium')
+                THEN ar.normalized_company_name
+                ELSE NULL
+            END
+        WHERE {filters}
+          AND (r.enrichment->>'urgency_score')::numeric >= $1
+          AND r.reviewer_company IS NOT NULL AND r.reviewer_company != ''
+          AND COALESCE(r.relevance_score, 0.5) >= 0.3
+          {signal_where}
+        ORDER BY (r.enrichment->>'urgency_score')::numeric
+                 * (0.7 + 0.3 * COALESCE(r.relevance_score, 0.5)) DESC{limit_clause}
+        """,
+        *params,
+    )
+    results = []
+    for r in rows:
+        alternatives = _safe_json(r["alternatives"])
+        blocked_names = {
+            normalize_company_name(name)
+            for name in _extract_alternative_names(alternatives)
+            if normalize_company_name(name)
+        }
+        seat_count = None
+        if r["seat_count"]:
+            try:
+                seat_count = int(r["seat_count"])
+            except (ValueError, TypeError):
+                pass
+        provisional_confidence = _compute_company_signal_confidence({
+            "source": r["source"],
+            "decision_maker": bool(r["is_dm"]) if r["is_dm"] is not None else None,
+            "buying_stage": r["buying_stage"],
+            "seat_count": seat_count,
+            "reviewer_title": r["reviewer_title"],
+            "company_size": r["company_size_raw"],
+            "industry": r["industry"],
+            "company_domain": r["company_domain"],
+            "resolution_confidence": r["resolution_confidence"],
+        })
+        if _company_signal_exclusion_reason(
+            r["reviewer_company"],
+            current_vendor=r["vendor_name"],
+            blocked_names=blocked_names,
+            source=r["source"],
+            confidence_score=provisional_confidence,
+        ):
+            continue
+        if _company_signal_named_account_gap_reason(
+            {
+                "source": r["source"],
+                "resolution_confidence": r["resolution_confidence"],
+                "reviewer_title": r["reviewer_title"],
+                "company_size_raw": r["company_size_raw"],
+                "industry": r["industry"],
+                "company_domain": r["company_domain"],
+            },
+            confidence_score=provisional_confidence,
+        ):
+            continue
+        if _high_intent_signal_evidence_enabled() and not _high_intent_row_has_signal_evidence(dict(r)):
+            continue
+        try:
+            urgency = float(r["urgency"]) if r["urgency"] is not None else 0
+        except (ValueError, TypeError):
+            urgency = 0
+        # Gate pain_category via the contract helper. High-intent rows are
+        # admitted on urgency + identity + relevance + signal evidence; pain
+        # is an annotation, not an admission ticket. So we keep the row even
+        # when gated_pain is None and surface pain_confidence so downstream
+        # consumers can decide how to render the annotation.
+        #
+        # Parse enrichment_raw into a dict or None (NOT {}). A None enrichment
+        # must propagate as None so the contract resolver returns 'unknown'
+        # for the malformed/missing case -- {} would incorrectly recompute to
+        # 'none' via the empty-signals path.
+        enrichment_dict = _parse_enrichment_dict(r["enrichment_raw"])
+        gated_pain = pain_category_for_bucket(
+            enrichment_dict, min_confidence="weak",
+        )
+        pain_conf = resolve_pain_confidence(enrichment_dict)
+        quote_rows = _quote_grade_rows_from_enrichment(
+            enrichment_dict,
+            urgency=urgency,
+            review_id=r["review_id"],
+            source=r["source"],
+            company=r["reviewer_company"],
+            title=r["reviewer_title"],
+            company_size=r["company_size_raw"],
+            industry=r["industry"],
+        )
+        results.append({
+            "company": r["reviewer_company"],
+            "raw_company": r["raw_reviewer_company"],
+            "resolution_confidence": r["resolution_confidence"],
+            "vendor": r["vendor_name"],
+            "category": r["product_category"],
+            "title": r["reviewer_title"],
+            "company_size": r["company_size_raw"],
+            "industry": r["industry"],
+            "verified_employee_count": r["verified_employee_count"],
+            "company_country": r["company_country"],
+            "company_domain": r["company_domain"],
+            "revenue_range": r["revenue_range"],
+            "founded_year": r["founded_year"],
+            "total_funding": r["total_funding"],
+            "funding_stage": r["latest_funding_stage"],
+            "headcount_growth_6m": float(r["headcount_growth_6m"]) if r["headcount_growth_6m"] is not None else None,
+            "headcount_growth_12m": float(r["headcount_growth_12m"]) if r["headcount_growth_12m"] is not None else None,
+            "headcount_growth_24m": float(r["headcount_growth_24m"]) if r["headcount_growth_24m"] is not None else None,
+            "publicly_traded": r["publicly_traded_exchange"] or None,
+            "ticker": r["publicly_traded_symbol"] or None,
+            "company_description": r["company_description"],
+            "role_level": r["role_level"],
+            "decision_maker": r["is_dm"],
+            "urgency": urgency,
+            "pain": gated_pain,
+            "pain_confidence": pain_conf,
+            "alternatives": alternatives,
+            "quotes": quote_rows,
+            "contract_signal": r["value_signal"],
+            "review_id": str(r["review_id"]) if r["review_id"] else None,
+            "source": r["source"],
+            "seat_count": seat_count,
+            "lock_in_level": r["lock_in_level"],
+            "contract_end": r["contract_end"],
+            "buying_stage": r["buying_stage"],
+            "relevance_score": float(r["relevance_score"]) if r["relevance_score"] is not None else None,
+            "author_churn_score": float(r["author_churn_score"]) if r["author_churn_score"] is not None else None,
+            "intent_signals": {
+                "cancel": bool(r.get("indicator_cancel")),
+                "migration": bool(r.get("indicator_migration")),
+                "evaluation": bool(r.get("indicator_evaluation")),
+                "completed_switch": bool(r.get("indicator_switch")),
+            },
+        })
+    return results
+
+
+async def _fetch_company_signal_review_candidates(
+    pool,
+    *,
+    window_days: int,
+    urgency_threshold: float | None = None,
+    vendor_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    candidate_bucket: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch review-level company-signal candidates for analyst-assist workflows."""
+    sources = _intelligence_source_allowlist()
+    params: list[Any] = [window_days, sources]
+    idx = 3
+    vendor_param = None
+    scoped_param = None
+    if vendor_name:
+        vendor_param = idx
+        params.append(vendor_name)
+        idx += 1
+    if scoped_vendors is not None:
+        if not scoped_vendors:
+            return []
+        scoped_param = idx
+        params.append(scoped_vendors)
+        idx += 1
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="matched_vm.vendor_name",
+    )
+    vendor_join = _review_vendor_match_join(
+        review_alias="r",
+        vendor_param=vendor_param,
+        scoped_param=scoped_param,
+    )
+    limit_clause = ""
+    if limit is not None:
+        limit_clause = f"\n        LIMIT ${idx}"
+        params.append(limit)
+        idx += 1
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id AS review_id,
+               r.source,
+               COALESCE(
+                   CASE
+                       WHEN ar.confidence_label IN ('high', 'medium')
+                       THEN ar.resolved_company_name
+                       ELSE NULL
+                   END,
+                   r.reviewer_company
+               ) AS reviewer_company,
+               r.reviewer_company AS raw_reviewer_company,
+               ar.confidence_label AS resolution_confidence,
+               matched_vm.vendor_name AS vendor_name,
+               r.product_category,
+               COALESCE(r.reviewed_at, r.imported_at, r.enriched_at) AS reviewed_at,
+               r.reviewer_title,
+               r.company_size_raw,
+               COALESCE(
+                   poc.industry,
+                   r.reviewer_industry,
+                   r.enrichment->'reviewer_context'->>'industry'
+               ) AS industry,
+               poc.domain AS company_domain,
+               r.enrichment->'reviewer_context'->>'role_level' AS role_level,
+               (r.enrichment->'reviewer_context'->>'decision_maker')::boolean AS is_dm,
+               (r.enrichment->>'urgency_score')::numeric AS urgency,
+               r.enrichment->>'pain_category' AS pain,
+               r.enrichment->'competitors_mentioned' AS alternatives,
+               r.enrichment->'budget_signals'->>'seat_count' AS seat_count,
+               r.enrichment->'timeline'->>'contract_end' AS contract_end,
+               r.enrichment->'buyer_authority'->>'buying_stage' AS buying_stage,
+               r.relevance_score,
+               r.author_churn_score,
+               (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean AS intent_to_leave,
+               (r.enrichment->'churn_signals'->>'actively_evaluating')::boolean AS actively_evaluating,
+               (r.enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean AS contract_renewal_mentioned,
+               (r.enrichment->'urgency_indicators'->>'explicit_cancel_language')::boolean AS indicator_cancel,
+               (r.enrichment->'urgency_indicators'->>'active_migration_language')::boolean AS indicator_migration,
+               (r.enrichment->'urgency_indicators'->>'active_evaluation_language')::boolean AS indicator_evaluation,
+               (r.enrichment->'urgency_indicators'->>'completed_switch_language')::boolean AS indicator_switch,
+               (r.enrichment->'urgency_indicators'->>'named_alternative_with_reason')::boolean AS indicator_named_alternative,
+               (r.enrichment->'urgency_indicators'->>'timeline_mentioned')::boolean AS indicator_timeline,
+               (r.enrichment->'urgency_indicators'->>'price_pressure_language')::boolean AS indicator_price_pressure,
+               (r.enrichment->'buyer_authority'->>'has_budget_authority')::boolean AS has_budget_authority
+        FROM b2b_reviews r
+        {vendor_join}
+        LEFT JOIN b2b_account_resolution ar
+            ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
+        LEFT JOIN prospect_org_cache poc
+            ON poc.company_name_norm = CASE
+                WHEN ar.confidence_label IN ('high', 'medium')
+                THEN ar.normalized_company_name
+                ELSE NULL
+            END
+        WHERE {filters}
+          AND r.reviewer_company IS NOT NULL AND r.reviewer_company <> ''
+          AND COALESCE(r.relevance_score, 0.5) >= 0.3
+        ORDER BY COALESCE((r.enrichment->>'urgency_score')::numeric, 0) DESC,
+                 COALESCE(r.relevance_score, 0.5) DESC,
+                 COALESCE(r.reviewed_at, r.imported_at, r.enriched_at) DESC{limit_clause}
+        """,
+        *params,
+    )
+    min_urgency = float(
+        urgency_threshold
+        if urgency_threshold is not None
+        else getattr(settings.b2b_churn, "high_churn_urgency_threshold", 7.0)
+    )
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        alternatives = _safe_json(row.get("alternatives"))
+        blocked_names = {
+            normalize_company_name(name)
+            for name in _extract_alternative_names(alternatives)
+            if normalize_company_name(name)
+        }
+        seat_count = None
+        if row.get("seat_count"):
+            try:
+                seat_count = int(row["seat_count"])
+            except (TypeError, ValueError):
+                pass
+        confidence_score = _compute_company_signal_confidence({
+            "source": row.get("source"),
+            "decision_maker": bool(row["is_dm"]) if row.get("is_dm") is not None else None,
+            "buying_stage": row.get("buying_stage"),
+            "seat_count": seat_count,
+            "reviewer_title": row.get("reviewer_title"),
+            "company_size": row.get("company_size_raw"),
+            "industry": row.get("industry"),
+            "company_domain": row.get("company_domain"),
+            "resolution_confidence": row.get("resolution_confidence"),
+        })
+        exclusion_reason = _company_signal_exclusion_reason(
+            row.get("reviewer_company"),
+            current_vendor=row.get("vendor_name") or "",
+            blocked_names=blocked_names,
+            source=row.get("source"),
+            confidence_score=confidence_score,
+        )
+        if exclusion_reason in {"ineligible_company_name", "deprecated_source"}:
+            continue
+        try:
+            urgency = float(row["urgency"]) if row.get("urgency") is not None else 0.0
+        except (TypeError, ValueError):
+            urgency = 0.0
+        signal_evidence_present = _high_intent_row_has_signal_evidence(dict(row))
+        canonical_gap_reason = exclusion_reason
+        if canonical_gap_reason is None:
+            canonical_gap_reason = _company_signal_named_account_gap_reason(
+                {
+                    "source": row.get("source"),
+                    "resolution_confidence": row.get("resolution_confidence"),
+                    "reviewer_title": row.get("reviewer_title"),
+                    "company_size_raw": row.get("company_size_raw"),
+                    "industry": row.get("industry"),
+                    "company_domain": row.get("company_domain"),
+                },
+                confidence_score=confidence_score,
+            )
+        if canonical_gap_reason is None and urgency < min_urgency:
+            canonical_gap_reason = "below_high_intent_threshold"
+        if (
+            canonical_gap_reason is None
+            and _high_intent_signal_evidence_enabled()
+            and not signal_evidence_present
+        ):
+            canonical_gap_reason = "missing_signal_evidence"
+        normalized_source = str(row.get("source") or "").strip().lower()
+        if (
+            canonical_gap_reason == "low_confidence_low_trust_source"
+            and normalized_source in _company_signal_low_trust_sources()
+            and confidence_score < _company_signal_low_trust_analyst_min_confidence()
+        ):
+            continue
+        if canonical_gap_reason == "non_actionable_named_account_source":
+            continue
+        if canonical_gap_reason == "below_high_intent_threshold":
+            urgency_gap = max(0.0, min_urgency - urgency)
+            if (
+                not signal_evidence_present
+                and urgency_gap > _company_signal_below_threshold_analyst_max_urgency_gap()
+            ):
+                continue
+        bucket = "canonical_ready" if canonical_gap_reason is None else "analyst_review"
+        if candidate_bucket and bucket != candidate_bucket:
+            continue
+        results.append({
+            "review_id": str(row["review_id"]) if row.get("review_id") else None,
+            "company_name": row.get("reviewer_company"),
+            "company_name_raw": row.get("raw_reviewer_company"),
+            "resolution_confidence": row.get("resolution_confidence"),
+            "vendor_name": row.get("vendor_name"),
+            "product_category": row.get("product_category"),
+            "source": row.get("source"),
+            "reviewed_at": row.get("reviewed_at"),
+            "title": row.get("reviewer_title"),
+            "company_size": row.get("company_size_raw"),
+            "industry": row.get("industry"),
+            "company_domain": row.get("company_domain"),
+            "role_level": row.get("role_level"),
+            "decision_maker": row.get("is_dm"),
+            "urgency_score": urgency,
+            "pain_category": row.get("pain"),
+            "seat_count": seat_count,
+            "contract_end": row.get("contract_end"),
+            "buying_stage": row.get("buying_stage"),
+            "relevance_score": float(row["relevance_score"]) if row.get("relevance_score") is not None else None,
+            "author_churn_score": float(row["author_churn_score"]) if row.get("author_churn_score") is not None else None,
+            "confidence_score": confidence_score,
+            "confidence_tier": _company_signal_candidate_confidence_tier(confidence_score),
+            "signal_evidence_present": signal_evidence_present,
+            "canonical_gap_reason": canonical_gap_reason,
+            "candidate_bucket": bucket,
+        })
+    return results
+
+
+async def _fetch_existing_company_signals(
+    pool,
+    *,
+    window_days: int,
+) -> dict[str, list[dict[str, Any]]]:
+    """Fetch canonical company-signal rows still active in the analysis window."""
+    rows = await pool.fetch(
+        """
+        SELECT cs.company_name, cs.vendor_name, cs.urgency_score,
+               pain_category, buyer_role, decision_maker,
+               seat_count, contract_end, buying_stage,
+               cs.review_id, cs.source, cs.confidence_score,
+               cs.first_seen_at, cs.last_seen_at,
+               r.content_type,
+               (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean AS intent_to_leave,
+               (r.enrichment->'churn_signals'->>'actively_evaluating')::boolean AS actively_evaluating,
+               (r.enrichment->'churn_signals'->>'contract_renewal_mentioned')::boolean AS contract_renewal_mentioned,
+               (r.enrichment->'urgency_indicators'->>'explicit_cancel_language')::boolean AS indicator_cancel,
+               (r.enrichment->'urgency_indicators'->>'active_migration_language')::boolean AS indicator_migration,
+               (r.enrichment->'urgency_indicators'->>'active_evaluation_language')::boolean AS indicator_evaluation,
+               (r.enrichment->'urgency_indicators'->>'completed_switch_language')::boolean AS indicator_switch,
+               (r.enrichment->'urgency_indicators'->>'named_alternative_with_reason')::boolean AS indicator_named_alternative,
+               (r.enrichment->'urgency_indicators'->>'timeline_mentioned')::boolean AS indicator_timeline,
+               (r.enrichment->'urgency_indicators'->>'price_pressure_language')::boolean AS indicator_price_pressure,
+               (r.enrichment->'buyer_authority'->>'has_budget_authority')::boolean AS has_budget_authority,
+               r.reviewer_title,
+               r.company_size_raw,
+               COALESCE(
+                   poc.industry,
+                   r.reviewer_industry,
+                   r.enrichment->'reviewer_context'->>'industry'
+               ) AS industry,
+               poc.employee_count AS verified_employee_count,
+               poc.country AS company_country,
+               poc.domain AS company_domain,
+               poc.founded_year,
+               poc.total_funding,
+               poc.latest_funding_stage,
+               poc.headcount_growth_6m,
+               poc.headcount_growth_12m,
+               poc.headcount_growth_24m,
+               poc.publicly_traded_exchange,
+               poc.publicly_traded_symbol,
+               poc.short_description AS company_description,
+               r.enrichment->'competitors_mentioned' AS alternatives,
+               r.enrichment->'quotable_phrases' AS quotes
+        FROM b2b_company_signals cs
+        LEFT JOIN b2b_reviews r ON r.id = cs.review_id
+        LEFT JOIN b2b_account_resolution ar
+            ON ar.review_id = cs.review_id AND ar.resolution_status = 'resolved'
+        LEFT JOIN prospect_org_cache poc
+            ON poc.company_name_norm = ar.normalized_company_name
+        WHERE cs.last_seen_at >= NOW() - make_interval(days => $1)
+        ORDER BY cs.vendor_name, cs.urgency_score DESC NULLS LAST, cs.last_seen_at DESC
+        """,
+        window_days,
+    )
+    lookup: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        if _high_intent_signal_evidence_enabled() and not _high_intent_row_has_signal_evidence(dict(row)):
+            continue
+        lookup.setdefault(vendor, []).append({
+            "company_name": row.get("company_name"),
+            "vendor_name": vendor,
+            "urgency_score": float(row["urgency_score"]) if row.get("urgency_score") is not None else None,
+            "pain_category": row.get("pain_category"),
+            "buyer_role": row.get("buyer_role"),
+            "decision_maker": row.get("decision_maker"),
+            "seat_count": row.get("seat_count"),
+            "contract_end": str(row.get("contract_end") or "") or None,
+            "buying_stage": row.get("buying_stage"),
+            "review_id": str(row.get("review_id") or "") or None,
+            "source": row.get("source"),
+            "content_type": row.get("content_type"),
+            "confidence_score": float(row["confidence_score"]) if row.get("confidence_score") is not None else None,
+            "first_seen_at": str(row.get("first_seen_at") or "") or None,
+            "last_seen_at": str(row.get("last_seen_at") or "") or None,
+            "title": row.get("reviewer_title"),
+            "company_size": row.get("company_size_raw"),
+            "industry": row.get("industry"),
+            "verified_employee_count": row.get("verified_employee_count"),
+            "company_country": row.get("company_country"),
+            "company_domain": row.get("company_domain"),
+            "founded_year": row.get("founded_year"),
+            "total_funding": row.get("total_funding"),
+            "funding_stage": row.get("latest_funding_stage"),
+            "headcount_growth_6m": float(row["headcount_growth_6m"]) if row.get("headcount_growth_6m") is not None else None,
+            "headcount_growth_12m": float(row["headcount_growth_12m"]) if row.get("headcount_growth_12m") is not None else None,
+            "headcount_growth_24m": float(row["headcount_growth_24m"]) if row.get("headcount_growth_24m") is not None else None,
+            "publicly_traded": row.get("publicly_traded_exchange") or None,
+            "ticker": row.get("publicly_traded_symbol") or None,
+            "company_description": row.get("company_description"),
+            "alternatives": _safe_json(row.get("alternatives"), default=[]),
+            "quotes": _safe_json(row.get("quotes"), default=[]),
+        })
+    return lookup
+
+
+async def _fetch_competitive_displacement(pool, window_days: int) -> list[dict[str, Any]]:
+    """Competitive displacement flows -- filtered to real displacement evidence only.
+
+    Uses evidence_type (new schema) with COALESCE fallback to context (legacy).
+    Excludes reverse_flow, neutral_mention, and low-confidence implied_preference.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            comp.value->>'name' AS competitor,
+            COALESCE(
+                comp.value->>'evidence_type',
+                CASE comp.value->>'context'
+                    WHEN 'switched_to' THEN 'explicit_switch'
+                    WHEN 'considering' THEN 'active_evaluation'
+                    WHEN 'compared' THEN 'implied_preference'
+                    WHEN 'switched_from' THEN 'reverse_flow'
+                    ELSE 'neutral_mention'
+                END
+            ) AS evidence_type,
+            COALESCE(
+                comp.value->>'displacement_confidence', 'low'
+            ) AS displacement_confidence,
+            comp.value->>'reason_category' AS reason_category,
+            comp.value->>'context' AS direction,
+            count(*) AS mention_count,
+            array_agg(DISTINCT company_size_raw) FILTER (WHERE company_size_raw IS NOT NULL) AS sizes,
+            array_agg(DISTINCT COALESCE(reviewer_industry, enrichment->'reviewer_context'->>'industry'))
+                FILTER (WHERE COALESCE(reviewer_industry, enrichment->'reviewer_context'->>'industry') IS NOT NULL) AS industries
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(r.enrichment->'competitors_mentioned') AS comp(value)
+        WHERE {filters}
+          AND COALESCE(
+                comp.value->>'evidence_type',
+                CASE comp.value->>'context'
+                    WHEN 'switched_to' THEN 'explicit_switch'
+                    WHEN 'considering' THEN 'active_evaluation'
+                    WHEN 'compared' THEN 'implied_preference'
+                    WHEN 'switched_from' THEN 'reverse_flow'
+                    ELSE 'neutral_mention'
+                END
+              ) IN ('explicit_switch', 'active_evaluation', 'implied_preference')
+          AND NOT (
+              COALESCE(
+                comp.value->>'evidence_type',
+                CASE comp.value->>'context'
+                    WHEN 'compared' THEN 'implied_preference'
+                    ELSE 'neutral_mention'
+                END
+              ) = 'implied_preference'
+              AND COALESCE(comp.value->>'displacement_confidence', 'low') = 'low'
+          )
+        GROUP BY vm.vendor_name, comp.value->>'name',
+                 evidence_type, displacement_confidence, reason_category,
+                 comp.value->>'context'
+        HAVING count(*) >= 2
+        ORDER BY mention_count DESC
+        """,
+        window_days,
+        sources,
+    )
+    # Post-process: canonicalize competitors, filter self-flows, re-aggregate
+    MergeKey = tuple[str, str, str]  # (vendor, competitor, evidence_type)
+    merged: dict[MergeKey, int] = {}
+    merged_industries: dict[MergeKey, list[str]] = {}
+    merged_sizes: dict[MergeKey, list[str]] = {}
+    merged_reason_cats: dict[MergeKey, dict[str, int]] = {}
+    for r in rows:
+        canon = _canonicalize_competitor(r["competitor"] or "")
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        if canon and vendor and canon.lower() == vendor.lower():
+            continue
+        et = r["evidence_type"] or "implied_preference"
+        key: MergeKey = (vendor, canon, et)
+        merged[key] = merged.get(key, 0) + r["mention_count"]
+        if r.get("industries"):
+            merged_industries.setdefault(key, []).extend(r["industries"])
+        if r.get("sizes"):
+            merged_sizes.setdefault(key, []).extend(r["sizes"])
+        rc = r.get("reason_category")
+        if rc:
+            cats = merged_reason_cats.setdefault(key, {})
+            cats[rc] = cats.get(rc, 0) + r["mention_count"]
+
+    # Re-apply HAVING count >= 2, sort by mention_count DESC
+    results = []
+    for k, cnt in merged.items():
+        if cnt < 2:
+            continue
+        ind_list = merged_industries.get(k, [])
+        sz_list = merged_sizes.get(k, [])
+        results.append({
+            "vendor": k[0],
+            "competitor": k[1],
+            "evidence_type": k[2],
+            "mention_count": cnt,
+            "reason_categories": merged_reason_cats.get(k, {}),
+            "industries": sorted(set(i for i in ind_list if i and i != "unknown")),
+            "company_sizes": sorted(set(s for s in sz_list if s)),
+        })
+    results.sort(key=lambda x: x["mention_count"], reverse=True)
+    return results
+
+
+async def _fetch_displacement_provenance(pool, window_days: int) -> dict[tuple[str, str], dict]:
+    """Per-edge source distribution and sample review IDs for confidence scoring.
+
+    Returns a dict keyed by ``(from_vendor, to_vendor)`` with:
+      - ``source_distribution``: ``{source: count}``
+      - ``sample_review_ids``:   list of UUID strings (top 20 by urgency)
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            comp.value->>'name' AS competitor,
+            r.source,
+            count(*) AS cnt,
+            array_agg(r.id ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST)
+                FILTER (WHERE r.id IS NOT NULL) AS review_ids
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(r.enrichment->'competitors_mentioned') AS comp(value)
+        WHERE {filters}
+        GROUP BY vm.vendor_name, comp.value->>'name', r.source
+        HAVING count(*) >= 1
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+
+    # Aggregate by canonicalized (from_vendor, to_vendor)
+    result: dict[tuple[str, str], dict] = {}
+    for r in rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        competitor = _canonicalize_competitor(r["competitor"] or "")
+        if not vendor or not competitor or vendor.lower() == competitor.lower():
+            continue
+        key = (vendor, competitor)
+        if key not in result:
+            result[key] = {"source_distribution": {}, "sample_review_ids": []}
+        entry = result[key]
+        source = r["source"] or "unknown"
+        entry["source_distribution"][source] = entry["source_distribution"].get(source, 0) + r["cnt"]
+        # Collect review IDs (cap at 20 per edge)
+        rids = r["review_ids"] or []
+        for rid in rids:
+            if len(entry["sample_review_ids"]) < 20 and str(rid) not in entry["sample_review_ids"]:
+                entry["sample_review_ids"].append(str(rid))
+
+    return result
+
+
+async def _fetch_pain_provenance(
+    pool, window_days: int,
+) -> dict[tuple[str, str], dict]:
+    """Per-vendor/pain_category provenance for the b2b_vendor_pain_points table.
+
+    Returns ``{(vendor, pain_category): {mention_count, primary_count,
+    secondary_count, minor_count, avg_urgency, avg_rating,
+    source_distribution, sample_review_ids}}``.
+
+    Phase 2.2.B: aggregation moved from SQL GROUP BY to Python so each row
+    can be gated through ``pain_category_for_bucket`` before contributing
+    to the rollup. The contract resolver also handles legacy v3 rows that
+    have no stamped ``pain_confidence`` -- those resolve via the
+    deterministic recompute path. Severity-breakdown rows continue to come
+    from a separate SQL aggregate and remain augment-only (they only
+    update keys already populated by the gated core pass).
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+
+    # 1. Core: fetch un-aggregated rows so we can apply the contract gate
+    #    per-review before bucketing. ORDER BY urgency keeps the highest
+    #    urgency reviews first inside each (vendor, pain) bucket up to the
+    #    20-row sample cap.
+    core_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.id AS review_id,
+            r.source,
+            r.rating,
+            r.enrichment AS enrichment_raw,
+            (r.enrichment->>'urgency_score')::numeric AS urgency_score
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->>'pain_category' IS NOT NULL
+        ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
+        """,
+        window_days,
+        sources,
+    )
+
+    # 2. Severity breakdown from the pain_categories array
+    severity_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            p.value->>'category' AS pain_category,
+            p.value->>'severity' AS severity,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'pain_categories', '[]'::jsonb)
+        ) AS p(value)
+        WHERE {filters}
+          AND p.value->>'category' IS NOT NULL
+        GROUP BY vm.vendor_name, p.value->>'category', p.value->>'severity'
+        """,
+        window_days,
+        sources,
+    )
+
+    result: dict[tuple[str, str], dict] = {}
+
+    # Aggregate core rows in Python after applying the contract gate.
+    for r in core_rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        if not vendor:
+            continue
+        raw_enrichment = r["enrichment_raw"]
+        if isinstance(raw_enrichment, dict):
+            enrichment_dict = raw_enrichment
+        elif isinstance(raw_enrichment, str) and raw_enrichment:
+            try:
+                parsed = json.loads(raw_enrichment)
+                enrichment_dict = parsed if isinstance(parsed, dict) else None
+            except (json.JSONDecodeError, TypeError):
+                enrichment_dict = None
+        else:
+            enrichment_dict = None
+        gated_pain = pain_category_for_bucket(
+            enrichment_dict, min_confidence="weak", allow_generic=True,
+        )
+        if not gated_pain:
+            continue
+        key = (vendor, gated_pain)
+        if key not in result:
+            result[key] = {
+                "mention_count": 0,
+                "primary_count": 0,
+                "secondary_count": 0,
+                "minor_count": 0,
+                "avg_urgency": 0.0,
+                "avg_rating": 0.0,
+                "source_distribution": {},
+                "sample_review_ids": [],
+                "_urgency_sum": 0.0,
+                "_urgency_count": 0,
+                "_rating_sum": 0.0,
+                "_rating_count": 0,
+            }
+        entry = result[key]
+        entry["mention_count"] += 1
+        urgency = r["urgency_score"]
+        if urgency is not None:
+            try:
+                entry["_urgency_sum"] += float(urgency)
+                entry["_urgency_count"] += 1
+            except (TypeError, ValueError):
+                pass
+        rating = r["rating"]
+        if rating is not None:
+            try:
+                entry["_rating_sum"] += float(rating)
+                entry["_rating_count"] += 1
+            except (TypeError, ValueError):
+                pass
+        source = r["source"] or "unknown"
+        entry["source_distribution"][source] = (
+            entry["source_distribution"].get(source, 0) + 1
+        )
+        rid = r["review_id"]
+        if rid is not None and len(entry["sample_review_ids"]) < 20:
+            rid_str = str(rid)
+            if rid_str not in entry["sample_review_ids"]:
+                entry["sample_review_ids"].append(rid_str)
+
+    # Aggregate severity breakdown -- augment-only against keys already
+    # populated by the gated core pass.
+    for r in severity_rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        pain = r["pain_category"] or ""
+        if not vendor or not pain:
+            continue
+        key = (vendor, pain)
+        if key not in result:
+            continue  # only augment keys from core query
+        severity = (r["severity"] or "").lower()
+        cnt = r["cnt"]
+        if severity == "primary":
+            result[key]["primary_count"] += cnt
+        elif severity == "secondary":
+            result[key]["secondary_count"] += cnt
+        elif severity == "minor":
+            result[key]["minor_count"] += cnt
+
+    # Finalize averages and clean internal fields. NULL-safe: divides by
+    # the count of rows that actually contributed a value, not by total
+    # mention_count, so a vendor with a few null-rating sources isn't
+    # punished by the missing values.
+    for entry in result.values():
+        urg_sum = entry.pop("_urgency_sum", 0.0)
+        urg_count = entry.pop("_urgency_count", 0)
+        rat_sum = entry.pop("_rating_sum", 0.0)
+        rat_count = entry.pop("_rating_count", 0)
+        entry["avg_urgency"] = round(urg_sum / urg_count, 1) if urg_count else 0.0
+        entry["avg_rating"] = round(rat_sum / rat_count, 2) if rat_count else 0.0
+
+    return result
+
+
+async def _fetch_use_case_provenance(
+    pool, window_days: int,
+) -> dict[tuple[str, str], dict]:
+    """Per-vendor/module provenance for the b2b_vendor_use_cases table.
+
+    Returns ``{(vendor, module_name): {mention_count, avg_urgency,
+    lock_in_distribution, source_distribution, sample_review_ids}}``.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+
+    # 1. Module mentions with source + urgency + sample IDs
+    module_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            mod.value #>> '{{}}' AS module_name,
+            r.source,
+            count(*) AS cnt,
+            avg((r.enrichment->>'urgency_score')::numeric) AS avg_urgency,
+            array_agg(r.id ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST)
+                FILTER (WHERE r.id IS NOT NULL) AS review_ids
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'use_case'->'modules_mentioned', '[]'::jsonb)
+        ) AS mod(value)
+        WHERE {filters}
+        GROUP BY vm.vendor_name, mod.value #>> '{{}}', r.source
+        """,
+        window_days,
+        sources,
+    )
+
+    # 2. Lock-in distribution per vendor/module
+    lock_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            mod.value #>> '{{}}' AS module_name,
+            r.enrichment->'use_case'->>'lock_in_level' AS lock_in_level,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'use_case'->'modules_mentioned', '[]'::jsonb)
+        ) AS mod(value)
+        WHERE {filters}
+          AND r.enrichment->'use_case'->>'lock_in_level' IS NOT NULL
+        GROUP BY vm.vendor_name, mod.value #>> '{{}}', r.enrichment->'use_case'->>'lock_in_level'
+        """,
+        window_days,
+        sources,
+    )
+
+    result: dict[tuple[str, str], dict] = {}
+
+    for r in module_rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        module = r["module_name"] or ""
+        if not vendor or not module:
+            continue
+        key = (vendor, module)
+        if key not in result:
+            result[key] = {
+                "mention_count": 0,
+                "avg_urgency": 0.0,
+                "lock_in_distribution": {},
+                "source_distribution": {},
+                "sample_review_ids": [],
+                "_urgency_sum": 0.0,
+                "_total": 0,
+            }
+        entry = result[key]
+        cnt = r["cnt"]
+        entry["mention_count"] += cnt
+        entry["_total"] += cnt
+        entry["_urgency_sum"] += float(r["avg_urgency"] or 0) * cnt
+        source = r["source"] or "unknown"
+        entry["source_distribution"][source] = (
+            entry["source_distribution"].get(source, 0) + cnt
+        )
+        for rid in (r["review_ids"] or []):
+            if len(entry["sample_review_ids"]) < 20 and str(rid) not in entry["sample_review_ids"]:
+                entry["sample_review_ids"].append(str(rid))
+
+    for r in lock_rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        module = r["module_name"] or ""
+        key = (vendor, module)
+        if key not in result:
+            continue
+        level = r["lock_in_level"] or "unknown"
+        result[key]["lock_in_distribution"][level] = (
+            result[key]["lock_in_distribution"].get(level, 0) + r["cnt"]
+        )
+
+    for entry in result.values():
+        total = entry.pop("_total", 0) or 1
+        entry["avg_urgency"] = round(entry.pop("_urgency_sum", 0) / total, 1)
+
+    return result
+
+
+async def _fetch_integration_provenance(
+    pool, window_days: int,
+) -> dict[tuple[str, str], dict]:
+    """Per-vendor/integration provenance for the b2b_vendor_integrations table.
+
+    Returns ``{(vendor, tool_name): {mention_count, source_distribution,
+    sample_review_ids}}``.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            tool.value #>> '{{}}' AS tool_name,
+            r.source,
+            count(*) AS cnt,
+            array_agg(r.id ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST)
+                FILTER (WHERE r.id IS NOT NULL) AS review_ids
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'use_case'->'integration_stack', '[]'::jsonb)
+        ) AS tool(value)
+        WHERE {filters}
+        GROUP BY vm.vendor_name, tool.value #>> '{{}}', r.source
+        """,
+        window_days,
+        sources,
+    )
+
+    result: dict[tuple[str, str], dict] = {}
+    for r in rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        tool = r["tool_name"] or ""
+        if not vendor or not tool:
+            continue
+        key = (vendor, tool)
+        if key not in result:
+            result[key] = {
+                "mention_count": 0,
+                "source_distribution": {},
+                "sample_review_ids": [],
+            }
+        entry = result[key]
+        cnt = r["cnt"]
+        entry["mention_count"] += cnt
+        source = r["source"] or "unknown"
+        entry["source_distribution"][source] = (
+            entry["source_distribution"].get(source, 0) + cnt
+        )
+        for rid in (r["review_ids"] or []):
+            if len(entry["sample_review_ids"]) < 20 and str(rid) not in entry["sample_review_ids"]:
+                entry["sample_review_ids"].append(str(rid))
+
+    return result
+
+
+async def _fetch_buyer_profile_provenance(
+    pool, window_days: int,
+) -> dict[tuple[str, str, str], dict]:
+    """Per-vendor/role_type/buying_stage provenance for buyer profiles.
+
+    Returns ``{(vendor, role_type, buying_stage): {review_count, dm_count,
+    avg_urgency, source_distribution, sample_review_ids}}``.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            COALESCE(r.enrichment->'buyer_authority'->>'role_type', 'unknown') AS role_type,
+            COALESCE(r.enrichment->'buyer_authority'->>'buying_stage', 'unknown') AS buying_stage,
+            r.source,
+            count(*) AS cnt,
+            count(*) FILTER (
+                WHERE (r.enrichment->'reviewer_context'->>'decision_maker')::boolean IS TRUE
+            ) AS dm_cnt,
+            avg((r.enrichment->>'urgency_score')::numeric) AS avg_urg,
+            array_agg(r.id ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST)
+                FILTER (WHERE r.id IS NOT NULL) AS review_ids
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->'buyer_authority' IS NOT NULL
+          AND r.enrichment->'buyer_authority' != 'null'::jsonb
+        GROUP BY vm.vendor_name,
+            r.enrichment->'buyer_authority'->>'role_type',
+            r.enrichment->'buyer_authority'->>'buying_stage',
+            r.source
+        """,
+        window_days,
+        sources,
+    )
+
+    result: dict[tuple[str, str, str], dict] = {}
+    for r in rows:
+        vendor = _canonicalize_vendor(r["vendor_name"] or "")
+        role = r["role_type"] or "unknown"
+        stage = r["buying_stage"] or "unknown"
+        if not vendor:
+            continue
+        key = (vendor, role, stage)
+        if key not in result:
+            result[key] = {
+                "review_count": 0,
+                "dm_count": 0,
+                "avg_urgency": 0.0,
+                "source_distribution": {},
+                "sample_review_ids": [],
+                "_weighted_urgency_sum": 0.0,
+            }
+        entry = result[key]
+        cnt = r["cnt"]
+        entry["review_count"] += cnt
+        entry["dm_count"] += r["dm_cnt"]
+        entry["_weighted_urgency_sum"] += float(r["avg_urg"] or 0) * cnt
+        source = r["source"] or "unknown"
+        entry["source_distribution"][source] = (
+            entry["source_distribution"].get(source, 0) + cnt
+        )
+        for rid in (r["review_ids"] or []):
+            if len(entry["sample_review_ids"]) < 20 and str(rid) not in entry["sample_review_ids"]:
+                entry["sample_review_ids"].append(str(rid))
+
+    # Compute weighted avg urgency
+    for entry in result.values():
+        total = entry["review_count"]
+        entry["avg_urgency"] = round(entry.pop("_weighted_urgency_sum") / total, 1) if total else 0.0
+
+    return result
+
+
+async def _fetch_pain_distribution(pool, window_days: int) -> list[dict[str, Any]]:
+    """What's driving churn per vendor.
+
+    Uses the multi-label pain_categories array when present (primary=1.0,
+    secondary=0.4, minor=0.1 weights) so that secondary signals are counted
+    rather than dropped.  Falls back to the singular pain_category field for
+    reviews that pre-date the multi-label schema.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        WITH base AS (
+            SELECT vm.vendor_name,
+                   (r.enrichment->>'urgency_score')::numeric AS urgency,
+                   r.enrichment->'pain_categories'           AS cats,
+                   r.enrichment->>'pain_category'            AS fallback_pain,
+                   r.enrichment->>'pain_cluster'             AS pain_cluster
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            WHERE {filters}
+        ),
+        pain_labels AS (
+            -- Multi-label path: unnest pain_categories array with severity weights.
+            -- When a label is the generic fallback bucket and pain_cluster is set,
+            -- substitute the cluster name so reports show something more specific.
+            SELECT b.vendor_name,
+                   b.urgency,
+                   CASE
+                       WHEN p.value->>'category' IN ('other', 'general_dissatisfaction', 'overall_dissatisfaction') AND b.pain_cluster IS NOT NULL
+                       THEN b.pain_cluster
+                       WHEN p.value->>'category' IN ('other', 'general_dissatisfaction', 'overall_dissatisfaction')
+                       THEN 'overall_dissatisfaction'
+                       ELSE p.value->>'category'
+                   END AS pain,
+                   CASE p.value->>'severity'
+                       WHEN 'primary'   THEN 1.0
+                       WHEN 'secondary' THEN 0.4
+                       WHEN 'minor'     THEN 0.1
+                       ELSE 1.0
+                   END AS weight
+            FROM base b
+            CROSS JOIN LATERAL jsonb_array_elements(
+                COALESCE(b.cats, '[]'::jsonb)
+            ) AS p(value)
+            WHERE jsonb_array_length(COALESCE(b.cats, '[]'::jsonb)) > 0
+              AND p.value->>'category' IS NOT NULL
+              AND p.value->>'category' != ''
+
+            UNION ALL
+
+            -- Fallback: reviews with no pain_categories array.
+            -- Same cluster substitution for generic fallback labels.
+            SELECT b.vendor_name,
+                   b.urgency,
+                   CASE
+                       WHEN b.fallback_pain IN ('other', 'general_dissatisfaction', 'overall_dissatisfaction') AND b.pain_cluster IS NOT NULL
+                       THEN b.pain_cluster
+                       WHEN b.fallback_pain IN ('other', 'general_dissatisfaction', 'overall_dissatisfaction')
+                       THEN 'overall_dissatisfaction'
+                       ELSE b.fallback_pain
+                   END AS pain,
+                   1.0 AS weight
+            FROM base b
+            WHERE jsonb_array_length(COALESCE(b.cats, '[]'::jsonb)) = 0
+              AND b.fallback_pain IS NOT NULL
+              AND b.fallback_pain != ''
+        )
+        SELECT vendor_name,
+               pain,
+               round(sum(weight)::numeric, 1) AS complaint_count,
+               avg(urgency)                   AS avg_urgency
+        FROM pain_labels
+        GROUP BY vendor_name, pain
+        ORDER BY complaint_count DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "pain": r["pain"],
+            "complaint_count": float(r["complaint_count"]),
+            "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_feature_gaps(pool, window_days: int, *, min_mentions: int = 2) -> list[dict[str, Any]]:
+    """Most-mentioned missing features per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=3,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            gap.value #>> '{{}}' AS feature_gap,
+            count(*) AS mentions
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(r.enrichment->'feature_gaps') AS gap(value)
+        WHERE {filters}
+        GROUP BY vm.vendor_name, gap.value #>> '{{}}'
+        HAVING count(*) >= $2
+        ORDER BY mentions DESC
+        """,
+        window_days,
+        min_mentions,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "feature_gap": r["feature_gap"],
+            "mentions": r["mentions"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_negative_review_counts(pool, window_days: int, *, threshold: float = 0.5) -> list[dict[str, Any]]:
+    """Count reviews with below-threshold ratings per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=3,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name, count(*) AS negative_count
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.rating IS NOT NULL AND r.rating_max > 0
+          AND (r.rating / r.rating_max) < $2
+        GROUP BY vm.vendor_name
+        """,
+        window_days,
+        threshold,
+        sources,
+    )
+    return [{"vendor": r["vendor_name"], "negative_count": r["negative_count"]} for r in rows]
+
+
+async def _fetch_price_complaint_rates(pool, window_days: int) -> list[dict[str, Any]]:
+    """Fraction of reviews with pain_category='pricing' per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            count(*) FILTER (WHERE r.enrichment->>'pain_category' = 'pricing') AS pricing_count,
+            count(*) FILTER (
+                WHERE (r.enrichment->'contract_context'->>'price_complaint')::boolean = true
+            ) AS price_complaint_count,
+            count(*) FILTER (
+                WHERE jsonb_array_length(COALESCE(r.enrichment->'pricing_phrases', '[]'::jsonb)) > 0
+            ) AS pricing_phrases_count,
+            count(*) AS total
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+        GROUP BY vm.vendor_name
+        HAVING count(*) > 0
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "price_complaint_rate": max(
+                r["pricing_count"] / r["total"] if r["total"] else 0,
+                r["price_complaint_count"] / r["total"] if r["total"] else 0,
+            ),
+            "pricing_phrases_rate": r["pricing_phrases_count"] / r["total"] if r["total"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_dm_churn_rates(pool, window_days: int) -> list[dict[str, Any]]:
+    """Decision-maker churn rate: DMs with intent_to_leave / total DMs, per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            count(*) FILTER (
+                WHERE (r.enrichment->'reviewer_context'->>'decision_maker')::boolean = true
+                  AND (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+            ) AS dm_churning,
+            count(*) FILTER (
+                WHERE (r.enrichment->'reviewer_context'->>'decision_maker')::boolean = true
+            ) AS dm_total
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+        GROUP BY vm.vendor_name
+        HAVING count(*) FILTER (
+            WHERE (r.enrichment->'reviewer_context'->>'decision_maker')::boolean = true
+        ) > 0
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "dm_churn_rate": r["dm_churning"] / r["dm_total"] if r["dm_total"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_churning_companies(pool, window_days: int) -> list[dict[str, Any]]:
+    """Companies with high churn intent, aggregated per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            jsonb_agg(jsonb_build_object(
+                'company', r.reviewer_company,
+                'urgency', (r.enrichment->>'urgency_score')::numeric,
+                'role', r.enrichment->'reviewer_context'->>'role_level',
+                'pain', r.enrichment->>'pain_category',
+                'decision_maker', (r.enrichment->'reviewer_context'->>'decision_maker')::boolean,
+                'buying_stage', r.enrichment->'buyer_authority'->>'buying_stage',
+                'title', r.reviewer_title,
+                'company_size', r.company_size_raw,
+                'industry', COALESCE(r.reviewer_industry, r.enrichment->'reviewer_context'->>'industry')
+            ) ORDER BY (r.enrichment->>'urgency_score')::numeric DESC)
+            AS companies
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+          AND r.reviewer_company IS NOT NULL AND r.reviewer_company != ''
+        GROUP BY vm.vendor_name
+        """,
+        window_days,
+        sources,
+    )
+    results = []
+    for r in rows:
+        companies = _safe_json(r["companies"])
+        results.append({"vendor": r["vendor_name"], "companies": companies})
+    return results
+
+
+async def _fetch_quotable_evidence(pool, window_days: int, *, min_urgency: float = 4.5) -> list[dict[str, Any]]:
+    """Top quote-grade phrases per vendor (highest urgency, deduplicated).
+
+    Each quote is a dict with quote text, traceability, and
+    ``phrase_verbatim=True``. Legacy v3 phrases are intentionally excluded.
+    """
+    sources = _executive_source_list()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=3,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT DISTINCT ON (vm.vendor_name, r.id)
+            vm.vendor_name AS vendor_name,
+            r.id AS review_id,
+            r.enrichment AS enrichment_raw,
+            (r.enrichment->>'urgency_score')::numeric AS urgency,
+            r.source,
+            r.reviewed_at,
+            r.rating,
+            r.rating_max,
+            r.reviewer_company,
+            r.reviewer_title,
+            r.company_size_raw,
+            COALESCE(r.reviewer_industry, r.enrichment->'reviewer_context'->>'industry') AS industry,
+            r.enrichment->'churn_signals' AS churn_signals,
+            r.enrichment->'salience_flags' AS salience_flags
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND (r.enrichment->>'urgency_score')::numeric >= $2
+        ORDER BY vm.vendor_name, r.id, (r.enrichment->>'urgency_score')::numeric DESC
+        """,
+        window_days,
+        min_urgency,
+        sources,
+    )
+    ranked_by_vendor: dict[str, list[tuple[tuple[int, int, float, int], dict[str, Any]]]] = {}
+    for r in rows:
+        enrichment = _parse_enrichment_dict(r["enrichment_raw"])
+        urgency = float(r["urgency"]) if r["urgency"] is not None else 0.0
+        quotes = _quote_grade_rows_from_enrichment(
+            enrichment,
+            urgency=urgency,
+            review_id=r["review_id"],
+            source=r["source"],
+            company=r["reviewer_company"],
+            title=r["reviewer_title"],
+            company_size=r["company_size_raw"],
+            industry=r["industry"],
+        )
+        if not quotes:
+            continue
+        reviewed_at = r["reviewed_at"]
+        reviewed_at_text = reviewed_at.isoformat() if hasattr(reviewed_at, "isoformat") else reviewed_at
+        churn_signals = _safe_json(r["churn_signals"], {})
+        salience_flags = _safe_json(r["salience_flags"])
+        salience_count = len(salience_flags) if isinstance(salience_flags, list) else 0
+        intent_order = 0 if isinstance(churn_signals, dict) and churn_signals.get("intent_to_leave") is True else 1
+        vendor_quotes = ranked_by_vendor.setdefault(r["vendor_name"], [])
+        for idx, quote in enumerate(quotes):
+            quote["reviewed_at"] = reviewed_at_text
+            if r["rating"] is not None:
+                quote["rating"] = float(r["rating"])
+            if r["rating_max"] is not None:
+                quote["rating_max"] = float(r["rating_max"])
+            vendor_quotes.append((
+                (intent_order, -salience_count, -urgency, idx),
+                quote,
+            ))
+    results: list[dict[str, Any]] = []
+    for vendor, ranked_quotes in ranked_by_vendor.items():
+        ranked_quotes.sort(key=lambda item: item[0])
+        results.append({
+            "vendor": vendor,
+            "quotes": [quote for _, quote in ranked_quotes[:15]],
+        })
+    return results
+
+
+async def _fetch_evidence_vault_review_rows(
+    pool,
+    window_days: int,
+) -> list[dict[str, Any]]:
+    """Fetch review-level evidence rows used for pass-2 vault aggregation."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id AS review_id,
+            vm.vendor_name AS vendor_name,
+            r.source,
+            r.reviewed_at,
+            r.enriched_at,
+            r.rating,
+            r.rating_max,
+            r.reviewer_title,
+            r.company_size_raw,
+            COALESCE(r.reviewer_industry, r.enrichment->'reviewer_context'->>'industry') AS industry,
+            r.enrichment->'reviewer_context'->>'role_level' AS role_level,
+            r.enrichment->>'pain_category' AS pain_category,
+            COALESCE(r.enrichment->'feature_gaps', '[]'::jsonb) AS feature_gaps,
+            COALESCE(r.enrichment->'positive_aspects', '[]'::jsonb) AS positive_aspects,
+            (r.enrichment->>'urgency_score')::numeric AS urgency
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+        """,
+        window_days,
+        sources,
+    )
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        results.append({
+            "review_id": str(row["review_id"]) if row.get("review_id") else None,
+            "vendor_name": row.get("vendor_name"),
+            "source": row.get("source"),
+            "reviewed_at": row.get("reviewed_at"),
+            "enriched_at": row.get("enriched_at"),
+            "rating": float(row["rating"]) if row.get("rating") is not None else None,
+            "rating_max": float(row["rating_max"]) if row.get("rating_max") is not None else None,
+            "reviewer_title": row.get("reviewer_title"),
+            "company_size_raw": row.get("company_size_raw"),
+            "industry": row.get("industry"),
+            "role_level": row.get("role_level"),
+            "pain_category": row.get("pain_category"),
+            "feature_gaps": _safe_json(row.get("feature_gaps"), default=[]),
+            "positive_aspects": _safe_json(row.get("positive_aspects"), default=[]),
+            "urgency": float(row["urgency"]) if row.get("urgency") is not None else 0.0,
+        })
+    return results
+
+
+async def _fetch_insider_aggregates(pool, window_days: int) -> list[dict[str, Any]]:
+    """Aggregate insider account signals per vendor.
+
+    Reads b2b_reviews WHERE content_type = 'insider_account' and extracts:
+    - signal count
+    - org health summary (mode of bureaucracy_level / leadership_quality / innovation_climate)
+    - talent drain rate (fraction mentioning departures)
+    - top quotable phrases from high-urgency insider posts
+    """
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            vm.vendor_name,
+            COUNT(DISTINCT r.id)::int AS signal_count,
+            ROUND(
+                COUNT(DISTINCT CASE
+                    WHEN (enrichment->'insider_signals'->>'departures_mentioned')::boolean = true
+                      OR (enrichment->'insider_signals'->'talent_drain'->>'departures_mentioned')::boolean = true
+                    THEN r.id END)::numeric
+                / NULLIF(COUNT(DISTINCT r.id), 0)::numeric,
+                4
+            ) AS talent_drain_rate,
+            -- v2 flattened insider fields (with v1 nested fallback)
+            jsonb_agg(DISTINCT jsonb_build_object(
+                'bureaucracy_level', COALESCE(
+                    enrichment->'insider_signals'->>'bureaucracy_level',
+                    enrichment->'insider_signals'->'org_health'->>'bureaucracy_level'
+                ),
+                'leadership_quality', COALESCE(
+                    enrichment->'insider_signals'->>'leadership_quality',
+                    enrichment->'insider_signals'->'org_health'->>'leadership_quality'
+                ),
+                'innovation_climate', COALESCE(
+                    enrichment->'insider_signals'->>'innovation_climate',
+                    enrichment->'insider_signals'->'org_health'->>'innovation_climate'
+                ),
+                'morale', COALESCE(
+                    enrichment->'insider_signals'->>'morale',
+                    enrichment->'insider_signals'->'talent_drain'->>'morale'
+                )
+            )) FILTER (WHERE enrichment->'insider_signals' IS NOT NULL) AS org_health_array,
+            jsonb_agg(
+                jsonb_build_object(
+                    'quote', ph.value,
+                    'urgency', (enrichment->>'urgency_score')::numeric,
+                    'review_id', r.id::text
+                )
+                ORDER BY (enrichment->>'urgency_score')::numeric DESC NULLS LAST
+            ) FILTER (WHERE ph.value IS NOT NULL) AS quotable_phrases
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        LEFT JOIN LATERAL jsonb_array_elements_text(
+            COALESCE(r.enrichment->'quotable_phrases', '[]'::jsonb)
+        ) AS ph(value) ON true
+        WHERE r.content_type = 'insider_account'
+          AND r.enrichment_status = 'enriched'
+          AND r.duplicate_of_review_id IS NULL
+          AND r.imported_at > NOW() - make_interval(days => $1)
+        GROUP BY vm.vendor_name
+        """,
+        window_days,
+    )
+    return list(rows)
+
+
+async def _fetch_product_profiles(pool) -> list[dict[str, Any]]:
+    """Fetch pre-computed product profiles for battle card enrichment."""
+    rows = await pool.fetch("""
+        SELECT vendor_name, product_category, strengths, weaknesses,
+               pain_addressed, commonly_compared_to, commonly_switched_from,
+               total_reviews_analyzed, avg_rating, recommend_rate,
+               primary_use_cases, typical_company_size, typical_industries,
+               top_integrations, profile_summary
+        FROM b2b_product_profiles
+        ORDER BY total_reviews_analyzed DESC
+    """)
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        profile = dict(row)
+        profile["strengths"] = _safe_json(profile.get("strengths"), default=[])
+        profile["weaknesses"] = _safe_json(profile.get("weaknesses"), default=[])
+        profile["pain_addressed"] = _safe_json(profile.get("pain_addressed"), default={})
+        profile["commonly_compared_to"] = _safe_json(profile.get("commonly_compared_to"), default=[])
+        profile["commonly_switched_from"] = _safe_json(profile.get("commonly_switched_from"), default=[])
+        profile["primary_use_cases"] = _safe_json(profile.get("primary_use_cases"), default=[])
+        profile["typical_company_size"] = _safe_json(profile.get("typical_company_size"), default=[])
+        profile["typical_industries"] = _safe_json(profile.get("typical_industries"), default=[])
+        profile["top_integrations"] = _safe_json(profile.get("top_integrations"), default=[])
+        normalized.append(profile)
+    return normalized
+
+
+def _normalize_vendor_intelligence_record(row: Any) -> dict[str, Any] | None:
+    """Normalize a latest-row evidence-vault record into a stable dict."""
+    if not row:
+        return None
+    vendor_name = str(row.get("vendor_name") or "").strip()
+    if not vendor_name:
+        return None
+    vault = _safe_json(row.get("vault"), default={})
+    if not isinstance(vault, dict):
+        vault = {}
+    return {
+        "vendor_name": vendor_name,
+        "as_of_date": row.get("as_of_date"),
+        "analysis_window_days": row.get("analysis_window_days"),
+        "schema_version": row.get("schema_version"),
+        "materialization_run_id": row.get("materialization_run_id"),
+        "created_at": row.get("created_at"),
+        "vault": vault,
+    }
+
+
+async def read_vendor_intelligence_records(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+    vendor_names: Iterable[Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Read the latest canonical vendor intelligence row per vendor."""
+    requested_vendors = _canonicalize_vendor_name_filters(vendor_names)
+    vendor_filter_clause = "AND LOWER(vendor_name) = ANY($3::text[])" if requested_vendors else ""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (vendor_name)
+               vendor_name,
+               as_of_date,
+               analysis_window_days,
+               schema_version,
+               materialization_run_id,
+               vault,
+               created_at
+        FROM b2b_evidence_vault
+        WHERE as_of_date <= $1
+          AND analysis_window_days = $2
+          """ + vendor_filter_clause + """
+        ORDER BY vendor_name, as_of_date DESC, created_at DESC
+        """,
+        as_of,
+        analysis_window_days,
+        *([requested_vendors] if requested_vendors else []),
+    )
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        record = _normalize_vendor_intelligence_record(row)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+async def read_vendor_intelligence_record(
+    pool,
+    vendor_name: str,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[str, Any] | None:
+    """Read the latest canonical vendor intelligence row for one vendor."""
+    canonical_vendor = _canonicalize_vendor(vendor_name)
+    if not canonical_vendor:
+        return None
+    records = await read_vendor_intelligence_records(
+        pool,
+        as_of=as_of,
+        analysis_window_days=analysis_window_days,
+        vendor_names=[vendor_name],
+    )
+    for record in records:
+        if _canonicalize_vendor(record.get("vendor_name") or "") == canonical_vendor:
+            return record
+    return None
+
+
+async def search_vendor_intelligence_record(
+    pool,
+    *,
+    vendor_query: str,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[str, Any] | None:
+    """Read the latest canonical vendor intelligence row matching a partial vendor query."""
+    normalized_query = str(vendor_query or "").strip()
+    if not normalized_query:
+        return None
+    row = await pool.fetchrow(
+        """
+        SELECT vendor_name,
+               as_of_date,
+               analysis_window_days,
+               schema_version,
+               materialization_run_id,
+               vault,
+               created_at
+        FROM b2b_evidence_vault
+        WHERE vendor_name ILIKE '%' || $1 || '%'
+          AND as_of_date <= $2
+          AND analysis_window_days = $3
+        ORDER BY as_of_date DESC, created_at DESC
+        LIMIT 1
+        """,
+        normalized_query,
+        as_of,
+        analysis_window_days,
+    )
+    return _normalize_vendor_intelligence_record(row)
+
+
+async def search_vendor_intelligence_records(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+    vendor_query: str | None = None,
+) -> list[dict[str, Any]]:
+    """Read the latest canonical vendor intelligence row for each matching vendor."""
+    conditions = [
+        "as_of_date <= $1",
+        "analysis_window_days = $2",
+    ]
+    params: list[Any] = [as_of, analysis_window_days]
+    if str(vendor_query or "").strip():
+        conditions.append("vendor_name ILIKE '%' || $3 || '%'")
+        params.append(str(vendor_query).strip())
+    where = " AND ".join(conditions)
+    rows = await pool.fetch(
+        f"""
+        SELECT DISTINCT ON (vendor_name)
+               vendor_name,
+               as_of_date,
+               analysis_window_days,
+               schema_version,
+               materialization_run_id,
+               vault,
+               created_at
+        FROM b2b_evidence_vault
+        WHERE {where}
+        ORDER BY vendor_name, as_of_date DESC, created_at DESC
+        """,
+        *params,
+    )
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        record = _normalize_vendor_intelligence_record(row)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+async def read_vendor_intelligence_record_nearest_window(
+    pool,
+    *,
+    vendor_name: str,
+    analysis_window_days: int,
+) -> dict[str, Any] | None:
+    """Read the nearest-window canonical vendor intelligence row for one vendor."""
+    normalized_vendor = _canonicalize_vendor(vendor_name) or str(vendor_name or "").strip()
+    if not normalized_vendor:
+        return None
+    row = await pool.fetchrow(
+        """
+        SELECT vendor_name,
+               as_of_date,
+               analysis_window_days,
+               schema_version,
+               materialization_run_id,
+               vault,
+               created_at
+        FROM b2b_evidence_vault
+        WHERE LOWER(vendor_name) = LOWER($1)
+        ORDER BY
+            CASE WHEN analysis_window_days = $2 THEN 0 ELSE 1 END,
+            ABS(analysis_window_days - $2),
+            as_of_date DESC,
+            created_at DESC
+        LIMIT 1
+        """,
+        normalized_vendor,
+        analysis_window_days,
+    )
+    return _normalize_vendor_intelligence_record(row)
+
+
+async def read_vendor_intelligence_map(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+    vendor_names: Iterable[Any] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Read canonical vendor intelligence objects from ``b2b_evidence_vault``."""
+    records = await read_vendor_intelligence_records(
+        pool,
+        as_of=as_of,
+        analysis_window_days=analysis_window_days,
+        vendor_names=vendor_names,
+    )
+    vault_lookup: dict[str, dict[str, Any]] = {}
+    for record in records:
+        vendor = _canonicalize_vendor(record.get("vendor_name") or "")
+        if not vendor:
+            continue
+        vault_lookup[vendor] = record.get("vault") or {}
+    return vault_lookup
+
+
+async def read_vendor_intelligence(
+    pool,
+    vendor_name: str,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[str, Any] | None:
+    """Read the canonical vendor intelligence object for a single vendor."""
+    lookup = await read_vendor_intelligence_map(
+        pool,
+        as_of=as_of,
+        analysis_window_days=analysis_window_days,
+        vendor_names=[vendor_name],
+    )
+    canonical = _canonicalize_vendor(vendor_name)
+    if not canonical:
+        return None
+    return lookup.get(canonical)
+
+
+async def _fetch_latest_evidence_vault(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[str, dict[str, Any]]:
+    """Deprecated wrapper. Use ``read_vendor_intelligence_map`` instead."""
+    return await read_vendor_intelligence_map(
+        pool,
+        as_of=as_of,
+        analysis_window_days=analysis_window_days,
+    )
+
+
+async def fetch_all_pool_layers(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+    vendor_names: list[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Load all 6 pool layers and merge into one dict per vendor.
+
+    Returns: {vendor_name: {evidence_vault: {...}, segment: {...},
+    temporal: {...}, displacement: [...], category: {...}, accounts: {...}}}
+    """
+    _POOL_TABLES = [
+        ("b2b_evidence_vault", "vault", "evidence_vault"),
+        ("b2b_segment_intelligence", "segments", "segment"),
+        ("b2b_temporal_intelligence", "temporal", "temporal"),
+        ("b2b_account_intelligence", "accounts", "accounts"),
+    ]
+    generic_categories = {"", "unknown", "b2b software"}
+    result: dict[str, dict[str, Any]] = {}
+    requested_vendors = sorted(
+        {
+            _canonicalize_vendor(name).lower()
+            for name in (vendor_names or [])
+            if _canonicalize_vendor(name)
+        }
+    )
+    vendor_filter_clause = "AND LOWER(vendor_name) = ANY($3::text[])" if requested_vendors else ""
+    vendor_filter_args: list[Any] = [requested_vendors] if requested_vendors else []
+
+    for table, col, key in _POOL_TABLES:
+        try:
+            rows = await pool.fetch(
+                f"""
+                SELECT DISTINCT ON (vendor_name)
+                       vendor_name, {col}
+                FROM {table}
+                WHERE as_of_date <= $1
+                  AND analysis_window_days = $2
+                  {vendor_filter_clause}
+                ORDER BY vendor_name, as_of_date DESC, created_at DESC
+                """,
+                as_of,
+                analysis_window_days,
+                *vendor_filter_args,
+            )
+            for row in rows:
+                vn = _canonicalize_vendor(row.get("vendor_name") or "")
+                if not vn:
+                    continue
+                data = _safe_json(row.get(col), default={})
+                if isinstance(data, dict):
+                    result.setdefault(vn, {})[key] = data
+        except Exception:
+            logger.debug("Pool layer %s unavailable", table, exc_info=True)
+
+    # Displacement dynamics: keyed by (from_vendor, to_vendor)
+    try:
+        displacement_filter_clause = "AND LOWER(from_vendor) = ANY($3::text[])" if requested_vendors else ""
+        disp_rows = await pool.fetch(
+            """
+            SELECT DISTINCT ON (from_vendor, to_vendor)
+                   from_vendor, to_vendor, dynamics
+            FROM b2b_displacement_dynamics
+            WHERE as_of_date <= $1
+              AND analysis_window_days = $2
+              """ + displacement_filter_clause + """
+            ORDER BY from_vendor, to_vendor, as_of_date DESC, created_at DESC
+            """,
+            as_of,
+            analysis_window_days,
+            *vendor_filter_args,
+        )
+        for row in disp_rows:
+            fv = _canonicalize_vendor(row.get("from_vendor") or "")
+            data = _safe_json(row.get("dynamics"), default={})
+            if fv and isinstance(data, dict):
+                result.setdefault(fv, {}).setdefault(
+                    "displacement", [],
+                ).append(data)
+    except Exception:
+        logger.debug("Displacement dynamics unavailable", exc_info=True)
+
+    # Category dynamics: keyed by category
+    try:
+        if requested_vendors:
+            profile_rows = await pool.fetch(
+                """
+                SELECT DISTINCT ON (vendor_name)
+                       vendor_name, product_category
+                FROM b2b_product_profiles
+                WHERE LOWER(vendor_name) = ANY($1::text[])
+                ORDER BY vendor_name,
+                         CASE
+                             WHEN lower(COALESCE(product_category, '')) IN ('', 'unknown', 'b2b software')
+                             THEN 1 ELSE 0
+                         END,
+                         total_reviews_analyzed DESC NULLS LAST
+                """,
+                requested_vendors,
+            )
+        else:
+            profile_rows = await pool.fetch(
+                """
+                SELECT DISTINCT ON (vendor_name)
+                       vendor_name, product_category
+                FROM b2b_product_profiles
+                ORDER BY vendor_name,
+                         CASE
+                             WHEN lower(COALESCE(product_category, '')) IN ('', 'unknown', 'b2b software')
+                             THEN 1 ELSE 0
+                         END,
+                         total_reviews_analyzed DESC NULLS LAST
+                """,
+            )
+        preferred_vendor_categories: dict[str, str] = {}
+        for row in profile_rows:
+            vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+            category = str(row.get("product_category") or "").strip()
+            if vendor and category:
+                preferred_vendor_categories[vendor] = category
+
+        cat_rows = await pool.fetch(
+            """
+            SELECT DISTINCT ON (category)
+                   category, dynamics
+            FROM b2b_category_dynamics
+            WHERE as_of_date <= $1
+              AND analysis_window_days = $2
+            ORDER BY category, as_of_date DESC, created_at DESC
+            """,
+            as_of,
+            analysis_window_days,
+        )
+        cat_map: dict[str, dict] = {}
+        for row in cat_rows:
+            cat = row.get("category") or ""
+            data = _safe_json(row.get("dynamics"), default={})
+            if cat and isinstance(data, dict):
+                cat_map[cat] = data
+        # Attach category to each vendor based on evidence_vault
+        for vn, layers in result.items():
+            ev = layers.get("evidence_vault") or {}
+            cat = str(ev.get("product_category") or "").strip()
+            preferred = str(preferred_vendor_categories.get(vn) or "").strip()
+            if preferred and preferred in cat_map and cat.lower() in generic_categories:
+                cat = preferred
+            if cat.lower() in generic_categories:
+                continue
+            if cat and cat in cat_map:
+                layers["category"] = cat_map[cat]
+    except Exception:
+        logger.debug("Category dynamics unavailable", exc_info=True)
+
+    # Review candidates for witness-pack building.
+    try:
+        review_filter_clause = "AND LOWER(vm.vendor_name) = ANY($3::text[])" if requested_vendors else ""
+        review_rows = await pool.fetch(
+            """
+                SELECT
+                    vm.vendor_name AS vendor_name,
+                    r.id,
+                    r.source,
+                rating,
+                rating_max,
+                summary,
+                review_text,
+                pros,
+                cons,
+                r.reviewer_title,
+                COALESCE(
+                    r.reviewer_company,
+                    CASE
+                        WHEN ar.confidence_label IN ('high', 'medium')
+                        THEN ar.resolved_company_name
+                        ELSE NULL
+                    END
+                ) AS reviewer_company,
+                r.reviewer_company AS raw_reviewer_company,
+                ar.confidence_label AS resolution_confidence,
+                r.reviewed_at,
+                r.imported_at,
+                r.raw_metadata,
+                r.enrichment
+                FROM b2b_reviews r
+                JOIN b2b_review_vendor_mentions vm
+                  ON vm.review_id = r.id
+                LEFT JOIN b2b_account_resolution ar
+                  ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
+                WHERE r.enrichment_status = 'enriched'
+                  AND r.duplicate_of_review_id IS NULL
+                  AND COALESCE(r.reviewed_at, r.imported_at) <= ($1::date + INTERVAL '1 day')
+                  AND COALESCE(r.reviewed_at, r.imported_at) >= ($1::date - ($2::int * INTERVAL '1 day'))
+                  """ + review_filter_clause + """
+                ORDER BY
+                    vm.vendor_name,
+                    COALESCE(r.reviewed_at, r.imported_at) DESC,
+                r.imported_at DESC,
+                r.id DESC
+            """,
+            as_of,
+            analysis_window_days,
+            *vendor_filter_args,
+        )
+        for row in review_rows:
+            vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+            if not vendor:
+                continue
+            review = {
+                "id": str(row.get("id") or ""),
+                "source": row.get("source"),
+                "rating": row.get("rating"),
+                "rating_max": row.get("rating_max"),
+                "summary": row.get("summary"),
+                "review_text": row.get("review_text"),
+                "pros": row.get("pros"),
+                "cons": row.get("cons"),
+                "reviewer_title": row.get("reviewer_title"),
+                "reviewer_company": row.get("reviewer_company"),
+                "raw_reviewer_company": row.get("raw_reviewer_company"),
+                "resolution_confidence": row.get("resolution_confidence"),
+                "reviewed_at": row.get("reviewed_at"),
+                "imported_at": row.get("imported_at"),
+                "raw_metadata": _safe_json(row.get("raw_metadata"), default={}),
+                "enrichment": _safe_json(row.get("enrichment"), default={}),
+            }
+            result.setdefault(vendor, {}).setdefault("reviews", []).append(review)
+    except Exception:
+        logger.debug("Review candidates unavailable", exc_info=True)
+
+    return result
+
+
+async def _fetch_latest_account_intelligence(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[str, dict[str, Any]]:
+    """Load latest canonical account-intelligence rows per vendor."""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (vendor_name)
+               vendor_name, accounts
+        FROM b2b_account_intelligence
+        WHERE as_of_date <= $1
+          AND analysis_window_days = $2
+        ORDER BY vendor_name, as_of_date DESC, created_at DESC
+        """,
+        as_of,
+        analysis_window_days,
+    )
+    lookup: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        data = _safe_json(row.get("accounts"), default={})
+        if isinstance(data, dict):
+            summary = data.get("summary")
+            if isinstance(summary, dict):
+                tier = summary.get("account_actionability_tier")
+                note = summary.get("account_actionability_note")
+                if not tier or not note:
+                    derived_tier, derived_note = _derive_account_actionability_summary(summary)
+                    if derived_tier and not tier:
+                        summary["account_actionability_tier"] = derived_tier
+                    if derived_note and not note:
+                        summary["account_actionability_note"] = derived_note
+            lookup[vendor] = data
+    return lookup
+
+
+async def _fetch_latest_displacement_dynamics(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> dict[str, list[dict[str, Any]]]:
+    """Load latest canonical displacement dynamics rows keyed by vendor."""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (from_vendor, to_vendor)
+               from_vendor, to_vendor, dynamics
+        FROM b2b_displacement_dynamics
+        WHERE as_of_date <= $1
+          AND analysis_window_days = $2
+        ORDER BY from_vendor, to_vendor, as_of_date DESC, created_at DESC
+        """,
+        as_of,
+        analysis_window_days,
+    )
+    lookup: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        from_vendor = _canonicalize_vendor(row.get("from_vendor") or "")
+        to_vendor = str(row.get("to_vendor") or "").strip()
+        data = _safe_json(row.get("dynamics"), default={})
+        if not from_vendor or not to_vendor or not isinstance(data, dict):
+            continue
+        data.setdefault("from_vendor", row.get("from_vendor") or from_vendor)
+        data.setdefault("to_vendor", row.get("to_vendor") or to_vendor)
+        lookup.setdefault(from_vendor, []).append(data)
+    return lookup
+
+
+def _normalize_displacement_driver_label(value: Any) -> str:
+    """Map free-text displacement reasons into stable seller-safe driver buckets."""
+    text = str(value or "").strip()
+    lower = text.lower()
+    if not lower:
+        return ""
+    if any(token in lower for token in ("price", "pricing", "cost", "budget", "cheap", "cheaper", "affordable", "economics", "refund", "free", "fee")):
+        return "pricing"
+    if any(token in lower for token in ("feature", "capability", "automation", "workflow", "ai", "reporting", "dashboard", "customization")):
+        return "features"
+    if any(token in lower for token in ("integrat", "api", "connector", "webhook", "plugin", "stack")):
+        return "integration"
+    if any(token in lower for token in ("ux", "ui", "usability", "easy", "easier", "simple", "onboarding", "setup", "interface")):
+        return "ux"
+    if any(token in lower for token in ("support", "service", "response", "help desk", "ticket")):
+        return "support"
+    if any(token in lower for token in ("reliab", "uptime", "outage", "stability", "downtime")):
+        return "reliability"
+    if any(token in lower for token in ("security", "privacy", "server", "governance", "data residency", "encryption")):
+        return "security"
+    if any(token in lower for token in ("compliance", "gdpr", "hipaa", "soc2", "soc 2", "regulatory", "certification")):
+        return "compliance"
+    if any(token in lower for token in ("performance", "slow", "latency", "speed")):
+        return "performance"
+    if any(token in lower for token in ("migrat", "import", "export")):
+        return "migration"
+    return ""
+
+
+def _competitive_disp_from_dynamics(
+    displacement_lookup: dict[str, list[dict[str, Any]]] | None,
+) -> list[dict[str, Any]]:
+    """Normalize canonical displacement dynamics into legacy competitor rows."""
+    def _normalize_evidence_type(value: Any) -> str | None:
+        text = str(value or "").strip().lower()
+        if not text:
+            return None
+        if text in {"explicit_switch", "switch", "switched_to"}:
+            return "explicit_switch"
+        if text in {"active_evaluation", "evaluation", "considering", "trial", "poc"}:
+            return "active_evaluation"
+        if text in {"implied_preference", "compared", "preference"}:
+            return "implied_preference"
+        return None
+
+    def _direction_to_evidence_type(value: Any) -> str:
+        text = str(value or "").strip().lower()
+        if not text:
+            return "implied_preference"
+        if text in {"switched_to", "migrated_to", "replaced_with"}:
+            return "explicit_switch"
+        if text in {
+            "considering", "evaluation", "evaluating", "active_evaluation",
+            "trial", "poc", "active_purchase",
+        }:
+            return "active_evaluation"
+        if "switch" in text and "from" not in text:
+            return "explicit_switch"
+        if "consider" in text or "evaluat" in text or "trial" in text:
+            return "active_evaluation"
+        return "implied_preference"
+
+    def _intish(value: Any, default: int = 0) -> int:
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+
+    rows: list[dict[str, Any]] = []
+    for vendor, flows in (displacement_lookup or {}).items():
+        for flow in flows:
+            competitor = _canonicalize_competitor(str(
+                flow.get("to_vendor") or flow.get("competitor") or "",
+            ).strip())
+            if not competitor:
+                continue
+            flow_summary = flow.get("flow_summary") or {}
+            edge_metrics = flow.get("edge_metrics") or {}
+            reason_categories: dict[str, int] = {}
+            industries: list[str] = []
+            company_sizes: list[str] = []
+            normalized_breakdown: list[dict[str, Any]] = []
+            breakdown_counts = {
+                "explicit_switch": 0,
+                "active_evaluation": 0,
+                "implied_preference": 0,
+            }
+            for item in flow.get("evidence_breakdown") or []:
+                if not isinstance(item, dict):
+                    continue
+                evidence_type = _normalize_evidence_type(item.get("evidence_type"))
+                cats = item.get("reason_categories") or {}
+                mention_count = _intish(item.get("mention_count"))
+                if mention_count <= 0 and isinstance(cats, dict):
+                    mention_count = sum(_intish(v) for v in cats.values())
+                if evidence_type and mention_count > 0:
+                    normalized_breakdown.append({
+                        "evidence_type": evidence_type,
+                        "mention_count": mention_count,
+                        "reason_categories": {
+                            str(k): _intish(v)
+                            for k, v in cats.items()
+                            if str(k or "").strip() and _intish(v) > 0
+                        },
+                        "industries": [
+                            str(v).strip()
+                            for v in (item.get("industries") or [])
+                            if str(v or "").strip() and str(v).strip().lower() != "unknown"
+                        ],
+                        "company_sizes": [
+                            str(v).strip()
+                            for v in (item.get("company_sizes") or [])
+                            if str(v or "").strip()
+                        ],
+                    })
+                    breakdown_counts[evidence_type] += mention_count
+                industries.extend(
+                    str(v).strip()
+                    for v in (item.get("industries") or [])
+                    if str(v or "").strip() and str(v).strip().lower() != "unknown"
+                )
+                company_sizes.extend(
+                    str(v).strip()
+                    for v in (item.get("company_sizes") or [])
+                    if str(v or "").strip()
+                )
+
+            reason_direction_counts = {
+                "explicit_switch": 0,
+                "active_evaluation": 0,
+                "implied_preference": 0,
+            }
+            for item in flow.get("switch_reasons") or []:
+                if not isinstance(item, dict):
+                    continue
+                key = str(
+                    item.get("reason_category") or item.get("reason") or "",
+                ).strip()
+                reason_count = _intish(item.get("mention_count"), default=1)
+                if not key:
+                    key = str(item.get("reason_detail") or "").strip()
+                key = _normalize_displacement_driver_label(key)
+                if key:
+                    reason_categories[key] = (
+                        reason_categories.get(key, 0) + reason_count
+                    )
+                evidence_type = _direction_to_evidence_type(item.get("direction"))
+                reason_direction_counts[evidence_type] += reason_count
+            mention_count = max(
+                _intish(
+                    flow_summary.get("total_flow_mentions")
+                    or edge_metrics.get("mention_count"),
+                ),
+                sum(breakdown_counts.values()),
+                sum(reason_direction_counts.values()),
+            )
+            explicit_switches = max(
+                _intish(flow_summary.get("explicit_switch_count")),
+                breakdown_counts["explicit_switch"],
+                reason_direction_counts["explicit_switch"],
+            )
+            active_evaluations = max(
+                _intish(flow_summary.get("active_evaluation_count")),
+                breakdown_counts["active_evaluation"],
+                reason_direction_counts["active_evaluation"],
+            )
+            implied_preferences = max(
+                mention_count - explicit_switches - active_evaluations,
+                breakdown_counts["implied_preference"],
+                reason_direction_counts["implied_preference"],
+            )
+            if not normalized_breakdown:
+                for evidence_type, count in (
+                    ("explicit_switch", explicit_switches),
+                    ("active_evaluation", active_evaluations),
+                    ("implied_preference", implied_preferences),
+                ):
+                    if count <= 0:
+                        continue
+                    normalized_breakdown.append({
+                        "evidence_type": evidence_type,
+                        "mention_count": count,
+                        "reason_categories": {},
+                        "industries": [],
+                        "company_sizes": [],
+                    })
+            if not mention_count:
+                mention_count = sum(item["mention_count"] for item in normalized_breakdown)
+            rows.append({
+                "vendor": vendor,
+                "competitor": competitor,
+                "mention_count": mention_count,
+                "explicit_switches": explicit_switches,
+                "active_evaluations": active_evaluations,
+                "implied_preferences": implied_preferences,
+                "reason_categories": reason_categories,
+                "industries": sorted(set(i for i in industries if i)),
+                "company_sizes": sorted(set(s for s in company_sizes if s)),
+                "evidence_breakdown": normalized_breakdown,
+            })
+    return rows
+
+
+async def _fetch_competitive_displacement_source_of_truth(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+) -> list[dict[str, Any]]:
+    """Prefer canonical displacement dynamics, fall back to legacy review query."""
+    try:
+        lookup = await _fetch_latest_displacement_dynamics(
+            pool,
+            as_of=as_of,
+            analysis_window_days=analysis_window_days,
+        )
+    except Exception:
+        logger.debug("Displacement dynamics lookup failed", exc_info=True)
+        lookup = {}
+    rows = _competitive_disp_from_dynamics(lookup)
+    if rows:
+        return rows
+    return await _fetch_competitive_displacement(pool, analysis_window_days)
+
+
+def _merge_pain_lookup_with_evidence_vault(
+    raw_pain_lookup: dict[str, list[dict[str, Any]]],
+    evidence_vault_lookup: dict[str, dict[str, Any]] | None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Prefer canonical vault pain rows while preserving raw fallback entries."""
+    merged: dict[str, list[dict[str, Any]]] = {}
+    vendors = set(raw_pain_lookup) | set((evidence_vault_lookup or {}))
+    for vendor in vendors:
+        raw_entries = list(raw_pain_lookup.get(vendor, []))
+        vault_entries: list[dict[str, Any]] = []
+        for item in ((evidence_vault_lookup or {}).get(vendor, {}) or {}).get("weakness_evidence") or []:
+            if str(item.get("evidence_type") or "") != "pain_category":
+                continue
+            key = str(item.get("key") or "").strip().lower()
+            if not key:
+                continue
+            if key in {"other", "general_dissatisfaction"}:
+                key = "overall_dissatisfaction"
+            metrics = item.get("supporting_metrics") or {}
+            vault_entries.append({
+                "category": key,
+                "count": int(item.get("mention_count_total") or 0),
+                "avg_urgency": metrics.get("avg_urgency") or metrics.get("avg_urgency_when_mentioned"),
+            })
+        if not vault_entries:
+            if raw_entries:
+                merged[vendor] = raw_entries
+            continue
+        seen = {str(item.get("category") or "").strip().lower() for item in vault_entries}
+        for item in raw_entries:
+            category = str(item.get("category") or "").strip().lower()
+            if category and category not in seen:
+                vault_entries.append(item)
+        vault_entries.sort(key=lambda item: int(item.get("count") or 0), reverse=True)
+        merged[vendor] = vault_entries
+    return merged
+
+
+def _merge_feature_gap_lookup_with_evidence_vault(
+    raw_feature_gap_lookup: dict[str, list[dict[str, Any]]],
+    evidence_vault_lookup: dict[str, dict[str, Any]] | None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Prefer canonical vault feature-gap rows while preserving raw fallback entries."""
+    merged: dict[str, list[dict[str, Any]]] = {}
+    vendors = set(raw_feature_gap_lookup) | set((evidence_vault_lookup or {}))
+    for vendor in vendors:
+        raw_entries = list(raw_feature_gap_lookup.get(vendor, []))
+        vault_entries: list[dict[str, Any]] = []
+        for item in ((evidence_vault_lookup or {}).get(vendor, {}) or {}).get("weakness_evidence") or []:
+            if str(item.get("evidence_type") or "") != "feature_gap":
+                continue
+            label = str(item.get("label") or item.get("key") or "").strip()
+            if not label:
+                continue
+            vault_entries.append({
+                "feature": label,
+                "mentions": int(item.get("mention_count_total") or 0),
+            })
+        if not vault_entries:
+            if raw_entries:
+                merged[vendor] = raw_entries
+            continue
+        seen = {str(item.get("feature") or "").strip().lower() for item in vault_entries}
+        for item in raw_entries:
+            feature = str(item.get("feature") or "").strip().lower()
+            if feature and feature not in seen:
+                vault_entries.append(item)
+        vault_entries.sort(key=lambda item: int(item.get("mentions") or 0), reverse=True)
+        merged[vendor] = vault_entries
+    return merged
+
+
+def _merge_company_lookup_with_evidence_vault(
+    raw_company_lookup: dict[str, list[dict[str, Any]]],
+    evidence_vault_lookup: dict[str, dict[str, Any]] | None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Merge raw company context with canonical vault company signals."""
+    merged: dict[str, list[dict[str, Any]]] = {}
+    vendors = set(raw_company_lookup) | set((evidence_vault_lookup or {}))
+    for vendor in vendors:
+        bucket: dict[str, dict[str, Any]] = {}
+        for item in raw_company_lookup.get(vendor, []):
+            if not isinstance(item, dict):
+                continue
+            company = str(item.get("company") or item.get("company_name") or "").strip()
+            key = normalize_company_name(company)
+            if not key:
+                continue
+            bucket[key] = dict(item)
+            bucket[key]["company"] = company or key
+        for item in ((evidence_vault_lookup or {}).get(vendor, {}) or {}).get("company_signals") or []:
+            key = normalize_company_name(item.get("company_name") or item.get("company") or "")
+            if not key:
+                continue
+            current = bucket.get(key, {})
+            current_urgency = current.get("urgency")
+            signal_urgency = item.get("urgency_score")
+            if current_urgency is None:
+                urgency = signal_urgency
+            elif signal_urgency is None:
+                urgency = current_urgency
+            else:
+                urgency = max(float(current_urgency), float(signal_urgency))
+            bucket[key] = {
+                **current,
+                "company": current.get("company") or str(item.get("company_name") or key),
+                "urgency": urgency,
+                "title": current.get("title") or item.get("buyer_role"),
+                "company_size": current.get("company_size"),
+                "industry": current.get("industry"),
+                "source": item.get("source") or current.get("source"),
+                "buying_stage": item.get("buying_stage") or current.get("buying_stage"),
+                "confidence_score": item.get("confidence_score") if item.get("confidence_score") is not None else current.get("confidence_score"),
+                "decision_maker": item.get("decision_maker") if item.get("decision_maker") is not None else current.get("decision_maker"),
+                "first_seen_at": item.get("first_seen_at") or current.get("first_seen_at"),
+                "last_seen_at": item.get("last_seen_at") or current.get("last_seen_at"),
+                "review_id": item.get("review_id") or current.get("review_id"),
+            }
+        ordered = sorted(
+            bucket.values(),
+            key=lambda item: (
+                -(float(item.get("urgency") or 0)),
+                -(float(item.get("confidence_score") or 0)),
+                str(item.get("company") or ""),
+            ),
+        )
+        if ordered:
+            merged[vendor] = ordered
+    return merged
+
+
+async def _fetch_budget_signals(pool, window_days: int) -> list[dict[str, Any]]:
+    """Aggregate budget signals: seat_count stats and price-increase mentions per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            avg(NULLIF(
+                CASE WHEN r.enrichment->'budget_signals'->>'seat_count' ~ '^\\d+$'
+                     THEN (r.enrichment->'budget_signals'->>'seat_count')::numeric END,
+                0)) AS avg_seat_count,
+            percentile_cont(0.5) WITHIN GROUP (
+                ORDER BY NULLIF(
+                    CASE WHEN r.enrichment->'budget_signals'->>'seat_count' ~ '^\\d+$'
+                         THEN (r.enrichment->'budget_signals'->>'seat_count')::numeric END,
+                    0)
+            ) AS median_seat_count,
+            max(NULLIF(
+                CASE WHEN r.enrichment->'budget_signals'->>'seat_count' ~ '^\\d+$'
+                     THEN (r.enrichment->'budget_signals'->>'seat_count')::numeric END,
+                0)) AS max_seat_count,
+            count(*) FILTER (
+                WHERE (r.enrichment->'budget_signals'->>'price_increase_mentioned')::boolean = true
+            ) AS price_increase_count,
+            count(*) AS total,
+            array_agg(DISTINCT r.enrichment->'budget_signals'->>'annual_spend_estimate')
+                FILTER (WHERE r.enrichment->'budget_signals'->>'annual_spend_estimate' IS NOT NULL
+                        AND r.enrichment->'budget_signals'->>'annual_spend_estimate' != '')
+                AS annual_spend_values,
+            array_agg(DISTINCT r.enrichment->'budget_signals'->>'price_per_seat')
+                FILTER (WHERE r.enrichment->'budget_signals'->>'price_per_seat' IS NOT NULL
+                        AND r.enrichment->'budget_signals'->>'price_per_seat' != '')
+                AS price_per_seat_values
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->'budget_signals' IS NOT NULL
+          AND r.enrichment->'budget_signals' != 'null'::jsonb
+        GROUP BY vm.vendor_name
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "avg_seat_count": float(r["avg_seat_count"]) if r["avg_seat_count"] else None,
+            "median_seat_count": float(r["median_seat_count"]) if r["median_seat_count"] else None,
+            "max_seat_count": float(r["max_seat_count"]) if r["max_seat_count"] else None,
+            "price_increase_count": r["price_increase_count"],
+            "price_increase_rate": r["price_increase_count"] / r["total"] if r["total"] else 0,
+            "annual_spend_signals": [v for v in (r["annual_spend_values"] or []) if v],
+            "price_per_seat_signals": [v for v in (r["price_per_seat_values"] or []) if v],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_use_case_distribution(pool, window_days: int) -> list[dict[str, Any]]:
+    """Explode use_case modules and integration stacks, count per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    module_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            mod.value #>> '{{}}' AS module_name,
+            count(*) AS mentions
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'use_case'->'modules_mentioned', '[]'::jsonb)
+        ) AS mod(value)
+        WHERE {filters}
+        GROUP BY vm.vendor_name, mod.value #>> '{{}}'
+        HAVING count(*) >= 2
+        ORDER BY mentions DESC
+        """,
+        window_days,
+        sources,
+    )
+    stack_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            tool.value #>> '{{}}' AS tool_name,
+            count(*) AS mentions
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'use_case'->'integration_stack', '[]'::jsonb)
+        ) AS tool(value)
+        WHERE {filters}
+        GROUP BY vm.vendor_name, tool.value #>> '{{}}'
+        HAVING count(*) >= 2
+        ORDER BY mentions DESC
+        """,
+        window_days,
+        sources,
+    )
+    lock_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.enrichment->'use_case'->>'lock_in_level' AS lock_in_level,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->'use_case'->>'lock_in_level' IS NOT NULL
+        GROUP BY vm.vendor_name, r.enrichment->'use_case'->>'lock_in_level'
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {"type": "modules", "data": [dict(r) for r in module_rows]},
+        {"type": "stacks", "data": [dict(r) for r in stack_rows]},
+        {"type": "lock_in", "data": [dict(r) for r in lock_rows]},
+    ]
+
+
+async def _fetch_sentiment_trajectory(pool, window_days: int) -> list[dict[str, Any]]:
+    """Count reviews per sentiment direction per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.sentiment_direction AS direction,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.sentiment_direction IS NOT NULL
+          AND r.sentiment_direction != 'unknown'
+        GROUP BY vm.vendor_name, r.sentiment_direction
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "direction": r["direction"],
+            "count": r["cnt"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_sentiment_tenure(pool, window_days: int) -> list[dict[str, Any]]:
+    """Aggregate customer tenure from sentiment_trajectory per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.sentiment_tenure AS tenure,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.sentiment_tenure IS NOT NULL
+          AND r.sentiment_tenure != ''
+        GROUP BY vm.vendor_name, r.sentiment_tenure
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {"vendor": r["vendor_name"], "tenure": r["tenure"], "count": r["cnt"]}
+        for r in rows
+    ]
+
+
+async def _fetch_turning_points(pool, window_days: int) -> list[dict[str, Any]]:
+    """Aggregate churn turning points from sentiment_trajectory per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.sentiment_turning_point AS turning_point,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.sentiment_turning_point IS NOT NULL
+          AND r.sentiment_turning_point != ''
+        GROUP BY vm.vendor_name, r.sentiment_turning_point
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    results = [
+        {"vendor": r["vendor_name"], "trigger": r["turning_point"], "mentions": r["cnt"]}
+        for r in rows
+    ]
+
+    # Supplement with v2 event_mentions for richer temporal data
+    event_rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            ev.value->>'event' AS event_text,
+            ev.value->>'timeframe' AS timeframe,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(r.enrichment->'event_mentions', '[]'::jsonb)
+        ) AS ev(value)
+        WHERE {filters}
+          AND jsonb_array_length(COALESCE(r.enrichment->'event_mentions', '[]'::jsonb)) > 0
+        GROUP BY vm.vendor_name, ev.value->>'event', ev.value->>'timeframe'
+        HAVING count(*) >= 2
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    seen_triggers = {(r["vendor"], r["trigger"]) for r in results}
+    for r in event_rows:
+        trigger = r["event_text"] or ""
+        if not trigger:
+            continue
+        if r["timeframe"]:
+            trigger = f"{trigger} ({r['timeframe']})"
+        if (r["vendor_name"], trigger) not in seen_triggers:
+            seen_triggers.add((r["vendor_name"], trigger))
+            results.append({
+                "vendor": r["vendor_name"],
+                "trigger": trigger,
+                "mentions": r["cnt"],
+            })
+
+    results.sort(key=lambda x: x.get("mentions", 0), reverse=True)
+    return results
+
+
+async def _fetch_review_text_aggregates(pool, window_days: int) -> tuple[list[dict], list[dict]]:
+    """Aggregate specific_complaints and positive_aspects per vendor.
+
+    Returns (complaint_rows, positive_rows) where each row has
+    vendor, text, mentions. Only includes items with 2+ mentions.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+
+    complaint_rows, positive_rows = await asyncio.gather(
+        pool.fetch(
+            f"""
+            SELECT vm.vendor_name AS vendor_name, c.value #>> '{{}}' AS text, count(*) AS mentions
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            CROSS JOIN LATERAL jsonb_array_elements(
+                COALESCE(r.enrichment->'specific_complaints', '[]'::jsonb)
+            ) AS c(value)
+            WHERE {filters}
+            GROUP BY vm.vendor_name, c.value #>> '{{}}'
+            HAVING count(*) >= 2
+            ORDER BY mentions DESC
+            """,
+            window_days,
+            sources,
+        ),
+        pool.fetch(
+            f"""
+            SELECT vm.vendor_name AS vendor_name, a.value #>> '{{}}' AS text, count(*) AS mentions
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            CROSS JOIN LATERAL jsonb_array_elements(
+                COALESCE(r.enrichment->'positive_aspects', '[]'::jsonb)
+            ) AS a(value)
+            WHERE {filters}
+            GROUP BY vm.vendor_name, a.value #>> '{{}}'
+            HAVING count(*) >= 2
+            ORDER BY mentions DESC
+            """,
+            window_days,
+            sources,
+        ),
+    )
+
+    complaints = [
+        {"vendor": r["vendor_name"], "text": r["text"], "mentions": r["mentions"]}
+        for r in complaint_rows
+    ]
+    positives = [
+        {"vendor": r["vendor_name"], "aspect": r["text"], "mentions": r["mentions"]}
+        for r in positive_rows
+    ]
+    return complaints, positives
+
+
+async def _fetch_department_distribution(pool, window_days: int) -> list[dict[str, Any]]:
+    """Count reviews and churn rate per department per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.enrichment->'reviewer_context'->>'department' AS department,
+            count(*) AS review_count,
+            count(*) FILTER (
+                WHERE (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+            ) AS churning_count,
+            round(avg((r.enrichment->>'urgency_score')::numeric), 1) AS avg_urgency
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->'reviewer_context'->>'department' IS NOT NULL
+          AND r.enrichment->'reviewer_context'->>'department' != ''
+          AND r.enrichment->'reviewer_context'->>'department' != 'unknown'
+        GROUP BY vm.vendor_name, r.enrichment->'reviewer_context'->>'department'
+        ORDER BY review_count DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "department": r["department"],
+            "review_count": r["review_count"],
+            "churn_rate": round(r["churning_count"] / r["review_count"], 2) if r["review_count"] else 0,
+            "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_company_size_distribution(pool, window_days: int) -> list[dict[str, Any]]:
+    """Count reviews per normalized company-size segment per vendor.
+
+    Segment source priority:
+      1. Enrichment LLM label (startup/smb/mid_market/enterprise) when not 'unknown'
+      2. Apollo-verified employee_count bucket via account resolution
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            COALESCE(
+                NULLIF(NULLIF(r.enrichment->'reviewer_context'->>'company_size_segment', 'unknown'), ''),
+                CASE
+                    WHEN poc.employee_count >= 1001 THEN 'enterprise'
+                    WHEN poc.employee_count >= 201  THEN 'mid_market'
+                    WHEN poc.employee_count >= 11   THEN 'smb'
+                    WHEN poc.employee_count >= 1    THEN 'startup'
+                END
+            ) AS segment,
+            count(*) AS review_count,
+            count(*) FILTER (
+                WHERE (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+            ) AS churning_count
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        LEFT JOIN b2b_account_resolution ar
+            ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
+        LEFT JOIN prospect_org_cache poc
+            ON poc.company_name_norm = ar.normalized_company_name
+        WHERE {filters}
+        GROUP BY vm.vendor_name,
+            COALESCE(
+                NULLIF(NULLIF(r.enrichment->'reviewer_context'->>'company_size_segment', 'unknown'), ''),
+                CASE
+                    WHEN poc.employee_count >= 1001 THEN 'enterprise'
+                    WHEN poc.employee_count >= 201  THEN 'mid_market'
+                    WHEN poc.employee_count >= 11   THEN 'smb'
+                    WHEN poc.employee_count >= 1    THEN 'startup'
+                END
+            )
+        HAVING COALESCE(
+                NULLIF(NULLIF(r.enrichment->'reviewer_context'->>'company_size_segment', 'unknown'), ''),
+                CASE
+                    WHEN poc.employee_count >= 1001 THEN 'enterprise'
+                    WHEN poc.employee_count >= 201  THEN 'mid_market'
+                    WHEN poc.employee_count >= 11   THEN 'smb'
+                    WHEN poc.employee_count >= 1    THEN 'startup'
+                END
+            ) IS NOT NULL
+        ORDER BY review_count DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "segment": r["segment"],
+            "review_count": r["review_count"],
+            "churn_rate": round(r["churning_count"] / r["review_count"], 2) if r["review_count"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_contract_context_distribution(pool, window_days: int) -> tuple[list[dict], list[dict]]:
+    """Aggregate contract_value_signal and usage_duration per vendor.
+
+    Returns (value_signal_rows, duration_rows).
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+
+    value_rows, duration_rows = await asyncio.gather(
+        pool.fetch(
+            f"""
+            SELECT vm.vendor_name AS vendor_name,
+                r.enrichment->'contract_context'->>'contract_value_signal' AS segment,
+                count(*) AS cnt,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+                ) AS churning
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            WHERE {filters}
+              AND r.enrichment->'contract_context'->>'contract_value_signal' IS NOT NULL
+              AND r.enrichment->'contract_context'->>'contract_value_signal' NOT IN ('unknown', '')
+            GROUP BY vm.vendor_name, r.enrichment->'contract_context'->>'contract_value_signal'
+            ORDER BY cnt DESC
+            """,
+            window_days,
+            sources,
+        ),
+        pool.fetch(
+            f"""
+            SELECT vm.vendor_name AS vendor_name,
+                r.enrichment->'contract_context'->>'usage_duration' AS duration,
+                count(*) AS cnt,
+                count(*) FILTER (
+                    WHERE (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = true
+                ) AS churning
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            WHERE {filters}
+              AND r.enrichment->'contract_context'->>'usage_duration' IS NOT NULL
+              AND r.enrichment->'contract_context'->>'usage_duration' != ''
+            GROUP BY vm.vendor_name, r.enrichment->'contract_context'->>'usage_duration'
+            ORDER BY cnt DESC
+            """,
+            window_days,
+            sources,
+        ),
+    )
+
+    values = [
+        {
+            "vendor": r["vendor_name"],
+            "segment": r["segment"],
+            "count": r["cnt"],
+            "churn_rate": round(r["churning"] / r["cnt"], 2) if r["cnt"] else 0,
+        }
+        for r in value_rows
+    ]
+    durations = [
+        {
+            "vendor": r["vendor_name"],
+            "duration": r["duration"],
+            "count": r["cnt"],
+            "churn_rate": round(r["churning"] / r["cnt"], 2) if r["cnt"] else 0,
+        }
+        for r in duration_rows
+    ]
+    return values, durations
+
+
+async def _fetch_buyer_authority_summary(pool, window_days: int) -> list[dict[str, Any]]:
+    """Count reviews per role_type and buying_stage per vendor."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.enrichment->'buyer_authority'->>'role_type' AS role_type,
+            r.enrichment->'buyer_authority'->>'buying_stage' AS buying_stage,
+            count(*) AS cnt
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->'buyer_authority' IS NOT NULL
+          AND r.enrichment->'buyer_authority' != 'null'::jsonb
+        GROUP BY vm.vendor_name,
+            r.enrichment->'buyer_authority'->>'role_type',
+            r.enrichment->'buyer_authority'->>'buying_stage'
+        ORDER BY cnt DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "role_type": r["role_type"],
+            "buying_stage": r["buying_stage"],
+            "count": r["cnt"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_role_churn_summary(pool, window_days: int) -> list[dict[str, Any]]:
+    """Per-vendor, per-role_type churn rate and dominant pain category.
+
+    Returns one row per (vendor, role_type) with the fraction of reviews
+    showing churn intent and the most common pain_category for that role.
+    """
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT vm.vendor_name AS vendor_name,
+            r.enrichment->'buyer_authority'->>'role_type' AS role_type,
+            count(*) AS total,
+            count(*) FILTER (
+                WHERE (r.enrichment->>'churn_intent')::boolean IS TRUE
+            ) AS churn_count,
+            mode() WITHIN GROUP (
+                ORDER BY r.enrichment->>'pain_category'
+            ) FILTER (
+                WHERE r.enrichment->>'pain_category' IS NOT NULL
+            ) AS top_pain
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND r.enrichment->'buyer_authority' IS NOT NULL
+          AND r.enrichment->'buyer_authority' != 'null'::jsonb
+        GROUP BY vm.vendor_name,
+            r.enrichment->'buyer_authority'->>'role_type'
+        HAVING count(*) >= 3
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "role_type": r["role_type"],
+            "total": r["total"],
+            "churn_count": r["churn_count"],
+            "churn_rate": round(r["churn_count"] / r["total"], 3) if r["total"] else 0.0,
+            "top_pain": r["top_pain"],
+        }
+        for r in rows
+    ]
+
+
+def _build_role_churn_lookup(
+    role_churn_rows: list[dict[str, Any]],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """vendor -> role_type -> {churn_rate, top_pain}."""
+    lookup: dict[str, dict[str, dict[str, Any]]] = {}
+    for row in role_churn_rows:
+        vendor = row.get("vendor", "")
+        rt = row.get("role_type", "unknown")
+        lookup.setdefault(vendor, {})[rt] = {
+            "churn_rate": row.get("churn_rate"),
+            "top_pain": row.get("top_pain"),
+        }
+    return lookup
+
+
+async def _fetch_timeline_signals(pool, window_days: int, *, limit: int = 50) -> list[dict[str, Any]]:
+    """Extract reviews with non-null contract_end or evaluation_deadline -- hottest leads."""
+    sources = _executive_source_list()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=3,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT r.reviewer_company, vm.vendor_name AS vendor_name,
+            r.enrichment->'timeline'->>'contract_end' AS contract_end,
+            r.enrichment->'timeline'->>'evaluation_deadline' AS evaluation_deadline,
+            r.enrichment->'timeline'->>'decision_timeline' AS decision_timeline,
+            (r.enrichment->>'urgency_score')::numeric AS urgency,
+            r.reviewer_title, r.company_size_raw,
+            COALESCE(r.reviewer_industry, r.enrichment->'reviewer_context'->>'industry') AS industry
+        FROM b2b_reviews r
+        {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+        WHERE {filters}
+          AND (
+              r.enrichment->'timeline'->>'contract_end' IS NOT NULL
+              OR r.enrichment->'timeline'->>'evaluation_deadline' IS NOT NULL
+              OR NULLIF(r.enrichment->'timeline'->>'decision_timeline', '') IS NOT NULL
+          )
+        ORDER BY (r.enrichment->>'urgency_score')::numeric DESC
+        LIMIT $2
+        """,
+        window_days,
+        limit,
+        sources,
+    )
+    return [
+        {
+            "company": r["reviewer_company"],
+            "vendor": r["vendor_name"],
+            "contract_end": r["contract_end"],
+            "evaluation_deadline": r["evaluation_deadline"],
+            "decision_timeline": r["decision_timeline"],
+            "urgency": float(r["urgency"]) if r["urgency"] else 0,
+            "title": r["reviewer_title"],
+            "company_size": r["company_size_raw"],
+            "industry": r["industry"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_competitor_reasons(pool, window_days: int) -> list[dict[str, Any]]:
+    """Top reasons per vendor/competitor pair -- prefers structured reason_category."""
+    sources = _intelligence_source_allowlist()
+    filters = _eligible_review_filters(
+        window_param=1,
+        source_param=2,
+        alias="r",
+        vendor_expr="vm.vendor_name",
+    )
+    rows = await pool.fetch(
+        f"""
+        WITH ranked_reasons AS (
+            SELECT vm.vendor_name AS vendor_name,
+                comp.value->>'name' AS competitor,
+                comp.value->>'context' AS direction,
+                COALESCE(comp.value->>'reason_category', comp.value->>'reason') AS reason,
+                comp.value->>'reason_category' AS reason_category,
+                comp.value->>'reason_detail' AS reason_detail,
+                count(*) AS mention_count,
+                ROW_NUMBER() OVER (
+                    PARTITION BY vm.vendor_name, comp.value->>'name'
+                    ORDER BY count(*) DESC
+                ) AS rn
+            FROM b2b_reviews r
+            {_review_vendor_association_join(review_alias='r', output_alias='vm')}
+            CROSS JOIN LATERAL jsonb_array_elements(r.enrichment->'competitors_mentioned') AS comp(value)
+            WHERE {filters}
+              AND COALESCE(comp.value->>'reason_category', comp.value->>'reason') IS NOT NULL
+            GROUP BY vm.vendor_name, comp.value->>'name', comp.value->>'context',
+                     reason, reason_category, reason_detail
+        )
+        SELECT vendor_name, competitor, direction, reason, reason_category, reason_detail, mention_count
+        FROM ranked_reasons WHERE rn <= 3
+        ORDER BY mention_count DESC
+        """,
+        window_days,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor_name"],
+            "competitor": r["competitor"],
+            "direction": r["direction"],
+            "reason": r["reason"],
+            "reason_category": r["reason_category"],
+            "reason_detail": r["reason_detail"],
+            "mention_count": r["mention_count"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_prior_reports(pool, *, limit: int = 4) -> list[dict[str, Any]]:
+    """Fetch most recent prior intelligence reports for trend comparison.
+
+    Includes both weekly_churn_feed and vendor_scorecard, with full
+    intelligence_data so the LLM can compute trends from actual numbers
+    instead of guessing from prose.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT report_type, intelligence_data, executive_summary, report_date
+        FROM b2b_intelligence
+        WHERE report_type IN ('weekly_churn_feed', 'vendor_scorecard')
+        ORDER BY report_date DESC
+        LIMIT $1
+        """,
+        limit,
+    )
+    results = []
+    for r in rows:
+        intel_data = r["intelligence_data"]
+        # asyncpg auto-deserializes JSONB to dict/list, but handle string fallback
+        if isinstance(intel_data, str):
+            try:
+                intel_data = json.loads(intel_data)
+            except (json.JSONDecodeError, TypeError):
+                intel_data = {}
+        results.append({
+            "report_type": r["report_type"],
+            "report_date": str(r["report_date"]),
+            "executive_summary": r["executive_summary"],
+            "intelligence_data": intel_data,
+        })
+    return results
+
+
+async def _fetch_keyword_spikes(pool) -> list[dict[str, Any]]:
+    """Fetch recent keyword spikes from b2b_keyword_signals.
+
+    Returns one row per vendor with spike count and spike keywords.
+    Uses only the latest snapshot per keyword (most recent week) to avoid
+    JSONB_OBJECT_AGG duplicate key non-determinism.
+    """
+    rows = await pool.fetch(
+        """
+        WITH latest AS (
+            SELECT DISTINCT ON (vendor_name, keyword)
+                   vendor_name, keyword, volume_relative,
+                   volume_change_pct, is_spike
+            FROM b2b_keyword_signals
+            WHERE snapshot_week >= CURRENT_DATE - INTERVAL '28 days'
+            ORDER BY vendor_name, keyword, snapshot_week DESC
+        )
+        SELECT vendor_name,
+               COUNT(*) FILTER (WHERE is_spike) AS spike_count,
+               ARRAY_AGG(DISTINCT keyword) FILTER (WHERE is_spike) AS spike_keywords,
+               JSONB_OBJECT_AGG(
+                   keyword,
+                   JSONB_BUILD_OBJECT(
+                       'volume', volume_relative,
+                       'change_pct', volume_change_pct,
+                       'is_spike', is_spike
+                   )
+               ) AS trend_summary
+        FROM latest
+        GROUP BY vendor_name
+        """
+    )
+    return [dict(r) for r in rows]
+
+
+# ------------------------------------------------------------------
+# Layer 3: lookup builders (pure Python, no DB)
+# ------------------------------------------------------------------
+
+
+def _build_pain_lookup(pain_dist: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {category, count, avg_urgency}."""
+    lookup: dict[str, list[dict]] = {}
+    for row in pain_dist:
+        vendor = row.get("vendor", "")
+        lookup.setdefault(vendor, []).append({
+            "category": _normalize_generic_pain_label(row.get("pain")) or "overall_dissatisfaction",
+            "count": row.get("complaint_count", 0),
+            "avg_urgency": round(row.get("avg_urgency", 0), 1),
+        })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: x["count"], reverse=True)
+    return lookup
+
+
+def _aggregate_competitive_disp(competitive_disp: list[dict]) -> list[dict]:
+    """Merge rows with same (vendor, competitor), preserving evidence breakdown."""
+    agg: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def _intish(value: Any, default: int = 0) -> int:
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+
+    def _normalize_evidence_type(value: Any) -> str | None:
+        text = str(value or "").strip().lower()
+        if not text:
+            return None
+        if text in {"explicit_switch", "switch", "switched_to"}:
+            return "explicit_switch"
+        if text in {"active_evaluation", "evaluation", "considering", "trial", "poc"}:
+            return "active_evaluation"
+        if text in {"implied_preference", "compared", "preference"}:
+            return "implied_preference"
+        return None
+
+    def _merge_breakdown_item(
+        entry: dict[str, Any],
+        evidence_type: str | None,
+        mention_count: int,
+        reason_categories: dict[str, Any] | None = None,
+        industries: list[str] | None = None,
+        company_sizes: list[str] | None = None,
+    ) -> None:
+        if not evidence_type or mention_count <= 0:
+            return
+        bucket = entry["evidence_breakdown"].setdefault(
+            evidence_type,
+            {
+                "evidence_type": evidence_type,
+                "mention_count": 0,
+                "reason_categories": {},
+                "industries": set(),
+                "company_sizes": set(),
+            },
+        )
+        bucket["mention_count"] += mention_count
+        for rc, rc_cnt in (reason_categories or {}).items():
+            if not str(rc or "").strip():
+                continue
+            count = _intish(rc_cnt)
+            if count <= 0:
+                continue
+            bucket["reason_categories"][rc] = (
+                bucket["reason_categories"].get(rc, 0) + count
+            )
+        for value in industries or []:
+            text = str(value or "").strip()
+            if text and text.lower() != "unknown":
+                bucket["industries"].add(text)
+        for value in company_sizes or []:
+            text = str(value or "").strip()
+            if text:
+                bucket["company_sizes"].add(text)
+
+    for row in competitive_disp:
+        key = (row.get("vendor", ""), row.get("competitor", ""))
+        if key not in agg:
+            agg[key] = {
+                "mention_count": 0,
+                "explicit_switches": 0,
+                "active_evaluations": 0,
+                "implied_preferences": 0,
+                "reason_categories": {},
+                "industries": set(),
+                "company_sizes": set(),
+                "evidence_breakdown": {},
+            }
+        entry = agg[key]
+        cnt = _intish(row.get("mention_count") or 0)
+        explicit = _intish(row.get("explicit_switches") or 0)
+        active_eval = _intish(row.get("active_evaluations") or 0)
+        implied = _intish(row.get("implied_preferences") or 0)
+        breakdown_seen = False
+        for item in row.get("evidence_breakdown") or []:
+            if not isinstance(item, dict):
+                continue
+            evidence_type = _normalize_evidence_type(item.get("evidence_type"))
+            reason_categories = item.get("reason_categories") or {}
+            mention_count = _intish(item.get("mention_count") or 0)
+            if mention_count <= 0 and isinstance(reason_categories, dict):
+                mention_count = sum(_intish(v) for v in reason_categories.values())
+            if not evidence_type or mention_count <= 0:
+                continue
+            breakdown_seen = True
+            _merge_breakdown_item(
+                entry,
+                evidence_type,
+                mention_count,
+                reason_categories,
+                item.get("industries") or [],
+                item.get("company_sizes") or [],
+            )
+        if not breakdown_seen:
+            evidence_type = _normalize_evidence_type(row.get("evidence_type"))
+            if explicit <= 0 and active_eval <= 0 and implied <= 0 and evidence_type:
+                if evidence_type == "explicit_switch":
+                    explicit = cnt
+                elif evidence_type == "active_evaluation":
+                    active_eval = cnt
+                else:
+                    implied = cnt
+            if cnt <= 0:
+                cnt = explicit + active_eval + implied
+            for evidence_type, count in (
+                ("explicit_switch", explicit),
+                ("active_evaluation", active_eval),
+                ("implied_preference", implied),
+            ):
+                _merge_breakdown_item(
+                    entry,
+                    evidence_type,
+                    count,
+                    row.get("reason_categories") or {},
+                    row.get("industries") or [],
+                    row.get("company_sizes") or [],
+                )
+        entry["mention_count"] += cnt or (explicit + active_eval + implied)
+        entry["explicit_switches"] += explicit
+        entry["active_evaluations"] += active_eval
+        entry["implied_preferences"] += implied
+        # Merge reason_categories from this row
+        for rc, rc_cnt in (row.get("reason_categories") or {}).items():
+            count = _intish(rc_cnt)
+            if count <= 0:
+                continue
+            entry["reason_categories"][rc] = entry["reason_categories"].get(rc, 0) + count
+        for value in row.get("industries") or []:
+            text = str(value or "").strip()
+            if text and text.lower() != "unknown":
+                entry["industries"].add(text)
+        for value in row.get("company_sizes") or []:
+            text = str(value or "").strip()
+            if text:
+                entry["company_sizes"].add(text)
+
+    results = []
+    for (v, c), data in sorted(agg.items(), key=lambda x: x[1]["mention_count"], reverse=True):
+        breakdown = sorted(
+            (
+                {
+                    "evidence_type": item["evidence_type"],
+                    "mention_count": item["mention_count"],
+                    "reason_categories": dict(
+                        sorted(
+                            item["reason_categories"].items(),
+                            key=lambda kv: kv[1],
+                            reverse=True,
+                        ),
+                    ),
+                    "industries": sorted(item["industries"]),
+                    "company_sizes": sorted(item["company_sizes"]),
+                }
+                for item in data["evidence_breakdown"].values()
+                if item["mention_count"] > 0
+            ),
+            key=lambda item: item["mention_count"],
+            reverse=True,
+        )
+        if not breakdown:
+            for evidence_type, count in (
+                ("explicit_switch", data["explicit_switches"]),
+                ("active_evaluation", data["active_evaluations"]),
+                ("implied_preference", data["implied_preferences"]),
+            ):
+                if count <= 0:
+                    continue
+                breakdown.append({
+                    "evidence_type": evidence_type,
+                    "mention_count": count,
+                    "reason_categories": {},
+                    "industries": [],
+                    "company_sizes": [],
+                })
+        results.append({
+            "vendor": v,
+            "competitor": c,
+            "mention_count": data["mention_count"],
+            "explicit_switches": data["explicit_switches"],
+            "active_evaluations": data["active_evaluations"],
+            "implied_preferences": data["implied_preferences"],
+            "reason_categories": data["reason_categories"],
+            "industries": sorted(data["industries"]),
+            "company_sizes": sorted(data["company_sizes"]),
+            "evidence_breakdown": breakdown,
+        })
+    return results
+
+
+def _build_competitor_lookup(competitive_disp: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {name, mentions} (aggregated across directions)."""
+    # First pass: sum mentions per (vendor, competitor) across all directions.
+    agg: dict[str, dict[str, int]] = {}
+    for row in competitive_disp:
+        vendor = row.get("vendor", "")
+        comp = row.get("competitor", "")
+        mentions = row.get("mention_count", 0)
+        agg.setdefault(vendor, {})
+        agg[vendor][comp] = agg[vendor].get(comp, 0) + mentions
+    # Second pass: build sorted list per vendor.
+    lookup: dict[str, list[dict]] = {}
+    for vendor, comps in agg.items():
+        lookup[vendor] = sorted(
+            [{"name": c, "mentions": m} for c, m in comps.items()],
+            key=lambda x: x["mentions"],
+            reverse=True,
+        )
+    return lookup
+
+
+def _build_inbound_displacement_lookup(competitive_disp: list[dict]) -> dict[str, int]:
+    """Sum mentions where vendor is the target (inbound displacement)."""
+    inbound: dict[str, int] = {}
+    for row in competitive_disp:
+        comp = row.get("competitor", "")
+        mentions = row.get("mention_count", 0)
+        if comp:
+            inbound[comp] = inbound.get(comp, 0) + mentions
+    return inbound
+
+
+def _build_feature_gap_lookup(feature_gaps: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {feature, mentions}."""
+    lookup: dict[str, list[dict]] = {}
+    for row in feature_gaps:
+        vendor = row.get("vendor", "")
+        lookup.setdefault(vendor, []).append({
+            "feature": row.get("feature_gap", ""),
+            "mentions": row.get("mentions", 0),
+        })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: x["mentions"], reverse=True)
+    return lookup
+
+
+def _build_use_case_lookup(use_case_dist: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {module, mentions}."""
+    lookup: dict[str, list[dict]] = {}
+    for entry in use_case_dist:
+        if entry.get("type") != "modules":
+            continue
+        for row in entry.get("data", []):
+            vendor = row.get("vendor_name", "")
+            lookup.setdefault(vendor, []).append({
+                "module": row.get("module_name", ""),
+                "mentions": row.get("mentions", 0),
+            })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: x["mentions"], reverse=True)
+    return lookup
+
+
+def _build_integration_lookup(use_case_dist: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {tool, mentions}."""
+    lookup: dict[str, list[dict]] = {}
+    for entry in use_case_dist:
+        if entry.get("type") != "stacks":
+            continue
+        for row in entry.get("data", []):
+            vendor = row.get("vendor_name", "")
+            lookup.setdefault(vendor, []).append({
+                "tool": row.get("tool_name", ""),
+                "mentions": row.get("mentions", 0),
+            })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: x["mentions"], reverse=True)
+    return lookup
+
+
+def _build_lock_in_lookup(use_case_dist: list[dict]) -> dict[str, str]:
+    """vendor -> dominant lock_in_level (high/medium/low)."""
+    vendor_counts: dict[str, dict[str, int]] = {}
+    for entry in use_case_dist:
+        if entry.get("type") != "lock_in":
+            continue
+        for row in entry.get("data", []):
+            vendor = row.get("vendor_name", "")
+            level = str(row.get("lock_in_level") or "unknown").lower().strip()
+            if not vendor or level in ("unknown", "none", "null"):
+                continue
+            vendor_counts.setdefault(vendor, {})[level] = (
+                vendor_counts.get(vendor, {}).get(level, 0) + int(row.get("cnt") or 0)
+            )
+    lookup: dict[str, str] = {}
+    for vendor, counts in vendor_counts.items():
+        if counts:
+            lookup[vendor] = max(counts, key=counts.get)
+    return lookup
+
+
+def _build_sentiment_lookup(sentiment_traj: list[dict]) -> dict[str, dict[str, int]]:
+    """vendor -> {direction: count}."""
+    lookup: dict[str, dict[str, int]] = {}
+    for row in sentiment_traj:
+        vendor = row.get("vendor", "")
+        direction = row.get("direction", "unknown")
+        lookup.setdefault(vendor, {})[direction] = row.get("count", 0)
+    return lookup
+
+
+def _build_buyer_auth_lookup(buyer_auth: list[dict]) -> dict[str, dict]:
+    """vendor -> role and buying-stage summaries for segment intelligence."""
+    lookup: dict[str, dict] = {}
+    for row in buyer_auth:
+        vendor = row.get("vendor", "")
+        if vendor not in lookup:
+            lookup[vendor] = {
+                "role_types": {},
+                "buying_stages": {},
+                "role_buying_stages": {},
+            }
+        rt = row.get("role_type", "unknown")
+        bs = row.get("buying_stage", "unknown")
+        cnt = row.get("count", 0)
+        lookup[vendor]["role_types"][rt] = lookup[vendor]["role_types"].get(rt, 0) + cnt
+        lookup[vendor]["buying_stages"][bs] = lookup[vendor]["buying_stages"].get(bs, 0) + cnt
+        role_stage_counts = lookup[vendor]["role_buying_stages"].setdefault(rt, {})
+        role_stage_counts[bs] = role_stage_counts.get(bs, 0) + cnt
+    return lookup
+
+
+def _build_timeline_lookup(timeline_signals: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> list of timeline entries."""
+    lookup: dict[str, list[dict]] = {}
+    for row in timeline_signals:
+        vendor = row.get("vendor", "")
+        lookup.setdefault(vendor, []).append({
+            "company": row.get("company"),
+            "contract_end": row.get("contract_end"),
+            "evaluation_deadline": row.get("evaluation_deadline"),
+            "decision_timeline": row.get("decision_timeline"),
+            "urgency": row.get("urgency", 0),
+            "title": row.get("title"),
+            "company_size": row.get("company_size"),
+            "industry": row.get("industry"),
+        })
+    return lookup
+
+
+def _parse_timeline_date(raw: Any) -> date | None:
+    """Parse common timeline date formats from review enrichment."""
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%d", "%B %d, %Y", "%b %d, %Y"):
+        try:
+            return datetime.strptime(text[:32], fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _build_active_evaluation_deadlines(
+    timeline_entries: list[dict[str, Any]],
+    *,
+    limit: int,
+    today: date | None = None,
+) -> list[dict[str, Any]]:
+    """Convert raw timeline entries into actionable deadline/timing signals."""
+    today = today or date.today()
+    entries: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for row in timeline_entries:
+        eval_date = _parse_timeline_date(row.get("evaluation_deadline"))
+        contract_date = _parse_timeline_date(row.get("contract_end"))
+        timeline = str(row.get("decision_timeline") or "").strip().lower()
+        if eval_date and eval_date < today:
+            eval_date = None
+        if contract_date and contract_date < today:
+            contract_date = None
+        trigger = "deadline" if eval_date else ("contract_end" if contract_date else "timeline_signal")
+        if trigger == "timeline_signal" and timeline in {"", "unknown", "none", "n/a"}:
+            continue
+        dedupe = (str(row.get("company") or ""), str(eval_date or contract_date or ""), timeline)
+        if dedupe in seen:
+            continue
+        seen.add(dedupe)
+        entries.append({
+            "company": row.get("company"),
+            "evaluation_deadline": eval_date.isoformat() if eval_date else None,
+            "contract_end": contract_date.isoformat() if contract_date else None,
+            "decision_timeline": row.get("decision_timeline"),
+            "urgency": row.get("urgency", 0),
+            "title": row.get("title"),
+            "company_size": row.get("company_size"),
+            "industry": row.get("industry"),
+            "trigger_type": trigger,
+        })
+    entries.sort(key=lambda item: (0 if item.get("evaluation_deadline") else 1, item.get("evaluation_deadline") or item.get("contract_end") or "9999-12-31", -float(item.get("urgency") or 0)))
+    return entries[:limit]
+
+
+def _build_complaint_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {text, mentions}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({"text": r["text"], "mentions": r["mentions"]})
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["mentions"])
+    return lookup
+
+
+def _build_positive_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {aspect, mentions}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({"aspect": r["aspect"], "mentions": r["mentions"]})
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["mentions"])
+    return lookup
+
+
+def _build_department_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> sorted list of {department, review_count, churn_rate, avg_urgency}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({
+            "department": r["department"],
+            "review_count": r["review_count"],
+            "churn_rate": r["churn_rate"],
+            "avg_urgency": r["avg_urgency"],
+        })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["review_count"])
+    return lookup
+
+
+def _build_contract_value_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> list of {segment, count, churn_rate}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({
+            "segment": r["segment"],
+            "count": r["count"],
+            "churn_rate": r["churn_rate"],
+        })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["count"])
+    return lookup
+
+
+def _build_usage_duration_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> list of {duration, count, churn_rate}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({
+            "duration": r["duration"],
+            "count": r["count"],
+            "churn_rate": r["churn_rate"],
+        })
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["count"])
+    return lookup
+
+
+def _build_tenure_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> list of {tenure, count}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({"tenure": r["tenure"], "count": r["count"]})
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["count"])
+    return lookup
+
+
+def _build_turning_point_lookup(rows: list[dict]) -> dict[str, list[dict]]:
+    """vendor -> list of {trigger, mentions}."""
+    lookup: dict[str, list[dict]] = {}
+    for r in rows:
+        vendor = r.get("vendor", "")
+        lookup.setdefault(vendor, []).append({"trigger": r["trigger"], "mentions": r["mentions"]})
+    for v in lookup:
+        lookup[v].sort(key=lambda x: -x["mentions"])
+    return lookup
+
+
+def _build_keyword_spike_lookup(
+    keyword_spikes: list[dict],
+) -> dict[str, dict]:
+    """vendor -> {spike_count, spike_keywords, trend_summary}."""
+    lookup: dict[str, dict] = {}
+    for row in keyword_spikes:
+        vendor = row.get("vendor_name", "")
+        lookup[vendor] = {
+            "spike_count": row.get("spike_count", 0),
+            "spike_keywords": row.get("spike_keywords") or [],
+            "trend_summary": row.get("trend_summary") or {},
+        }
+    return lookup
+
+
+def _build_insider_lookup(rows: list[Any]) -> dict[str, dict]:
+    """Build vendor -> insider aggregate dict from _fetch_insider_aggregates rows."""
+    result: dict[str, dict] = {}
+    for r in rows:
+        vendor = r["vendor_name"]
+        org_health_array = _safe_json(r["org_health_array"]) if r["org_health_array"] else []
+        quotable_raw = _safe_json(r["quotable_phrases"]) if r["quotable_phrases"] else []
+
+        # Mode of org health fields across all insider posts
+        bureaucracy = Counter(
+            h.get("bureaucracy_level") for h in org_health_array if h and h.get("bureaucracy_level")
+        )
+        leadership = Counter(
+            h.get("leadership_quality") for h in org_health_array if h and h.get("leadership_quality")
+        )
+        innovation = Counter(
+            h.get("innovation_climate") for h in org_health_array if h and h.get("innovation_climate")
+        )
+
+        # Flatten all culture_indicators
+        culture_indicators: list[str] = []
+        for h in org_health_array:
+            if h and isinstance(h.get("culture_indicators"), list):
+                culture_indicators.extend(h["culture_indicators"])
+        top_culture = [item for item, _ in Counter(culture_indicators).most_common(10)]
+
+        org_health_summary = {
+            "bureaucracy_level": bureaucracy.most_common(1)[0][0] if bureaucracy else "unknown",
+            "leadership_quality": leadership.most_common(1)[0][0] if leadership else "unknown",
+            "innovation_climate": innovation.most_common(1)[0][0] if innovation else "unknown",
+            "culture_indicators": top_culture,
+        }
+
+        # Keep top 5 quotable phrases, deduplicate
+        seen_quotes: set[str] = set()
+        quotable_evidence = []
+        for q in quotable_raw:
+            if isinstance(q, dict) and q.get("quote") and q["quote"] not in seen_quotes:
+                seen_quotes.add(q["quote"])
+                quotable_evidence.append(q)
+                if len(quotable_evidence) >= 5:
+                    break
+
+        result[vendor] = {
+            "signal_count": r["signal_count"] or 0,
+            "org_health_summary": org_health_summary,
+            "talent_drain_rate": float(r["talent_drain_rate"]) if r["talent_drain_rate"] is not None else None,
+            "quotable_evidence": quotable_evidence,
+        }
+    return result
+
+
+def _normalize_vault_feature_key(raw: Any) -> str:
+    """Normalize a feature-gap label into the vault key format."""
+    return str(raw or "").strip().lower().replace(" ", "_")[:50]
+
+
+def _normalize_vault_aspect_key(raw: Any) -> str:
+    """Normalize a positive-aspect label into the vault key format."""
+    return str(raw or "").strip().lower()
+
+
+def _evidence_rollup_review_date(row: dict[str, Any]) -> date | None:
+    """Return the best available event date for review-level vault rollups."""
+    raw = row.get("reviewed_at") or row.get("enriched_at")
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, date):
+        return raw
+    parsed = _parse_timeline_date(raw)
+    return parsed if parsed else None
+
+
+def _quote_reviewed_at_text(raw: Any) -> str | None:
+    """Convert quote provenance timestamps into a stable ISO date string."""
+    if isinstance(raw, datetime):
+        return raw.date().isoformat()
+    if isinstance(raw, date):
+        return raw.isoformat()
+    text = str(raw or "").strip()
+    return text[:10] if text else None
+
+
+def _build_evidence_vault_trend(
+    recent_count: int,
+    prior_count: int,
+) -> dict[str, Any]:
+    """Classify evidence trend from recent and prior same-length windows."""
+    direction = "stable"
+    if prior_count <= 0 and recent_count >= _evidence_vault_trend_new_min_recent():
+        direction = "new"
+    elif prior_count > 0:
+        ratio = recent_count / prior_count
+        if recent_count > prior_count and ratio >= _evidence_vault_trend_accelerating_ratio():
+            direction = "accelerating"
+        elif recent_count < prior_count and ratio <= _evidence_vault_trend_declining_ratio():
+            direction = "declining"
+    return {
+        "direction": direction,
+        "prior_count": prior_count,
+        "recent_count": recent_count,
+        "delta_pct": round((recent_count - prior_count) / prior_count, 2) if prior_count > 0 else None,
+        "basis": "recent_vs_prior_window",
+    }
+
+
+def _build_evidence_quote_lookup(
+    quotes_by_vendor: dict[str, list[dict[str, Any]]],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Group vendor quotes by review ID for weakness/strength matching."""
+    lookup: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    for raw_vendor, quotes in (quotes_by_vendor or {}).items():
+        vendor = _canonicalize_vendor(raw_vendor or "")
+        if not vendor:
+            continue
+        bucket: dict[str, list[dict[str, Any]]] = {}
+        for item in quotes or []:
+            if not isinstance(item, dict):
+                continue
+            review_id = str(item.get("review_id") or "").strip()
+            if not review_id:
+                continue
+            bucket.setdefault(review_id, []).append(item)
+        for review_id, items in bucket.items():
+            items.sort(key=_battle_card_quote_sort_key, reverse=True)
+            bucket[review_id] = items
+        lookup[vendor] = bucket
+    return lookup
+
+
+def _build_evidence_vault_pass2_rollups(
+    review_rows: list[dict[str, Any]],
+    quotes_by_vendor: dict[str, list[dict[str, Any]]],
+    *,
+    recent_window_days: int,
+    today: date | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate review-level pass-2 rollups for the evidence vault."""
+    today = today or date.today()
+    recent_cutoff = today - timedelta(days=max(int(recent_window_days), 1))
+    prior_cutoff = recent_cutoff - timedelta(days=max(int(recent_window_days), 1))
+    supporting_limit = _evidence_vault_supporting_review_limit()
+    segment_limit = _evidence_vault_segment_limit()
+    role_limit = _evidence_vault_role_limit()
+
+    quote_lookup = _build_evidence_quote_lookup(quotes_by_vendor)
+    vendor_rollups: dict[str, dict[str, Any]] = {}
+
+    def _vendor_bucket(vendor: str) -> dict[str, Any]:
+        return vendor_rollups.setdefault(vendor, {
+            "reviews_in_recent_window": 0,
+            "_recent_review_ids": set(),
+            "weaknesses": {},
+            "strengths": {},
+        })
+
+    def _entry(bucket: dict[str, Any], evidence_type: str, key: str) -> dict[str, Any]:
+        return bucket.setdefault((evidence_type, key), {
+            "mention_count_recent": 0,
+            "_prior_count": 0,
+            "_urgency_sum": 0.0,
+            "_urgency_count": 0,
+            "_rating_sum": 0.0,
+            "_rating_count": 0,
+            "_segment_counts": {},
+            "_role_counts": {},
+            "_supporting_reviews": [],
+            "_supporting_seen": set(),
+            "best_quote": None,
+            "quote_source": None,
+            "phrase_verbatim": None,
+            "quote_origin": None,
+            "_best_quote_key": None,
+        })
+
+    def _update_entry(
+        item: dict[str, Any],
+        *,
+        is_recent: bool,
+        is_prior: bool,
+        review_id: str | None,
+        urgency: float,
+        rating_5: float | None,
+        segment: str | None,
+        role: str | None,
+        quote_item: dict[str, Any] | None,
+    ) -> None:
+        if is_recent:
+            item["mention_count_recent"] += 1
+        elif is_prior:
+            item["_prior_count"] += 1
+        item["_urgency_sum"] += urgency
+        item["_urgency_count"] += 1
+        if rating_5 is not None:
+            item["_rating_sum"] += rating_5
+            item["_rating_count"] += 1
+        if segment:
+            seg = item["_segment_counts"].setdefault(segment, {"count": 0, "recent_count": 0})
+            seg["count"] += 1
+            if is_recent:
+                seg["recent_count"] += 1
+        if role:
+            role_entry = item["_role_counts"].setdefault(role, {"count": 0, "recent_count": 0})
+            role_entry["count"] += 1
+            if is_recent:
+                role_entry["recent_count"] += 1
+        if review_id and review_id not in item["_supporting_seen"]:
+            item["_supporting_seen"].add(review_id)
+            item["_supporting_reviews"].append((urgency, review_id))
+        if quote_item:
+            quote_key = _battle_card_quote_sort_key(quote_item)
+            if item["_best_quote_key"] is None or quote_key > item["_best_quote_key"]:
+                item["_best_quote_key"] = quote_key
+                item["best_quote"] = quote_item.get("quote")
+                if quote_item.get("phrase_verbatim") is True:
+                    item["phrase_verbatim"] = True
+                    item["quote_origin"] = str(quote_item.get("quote_origin") or "review").strip() or "review"
+                else:
+                    item["phrase_verbatim"] = None
+                    item["quote_origin"] = None
+                item["quote_source"] = {
+                    "review_id": str(quote_item.get("review_id") or "") or None,
+                    "source": quote_item.get("source"),
+                    "company": quote_item.get("company"),
+                    "reviewer_title": quote_item.get("title"),
+                    "company_size": quote_item.get("company_size"),
+                    "industry": quote_item.get("industry"),
+                    "reviewed_at": _quote_reviewed_at_text(quote_item.get("reviewed_at")),
+                    "rating": float(quote_item["rating"]) if quote_item.get("rating") is not None else None,
+                }
+
+    for row in review_rows or []:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or row.get("vendor") or "")
+        if not vendor:
+            continue
+        vendor_bucket = _vendor_bucket(vendor)
+        review_id = str(row.get("review_id") or "").strip() or None
+        review_date = _evidence_rollup_review_date(row)
+        is_recent = bool(review_date and review_date >= recent_cutoff)
+        is_prior = bool(review_date and prior_cutoff <= review_date < recent_cutoff)
+        if review_id and is_recent and review_id not in vendor_bucket["_recent_review_ids"]:
+            vendor_bucket["_recent_review_ids"].add(review_id)
+            vendor_bucket["reviews_in_recent_window"] += 1
+
+        urgency = float(row.get("urgency") or 0.0)
+        rating = row.get("rating")
+        rating_max = row.get("rating_max")
+        rating_5 = None
+        if rating is not None and rating_max:
+            try:
+                rating_5 = round((float(rating) / float(rating_max)) * 5.0, 2)
+            except (TypeError, ValueError, ZeroDivisionError):
+                rating_5 = None
+
+        segment = str(row.get("company_size_raw") or "").strip() or None
+        role = str(row.get("reviewer_title") or row.get("role_level") or "").strip() or None
+        quote_item = None
+        if review_id:
+            quote_item = (quote_lookup.get(vendor, {}).get(review_id) or [None])[0]
+
+        pain_key = str(row.get("pain_category") or "").strip().lower()
+        if pain_key:
+            item = _entry(vendor_bucket["weaknesses"], "pain_category", pain_key)
+            _update_entry(
+                item,
+                is_recent=is_recent,
+                is_prior=is_prior,
+                review_id=review_id,
+                urgency=urgency,
+                rating_5=rating_5,
+                segment=segment,
+                role=role,
+                quote_item=quote_item,
+            )
+
+        feature_gaps = {
+            str(gap).strip() for gap in (_safe_json(row.get("feature_gaps"), default=[]) or [])
+            if str(gap).strip()
+        }
+        for raw_gap in feature_gaps:
+            key = _normalize_vault_feature_key(raw_gap)
+            if not key:
+                continue
+            item = _entry(vendor_bucket["weaknesses"], "feature_gap", key)
+            _update_entry(
+                item,
+                is_recent=is_recent,
+                is_prior=is_prior,
+                review_id=review_id,
+                urgency=urgency,
+                rating_5=rating_5,
+                segment=segment,
+                role=role,
+                quote_item=quote_item,
+            )
+
+        positive_aspects = {
+            str(aspect).strip() for aspect in (_safe_json(row.get("positive_aspects"), default=[]) or [])
+            if str(aspect).strip()
+        }
+        for raw_aspect in positive_aspects:
+            key = _normalize_vault_aspect_key(raw_aspect)
+            if not key:
+                continue
+            item = _entry(vendor_bucket["strengths"], "retention_signal", key)
+            _update_entry(
+                item,
+                is_recent=is_recent,
+                is_prior=is_prior,
+                review_id=review_id,
+                urgency=urgency,
+                rating_5=rating_5,
+                segment=segment,
+                role=role,
+                quote_item=quote_item,
+            )
+
+    for vendor, bucket in vendor_rollups.items():
+        bucket.pop("_recent_review_ids", None)
+        for section_name in ("weaknesses", "strengths"):
+            finalized: dict[tuple[str, str], dict[str, Any]] = {}
+            for section_key, item in bucket[section_name].items():
+                segments = sorted(
+                    item["_segment_counts"].items(),
+                    key=lambda entry: (-entry[1]["count"], -entry[1]["recent_count"], entry[0]),
+                )
+                roles = sorted(
+                    item["_role_counts"].items(),
+                    key=lambda entry: (-entry[1]["count"], -entry[1]["recent_count"], entry[0]),
+                )
+                supporting = sorted(
+                    item["_supporting_reviews"],
+                    key=lambda entry: (-entry[0], entry[1]),
+                )
+                metrics: dict[str, Any] = {}
+                if item["_urgency_count"]:
+                    metrics["avg_urgency_when_mentioned"] = round(
+                        item["_urgency_sum"] / item["_urgency_count"], 1,
+                    )
+                if item["_rating_count"]:
+                    metrics["avg_rating_when_mentioned"] = round(
+                        item["_rating_sum"] / item["_rating_count"], 2,
+                    )
+                finalized[section_key] = {
+                    "best_quote": item["best_quote"],
+                    "quote_source": item["quote_source"],
+                    "phrase_verbatim": item["phrase_verbatim"],
+                    "quote_origin": item["quote_origin"],
+                    "mention_count_recent": item["mention_count_recent"],
+                    "trend": _build_evidence_vault_trend(
+                        item["mention_count_recent"],
+                        item["_prior_count"],
+                    ),
+                    "affected_segments": [
+                        {
+                            "segment": segment,
+                            "count": counts["count"],
+                            "recent_count": counts["recent_count"],
+                        }
+                        for segment, counts in segments[:segment_limit]
+                    ] or None,
+                    "affected_roles": [
+                        {
+                            "role": role_name,
+                            "count": counts["count"],
+                            "recent_count": counts["recent_count"],
+                        }
+                        for role_name, counts in roles[:role_limit]
+                    ] or None,
+                    "supporting_metrics": metrics,
+                    "supporting_review_ids": [
+                        review_id for _, review_id in supporting[:supporting_limit]
+                    ],
+                }
+            bucket[section_name] = finalized
+    return vendor_rollups
+
+
+def _compute_company_signal_confidence(signal: dict[str, Any]) -> float:
+    """Compute the canonical confidence score for a company-signal row."""
+    source = str(signal.get("source") or "").strip()
+    source_dist = {source: 1} if source else {}
+    score = _compute_evidence_confidence(1, source_dist)
+    completeness = sum(
+        1
+        for field in (
+            signal.get("decision_maker"),
+            signal.get("buying_stage"),
+            signal.get("seat_count"),
+        )
+        if field is not None
+    )
+    identity_fields = sum(
+        1
+        for field in (
+            signal.get("reviewer_title"),
+            signal.get("company_size"),
+            signal.get("industry"),
+            signal.get("company_domain"),
+        )
+        if str(field or "").strip()
+    )
+    field_bonus = float(
+        getattr(settings.b2b_churn, "company_signal_identity_field_bonus", 0.03),
+    )
+    field_bonus_cap = float(
+        getattr(settings.b2b_churn, "company_signal_identity_field_bonus_cap", 0.12),
+    )
+    identity_bonus = min(field_bonus_cap, identity_fields * field_bonus)
+    identity_bonus += _company_signal_effective_source_identity_bonus(signal)
+    if str(signal.get("resolution_confidence") or "").strip().lower() in {"high", "medium"}:
+        identity_bonus += field_bonus
+    return round(min(score + completeness * 0.05 + identity_bonus, 1.0), 2)
+
+
+def _merge_canonical_company_signals(
+    current_high_intent: list[dict[str, Any]],
+    persisted_lookup: dict[str, list[dict[str, Any]]] | None,
+    *,
+    as_of: datetime | None = None,
+    blocked_names_by_vendor: dict[str, set[str]] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Merge current high-intent rows with canonical persisted company signals."""
+    as_of = as_of or datetime.now(timezone.utc)
+    merged: dict[str, dict[str, dict[str, Any]]] = {}
+
+    def _signal_rank(signal: dict[str, Any]) -> tuple[float, float, int, int, int]:
+        urgency = signal.get("urgency_score")
+        if urgency is None:
+            urgency = signal.get("urgency")
+        try:
+            urgency_value = float(urgency) if urgency is not None else 0.0
+        except (TypeError, ValueError):
+            urgency_value = 0.0
+        confidence = signal.get("confidence_score")
+        if confidence is None:
+            confidence_value = _compute_company_signal_confidence(signal)
+        else:
+            try:
+                confidence_value = float(confidence)
+            except (TypeError, ValueError):
+                confidence_value = 0.0
+        return (
+            urgency_value,
+            confidence_value,
+            _company_signal_effective_source_identity_bonus(signal),
+            1 if signal.get("decision_maker") else 0,
+            1 if signal.get("review_id") else 0,
+            1 if signal.get("buying_stage") else 0,
+        )
+
+    def _merge_record_list(primary: Any, secondary: Any, *, quote_mode: bool = False) -> list[Any]:
+        merged_items: list[Any] = []
+        seen_keys: set[str] = set()
+        for source in (primary, secondary):
+            if not isinstance(source, list):
+                continue
+            for item in source:
+                if quote_mode:
+                    text = _quote_text(item) if isinstance(item, dict) else str(item or "").strip()
+                    key = text.lower()
+                else:
+                    name = item.get("name") if isinstance(item, dict) else item
+                    key = normalize_company_name(name) or str(name or "").strip().lower()
+                if not key or key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                merged_items.append(item)
+        return merged_items
+
+    for vendor, items in (persisted_lookup or {}).items():
+        vendor_bucket = merged.setdefault(vendor, {})
+        base_blocked_names = (blocked_names_by_vendor or {}).get(vendor) or set()
+        for item in items or []:
+            company_name = normalize_company_name(item.get("company_name") or "")
+            if not company_name:
+                continue
+            blocked_names = set(base_blocked_names)
+            blocked_names.update(
+                normalize_company_name(name)
+                for name in _extract_alternative_names(item.get("alternatives") or [])
+                if normalize_company_name(name)
+            )
+            if not _company_signal_name_is_eligible(
+                item.get("company_name"),
+                current_vendor=vendor,
+                blocked_names=blocked_names,
+            ):
+                continue
+            current = dict(item)
+            current["company_name"] = company_name
+            current["_merge_rank"] = _signal_rank(current)
+            vendor_bucket[company_name] = current
+
+    for hi in current_high_intent or []:
+        vendor = _canonicalize_vendor(hi.get("vendor") or hi.get("vendor_name") or "")
+        company_name = normalize_company_name(hi.get("company") or hi.get("company_name") or "")
+        if not vendor or not company_name:
+            continue
+        blocked_names = set((blocked_names_by_vendor or {}).get(vendor) or set())
+        blocked_names.update(
+            normalize_company_name(name)
+            for name in _extract_alternative_names(hi.get("alternatives") or [])
+            if normalize_company_name(name)
+        )
+        if not _company_signal_name_is_eligible(
+            hi.get("company") or hi.get("company_name"),
+            current_vendor=vendor,
+            blocked_names=blocked_names,
+        ):
+            continue
+        vendor_bucket = merged.setdefault(vendor, {})
+        existing = vendor_bucket.get(company_name, {})
+        current_confidence = _compute_company_signal_confidence(hi)
+        current_rank = _signal_rank({
+            "urgency_score": hi.get("urgency_score"),
+            "urgency": hi.get("urgency"),
+            "confidence_score": current_confidence,
+            "decision_maker": hi.get("decision_maker"),
+            "review_id": hi.get("review_id"),
+            "buying_stage": hi.get("buying_stage"),
+        })
+        existing_rank = existing.get("_merge_rank") or (0.0, 0.0, 0, 0, 0)
+        field_source = hi if current_rank >= existing_rank else existing
+        fallback_source = existing if field_source is hi else hi
+        now_text = as_of.isoformat()
+        urgency_score = hi.get("urgency")
+        if urgency_score is None:
+            urgency_score = hi.get("urgency_score")
+        existing_urgency = existing.get("urgency_score")
+        if existing_urgency is None:
+            merged_urgency = urgency_score
+        elif urgency_score is None:
+            merged_urgency = existing_urgency
+        else:
+            merged_urgency = max(float(existing_urgency), float(urgency_score))
+        vendor_bucket[company_name] = {
+            "company_name": company_name,
+            "vendor_name": vendor,
+            "urgency_score": float(merged_urgency) if merged_urgency is not None else None,
+            "pain_category": (
+                field_source.get("pain")
+                or field_source.get("pain_category")
+                or fallback_source.get("pain")
+                or fallback_source.get("pain_category")
+            ),
+            "buyer_role": (
+                field_source.get("role_level")
+                or field_source.get("buyer_role")
+                or fallback_source.get("role_level")
+                or fallback_source.get("buyer_role")
+            ),
+            "decision_maker": (
+                field_source.get("decision_maker")
+                if field_source.get("decision_maker") is not None
+                else fallback_source.get("decision_maker")
+            ),
+            "seat_count": (
+                field_source.get("seat_count")
+                if field_source.get("seat_count") is not None
+                else fallback_source.get("seat_count")
+            ),
+            "contract_end": (
+                str(field_source.get("contract_end") or "")
+                or str(fallback_source.get("contract_end") or "")
+                or None
+            ),
+            "buying_stage": field_source.get("buying_stage") or fallback_source.get("buying_stage"),
+            "review_id": (
+                str(field_source.get("review_id") or "")
+                or str(fallback_source.get("review_id") or "")
+                or None
+            ),
+            "title": field_source.get("title") or fallback_source.get("title"),
+            "company_size": field_source.get("company_size") or fallback_source.get("company_size"),
+            "industry": field_source.get("industry") or fallback_source.get("industry"),
+            "source": field_source.get("source") or fallback_source.get("source"),
+            "confidence_score": max(
+                float(existing.get("confidence_score") or 0),
+                current_confidence,
+            ),
+            "first_seen_at": existing.get("first_seen_at") or now_text,
+            "last_seen_at": now_text,
+            "alternatives": _merge_record_list(
+                field_source.get("alternatives"),
+                fallback_source.get("alternatives"),
+            ),
+            "quotes": _merge_record_list(
+                field_source.get("quotes"),
+                fallback_source.get("quotes"),
+                quote_mode=True,
+            ),
+            "_merge_rank": max(existing_rank, current_rank),
+        }
+
+    result: dict[str, list[dict[str, Any]]] = {}
+    for vendor, items in merged.items():
+        ordered = sorted(
+            items.values(),
+            key=lambda item: (
+                -(float(item.get("urgency_score") or 0)),
+                -(float(item.get("confidence_score") or 0)),
+                str(item.get("company_name") or ""),
+            ),
+        )
+        cleaned: list[dict[str, Any]] = []
+        for item in ordered:
+            current = dict(item)
+            current.pop("_merge_rank", None)
+            cleaned.append(current)
+        result[vendor] = cleaned
+    return result
+
+
+# ------------------------------------------------------------------
+# Layer 4: deterministic builders (depend on all above)
+# ------------------------------------------------------------------
+
+
+_EVIDENCE_VAULT_SCHEMA_VERSION = "v1"
+
+_WEAKNESS_CORRELATION_MIN_OVERLAP = 0.3
+_WEAKNESS_CORRELATION_MIN_SHARED = 3
+
+
+def _correlate_weakness_clusters(
+    weakness_evidence: list[dict[str, Any]],
+    *,
+    min_overlap_ratio: float = _WEAKNESS_CORRELATION_MIN_OVERLAP,
+    min_shared_reviews: int = _WEAKNESS_CORRELATION_MIN_SHARED,
+) -> None:
+    """Detect co-mentioned weaknesses and annotate correlation metadata.
+
+    Two weaknesses are correlated when they share a meaningful fraction of
+    their supporting reviews -- indicating a common root cause.  For example,
+    "poor support" and "slow response times" often co-occur in the same
+    reviews, so they should be treated as one amplified signal rather than
+    two independent items.
+
+    Mutates *weakness_evidence* in place: adds ``correlated_with`` (list of
+    related keys) and ``correlation_bonus`` (float added to confidence).
+    """
+    if len(weakness_evidence) < 2:
+        return
+
+    # Build review-ID sets per weakness (index-keyed for speed)
+    id_sets: list[set[str]] = []
+    for w in weakness_evidence:
+        ids = w.get("supporting_review_ids") or []
+        id_sets.append({str(rid) for rid in ids if rid})
+
+    n = len(weakness_evidence)
+
+    # Pairwise overlap check
+    edges: list[tuple[int, int, float]] = []
+    for i in range(n):
+        if not id_sets[i]:
+            continue
+        for j in range(i + 1, n):
+            if not id_sets[j]:
+                continue
+            shared = id_sets[i] & id_sets[j]
+            if len(shared) < min_shared_reviews:
+                continue
+            smaller = min(len(id_sets[i]), len(id_sets[j])) or 1
+            ratio = len(shared) / smaller
+            if ratio >= min_overlap_ratio:
+                edges.append((i, j, ratio))
+
+    if not edges:
+        return
+
+    # Union-find to group into clusters
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for i, j, _ in edges:
+        union(i, j)
+
+    # Build cluster membership
+    clusters: dict[int, list[int]] = {}
+    for idx in range(n):
+        root = find(idx)
+        clusters.setdefault(root, []).append(idx)
+
+    # Annotate each weakness with its cluster peers
+    for members in clusters.values():
+        if len(members) < 2:
+            continue
+        member_keys = [weakness_evidence[m]["key"] for m in members]
+        combined_ids: set[str] = set()
+        for m in members:
+            combined_ids |= id_sets[m]
+        for m in members:
+            own_key = weakness_evidence[m]["key"]
+            peers = [k for k in member_keys if k != own_key]
+            weakness_evidence[m]["correlated_with"] = peers
+            weakness_evidence[m]["cluster_review_count"] = len(combined_ids)
+            weakness_evidence[m]["correlation_bonus"] = round(
+                min(0.1, 0.05 * (len(members) - 1)), 2,
+            )
+
+
+def build_evidence_vault(
+    vendor_name: str,
+    vs: dict[str, Any],
+    *,
+    pain_entries: list[dict],
+    feature_gap_entries: list[dict],
+    quotes: list[dict],
+    positive_entries: list[dict],
+    product_profile: dict | None = None,
+    keyword_spikes: dict | None = None,
+    company_signals: list[dict],
+    provenance: dict | None = None,
+    data_context: dict | None = None,
+    pass2_rollups: dict[str, Any] | None = None,
+    dm_rate: float | None = None,
+    price_rate: float | None = None,
+    product_category: str | None = None,
+    blocked_names: set[str] | None = None,
+    analysis_window_days: int = 90,
+    recent_window_days: int = 30,
+) -> dict[str, Any]:
+    """Build a canonical evidence vault object for a single vendor.
+
+    Pass 2 populates review-level recency, trend, per-weakness quote matching,
+    affected segments, affected roles, supporting review IDs, and recent-review
+    counts when direct review evidence is available.
+    """
+    from datetime import date
+
+    as_of = date.today().isoformat()
+    pass2 = pass2_rollups or {}
+    weakness_rollups = pass2.get("weaknesses") if isinstance(pass2.get("weaknesses"), dict) else {}
+    strength_rollups = pass2.get("strengths") if isinstance(pass2.get("strengths"), dict) else {}
+
+    # --- Weakness evidence ---
+    weakness_evidence: list[dict] = []
+    _seen_keys: set[str] = set()
+
+    def _rollup_quote_metadata(rollup: dict[str, Any]) -> dict[str, Any]:
+        if rollup.get("phrase_verbatim") is not True:
+            return {"phrase_verbatim": None, "quote_origin": None}
+        origin = str(rollup.get("quote_origin") or "review").strip() or "review"
+        return {"phrase_verbatim": True, "quote_origin": origin}
+
+    def _apply_quote_metadata(target: dict[str, Any], quote: dict[str, Any]) -> None:
+        if quote.get("phrase_verbatim") is not True:
+            return
+        target["phrase_verbatim"] = True
+        target["quote_origin"] = str(quote.get("quote_origin") or "review").strip() or "review"
+
+    # 1. Pain categories
+    for p in pain_entries:
+        key = str(p.get("category") or p.get("pain") or "").lower().strip()
+        if not key or key in _seen_keys:
+            continue
+        _seen_keys.add(key)
+        label = key.replace("_", " ").title()
+        rollup = weakness_rollups.get(("pain_category", key), {})
+        metrics = {"avg_urgency": p.get("avg_urgency")}
+        metrics.update(rollup.get("supporting_metrics") or {})
+        weakness_evidence.append({
+            "key": key,
+            "label": label,
+            "evidence_type": "pain_category",
+            "best_quote": rollup.get("best_quote"),
+            "quote_source": rollup.get("quote_source"),
+            **_rollup_quote_metadata(rollup),
+            "mention_count_total": p.get("complaint_count") or p.get("count") or 0,
+            "mention_count_recent": rollup.get("mention_count_recent"),
+            "trend": rollup.get("trend"),
+            "affected_segments": rollup.get("affected_segments"),
+            "affected_roles": rollup.get("affected_roles"),
+            "supporting_metrics": metrics,
+            "supporting_review_ids": rollup.get("supporting_review_ids") or [],
+            "confidence_score": None,
+        })
+
+    # 2. Feature gaps
+    for fg in feature_gap_entries:
+        raw = str(fg.get("feature_gap") or fg.get("feature") or "").strip()
+        if not raw:
+            continue
+        key = _normalize_vault_feature_key(raw)
+        if key in _seen_keys:
+            continue
+        _seen_keys.add(key)
+        rollup = weakness_rollups.get(("feature_gap", key), {})
+        weakness_evidence.append({
+            "key": key,
+            "label": raw,
+            "evidence_type": "feature_gap",
+            "best_quote": rollup.get("best_quote"),
+            "quote_source": rollup.get("quote_source"),
+            **_rollup_quote_metadata(rollup),
+            "mention_count_total": fg.get("mentions") or 0,
+            "mention_count_recent": rollup.get("mention_count_recent"),
+            "trend": rollup.get("trend"),
+            "affected_segments": rollup.get("affected_segments"),
+            "affected_roles": rollup.get("affected_roles"),
+            "supporting_metrics": rollup.get("supporting_metrics") or {},
+            "supporting_review_ids": rollup.get("supporting_review_ids") or [],
+            "confidence_score": None,
+        })
+
+    # 3. Product profile weaknesses
+    if product_profile:
+        pp_weaknesses = _safe_json(product_profile.get("weaknesses"), default=[])
+        for w in pp_weaknesses:
+            if isinstance(w, str):
+                area = w.lower().strip()
+                score = None
+                evidence_count = 0
+            elif isinstance(w, dict):
+                area = str(w.get("area") or "").lower().strip()
+                score = w.get("score")
+                evidence_count = w.get("evidence_count") or 0
+            else:
+                continue
+            if not area or area in _seen_keys:
+                continue
+            _seen_keys.add(area)
+            rollup = weakness_rollups.get(("satisfaction_area", area), {})
+            metrics = {"satisfaction_score": score}
+            metrics.update(rollup.get("supporting_metrics") or {})
+            weakness_evidence.append({
+                "key": area,
+                "label": area.replace("_", " ").title(),
+                "evidence_type": "satisfaction_area",
+                "best_quote": rollup.get("best_quote"),
+                "quote_source": rollup.get("quote_source"),
+                **_rollup_quote_metadata(rollup),
+                "mention_count_total": evidence_count,
+                "mention_count_recent": rollup.get("mention_count_recent"),
+                "trend": rollup.get("trend"),
+                "affected_segments": rollup.get("affected_segments"),
+                "affected_roles": rollup.get("affected_roles"),
+                "supporting_metrics": metrics,
+                "supporting_review_ids": rollup.get("supporting_review_ids") or [],
+                "confidence_score": None,
+            })
+
+    # Sort weaknesses by composite signal: mention count + urgency weight.
+    # This prevents a high-urgency weakness with fewer mentions from being
+    # buried below a low-urgency weakness with more mentions.
+    def _weakness_sort_key(w: dict) -> float:
+        mc = float(w.get("mention_count_total") or 0)
+        sm = w.get("supporting_metrics") if isinstance(w.get("supporting_metrics"), dict) else {}
+        urg = float(sm.get("avg_urgency_when_mentioned") or sm.get("avg_urgency") or 0)
+        # Normalize urgency (0-10) to a 0-1 scale and weight it at 30% of
+        # the sort signal so urgency influences order without dominating.
+        return mc + (min(urg, 10.0) / 10.0) * max(mc, 1) * 0.3
+
+    weakness_evidence.sort(key=_weakness_sort_key, reverse=True)
+
+    # Detect co-mentioned weaknesses (shared root cause clustering)
+    _correlate_weakness_clusters(weakness_evidence)
+
+    # Derive pass-1 confidence: mention share + type + volume + correlation
+    # + recency + urgency bonuses
+    total_mentions = sum(w["mention_count_total"] or 0 for w in weakness_evidence) or 1
+    for w in weakness_evidence:
+        mc = w["mention_count_total"] or 0
+        share = mc / total_mentions
+        type_bonus = 0.1 if w["evidence_type"] == "pain_category" else 0.0
+        volume_bonus = 0.1 if mc >= 10 else 0.0
+        corr_bonus = float(w.get("correlation_bonus") or 0)
+        trend = w.get("trend") if isinstance(w.get("trend"), dict) else {}
+        direction = str(trend.get("direction") or "").strip()
+        if direction == "accelerating":
+            recency_bonus = 0.1
+        elif direction == "new":
+            recency_bonus = 0.1
+        elif direction == "declining":
+            recency_bonus = -0.05
+        else:
+            recency_bonus = 0.0
+        sm = w.get("supporting_metrics") if isinstance(w.get("supporting_metrics"), dict) else {}
+        urg = float(sm.get("avg_urgency_when_mentioned") or sm.get("avg_urgency") or 0)
+        urgency_bonus = 0.1 if urg >= 7.0 else (0.05 if urg >= 4.5 else 0.0)
+        w["confidence_score"] = round(min(0.95, max(0.0, share + type_bonus + volume_bonus + corr_bonus + recency_bonus + urgency_bonus)), 2)
+
+    # Fallback: assign vendor quotes to weaknesses that lack a best_quote
+    # from pass-2 review evidence.  Uses keyword matching to pair each quote
+    # to the weakness it is most relevant to, instead of blindly assigning
+    # the first quote to the top weakness.
+    if weakness_evidence and quotes:
+        unquoted = [w for w in weakness_evidence if not w.get("best_quote")]
+        if unquoted:
+            used_quote_ids: set[str] = set()
+            for w in unquoted:
+                wkey = str(w.get("key") or w.get("label") or "").lower()
+                wlabel = str(w.get("label") or w.get("key") or "").lower()
+                w_tokens = set(wkey.replace("_", " ").split()) | set(wlabel.replace("_", " ").split())
+                best_match = None
+                best_overlap = 0
+                for q in quotes:
+                    qid = str(q.get("review_id") or id(q))
+                    if qid in used_quote_ids:
+                        continue
+                    qtext = str(q.get("quote") or "").lower()
+                    overlap = sum(1 for t in w_tokens if len(t) >= 3 and t in qtext)
+                    if overlap > best_overlap:
+                        best_overlap = overlap
+                        best_match = q
+                        best_match_id = qid
+                if best_match and best_overlap > 0:
+                    used_quote_ids.add(best_match_id)
+                    w["best_quote"] = best_match.get("quote")
+                    _apply_quote_metadata(w, best_match)
+                    w["quote_source"] = {
+                        "review_id": str(best_match.get("review_id") or ""),
+                        "source": best_match.get("source"),
+                        "company": best_match.get("company"),
+                        "reviewer_title": best_match.get("title"),
+                        "company_size": best_match.get("company_size"),
+                        "industry": best_match.get("industry"),
+                        "reviewed_at": _quote_reviewed_at_text(best_match.get("reviewed_at")),
+                        "rating": float(best_match["rating"]) if best_match.get("rating") is not None else None,
+                    }
+            # Last resort: if no keyword match found for the top weakness,
+            # assign the first unused quote so the vault is never quote-less
+            if not weakness_evidence[0].get("best_quote") and quotes:
+                for q in quotes:
+                    qid = str(q.get("review_id") or id(q))
+                    if qid not in used_quote_ids:
+                        weakness_evidence[0]["best_quote"] = q.get("quote")
+                        _apply_quote_metadata(weakness_evidence[0], q)
+                        weakness_evidence[0]["quote_source"] = {
+                            "review_id": str(q.get("review_id") or ""),
+                            "source": q.get("source"),
+                            "company": q.get("company"),
+                            "reviewer_title": q.get("title"),
+                            "company_size": q.get("company_size"),
+                            "industry": q.get("industry"),
+                            "reviewed_at": _quote_reviewed_at_text(q.get("reviewed_at")),
+                            "rating": float(q["rating"]) if q.get("rating") is not None else None,
+                        }
+                        break
+
+    # --- Strength evidence ---
+    strength_evidence: list[dict] = []
+    _seen_strengths: set[str] = set()
+
+    # 1. Positive aspects
+    for pa in positive_entries:
+        aspect = str(pa.get("aspect") or "").lower().strip()
+        if not aspect or aspect in _seen_strengths:
+            continue
+        _seen_strengths.add(aspect)
+        rollup = strength_rollups.get(("retention_signal", aspect), {})
+        strength_evidence.append({
+            "key": aspect,
+            "label": aspect.replace("_", " ").title(),
+            "evidence_type": "retention_signal",
+            "best_quote": rollup.get("best_quote"),
+            "quote_source": rollup.get("quote_source"),
+            **_rollup_quote_metadata(rollup),
+            "mention_count_total": pa.get("mentions") or 0,
+            "mention_count_recent": rollup.get("mention_count_recent"),
+            "trend": rollup.get("trend"),
+            "affected_segments": rollup.get("affected_segments"),
+            "affected_roles": rollup.get("affected_roles"),
+            "supporting_metrics": rollup.get("supporting_metrics") or {},
+            "supporting_review_ids": rollup.get("supporting_review_ids") or [],
+            "confidence_score": None,
+        })
+
+    # 2. Product profile strengths
+    if product_profile:
+        pp_strengths = _safe_json(product_profile.get("strengths"), default=[])
+        for s in pp_strengths:
+            if isinstance(s, str):
+                area = s.lower().strip()
+                score = None
+                evidence_count = 0
+            elif isinstance(s, dict):
+                area = str(s.get("area") or "").lower().strip()
+                score = s.get("score")
+                evidence_count = s.get("evidence_count") or 0
+            else:
+                continue
+            if not area or area in _seen_strengths:
+                continue
+            _seen_strengths.add(area)
+            rollup = strength_rollups.get(("satisfaction_area", area), {})
+            metrics = {"satisfaction_score": score}
+            metrics.update(rollup.get("supporting_metrics") or {})
+            strength_evidence.append({
+                "key": area,
+                "label": area.replace("_", " ").title(),
+                "evidence_type": "satisfaction_area",
+                "best_quote": rollup.get("best_quote"),
+                "quote_source": rollup.get("quote_source"),
+                **_rollup_quote_metadata(rollup),
+                "mention_count_total": evidence_count,
+                "mention_count_recent": rollup.get("mention_count_recent"),
+                "trend": rollup.get("trend"),
+                "affected_segments": rollup.get("affected_segments"),
+                "affected_roles": rollup.get("affected_roles"),
+                "supporting_metrics": metrics,
+                "supporting_review_ids": rollup.get("supporting_review_ids") or [],
+                "confidence_score": None,
+            })
+
+    strength_evidence.sort(key=lambda s: s["mention_count_total"] or 0, reverse=True)
+
+    # Derive pass-1 confidence for strengths
+    total_str_mentions = sum(s["mention_count_total"] or 0 for s in strength_evidence) or 1
+    for s in strength_evidence:
+        mc = s["mention_count_total"] or 0
+        share = mc / total_str_mentions
+        s["confidence_score"] = round(min(0.95, share + (0.1 if mc >= 10 else 0.0)), 2)
+
+    # --- Metric snapshot ---
+    def _sf(v: Any) -> float | None:
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    kw = keyword_spikes or {}
+    metric_snapshot = {
+        "snapshot_date": as_of,
+        "total_reviews": vs.get("total_reviews") or 0,
+        "reviews_in_analysis_window": vs.get("total_reviews") or 0,
+        "reviews_in_recent_window": int(pass2.get("reviews_in_recent_window") or 0),
+        "churn_density": _sf(vs.get("churn_density")),
+        "avg_urgency": _sf(vs.get("avg_urgency")),
+        "recommend_yes": vs.get("recommend_yes") or 0,
+        "recommend_no": vs.get("recommend_no") or 0,
+        "recommend_ratio": _sf(vs.get("recommend_ratio")) or (
+            round((vs.get("recommend_yes") or 0) / max((vs.get("recommend_yes") or 0) + (vs.get("recommend_no") or 0), 1), 2)
+        ),
+        "price_complaint_rate": _sf(price_rate),
+        "dm_churn_rate": _sf(dm_rate),
+        "positive_review_pct": _sf(vs.get("positive_review_pct")),
+        "displacement_mention_count": vs.get("displacement_mention_count") or 0,
+        "keyword_spike_count": kw.get("spike_count") or 0,
+        # v2 indicator-based signal counts
+        "indicator_counts": {
+            "cancel": vs.get("indicator_cancel_count") or 0,
+            "migration": vs.get("indicator_migration_count") or 0,
+            "evaluation": vs.get("indicator_evaluation_count") or 0,
+            "completed_switch": vs.get("indicator_switch_count") or 0,
+            "named_alternative": vs.get("indicator_named_alt_count") or 0,
+            "decision_maker_language": vs.get("indicator_dm_language_count") or 0,
+        },
+        "has_pricing_phrases_count": vs.get("has_pricing_phrases_count") or 0,
+        "has_recommendation_language_count": vs.get("has_recommendation_language_count") or 0,
+    }
+
+    # --- Company signals (pre-filtered for this vendor) ---
+    cs_out: list[dict] = []
+    for cs in company_signals:
+        company_name = cs.get("company") or cs.get("company_name") or ""
+        if _company_signal_exclusion_reason(
+            company_name,
+            current_vendor=vendor_name,
+            blocked_names=blocked_names,
+            source=cs.get("source"),
+            confidence_score=cs.get("confidence_score"),
+        ):
+            continue
+        cs_out.append({
+            "company_name": company_name,
+            "signal_type": "churning",
+            "urgency_score": _sf(cs.get("urgency") or cs.get("urgency_score")),
+            "pain_category": cs.get("pain") or cs.get("pain_category"),
+            "buyer_role": cs.get("role_level") or cs.get("buyer_role"),
+            "decision_maker": cs.get("decision_maker"),
+            "seat_count": cs.get("seat_count"),
+            "contract_end": str(cs.get("contract_end") or "") or None,
+            "buying_stage": cs.get("buying_stage"),
+            "review_id": str(cs.get("review_id") or ""),
+            "source": cs.get("source"),
+            "confidence_score": _sf(cs.get("confidence_score")),
+            "first_seen_at": str(cs.get("first_seen_at") or "") or None,
+            "last_seen_at": str(cs.get("last_seen_at") or "") or None,
+        })
+
+    # --- Provenance ---
+    prov = provenance or {}
+    dc = data_context or {}
+    enrichment_period = dc.get("enrichment_period") or {}
+    provenance_out = {
+        "sources": list((prov.get("source_distribution") or {}).keys()),
+        "source_distribution": prov.get("source_distribution") or {},
+        "sample_review_ids": [str(rid) for rid in (prov.get("sample_review_ids") or [])[:5]],
+        "enrichment_window_start": str(prov.get("review_window_start") or enrichment_period.get("earliest") or ""),
+        "enrichment_window_end": str(prov.get("review_window_end") or enrichment_period.get("latest") or ""),
+    }
+
+    return {
+        "vendor_name": vendor_name,
+        "schema_version": _EVIDENCE_VAULT_SCHEMA_VERSION,
+        "as_of_date": as_of,
+        "analysis_window_days": analysis_window_days,
+        "recent_window_days": recent_window_days,
+        "product_category": product_category or "",
+        "weakness_evidence": weakness_evidence,
+        "strength_evidence": strength_evidence,
+        "company_signals": cs_out,
+        "metric_snapshot": metric_snapshot,
+        "provenance": provenance_out,
+    }
+
+
+_SEGMENT_INTELLIGENCE_SCHEMA_VERSION = "v1"
+_SEGMENT_ROLE_SCORES: dict[str, float] = {
+    "decision_maker": 20.0,
+    "economic_buyer": 15.0,
+    "champion": 15.0,
+    "evaluator": 10.0,
+    "end_user": 0.0,
+    "unknown": 0.0,
+}
+_SEGMENT_ROLE_SCORE_DIVISOR = 5.0
+
+
+def _segment_role_multiplier(role_type: Any) -> float:
+    role_name = str(role_type or "").strip() or "unknown"
+    role_score = _SEGMENT_ROLE_SCORES.get(role_name, 0.0)
+    return max(1.0, role_score / _SEGMENT_ROLE_SCORE_DIVISOR)
+
+
+def _segment_role_priority_score(role_type: Any, count: Any) -> float:
+    try:
+        raw_count = float(count or 0)
+    except (TypeError, ValueError):
+        raw_count = 0.0
+    return raw_count * _segment_role_multiplier(role_type)
+
+
+def _segment_role_count_value(count: Any) -> float:
+    try:
+        return float(count or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _sorted_segment_role_counts(role_types: dict[str, Any] | None) -> list[tuple[str, Any]]:
+    entries = list((role_types or {}).items())
+    return sorted(
+        entries,
+        key=lambda item: (
+            _segment_role_priority_score(item[0], item[1]),
+            _segment_role_count_value(item[1]),
+            _SEGMENT_ROLE_SCORES.get(str(item[0] or "").strip() or "unknown", 0.0),
+            str(item[0] or ""),
+        ),
+        reverse=True,
+    )
+
+
+def _known_buying_stage_counts(stage_counts: dict[str, Any] | None) -> dict[str, Any]:
+    """Prefer explicit buying stages over placeholder labels like 'unknown'."""
+    raw = stage_counts or {}
+    known: dict[str, Any] = {}
+    unknown_total = 0
+    for stage, count in raw.items():
+        stage_name = str(stage or "").strip() or "unknown"
+        if stage_name.lower() in {"unknown", "none", "null", "n/a", "na"}:
+            unknown_total += count or 0
+            continue
+        known[stage_name] = known.get(stage_name, 0) + (count or 0)
+    if known:
+        return known
+    if unknown_total:
+        return {"unknown": unknown_total}
+    return {}
+
+
+def _dominant_segment_role(role_types: dict[str, Any] | None) -> str:
+    ranked = _sorted_segment_role_counts(role_types)
+    if not ranked:
+        return "unknown"
+    return str(ranked[0][0] or "").strip() or "unknown"
+
+
+def build_segment_intelligence(
+    vendor_name: str,
+    *,
+    buyer_auth: dict | None = None,
+    department_entries: list[dict] | None = None,
+    company_size_entries: list[dict] | None = None,
+    budget: dict | None = None,
+    dm_rate: float | None = None,
+    contract_value_entries: list[dict] | None = None,
+    usage_duration_entries: list[dict] | None = None,
+    use_case_entries: list[dict] | None = None,
+    role_churn: dict[str, dict[str, Any]] | None = None,
+    vendor_lock_in_level: str | None = None,
+    analysis_window_days: int = 90,
+) -> dict[str, Any]:
+    """Build a canonical segment intelligence object for a single vendor.
+
+    Pass 1: populates affected_roles, departments, company sizes, budget
+    pressure, contract/duration segments, and top use cases under pressure.
+    Fields requiring cross-joins or LLM synthesis are set to null.
+    """
+    from datetime import date
+
+    as_of = date.today().isoformat()
+    ba = buyer_auth or {}
+    bg = budget or {}
+
+    def _sf(v: Any) -> float | None:
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    # --- Affected roles (from buyer_auth_lookup) ---
+    affected_roles: list[dict] = []
+    role_types_raw = ba.get("role_types") or {}
+    known_role_types: dict[str, Any] = {}
+    unknown_role_count = 0
+    for role_type, count in role_types_raw.items():
+        role_name = str(role_type or "").strip() or "unknown"
+        if role_name.lower() in {"unknown", "none", "null", "n/a", "na"}:
+            unknown_role_count += count or 0
+            continue
+        known_role_types[role_name] = (
+            known_role_types.get(role_name, 0) + (count or 0)
+        )
+    if known_role_types:
+        role_types = known_role_types
+    elif unknown_role_count:
+        role_types = {"unknown": unknown_role_count}
+    else:
+        role_types = {}
+    buying_stages = _known_buying_stage_counts(ba.get("buying_stages") or {})
+    role_buying_stages = ba.get("role_buying_stages") or {}
+    for rt, count in _sorted_segment_role_counts(role_types):
+        top_stage = None
+        per_role_stages = _known_buying_stage_counts(role_buying_stages.get(rt) or {})
+        if per_role_stages:
+            top_stage = max(
+                per_role_stages.items(),
+                key=lambda item: (item[1], str(item[0] or "")),
+            )[0]
+        rc = (role_churn or {}).get(rt) or {}
+        affected_roles.append({
+            "role_type": rt,
+            "review_count": count,
+            "priority_score": round(_segment_role_priority_score(rt, count), 2),
+            "top_buying_stage": top_stage,
+            "churn_rate": _sf(rc.get("churn_rate")),
+            "top_pain": rc.get("top_pain") or None,
+        })
+    # Fill remaining gaps with the dominant global stage.
+    if affected_roles and buying_stages:
+        top_stage = max(buying_stages, key=buying_stages.get)
+        for role in affected_roles:
+            if not role.get("top_buying_stage"):
+                role["top_buying_stage"] = top_stage
+
+    # --- Affected departments ---
+    affected_departments: list[dict] = []
+    for d in (department_entries or []):
+        affected_departments.append({
+            "department": d.get("department", ""),
+            "review_count": d.get("review_count", 0),
+            "churn_rate": _sf(d.get("churn_rate")),
+            "avg_urgency": _sf(d.get("avg_urgency")),
+        })
+
+    size_distribution = [
+        {
+            "segment": entry.get("segment", ""),
+            "review_count": entry.get("review_count", 0),
+            "churn_rate": _sf(entry.get("churn_rate")),
+        }
+        for entry in (company_size_entries or [])
+        if entry.get("segment")
+    ]
+
+    # --- Company size signals ---
+    affected_company_sizes = {
+        "avg_seat_count": _sf(bg.get("avg_seat_count")),
+        "median_seat_count": _sf(bg.get("median_seat_count")),
+        "max_seat_count": _sf(bg.get("max_seat_count")),
+        "size_distribution": size_distribution or None,
+    }
+
+    # --- Budget pressure ---
+    budget_pressure = {
+        "price_increase_count": bg.get("price_increase_count") or 0,
+        "price_increase_rate": _sf(bg.get("price_increase_rate")),
+        "dm_churn_rate": _sf(dm_rate),
+        "annual_spend_signals": bg.get("annual_spend_signals") or [],
+        "price_per_seat_signals": bg.get("price_per_seat_signals") or [],
+    }
+
+    # --- Contract segments ---
+    contract_segments: list[dict] = []
+    for cv in (contract_value_entries or []):
+        contract_segments.append({
+            "segment": cv.get("segment", ""),
+            "count": cv.get("count", 0),
+            "churn_rate": _sf(cv.get("churn_rate")),
+        })
+
+    # --- Usage duration segments ---
+    usage_duration_segments: list[dict] = []
+    for ud in (usage_duration_entries or []):
+        usage_duration_segments.append({
+            "duration": ud.get("duration", ""),
+            "count": ud.get("count", 0),
+            "churn_rate": _sf(ud.get("churn_rate")),
+        })
+
+    # --- Top use cases under pressure ---
+    _lock_in = vendor_lock_in_level or None
+    top_use_cases: list[dict] = []
+    for uc in (use_case_entries or [])[:10]:
+        top_use_cases.append({
+            "use_case": uc.get("module") or uc.get("use_case_name") or uc.get("use_case", ""),
+            "mention_count": uc.get("mentions") or uc.get("mention_count", 0),
+            "lock_in_level": _lock_in,
+            "confidence_score": _sf(uc.get("confidence_score")),
+        })
+
+    # --- Buying stage distribution ---
+    buying_stage_distribution: list[dict] = []
+    for stage, count in sorted(buying_stages.items(), key=lambda x: -x[1]):
+        buying_stage_distribution.append({
+            "stage": stage,
+            "count": count,
+        })
+
+    return {
+        "vendor_name": vendor_name,
+        "schema_version": _SEGMENT_INTELLIGENCE_SCHEMA_VERSION,
+        "as_of_date": as_of,
+        "analysis_window_days": analysis_window_days,
+        "affected_roles": affected_roles,
+        "affected_departments": affected_departments,
+        "affected_company_sizes": affected_company_sizes,
+        "budget_pressure": budget_pressure,
+        "contract_segments": contract_segments,
+        "usage_duration_segments": usage_duration_segments,
+        "top_use_cases_under_pressure": top_use_cases,
+        "buying_stage_distribution": buying_stage_distribution,
+        "best_fit_challenger_segments": None,
+    }
+
+
+_TEMPORAL_INTELLIGENCE_SCHEMA_VERSION = "v1"
+
+
+def build_temporal_intelligence(
+    vendor_name: str,
+    *,
+    timeline_entries: list[dict] | None = None,
+    keyword_spikes: dict | None = None,
+    sentiment: dict | None = None,
+    sentiment_tenure: list[dict[str, Any]] | None = None,
+    turning_points: list[dict[str, Any]] | None = None,
+    analysis_window_days: int = 90,
+) -> dict[str, Any]:
+    """Build a canonical temporal intelligence object for a single vendor.
+
+    Pass 1: populates evaluation deadlines, keyword spikes, sentiment
+    trajectory, and timeline signal counts.  Structured trend per-weakness
+    and acceleration metrics are deferred to pass 2.
+    """
+    from datetime import date
+
+    as_of = date.today().isoformat()
+    kw = keyword_spikes or {}
+    sent = sentiment or {}
+
+    # --- Active evaluation deadlines (processed from raw timeline) ---
+    eval_deadlines = _build_active_evaluation_deadlines(
+        timeline_entries or [],
+        limit=10,
+    )
+
+    # --- Immediate triggers (entries with concrete dates) ---
+    immediate_triggers: list[dict] = []
+    for ed in eval_deadlines:
+        if ed.get("evaluation_deadline") or ed.get("contract_end"):
+            immediate_triggers.append({
+                "company": ed.get("company"),
+                "trigger_type": ed.get("trigger_type", "unknown"),
+                "date": ed.get("evaluation_deadline") or ed.get("contract_end"),
+                "urgency": ed.get("urgency", 0),
+                "title": ed.get("title"),
+                "company_size": ed.get("company_size"),
+            })
+
+    # --- Keyword spike details ---
+    spike_keywords: list[dict] = []
+    trend_summary = kw.get("trend_summary") or {}
+    if isinstance(trend_summary, str):
+        trend_summary = _safe_json(trend_summary) or {}
+    if not isinstance(trend_summary, dict):
+        trend_summary = {}
+    for keyword, detail in trend_summary.items():
+        if isinstance(detail, dict):
+            spike_keywords.append({
+                "keyword": keyword,
+                "volume": detail.get("volume", 0),
+                "change_pct": detail.get("change_pct", 0),
+                "is_spike": bool(detail.get("is_spike")),
+            })
+    spike_keywords.sort(
+        key=lambda x: abs(x.get("change_pct") or 0), reverse=True,
+    )
+
+    # --- Sentiment trajectory ---
+    total_sentiment = sum(sent.values()) or 1
+    sentiment_trajectory = {
+        "declining": sent.get("declining", 0),
+        "stable": sent.get("stable", 0),
+        "improving": sent.get("improving", 0),
+        "total": sum(sent.values()),
+        "declining_pct": round(
+            sent.get("declining", 0) / total_sentiment, 2,
+        ),
+        "improving_pct": round(
+            sent.get("improving", 0) / total_sentiment, 2,
+        ),
+    }
+
+    # --- Timeline signal summary ---
+    raw_entries = timeline_entries or []
+    contract_end_count = sum(
+        1 for e in raw_entries if e.get("contract_end")
+    )
+    eval_deadline_count = sum(
+        1 for e in raw_entries if e.get("evaluation_deadline")
+    )
+    # Renewal signals: contract_end dates within the analysis window
+    _renewal_horizon = analysis_window_days
+    _today = date.today()
+    renewal_count = 0
+    for e in raw_entries:
+        ce = _parse_timeline_date(e.get("contract_end"))
+        if ce is not None and _today <= ce <= _today + timedelta(days=_renewal_horizon):
+            renewal_count += 1
+    # Budget cycle signals: decision_timeline mentions of budget/planning terms
+    _budget_terms = ("budget", "planning", "fiscal", "annual review", "quarterly review")
+    budget_cycle_count = sum(
+        1 for e in raw_entries
+        if any(t in str(e.get("decision_timeline") or "").lower() for t in _budget_terms)
+    )
+
+    tenure_distribution = [
+        {
+            "tenure": item.get("tenure"),
+            "count": item.get("count", 0),
+        }
+        for item in (sentiment_tenure or [])
+        if isinstance(item, dict) and item.get("tenure")
+    ]
+    turning_point_summary = [
+        {
+            "trigger": item.get("trigger"),
+            "mentions": item.get("mentions", 0),
+        }
+        for item in (turning_points or [])
+        if isinstance(item, dict) and item.get("trigger")
+    ]
+
+    return {
+        "vendor_name": vendor_name,
+        "schema_version": _TEMPORAL_INTELLIGENCE_SCHEMA_VERSION,
+        "as_of_date": as_of,
+        "analysis_window_days": analysis_window_days,
+        "immediate_triggers": immediate_triggers,
+        "evaluation_deadlines": eval_deadlines,
+        "keyword_spikes": {
+            "spike_count": kw.get("spike_count", 0),
+            "spike_keywords": kw.get("spike_keywords", []),
+            "keyword_details": spike_keywords,
+        },
+        "sentiment_trajectory": sentiment_trajectory,
+        "sentiment_tenure": tenure_distribution[:10],
+        "turning_points": turning_point_summary[:10],
+        "timeline_signal_summary": {
+            "total_signals": len(raw_entries),
+            "contract_end_signals": contract_end_count,
+            "evaluation_deadline_signals": eval_deadline_count,
+            "renewal_signals": renewal_count,
+            "budget_cycle_signals": budget_cycle_count,
+        },
+        "trend_per_weakness": None,
+        "acceleration_metrics": None,
+    }
+
+
+_DISPLACEMENT_DYNAMICS_SCHEMA_VERSION = "v1"
+
+
+def build_displacement_dynamics(
+    from_vendor: str,
+    to_vendor: str,
+    *,
+    edge: dict | None = None,
+    displacement_flows: list[dict] | None = None,
+    reasons: list[dict] | None = None,
+    battle_conclusion: dict | None = None,
+    analysis_window_days: int = 90,
+) -> dict[str, Any]:
+    """Build a canonical displacement dynamics object for a vendor pair.
+
+    Pass 1: populates edge metrics, switch reasons, evidence types,
+    and battle conclusion summary.  Segment-level displacement breakdowns
+    and trend acceleration are deferred to pass 2.
+
+    Args:
+        from_vendor: the vendor losing customers.
+        to_vendor: the vendor gaining customers.
+        edge: persisted displacement edge row (from b2b_displacement_edges).
+        displacement_flows: competitive_disp entries for this pair.
+        reasons: competitor_reasons entries for this pair.
+        battle_conclusion: cross-vendor pairwise battle conclusion (jsonb).
+    """
+    from datetime import date
+
+    as_of = date.today().isoformat()
+    eg = edge or {}
+
+    def _sf(v: Any) -> float | None:
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    def _intish(v: Any, default: int = 0) -> int:
+        try:
+            return int(float(v))
+        except (TypeError, ValueError):
+            return default
+
+    def _normalize_evidence_type(value: Any) -> str | None:
+        text = str(value or "").strip().lower()
+        if not text:
+            return None
+        if text in {"explicit_switch", "switch", "switched_to"}:
+            return "explicit_switch"
+        if text in {"active_evaluation", "evaluation", "considering", "trial", "poc"}:
+            return "active_evaluation"
+        if text in {"implied_preference", "compared", "preference"}:
+            return "implied_preference"
+        return None
+
+    # --- Edge metrics (from persisted displacement edges) ---
+    edge_metrics = {
+        "mention_count": eg.get("mention_count") or 0,
+        "primary_driver": eg.get("primary_driver") if not _is_generic_pain_label(eg.get("primary_driver")) else None,
+        "signal_strength": eg.get("signal_strength"),
+        "key_quote": eg.get("key_quote"),
+        "confidence_score": _sf(eg.get("confidence_score")),
+        "velocity_7d": eg.get("velocity_7d") or 0,
+        "velocity_30d": eg.get("velocity_30d") or 0,
+    }
+
+    # --- Evidence type breakdown (from competitive_disp flows) ---
+    evidence_breakdown: list[dict] = []
+    flows = displacement_flows or []
+    for f in flows:
+        row_breakdown = f.get("evidence_breakdown") or []
+        if isinstance(row_breakdown, list) and row_breakdown:
+            for item in row_breakdown:
+                if not isinstance(item, dict):
+                    continue
+                evidence_type = _normalize_evidence_type(item.get("evidence_type"))
+                mention_count = _intish(item.get("mention_count") or 0)
+                reason_categories = item.get("reason_categories") or {}
+                if mention_count <= 0 and isinstance(reason_categories, dict):
+                    mention_count = sum(_intish(v) for v in reason_categories.values())
+                if not evidence_type or mention_count <= 0:
+                    continue
+                evidence_breakdown.append({
+                    "evidence_type": evidence_type,
+                    "mention_count": mention_count,
+                    "reason_categories": reason_categories,
+                    "industries": item.get("industries") or f.get("industries") or [],
+                    "company_sizes": item.get("company_sizes") or f.get("company_sizes") or [],
+                })
+            continue
+
+        explicit = _intish(f.get("explicit_switches") or 0)
+        active_eval = _intish(f.get("active_evaluations") or 0)
+        implied = _intish(f.get("implied_preferences") or 0)
+        mention_count = _intish(f.get("mention_count") or 0)
+        if mention_count <= 0:
+            mention_count = explicit + active_eval + implied
+        if explicit <= 0 and active_eval <= 0 and implied <= 0:
+            evidence_type = _normalize_evidence_type(f.get("evidence_type")) or "implied_preference"
+            if mention_count > 0:
+                evidence_breakdown.append({
+                    "evidence_type": evidence_type,
+                    "mention_count": mention_count,
+                    "reason_categories": f.get("reason_categories") or {},
+                    "industries": f.get("industries") or [],
+                    "company_sizes": f.get("company_sizes") or [],
+                })
+            continue
+        for evidence_type, count in (
+            ("explicit_switch", explicit),
+            ("active_evaluation", active_eval),
+            ("implied_preference", max(implied, mention_count - explicit - active_eval)),
+        ):
+            if count <= 0:
+                continue
+            evidence_breakdown.append({
+                "evidence_type": evidence_type,
+                "mention_count": count,
+                "reason_categories": {},
+                "industries": f.get("industries") or [],
+                "company_sizes": f.get("company_sizes") or [],
+            })
+    evidence_breakdown.sort(
+        key=lambda x: x["mention_count"], reverse=True,
+    )
+
+    # --- Switch reasons (from competitor_reasons) ---
+    switch_reasons: list[dict] = []
+    for r in (reasons or []):
+        switch_reasons.append({
+            "reason": r.get("reason") or r.get("reason_category", ""),
+            "reason_category": r.get("reason_category"),
+            "reason_detail": r.get("reason_detail"),
+            "direction": r.get("direction"),
+            "mention_count": r.get("mention_count", 0),
+        })
+    switch_reasons.sort(
+        key=lambda x: x["mention_count"], reverse=True,
+    )
+
+    # --- Battle conclusion summary (from cross-vendor reasoning) ---
+    bc = battle_conclusion or {}
+    battle_summary = None
+    if bc:
+        battle_summary = {
+            "winner": bc.get("winner"),
+            "loser": bc.get("loser"),
+            "conclusion": bc.get("conclusion"),
+            "confidence": _sf(bc.get("confidence")),
+            "durability_assessment": bc.get("durability_assessment"),
+            "key_insights": bc.get("key_insights") or [],
+            "resource_advantage": bc.get("resource_advantage"),
+        }
+
+    # --- Net flow direction ---
+    total_explicit = sum(
+        f["mention_count"] for f in evidence_breakdown
+        if f["evidence_type"] == "explicit_switch"
+    )
+    total_eval = sum(
+        f["mention_count"] for f in evidence_breakdown
+        if f["evidence_type"] == "active_evaluation"
+    )
+    total_mentions = max(
+        _intish(edge_metrics.get("mention_count")),
+        sum(f["mention_count"] for f in evidence_breakdown),
+    )
+
+    return {
+        "from_vendor": from_vendor,
+        "to_vendor": to_vendor,
+        "schema_version": _DISPLACEMENT_DYNAMICS_SCHEMA_VERSION,
+        "as_of_date": as_of,
+        "analysis_window_days": analysis_window_days,
+        "edge_metrics": edge_metrics,
+        "evidence_breakdown": evidence_breakdown,
+        "switch_reasons": switch_reasons,
+        "battle_summary": battle_summary,
+        "flow_summary": {
+            "explicit_switch_count": total_explicit,
+            "active_evaluation_count": total_eval,
+            "total_flow_mentions": total_mentions,
+        },
+        "segment_displacement": None,
+        "trend_acceleration": None,
+    }
+
+
+_CATEGORY_DYNAMICS_SCHEMA_VERSION = "v1"
+
+
+def build_category_dynamics(
+    category: str,
+    *,
+    market_regime: dict | None = None,
+    council_conclusion: dict | None = None,
+    vendor_count: int = 0,
+    displacement_flow_count: int = 0,
+    analysis_window_days: int = 90,
+) -> dict[str, Any]:
+    """Build a canonical category dynamics object.
+
+    Pass 1: populates market regime, council conclusion summary,
+    vendor/flow counts, and structural indicators.
+    Cross-category comparisons deferred to pass 2.
+
+    Args:
+        category: product category name.
+        market_regime: MarketRegime as dict (from asdict()).
+        council_conclusion: cross-vendor category_council conclusion (jsonb).
+    """
+    from datetime import date
+
+    as_of = date.today().isoformat()
+    mr = market_regime or {}
+    cc = council_conclusion or {}
+
+    def _sf(v: Any) -> float | None:
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    # --- Market regime (from MarketPulseReasoner) ---
+    regime = {
+        "regime_type": mr.get("regime_type", "unknown"),
+        "confidence": _sf(mr.get("confidence")),
+        "avg_churn_velocity": _sf(mr.get("avg_churn_velocity")),
+        "avg_price_pressure": _sf(mr.get("avg_price_pressure")),
+        "outlier_vendors": mr.get("outlier_vendors") or [],
+        "narrative": mr.get("narrative") or "",
+    }
+
+    # --- Council conclusion (from cross-vendor LLM reasoning) ---
+    council_summary = None
+    if cc:
+        council_summary = {
+            "market_regime": cc.get("market_regime"),
+            "winner": cc.get("winner"),
+            "loser": cc.get("loser"),
+            "conclusion": cc.get("conclusion"),
+            "confidence": _sf(cc.get("confidence")),
+            "key_insights": cc.get("key_insights") or [],
+            "durability_assessment": cc.get("durability_assessment"),
+            "segment_dynamics": cc.get("segment_dynamics")
+            or cc.get("segment_winners_losers"),
+            "category_default": cc.get("category_default"),
+        }
+
+    return {
+        "category": category,
+        "schema_version": _CATEGORY_DYNAMICS_SCHEMA_VERSION,
+        "as_of_date": as_of,
+        "analysis_window_days": analysis_window_days,
+        "market_regime": regime,
+        "council_summary": council_summary,
+        "vendor_count": vendor_count,
+        "displacement_flow_count": displacement_flow_count,
+        "cross_category_comparison": None,
+    }
+
+
+_ACCOUNT_INTELLIGENCE_SCHEMA_VERSION = "v1"
+
+
+def _build_account_intelligence_quality_summary(accounts: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Summarize source actionability and identity-anchor quality for accounts."""
+    source_distribution: Counter[str] = Counter()
+    source_tier_distribution: Counter[str] = Counter()
+    identity_anchor_distribution: Counter[str] = Counter()
+    trusted_identity_count = 0
+    direct_anchor_count = 0
+    domain_only_count = 0
+
+    for account in accounts:
+        source_name = str(account.get("source") or "").strip().lower()
+        if source_name:
+            source_distribution[source_name] += 1
+        source_tier_distribution[_company_signal_source_actionability_tier(source_name)] += 1
+        anchor_quality = _company_signal_identity_anchor_quality(account)
+        identity_anchor_distribution[anchor_quality] += 1
+        if anchor_quality in {"trusted_resolution", "direct_company_anchor"}:
+            trusted_identity_count += 1
+        if anchor_quality == "direct_company_anchor":
+            direct_anchor_count += 1
+        elif anchor_quality == "domain_only":
+            domain_only_count += 1
+
+    return {
+        "trusted_identity_count": trusted_identity_count,
+        "direct_company_anchor_count": direct_anchor_count,
+        "domain_only_count": domain_only_count,
+        "source_distribution": dict(source_distribution),
+        "source_tier_distribution": dict(source_tier_distribution),
+        "identity_anchor_distribution": dict(identity_anchor_distribution),
+    }
+
+
+def _derive_account_actionability_summary(summary: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """Derive a stable actionability tier and note from account summary fields."""
+    if not isinstance(summary, Mapping):
+        return None, None
+    total_accounts = int(summary.get("total_accounts") or 0)
+    if total_accounts <= 0:
+        return None, None
+    trusted_identity_count = int(summary.get("trusted_identity_count") or 0)
+    domain_only_count = int(summary.get("domain_only_count") or 0)
+    if trusted_identity_count >= total_accounts:
+        return (
+            "high",
+            "High confidence: named accounts are backed by trusted identity anchors.",
+        )
+    if trusted_identity_count <= 0:
+        if domain_only_count > 0:
+            return (
+                "low",
+                "Low confidence: named accounts rely on weak or domain-only identity anchors.",
+            )
+        return (
+            "low",
+            "Low confidence: named accounts rely on context-rich evidence without trusted identity anchors.",
+        )
+    return (
+        "mixed",
+        f"Mixed confidence: {trusted_identity_count} of {total_accounts} named accounts are backed by trusted identity anchors.",
+    )
+
+
+def build_account_intelligence(
+    vendor_name: str,
+    *,
+    high_intent_entries: list[dict] | None = None,
+    persisted_signals: list[dict] | None = None,
+    blocked_names: set[str] | None = None,
+    analysis_window_days: int = 90,
+) -> dict[str, Any]:
+    """Build a canonical account intelligence object for a single vendor.
+
+    Aggregates company-level signals from high_intent (in-memory) and
+    b2b_company_signals (persisted).  Per-company scoring and enrichment
+    deferred to the accounts-in-motion task.
+    """
+    from datetime import date
+
+    as_of = date.today().isoformat()
+
+    def _sf(v: Any) -> float | None:
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    def _is_active_eval_stage(stage: Any) -> bool:
+        text = str(stage or "").strip().lower()
+        if not text:
+            return False
+        if text in {"evaluation", "active_purchase", "consideration", "trial", "poc"}:
+            return True
+        return "evaluat" in text or "consider" in text
+
+    # Merge: prefer persisted signals, supplement with high_intent
+    seen_companies: set[str] = set()
+    accounts: list[dict] = []
+
+    for ps in (persisted_signals or []):
+        cn = (ps.get("company_name") or "").strip()
+        if not cn:
+            continue
+        if _company_signal_exclusion_reason(
+            cn,
+            current_vendor=vendor_name,
+            blocked_names=blocked_names,
+            source=ps.get("source"),
+            confidence_score=ps.get("confidence_score"),
+        ):
+            continue
+        if ps.get("source") and _company_signal_named_account_gap_reason(
+            ps,
+            confidence_score=ps.get("confidence_score"),
+        ):
+            continue
+        key = cn.lower()
+        if key in seen_companies:
+            continue
+        seen_companies.add(key)
+        acct: dict[str, Any] = {
+            "company_name": cn,
+            "urgency_score": _sf(ps.get("urgency_score")),
+            "pain_category": ps.get("pain_category"),
+            "buyer_role": ps.get("buyer_role"),
+            "decision_maker": ps.get("decision_maker"),
+            "seat_count": ps.get("seat_count"),
+            "contract_end": (
+                str(ps.get("contract_end") or "") or None
+            ),
+            "buying_stage": ps.get("buying_stage"),
+            "source": ps.get("source"),
+            "content_type": ps.get("content_type"),
+            "confidence_score": _sf(ps.get("confidence_score")),
+            "resolution_confidence": ps.get("resolution_confidence"),
+            "company_domain": ps.get("company_domain"),
+            "first_seen_at": (
+                str(ps.get("first_seen_at") or "") or None
+            ),
+            "last_seen_at": (
+                str(ps.get("last_seen_at") or "") or None
+            ),
+            "source_actionability_tier": _company_signal_source_actionability_tier(ps.get("source")),
+            "identity_anchor_quality": _company_signal_identity_anchor_quality(ps),
+        }
+        if ps.get("title"):
+            acct["title"] = ps["title"]
+        if ps.get("company_size"):
+            acct["company_size"] = ps["company_size"]
+        if ps.get("industry"):
+            acct["industry"] = ps["industry"]
+        ps_alts = ps.get("alternatives")
+        if isinstance(ps_alts, list) and ps_alts:
+            acct["alternatives"] = ps_alts
+        ps_quotes = ps.get("quotes")
+        if isinstance(ps_quotes, list) and ps_quotes:
+            acct["quotes"] = ps_quotes
+        if ps.get("review_id"):
+            acct["review_id"] = str(ps["review_id"])
+        accounts.append(acct)
+
+    for hi in (high_intent_entries or []):
+        cn = (hi.get("company") or "").strip()
+        if not cn:
+            continue
+        blocked = set(blocked_names or set())
+        blocked.update(
+            normalize_company_name(name)
+            for name in _extract_alternative_names(hi.get("alternatives") or [])
+            if normalize_company_name(name)
+        )
+        if _company_signal_exclusion_reason(
+            cn,
+            current_vendor=vendor_name,
+            blocked_names=blocked,
+            source=hi.get("source"),
+            confidence_score=hi.get("confidence_score"),
+        ):
+            continue
+        if hi.get("source") and _company_signal_named_account_gap_reason(
+            hi,
+            confidence_score=hi.get("confidence_score"),
+        ):
+            continue
+        key = cn.lower()
+        if key in seen_companies:
+            continue
+        seen_companies.add(key)
+        acct_hi: dict[str, Any] = {
+            "company_name": cn,
+            "urgency_score": _sf(hi.get("urgency")),
+            "pain_category": hi.get("pain"),
+            "buyer_role": hi.get("role_level"),
+            "decision_maker": hi.get("decision_maker"),
+            "seat_count": hi.get("seat_count"),
+            "contract_end": (
+                str(hi.get("contract_end") or "") or None
+            ),
+            "buying_stage": hi.get("buying_stage"),
+            "source": hi.get("source"),
+            "confidence_score": None,
+            "resolution_confidence": hi.get("resolution_confidence"),
+            "company_domain": hi.get("company_domain"),
+            "first_seen_at": None,
+            "last_seen_at": None,
+            "source_actionability_tier": _company_signal_source_actionability_tier(hi.get("source")),
+            "identity_anchor_quality": _company_signal_identity_anchor_quality(hi),
+        }
+        if hi.get("title"):
+            acct_hi["title"] = hi["title"]
+        if hi.get("company_size"):
+            acct_hi["company_size"] = hi["company_size"]
+        if hi.get("industry"):
+            acct_hi["industry"] = hi["industry"]
+        if hi.get("review_id"):
+            acct_hi["review_id"] = str(hi["review_id"])
+        alts = hi.get("alternatives")
+        if alts:
+            acct_hi["alternatives"] = alts if isinstance(alts, list) else []
+        hi_quotes = hi.get("quotes")
+        if hi_quotes:
+            acct_hi["quotes"] = hi_quotes if isinstance(hi_quotes, list) else []
+        accounts.append(acct_hi)
+
+    accounts.sort(
+        key=lambda a: (
+            float(a.get("urgency_score") or 0),
+            float(a.get("confidence_score") or 0),
+            _company_signal_effective_source_identity_bonus(a),
+            1 if a.get("decision_maker") else 0,
+            1 if a.get("contract_end") else 0,
+        ),
+        reverse=True,
+    )
+
+    # Summary stats
+    dm_count = sum(1 for a in accounts if a.get("decision_maker"))
+    high_intent_count = sum(
+        1 for a in accounts if float(a.get("urgency_score") or 0) >= settings.b2b_churn.high_churn_urgency_threshold
+    )
+    active_eval_signal_count = sum(
+        1 for a in accounts if _is_active_eval_stage(a.get("buying_stage"))
+    )
+    with_contract_end = sum(
+        1 for a in accounts if a.get("contract_end")
+    )
+    with_seat_count = sum(
+        1 for a in accounts if a.get("seat_count")
+    )
+    quality_summary = _build_account_intelligence_quality_summary(accounts)
+    actionability_tier, actionability_note = _derive_account_actionability_summary(
+        {
+            "total_accounts": len(accounts),
+            **quality_summary,
+        }
+    )
+
+    return {
+        "vendor_name": vendor_name,
+        "schema_version": _ACCOUNT_INTELLIGENCE_SCHEMA_VERSION,
+        "as_of_date": as_of,
+        "analysis_window_days": analysis_window_days,
+        "accounts": accounts,
+        "summary": {
+            "total_accounts": len(accounts),
+            "decision_maker_count": dm_count,
+            "high_intent_count": high_intent_count,
+            "active_eval_signal_count": active_eval_signal_count,
+            "with_contract_end": with_contract_end,
+            "with_seat_count": with_seat_count,
+            "trusted_identity_count": quality_summary["trusted_identity_count"],
+            "direct_company_anchor_count": quality_summary["direct_company_anchor_count"],
+            "domain_only_count": quality_summary["domain_only_count"],
+            "source_distribution": quality_summary["source_distribution"],
+            "source_tier_distribution": quality_summary["source_tier_distribution"],
+            "identity_anchor_distribution": quality_summary["identity_anchor_distribution"],
+            "account_actionability_tier": actionability_tier,
+            "account_actionability_note": actionability_note,
+        },
+    }
+
+
+async def read_high_intent_companies(
+    pool,
+    *,
+    min_urgency: float = 7.0,
+    window_days: int = 30,
+    vendor_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Shared adapter for high-intent company reads.
+
+    Replaces direct enrichment reads in:
+      - api.b2b_dashboard.list_high_intent / export_high_intent
+      - api.b2b_tenant_dashboard.list_leads
+      - mcp.b2b.signals.list_high_intent_companies
+
+    Returns dicts with keys: company, raw_company, resolution_confidence,
+    vendor, category, title, company_size, industry, verified_employee_count,
+    company_country, company_domain, revenue_range, founded_year,
+    total_funding, funding_stage, headcount_growth_6m/12m/24m,
+    publicly_traded, ticker, company_description, role_level, decision_maker,
+    urgency, pain, alternatives, quotes, contract_signal, review_id, source,
+    seat_count, lock_in_level, contract_end, buying_stage, relevance_score,
+    author_churn_score, intent_signals.
+    """
+    return await _fetch_high_intent_companies(
+        pool,
+        urgency_threshold=min_urgency,
+        window_days=window_days,
+        vendor_name=vendor_name,
+        scoped_vendors=scoped_vendors,
+        limit=limit,
+    )
+
+
+async def read_company_signal_candidates(
+    pool,
+    *,
+    window_days: int = 90,
+    vendor_name: str | None = None,
+    company_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    candidate_bucket: str | None = None,
+    review_status: str | None = None,
+    canonical_gap_reason: str | None = None,
+    min_urgency: float = 0.0,
+    min_confidence: float | None = None,
+    decision_makers_only: bool = False,
+    signal_evidence_present: bool | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Shared adapter for persisted analyst-assist company-signal candidates."""
+    conditions = ["last_seen_at >= NOW() - make_interval(days => $1)"]
+    params: list[Any] = [window_days]
+    idx = 2
+
+    if scoped_vendors is not None:
+        if not scoped_vendors:
+            return []
+        conditions.append(f"vendor_name = ANY(${idx}::text[])")
+        params.append(scoped_vendors)
+        idx += 1
+    if vendor_name:
+        conditions.append(f"vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(vendor_name)
+        idx += 1
+    if company_name:
+        conditions.append(f"company_name ILIKE '%' || ${idx} || '%'")
+        params.append(company_name)
+        idx += 1
+    if candidate_bucket:
+        conditions.append(f"candidate_bucket = ${idx}")
+        params.append(candidate_bucket)
+        idx += 1
+    if review_status:
+        conditions.append(f"review_status = ${idx}")
+        params.append(review_status)
+        idx += 1
+    if canonical_gap_reason:
+        conditions.append(f"canonical_gap_reason = ${idx}")
+        params.append(canonical_gap_reason)
+        idx += 1
+    if min_urgency > 0:
+        conditions.append(f"COALESCE(urgency_score, 0) >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+    if min_confidence is not None:
+        conditions.append(f"COALESCE(confidence_score, 0) >= ${idx}")
+        params.append(min_confidence)
+        idx += 1
+    if decision_makers_only:
+        conditions.append("decision_maker = true")
+    if signal_evidence_present is not None:
+        conditions.append(f"signal_evidence_present = ${idx}")
+        params.append(signal_evidence_present)
+        idx += 1
+
+    limit_param = idx
+    params.append(limit)
+    rows = await pool.fetch(
+        f"""
+        SELECT review_id,
+               c.company_name,
+               c.company_name_raw,
+               c.vendor_name,
+               c.product_category,
+               c.source,
+               c.reviewed_at,
+               c.review_status_updated_at,
+               c.urgency_score,
+               c.relevance_score,
+               c.pain_category,
+               c.buyer_role,
+               c.decision_maker,
+               c.seat_count,
+               c.contract_end,
+               c.buying_stage,
+               c.resolution_confidence,
+               c.confidence_score,
+               c.confidence_tier,
+               c.signal_evidence_present,
+               c.canonical_gap_reason,
+               c.candidate_bucket,
+               c.review_status,
+               c.reviewed_by,
+               c.review_notes,
+               c.materialization_run_id,
+               c.first_seen_at,
+               c.last_seen_at,
+               r.summary,
+               LEFT(r.review_text, 500) AS review_excerpt,
+               r.pros,
+               r.cons,
+               r.content_type,
+               r.source_url,
+               r.enrichment->'quotable_phrases' AS quotable_phrases
+        FROM b2b_company_signal_candidates c
+        LEFT JOIN b2b_reviews r ON r.id = c.review_id
+        WHERE {" AND ".join(conditions)}
+        ORDER BY CASE WHEN candidate_bucket = 'canonical_ready' THEN 0 ELSE 1 END,
+                 review_status_updated_at DESC NULLS LAST,
+                 urgency_score DESC NULLS LAST,
+                 confidence_score DESC NULLS LAST,
+                 reviewed_at DESC NULLS LAST,
+                 last_seen_at DESC
+        LIMIT ${limit_param}
+        """,
+        *params,
+    )
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        quote_excerpt = None
+        for item in _safe_json(row.get("quotable_phrases")) or []:
+            text = _quote_text(item) if isinstance(item, dict) else str(item or "").strip()
+            if text:
+                quote_excerpt = text
+                break
+        results.append({
+            "review_id": str(row["review_id"]) if row.get("review_id") else None,
+            "company": row.get("company_name"),
+            "raw_company": row.get("company_name_raw"),
+            "vendor": row.get("vendor_name"),
+            "category": row.get("product_category"),
+            "source": row.get("source"),
+            "reviewed_at": str(row.get("reviewed_at") or "") or None,
+            "review_status_updated_at": str(row.get("review_status_updated_at") or "") or None,
+            "urgency": float(row["urgency_score"]) if row.get("urgency_score") is not None else None,
+            "relevance_score": float(row["relevance_score"]) if row.get("relevance_score") is not None else None,
+            "pain": row.get("pain_category"),
+            "role_level": row.get("buyer_role"),
+            "decision_maker": row.get("decision_maker"),
+            "seat_count": row.get("seat_count"),
+            "contract_end": row.get("contract_end"),
+            "buying_stage": row.get("buying_stage"),
+            "resolution_confidence": row.get("resolution_confidence"),
+            "confidence_score": float(row["confidence_score"]) if row.get("confidence_score") is not None else None,
+            "confidence_tier": row.get("confidence_tier"),
+            "signal_evidence_present": bool(row.get("signal_evidence_present")),
+            "canonical_gap_reason": row.get("canonical_gap_reason"),
+            "candidate_bucket": row.get("candidate_bucket"),
+            "review_status": row.get("review_status"),
+            "reviewed_by": row.get("reviewed_by"),
+            "review_notes": row.get("review_notes"),
+            "materialization_run_id": row.get("materialization_run_id"),
+            "first_seen_at": str(row.get("first_seen_at") or "") or None,
+            "last_seen_at": str(row.get("last_seen_at") or "") or None,
+            "summary": row.get("summary"),
+            "review_excerpt": row.get("review_excerpt"),
+            "pros": row.get("pros"),
+            "cons": row.get("cons"),
+            "content_type": row.get("content_type"),
+            "source_url": row.get("source_url"),
+            "quote_excerpt": quote_excerpt,
+        })
+    return results
+
+
+async def _load_company_signal_candidate_support_reviews(
+    pool,
+    review_ids: list[Any],
+) -> dict[str, dict[str, Any]]:
+    if not review_ids:
+        return {}
+    rows = await pool.fetch(
+        """
+        SELECT id,
+               source,
+               summary,
+               LEFT(review_text, 500) AS review_excerpt,
+               source_url,
+               COALESCE(reviewed_at, imported_at, enriched_at) AS reviewed_at,
+               enrichment->'quotable_phrases' AS quotable_phrases
+        FROM b2b_reviews
+        WHERE id = ANY($1::uuid[])
+        """,
+        review_ids,
+    )
+    results: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        quote_excerpt = None
+        for item in _safe_json(row.get("quotable_phrases")) or []:
+            text = _quote_text(item) if isinstance(item, dict) else str(item or "").strip()
+            if text:
+                quote_excerpt = text
+                break
+        rid = str(row["id"]) if row.get("id") else None
+        if not rid:
+            continue
+        results[rid] = {
+            "review_id": rid,
+            "source": row.get("source"),
+            "summary": row.get("summary"),
+            "review_excerpt": row.get("review_excerpt"),
+            "source_url": row.get("source_url"),
+            "reviewed_at": str(row.get("reviewed_at") or "") or None,
+            "quote_excerpt": quote_excerpt,
+        }
+    return results
+
+
+def _company_signal_candidate_group_filters(
+    *,
+    window_days: int = 90,
+    vendor_name: str | None = None,
+    company_name: str | None = None,
+    source_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    candidate_bucket: str | None = None,
+    review_status: str | None = None,
+    canonical_gap_reason: str | None = None,
+    min_urgency: float = 0.0,
+    min_confidence: float | None = None,
+    min_reviews: int = 1,
+    decision_makers_only: bool = False,
+    signal_evidence_present: bool | None = None,
+    review_priority_band: str | None = None,
+    review_priority_reason: str | None = None,
+) -> tuple[list[str], list[Any], int]:
+    conditions = ["last_seen_at >= NOW() - make_interval(days => $1)"]
+    params: list[Any] = [window_days]
+    idx = 2
+
+    if scoped_vendors is not None:
+        if not scoped_vendors:
+            return [], [], 0
+        conditions.append(f"vendor_name = ANY(${idx}::text[])")
+        params.append(scoped_vendors)
+        idx += 1
+    if vendor_name:
+        conditions.append(f"vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(vendor_name)
+        idx += 1
+    if company_name:
+        conditions.append(
+            f"(company_name ILIKE '%' || ${idx} || '%' OR display_company_name ILIKE '%' || ${idx} || '%')"
+        )
+        params.append(company_name)
+        idx += 1
+    if source_name:
+        conditions.append(
+            "EXISTS ("
+            "SELECT 1 "
+            "FROM jsonb_each_text(COALESCE(source_distribution, '{}'::jsonb)) AS source_entry(key, value) "
+            f"WHERE LOWER(source_entry.key) = LOWER(${idx})"
+            ")"
+        )
+        params.append(source_name)
+        idx += 1
+    if candidate_bucket:
+        conditions.append(f"candidate_bucket = ${idx}")
+        params.append(candidate_bucket)
+        idx += 1
+    if review_status:
+        conditions.append(f"review_status = ${idx}")
+        params.append(review_status)
+        idx += 1
+    if canonical_gap_reason:
+        conditions.append(f"canonical_gap_reason = ${idx}")
+        params.append(canonical_gap_reason)
+        idx += 1
+    if min_urgency > 0:
+        conditions.append(f"COALESCE(max_urgency_score, 0) >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+    if min_confidence is not None:
+        conditions.append(f"COALESCE(corroborated_confidence_score, 0) >= ${idx}")
+        params.append(min_confidence)
+        idx += 1
+    if min_reviews > 1:
+        conditions.append(f"review_count >= ${idx}")
+        params.append(min_reviews)
+        idx += 1
+    if decision_makers_only:
+        conditions.append("decision_maker_count > 0")
+    if signal_evidence_present is not None:
+        operator = ">" if signal_evidence_present else "="
+        conditions.append(f"signal_evidence_count {operator} 0")
+    if review_priority_band:
+        conditions.append(f"{_company_signal_candidate_group_priority_band_sql()} = ${idx}")
+        params.append(review_priority_band)
+        idx += 1
+    if review_priority_reason:
+        conditions.append(f"{_company_signal_candidate_group_priority_reason_sql()} = ${idx}")
+        params.append(review_priority_reason)
+        idx += 1
+
+    return conditions, params, idx
+
+
+def _company_signal_candidate_group_priority_rank_sql(alias: str = "") -> str:
+    prefix = f"{alias}." if alias else ""
+    return (
+        "CASE "
+        f"WHEN {prefix}candidate_bucket = 'canonical_ready' THEN 0 "
+        f"WHEN COALESCE({prefix}canonical_ready_review_count, 0) > 0 THEN 1 "
+        f"WHEN COALESCE({prefix}signal_evidence_count, 0) > 0 "
+        f"AND COALESCE({prefix}decision_maker_count, 0) > 0 THEN 2 "
+        f"WHEN COALESCE({prefix}signal_evidence_count, 0) > 0 THEN 3 "
+        f"WHEN COALESCE({prefix}decision_maker_count, 0) > 0 THEN 4 "
+        f"WHEN COALESCE({prefix}distinct_source_count, 0) > 1 THEN 5 "
+        "ELSE 6 END"
+    )
+
+
+def _company_signal_candidate_group_priority_band_sql(alias: str = "") -> str:
+    prefix = f"{alias}." if alias else ""
+    return (
+        "CASE "
+        f"WHEN {prefix}candidate_bucket = 'canonical_ready' THEN 'promote_now' "
+        f"WHEN COALESCE({prefix}canonical_ready_review_count, 0) > 0 THEN 'high' "
+        f"WHEN COALESCE({prefix}signal_evidence_count, 0) > 0 "
+        f"AND COALESCE({prefix}decision_maker_count, 0) > 0 THEN 'high' "
+        f"WHEN COALESCE({prefix}signal_evidence_count, 0) > 0 "
+        f"OR COALESCE({prefix}decision_maker_count, 0) > 0 "
+        f"OR COALESCE({prefix}distinct_source_count, 0) > 1 THEN 'medium' "
+        "ELSE 'low' END"
+    )
+
+
+def _company_signal_candidate_group_priority_reason_sql(alias: str = "") -> str:
+    prefix = f"{alias}." if alias else ""
+    return (
+        "CASE "
+        f"WHEN {prefix}candidate_bucket = 'canonical_ready' THEN 'canonical_ready' "
+        f"WHEN COALESCE({prefix}canonical_ready_review_count, 0) > 0 THEN 'has_canonical_ready_member' "
+        f"WHEN COALESCE({prefix}signal_evidence_count, 0) > 0 "
+        f"AND COALESCE({prefix}decision_maker_count, 0) > 0 THEN 'has_signal_evidence_and_decision_maker' "
+        f"WHEN COALESCE({prefix}signal_evidence_count, 0) > 0 THEN 'has_signal_evidence' "
+        f"WHEN COALESCE({prefix}decision_maker_count, 0) > 0 THEN 'has_decision_maker' "
+        f"WHEN COALESCE({prefix}distinct_source_count, 0) > 1 THEN 'cross_source_corroboration' "
+        f"ELSE COALESCE({prefix}canonical_gap_reason, 'low_signal') END"
+    )
+
+
+def _company_signal_candidate_group_priority_order_sql(alias: str = "") -> str:
+    prefix = f"{alias}." if alias else ""
+    return (
+        f"{_company_signal_candidate_group_priority_rank_sql(alias)}, "
+        f"COALESCE({prefix}canonical_ready_review_count, 0) DESC, "
+        f"COALESCE({prefix}signal_evidence_count, 0) DESC, "
+        f"COALESCE({prefix}decision_maker_count, 0) DESC, "
+        f"COALESCE({prefix}distinct_source_count, 0) DESC, "
+        f"COALESCE({prefix}corroborated_confidence_score, 0) DESC, "
+        f"COALESCE({prefix}max_urgency_score, 0) DESC, "
+        f"{prefix}review_count DESC, "
+        f"{prefix}last_seen_at DESC"
+    )
+
+
+def _company_signal_candidate_group_sla_days_sql(alias: str = "") -> str:
+    """Return SQL for the configured SLA target of a grouped review priority band."""
+    sla_days = _company_signal_queue_sla_days()
+    priority_band_sql = _company_signal_candidate_group_priority_band_sql(alias)
+    return (
+        "CASE "
+        f"WHEN {priority_band_sql} = 'promote_now' THEN {sla_days['promote_now']} "
+        f"WHEN {priority_band_sql} = 'high' THEN {sla_days['high']} "
+        f"WHEN {priority_band_sql} = 'medium' THEN {sla_days['medium']} "
+        f"ELSE {sla_days['low']} END"
+    )
+
+
+def _company_signal_candidate_group_near_threshold_sql(alias: str = "") -> str:
+    """Return SQL for blocked groups that are close to canonical confidence or urgency thresholds."""
+    p = f"{alias}." if alias else ""
+    windows = _company_signal_queue_near_threshold_windows()
+    confidence_floor = _normalize_company_signal_confidence(
+        getattr(settings.b2b_churn, "company_signal_low_trust_min_confidence", 0.6),
+    )
+    if confidence_floor is None:
+        confidence_floor = 0.6
+    confidence_min = max(0.0, confidence_floor - windows["confidence_gap"])
+    try:
+        urgency_threshold = float(getattr(settings.b2b_churn, "high_churn_urgency_threshold", 7.0))
+    except (TypeError, ValueError):
+        urgency_threshold = 7.0
+    urgency_min = max(0.0, urgency_threshold - windows["urgency_gap"])
+    return (
+        "("
+        f"({p}canonical_gap_reason = 'low_confidence_low_trust_source' "
+        f"AND COALESCE({p}corroborated_confidence_score, 0) >= {round(confidence_min, 3)}) "
+        "OR "
+        f"({p}canonical_gap_reason = 'below_high_intent_threshold' "
+        f"AND COALESCE({p}max_urgency_score, 0) >= {round(urgency_min, 3)})"
+        ")"
+    )
+
+
+def _company_signal_candidate_group_priority_values(row: Mapping[str, Any]) -> tuple[str, str]:
+    if row.get("candidate_bucket") == "canonical_ready":
+        return "promote_now", "canonical_ready"
+    if int(row.get("canonical_ready_review_count") or 0) > 0:
+        return "high", "has_canonical_ready_member"
+    if int(row.get("signal_evidence_count") or 0) > 0 and int(row.get("decision_maker_count") or 0) > 0:
+        return "high", "has_signal_evidence_and_decision_maker"
+    if int(row.get("signal_evidence_count") or 0) > 0:
+        return "medium", "has_signal_evidence"
+    if int(row.get("decision_maker_count") or 0) > 0:
+        return "medium", "has_decision_maker"
+    if int(row.get("distinct_source_count") or 0) > 1:
+        return "medium", "cross_source_corroboration"
+    return "low", str(row.get("canonical_gap_reason") or "low_signal")
+
+
+async def read_company_signal_candidate_groups(
+    pool,
+    *,
+    window_days: int = 90,
+    vendor_name: str | None = None,
+    company_name: str | None = None,
+    source_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    candidate_bucket: str | None = None,
+    review_status: str | None = None,
+    canonical_gap_reason: str | None = None,
+    min_urgency: float = 0.0,
+    min_confidence: float | None = None,
+    min_reviews: int = 1,
+    decision_makers_only: bool = False,
+    signal_evidence_present: bool | None = None,
+    review_priority_band: str | None = None,
+    review_priority_reason: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Primary grouped operator surface for analyst-assist company-signal review."""
+    conditions, params, idx = _company_signal_candidate_group_filters(
+        window_days=window_days,
+        vendor_name=vendor_name,
+        company_name=company_name,
+        source_name=source_name,
+        scoped_vendors=scoped_vendors,
+        candidate_bucket=candidate_bucket,
+        review_status=review_status,
+        canonical_gap_reason=canonical_gap_reason,
+        min_urgency=min_urgency,
+        min_confidence=min_confidence,
+        min_reviews=min_reviews,
+        decision_makers_only=decision_makers_only,
+        signal_evidence_present=signal_evidence_present,
+        review_priority_band=review_priority_band,
+        review_priority_reason=review_priority_reason,
+    )
+    if not conditions:
+        return []
+
+    priority_band_sql = _company_signal_candidate_group_priority_band_sql()
+    priority_reason_sql = _company_signal_candidate_group_priority_reason_sql()
+    if review_status in {None, "pending"}:
+        order_sql = _company_signal_candidate_group_priority_order_sql()
+    else:
+        order_sql = (
+            "review_status_updated_at DESC NULLS LAST, "
+            "last_seen_at DESC, "
+            "review_count DESC"
+        )
+
+    limit_param = idx
+    params.append(limit)
+    rows = await pool.fetch(
+        f"""
+        SELECT id,
+               company_name,
+               display_company_name,
+               vendor_name,
+               product_category,
+               review_count,
+               distinct_source_count,
+               decision_maker_count,
+               signal_evidence_count,
+               canonical_ready_review_count,
+               avg_urgency_score,
+               max_urgency_score,
+               avg_confidence_score,
+               max_confidence_score,
+               corroborated_confidence_score,
+               confidence_tier,
+               source_distribution,
+               gap_reason_distribution,
+               sample_review_ids,
+               representative_review_id,
+               representative_source,
+               representative_pain_category,
+               representative_buyer_role,
+               representative_decision_maker,
+               representative_seat_count,
+               representative_contract_end,
+               representative_buying_stage,
+               representative_confidence_score,
+               representative_urgency_score,
+               canonical_gap_reason,
+               candidate_bucket,
+               {priority_band_sql} AS review_priority_band,
+               {priority_reason_sql} AS review_priority_reason,
+               review_status,
+               review_status_updated_at,
+               reviewed_by,
+               review_notes,
+               materialization_run_id,
+               first_seen_at,
+               last_seen_at
+        FROM b2b_company_signal_candidate_groups
+        WHERE {" AND ".join(conditions)}
+        ORDER BY {order_sql}
+        LIMIT ${limit_param}
+        """,
+        *params,
+    )
+    sample_review_ids: list[Any] = []
+    for row in rows:
+        for review_id in row.get("sample_review_ids") or []:
+            if review_id and review_id not in sample_review_ids:
+                sample_review_ids.append(review_id)
+        representative_review_id = row.get("representative_review_id")
+        if representative_review_id and representative_review_id not in sample_review_ids:
+            sample_review_ids.append(representative_review_id)
+    support_reviews = await _load_company_signal_candidate_support_reviews(pool, sample_review_ids)
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        priority_band = row.get("review_priority_band")
+        priority_reason = row.get("review_priority_reason")
+        if not priority_band or not priority_reason:
+            priority_band, priority_reason = _company_signal_candidate_group_priority_values(row)
+        sample_ids = [str(review_id) for review_id in (row.get("sample_review_ids") or []) if review_id]
+        supporting_reviews = [
+            support_reviews[str(review_id)]
+            for review_id in sample_ids[:3]
+            if str(review_id) in support_reviews
+        ]
+        results.append({
+            "group_id": str(row["id"]) if row.get("id") else None,
+            "company": row.get("company_name"),
+            "display_company": row.get("display_company_name") or row.get("company_name"),
+            "vendor": row.get("vendor_name"),
+            "category": row.get("product_category"),
+            "review_count": row.get("review_count") or 0,
+            "distinct_source_count": row.get("distinct_source_count") or 0,
+            "decision_maker_count": row.get("decision_maker_count") or 0,
+            "signal_evidence_count": row.get("signal_evidence_count") or 0,
+            "canonical_ready_review_count": row.get("canonical_ready_review_count") or 0,
+            "avg_urgency": float(row["avg_urgency_score"]) if row.get("avg_urgency_score") is not None else None,
+            "max_urgency": float(row["max_urgency_score"]) if row.get("max_urgency_score") is not None else None,
+            "avg_confidence_score": float(row["avg_confidence_score"]) if row.get("avg_confidence_score") is not None else None,
+            "max_confidence_score": float(row["max_confidence_score"]) if row.get("max_confidence_score") is not None else None,
+            "corroborated_confidence_score": float(row["corroborated_confidence_score"]) if row.get("corroborated_confidence_score") is not None else None,
+            "confidence_tier": row.get("confidence_tier"),
+            "source_distribution": _safe_json(row.get("source_distribution")) or {},
+            "gap_reason_distribution": _safe_json(row.get("gap_reason_distribution")) or {},
+            "sample_review_ids": sample_ids,
+            "representative_review_id": str(row["representative_review_id"]) if row.get("representative_review_id") else None,
+            "representative_source": row.get("representative_source"),
+            "representative_pain_category": row.get("representative_pain_category"),
+            "representative_buyer_role": row.get("representative_buyer_role"),
+            "representative_decision_maker": row.get("representative_decision_maker"),
+            "representative_seat_count": row.get("representative_seat_count"),
+            "representative_contract_end": row.get("representative_contract_end"),
+            "representative_buying_stage": row.get("representative_buying_stage"),
+            "representative_confidence_score": float(row["representative_confidence_score"]) if row.get("representative_confidence_score") is not None else None,
+            "representative_urgency_score": float(row["representative_urgency_score"]) if row.get("representative_urgency_score") is not None else None,
+            "canonical_gap_reason": row.get("canonical_gap_reason"),
+            "candidate_bucket": row.get("candidate_bucket"),
+            "review_priority_band": priority_band,
+            "review_priority_reason": priority_reason,
+            "review_status": row.get("review_status"),
+            "review_status_updated_at": str(row.get("review_status_updated_at") or "") or None,
+            "reviewed_by": row.get("reviewed_by"),
+            "review_notes": row.get("review_notes"),
+            "materialization_run_id": row.get("materialization_run_id"),
+            "first_seen_at": str(row.get("first_seen_at") or "") or None,
+            "last_seen_at": str(row.get("last_seen_at") or "") or None,
+            "supporting_reviews": supporting_reviews,
+        })
+    return results
+
+
+def _empty_company_signal_candidate_group_totals() -> dict[str, Any]:
+    return {
+        "total_groups": 0,
+        "total_reviews": 0,
+        "canonical_ready_reviews": 0,
+        "pending_groups": 0,
+        "actionable_pending_groups": 0,
+        "actionable_pending_reviews": 0,
+        "blocked_pending_groups": 0,
+        "blocked_pending_reviews": 0,
+        "near_threshold_blocked_groups": 0,
+        "near_threshold_blocked_reviews": 0,
+        "approved_groups": 0,
+        "suppressed_groups": 0,
+        "canonical_ready_groups": 0,
+        "analyst_review_groups": 0,
+        "pending_canonical_ready_groups": 0,
+        "pending_analyst_review_groups": 0,
+        "decision_maker_groups": 0,
+        "signal_evidence_groups": 0,
+        "avg_pending_age_days": 0.0,
+        "oldest_pending_age_days": 0.0,
+        "overdue_pending_groups": 0,
+        "overdue_pending_reviews": 0,
+    }
+
+
+async def _read_company_signal_candidate_group_totals(
+    pool,
+    *,
+    window_days: int = 90,
+    vendor_name: str | None = None,
+    company_name: str | None = None,
+    source_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    candidate_bucket: str | None = None,
+    review_status: str | None = None,
+    canonical_gap_reason: str | None = None,
+    min_urgency: float = 0.0,
+    min_confidence: float | None = None,
+    min_reviews: int = 1,
+    decision_makers_only: bool = False,
+    signal_evidence_present: bool | None = None,
+    review_priority_band: str | None = None,
+    review_priority_reason: str | None = None,
+) -> dict[str, Any]:
+    conditions, params, _ = _company_signal_candidate_group_filters(
+        window_days=window_days,
+        vendor_name=vendor_name,
+        company_name=company_name,
+        source_name=source_name,
+        scoped_vendors=scoped_vendors,
+        candidate_bucket=candidate_bucket,
+        review_status=review_status,
+        canonical_gap_reason=canonical_gap_reason,
+        min_urgency=min_urgency,
+        min_confidence=min_confidence,
+        min_reviews=min_reviews,
+        decision_makers_only=decision_makers_only,
+        signal_evidence_present=signal_evidence_present,
+        review_priority_band=review_priority_band,
+        review_priority_reason=review_priority_reason,
+    )
+    if not conditions:
+        return _empty_company_signal_candidate_group_totals()
+
+    where_clause = " AND ".join(conditions)
+    pending_age_days_sql = _company_signal_candidate_group_pending_age_days_sql()
+    pending_priority_band_sql = _company_signal_candidate_group_priority_band_sql()
+    pending_sla_days_sql = _company_signal_candidate_group_sla_days_sql()
+    near_threshold_sql = _company_signal_candidate_group_near_threshold_sql()
+    row = await pool.fetchrow(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT COUNT(*)::int AS total_groups,
+               COALESCE(SUM(review_count), 0)::int AS total_reviews,
+               COALESCE(SUM(canonical_ready_review_count), 0)::int AS canonical_ready_reviews,
+               COUNT(*) FILTER (WHERE review_status = 'pending')::int AS pending_groups,
+               COUNT(*) FILTER (
+                   WHERE review_status = 'pending'
+                     AND {pending_priority_band_sql} IN ('promote_now', 'high', 'medium')
+               )::int AS actionable_pending_groups,
+               COALESCE(
+                   SUM(review_count) FILTER (
+                       WHERE review_status = 'pending'
+                         AND {pending_priority_band_sql} IN ('promote_now', 'high', 'medium')
+                   ),
+                   0
+               )::int AS actionable_pending_reviews,
+               COUNT(*) FILTER (
+                   WHERE review_status = 'pending'
+                     AND {pending_priority_band_sql} = 'low'
+               )::int AS blocked_pending_groups,
+               COALESCE(
+                   SUM(review_count) FILTER (
+                       WHERE review_status = 'pending'
+                         AND {pending_priority_band_sql} = 'low'
+                   ),
+                   0
+               )::int AS blocked_pending_reviews,
+               COUNT(*) FILTER (
+                   WHERE review_status = 'pending'
+                     AND {pending_priority_band_sql} = 'low'
+                     AND {near_threshold_sql}
+               )::int AS near_threshold_blocked_groups,
+               COALESCE(
+                   SUM(review_count) FILTER (
+                       WHERE review_status = 'pending'
+                         AND {pending_priority_band_sql} = 'low'
+                         AND {near_threshold_sql}
+                   ),
+                   0
+               )::int AS near_threshold_blocked_reviews,
+               COUNT(*) FILTER (WHERE review_status = 'approved')::int AS approved_groups,
+               COUNT(*) FILTER (WHERE review_status = 'suppressed')::int AS suppressed_groups,
+               COUNT(*) FILTER (WHERE candidate_bucket = 'canonical_ready')::int AS canonical_ready_groups,
+               COUNT(*) FILTER (WHERE candidate_bucket = 'analyst_review')::int AS analyst_review_groups,
+               COUNT(*) FILTER (
+                   WHERE review_status = 'pending' AND candidate_bucket = 'canonical_ready'
+               )::int AS pending_canonical_ready_groups,
+               COUNT(*) FILTER (
+                   WHERE review_status = 'pending' AND candidate_bucket = 'analyst_review'
+               )::int AS pending_analyst_review_groups,
+               COUNT(*) FILTER (WHERE decision_maker_count > 0)::int AS decision_maker_groups,
+               COUNT(*) FILTER (WHERE signal_evidence_count > 0)::int AS signal_evidence_groups,
+               COALESCE(
+                   AVG(
+                       EXTRACT(EPOCH FROM (NOW() - COALESCE(review_status_updated_at, first_seen_at))) / 86400.0
+                   ) FILTER (WHERE review_status = 'pending'),
+                   0
+               )::float8 AS avg_pending_age_days,
+               COALESCE(
+                   MAX(
+                       {pending_age_days_sql}
+                   ) FILTER (WHERE review_status = 'pending'),
+                   0
+               )::float8 AS oldest_pending_age_days,
+               COUNT(*) FILTER (
+                   WHERE review_status = 'pending'
+                     AND {pending_age_days_sql} > {pending_sla_days_sql}
+               )::int AS overdue_pending_groups,
+               COALESCE(
+                   SUM(review_count) FILTER (
+                       WHERE review_status = 'pending'
+                         AND {pending_age_days_sql} > {pending_sla_days_sql}
+                   ),
+                   0
+               )::int AS overdue_pending_reviews
+        FROM filtered
+        """,
+        *params,
+    )
+    return dict(row or _empty_company_signal_candidate_group_totals())
+
+
+def _company_signal_action_priority_rank(value: Any) -> int:
+    order = {
+        "high": 3,
+        "medium": 2,
+        "low": 1,
+    }
+    return order.get(str(value or "").lower(), 0)
+
+
+def _company_signal_action_type(action: Any) -> str | None:
+    action_name = str(action or "").strip()
+    if not action_name:
+        return None
+    if action_name in {
+        "clear_overdue_review_queue",
+        "review_prioritized_queue",
+        "increase_review_throughput",
+    }:
+        return "review_queue"
+    if action_name in {"review_low_trust_policy", "review_threshold_policy"}:
+        return "policy_threshold"
+    if action_name == "inspect_rebuild_pipeline":
+        return "rebuild_pipeline"
+    if action_name == "review_effect_quality":
+        return "review_quality"
+    if action_name in {"monitor_queue", "monitor_trends", "maintain_current_course"}:
+        return "monitor"
+    return None
+
+
+def _empty_company_signal_operator_action() -> dict[str, Any]:
+    return {
+        "status": "no_data",
+        "action_type": None,
+        "action": None,
+        "priority": None,
+        "owner": None,
+        "reason": None,
+        "rationale": None,
+        "queue_filters": {},
+        "queue_snapshot": None,
+        "primary_driver": None,
+    }
+
+
+def _build_company_signal_operator_action(
+    payload: Mapping[str, Any] | None,
+    *,
+    primary_driver: Any = None,
+    queue_filters: Mapping[str, Any] | None = None,
+    queue_snapshot: Mapping[str, Any] | None = None,
+    action_type: str | None = None,
+    reason: Any = None,
+    use_reason_override: bool = False,
+) -> dict[str, Any] | None:
+    if not isinstance(payload, Mapping):
+        return None
+    action = payload.get("action")
+    if not action:
+        return None
+
+    payload_queue_filters = payload.get("queue_filters")
+    if queue_filters is None and isinstance(payload_queue_filters, Mapping):
+        normalized_queue_filters = dict(payload_queue_filters)
+    else:
+        normalized_queue_filters = dict(queue_filters or {})
+
+    payload_queue_snapshot = payload.get("queue_snapshot")
+    if queue_snapshot is None and isinstance(payload_queue_snapshot, Mapping):
+        normalized_queue_snapshot = dict(payload_queue_snapshot)
+    elif isinstance(queue_snapshot, Mapping):
+        normalized_queue_snapshot = dict(queue_snapshot)
+    else:
+        normalized_queue_snapshot = None
+
+    payload_primary_driver = payload.get("primary_driver")
+    if primary_driver is None and isinstance(payload_primary_driver, Mapping):
+        normalized_primary_driver = dict(payload_primary_driver)
+    elif primary_driver is None:
+        normalized_primary_driver = payload_primary_driver
+    elif isinstance(primary_driver, Mapping):
+        normalized_primary_driver = dict(primary_driver)
+    else:
+        normalized_primary_driver = primary_driver
+
+    normalized = _empty_company_signal_operator_action()
+    normalized.update(
+        {
+            "status": payload.get("status"),
+            "action_type": action_type or payload.get("action_type") or _company_signal_action_type(action),
+            "action": action,
+            "priority": payload.get("priority"),
+            "owner": payload.get("owner"),
+            "reason": reason if use_reason_override else payload.get("reason"),
+            "rationale": payload.get("rationale"),
+            "queue_filters": normalized_queue_filters,
+            "queue_snapshot": normalized_queue_snapshot,
+            "primary_driver": normalized_primary_driver,
+        }
+    )
+    return normalized
+
+
+def _choose_company_signal_operator_focus(
+    preferred_payload: Mapping[str, Any] | None,
+    alternate_payload: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    default = _empty_company_signal_operator_action()
+    preferred_action = preferred_payload.get("action") if isinstance(preferred_payload, Mapping) else None
+    alternate_action = alternate_payload.get("action") if isinstance(alternate_payload, Mapping) else None
+    if preferred_action and alternate_action:
+        if _company_signal_action_priority_rank(alternate_payload.get("priority")) > _company_signal_action_priority_rank(
+            preferred_payload.get("priority")
+        ):
+            return dict(alternate_payload)
+        return dict(preferred_payload)
+    if preferred_action:
+        return dict(preferred_payload)
+    if alternate_action:
+        return dict(alternate_payload)
+    return default
+
+
+def _build_company_signal_queue_recommendation_payload(
+    *,
+    actionable_pending_groups: int,
+    blocked_pending_groups: int,
+    overdue_pending_groups: int,
+    low_trust_blocked: bool,
+    low_trust_dominant_priority: str,
+    promote_low_trust_when_blocked: bool,
+    prioritize_blocked_dominant: bool,
+    overdue_rationale: str,
+    actionable_rationale: str,
+    low_trust_dominant_rationale: str,
+    threshold_dominant_rationale: str,
+    low_trust_blocked_rationale: str,
+    threshold_blocked_rationale: str,
+    monitor_rationale: str,
+) -> dict[str, Any]:
+    def _dominant_blocked_payload() -> dict[str, Any] | None:
+        if not (blocked_pending_groups > actionable_pending_groups and blocked_pending_groups > 0):
+            return None
+        if low_trust_blocked:
+            return {
+                "status": "act",
+                "action": "review_low_trust_policy",
+                "priority": low_trust_dominant_priority,
+                "owner": "intelligence_policy",
+                "reason": "blocked_low_trust_policy",
+                "rationale": low_trust_dominant_rationale,
+                "driver_key": "dominant_blocked_low_trust",
+            }
+        return {
+            "status": "act",
+            "action": "review_threshold_policy",
+            "priority": "medium",
+            "owner": "intelligence_policy",
+            "reason": "blocked_canonical_threshold",
+            "rationale": threshold_dominant_rationale,
+            "driver_key": "dominant_blocked_threshold",
+        }
+
+    dominant_blocked_payload = _dominant_blocked_payload()
+    if prioritize_blocked_dominant and dominant_blocked_payload is not None:
+        return dominant_blocked_payload
+    if actionable_pending_groups > 0 and overdue_pending_groups > 0:
+        return {
+            "status": "act",
+            "action": "clear_overdue_review_queue",
+            "priority": "high",
+            "owner": "review_ops",
+            "reason": "overdue_actionable_backlog",
+            "rationale": overdue_rationale,
+            "driver_key": "overdue_actionable",
+        }
+    if dominant_blocked_payload is not None:
+        return dominant_blocked_payload
+    if actionable_pending_groups > 0:
+        return {
+            "status": "act",
+            "action": "review_prioritized_queue",
+            "priority": "medium",
+            "owner": "review_ops",
+            "reason": "actionable_backlog",
+            "rationale": actionable_rationale,
+            "driver_key": "actionable",
+        }
+    if blocked_pending_groups > 0:
+        if low_trust_blocked and promote_low_trust_when_blocked:
+            return {
+                "status": "act",
+                "action": "review_low_trust_policy",
+                "priority": "medium",
+                "owner": "intelligence_policy",
+                "reason": "blocked_low_trust_policy",
+                "rationale": low_trust_blocked_rationale,
+                "driver_key": "blocked_low_trust",
+            }
+        return {
+            "status": "watch",
+            "action": "review_threshold_policy",
+            "priority": "medium",
+            "owner": "intelligence_policy",
+            "reason": "blocked_backlog",
+            "rationale": threshold_blocked_rationale,
+            "driver_key": "blocked_threshold",
+        }
+    return {
+        "status": "monitor",
+        "action": "monitor_queue",
+        "priority": "low",
+        "owner": "review_ops",
+        "reason": "no_backlog_pressure",
+        "rationale": monitor_rationale,
+        "driver_key": "monitor",
+    }
+
+
+async def read_company_signal_candidate_group_summary(
+    pool,
+    *,
+    window_days: int = 90,
+    vendor_name: str | None = None,
+    company_name: str | None = None,
+    source_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    candidate_bucket: str | None = None,
+    review_status: str | None = None,
+    canonical_gap_reason: str | None = None,
+    min_urgency: float = 0.0,
+    min_confidence: float | None = None,
+    min_reviews: int = 1,
+    decision_makers_only: bool = False,
+    signal_evidence_present: bool | None = None,
+    review_priority_band: str | None = None,
+    review_priority_reason: str | None = None,
+    top_n: int = 10,
+) -> dict[str, Any]:
+    """Return queue-health summary for grouped company-signal candidates."""
+    conditions, params, idx = _company_signal_candidate_group_filters(
+        window_days=window_days,
+        vendor_name=vendor_name,
+        company_name=company_name,
+        source_name=source_name,
+        scoped_vendors=scoped_vendors,
+        candidate_bucket=candidate_bucket,
+        review_status=review_status,
+        canonical_gap_reason=canonical_gap_reason,
+        min_urgency=min_urgency,
+        min_confidence=min_confidence,
+        min_reviews=min_reviews,
+        decision_makers_only=decision_makers_only,
+        signal_evidence_present=signal_evidence_present,
+        review_priority_band=review_priority_band,
+        review_priority_reason=review_priority_reason,
+    )
+    if not conditions:
+        return {
+            "totals": _empty_company_signal_candidate_group_totals(),
+            "gap_reasons": [],
+            "top_vendors": [],
+            "actionable_top_vendors": [],
+            "actionable_top_vendor_reasons": [],
+            "blocked_top_vendors": [],
+            "blocked_top_vendor_reasons": [],
+            "blocked_source_mix": [],
+            "blocked_source_vendor_gaps": [],
+            "trusted_blocked_source_mix": [],
+            "trusted_blocked_source_vendor_gaps": [],
+            "near_threshold_top_vendors": [],
+            "near_threshold_gap_reasons": [],
+            "near_threshold_groups": [],
+            "near_threshold_source_mix": [],
+            "unlock_candidates": [],
+            "unlock_path_summary": [],
+            "unlock_focus": None,
+            "confidence_tiers": [],
+            "priority_groups": [],
+            "pending_priority_bands": [],
+            "pending_priority_reasons": [],
+            "pending_sla_bands": [],
+            "pending_sla_reasons": [],
+            "oldest_pending_group": None,
+            "queue_recommendation": {
+                "status": "no_data",
+                "action_type": None,
+                "action": None,
+                "priority": None,
+                "owner": None,
+                "reason": None,
+                "rationale": None,
+                "queue_filters": {},
+                "queue_snapshot": None,
+                "primary_driver": None,
+            },
+            "operator_focus": {
+                "status": "no_data",
+                "action_type": None,
+                "action": None,
+                "priority": None,
+                "owner": None,
+                "reason": None,
+                "rationale": None,
+                "queue_filters": {},
+                "queue_snapshot": None,
+                "primary_driver": None,
+            },
+        }
+
+    where_clause = " AND ".join(conditions)
+    requested_canonical_gap_reason = canonical_gap_reason
+    top_n_param = idx
+    pending_age_days_sql = _company_signal_candidate_group_pending_age_days_sql()
+    pending_priority_band_sql = _company_signal_candidate_group_priority_band_sql()
+    pending_priority_reason_sql = _company_signal_candidate_group_priority_reason_sql()
+    pending_sla_days_sql = _company_signal_candidate_group_sla_days_sql()
+    near_threshold_sql = _company_signal_candidate_group_near_threshold_sql()
+    low_trust_source_sql = _company_signal_low_trust_source_membership_sql("source")
+    low_trust_confidence_min = _normalize_company_signal_confidence(
+        getattr(settings.b2b_churn, "company_signal_low_trust_min_confidence", 0.6),
+    )
+    if low_trust_confidence_min is None:
+        low_trust_confidence_min = 0.6
+    try:
+        high_intent_urgency_threshold = float(getattr(settings.b2b_churn, "high_churn_urgency_threshold", 7.0))
+    except (TypeError, ValueError):
+        high_intent_urgency_threshold = 7.0
+    totals = await _read_company_signal_candidate_group_totals(
+        pool,
+        window_days=window_days,
+        vendor_name=vendor_name,
+        company_name=company_name,
+        source_name=source_name,
+        scoped_vendors=scoped_vendors,
+        candidate_bucket=candidate_bucket,
+        review_status=review_status,
+        canonical_gap_reason=canonical_gap_reason,
+        min_urgency=min_urgency,
+        min_confidence=min_confidence,
+        min_reviews=min_reviews,
+        decision_makers_only=decision_makers_only,
+        signal_evidence_present=signal_evidence_present,
+        review_priority_band=review_priority_band,
+        review_priority_reason=review_priority_reason,
+    )
+    gap_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT COALESCE(canonical_gap_reason, 'canonical_ready') AS gap_reason,
+               COUNT(*)::int AS group_count,
+               COALESCE(SUM(review_count), 0)::int AS review_count
+        FROM filtered
+        GROUP BY 1
+        ORDER BY group_count DESC, review_count DESC, gap_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    vendor_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT vendor_name,
+               COUNT(*)::int AS group_count,
+               COALESCE(SUM(review_count), 0)::int AS review_count,
+               COUNT(*) FILTER (WHERE review_status = 'pending')::int AS pending_groups,
+               COUNT(*) FILTER (WHERE candidate_bucket = 'canonical_ready')::int AS canonical_ready_groups
+        FROM filtered
+        GROUP BY 1
+        ORDER BY pending_groups DESC, group_count DESC, review_count DESC, vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    actionable_vendor_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT vendor_name,
+                   review_count,
+                   signal_evidence_count,
+                   decision_maker_count,
+                   {pending_priority_band_sql} AS review_priority_band
+            FROM filtered
+            WHERE review_status = 'pending'
+        )
+        SELECT vendor_name,
+               COUNT(*) FILTER (
+                   WHERE review_priority_band IN ('promote_now', 'high', 'medium')
+               )::int AS actionable_group_count,
+               COALESCE(SUM(review_count) FILTER (
+                   WHERE review_priority_band IN ('promote_now', 'high', 'medium')
+               ), 0)::int AS actionable_review_count,
+               COUNT(*) FILTER (WHERE review_priority_band = 'promote_now')::int AS promote_now_group_count,
+               COUNT(*) FILTER (WHERE review_priority_band = 'high')::int AS high_group_count,
+               COUNT(*) FILTER (WHERE review_priority_band = 'medium')::int AS medium_group_count,
+               COUNT(*) FILTER (
+                   WHERE review_priority_band IN ('promote_now', 'high', 'medium')
+                     AND signal_evidence_count > 0
+               )::int AS actionable_signal_evidence_groups,
+               COUNT(*) FILTER (
+                   WHERE review_priority_band IN ('promote_now', 'high', 'medium')
+                     AND decision_maker_count > 0
+               )::int AS actionable_decision_maker_groups
+        FROM pending
+        GROUP BY 1
+        HAVING COUNT(*) FILTER (
+            WHERE review_priority_band IN ('promote_now', 'high', 'medium')
+        ) > 0
+        ORDER BY actionable_group_count DESC,
+                 actionable_review_count DESC,
+                 vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    actionable_vendor_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT vendor_name,
+                   review_count,
+                   {pending_priority_band_sql} AS review_priority_band,
+                   {pending_priority_reason_sql} AS review_priority_reason
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} IN ('promote_now', 'high', 'medium')
+        )
+        SELECT vendor_name,
+               review_priority_band,
+               review_priority_reason,
+               COUNT(*)::int AS actionable_group_count,
+               COALESCE(SUM(review_count), 0)::int AS actionable_review_count
+        FROM pending
+        GROUP BY 1, 2, 3
+        ORDER BY actionable_group_count DESC,
+                 actionable_review_count DESC,
+                 CASE review_priority_band
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     ELSE 3
+                 END,
+                 vendor_name ASC,
+                 review_priority_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    blocked_vendor_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT vendor_name,
+                   review_count,
+                   {pending_priority_reason_sql} AS review_priority_reason,
+                   COALESCE(canonical_gap_reason, 'low_signal') AS canonical_gap_reason
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+        )
+        SELECT vendor_name,
+               COUNT(*)::int AS blocked_group_count,
+               COALESCE(SUM(review_count), 0)::int AS blocked_review_count,
+               COUNT(*) FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source')::int AS low_confidence_group_count,
+               COUNT(*) FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold')::int AS below_threshold_group_count,
+               COUNT(*) FILTER (WHERE canonical_gap_reason = 'missing_signal_evidence')::int AS missing_signal_evidence_group_count
+        FROM pending
+        GROUP BY 1
+        ORDER BY blocked_group_count DESC,
+                 blocked_review_count DESC,
+                 vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    blocked_vendor_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT vendor_name,
+                   review_count,
+                   {pending_priority_reason_sql} AS review_priority_reason,
+                   COALESCE(canonical_gap_reason, 'low_signal') AS canonical_gap_reason
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+        )
+        SELECT vendor_name,
+               canonical_gap_reason,
+               review_priority_reason,
+               COUNT(*)::int AS blocked_group_count,
+               COALESCE(SUM(review_count), 0)::int AS blocked_review_count
+        FROM pending
+        GROUP BY 1, 2, 3
+        ORDER BY blocked_group_count DESC,
+                 blocked_review_count DESC,
+                 vendor_name ASC,
+                 canonical_gap_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    near_threshold_vendor_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT vendor_name,
+                   review_count,
+                   COALESCE(canonical_gap_reason, 'low_signal') AS canonical_gap_reason
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+              AND {near_threshold_sql}
+        )
+        SELECT vendor_name,
+               COUNT(*)::int AS near_threshold_group_count,
+               COALESCE(SUM(review_count), 0)::int AS near_threshold_review_count,
+               COUNT(*) FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source')::int AS low_confidence_near_threshold_groups,
+               COUNT(*) FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold')::int AS below_threshold_near_threshold_groups
+        FROM pending
+        GROUP BY 1
+        ORDER BY near_threshold_group_count DESC,
+                 near_threshold_review_count DESC,
+                 vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    near_threshold_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT review_count,
+                   COALESCE(canonical_gap_reason, 'low_signal') AS canonical_gap_reason
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+              AND {near_threshold_sql}
+        )
+        SELECT canonical_gap_reason,
+               COUNT(*)::int AS near_threshold_group_count,
+               COALESCE(SUM(review_count), 0)::int AS near_threshold_review_count
+        FROM pending
+        GROUP BY 1
+        ORDER BY near_threshold_group_count DESC,
+                 near_threshold_review_count DESC,
+                 canonical_gap_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    near_threshold_group_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT id,
+               company_name,
+               display_company_name,
+               vendor_name,
+               review_count,
+               canonical_gap_reason,
+               candidate_bucket,
+               distinct_source_count,
+               max_urgency_score,
+               corroborated_confidence_score,
+               representative_source
+        FROM filtered
+        WHERE review_status = 'pending'
+          AND {pending_priority_band_sql} = 'low'
+          AND {near_threshold_sql}
+        ORDER BY COALESCE(corroborated_confidence_score, 0) DESC,
+                 COALESCE(max_urgency_score, 0) DESC,
+                 review_count DESC,
+                 vendor_name ASC,
+                 company_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    blocked_source_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT id,
+                   review_count,
+                   representative_source,
+                   COALESCE(source_distribution, '{{}}'::jsonb) AS source_distribution
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+        ),
+        expanded AS (
+            SELECT p.id,
+                   COALESCE(
+                       NULLIF(LOWER(TRIM(src.source)), ''),
+                       NULLIF(LOWER(TRIM(p.representative_source)), ''),
+                       'unknown'
+                   ) AS source,
+                   COALESCE(src.source_review_count, p.review_count, 0)::int AS source_review_count
+            FROM pending p
+            LEFT JOIN LATERAL (
+                SELECT key AS source,
+                       CASE
+                           WHEN value ~ '^[0-9]+$' THEN value::int
+                           ELSE NULL
+                       END AS source_review_count
+                FROM jsonb_each_text(p.source_distribution)
+            ) src ON TRUE
+        )
+        SELECT source,
+               COUNT(DISTINCT id)::int AS group_count,
+               COALESCE(SUM(source_review_count), 0)::int AS review_count
+        FROM expanded
+        GROUP BY 1
+        ORDER BY group_count DESC,
+                 review_count DESC,
+                 source ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    blocked_source_vendor_gap_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT id,
+                   vendor_name,
+                   review_count,
+                   representative_source,
+                   COALESCE(source_distribution, '{{}}'::jsonb) AS source_distribution,
+                   COALESCE(canonical_gap_reason, 'low_signal') AS canonical_gap_reason,
+                   COALESCE(corroborated_confidence_score, 0)::float8 AS corroborated_confidence_score,
+                   COALESCE(max_urgency_score, 0)::float8 AS max_urgency_score
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+        ),
+        expanded AS (
+            SELECT p.id,
+                   p.vendor_name,
+                   p.canonical_gap_reason,
+                   p.corroborated_confidence_score,
+                   p.max_urgency_score,
+                   COALESCE(
+                       NULLIF(LOWER(TRIM(src.source)), ''),
+                       NULLIF(LOWER(TRIM(p.representative_source)), ''),
+                       'unknown'
+                   ) AS source,
+                   COALESCE(src.source_review_count, p.review_count, 0)::int AS source_review_count
+            FROM pending p
+            LEFT JOIN LATERAL (
+                SELECT key AS source,
+                       CASE
+                           WHEN value ~ '^[0-9]+$' THEN value::int
+                           ELSE NULL
+                       END AS source_review_count
+                FROM jsonb_each_text(p.source_distribution)
+            ) src ON TRUE
+        )
+        SELECT source,
+               vendor_name,
+               COUNT(DISTINCT id)::int AS blocked_group_count,
+               COALESCE(SUM(source_review_count), 0)::int AS blocked_review_count,
+               COUNT(DISTINCT id) FILTER (
+                   WHERE canonical_gap_reason = 'low_confidence_low_trust_source'
+               )::int AS low_confidence_group_count,
+               COUNT(DISTINCT id) FILTER (
+                   WHERE canonical_gap_reason = 'below_high_intent_threshold'
+               )::int AS below_threshold_group_count,
+               MIN(GREATEST(0, {low_trust_confidence_min} - corroborated_confidence_score))
+                   FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source')::float8
+                   AS min_confidence_gap_to_canonical,
+               AVG(GREATEST(0, {low_trust_confidence_min} - corroborated_confidence_score))
+                   FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source')::float8
+                   AS avg_confidence_gap_to_canonical,
+               MIN(GREATEST(0, {high_intent_urgency_threshold} - max_urgency_score))
+                   FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold')::float8
+                   AS min_urgency_gap_to_high_intent,
+               AVG(GREATEST(0, {high_intent_urgency_threshold} - max_urgency_score))
+                   FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold')::float8
+                   AS avg_urgency_gap_to_high_intent
+        FROM expanded
+        GROUP BY 1, 2
+        ORDER BY LEAST(
+                     COALESCE(
+                         MIN(GREATEST(0, {low_trust_confidence_min} - corroborated_confidence_score))
+                             FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source'),
+                         999::float8
+                     ),
+                     COALESCE(
+                         MIN(GREATEST(0, {high_intent_urgency_threshold} - max_urgency_score))
+                             FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold'),
+                         999::float8
+                     )
+                 ) ASC,
+                 blocked_group_count DESC,
+                 blocked_review_count DESC,
+                 source ASC,
+                 vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    trusted_blocked_source_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT id,
+                   review_count,
+                   representative_source,
+                   COALESCE(source_distribution, '{{}}'::jsonb) AS source_distribution
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+        ),
+        expanded AS (
+            SELECT p.id,
+                   COALESCE(
+                       NULLIF(LOWER(TRIM(src.source)), ''),
+                       NULLIF(LOWER(TRIM(p.representative_source)), ''),
+                       'unknown'
+                   ) AS source,
+                   COALESCE(src.source_review_count, p.review_count, 0)::int AS source_review_count
+            FROM pending p
+            LEFT JOIN LATERAL (
+                SELECT key AS source,
+                       CASE
+                           WHEN value ~ '^[0-9]+$' THEN value::int
+                           ELSE NULL
+                       END AS source_review_count
+                FROM jsonb_each_text(p.source_distribution)
+            ) src ON TRUE
+        )
+        SELECT source,
+               COUNT(DISTINCT id)::int AS group_count,
+               COALESCE(SUM(source_review_count), 0)::int AS review_count
+        FROM expanded
+        WHERE NOT ({low_trust_source_sql})
+        GROUP BY 1
+        ORDER BY group_count DESC,
+                 review_count DESC,
+                 source ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    trusted_blocked_source_vendor_gap_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT id,
+                   vendor_name,
+                   review_count,
+                   representative_source,
+                   COALESCE(source_distribution, '{{}}'::jsonb) AS source_distribution,
+                   COALESCE(canonical_gap_reason, 'low_signal') AS canonical_gap_reason,
+                   COALESCE(corroborated_confidence_score, 0)::float8 AS corroborated_confidence_score,
+                   COALESCE(max_urgency_score, 0)::float8 AS max_urgency_score
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+        ),
+        expanded AS (
+            SELECT p.id,
+                   p.vendor_name,
+                   p.canonical_gap_reason,
+                   p.corroborated_confidence_score,
+                   p.max_urgency_score,
+                   COALESCE(
+                       NULLIF(LOWER(TRIM(src.source)), ''),
+                       NULLIF(LOWER(TRIM(p.representative_source)), ''),
+                       'unknown'
+                   ) AS source,
+                   COALESCE(src.source_review_count, p.review_count, 0)::int AS source_review_count
+            FROM pending p
+            LEFT JOIN LATERAL (
+                SELECT key AS source,
+                       CASE
+                           WHEN value ~ '^[0-9]+$' THEN value::int
+                           ELSE NULL
+                       END AS source_review_count
+                FROM jsonb_each_text(p.source_distribution)
+            ) src ON TRUE
+        )
+        SELECT source,
+               vendor_name,
+               COUNT(DISTINCT id)::int AS blocked_group_count,
+               COALESCE(SUM(source_review_count), 0)::int AS blocked_review_count,
+               COUNT(DISTINCT id) FILTER (
+                   WHERE canonical_gap_reason = 'low_confidence_low_trust_source'
+               )::int AS low_confidence_group_count,
+               COUNT(DISTINCT id) FILTER (
+                   WHERE canonical_gap_reason = 'below_high_intent_threshold'
+               )::int AS below_threshold_group_count,
+               MIN(GREATEST(0, {low_trust_confidence_min} - corroborated_confidence_score))
+                   FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source')::float8
+                   AS min_confidence_gap_to_canonical,
+               AVG(GREATEST(0, {low_trust_confidence_min} - corroborated_confidence_score))
+                   FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source')::float8
+                   AS avg_confidence_gap_to_canonical,
+               MIN(GREATEST(0, {high_intent_urgency_threshold} - max_urgency_score))
+                   FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold')::float8
+                   AS min_urgency_gap_to_high_intent,
+               AVG(GREATEST(0, {high_intent_urgency_threshold} - max_urgency_score))
+                   FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold')::float8
+                   AS avg_urgency_gap_to_high_intent
+        FROM expanded
+        WHERE NOT ({low_trust_source_sql})
+        GROUP BY 1, 2
+        ORDER BY LEAST(
+                     COALESCE(
+                         MIN(GREATEST(0, {low_trust_confidence_min} - corroborated_confidence_score))
+                             FILTER (WHERE canonical_gap_reason = 'low_confidence_low_trust_source'),
+                         999::float8
+                     ),
+                     COALESCE(
+                         MIN(GREATEST(0, {high_intent_urgency_threshold} - max_urgency_score))
+                             FILTER (WHERE canonical_gap_reason = 'below_high_intent_threshold'),
+                         999::float8
+                     )
+                 ) ASC,
+                 blocked_group_count DESC,
+                 blocked_review_count DESC,
+                 source ASC,
+                 vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    near_threshold_source_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT id,
+                   review_count,
+                   representative_source,
+                   COALESCE(source_distribution, '{{}}'::jsonb) AS source_distribution
+            FROM filtered
+            WHERE review_status = 'pending'
+              AND {pending_priority_band_sql} = 'low'
+              AND {near_threshold_sql}
+        ),
+        expanded AS (
+            SELECT p.id,
+                   COALESCE(
+                       NULLIF(LOWER(TRIM(src.source)), ''),
+                       NULLIF(LOWER(TRIM(p.representative_source)), ''),
+                       'unknown'
+                   ) AS source,
+                   COALESCE(src.source_review_count, p.review_count, 0)::int AS source_review_count
+            FROM pending p
+            LEFT JOIN LATERAL (
+                SELECT key AS source,
+                       CASE
+                           WHEN value ~ '^[0-9]+$' THEN value::int
+                           ELSE NULL
+                       END AS source_review_count
+                FROM jsonb_each_text(p.source_distribution)
+            ) src ON TRUE
+        )
+        SELECT source,
+               COUNT(DISTINCT id)::int AS group_count,
+               COALESCE(SUM(source_review_count), 0)::int AS review_count
+        FROM expanded
+        GROUP BY 1
+        ORDER BY group_count DESC,
+                 review_count DESC,
+                 source ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    confidence_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT COALESCE(confidence_tier, 'unknown') AS confidence_tier,
+               COUNT(*)::int AS group_count
+        FROM filtered
+        GROUP BY 1
+        ORDER BY CASE COALESCE(confidence_tier, 'unknown')
+                     WHEN 'high' THEN 0
+                     WHEN 'medium' THEN 1
+                     WHEN 'low' THEN 2
+                     ELSE 3
+                 END,
+                 group_count DESC
+        """,
+        *params,
+    )
+    priority_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT id,
+               company_name,
+               display_company_name,
+               vendor_name,
+               review_count,
+               distinct_source_count,
+               decision_maker_count,
+               signal_evidence_count,
+               canonical_ready_review_count,
+               max_urgency_score,
+               corroborated_confidence_score,
+               representative_source,
+               canonical_gap_reason,
+               candidate_bucket,
+               {_company_signal_candidate_group_priority_band_sql()} AS review_priority_band,
+               {_company_signal_candidate_group_priority_reason_sql()} AS review_priority_reason
+        FROM filtered
+        ORDER BY {_company_signal_candidate_group_priority_order_sql()}
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    pending_priority_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT {_company_signal_candidate_group_priority_band_sql()} AS review_priority_band,
+               COUNT(*)::int AS group_count,
+               COALESCE(SUM(review_count), 0)::int AS review_count
+        FROM filtered
+        WHERE review_status = 'pending'
+        GROUP BY 1
+        ORDER BY CASE {_company_signal_candidate_group_priority_band_sql()}
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     ELSE 3
+                 END,
+                 group_count DESC,
+                 review_count DESC
+        """,
+        *params,
+    )
+    pending_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT {_company_signal_candidate_group_priority_band_sql()} AS review_priority_band,
+               {_company_signal_candidate_group_priority_reason_sql()} AS review_priority_reason,
+               COUNT(*)::int AS group_count,
+               COALESCE(SUM(review_count), 0)::int AS review_count
+        FROM filtered
+        WHERE review_status = 'pending'
+        GROUP BY 1, 2
+        ORDER BY CASE {_company_signal_candidate_group_priority_band_sql()}
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     ELSE 3
+                 END,
+                 group_count DESC,
+                 review_count DESC,
+                 review_priority_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    pending_sla_band_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT review_count,
+                   {pending_priority_band_sql} AS review_priority_band,
+                   {pending_age_days_sql}::float8 AS pending_age_days,
+                   {pending_sla_days_sql}::float8 AS sla_days
+            FROM filtered
+            WHERE review_status = 'pending'
+        )
+        SELECT review_priority_band,
+               MAX(sla_days)::float8 AS sla_days,
+               COUNT(*)::int AS pending_group_count,
+               COALESCE(SUM(review_count), 0)::int AS pending_review_count,
+               COUNT(*) FILTER (WHERE pending_age_days > sla_days)::int AS overdue_group_count,
+               COALESCE(SUM(review_count) FILTER (WHERE pending_age_days > sla_days), 0)::int AS overdue_review_count,
+               COALESCE(MAX(pending_age_days), 0)::float8 AS oldest_pending_age_days,
+               COALESCE(MAX(pending_age_days) FILTER (WHERE pending_age_days > sla_days), 0)::float8 AS oldest_overdue_age_days
+        FROM pending
+        GROUP BY 1
+        ORDER BY CASE review_priority_band
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     ELSE 3
+                 END,
+                 pending_group_count DESC,
+                 pending_review_count DESC
+        """,
+        *params,
+    )
+    pending_sla_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        ),
+        pending AS (
+            SELECT review_count,
+                   {pending_priority_band_sql} AS review_priority_band,
+                   {pending_priority_reason_sql} AS review_priority_reason,
+                   {pending_age_days_sql}::float8 AS pending_age_days,
+                   {pending_sla_days_sql}::float8 AS sla_days
+            FROM filtered
+            WHERE review_status = 'pending'
+        )
+        SELECT review_priority_band,
+               review_priority_reason,
+               MAX(sla_days)::float8 AS sla_days,
+               COUNT(*)::int AS pending_group_count,
+               COALESCE(SUM(review_count), 0)::int AS pending_review_count,
+               COUNT(*) FILTER (WHERE pending_age_days > sla_days)::int AS overdue_group_count,
+               COALESCE(SUM(review_count) FILTER (WHERE pending_age_days > sla_days), 0)::int AS overdue_review_count,
+               COALESCE(MAX(pending_age_days), 0)::float8 AS oldest_pending_age_days,
+               COALESCE(MAX(pending_age_days) FILTER (WHERE pending_age_days > sla_days), 0)::float8 AS oldest_overdue_age_days
+        FROM pending
+        GROUP BY 1, 2
+        ORDER BY CASE review_priority_band
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     ELSE 3
+                 END,
+                 overdue_group_count DESC,
+                 pending_group_count DESC,
+                 pending_review_count DESC,
+                 review_priority_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    oldest_pending_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_candidate_groups
+            WHERE {where_clause}
+        )
+        SELECT id,
+               company_name,
+               display_company_name,
+               vendor_name,
+               review_count,
+               canonical_gap_reason,
+               candidate_bucket,
+               {pending_priority_band_sql} AS review_priority_band,
+               {pending_priority_reason_sql} AS review_priority_reason,
+               ({pending_age_days_sql})::float8 AS pending_age_days
+        FROM filtered
+        WHERE review_status = 'pending'
+        ORDER BY pending_age_days DESC,
+                 {_company_signal_candidate_group_priority_order_sql()}
+        LIMIT 1
+        """,
+        *params,
+    )
+    priority_groups: list[dict[str, Any]] = []
+    for row in priority_rows:
+        priority_band = row.get("review_priority_band")
+        priority_reason = row.get("review_priority_reason")
+        if not priority_band or not priority_reason:
+            priority_band, priority_reason = _company_signal_candidate_group_priority_values(row)
+        priority_groups.append({
+            "group_id": str(row["id"]) if row.get("id") else None,
+            "company": row.get("company_name"),
+            "display_company": row.get("display_company_name") or row.get("company_name"),
+            "vendor": row.get("vendor_name"),
+            "review_count": row.get("review_count") or 0,
+            "distinct_source_count": row.get("distinct_source_count") or 0,
+            "decision_maker_count": row.get("decision_maker_count") or 0,
+            "signal_evidence_count": row.get("signal_evidence_count") or 0,
+            "canonical_ready_review_count": row.get("canonical_ready_review_count") or 0,
+            "max_urgency": float(row["max_urgency_score"]) if row.get("max_urgency_score") is not None else None,
+            "corroborated_confidence_score": float(row["corroborated_confidence_score"]) if row.get("corroborated_confidence_score") is not None else None,
+            "representative_source": row.get("representative_source"),
+            "candidate_bucket": row.get("candidate_bucket"),
+            "canonical_gap_reason": row.get("canonical_gap_reason"),
+            "review_priority_band": priority_band,
+            "review_priority_reason": priority_reason,
+        })
+    oldest_pending_group = None
+    if oldest_pending_rows:
+        row = oldest_pending_rows[0]
+        priority_band = row.get("review_priority_band")
+        priority_reason = row.get("review_priority_reason")
+        if not priority_band or not priority_reason:
+            priority_band, priority_reason = _company_signal_candidate_group_priority_values(row)
+        oldest_pending_group = {
+            "group_id": str(row["id"]) if row.get("id") else None,
+            "company": row.get("company_name"),
+            "display_company": row.get("display_company_name") or row.get("company_name"),
+            "vendor": row.get("vendor_name"),
+            "review_count": row.get("review_count") or 0,
+            "candidate_bucket": row.get("candidate_bucket"),
+            "canonical_gap_reason": row.get("canonical_gap_reason"),
+            "review_priority_band": priority_band,
+            "review_priority_reason": priority_reason,
+            "pending_age_days": float(row["pending_age_days"]) if row.get("pending_age_days") is not None else 0.0,
+        }
+    near_threshold_groups: list[dict[str, Any]] = []
+    for row in near_threshold_group_rows:
+        confidence_value = (
+            float(row["corroborated_confidence_score"])
+            if row.get("corroborated_confidence_score") is not None
+            else None
+        )
+        urgency_value = (
+            float(row["max_urgency_score"])
+            if row.get("max_urgency_score") is not None
+            else None
+        )
+        gap_reason = row.get("canonical_gap_reason")
+        confidence_gap = None
+        urgency_gap = None
+        if gap_reason == "low_confidence_low_trust_source" and confidence_value is not None:
+            confidence_gap = max(0.0, round(low_trust_confidence_min - confidence_value, 3))
+        if gap_reason == "below_high_intent_threshold" and urgency_value is not None:
+            urgency_gap = max(0.0, round(high_intent_urgency_threshold - urgency_value, 2))
+        near_threshold_groups.append({
+            "group_id": str(row["id"]) if row.get("id") else None,
+            "company": row.get("company_name"),
+            "display_company": row.get("display_company_name") or row.get("company_name"),
+            "vendor": row.get("vendor_name"),
+            "review_count": row.get("review_count") or 0,
+            "distinct_source_count": row.get("distinct_source_count") or 0,
+            "candidate_bucket": row.get("candidate_bucket"),
+            "canonical_gap_reason": gap_reason,
+            "corroborated_confidence_score": confidence_value,
+            "max_urgency": urgency_value,
+            "representative_source": row.get("representative_source"),
+            "confidence_gap_to_canonical": confidence_gap,
+            "urgency_gap_to_high_intent": urgency_gap,
+        })
+    unlock_candidates: list[dict[str, Any]] = []
+    for row in near_threshold_groups:
+        unlock_candidates.append({
+            "unlock_candidate_type": "low_trust_near_threshold_group",
+            "unlock_reason": "close_low_trust_confidence",
+            "vendor": row.get("vendor"),
+            "company": row.get("company"),
+            "display_company": row.get("display_company"),
+            "source": row.get("representative_source"),
+            "group_count": 1,
+            "review_count": row.get("review_count") or 0,
+            "canonical_gap_reason": row.get("canonical_gap_reason"),
+            "confidence_gap_to_canonical": row.get("confidence_gap_to_canonical"),
+            "urgency_gap_to_high_intent": row.get("urgency_gap_to_high_intent"),
+        })
+    for row in trusted_blocked_source_vendor_gap_rows:
+        low_confidence_count = int(row.get("low_confidence_group_count") or 0)
+        below_threshold_count = int(row.get("below_threshold_group_count") or 0)
+        if low_confidence_count > 0 and below_threshold_count <= 0:
+            row_gap_reason = "low_confidence_low_trust_source"
+        elif below_threshold_count > 0 and low_confidence_count <= 0:
+            row_gap_reason = "below_high_intent_threshold"
+        else:
+            row_gap_reason = "mixed"
+        unlock_candidates.append({
+            "unlock_candidate_type": "trusted_source_urgency_gap",
+            "unlock_reason": "closest_trusted_urgency_gap",
+            "vendor": row.get("vendor_name"),
+            "company": None,
+            "display_company": None,
+            "source": row.get("source"),
+            "group_count": row.get("blocked_group_count") or 0,
+            "review_count": row.get("blocked_review_count") or 0,
+            "canonical_gap_reason": row_gap_reason,
+            "confidence_gap_to_canonical": row.get("min_confidence_gap_to_canonical"),
+            "urgency_gap_to_high_intent": row.get("min_urgency_gap_to_high_intent"),
+        })
+    unlock_candidates.sort(
+        key=lambda item: (
+            0 if item.get("unlock_candidate_type") == "low_trust_near_threshold_group" else 1,
+            float(item.get("confidence_gap_to_canonical") or item.get("urgency_gap_to_high_intent") or 999.0),
+            -int(item.get("review_count") or 0),
+            str(item.get("vendor") or ""),
+            str(item.get("company") or ""),
+            str(item.get("source") or ""),
+        )
+    )
+    unlock_candidates = unlock_candidates[:top_n]
+    unlock_path_order = [
+        "low_trust_near_threshold_group",
+        "trusted_source_urgency_gap",
+    ]
+    unlock_path_summary: list[dict[str, Any]] = []
+    for unlock_candidate_type in unlock_path_order:
+        shortlisted = [
+            item
+            for item in unlock_candidates
+            if item.get("unlock_candidate_type") == unlock_candidate_type
+        ]
+        if not shortlisted:
+            continue
+        confidence_gaps = [
+            float(item["confidence_gap_to_canonical"])
+            for item in shortlisted
+            if item.get("confidence_gap_to_canonical") is not None
+        ]
+        urgency_gaps = [
+            float(item["urgency_gap_to_high_intent"])
+            for item in shortlisted
+            if item.get("urgency_gap_to_high_intent") is not None
+        ]
+        lead_vendor = max(
+            shortlisted,
+            key=lambda item: (
+                int(item.get("review_count") or 0),
+                int(item.get("group_count") or 0),
+                str(item.get("vendor") or ""),
+                str(item.get("source") or ""),
+            ),
+        )
+        lead_source = max(
+            shortlisted,
+            key=lambda item: (
+                int(item.get("review_count") or 0),
+                int(item.get("group_count") or 0),
+                str(item.get("source") or ""),
+                str(item.get("vendor") or ""),
+            ),
+        )
+        unlock_path_summary.append({
+            "unlock_candidate_type": unlock_candidate_type,
+            "unlock_reason": shortlisted[0].get("unlock_reason"),
+            "shortlist_entries": len(shortlisted),
+            "shortlist_groups": sum(int(item.get("group_count") or 0) for item in shortlisted),
+            "shortlist_reviews": sum(int(item.get("review_count") or 0) for item in shortlisted),
+            "lead_vendor": lead_vendor.get("vendor"),
+            "lead_source": lead_source.get("source"),
+            "min_confidence_gap_to_canonical": min(confidence_gaps) if confidence_gaps else None,
+            "avg_confidence_gap_to_canonical": (
+                round(sum(confidence_gaps) / len(confidence_gaps), 3)
+                if confidence_gaps
+                else None
+            ),
+            "min_urgency_gap_to_high_intent": min(urgency_gaps) if urgency_gaps else None,
+            "avg_urgency_gap_to_high_intent": (
+                round(sum(urgency_gaps) / len(urgency_gaps), 2)
+                if urgency_gaps
+                else None
+            ),
+        })
+
+    def _unlock_queue_filters(item: Mapping[str, Any] | None) -> dict[str, Any] | None:
+        if item is None:
+            return None
+        filters: dict[str, Any] = {
+            "candidate_bucket": "analyst_review",
+            "review_status": "pending",
+            "review_priority_band": "low",
+        }
+        if item.get("vendor"):
+            filters["vendor_name"] = item.get("vendor")
+        if item.get("company"):
+            filters["company_name"] = item.get("company")
+        if item.get("source"):
+            filters["source_name"] = item.get("source")
+        canonical_gap_reason = item.get("canonical_gap_reason")
+        if canonical_gap_reason and canonical_gap_reason != "mixed":
+            filters["canonical_gap_reason"] = canonical_gap_reason
+        return filters
+
+    def _build_queue_summary_filters() -> dict[str, Any]:
+        filters: dict[str, Any] = {
+            "review_status": review_status or "pending",
+        }
+        if vendor_name:
+            filters["vendor_name"] = vendor_name
+        if company_name:
+            filters["company_name"] = company_name
+        if source_name:
+            filters["source_name"] = source_name
+        if candidate_bucket:
+            filters["candidate_bucket"] = candidate_bucket
+        if requested_canonical_gap_reason:
+            filters["canonical_gap_reason"] = requested_canonical_gap_reason
+        if review_priority_band:
+            filters["review_priority_band"] = review_priority_band
+        if review_priority_reason:
+            filters["review_priority_reason"] = review_priority_reason
+        if min_urgency > 0:
+            filters["min_urgency"] = min_urgency
+        if min_confidence is not None:
+            filters["min_confidence"] = min_confidence
+        if min_reviews > 1:
+            filters["min_reviews"] = min_reviews
+        if decision_makers_only:
+            filters["decision_makers_only"] = True
+        if signal_evidence_present is not None:
+            filters["signal_evidence_present"] = signal_evidence_present
+        return filters
+
+    def _build_queue_summary_snapshot() -> dict[str, Any]:
+        totals_payload = dict(totals or {})
+        return {
+            "total_groups": int(totals_payload.get("total_groups") or 0),
+            "total_reviews": int(totals_payload.get("total_reviews") or 0),
+            "pending_groups": int(totals_payload.get("pending_groups") or 0),
+            "actionable_pending_groups": int(totals_payload.get("actionable_pending_groups") or 0),
+            "actionable_pending_reviews": int(totals_payload.get("actionable_pending_reviews") or 0),
+            "blocked_pending_groups": int(totals_payload.get("blocked_pending_groups") or 0),
+            "blocked_pending_reviews": int(totals_payload.get("blocked_pending_reviews") or 0),
+            "avg_pending_age_days": float(totals_payload.get("avg_pending_age_days") or 0.0),
+            "oldest_pending_age_days": float(totals_payload.get("oldest_pending_age_days") or 0.0),
+            "overdue_pending_groups": int(totals_payload.get("overdue_pending_groups") or 0),
+            "overdue_pending_reviews": int(totals_payload.get("overdue_pending_reviews") or 0),
+            "near_threshold_blocked_groups": int(totals_payload.get("near_threshold_blocked_groups") or 0),
+            "near_threshold_blocked_reviews": int(totals_payload.get("near_threshold_blocked_reviews") or 0),
+        }
+
+    def _build_queue_summary_driver(kind: str) -> dict[str, Any] | None:
+        if kind == "unlock_focus" and unlock_focus is not None:
+            return {
+                "kind": "unlock_focus",
+                "label": unlock_focus.get("action") or unlock_focus.get("recommended_action") or "unlock_focus",
+                "status": unlock_focus.get("status"),
+                "action_type": unlock_focus.get("action_type"),
+                "action": unlock_focus.get("action"),
+                "priority": unlock_focus.get("priority"),
+                "owner": unlock_focus.get("owner"),
+                "reason": unlock_focus.get("reason"),
+                "recommended_action": unlock_focus.get("recommended_action"),
+                "rationale": unlock_focus.get("rationale"),
+                "primary_unlock_candidate_type": unlock_focus.get("primary_unlock_candidate_type"),
+                "primary_vendor": unlock_focus.get("primary_vendor"),
+                "primary_company": unlock_focus.get("primary_company"),
+                "primary_source": unlock_focus.get("primary_source"),
+                "primary_confidence_gap_to_canonical": unlock_focus.get("primary_confidence_gap_to_canonical"),
+                "primary_urgency_gap_to_high_intent": unlock_focus.get("primary_urgency_gap_to_high_intent"),
+            }
+        snapshot = _build_queue_summary_snapshot()
+        return {
+            "kind": "queue_totals",
+            "label": kind,
+            "pending_groups": snapshot.get("pending_groups"),
+            "actionable_pending_groups": snapshot.get("actionable_pending_groups"),
+            "blocked_pending_groups": snapshot.get("blocked_pending_groups"),
+            "overdue_pending_groups": snapshot.get("overdue_pending_groups"),
+            "oldest_pending_age_days": snapshot.get("oldest_pending_age_days"),
+        }
+
+    unlock_focus = None
+    if unlock_candidates:
+        primary_unlock_candidate = unlock_candidates[0]
+        alternate_unlock_candidate = next(
+            (
+                item
+                for item in unlock_candidates[1:]
+                if item.get("unlock_candidate_type") != primary_unlock_candidate.get("unlock_candidate_type")
+            ),
+            unlock_candidates[1] if len(unlock_candidates) > 1 else None,
+        )
+        if primary_unlock_candidate.get("unlock_candidate_type") == "low_trust_near_threshold_group":
+            recommended_action = "review_near_threshold_low_trust"
+            rationale = (
+                "closer_than_trusted_source_backlog"
+                if alternate_unlock_candidate is not None
+                else "only_near_threshold_path_available"
+            )
+            action_status = "act"
+            action_type = "policy_threshold"
+            action = "review_low_trust_policy"
+            action_priority = "high"
+            action_owner = "intelligence_policy"
+            action_reason = "blocked_low_trust_policy"
+        else:
+            recommended_action = "review_trusted_source_urgency_gap"
+            rationale = "no_near_threshold_low_trust_groups"
+            action_status = "act"
+            action_type = "policy_threshold"
+            action = "review_threshold_policy"
+            action_priority = "medium"
+            action_owner = "intelligence_policy"
+            action_reason = "blocked_canonical_threshold"
+        primary_queue_filters = _unlock_queue_filters(primary_unlock_candidate)
+        alternate_queue_filters = _unlock_queue_filters(alternate_unlock_candidate)
+        unlock_focus = {
+            "status": action_status,
+            "action_type": action_type,
+            "action": action,
+            "priority": action_priority,
+            "owner": action_owner,
+            "reason": action_reason,
+            "queue_filters": primary_queue_filters,
+            "recommended_action": recommended_action,
+            "rationale": rationale,
+            "primary_unlock_candidate_type": primary_unlock_candidate.get("unlock_candidate_type"),
+            "primary_unlock_reason": primary_unlock_candidate.get("unlock_reason"),
+            "primary_vendor": primary_unlock_candidate.get("vendor"),
+            "primary_company": primary_unlock_candidate.get("company"),
+            "primary_display_company": primary_unlock_candidate.get("display_company"),
+            "primary_source": primary_unlock_candidate.get("source"),
+            "primary_group_count": primary_unlock_candidate.get("group_count"),
+            "primary_review_count": primary_unlock_candidate.get("review_count"),
+            "primary_confidence_gap_to_canonical": primary_unlock_candidate.get("confidence_gap_to_canonical"),
+            "primary_urgency_gap_to_high_intent": primary_unlock_candidate.get("urgency_gap_to_high_intent"),
+            "primary_queue_filters": primary_queue_filters,
+            "alternate_unlock_candidate_type": (
+                alternate_unlock_candidate.get("unlock_candidate_type")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_vendor": (
+                alternate_unlock_candidate.get("vendor")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_company": (
+                alternate_unlock_candidate.get("company")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_display_company": (
+                alternate_unlock_candidate.get("display_company")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_source": (
+                alternate_unlock_candidate.get("source")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_group_count": (
+                alternate_unlock_candidate.get("group_count")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_review_count": (
+                alternate_unlock_candidate.get("review_count")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_confidence_gap_to_canonical": (
+                alternate_unlock_candidate.get("confidence_gap_to_canonical")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_urgency_gap_to_high_intent": (
+                alternate_unlock_candidate.get("urgency_gap_to_high_intent")
+                if alternate_unlock_candidate is not None
+                else None
+            ),
+            "alternate_queue_filters": alternate_queue_filters,
+        }
+    def _build_operator_focus(
+        queue_recommendation: Mapping[str, Any] | None,
+        unlock_focus: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        queue_payload = _build_company_signal_operator_action(queue_recommendation)
+        unlock_payload = _build_company_signal_operator_action(
+            unlock_focus,
+            primary_driver=_build_queue_summary_driver("unlock_focus"),
+        )
+        return _choose_company_signal_operator_focus(queue_payload, unlock_payload)
+
+    queue_filters = _build_queue_summary_filters()
+    queue_snapshot = _build_queue_summary_snapshot()
+    actionable_pending_groups = int(queue_snapshot.get("actionable_pending_groups") or 0)
+    blocked_pending_groups = int(queue_snapshot.get("blocked_pending_groups") or 0)
+    overdue_pending_groups = int(queue_snapshot.get("overdue_pending_groups") or 0)
+    near_threshold_blocked_groups = int(queue_snapshot.get("near_threshold_blocked_groups") or 0)
+    pending_groups = int(queue_snapshot.get("pending_groups") or 0)
+    queue_recommendation_payload = _build_company_signal_queue_recommendation_payload(
+        actionable_pending_groups=actionable_pending_groups,
+        blocked_pending_groups=blocked_pending_groups,
+        overdue_pending_groups=overdue_pending_groups,
+        low_trust_blocked=bool(unlock_focus is not None and unlock_focus.get("recommended_action") == "review_near_threshold_low_trust"),
+        low_trust_dominant_priority="high" if near_threshold_blocked_groups > 0 else "medium",
+        promote_low_trust_when_blocked=True,
+        prioritize_blocked_dominant=False,
+        overdue_rationale="This queue slice has actionable pending groups that are already overdue and should be cleared before lower-yield backlog.",
+        actionable_rationale="This queue slice is actionable and should be worked in priority order.",
+        low_trust_dominant_rationale="Blocked low-trust backlog is outweighing actionable review work in this queue slice.",
+        threshold_dominant_rationale="Blocked canonical-threshold backlog is outweighing actionable review work in this queue slice.",
+        low_trust_blocked_rationale="This queue slice is blocked mainly by low-trust confidence policy rather than missing analyst review work.",
+        threshold_blocked_rationale="This queue slice has blocked backlog but little actionable review work, so policy thresholds are the main lever.",
+        monitor_rationale=(
+            "The current queue slice does not have pending backlog pressure."
+            if pending_groups <= 0
+            else "The current queue slice does not have material pending backlog pressure."
+        ),
+    )
+    queue_driver_map = {
+        "overdue_actionable": _build_queue_summary_driver("overdue_actionable_backlog"),
+        "dominant_blocked_low_trust": _build_queue_summary_driver("unlock_focus"),
+        "dominant_blocked_threshold": _build_queue_summary_driver("unlock_focus"),
+        "actionable": _build_queue_summary_driver("actionable_backlog"),
+        "blocked_low_trust": _build_queue_summary_driver("unlock_focus"),
+        "blocked_threshold": _build_queue_summary_driver("queue_totals"),
+        "monitor": _build_queue_summary_driver("queue_totals"),
+    }
+    queue_driver_key = str(queue_recommendation_payload.pop("driver_key", "monitor"))
+    queue_recommendation = _build_company_signal_operator_action(
+        queue_recommendation_payload,
+        primary_driver=queue_driver_map.get(queue_driver_key),
+        queue_filters=queue_filters,
+        queue_snapshot=queue_snapshot,
+    ) or _empty_company_signal_operator_action()
+    operator_focus = _build_operator_focus(queue_recommendation, unlock_focus)
+    return {
+        "totals": dict(totals or {}),
+        "gap_reasons": [dict(row) for row in gap_rows],
+        "top_vendors": [dict(row) for row in vendor_rows],
+        "actionable_top_vendors": [dict(row) for row in actionable_vendor_rows],
+        "actionable_top_vendor_reasons": [dict(row) for row in actionable_vendor_reason_rows],
+        "blocked_top_vendors": [dict(row) for row in blocked_vendor_rows],
+        "blocked_top_vendor_reasons": [dict(row) for row in blocked_vendor_reason_rows],
+        "blocked_source_mix": [dict(row) for row in blocked_source_rows],
+        "blocked_source_vendor_gaps": [dict(row) for row in blocked_source_vendor_gap_rows],
+        "trusted_blocked_source_mix": [dict(row) for row in trusted_blocked_source_rows],
+        "trusted_blocked_source_vendor_gaps": [dict(row) for row in trusted_blocked_source_vendor_gap_rows],
+        "near_threshold_top_vendors": [dict(row) for row in near_threshold_vendor_rows],
+        "near_threshold_gap_reasons": [dict(row) for row in near_threshold_reason_rows],
+        "near_threshold_groups": near_threshold_groups,
+        "near_threshold_source_mix": [dict(row) for row in near_threshold_source_rows],
+        "unlock_candidates": unlock_candidates,
+        "unlock_path_summary": unlock_path_summary,
+        "unlock_focus": unlock_focus,
+        "confidence_tiers": [dict(row) for row in confidence_rows],
+        "priority_groups": priority_groups,
+        "pending_priority_bands": [dict(row) for row in pending_priority_rows],
+        "pending_priority_reasons": [dict(row) for row in pending_reason_rows],
+        "pending_sla_bands": [dict(row) for row in pending_sla_band_rows],
+        "pending_sla_reasons": [dict(row) for row in pending_sla_reason_rows],
+        "oldest_pending_group": oldest_pending_group,
+        "queue_recommendation": queue_recommendation,
+        "operator_focus": operator_focus,
+    }
+
+
+def _company_signal_consumer_preview_limit() -> int:
+    return int(getattr(settings.b2b_churn, "company_signal_consumer_preview_limit", 3))
+
+
+def _company_signal_consumer_window_days() -> int:
+    core_window = int(getattr(settings.b2b_churn, "intelligence_window_days", 30) or 30)
+    company_signal_window = int(
+        getattr(settings.b2b_churn, "company_signal_window_days", core_window)
+        or core_window
+    )
+    return max(core_window, company_signal_window)
+
+
+def _company_signal_consumer_group_payload(group: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "group_id": group.get("group_id"),
+        "company": group.get("company"),
+        "display_company": group.get("display_company"),
+        "review_count": int(group.get("review_count") or 0),
+        "decision_maker_count": int(group.get("decision_maker_count") or 0),
+        "signal_evidence_count": int(group.get("signal_evidence_count") or 0),
+        "corroborated_confidence_score": group.get("corroborated_confidence_score"),
+        "canonical_gap_reason": group.get("canonical_gap_reason"),
+        "representative_source": group.get("representative_source"),
+        "representative_buying_stage": group.get("representative_buying_stage"),
+        "representative_urgency_score": group.get("representative_urgency_score"),
+        "review_priority_band": group.get("review_priority_band"),
+        "review_priority_reason": group.get("review_priority_reason"),
+        "supporting_reviews": list(group.get("supporting_reviews") or []),
+    }
+
+
+async def read_vendor_company_signal_review_queue(
+    pool,
+    *,
+    vendor_name: str,
+    window_days: int | None = None,
+    preview_limit: int | None = None,
+) -> dict[str, Any]:
+    """Return additive analyst-review backlog context for a vendor consumer."""
+    vendor = _canonicalize_vendor(vendor_name or "")
+    if not vendor:
+        return {}
+
+    limit = preview_limit if preview_limit is not None else _company_signal_consumer_preview_limit()
+    limit = max(1, int(limit))
+    resolved_window_days = (
+        int(window_days)
+        if window_days is not None
+        else _company_signal_consumer_window_days()
+    )
+
+    summary = await read_company_signal_candidate_group_summary(
+        pool,
+        window_days=resolved_window_days,
+        vendor_name=vendor,
+        candidate_bucket="analyst_review",
+        review_status="pending",
+        top_n=limit,
+    )
+    groups = await read_company_signal_candidate_groups(
+        pool,
+        window_days=resolved_window_days,
+        vendor_name=vendor,
+        candidate_bucket="analyst_review",
+        review_status="pending",
+        limit=limit,
+    )
+
+    totals = summary.get("totals") or {}
+    pending_groups = int(totals.get("pending_groups") or 0)
+    if pending_groups <= 0 and not groups:
+        return {}
+
+    return {
+        "vendor": vendor,
+        "candidate_bucket": "analyst_review",
+        "review_status": "pending",
+        "totals": {
+            "pending_groups": pending_groups,
+            "actionable_pending_groups": int(totals.get("actionable_pending_groups") or 0),
+            "blocked_pending_groups": int(totals.get("blocked_pending_groups") or 0),
+            "overdue_pending_groups": int(totals.get("overdue_pending_groups") or 0),
+            "pending_reviews": (
+                int(totals.get("actionable_pending_reviews") or 0)
+                + int(totals.get("blocked_pending_reviews") or 0)
+            ),
+        },
+        "operator_focus": dict(summary.get("operator_focus") or {}),
+        "groups": [
+            _company_signal_consumer_group_payload(group)
+            for group in groups
+            if isinstance(group, Mapping)
+        ],
+    }
+
+
+def _company_signal_review_event_filters(
+    *,
+    window_days: int = 30,
+    vendor_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    review_scope: str | None = None,
+    review_action: str | None = None,
+    company_signal_action: str | None = None,
+    canonical_gap_reason: str | None = None,
+    review_priority_band: str | None = None,
+    review_priority_reason: str | None = None,
+    review_unlock_path: str | None = None,
+    review_unlock_reason: str | None = None,
+    candidate_source: str | None = None,
+    rebuild_outcome: str | None = None,
+    rebuild_reason: str | None = None,
+) -> tuple[list[str], list[Any], int]:
+    conditions = ["created_at >= NOW() - make_interval(days => $1)"]
+    params: list[Any] = [window_days]
+    idx = 2
+
+    if scoped_vendors is not None:
+        if not scoped_vendors:
+            return [], [], 0
+        conditions.append(f"vendor_name = ANY(${idx}::text[])")
+        params.append(scoped_vendors)
+        idx += 1
+    if vendor_name:
+        conditions.append(f"vendor_name ILIKE '%' || ${idx} || '%'")
+        params.append(vendor_name)
+        idx += 1
+    if review_scope:
+        conditions.append(f"review_scope = ${idx}")
+        params.append(review_scope)
+        idx += 1
+    if review_action:
+        conditions.append(f"review_action = ${idx}")
+        params.append(review_action)
+        idx += 1
+    if company_signal_action:
+        conditions.append(f"company_signal_action = ${idx}")
+        params.append(company_signal_action)
+        idx += 1
+    if canonical_gap_reason:
+        conditions.append(f"COALESCE(canonical_gap_reason, 'unknown') = ${idx}")
+        params.append(canonical_gap_reason)
+        idx += 1
+    if review_priority_band:
+        conditions.append(f"COALESCE(review_priority_band, 'unknown') = ${idx}")
+        params.append(review_priority_band)
+        idx += 1
+    if review_priority_reason:
+        conditions.append(f"COALESCE(review_priority_reason, 'unknown') = ${idx}")
+        params.append(review_priority_reason)
+        idx += 1
+    if review_unlock_path:
+        conditions.append(f"COALESCE(review_unlock_path, 'unknown') = ${idx}")
+        params.append(review_unlock_path)
+        idx += 1
+    if review_unlock_reason:
+        conditions.append(f"COALESCE(review_unlock_reason, 'unknown') = ${idx}")
+        params.append(review_unlock_reason)
+        idx += 1
+    if candidate_source:
+        conditions.append(f"COALESCE(candidate_source, 'unknown') = ${idx}")
+        params.append(candidate_source)
+        idx += 1
+    if rebuild_reason:
+        conditions.append(f"COALESCE(rebuild_reason, 'unknown') = ${idx}")
+        params.append(rebuild_reason)
+        idx += 1
+    if rebuild_outcome == "requested":
+        conditions.append(f"COALESCE(rebuild_requested, FALSE) = ${idx}")
+        params.append(True)
+        idx += 1
+    elif rebuild_outcome == "triggered":
+        conditions.append(f"COALESCE(rebuild_triggered, FALSE) = ${idx}")
+        params.append(True)
+        idx += 1
+    elif rebuild_outcome == "blocked":
+        conditions.append(f"COALESCE(rebuild_requested, FALSE) = ${idx}")
+        params.append(True)
+        idx += 1
+        conditions.append(f"COALESCE(rebuild_triggered, FALSE) = ${idx}")
+        params.append(False)
+        idx += 1
+    elif rebuild_outcome == "not_requested":
+        conditions.append(f"COALESCE(rebuild_requested, FALSE) = ${idx}")
+        params.append(False)
+        idx += 1
+
+    return conditions, params, idx
+
+
+async def read_company_signal_review_impact_summary(
+    pool,
+    *,
+    window_days: int = 30,
+    vendor_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    review_scope: str | None = None,
+    review_action: str | None = None,
+    company_signal_action: str | None = None,
+    canonical_gap_reason: str | None = None,
+    review_priority_band: str | None = None,
+    review_priority_reason: str | None = None,
+    review_unlock_path: str | None = None,
+    review_unlock_reason: str | None = None,
+    candidate_source: str | None = None,
+    rebuild_outcome: str | None = None,
+    rebuild_reason: str | None = None,
+    top_n: int = 10,
+) -> dict[str, Any]:
+    """Summarize downstream impact from company-signal review actions."""
+    conditions, params, idx = _company_signal_review_event_filters(
+        window_days=window_days,
+        vendor_name=vendor_name,
+        scoped_vendors=scoped_vendors,
+        review_scope=review_scope,
+        review_action=review_action,
+        company_signal_action=company_signal_action,
+        canonical_gap_reason=canonical_gap_reason,
+        review_priority_band=review_priority_band,
+        review_priority_reason=review_priority_reason,
+        review_unlock_path=review_unlock_path,
+        review_unlock_reason=review_unlock_reason,
+        candidate_source=candidate_source,
+        rebuild_outcome=rebuild_outcome,
+        rebuild_reason=rebuild_reason,
+    )
+    if not conditions:
+        return {
+            "totals": {
+                "total_actions": 0,
+                "total_batches": 0,
+                "distinct_vendors": 0,
+                "approvals": 0,
+                "suppressions": 0,
+                "company_signal_creations": 0,
+                "company_signal_updates": 0,
+                "company_signal_deletions": 0,
+                "company_signal_noops": 0,
+                "rebuild_requests": 0,
+                "rebuild_triggered": 0,
+                "rebuild_blocked": 0,
+                "rebuild_persisted_runs": 0,
+                "rebuild_persisted_reports": 0,
+                "rebuild_total_accounts": 0,
+                "company_signal_effect_rate": 0.0,
+                "company_signal_creation_rate": 0.0,
+                "rebuild_trigger_rate": 0.0,
+                "avg_rebuild_reports_per_triggered": 0.0,
+                "avg_rebuild_accounts_per_triggered": 0.0,
+            },
+            "scopes": [],
+            "review_scope": review_scope,
+            "canonical_gap_reason": canonical_gap_reason,
+            "rebuild_outcome": rebuild_outcome,
+            "rebuild_reason": rebuild_reason,
+            "unlock_paths": [],
+            "priority_bands": [],
+            "priority_reasons": [],
+            "top_vendors": [],
+            "top_vendor_reasons": [],
+            "rebuild_reasons": [],
+            "daily_trends": [],
+            "trend_comparison": {
+                "comparison_window_days": 7,
+                "anchor_day": None,
+                "recent_start_day": None,
+                "recent_end_day": None,
+                "recent_days_present": 0,
+                "prior_start_day": None,
+                "prior_end_day": None,
+                "prior_days_present": 0,
+                "recent": {
+                    "action_count": 0,
+                    "approvals": 0,
+                    "suppressions": 0,
+                    "company_signal_creations": 0,
+                    "company_signal_updates": 0,
+                    "company_signal_deletions": 0,
+                    "company_signal_noops": 0,
+                    "rebuild_requests": 0,
+                    "rebuild_triggered": 0,
+                    "rebuild_blocked": 0,
+                    "rebuild_persisted_runs": 0,
+                    "rebuild_persisted_reports": 0,
+                    "rebuild_total_accounts": 0,
+                    "company_signal_effect_rate": 0.0,
+                    "company_signal_creation_rate": 0.0,
+                    "rebuild_trigger_rate": 0.0,
+                    "rebuild_block_rate": 0.0,
+                    "avg_rebuild_reports_per_triggered": 0.0,
+                    "avg_rebuild_accounts_per_triggered": 0.0,
+                },
+                "prior": {
+                    "action_count": 0,
+                    "approvals": 0,
+                    "suppressions": 0,
+                    "company_signal_creations": 0,
+                    "company_signal_updates": 0,
+                    "company_signal_deletions": 0,
+                    "company_signal_noops": 0,
+                    "rebuild_requests": 0,
+                    "rebuild_triggered": 0,
+                    "rebuild_blocked": 0,
+                    "rebuild_persisted_runs": 0,
+                    "rebuild_persisted_reports": 0,
+                    "rebuild_total_accounts": 0,
+                    "company_signal_effect_rate": 0.0,
+                    "company_signal_creation_rate": 0.0,
+                    "rebuild_trigger_rate": 0.0,
+                    "rebuild_block_rate": 0.0,
+                    "avg_rebuild_reports_per_triggered": 0.0,
+                    "avg_rebuild_accounts_per_triggered": 0.0,
+                },
+                "deltas": {
+                    "action_count": 0,
+                    "approvals": 0,
+                    "suppressions": 0,
+                    "company_signal_creations": 0,
+                    "company_signal_updates": 0,
+                    "company_signal_deletions": 0,
+                    "company_signal_noops": 0,
+                    "rebuild_requests": 0,
+                    "rebuild_triggered": 0,
+                    "rebuild_blocked": 0,
+                    "rebuild_persisted_runs": 0,
+                    "rebuild_persisted_reports": 0,
+                    "rebuild_total_accounts": 0,
+                    "company_signal_effect_rate": 0.0,
+                    "company_signal_creation_rate": 0.0,
+                    "rebuild_trigger_rate": 0.0,
+                    "rebuild_block_rate": 0.0,
+                    "avg_rebuild_reports_per_triggered": 0.0,
+                    "avg_rebuild_accounts_per_triggered": 0.0,
+                },
+            },
+            "trend_focus": {
+                "status": "no_data",
+                "focus": None,
+                "metric": None,
+                "direction": None,
+                "delta": 0.0,
+                "recent_value": 0.0,
+                "prior_value": 0.0,
+                "rationale": None,
+                "impact_filters": {},
+                "queue_filters": {},
+                "queue_snapshot": None,
+            },
+            "trend_alerts": [],
+            "trend_recommendation": {
+                "status": "no_data",
+                "action": None,
+                "priority": None,
+                "owner": None,
+                "rationale": None,
+                "supporting_focuses": [],
+            },
+            "trend_recommendation_filters": {},
+            "trend_recommendation_queue_filters": {},
+            "trend_recommendation_queue_snapshot": None,
+            "trend_queue_rankings": [],
+            "trend_queue_focus": None,
+            "trend_queue_recommendation": {
+                "status": "no_data",
+                "action_type": None,
+                "action": None,
+                "priority": None,
+                "owner": None,
+                "reason": None,
+                "rationale": None,
+                "queue_filters": {},
+                "queue_snapshot": None,
+                "primary_driver": None,
+            },
+            "operator_focus": {
+                "status": "no_data",
+                "action_type": None,
+                "action": None,
+                "priority": None,
+                "owner": None,
+                "reason": None,
+                "rationale": None,
+                "queue_filters": {},
+                "queue_snapshot": None,
+                "primary_driver": None,
+            },
+        }
+
+    where_clause = " AND ".join(conditions)
+    top_n_param = idx
+    totals = await pool.fetchrow(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        rebuilds AS (
+            SELECT DISTINCT ON (review_batch_id, vendor_name)
+                   review_batch_id,
+                   vendor_name,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_reason, '') AS rebuild_reason,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id, vendor_name, created_at DESC
+        )
+        SELECT COUNT(*)::int AS total_actions,
+               COUNT(DISTINCT review_batch_id)::int AS total_batches,
+               COUNT(DISTINCT vendor_name)::int AS distinct_vendors,
+               COUNT(*) FILTER (WHERE review_action = 'approved')::int AS approvals,
+               COUNT(*) FILTER (WHERE review_action = 'suppressed')::int AS suppressions,
+               COUNT(*) FILTER (WHERE company_signal_action = 'created')::int AS company_signal_creations,
+               COUNT(*) FILTER (WHERE company_signal_action = 'updated')::int AS company_signal_updates,
+               COUNT(*) FILTER (WHERE company_signal_action = 'deleted')::int AS company_signal_deletions,
+               COUNT(*) FILTER (WHERE company_signal_action = 'none')::int AS company_signal_noops,
+               COALESCE((SELECT COUNT(*) FROM rebuilds WHERE rebuild_requested), 0)::int AS rebuild_requests,
+               COALESCE((SELECT COUNT(*) FROM rebuilds WHERE rebuild_triggered), 0)::int AS rebuild_triggered,
+               COALESCE((SELECT COUNT(*) FROM rebuilds WHERE rebuild_requested AND NOT rebuild_triggered), 0)::int AS rebuild_blocked,
+               COALESCE((SELECT COUNT(*) FROM rebuilds WHERE rebuild_triggered AND rebuild_persisted_count > 0), 0)::int AS rebuild_persisted_runs,
+               COALESCE((SELECT SUM(rebuild_persisted_count) FROM rebuilds WHERE rebuild_triggered), 0)::int AS rebuild_persisted_reports,
+               COALESCE((SELECT SUM(rebuild_total_accounts) FROM rebuilds WHERE rebuild_triggered), 0)::int AS rebuild_total_accounts
+        FROM filtered
+        """,
+        *params,
+    )
+    scope_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        )
+        SELECT review_scope,
+               COUNT(*)::int AS action_count
+        FROM filtered
+        GROUP BY 1
+        ORDER BY action_count DESC, review_scope ASC
+        """,
+        *params,
+    )
+    unlock_path_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (
+                review_batch_id,
+                vendor_name,
+                COALESCE(review_unlock_path, 'unknown'),
+                COALESCE(review_unlock_reason, 'unknown'),
+                COALESCE(candidate_source, 'unknown')
+            )
+                   review_batch_id,
+                   vendor_name,
+                   COALESCE(review_unlock_path, 'unknown') AS review_unlock_path,
+                   COALESCE(review_unlock_reason, 'unknown') AS review_unlock_reason,
+                   COALESCE(candidate_source, 'unknown') AS candidate_source,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id,
+                     vendor_name,
+                     COALESCE(review_unlock_path, 'unknown'),
+                     COALESCE(review_unlock_reason, 'unknown'),
+                     COALESCE(candidate_source, 'unknown'),
+                     created_at DESC
+        ),
+        unlock_rebuilds AS (
+            SELECT review_unlock_path,
+                   review_unlock_reason,
+                   candidate_source,
+                   COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+                   COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+                   COALESCE(SUM(rebuild_persisted_count), 0)::int AS rebuild_persisted_reports,
+                   COALESCE(SUM(rebuild_total_accounts), 0)::int AS rebuild_total_accounts
+            FROM rebuild_rows
+            GROUP BY 1, 2, 3
+        )
+        SELECT COALESCE(f.review_unlock_path, 'unknown') AS review_unlock_path,
+               COALESCE(f.review_unlock_reason, 'unknown') AS review_unlock_reason,
+               COALESCE(f.candidate_source, 'unknown') AS candidate_source,
+               COUNT(*)::int AS action_count,
+               COUNT(*) FILTER (WHERE f.review_action = 'approved')::int AS approvals,
+               COUNT(*) FILTER (WHERE f.review_action = 'suppressed')::int AS suppressions,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'created')::int AS company_signal_creations,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'updated')::int AS company_signal_updates,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'deleted')::int AS company_signal_deletions,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'none')::int AS company_signal_noops,
+               COALESCE(ur.rebuild_requests, 0)::int AS rebuild_requests,
+               COALESCE(ur.rebuild_triggered, 0)::int AS rebuild_triggered,
+               COALESCE(ur.rebuild_persisted_reports, 0)::int AS rebuild_persisted_reports,
+               COALESCE(ur.rebuild_total_accounts, 0)::int AS rebuild_total_accounts
+        FROM filtered f
+        LEFT JOIN unlock_rebuilds ur
+          ON ur.review_unlock_path = COALESCE(f.review_unlock_path, 'unknown')
+         AND ur.review_unlock_reason = COALESCE(f.review_unlock_reason, 'unknown')
+         AND ur.candidate_source = COALESCE(f.candidate_source, 'unknown')
+        GROUP BY 1, 2, 3, ur.rebuild_requests, ur.rebuild_triggered, ur.rebuild_persisted_reports, ur.rebuild_total_accounts
+        ORDER BY action_count DESC,
+                 approvals DESC,
+                 review_unlock_path ASC,
+                 candidate_source ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    priority_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (review_batch_id, vendor_name)
+                   review_batch_id,
+                   vendor_name,
+                   COALESCE(review_priority_band, 'unknown') AS review_priority_band,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id, vendor_name, created_at DESC
+        ),
+        band_rebuilds AS (
+            SELECT review_priority_band,
+                   COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+                   COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+                   COALESCE(SUM(rebuild_persisted_count), 0)::int AS rebuild_persisted_reports,
+                   COALESCE(SUM(rebuild_total_accounts), 0)::int AS rebuild_total_accounts
+            FROM rebuild_rows
+            GROUP BY 1
+        )
+        SELECT COALESCE(f.review_priority_band, 'unknown') AS review_priority_band,
+               COUNT(*)::int AS action_count,
+               COUNT(*) FILTER (WHERE f.review_action = 'approved')::int AS approvals,
+               COUNT(*) FILTER (WHERE f.review_action = 'suppressed')::int AS suppressions,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'created')::int AS company_signal_creations,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'updated')::int AS company_signal_updates,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'deleted')::int AS company_signal_deletions,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'none')::int AS company_signal_noops,
+               COALESCE(br.rebuild_requests, 0)::int AS rebuild_requests,
+               COALESCE(br.rebuild_triggered, 0)::int AS rebuild_triggered,
+               COALESCE(br.rebuild_persisted_reports, 0)::int AS rebuild_persisted_reports,
+               COALESCE(br.rebuild_total_accounts, 0)::int AS rebuild_total_accounts
+        FROM filtered f
+        LEFT JOIN band_rebuilds br
+          ON br.review_priority_band = COALESCE(f.review_priority_band, 'unknown')
+        GROUP BY 1, br.rebuild_requests, br.rebuild_triggered, br.rebuild_persisted_reports, br.rebuild_total_accounts
+        ORDER BY CASE COALESCE(f.review_priority_band, 'unknown')
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     WHEN 'low' THEN 3
+                     ELSE 4
+                 END,
+                 action_count DESC
+        """,
+        *params,
+    )
+    priority_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (review_batch_id, vendor_name)
+                   review_batch_id,
+                   vendor_name,
+                   COALESCE(review_priority_band, 'unknown') AS review_priority_band,
+                   COALESCE(review_priority_reason, 'unknown') AS review_priority_reason,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id, vendor_name, created_at DESC
+        ),
+        reason_rebuilds AS (
+            SELECT review_priority_band,
+                   review_priority_reason,
+                   COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+                   COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+                   COALESCE(SUM(rebuild_persisted_count), 0)::int AS rebuild_persisted_reports,
+                   COALESCE(SUM(rebuild_total_accounts), 0)::int AS rebuild_total_accounts
+            FROM rebuild_rows
+            GROUP BY 1, 2
+        )
+        SELECT COALESCE(f.review_priority_band, 'unknown') AS review_priority_band,
+               COALESCE(f.review_priority_reason, 'unknown') AS review_priority_reason,
+               COUNT(*)::int AS action_count,
+               COUNT(*) FILTER (WHERE f.review_action = 'approved')::int AS approvals,
+               COUNT(*) FILTER (WHERE f.review_action = 'suppressed')::int AS suppressions,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'created')::int AS company_signal_creations,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'updated')::int AS company_signal_updates,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'deleted')::int AS company_signal_deletions,
+               COUNT(*) FILTER (WHERE f.company_signal_action = 'none')::int AS company_signal_noops,
+               COALESCE(rr.rebuild_requests, 0)::int AS rebuild_requests,
+               COALESCE(rr.rebuild_triggered, 0)::int AS rebuild_triggered,
+               COALESCE(rr.rebuild_persisted_reports, 0)::int AS rebuild_persisted_reports,
+               COALESCE(rr.rebuild_total_accounts, 0)::int AS rebuild_total_accounts
+        FROM filtered f
+        LEFT JOIN reason_rebuilds rr
+          ON rr.review_priority_band = COALESCE(f.review_priority_band, 'unknown')
+         AND rr.review_priority_reason = COALESCE(f.review_priority_reason, 'unknown')
+        GROUP BY 1, 2, rr.rebuild_requests, rr.rebuild_triggered, rr.rebuild_persisted_reports, rr.rebuild_total_accounts
+        ORDER BY CASE COALESCE(f.review_priority_band, 'unknown')
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     WHEN 'low' THEN 3
+                     ELSE 4
+                 END,
+                 action_count DESC,
+                 review_priority_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    vendor_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        vendor_actions AS (
+            SELECT vendor_name,
+                   COUNT(*)::int AS action_count,
+                   COUNT(*) FILTER (WHERE review_action = 'approved')::int AS approvals,
+                   COUNT(*) FILTER (WHERE review_action = 'suppressed')::int AS suppressions,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'created')::int AS company_signal_creations,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'updated')::int AS company_signal_updates,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'deleted')::int AS company_signal_deletions
+            FROM filtered
+            GROUP BY 1
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (review_batch_id, vendor_name)
+                   review_batch_id,
+                   vendor_name,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id, vendor_name, created_at DESC
+        ),
+        vendor_rebuilds AS (
+            SELECT vendor_name,
+                   COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+                   COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+                   COALESCE(SUM(rebuild_persisted_count), 0)::int AS rebuild_persisted_reports,
+                   COALESCE(SUM(rebuild_total_accounts), 0)::int AS rebuild_total_accounts
+            FROM rebuild_rows
+            GROUP BY 1
+        )
+        SELECT va.vendor_name,
+               va.action_count,
+               va.approvals,
+               va.suppressions,
+               va.company_signal_creations,
+               va.company_signal_updates,
+               va.company_signal_deletions,
+               COALESCE(vr.rebuild_requests, 0)::int AS rebuild_requests,
+               COALESCE(vr.rebuild_triggered, 0)::int AS rebuild_triggered,
+               COALESCE(vr.rebuild_persisted_reports, 0)::int AS rebuild_persisted_reports,
+               COALESCE(vr.rebuild_total_accounts, 0)::int AS rebuild_total_accounts
+        FROM vendor_actions va
+        LEFT JOIN vendor_rebuilds vr ON vr.vendor_name = va.vendor_name
+        ORDER BY va.approvals DESC,
+                 va.action_count DESC,
+                 va.vendor_name ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    vendor_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        vendor_reason_actions AS (
+            SELECT vendor_name,
+                   COALESCE(review_priority_band, 'unknown') AS review_priority_band,
+                   COALESCE(review_priority_reason, 'unknown') AS review_priority_reason,
+                   COUNT(*)::int AS action_count,
+                   COUNT(*) FILTER (WHERE review_action = 'approved')::int AS approvals,
+                   COUNT(*) FILTER (WHERE review_action = 'suppressed')::int AS suppressions,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'created')::int AS company_signal_creations,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'updated')::int AS company_signal_updates,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'deleted')::int AS company_signal_deletions,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'none')::int AS company_signal_noops
+            FROM filtered
+            GROUP BY 1, 2, 3
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (review_batch_id, vendor_name, COALESCE(review_priority_band, 'unknown'), COALESCE(review_priority_reason, 'unknown'))
+                   review_batch_id,
+                   vendor_name,
+                   COALESCE(review_priority_band, 'unknown') AS review_priority_band,
+                   COALESCE(review_priority_reason, 'unknown') AS review_priority_reason,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id, vendor_name, COALESCE(review_priority_band, 'unknown'), COALESCE(review_priority_reason, 'unknown'), created_at DESC
+        ),
+        vendor_reason_rebuilds AS (
+            SELECT vendor_name,
+                   review_priority_band,
+                   review_priority_reason,
+                   COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+                   COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+                   COALESCE(SUM(rebuild_persisted_count), 0)::int AS rebuild_persisted_reports,
+                   COALESCE(SUM(rebuild_total_accounts), 0)::int AS rebuild_total_accounts
+            FROM rebuild_rows
+            GROUP BY 1, 2, 3
+        )
+        SELECT vra.vendor_name,
+               vra.review_priority_band,
+               vra.review_priority_reason,
+               vra.action_count,
+               vra.approvals,
+               vra.suppressions,
+               vra.company_signal_creations,
+               vra.company_signal_updates,
+               vra.company_signal_deletions,
+               vra.company_signal_noops,
+               COALESCE(vrr.rebuild_requests, 0)::int AS rebuild_requests,
+               COALESCE(vrr.rebuild_triggered, 0)::int AS rebuild_triggered,
+               COALESCE(vrr.rebuild_persisted_reports, 0)::int AS rebuild_persisted_reports,
+               COALESCE(vrr.rebuild_total_accounts, 0)::int AS rebuild_total_accounts
+        FROM vendor_reason_actions vra
+        LEFT JOIN vendor_reason_rebuilds vrr
+          ON vrr.vendor_name = vra.vendor_name
+         AND vrr.review_priority_band = vra.review_priority_band
+         AND vrr.review_priority_reason = vra.review_priority_reason
+        ORDER BY vra.action_count DESC,
+                 vra.approvals DESC,
+                 CASE vra.review_priority_band
+                     WHEN 'promote_now' THEN 0
+                     WHEN 'high' THEN 1
+                     WHEN 'medium' THEN 2
+                     WHEN 'low' THEN 3
+                     ELSE 4
+                 END,
+                 vra.vendor_name ASC,
+                 vra.review_priority_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    rebuild_reason_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (review_batch_id, vendor_name)
+                   review_batch_id,
+                   vendor_name,
+                   COALESCE(rebuild_reason, 'unknown') AS rebuild_reason,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY review_batch_id, vendor_name, created_at DESC
+        )
+        SELECT rebuild_reason,
+               COUNT(*)::int AS rebuild_rows,
+               COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+               COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+               COUNT(*) FILTER (WHERE rebuild_requested AND NOT rebuild_triggered)::int AS rebuild_blocked,
+               COUNT(*) FILTER (WHERE rebuild_triggered AND rebuild_persisted_count > 0)::int AS rebuild_persisted_runs,
+               COALESCE(SUM(rebuild_persisted_count) FILTER (WHERE rebuild_triggered), 0)::int AS rebuild_persisted_reports,
+               COALESCE(SUM(rebuild_total_accounts) FILTER (WHERE rebuild_triggered), 0)::int AS rebuild_total_accounts
+        FROM rebuild_rows
+        GROUP BY 1
+        ORDER BY rebuild_rows DESC,
+                 rebuild_triggered DESC,
+                 rebuild_reason ASC
+        LIMIT ${top_n_param}
+        """,
+        *params,
+        top_n,
+    )
+    daily_trend_rows = await pool.fetch(
+        f"""
+        WITH filtered AS (
+            SELECT *,
+                   DATE_TRUNC('day', created_at AT TIME ZONE 'UTC')::date AS action_day
+            FROM b2b_company_signal_review_events
+            WHERE {where_clause}
+        ),
+        daily_actions AS (
+            SELECT action_day,
+                   COUNT(*)::int AS action_count,
+                   COUNT(*) FILTER (WHERE review_action = 'approved')::int AS approvals,
+                   COUNT(*) FILTER (WHERE review_action = 'suppressed')::int AS suppressions,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'created')::int AS company_signal_creations,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'updated')::int AS company_signal_updates,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'deleted')::int AS company_signal_deletions,
+                   COUNT(*) FILTER (WHERE company_signal_action = 'none')::int AS company_signal_noops
+            FROM filtered
+            GROUP BY 1
+        ),
+        rebuild_rows AS (
+            SELECT DISTINCT ON (action_day, review_batch_id, vendor_name)
+                   action_day,
+                   review_batch_id,
+                   vendor_name,
+                   rebuild_requested,
+                   rebuild_triggered,
+                   COALESCE(rebuild_persisted_count, 0) AS rebuild_persisted_count,
+                   COALESCE(rebuild_total_accounts, 0) AS rebuild_total_accounts
+            FROM filtered
+            ORDER BY action_day, review_batch_id, vendor_name, created_at DESC
+        ),
+        daily_rebuilds AS (
+            SELECT action_day,
+                   COUNT(*) FILTER (WHERE rebuild_requested)::int AS rebuild_requests,
+                   COUNT(*) FILTER (WHERE rebuild_triggered)::int AS rebuild_triggered,
+                   COUNT(*) FILTER (WHERE rebuild_requested AND NOT rebuild_triggered)::int AS rebuild_blocked,
+                   COUNT(*) FILTER (WHERE rebuild_triggered AND rebuild_persisted_count > 0)::int AS rebuild_persisted_runs,
+                   COALESCE(SUM(rebuild_persisted_count) FILTER (WHERE rebuild_triggered), 0)::int AS rebuild_persisted_reports,
+                   COALESCE(SUM(rebuild_total_accounts) FILTER (WHERE rebuild_triggered), 0)::int AS rebuild_total_accounts
+            FROM rebuild_rows
+            GROUP BY 1
+        )
+        SELECT da.action_day::text AS action_day,
+               da.action_count,
+               da.approvals,
+               da.suppressions,
+               da.company_signal_creations,
+               da.company_signal_updates,
+               da.company_signal_deletions,
+               da.company_signal_noops,
+               COALESCE(dr.rebuild_requests, 0)::int AS rebuild_requests,
+               COALESCE(dr.rebuild_triggered, 0)::int AS rebuild_triggered,
+               COALESCE(dr.rebuild_blocked, 0)::int AS rebuild_blocked,
+               COALESCE(dr.rebuild_persisted_runs, 0)::int AS rebuild_persisted_runs,
+               COALESCE(dr.rebuild_persisted_reports, 0)::int AS rebuild_persisted_reports,
+               COALESCE(dr.rebuild_total_accounts, 0)::int AS rebuild_total_accounts
+        FROM daily_actions da
+        LEFT JOIN daily_rebuilds dr ON dr.action_day = da.action_day
+        ORDER BY da.action_day DESC
+        """,
+        *params,
+    )
+    def _safe_rate(numerator: Any, denominator: Any) -> float:
+        try:
+            num = float(numerator or 0)
+            den = float(denominator or 0)
+        except (TypeError, ValueError):
+            return 0.0
+        if den <= 0:
+            return 0.0
+        return num / den
+
+    def _with_effect_metrics(row: Mapping[str, Any], *, action_key: str = "action_count") -> dict[str, Any]:
+        payload = dict(row)
+        action_count = payload.get(action_key) or 0
+        effect_count = (
+            (payload.get("company_signal_creations") or 0)
+            + (payload.get("company_signal_updates") or 0)
+            + (payload.get("company_signal_deletions") or 0)
+        )
+        payload["company_signal_effect_rate"] = _safe_rate(effect_count, action_count)
+        payload["company_signal_creation_rate"] = _safe_rate(
+            payload.get("company_signal_creations") or 0,
+            action_count,
+        )
+        payload["rebuild_trigger_rate"] = _safe_rate(
+            payload.get("rebuild_triggered") or 0,
+            payload.get("rebuild_requests") or 0,
+        )
+        payload["avg_rebuild_reports_per_triggered"] = _safe_rate(
+            payload.get("rebuild_persisted_reports") or 0,
+            payload.get("rebuild_triggered") or 0,
+        )
+        payload["avg_rebuild_accounts_per_triggered"] = _safe_rate(
+            payload.get("rebuild_total_accounts") or 0,
+            payload.get("rebuild_triggered") or 0,
+        )
+        return payload
+
+    def _with_rebuild_metrics(row: Mapping[str, Any]) -> dict[str, Any]:
+        payload = dict(row)
+        payload["rebuild_trigger_rate"] = _safe_rate(
+            payload.get("rebuild_triggered") or 0,
+            payload.get("rebuild_requests") or 0,
+        )
+        payload["rebuild_block_rate"] = _safe_rate(
+            payload.get("rebuild_blocked") or 0,
+            payload.get("rebuild_requests") or 0,
+        )
+        payload["avg_rebuild_reports_per_triggered"] = _safe_rate(
+            payload.get("rebuild_persisted_reports") or 0,
+            payload.get("rebuild_triggered") or 0,
+        )
+        payload["avg_rebuild_accounts_per_triggered"] = _safe_rate(
+            payload.get("rebuild_total_accounts") or 0,
+            payload.get("rebuild_triggered") or 0,
+        )
+        return payload
+
+    def _build_empty_trend_window() -> dict[str, Any]:
+        return {
+            "action_count": 0,
+            "approvals": 0,
+            "suppressions": 0,
+            "company_signal_creations": 0,
+            "company_signal_updates": 0,
+            "company_signal_deletions": 0,
+            "company_signal_noops": 0,
+            "rebuild_requests": 0,
+            "rebuild_triggered": 0,
+            "rebuild_blocked": 0,
+            "rebuild_persisted_runs": 0,
+            "rebuild_persisted_reports": 0,
+            "rebuild_total_accounts": 0,
+            "company_signal_effect_rate": 0.0,
+            "company_signal_creation_rate": 0.0,
+            "rebuild_trigger_rate": 0.0,
+            "rebuild_block_rate": 0.0,
+            "avg_rebuild_reports_per_triggered": 0.0,
+            "avg_rebuild_accounts_per_triggered": 0.0,
+        }
+
+    def _summarize_trend_window(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
+        if not rows:
+            return _build_empty_trend_window()
+        aggregate = {
+            "action_count": 0,
+            "approvals": 0,
+            "suppressions": 0,
+            "company_signal_creations": 0,
+            "company_signal_updates": 0,
+            "company_signal_deletions": 0,
+            "company_signal_noops": 0,
+            "rebuild_requests": 0,
+            "rebuild_triggered": 0,
+            "rebuild_blocked": 0,
+            "rebuild_persisted_runs": 0,
+            "rebuild_persisted_reports": 0,
+            "rebuild_total_accounts": 0,
+        }
+        for row in rows:
+            for key in aggregate:
+                aggregate[key] += int(row.get(key) or 0)
+        return _with_rebuild_metrics(_with_effect_metrics(aggregate))
+
+    def _build_trend_comparison(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
+        window_days = 7
+        empty_window = _build_empty_trend_window()
+        empty_deltas = dict(empty_window)
+        parsed: list[tuple[date, Mapping[str, Any]]] = []
+        for row in rows:
+            action_day = row.get("action_day")
+            if not action_day:
+                continue
+            try:
+                parsed.append((date.fromisoformat(str(action_day)), row))
+            except (TypeError, ValueError):
+                continue
+        if not parsed:
+            return {
+                "comparison_window_days": window_days,
+                "anchor_day": None,
+                "recent_start_day": None,
+                "recent_end_day": None,
+                "recent_days_present": 0,
+                "prior_start_day": None,
+                "prior_end_day": None,
+                "prior_days_present": 0,
+                "recent": dict(empty_window),
+                "prior": dict(empty_window),
+                "deltas": empty_deltas,
+            }
+        anchor_day = max(day for day, _ in parsed)
+        recent_end = anchor_day
+        recent_start = recent_end - timedelta(days=window_days - 1)
+        prior_end = recent_start - timedelta(days=1)
+        prior_start = prior_end - timedelta(days=window_days - 1)
+        recent_rows = [row for day, row in parsed if recent_start <= day <= recent_end]
+        prior_rows = [row for day, row in parsed if prior_start <= day <= prior_end]
+        recent_summary = _summarize_trend_window(recent_rows)
+        prior_summary = _summarize_trend_window(prior_rows)
+        deltas: dict[str, Any] = {}
+        for key, value in recent_summary.items():
+            prior_value = prior_summary.get(key, 0)
+            if isinstance(value, float) or isinstance(prior_value, float):
+                deltas[key] = float(value or 0.0) - float(prior_value or 0.0)
+            else:
+                deltas[key] = int(value or 0) - int(prior_value or 0)
+        return {
+            "comparison_window_days": window_days,
+            "anchor_day": anchor_day.isoformat(),
+            "recent_start_day": recent_start.isoformat(),
+            "recent_end_day": recent_end.isoformat(),
+            "recent_days_present": len(recent_rows),
+            "prior_start_day": prior_start.isoformat(),
+            "prior_end_day": prior_end.isoformat(),
+            "prior_days_present": len(prior_rows),
+            "recent": recent_summary,
+            "prior": prior_summary,
+            "deltas": deltas,
+        }
+
+    def _build_trend_alerts(comparison: Mapping[str, Any]) -> list[dict[str, Any]]:
+        recent = comparison.get("recent") if isinstance(comparison, Mapping) else None
+        prior = comparison.get("prior") if isinstance(comparison, Mapping) else None
+        deltas = comparison.get("deltas") if isinstance(comparison, Mapping) else None
+        if not isinstance(recent, Mapping) or not isinstance(prior, Mapping) or not isinstance(deltas, Mapping):
+            return []
+        if not comparison.get("anchor_day"):
+            return []
+
+        alerts: list[dict[str, Any]] = []
+
+        def _maybe_add(*, status: str, focus: str, metric: str, direction: str, rationale: str, include: bool) -> None:
+            if not include:
+                return
+            alerts.append(
+                {
+                    "status": status,
+                    "focus": focus,
+                    "metric": metric,
+                    "direction": direction,
+                    "delta": float(deltas.get(metric) or 0.0),
+                    "recent_value": float(recent.get(metric) or 0.0),
+                    "prior_value": float(prior.get(metric) or 0.0),
+                    "rationale": rationale,
+                }
+            )
+
+        _maybe_add(
+            status="watch",
+            focus="rebuild_blocks_up",
+            metric="rebuild_blocked",
+            direction="up",
+            rationale="More requested rebuilds are blocking in the recent window than in the prior window.",
+            include=float(deltas.get("rebuild_blocked") or 0.0) > 0 and float(recent.get("rebuild_requests") or 0.0) > 0,
+        )
+        _maybe_add(
+            status="watch",
+            focus="rebuild_trigger_rate_down",
+            metric="rebuild_trigger_rate",
+            direction="down",
+            rationale="Requested rebuilds are converting to triggered rebuilds less often in the recent window.",
+            include=float(deltas.get("rebuild_trigger_rate") or 0.0) < 0 and float(recent.get("rebuild_requests") or 0.0) > 0,
+        )
+        _maybe_add(
+            status="watch",
+            focus="effect_rate_down",
+            metric="company_signal_effect_rate",
+            direction="down",
+            rationale="Review actions are producing fewer downstream company-signal effects per action than in the prior window.",
+            include=float(deltas.get("company_signal_effect_rate") or 0.0) < 0 and float(recent.get("action_count") or 0.0) > 0,
+        )
+        _maybe_add(
+            status="watch",
+            focus="approval_volume_down",
+            metric="approvals",
+            direction="down",
+            rationale="Fewer approvals landed in the recent window than in the prior window.",
+            include=float(deltas.get("approvals") or 0.0) < 0,
+        )
+        _maybe_add(
+            status="improving",
+            focus="effect_rate_up",
+            metric="company_signal_effect_rate",
+            direction="up",
+            rationale="Review actions are converting into downstream company-signal effects more efficiently than in the prior window.",
+            include=float(deltas.get("company_signal_effect_rate") or 0.0) > 0 and float(recent.get("action_count") or 0.0) > 0,
+        )
+        _maybe_add(
+            status="improving",
+            focus="approval_volume_up",
+            metric="approvals",
+            direction="up",
+            rationale="More approvals landed in the recent window than in the prior window.",
+            include=float(deltas.get("approvals") or 0.0) > 0,
+        )
+        return alerts
+
+    def _build_trend_focus(comparison: Mapping[str, Any], alerts: list[Mapping[str, Any]]) -> dict[str, Any]:
+        default = {
+            "status": "no_data",
+            "focus": None,
+            "metric": None,
+            "direction": None,
+            "delta": 0.0,
+            "recent_value": 0.0,
+            "prior_value": 0.0,
+            "rationale": None,
+        }
+        if not comparison.get("anchor_day"):
+            return default
+        if alerts:
+            return dict(alerts[0])
+        return {
+            **default,
+            "status": "stable",
+            "rationale": "Recent review impact is broadly flat relative to the prior window.",
+        }
+
+    def _build_trend_recommendation(
+        comparison: Mapping[str, Any],
+        focus: Mapping[str, Any],
+        alerts: list[Mapping[str, Any]],
+    ) -> dict[str, Any]:
+        default = {
+            "status": "no_data",
+            "action": None,
+            "priority": None,
+            "owner": None,
+            "rationale": None,
+            "supporting_focuses": [],
+        }
+        if not comparison.get("anchor_day"):
+            return default
+        focus_name = focus.get("focus") if isinstance(focus, Mapping) else None
+        supporting_focuses = [str(item.get("focus")) for item in alerts if item.get("focus")]
+        if focus_name in {"rebuild_blocks_up", "rebuild_trigger_rate_down"}:
+            return {
+                "status": "act",
+                "action": "inspect_rebuild_pipeline",
+                "priority": "high",
+                "owner": "backend_pipeline",
+                "rationale": "Recent review actions are losing momentum in the rebuild handoff path.",
+                "supporting_focuses": supporting_focuses,
+            }
+        if focus_name == "effect_rate_down":
+            return {
+                "status": "act",
+                "action": "review_effect_quality",
+                "priority": "high",
+                "owner": "review_ops",
+                "rationale": "Recent review actions are producing fewer downstream company-signal effects per action.",
+                "supporting_focuses": supporting_focuses,
+            }
+        if focus_name == "approval_volume_down":
+            return {
+                "status": "act",
+                "action": "increase_review_throughput",
+                "priority": "medium",
+                "owner": "review_ops",
+                "rationale": "Approval throughput is down relative to the prior window.",
+                "supporting_focuses": supporting_focuses,
+            }
+        if focus.get("status") == "improving":
+            return {
+                "status": "maintain",
+                "action": "maintain_current_course",
+                "priority": "low",
+                "owner": "review_ops",
+                "rationale": "Recent review impact is improving; keep the current operating path stable.",
+                "supporting_focuses": supporting_focuses,
+            }
+        return {
+            "status": "monitor",
+            "action": "monitor_trends",
+            "priority": "low",
+            "owner": "review_ops",
+            "rationale": "Recent review impact is broadly flat relative to the prior window.",
+            "supporting_focuses": supporting_focuses,
+        }
+
+    def _build_trend_recommendation_filters(
+        recommendation: Mapping[str, Any],
+        focus: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        filters: dict[str, Any] = {}
+        if vendor_name:
+            filters["vendor_name"] = vendor_name
+        if review_scope:
+            filters["review_scope"] = review_scope
+        if review_action:
+            filters["review_action"] = review_action
+        if company_signal_action:
+            filters["company_signal_action"] = company_signal_action
+        if canonical_gap_reason:
+            filters["canonical_gap_reason"] = canonical_gap_reason
+        if review_priority_band:
+            filters["review_priority_band"] = review_priority_band
+        if review_priority_reason:
+            filters["review_priority_reason"] = review_priority_reason
+        if review_unlock_path:
+            filters["review_unlock_path"] = review_unlock_path
+        if review_unlock_reason:
+            filters["review_unlock_reason"] = review_unlock_reason
+        if candidate_source:
+            filters["candidate_source"] = candidate_source
+        if rebuild_reason:
+            filters["rebuild_reason"] = rebuild_reason
+        focus_name = focus.get("focus") if isinstance(focus, Mapping) else None
+        if focus_name == "rebuild_blocks_up":
+            filters["rebuild_outcome"] = "blocked"
+        elif focus_name == "rebuild_trigger_rate_down":
+            filters["rebuild_outcome"] = "requested"
+        elif focus_name == "effect_rate_down":
+            filters["company_signal_action"] = "none"
+        elif focus_name == "approval_volume_down":
+            filters["review_action"] = "approved"
+        elif focus_name == "effect_rate_up":
+            filters["company_signal_action"] = "created"
+        elif focus_name == "approval_volume_up":
+            filters["review_action"] = "approved"
+        elif rebuild_outcome:
+            filters["rebuild_outcome"] = rebuild_outcome
+        return filters
+
+    def _base_trend_queue_filters() -> dict[str, Any]:
+        filters: dict[str, Any] = {
+            "candidate_bucket": "analyst_review",
+            "review_status": "pending",
+        }
+        if vendor_name:
+            filters["vendor_name"] = vendor_name
+        if canonical_gap_reason:
+            filters["canonical_gap_reason"] = canonical_gap_reason
+        if review_priority_band:
+            filters["review_priority_band"] = review_priority_band
+        if review_priority_reason:
+            filters["review_priority_reason"] = review_priority_reason
+        if candidate_source:
+            filters["source_name"] = candidate_source
+        return filters
+
+    def _build_trend_alert_queue_filters(
+        focus: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        focus_name = focus.get("focus") if isinstance(focus, Mapping) else None
+        if focus_name not in {"effect_rate_down", "approval_volume_down"}:
+            return {}
+        return _base_trend_queue_filters()
+
+    def _build_trend_recommendation_queue_filters(
+        recommendation: Mapping[str, Any],
+        focus: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        action = recommendation.get("action") if isinstance(recommendation, Mapping) else None
+        if action not in {"review_effect_quality", "increase_review_throughput"}:
+            return {}
+        return _build_trend_alert_queue_filters(focus)
+
+    def _build_trend_recommendation_queue_snapshot(
+        totals: Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if not totals:
+            return None
+        return {
+            "total_groups": int(totals.get("total_groups") or 0),
+            "total_reviews": int(totals.get("total_reviews") or 0),
+            "pending_groups": int(totals.get("pending_groups") or 0),
+            "actionable_pending_groups": int(totals.get("actionable_pending_groups") or 0),
+            "actionable_pending_reviews": int(totals.get("actionable_pending_reviews") or 0),
+            "blocked_pending_groups": int(totals.get("blocked_pending_groups") or 0),
+            "blocked_pending_reviews": int(totals.get("blocked_pending_reviews") or 0),
+            "avg_pending_age_days": float(totals.get("avg_pending_age_days") or 0.0),
+            "oldest_pending_age_days": float(totals.get("oldest_pending_age_days") or 0.0),
+            "overdue_pending_groups": int(totals.get("overdue_pending_groups") or 0),
+            "overdue_pending_reviews": int(totals.get("overdue_pending_reviews") or 0),
+        }
+
+    def _build_review_impact_operator_focus(
+        trend_recommendation: Mapping[str, Any],
+        trend_recommendation_queue_filters: Mapping[str, Any],
+        trend_recommendation_queue_snapshot: Mapping[str, Any] | None,
+        trend_focus: Mapping[str, Any],
+        trend_queue_recommendation: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        trend_payload = _build_company_signal_operator_action(
+            trend_recommendation,
+            primary_driver=_build_trend_queue_driver("trend_recommendation", trend_recommendation),
+            queue_filters=trend_recommendation_queue_filters,
+            queue_snapshot=trend_recommendation_queue_snapshot,
+            reason=trend_focus.get("focus") if isinstance(trend_focus, Mapping) else None,
+            use_reason_override=True,
+        )
+        queue_payload = _build_company_signal_operator_action(trend_queue_recommendation)
+        return _choose_company_signal_operator_focus(queue_payload, trend_payload)
+
+    def _build_trend_queue_recommendation(
+        queue_focus: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        default = _empty_company_signal_operator_action()
+        if not isinstance(queue_focus, Mapping):
+            return default
+        queue_filters = dict(queue_focus.get("queue_filters") or {})
+        queue_snapshot = queue_focus.get("queue_snapshot")
+        primary_driver = queue_focus.get("primary_driver")
+        if not isinstance(queue_snapshot, Mapping):
+            return default
+        actionable_pending_groups = int(
+            queue_focus.get("actionable_pending_groups")
+            or queue_snapshot.get("actionable_pending_groups")
+            or 0
+        )
+        blocked_pending_groups = int(
+            queue_focus.get("blocked_pending_groups")
+            or queue_snapshot.get("blocked_pending_groups")
+            or 0
+        )
+        overdue_pending_groups = int(
+            queue_focus.get("overdue_pending_groups")
+            or queue_snapshot.get("overdue_pending_groups")
+            or 0
+        )
+        queue_recommendation_payload = _build_company_signal_queue_recommendation_payload(
+            actionable_pending_groups=actionable_pending_groups,
+            blocked_pending_groups=blocked_pending_groups,
+            overdue_pending_groups=overdue_pending_groups,
+            low_trust_blocked=str(queue_filters.get("canonical_gap_reason") or "") == "low_confidence_low_trust_source",
+            low_trust_dominant_priority="high" if overdue_pending_groups > 0 else "medium",
+            promote_low_trust_when_blocked=False,
+            prioritize_blocked_dominant=True,
+            overdue_rationale="The top queue slice has actionable pending groups that are already overdue and should be cleared first.",
+            actionable_rationale="The top queue slice is actionable and should be worked in priority order before lower-yield backlog.",
+            low_trust_dominant_rationale="The top queue slice is dominated by low-trust candidates blocked on canonical confidence policy, not waiting for analyst approvals.",
+            threshold_dominant_rationale="The top queue slice is dominated by candidates blocked on canonical readiness thresholds instead of pending analyst review.",
+            low_trust_blocked_rationale="The top queue slice is dominated by low-trust candidates blocked on canonical confidence policy, not waiting for analyst approvals.",
+            threshold_blocked_rationale="The top queue slice has blocked backlog but little actionable review work, so threshold policy is the main lever.",
+            monitor_rationale="The current impact focus does not map to material pending queue work.",
+        )
+        queue_recommendation_payload.pop("driver_key", None)
+        return _build_company_signal_operator_action(
+            queue_recommendation_payload,
+            primary_driver=primary_driver,
+            queue_filters=queue_filters,
+            queue_snapshot=queue_snapshot,
+        ) or default
+
+    def _queue_snapshot_cache_key(filters: Mapping[str, Any]) -> tuple[tuple[str, Any], ...]:
+        return tuple(sorted((str(key), value) for key, value in filters.items()))
+
+    def _build_trend_queue_driver(kind: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        driver = {
+            "kind": kind,
+            "status": payload.get("status"),
+            "focus": payload.get("focus"),
+            "action": payload.get("action"),
+            "metric": payload.get("metric"),
+            "direction": payload.get("direction"),
+            "rationale": payload.get("rationale"),
+        }
+        if kind == "trend_alert":
+            driver["label"] = payload.get("focus") or "trend_alert"
+        elif kind == "trend_focus":
+            driver["label"] = payload.get("focus") or "trend_focus"
+        elif kind == "trend_recommendation":
+            driver["label"] = payload.get("action") or "trend_recommendation"
+        else:
+            driver["label"] = kind
+        return driver
+
+    def _sort_trend_queue_rankings(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                -(row.get("actionable_pending_groups") or 0),
+                -(row.get("pending_groups") or 0),
+                -(row.get("overdue_pending_groups") or 0),
+                -(row.get("oldest_pending_age_days") or 0.0),
+                str(row.get("primary_driver", {}).get("label") or ""),
+            ),
+        )
+
+    async def _resolve_queue_snapshot(filters: Mapping[str, Any]) -> dict[str, Any] | None:
+        if not filters:
+            return None
+        key = _queue_snapshot_cache_key(filters)
+        if key not in queue_snapshot_cache:
+            queue_snapshot_cache[key] = _build_trend_recommendation_queue_snapshot(
+                await _read_company_signal_candidate_group_totals(
+                    pool,
+                    window_days=window_days,
+                    vendor_name=filters.get("vendor_name"),
+                    source_name=filters.get("source_name"),
+                    scoped_vendors=scoped_vendors,
+                    candidate_bucket=filters.get("candidate_bucket"),
+                    review_status=filters.get("review_status"),
+                    canonical_gap_reason=filters.get("canonical_gap_reason"),
+                    review_priority_band=filters.get("review_priority_band"),
+                    review_priority_reason=filters.get("review_priority_reason"),
+                )
+            )
+        return queue_snapshot_cache[key]
+
+    totals_payload = _with_effect_metrics(dict(totals or {}), action_key="total_actions")
+    daily_trends = [_with_rebuild_metrics(_with_effect_metrics(row)) for row in daily_trend_rows]
+    trend_comparison = _build_trend_comparison(daily_trends)
+    raw_trend_alerts = _build_trend_alerts(trend_comparison)
+    queue_snapshot_cache: dict[tuple[tuple[str, Any], ...], dict[str, Any] | None] = {}
+    trend_alerts = []
+    for alert in raw_trend_alerts:
+        impact_filters = _build_trend_recommendation_filters({}, alert)
+        queue_filters = _build_trend_alert_queue_filters(alert)
+        trend_alerts.append(
+            {
+                **dict(alert),
+                "impact_filters": impact_filters,
+                "queue_filters": queue_filters,
+                "queue_snapshot": await _resolve_queue_snapshot(queue_filters),
+            }
+        )
+    trend_focus = _build_trend_focus(trend_comparison, trend_alerts)
+    trend_focus = {
+        **dict(trend_focus),
+        "impact_filters": (
+            _build_trend_recommendation_filters({}, trend_focus)
+            if trend_focus.get("focus")
+            else {}
+        ),
+        "queue_filters": (
+            _build_trend_alert_queue_filters(trend_focus)
+            if trend_focus.get("focus")
+            else {}
+        ),
+    }
+    trend_recommendation = _build_trend_recommendation(trend_comparison, trend_focus, trend_alerts)
+    trend_recommendation_filters = _build_trend_recommendation_filters(trend_recommendation, trend_focus)
+    trend_recommendation_queue_filters = _build_trend_recommendation_queue_filters(trend_recommendation, trend_focus)
+    trend_recommendation_queue_snapshot = await _resolve_queue_snapshot(trend_recommendation_queue_filters)
+    trend_focus["queue_snapshot"] = await _resolve_queue_snapshot(trend_focus.get("queue_filters") or {})
+
+    ranking_buckets: dict[tuple[tuple[str, Any], ...], dict[str, Any]] = {}
+    queue_candidates = [
+        ("trend_focus", trend_focus),
+        *(("trend_alert", alert) for alert in trend_alerts),
+        (
+            "trend_recommendation",
+            {
+                **dict(trend_recommendation),
+                "queue_filters": trend_recommendation_queue_filters,
+                "queue_snapshot": trend_recommendation_queue_snapshot,
+            },
+        ),
+    ]
+    for kind, payload in queue_candidates:
+        queue_filters = payload.get("queue_filters") if isinstance(payload, Mapping) else None
+        queue_snapshot = payload.get("queue_snapshot") if isinstance(payload, Mapping) else None
+        if not queue_filters or not queue_snapshot:
+            continue
+        key = _queue_snapshot_cache_key(queue_filters)
+        bucket = ranking_buckets.get(key)
+        driver = _build_trend_queue_driver(kind, payload)
+        if bucket is None:
+            bucket = {
+                "queue_filters": dict(queue_filters),
+                "queue_snapshot": dict(queue_snapshot),
+                "drivers": [],
+            }
+            ranking_buckets[key] = bucket
+        bucket["drivers"].append(driver)
+
+    trend_queue_rankings: list[dict[str, Any]] = []
+    for bucket in ranking_buckets.values():
+        queue_snapshot = bucket["queue_snapshot"]
+        drivers = bucket["drivers"]
+        primary_driver = drivers[0] if drivers else None
+        trend_queue_rankings.append(
+            {
+                "primary_driver": primary_driver,
+                "drivers": drivers,
+                "queue_filters": bucket["queue_filters"],
+                "queue_snapshot": queue_snapshot,
+                "pending_groups": int(queue_snapshot.get("pending_groups") or 0),
+                "actionable_pending_groups": int(queue_snapshot.get("actionable_pending_groups") or 0),
+                "blocked_pending_groups": int(queue_snapshot.get("blocked_pending_groups") or 0),
+                "overdue_pending_groups": int(queue_snapshot.get("overdue_pending_groups") or 0),
+                "oldest_pending_age_days": float(queue_snapshot.get("oldest_pending_age_days") or 0.0),
+            }
+        )
+    trend_queue_rankings = _sort_trend_queue_rankings(trend_queue_rankings)
+    trend_queue_focus = trend_queue_rankings[0] if trend_queue_rankings else None
+    trend_queue_recommendation = _build_trend_queue_recommendation(trend_queue_focus)
+    operator_focus = _build_review_impact_operator_focus(
+        trend_recommendation,
+        trend_recommendation_queue_filters,
+        trend_recommendation_queue_snapshot,
+        trend_focus,
+        trend_queue_recommendation,
+    )
+    return {
+        "totals": totals_payload,
+        "review_scope": review_scope,
+        "canonical_gap_reason": canonical_gap_reason,
+        "rebuild_outcome": rebuild_outcome,
+        "rebuild_reason": rebuild_reason,
+        "scopes": [dict(row) for row in scope_rows],
+        "unlock_paths": [_with_effect_metrics(row) for row in unlock_path_rows],
+        "priority_bands": [_with_effect_metrics(row) for row in priority_rows],
+        "priority_reasons": [_with_effect_metrics(row) for row in priority_reason_rows],
+        "top_vendors": [_with_effect_metrics(row) for row in vendor_rows],
+        "top_vendor_reasons": [_with_effect_metrics(row) for row in vendor_reason_rows],
+        "rebuild_reasons": [_with_rebuild_metrics(row) for row in rebuild_reason_rows],
+        "daily_trends": daily_trends,
+        "trend_comparison": trend_comparison,
+        "trend_focus": trend_focus,
+        "trend_alerts": trend_alerts,
+        "trend_recommendation": trend_recommendation,
+        "trend_recommendation_filters": trend_recommendation_filters,
+        "trend_recommendation_queue_filters": trend_recommendation_queue_filters,
+        "trend_recommendation_queue_snapshot": trend_recommendation_queue_snapshot,
+        "trend_queue_rankings": trend_queue_rankings,
+        "trend_queue_focus": trend_queue_focus,
+        "trend_queue_recommendation": trend_queue_recommendation,
+        "operator_focus": operator_focus,
+    }
+
+
+async def read_review_details(
+    pool,
+    *,
+    window_days: int = 30,
+    vendor_name: str | None = None,
+    scoped_vendors: list[str] | None = None,
+    pain_category: str | None = None,
+    min_urgency: float | None = None,
+    company: str | None = None,
+    has_churn_intent: bool | None = None,
+    min_relevance: float | None = None,
+    exclude_low_fidelity: bool = False,
+    content_type: str | None = None,
+    recency_column: str = "enriched_at",
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Shared adapter for review detail reads.
+
+    Replaces direct enrichment reads in:
+      - api.b2b_dashboard.search_reviews / export_reviews
+      - api.b2b_tenant_dashboard.list_tenant_reviews
+      - mcp.b2b.reviews.search_reviews
+
+    Returns dicts with keys: id, vendor_name, product_category,
+    reviewer_company, rating, source, reviewed_at, enriched_at,
+    urgency_score, pain_category, intent_to_leave, decision_maker,
+    role_level, buying_stage, sentiment_direction, industry,
+    reviewer_title, company_size, content_type, thread_id,
+    competitors_mentioned, quotable_phrases, positive_aspects,
+    specific_complaints, relevance_score, author_churn_score,
+    low_fidelity, low_fidelity_reasons.
+    """
+    from atlas_brain.services.b2b.corrections import suppress_predicate
+
+    if recency_column == "enriched_at":
+        recency_expr = "r.enriched_at"
+    else:
+        recency_expr = "COALESCE(r.reviewed_at, r.imported_at, r.enriched_at)"
+    conditions = [
+        "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
+        f"{recency_expr} > NOW() - make_interval(days => $1)",
+    ]
+    params: list = [window_days]
+    idx = 2
+    vendor_param = None
+    scoped_param = None
+
+    if scoped_vendors is not None:
+        if not scoped_vendors:
+            return []  # scoped user with no tracked vendors = zero results
+        scoped_param = idx
+        params.append(scoped_vendors)
+        idx += 1
+    if vendor_name:
+        vendor_param = idx
+        params.append(vendor_name)
+        idx += 1
+    if pain_category:
+        conditions.append(f"r.enrichment->>'pain_category' = ${idx}")
+        params.append(pain_category)
+        idx += 1
+    if min_urgency is not None:
+        conditions.append(f"(r.enrichment->>'urgency_score')::numeric >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+    if company:
+        conditions.append(f"r.reviewer_company ILIKE '%' || ${idx} || '%'")
+        params.append(company)
+        idx += 1
+    if has_churn_intent is not None:
+        conditions.append(
+            f"(r.enrichment->'churn_signals'->>'intent_to_leave')::boolean = ${idx}"
+        )
+        params.append(has_churn_intent)
+        idx += 1
+    if min_relevance is not None:
+        conditions.append(f"COALESCE(r.relevance_score, 0.5) >= ${idx}")
+        params.append(min_relevance)
+        idx += 1
+    if exclude_low_fidelity:
+        conditions.append("(r.low_fidelity IS NULL OR r.low_fidelity = false)")
+
+    if content_type:
+        conditions.append(f"r.content_type = ${idx}")
+        params.append(content_type)
+        idx += 1
+    else:
+        conditions.append(
+            suppress_predicate(
+                "review", id_expr="r.id", source_expr="r.source",
+                vendor_expr="matched_vm.vendor_name",
+            )
+        )
+    params.append(limit)
+    where = " AND ".join(conditions)
+    vendor_join = _review_vendor_match_join(
+        review_alias="r",
+        vendor_param=vendor_param,
+        scoped_param=scoped_param,
+        output_alias="matched_vm",
+    )
+
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id, matched_vm.vendor_name AS vendor_name, r.product_category, r.reviewer_company,
+               r.rating, r.source, r.reviewed_at, r.enriched_at,
+               (r.enrichment->>'urgency_score')::numeric AS urgency_score,
+               r.enrichment->>'pain_category' AS pain_category,
+               (r.enrichment->'churn_signals'->>'intent_to_leave')::boolean AS intent_to_leave,
+               (r.enrichment->'reviewer_context'->>'decision_maker')::boolean AS decision_maker,
+               r.enrichment->'reviewer_context'->>'role_level' AS role_level,
+               r.enrichment->'buyer_authority'->>'buying_stage' AS buying_stage,
+               r.sentiment_direction,
+               COALESCE(r.reviewer_industry,
+                        r.enrichment->'reviewer_context'->>'industry') AS industry,
+               r.reviewer_title, r.company_size_raw,
+               r.content_type, r.thread_id,
+               r.enrichment->'competitors_mentioned' AS competitors_raw,
+               r.enrichment->'quotable_phrases' AS quotable_raw,
+               r.enrichment->'positive_aspects' AS positive_raw,
+               r.enrichment->'specific_complaints' AS complaints_raw,
+               r.relevance_score, r.author_churn_score,
+               r.low_fidelity, r.low_fidelity_reasons
+        FROM b2b_reviews r
+        {vendor_join}
+        WHERE {where}
+        ORDER BY (r.enrichment->>'urgency_score')::numeric DESC
+        LIMIT ${idx}
+        """,
+        *params,
+    )
+
+    results = []
+    for r in rows:
+        urg = None
+        if r["urgency_score"] is not None:
+            try:
+                urg = float(r["urgency_score"])
+            except (ValueError, TypeError):
+                pass
+        results.append({
+            "id": str(r["id"]) if r["id"] else None,
+            "vendor_name": r["vendor_name"],
+            "product_category": r["product_category"],
+            "reviewer_company": r["reviewer_company"],
+            "rating": float(r["rating"]) if r["rating"] is not None else None,
+            "source": r["source"],
+            "reviewed_at": r["reviewed_at"],
+            "enriched_at": r["enriched_at"],
+            "urgency_score": urg,
+            "pain_category": r["pain_category"],
+            "intent_to_leave": bool(r["intent_to_leave"]) if r["intent_to_leave"] is not None else None,
+            "decision_maker": bool(r["decision_maker"]) if r["decision_maker"] is not None else None,
+            "role_level": r["role_level"] if r["role_level"] != "unknown" else None,
+            "buying_stage": r["buying_stage"] if r["buying_stage"] != "unknown" else None,
+            "sentiment_direction": r["sentiment_direction"],
+            "industry": r["industry"],
+            "reviewer_title": r["reviewer_title"],
+            "company_size": r["company_size_raw"],
+            "content_type": r["content_type"],
+            "thread_id": r["thread_id"],
+            "competitors_mentioned": _safe_json(r["competitors_raw"]),
+            "quotable_phrases": _safe_json(r["quotable_raw"]),
+            "positive_aspects": _safe_json(r["positive_raw"]),
+            "specific_complaints": _safe_json(r["complaints_raw"]),
+            "relevance_score": float(r["relevance_score"]) if r["relevance_score"] is not None else None,
+            "author_churn_score": float(r["author_churn_score"]) if r["author_churn_score"] is not None else None,
+            "low_fidelity": bool(r["low_fidelity"]) if r["low_fidelity"] is not None else None,
+            "low_fidelity_reasons": _safe_json(r["low_fidelity_reasons"]),
+        })
+    return results
+
+
+async def read_campaign_opportunities(
+    pool,
+    *,
+    window_days: int = 90,
+    min_urgency: float = 5.0,
+    vendor_name: str | None = None,
+    company: str | None = None,
+    dm_only: bool = True,
+    limit: int = 500,
+) -> list[dict[str, Any]]:
+    """Shared adapter for campaign opportunity enrichment reads.
+
+    Replaces direct enrichment reads in:
+      - tasks.b2b_campaign_generation._fetch_opportunities
+      - api.b2b_affiliates.list_opportunities
+
+    Returns review-level dicts with buyer authority, timeline, competitor
+    context, pain categories, and quotable phrases extracted from enrichment.
+    Consumers add domain-specific logic (scoring, affiliate matching, etc.).
+    """
+    from atlas_brain.services.b2b.corrections import suppress_predicate
+
+    conditions = [
+        "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
+        "COALESCE(r.reviewed_at, r.imported_at, r.enriched_at)"
+        " > NOW() - make_interval(days => $1)",
+        "(r.enrichment->>'urgency_score')::numeric >= $2",
+    ]
+    params: list = [window_days, min_urgency]
+    idx = 3
+    vendor_param = None
+
+    if vendor_name:
+        vendor_param = idx
+        params.append(vendor_name)
+        idx += 1
+    if company:
+        conditions.append(
+            f"COALESCE(NULLIF(BTRIM(r.reviewer_company), ''),"
+            f" NULLIF(BTRIM(r.reviewer_company_norm), ''))"
+            f" ILIKE '%' || ${idx} || '%'"
+        )
+        params.append(company)
+        idx += 1
+    if dm_only:
+        conditions.append(
+            "(r.enrichment->'reviewer_context'->>'decision_maker')::boolean = true"
+        )
+
+    conditions.append(
+        suppress_predicate(
+            "review", id_expr="r.id", source_expr="r.source",
+            vendor_expr="matched_vm.vendor_name",
+        )
+    )
+    params.append(limit)
+    where = " AND ".join(conditions)
+    vendor_join = _review_vendor_match_join(
+        review_alias="r",
+        vendor_param=vendor_param,
+        output_alias="matched_vm",
+    )
+
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id AS review_id,
+               matched_vm.vendor_name AS vendor_name,
+               COALESCE(NULLIF(BTRIM(r.reviewer_company), ''),
+                        NULLIF(BTRIM(r.reviewer_company_norm), '')) AS reviewer_company,
+               r.product_category, r.source, r.reviewed_at,
+               (r.enrichment->>'urgency_score')::numeric AS urgency,
+               (r.enrichment->'reviewer_context'->>'decision_maker')::boolean AS is_dm,
+               r.enrichment->'buyer_authority'->>'role_type' AS role_type,
+               r.enrichment->'buyer_authority'->>'buying_stage' AS buying_stage,
+               CASE WHEN r.enrichment->'budget_signals'->>'seat_count' ~ '^\\d+$'
+                    THEN (r.enrichment->'budget_signals'->>'seat_count')::int END AS seat_count,
+               r.enrichment->'timeline'->>'contract_end' AS contract_end,
+               r.enrichment->'timeline'->>'decision_timeline' AS decision_timeline,
+               r.enrichment->'competitors_mentioned' AS competitors_json,
+               r.enrichment->'pain_categories' AS pain_json,
+               r.enrichment AS enrichment_raw,
+               r.enrichment->'feature_gaps' AS feature_gaps,
+               r.enrichment->'use_case'->>'primary_workflow' AS primary_workflow,
+               r.enrichment->'use_case'->'integration_stack' AS integration_stack,
+               r.sentiment_direction,
+               COALESCE(r.reviewer_industry,
+                        r.enrichment->'reviewer_context'->>'industry') AS industry,
+               r.reviewer_title, r.company_size_raw,
+               NULLIF(BTRIM(r.reviewer_name), '') AS reviewer_name
+        FROM b2b_reviews r
+        {vendor_join}
+        WHERE {where}
+        ORDER BY (r.enrichment->>'urgency_score')::numeric DESC
+        LIMIT ${idx}
+        """,
+        *params,
+    )
+
+    results = []
+    for r in rows:
+        competitors = _safe_json(r["competitors_json"])
+        if not isinstance(competitors, list):
+            competitors = []
+        seat_count = r["seat_count"]
+        urgency = float(r["urgency"]) if r["urgency"] is not None else None
+        enrichment = _parse_enrichment_dict(r["enrichment_raw"])
+        results.append({
+            "review_id": str(r["review_id"]) if r["review_id"] else None,
+            "vendor_name": r["vendor_name"],
+            "reviewer_company": r["reviewer_company"],
+            "reviewer_name": r["reviewer_name"],
+            "product_category": r["product_category"],
+            "source": r["source"],
+            "reviewed_at": r["reviewed_at"],
+            "urgency": urgency,
+            "is_dm": bool(r["is_dm"]) if r["is_dm"] is not None else None,
+            "role_type": r["role_type"],
+            "buying_stage": r["buying_stage"],
+            "seat_count": seat_count,
+            "contract_end": r["contract_end"],
+            "decision_timeline": r["decision_timeline"],
+            "competitors": competitors,
+            "competitors_json": r["competitors_json"],
+            "pain_json": r["pain_json"],
+            "quotable_phrases": _quote_grade_rows_from_enrichment(
+                enrichment,
+                urgency=urgency,
+                review_id=r["review_id"],
+                source=r["source"],
+                company=r["reviewer_company"],
+                title=r["reviewer_title"],
+                company_size=r["company_size_raw"],
+                industry=r["industry"],
+            ),
+            "feature_gaps": _safe_json(r["feature_gaps"]),
+            "primary_workflow": r["primary_workflow"],
+            "integration_stack": _safe_json(r["integration_stack"]),
+            "sentiment_direction": r["sentiment_direction"],
+            "industry": r["industry"],
+            "reviewer_title": r["reviewer_title"],
+            "company_size_raw": r["company_size_raw"],
+        })
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Class 2: Shared SQL fragment helpers for repeated aggregate patterns
+# ---------------------------------------------------------------------------
+
+def _vendor_evidence_base_filters(
+    *,
+    alias: str = "r",
+    window_param: int = 1,
+    recency_column: str = "enriched_at",
+    vendor_expr: str | None = None,
+) -> str:
+    """Base WHERE clause for vendor evidence queries.
+
+    Centralizes enrichment status check, recency semantics, and suppression.
+    Returns a SQL fragment with $<window_param> as the window_days placeholder.
+    """
+    from atlas_brain.services.b2b.corrections import suppress_predicate
+
+    if recency_column == "enriched_at":
+        recency = f"{alias}.enriched_at"
+    else:
+        recency = f"COALESCE({alias}.reviewed_at, {alias}.imported_at, {alias}.enriched_at)"
+    suppress_vendor_expr = vendor_expr or f"{alias}.vendor_name"
+
+    return (
+        f"{alias}.enrichment_status = 'enriched'"
+        f" AND {recency} > NOW() - make_interval(days => ${window_param})"
+        f" AND {suppress_predicate('review', id_expr=f'{alias}.id', source_expr=f'{alias}.source', vendor_expr=suppress_vendor_expr)}"
+    )
+
+
+def _competitor_unnest_sql(alias: str = "r") -> str:
+    """SQL fragment for CROSS JOIN LATERAL on competitors_mentioned."""
+    return (
+        f"CROSS JOIN LATERAL jsonb_array_elements("
+        f"CASE WHEN jsonb_typeof({alias}.enrichment->'competitors_mentioned') = 'array'"
+        f" THEN {alias}.enrichment->'competitors_mentioned'"
+        f" ELSE '[]'::jsonb END) AS comp(value)"
+    )
+
+
+def _integration_stack_unnest_sql(alias: str = "r") -> str:
+    """SQL fragment for jsonb_array_elements_text on use_case.integration_stack."""
+    return (
+        f"jsonb_array_elements_text("
+        f"CASE WHEN jsonb_typeof({alias}.enrichment->'use_case'->'integration_stack') = 'array'"
+        f" THEN {alias}.enrichment->'use_case'->'integration_stack'"
+        f" ELSE '[]'::jsonb END)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class 1: Row-level evidence readers
+# ---------------------------------------------------------------------------
+
+async def read_vendor_quote_evidence(
+    pool,
+    *,
+    vendor_name: str,
+    window_days: int = 90,
+    min_urgency: float = 5.0,
+    limit: int = 10,
+    sources: list[str] | None = None,
+    pain_filter: str | None = None,
+    require_quotes: bool = False,
+    recency_column: str = "enriched_at",
+) -> list[dict[str, Any]]:
+    """Row-level quote evidence for a vendor.
+
+    Replaces direct enrichment reads in:
+      - b2b_blog_post_generation._resolve_blog_battle_summary (pricing/switching)
+      - b2b_blog_post_generation._fetch_high_urgency_quotes (vendor variant)
+      - b2b_challenger_brief._fetch_review_pain_quotes
+
+    Args:
+      require_quotes: When True, only returns reviews with non-empty
+          quotable_phrases (matches challenger_brief semantics).
+      recency_column: 'enriched_at' (default), 'imported_at' (challenger_brief),
+          or 'coalesce' (reviewed_at -> imported_at -> enriched_at).
+
+    Returns dicts with: vendor_name, source, reviewer_company, reviewer_title,
+    role_level, pain_category, urgency, review_text, quotable_phrases, rating.
+    """
+    from atlas_brain.services.b2b.corrections import suppress_predicate
+
+    if recency_column == "imported_at":
+        recency_expr = "r.imported_at"
+    elif recency_column == "coalesce":
+        recency_expr = "COALESCE(r.reviewed_at, r.imported_at, r.enriched_at)"
+    else:
+        recency_expr = "r.enriched_at"
+
+    conditions = [
+        "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
+        f"{recency_expr} > NOW() - make_interval(days => $1)",
+        "LOWER(matched_vm.vendor_name) = LOWER($2)",
+    ]
+    params: list = [window_days, vendor_name]
+    idx = 3
+
+    if min_urgency > 0:
+        conditions.append(f"(r.enrichment->>'urgency_score')::numeric >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+    if sources:
+        conditions.append(f"r.source = ANY(${idx}::text[])")
+        params.append(sources)
+        idx += 1
+    if pain_filter:
+        conditions.append(f"r.enrichment->>'pain_categories' ILIKE '%' || ${idx} || '%'")
+        params.append(pain_filter)
+        idx += 1
+    if require_quotes:
+        conditions.append(
+            "r.enrichment->'quotable_phrases' IS NOT NULL"
+            " AND jsonb_array_length(r.enrichment->'quotable_phrases') > 0"
+        )
+
+    conditions.append(
+        suppress_predicate(
+            "review",
+            id_expr="r.id",
+            source_expr="r.source",
+            vendor_expr="matched_vm.vendor_name",
+        )
+    )
+    params.append(limit)
+    where = " AND ".join(conditions)
+    vendor_join = _review_vendor_match_join(
+        review_alias="r",
+        vendor_param=2,
+        output_alias="matched_vm",
+    )
+
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id AS review_id, matched_vm.vendor_name AS vendor_name,
+               r.source, r.reviewer_company, r.reviewer_title,
+               COALESCE(r.reviewer_title, r.enrichment->'reviewer_context'->>'role_level') AS role_level,
+               r.enrichment->>'pain_category' AS pain_category,
+               (r.enrichment->>'urgency_score')::numeric AS urgency,
+               r.review_text, r.rating,
+               r.enrichment->'quotable_phrases' AS quotable_raw,
+               r.enrichment AS enrichment_raw
+        FROM b2b_reviews r
+        {vendor_join}
+        WHERE {where}
+        ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
+        LIMIT ${idx}
+        """,
+        *params,
+    )
+
+    return [
+        {
+            "review_id": str(r["review_id"]) if r["review_id"] is not None else None,
+            "vendor_name": r["vendor_name"],
+            "source": r["source"],
+            "reviewer_company": r["reviewer_company"],
+            "reviewer_title": r["reviewer_title"],
+            "role_level": r["role_level"],
+            "pain_category": r["pain_category"],
+            "urgency": float(r["urgency"]) if r["urgency"] is not None else None,
+            "review_text": r["review_text"],
+            "rating": float(r["rating"]) if r["rating"] is not None else None,
+            "quotable_phrases": _safe_json(r["quotable_raw"]),
+            "enrichment_raw": r["enrichment_raw"],
+        }
+        for r in rows
+    ]
+
+
+async def read_category_quote_evidence(
+    pool,
+    *,
+    product_category: str,
+    window_days: int = 90,
+    min_urgency: float = 5.0,
+    limit: int = 10,
+    sources: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Row-level quote evidence for a product category.
+
+    Replaces direct enrichment reads in:
+      - b2b_blog_post_generation._fetch_high_urgency_quotes (category variant)
+
+    Same return shape as read_vendor_quote_evidence.
+    """
+    from atlas_brain.services.b2b.corrections import suppress_predicate
+
+    conditions = [
+        "r.enrichment_status = 'enriched'",
+        "r.duplicate_of_review_id IS NULL",
+        "r.enriched_at > NOW() - make_interval(days => $1)",
+        "r.product_category = $2",
+    ]
+    params: list = [window_days, product_category]
+    idx = 3
+
+    if min_urgency > 0:
+        conditions.append(f"(r.enrichment->>'urgency_score')::numeric >= ${idx}")
+        params.append(min_urgency)
+        idx += 1
+    if sources:
+        conditions.append(f"r.source = ANY(${idx}::text[])")
+        params.append(sources)
+        idx += 1
+
+    conditions.append(
+        suppress_predicate(
+            "review",
+            id_expr="r.id",
+            source_expr="r.source",
+            vendor_expr="matched_vm.vendor_name",
+        )
+    )
+    params.append(limit)
+    where = " AND ".join(conditions)
+    vendor_join = _review_vendor_match_join(
+        review_alias="r",
+        output_alias="matched_vm",
+    )
+
+    rows = await pool.fetch(
+        f"""
+        SELECT r.id AS review_id, matched_vm.vendor_name AS vendor_name,
+               r.source, r.reviewer_company, r.reviewer_title,
+               COALESCE(r.reviewer_title, r.enrichment->'reviewer_context'->>'role_level') AS role_level,
+               r.enrichment->>'pain_category' AS pain_category,
+               (r.enrichment->>'urgency_score')::numeric AS urgency,
+               r.review_text, r.rating,
+               r.enrichment->'quotable_phrases' AS quotable_raw,
+               r.enrichment AS enrichment_raw
+        FROM b2b_reviews r
+        {vendor_join}
+        WHERE {where}
+        ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
+        LIMIT ${idx}
+        """,
+        *params,
+    )
+
+    return [
+        {
+            "review_id": str(r["review_id"]) if r["review_id"] is not None else None,
+            "vendor_name": r["vendor_name"],
+            "source": r["source"],
+            "reviewer_company": r["reviewer_company"],
+            "reviewer_title": r["reviewer_title"],
+            "role_level": r["role_level"],
+            "pain_category": r["pain_category"],
+            "urgency": float(r["urgency"]) if r["urgency"] is not None else None,
+            "review_text": r["review_text"],
+            "rating": float(r["rating"]) if r["rating"] is not None else None,
+            "quotable_phrases": _safe_json(r["quotable_raw"]),
+            "enrichment_raw": r["enrichment_raw"],
+        }
+        for r in rows
+    ]
+
+
+def _battle_card_weaknesses_from_evidence_vault(
+    vault: dict[str, Any] | None,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Normalize vault weakness evidence into the current battle-card shape."""
+    if not isinstance(vault, dict):
+        return []
+    weaknesses: list[dict[str, Any]] = []
+    for item in vault.get("weakness_evidence") or []:
+        if not isinstance(item, dict):
+            continue
+        area = str(item.get("label") or item.get("key") or "").strip()
+        if not area:
+            continue
+        entry = {
+            "area": area,
+            "evidence_count": int(item.get("mention_count_total") or 0),
+            "source": str(item.get("evidence_type") or "evidence_vault"),
+        }
+        if item.get("supporting_metrics", {}).get("satisfaction_score") is not None:
+            entry["score"] = item["supporting_metrics"]["satisfaction_score"]
+        weaknesses.append(entry)
+    weaknesses.sort(key=lambda item: -int(item.get("evidence_count") or 0))
+    return weaknesses[:limit]
+
+
+def _battle_card_strengths_from_evidence_vault(
+    vault: dict[str, Any] | None,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Normalize vault strength evidence into battle-card shape.
+
+    Mirrors ``_battle_card_weaknesses_from_evidence_vault`` so the LLM can
+    ground objection handler ``acknowledge`` fields in real incumbent strengths.
+    """
+    if not isinstance(vault, dict):
+        return []
+    strengths: list[dict[str, Any]] = []
+    for item in vault.get("strength_evidence") or []:
+        if not isinstance(item, dict):
+            continue
+        area = str(item.get("label") or item.get("key") or "").strip()
+        if not area:
+            continue
+        total = int(item.get("mention_count_total") or 0)
+        trend = item.get("trend") if isinstance(item.get("trend"), dict) else {}
+        entry: dict[str, Any] = {
+            "area": area,
+            "mention_count": total,
+            "source": str(item.get("evidence_type") or "evidence_vault"),
+        }
+        direction = str(trend.get("direction") or "").strip()
+        if direction:
+            entry["trend"] = direction
+        quote = str(item.get("best_quote") or "").strip()
+        if quote:
+            entry["customer_quote"] = quote
+        strengths.append(entry)
+    strengths.sort(key=lambda s: -int(s.get("mention_count") or 0))
+    return strengths[:limit]
+
+
+def _looks_like_company_domain(raw_name: str) -> bool:
+    text = str(raw_name or "").strip().lower()
+    if not text or " " in text or "/" in text or "@" in text:
+        return False
+    return bool(re.fullmatch(r"[a-z0-9-]+(?:\.[a-z0-9-]+)+", text))
+
+
+def _looks_like_company_url(raw_name: Any) -> bool:
+    """Return True for URL-like labels that should never become company names."""
+    text = str(raw_name or "").strip().lower()
+    if not text:
+        return False
+    if re.match(r"^[a-z][a-z0-9+.-]*://", text):
+        return True
+    if text.startswith("www.") and "." in text:
+        return True
+    candidate = text
+    for separator in ("/", "?", "#"):
+        if separator in candidate:
+            candidate = candidate.split(separator, 1)[0]
+            break
+    return candidate != text and _looks_like_company_domain(candidate)
+
+
+_GENERIC_COMPANY_PATTERNS = (
+    re.compile(r"^(msp|saas|fintech|startup|start up|non-?profit|university|school|government|public sector)$", re.I),
+    re.compile(r"(^| )(software company|tech company|saas company|consulting company)( |$)", re.I),
+    re.compile(r"(^| )(government agency|b2c fintech|b2c fintech company|b2b fintech|b2b fintech company)( |$)", re.I),
+    re.compile(
+        r"(^| )(b2b|b2c|e-?commerce|ecommerce|support|video|marketing|design|creative|recruitment|retail|fintech)( |-|_).*(startup|agency|studio|company|team|business|organization|department)( |$)",
+        re.I,
+    ),
+    re.compile(r"(^| )(agency|organization|vendor|provider|department)( |$)", re.I),
+    re.compile(
+        r"(^| )(senior|sr|junior|jr|staff|lead|head|director|manager|founder|owner|principal|regional|student|vp|vice president|ceo|cto|cfo|coo|engineer|developer|analyst|architect|consultant|specialist)( |-|_).*(business|company|startup|team|product|ops|operations|marketing|sales|support|tech|solution|solutions|cloud|landscaping)( |$)",
+        re.I,
+    ),
+    re.compile(r"(^| )(founder|owner|head|director|manager|lead|student) of (a |an )?(tech|software|cloud|landscaping|marketing|design|support|sales) (company|business|startup|team)( |$)", re.I),
+    re.compile(r"(^| )(aws|azure|gcp|cloud)( |-|_).*(solution|solutions|services?)( |$)", re.I),
+    re.compile(r"(^| )\d+\s+employees?( |$)", re.I),
+)
+
+_GENERIC_COMPANY_DESCRIPTOR_PREFIXES = {
+    "small",
+    "medium",
+    "midsized",
+    "mid",
+    "large",
+    "enterprise",
+    "multinational",
+    "global",
+    "regional",
+    "local",
+    "private",
+    "public",
+    "independent",
+    "boutique",
+    "senior",
+    "junior",
+    "staff",
+    "lead",
+    "head",
+    "director",
+    "manager",
+    "founder",
+    "owner",
+    "student",
+}
+
+_GENERIC_COMPANY_DESCRIPTOR_TOKENS = {
+    "agency",
+    "bank",
+    "banking",
+    "business",
+    "company",
+    "consulting",
+    "creative",
+    "department",
+    "design",
+    "ecommerce",
+    "erp",
+    "fintech",
+    "firm",
+    "health",
+    "healthcare",
+    "insurance",
+    "management",
+    "manufacturing",
+    "marketing",
+    "organization",
+    "pharmaceutical",
+    "pharma",
+    "project",
+    "product",
+    "provider",
+    "recruitment",
+    "retail",
+    "saas",
+    "software",
+    "cloud",
+    "solution",
+    "solutions",
+    "support",
+    "sized",
+    "tech",
+    "team",
+    "technical",
+    "vendor",
+    "video",
+    "landscaping",
+}
+
+_PLACEHOLDER_COMPANY_NAMES = {
+    "company",
+    "mycompany",
+    "my company",
+    "ourcompany",
+    "our company",
+    "ourdomain",
+    "customer",
+    "client",
+}
+
+_LOCATION_LIKE_COMPANY_NAMES = {
+    "costa rica",
+    "united states",
+    "usa",
+    "united kingdom",
+    "uk",
+    "canada",
+    "australia",
+    "india",
+    "germany",
+    "france",
+    "mexico",
+    "brazil",
+}
+
+_PARTNERISH_COMPANY_PATTERNS = (
+    re.compile(r".*partners?$", re.I),
+    re.compile(r".*(reseller|consulting|consultancy|implementer|implementation)$", re.I),
+)
+
+
+def _looks_like_generic_company_descriptor(raw_name: Any) -> bool:
+    """Return True for descriptive labels that are not seller-usable org names."""
+    text = str(raw_name or "").strip()
+    if not text:
+        return True
+    normalized = normalize_company_name(text)
+    if not normalized:
+        return True
+    if normalized in _PLACEHOLDER_COMPANY_NAMES:
+        return True
+    tokens = [token for token in re.split(r"[\s/_-]+", normalized) if token]
+    if tokens and tokens[0] in {"a", "an"}:
+        tokens = tokens[1:]
+    if len(tokens) >= 2 and tokens[0] in _GENERIC_COMPANY_DESCRIPTOR_PREFIXES:
+        if all(token in _GENERIC_COMPANY_DESCRIPTOR_TOKENS for token in tokens[1:]):
+            return True
+    return any(pattern.search(normalized) for pattern in _GENERIC_COMPANY_PATTERNS)
+
+
+def _looks_like_location_label(raw_name: Any) -> bool:
+    normalized = normalize_company_name(raw_name)
+    if not normalized:
+        return False
+    return normalized in _LOCATION_LIKE_COMPANY_NAMES
+
+
+def _looks_like_partner_or_tool_label(raw_name: Any) -> bool:
+    normalized = normalize_company_name(raw_name)
+    if not normalized:
+        return False
+    return any(pattern.fullmatch(normalized) for pattern in _PARTNERISH_COMPANY_PATTERNS)
+
+
+def _build_company_signal_blocked_names_by_vendor(
+    vendor_names: Iterable[Any],
+    *,
+    high_intent_entries: list[dict[str, Any]] | None = None,
+    integration_lookup: dict[str, list[Any]] | None = None,
+) -> dict[str, set[str]]:
+    """Build vendor-specific blocklists for non-prospect company labels."""
+    vendor_list = list(vendor_names or [])
+    normalized_vendors = {
+        normalize_company_name(name)
+        for name in vendor_list
+        if normalize_company_name(name)
+    }
+    blocked_by_vendor: dict[str, set[str]] = {}
+    for name in vendor_list:
+        vendor = _canonicalize_vendor(name or "")
+        if vendor:
+            blocked_by_vendor[vendor] = set(normalized_vendors)
+
+    for vendor, items in (integration_lookup or {}).items():
+        vendor_key = _canonicalize_vendor(vendor or "")
+        if not vendor_key:
+            continue
+        bucket = blocked_by_vendor.setdefault(vendor_key, set(normalized_vendors))
+        for item in items or []:
+            if isinstance(item, dict):
+                raw_name = (
+                    item.get("integration_name")
+                    or item.get("integration")
+                    or item.get("name")
+                    or ""
+                )
+            else:
+                raw_name = item
+            normalized = normalize_company_name(raw_name)
+            if normalized:
+                bucket.add(normalized)
+
+    for hi in high_intent_entries or []:
+        vendor = _canonicalize_vendor(hi.get("vendor") or hi.get("vendor_name") or "")
+        if not vendor:
+            continue
+        bucket = blocked_by_vendor.setdefault(vendor, set(normalized_vendors))
+        for name in _extract_alternative_names(hi.get("alternatives") or []):
+            normalized = normalize_company_name(name)
+            if normalized:
+                bucket.add(normalized)
+
+    return blocked_by_vendor
+
+
+def _company_signal_name_is_eligible(
+    raw_name: Any,
+    *,
+    current_vendor: str = "",
+    blocked_names: set[str] | None = None,
+) -> bool:
+    """Return True when a company-like label is safe to keep as a signal."""
+    name = str(raw_name or "").strip()
+    if not name:
+        return False
+    normalized = normalize_company_name(name)
+    if not normalized:
+        return False
+    if _company_signal_looks_like_company_size_label(name):
+        return False
+    if _looks_like_company_domain(name):
+        return False
+    if _looks_like_company_url(name):
+        return False
+    if _looks_like_generic_company_descriptor(name):
+        return False
+    if _looks_like_location_label(name):
+        return False
+    if _looks_like_partner_or_tool_label(name):
+        return False
+    if current_vendor and normalized == normalize_company_name(current_vendor):
+        return False
+    blocked = blocked_names or set()
+    if normalized in blocked:
+        return False
+    return True
+
+
+def _company_signal_exclusion_reason(
+    raw_name: Any,
+    *,
+    current_vendor: str = "",
+    blocked_names: set[str] | None = None,
+    source: Any = None,
+    confidence_score: Any = None,
+) -> str | None:
+    """Return a stable exclusion reason for non-actionable company signals."""
+    if not _company_signal_name_is_eligible(
+        raw_name,
+        current_vendor=current_vendor,
+        blocked_names=blocked_names,
+    ):
+        return "ineligible_company_name"
+
+    normalized_source = str(source or "").strip().lower()
+    if normalized_source and normalized_source in _company_signal_skip_sources():
+        return "deprecated_source"
+
+    if normalized_source and normalized_source in _company_signal_named_account_blocked_sources():
+        return "non_actionable_named_account_source"
+
+    if normalized_source and normalized_source in _company_signal_low_trust_sources():
+        confidence = _normalize_company_signal_confidence(confidence_score)
+        if confidence is None or confidence < float(settings.b2b_churn.company_signal_low_trust_min_confidence):
+            return "low_confidence_low_trust_source"
+
+    return None
+
+
+def company_signal_review_unlock_snapshot(
+    *,
+    source: Any = None,
+    canonical_gap_reason: Any = None,
+    confidence_score: Any = None,
+    urgency_score: Any = None,
+) -> dict[str, Any]:
+    """Classify a review/group into a stable unlock path for review telemetry."""
+    normalized_source = str(source or "").strip().lower() or None
+    gap_reason = str(canonical_gap_reason or "").strip() or None
+    confidence = _normalize_company_signal_confidence(confidence_score)
+    try:
+        urgency = float(urgency_score) if urgency_score is not None else None
+    except (TypeError, ValueError):
+        urgency = None
+
+    windows = _company_signal_queue_near_threshold_windows()
+    confidence_floor = _normalize_company_signal_confidence(
+        getattr(settings.b2b_churn, "company_signal_low_trust_min_confidence", 0.6),
+    )
+    if confidence_floor is None:
+        confidence_floor = 0.6
+    try:
+        urgency_threshold = float(getattr(settings.b2b_churn, "high_churn_urgency_threshold", 7.0))
+    except (TypeError, ValueError):
+        urgency_threshold = 7.0
+
+    confidence_gap = None
+    if gap_reason == "low_confidence_low_trust_source" and confidence is not None:
+        confidence_gap = max(0.0, round(confidence_floor - confidence, 3))
+
+    urgency_gap = None
+    if gap_reason == "below_high_intent_threshold" and urgency is not None:
+        urgency_gap = max(0.0, round(urgency_threshold - urgency, 2))
+
+    low_trust = normalized_source in _company_signal_low_trust_sources() if normalized_source else False
+    if gap_reason == "low_confidence_low_trust_source" and low_trust:
+        if confidence_gap is not None and confidence_gap <= windows["confidence_gap"]:
+            review_unlock_path = "low_trust_near_threshold_group"
+            review_unlock_reason = "close_low_trust_confidence"
+        else:
+            review_unlock_path = "low_trust_confidence_gap"
+            review_unlock_reason = "low_trust_below_confidence_threshold"
+    elif gap_reason == "below_high_intent_threshold" and not low_trust:
+        review_unlock_path = "trusted_source_urgency_gap"
+        review_unlock_reason = "trusted_source_below_high_intent_threshold"
+    elif gap_reason == "missing_signal_evidence":
+        review_unlock_path = "missing_signal_evidence"
+        review_unlock_reason = "missing_signal_evidence"
+    elif gap_reason:
+        review_unlock_path = "other"
+        review_unlock_reason = gap_reason
+    else:
+        review_unlock_path = "canonical_or_unblocked"
+        review_unlock_reason = "canonical_or_unblocked"
+
+    return {
+        "candidate_source": normalized_source,
+        "canonical_gap_reason": gap_reason,
+        "review_unlock_path": review_unlock_path,
+        "review_unlock_reason": review_unlock_reason,
+        "confidence_gap_to_canonical": confidence_gap,
+        "urgency_gap_to_high_intent": urgency_gap,
+    }
+
+
+def _high_intent_signal_evidence_enabled() -> bool:
+    return bool(getattr(settings.b2b_churn, "high_intent_require_signal_evidence", True))
+
+
+def _high_intent_row_has_structured_signal_support(row: dict[str, Any]) -> bool:
+    if not bool(row.get("indicator_named_alternative")):
+        return False
+    if bool(row.get("has_budget_authority")):
+        return True
+    if bool(row.get("indicator_timeline")) and bool(row.get("indicator_price_pressure")):
+        return True
+    buying_stage = _normalize_buying_stage(row.get("buying_stage"))
+    if buying_stage in {"evaluation", "active_purchase", "renewal_decision"} and bool(row.get("indicator_timeline")):
+        return True
+    return False
+
+
+def _high_intent_row_has_signal_evidence(row: dict[str, Any]) -> bool:
+    if any(
+        bool(row.get(key))
+        for key in (
+            "intent_to_leave",
+            "actively_evaluating",
+            "contract_renewal_mentioned",
+            "indicator_cancel",
+            "indicator_migration",
+            "indicator_evaluation",
+            "indicator_switch",
+        )
+    ):
+        return True
+    return _high_intent_row_has_structured_signal_support(row)
+
+
+def _battle_card_company_is_display_safe(
+    raw_name: Any,
+    *,
+    current_vendor: str = "",
+    blocked_names: set[str] | None = None,
+    role: Any = None,
+    company_size: Any = None,
+    buying_stage: Any = None,
+) -> bool:
+    if not _company_signal_name_is_eligible(
+        raw_name,
+        current_vendor=current_vendor,
+        blocked_names=blocked_names,
+    ):
+        return False
+    # Seller-facing rows need at least one qualifier beyond just a name.
+    return any(bool(val) for val in (role, company_size, buying_stage))
+
+
+def _normalize_buying_stage(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    if not text:
+        return ""
+    return text.replace("-", "_").replace(" ", "_")
+
+
+def _battle_card_required_buying_stages() -> set[str]:
+    raw = getattr(settings.b2b_churn, "battle_card_quality_required_stages", None)
+    if not isinstance(raw, list):
+        return set()
+    return {_normalize_buying_stage(item) for item in raw if str(item or "").strip()}
+
+
+def _battle_card_min_high_intent_urgency() -> float:
+    return float(getattr(settings.b2b_churn, "battle_card_quality_min_high_intent_urgency", 7.0))
+
+
+def _rank_high_intent_companies(companies: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    required_stages = _battle_card_required_buying_stages()
+    min_urgency = _battle_card_min_high_intent_urgency()
+
+    def _score(item: dict[str, Any]) -> tuple[int, float, int, float, str]:
+        try:
+            urgency = float(item.get("urgency") or 0)
+        except (TypeError, ValueError):
+            urgency = 0.0
+        stage = _normalize_buying_stage(item.get("buying_stage"))
+        stage_qualified = int(bool(required_stages) and stage in required_stages and urgency >= min_urgency)
+        dm = int(bool(item.get("decision_maker")))
+        try:
+            confidence = float(item.get("confidence_score") or 0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        name = str(item.get("company") or "").strip().lower()
+        return (stage_qualified, urgency, dm, confidence, name)
+
+    return sorted(companies, key=_score, reverse=True)
+
+
+def _normalize_canonical_accounts_for_battle_card(
+    accounts: list[dict[str, Any]],
+    *,
+    current_vendor: str = "",
+    blocked_names: set[str] | None = None,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Convert canonical account-intelligence rows to battle-card company shape."""
+    candidates: list[dict[str, Any]] = []
+    for a in accounts:
+        if not isinstance(a, dict):
+            continue
+        company = a.get("company_name") or a.get("name") or ""
+        if not company:
+            continue
+        role = a.get("buyer_role") or a.get("title") or ""
+        if role.lower() in ("unknown", ""):
+            role = ""
+        entry: dict[str, Any] = {
+            "company": company,
+            "urgency": float(a.get("urgency_score") or a.get("urgency") or 0),
+            "role": role or None,
+            "pain": a.get("pain_category") or None,
+            "company_size": a.get("company_size"),
+            "source": a.get("source"),
+            "buying_stage": a.get("buying_stage"),
+            "decision_maker": bool(a.get("decision_maker")),
+            "confidence_score": float(a.get("confidence_score") or 0),
+            "contract_end": a.get("contract_end"),
+            "industry": a.get("industry"),
+        }
+        if not _battle_card_company_is_display_safe(
+            entry["company"],
+            current_vendor=current_vendor,
+            blocked_names=blocked_names,
+            role=entry.get("role"),
+            company_size=entry.get("company_size"),
+            buying_stage=entry.get("buying_stage"),
+        ):
+            continue
+        candidates.append(entry)
+    return _rank_high_intent_companies(candidates)[:limit]
+
+
+def _battle_card_companies_from_evidence_vault(
+    vault: dict[str, Any] | None,
+    *,
+    current_vendor: str = "",
+    blocked_names: set[str] | None = None,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Normalize vault company signals into the current battle-card shape."""
+    if not isinstance(vault, dict):
+        return []
+    companies: list[dict[str, Any]] = []
+    for item in vault.get("company_signals") or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("company_name") or "").strip()
+        if _company_signal_exclusion_reason(
+            name,
+            current_vendor=current_vendor,
+            blocked_names=blocked_names,
+            source=item.get("source"),
+            confidence_score=item.get("confidence_score"),
+        ):
+            continue
+        if not _battle_card_company_is_display_safe(
+            name,
+            current_vendor=current_vendor,
+            blocked_names=blocked_names,
+            role=item.get("buyer_role"),
+            company_size=item.get("seat_count"),
+            buying_stage=item.get("buying_stage"),
+        ):
+            continue
+        entry: dict[str, Any] = {
+            "company": name,
+            "urgency": item.get("urgency_score"),
+            "role": item.get("buyer_role"),
+            "pain": item.get("pain_category"),
+            "company_size": item.get("seat_count"),
+            "source": item.get("source"),
+            "buying_stage": item.get("buying_stage"),
+        }
+        if item.get("decision_maker") is not None:
+            entry["decision_maker"] = item["decision_maker"]
+        if item.get("confidence_score") is not None:
+            entry["confidence_score"] = item["confidence_score"]
+        if item.get("contract_end"):
+            entry["contract_end"] = str(item["contract_end"])
+        companies.append(entry)
+    return _rank_high_intent_companies(companies)[:limit]
+
+
+def _battle_card_provenance_from_evidence_vault(
+    vault: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Map vault provenance into the battle-card provenance attachment shape."""
+    if not isinstance(vault, dict):
+        return {}
+    provenance = vault.get("provenance") or {}
+    if not isinstance(provenance, dict):
+        return {}
+    mapped: dict[str, Any] = {}
+    if provenance.get("source_distribution"):
+        mapped["source_distribution"] = provenance["source_distribution"]
+    if provenance.get("sample_review_ids"):
+        mapped["sample_review_ids"] = provenance["sample_review_ids"]
+    if provenance.get("enrichment_window_start"):
+        mapped["review_window_start"] = provenance["enrichment_window_start"]
+    if provenance.get("enrichment_window_end"):
+        mapped["review_window_end"] = provenance["enrichment_window_end"]
+    return mapped
+
+
+def _build_vendor_evidence(
+    vs: dict[str, Any],
+    *,
+    pain_lookup: dict[str, list[dict]],
+    competitor_lookup: dict[str, list[dict]],
+    feature_gap_lookup: dict[str, list[dict]],
+    insider_lookup: dict[str, dict],
+    keyword_spike_lookup: dict[str, dict],
+    temporal_lookup: dict[str, dict] | None = None,
+    archetype_lookup: dict[str, list[dict]] | None = None,
+    dm_lookup: dict[str, float] | None = None,
+    price_lookup: dict[str, float] | None = None,
+    quote_lookup: dict[str, list] | None = None,
+    budget_lookup: dict[str, dict] | None = None,
+    buyer_auth_lookup: dict[str, dict] | None = None,
+    use_case_lookup: dict[str, list[dict]] | None = None,
+    velocity_lookup: dict[str, dict] | None = None,
+    market_regime_lookup: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Merge vendor score row + all available lookups into a single evidence
+    dict for synthesis and deterministic reasoning consumers.
+
+    Includes pain, competitors, feature gaps, insider signals, keyword spikes,
+    temporal velocities, archetype pre-scores, and optionally DM rate, price
+    complaint rate, budget signals, buyer authority, use cases, and quotes.
+    """
+    vendor = _canonicalize_vendor(vs.get("vendor_name") or "")
+    total = int(vs.get("total_reviews") or 0)
+    signal_total = int(vs.get("signal_reviews") or 0) or total
+    churn = int(vs.get("churn_intent") or 0)
+    churn_density = round((churn * 100.0 / signal_total), 1) if signal_total else 0.0
+    avg_urgency = round(float(vs.get("avg_urgency") or 0), 1)
+
+    evidence: dict[str, Any] = {
+        "vendor_name": vendor,
+        "product_category": vs.get("product_category") or "",
+        "total_reviews": total,
+        "churn_intent": churn,
+        "churn_density": churn_density,
+        "avg_urgency": avg_urgency,
+        "recommend_yes": int(vs.get("recommend_yes") or 0),
+        "recommend_no": int(vs.get("recommend_no") or 0),
+        "displacement_mention_count": 0,
+        "quote_count": 0,
+    }
+    for raw_key in (
+        "support_sentiment",
+        "legacy_support_score",
+        "new_feature_velocity",
+        "employee_growth_rate",
+        "positive_review_pct",
+        "avg_rating_normalized",
+    ):
+        raw_val = vs.get(raw_key)
+        if raw_val is not None:
+            evidence[raw_key] = raw_val
+
+    pains = pain_lookup.get(vendor, [])
+    if pains:
+        evidence["pain_categories"] = [
+            {"category": p.get("category", ""), "count": p.get("count", 0)}
+            for p in pains[:5]
+        ]
+
+    comps = competitor_lookup.get(vendor, [])
+    if comps:
+        evidence["competitors"] = [
+            {"name": c.get("name", ""), "mentions": c.get("mentions", 0)}
+            for c in comps[:5]
+        ]
+        evidence["displacement_mention_count"] = sum(c.get("mentions", 0) for c in comps)
+
+    gaps = feature_gap_lookup.get(vendor, [])
+    if gaps:
+        evidence["feature_gaps"] = [
+            {"feature": g.get("feature", ""), "mentions": g.get("count", g.get("mentions", 0))}
+            for g in gaps[:5]
+        ]
+
+    insider = insider_lookup.get(vendor, {})
+    if insider:
+        evidence["insider_signal_count"] = insider.get("signal_count", 0)
+        evidence["insider_talent_drain_rate"] = insider.get("talent_drain_rate")
+
+    kw = keyword_spike_lookup.get(vendor, {})
+    if kw.get("spike_count"):
+        evidence["keyword_spike_count"] = kw["spike_count"]
+        evidence["keyword_spike_keywords"] = kw.get("spike_keywords", [])
+
+    if temporal_lookup:
+        td = temporal_lookup.get(vendor, {})
+        if td:
+            evidence.update(td)
+
+    if archetype_lookup:
+        arch = archetype_lookup.get(vendor, [])
+        if arch:
+            evidence["archetype_scores"] = arch
+    if market_regime_lookup:
+        regime = market_regime_lookup.get(vendor)
+        if regime:
+            evidence["market_regime"] = regime
+
+    # Additional context (when available)
+    if dm_lookup:
+        dm = dm_lookup.get(vendor)
+        if dm is not None:
+            evidence["dm_churn_rate"] = dm
+    if price_lookup:
+        pr = price_lookup.get(vendor)
+        if pr is not None:
+            evidence["price_complaint_rate"] = pr
+    if quote_lookup:
+        quotes = quote_lookup.get(vendor, [])
+        if quotes:
+            evidence["quote_count"] = len(quotes)
+            q0 = quotes[0]
+            if isinstance(q0, dict):
+                evidence["top_quote"] = str(q0.get("quote") or q0.get("text") or "")[:200] or None
+            elif isinstance(q0, str):
+                evidence["top_quote"] = q0[:200]
+            else:
+                evidence["top_quote"] = None
+    if budget_lookup:
+        budget = budget_lookup.get(vendor, {})
+        if budget:
+            evidence["budget_context"] = budget
+    if buyer_auth_lookup:
+        ba = buyer_auth_lookup.get(vendor, {})
+        if ba:
+            evidence["buyer_authority"] = ba
+    if use_case_lookup:
+        ucs = use_case_lookup.get(vendor, [])
+        if ucs:
+            evidence["top_use_cases"] = [u.get("use_case", u.get("name", "")) for u in ucs[:3] if isinstance(u, dict)]
+    if velocity_lookup:
+        vel = velocity_lookup.get(vendor, {})
+        if vel:
+            evidence["displacement_velocity_7d"] = vel.get("velocity_7d")
+            evidence["displacement_velocity_30d"] = vel.get("velocity_30d")
+            v7 = vel.get("velocity_7d") or 0
+            evidence["velocity_trend"] = (
+                "accelerating" if v7 > 0
+                else "decelerating" if v7 < 0
+                else "stable"
+            )
+
+    return evidence
+
+
+async def _fetch_latest_category_overview_entry(
+    pool,
+    category: str,
+) -> dict[str, Any] | None:
+    """Fetch the latest persisted category overview entry for a category."""
+    if not category:
+        return None
+
+    row = await pool.fetchrow(
+        """
+        SELECT intelligence_data
+        FROM b2b_intelligence
+        WHERE report_type = 'category_overview'
+        ORDER BY report_date DESC, created_at DESC
+        LIMIT 1
+        """,
+    )
+    if not row:
+        return None
+
+    data = row["intelligence_data"]
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    entries = data if isinstance(data, list) else data.get("category_overview", data)
+    if not isinstance(entries, list):
+        return None
+
+    wanted = str(category).strip().lower()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("category", "")).strip().lower() == wanted:
+            return entry
+    return None
+
+
+async def fetch_vendor_evidence(
+    pool,
+    vendor_name: str,
+    *,
+    window_days: int = 90,
+) -> dict[str, Any] | None:
+    """Build a rich evidence dict for a single vendor from current DB data.
+
+    Used for on-demand reasoning (API + MCP).  Returns None if the vendor
+    has no churn signal rows.
+    """
+    from ...config import settings
+    cfg = settings.b2b_churn
+    min_reviews = cfg.intelligence_min_reviews
+    canonical = _canonicalize_vendor(vendor_name)
+    if not canonical:
+        return None
+
+    # Fetch vendor score rows
+    all_scores = await read_vendor_scorecards(
+        pool,
+        window_days=window_days,
+        min_reviews=min_reviews,
+        vendor_names=[vendor_name],
+    )
+    vs_match = [v for v in all_scores if _canonicalize_vendor(v.get("vendor_name", "")) == canonical]
+    if not vs_match:
+        return None
+    vs = vs_match[0]
+
+    # Parallel fetches for lookups
+    (
+        pain_dist, competitive_disp, feature_gaps,
+        price_rates, dm_rates, keyword_spikes,
+        insider_raw, quotable_evidence, budget_signals,
+        use_case_dist, buyer_auth,
+    ) = await asyncio.gather(
+        _fetch_pain_distribution(pool, window_days),
+        _fetch_competitive_displacement_source_of_truth(
+            pool,
+            as_of=date.today(),
+            analysis_window_days=window_days,
+        ),
+        _fetch_feature_gaps(pool, window_days),
+        _fetch_price_complaint_rates(pool, window_days),
+        _fetch_dm_churn_rates(pool, window_days),
+        _fetch_keyword_spikes(pool),
+        _fetch_insider_aggregates(pool, window_days),
+        _fetch_quotable_evidence(pool, window_days),
+        _fetch_budget_signals(pool, window_days),
+        _fetch_use_case_distribution(pool, window_days),
+        _fetch_buyer_authority_summary(pool, window_days),
+    )
+
+    pain_lookup = _build_pain_lookup(pain_dist)
+    comp_lookup = _build_competitor_lookup(competitive_disp)
+    fg_lookup = _build_feature_gap_lookup(feature_gaps)
+    kw_lookup = _build_keyword_spike_lookup(keyword_spikes)
+    insider_lookup = _build_insider_lookup(insider_raw)
+    dm_lookup = {r["vendor"]: r["dm_churn_rate"] for r in dm_rates}
+    price_lookup = {r["vendor"]: r["price_complaint_rate"] for r in price_rates}
+    quote_lookup = {r["vendor"]: r["quotes"] for r in quotable_evidence}
+    budget_lookup = {r["vendor"]: {k: v for k, v in r.items() if k != "vendor"} for r in budget_signals}
+    ba_lookup = _build_buyer_auth_lookup(buyer_auth)
+    uc_lookup = _build_use_case_lookup(use_case_dist)
+
+    # Temporal analysis (non-fatal)
+    temporal_lookup: dict[str, dict] = {}
+    archetype_lookup: dict[str, list[dict]] = {}
+    market_regime_lookup: dict[str, dict[str, Any]] = {}
+    try:
+        from ...reasoning.temporal import TemporalEngine
+        from ...reasoning.archetypes import enrich_evidence_with_archetypes
+        te = TemporalEngine(pool)
+        td_result = await te.analyze_vendor(canonical)
+        td = TemporalEngine.to_evidence_dict(td_result)
+        temporal_lookup[canonical] = td
+        evidence_seed = {
+            "vendor_name": canonical,
+            "support_sentiment": vs.get("support_sentiment"),
+            "legacy_support_score": vs.get("legacy_support_score"),
+            "new_feature_velocity": vs.get("new_feature_velocity"),
+            "employee_growth_rate": vs.get("employee_growth_rate"),
+            **td,
+        }
+        enriched = enrich_evidence_with_archetypes(evidence_seed, td)
+        arch_scores = enriched.get("archetype_scores", [])
+        if arch_scores:
+            archetype_lookup[canonical] = arch_scores
+    except Exception:
+        logger.debug("Temporal analysis unavailable for %s", canonical)
+
+    try:
+        cat_entry = await _fetch_latest_category_overview_entry(
+            pool, str(vs.get("product_category") or ""),
+        )
+        regime = (cat_entry or {}).get("cross_vendor_analysis", {}).get("market_regime")
+        if regime:
+            market_regime_lookup[canonical] = regime
+    except Exception:
+        logger.debug("Market regime unavailable for %s", canonical, exc_info=True)
+
+    return _build_vendor_evidence(
+        vs,
+        pain_lookup=pain_lookup,
+        competitor_lookup=comp_lookup,
+        feature_gap_lookup=fg_lookup,
+        insider_lookup=insider_lookup,
+        keyword_spike_lookup=kw_lookup,
+        temporal_lookup=temporal_lookup or None,
+        archetype_lookup=archetype_lookup or None,
+        dm_lookup=dm_lookup,
+        price_lookup=price_lookup,
+        quote_lookup=quote_lookup,
+        budget_lookup=budget_lookup,
+        buyer_auth_lookup=ba_lookup,
+        use_case_lookup=uc_lookup,
+        market_regime_lookup=market_regime_lookup or None,
+    )
+
+
+def _build_deterministic_weekly_feed(high_intent: list[dict[str, Any]], *, limit: int = 10) -> list[dict[str, Any]]:
+    """Build weekly churn feed directly from validated high-intent rows."""
+    seen: set[tuple[str, str]] = set()
+    ordered = sorted(
+        high_intent,
+        key=lambda r: (
+            -(r.get("urgency") or 0),
+            -(1 if r.get("decision_maker") else 0),
+            str(r.get("company") or ""),
+        ),
+    )
+    results: list[dict[str, Any]] = []
+    for row in ordered:
+        company = row.get("company") or ""
+        vendor = _canonicalize_vendor(row.get("vendor") or "")
+        if not company or not vendor:
+            continue
+        key = (company, vendor)
+        if key in seen:
+            continue
+        seen.add(key)
+        alternatives = _extract_alternative_names(row.get("alternatives") or [])
+        quotes = [q for q in (row.get("quotes") or []) if isinstance(q, str)]
+        results.append({
+            "company": company,
+            "vendor": vendor,
+            "urgency": row.get("urgency") or 0,
+            "pain": row.get("pain") or "unknown",
+            "alternatives_evaluating": alternatives,
+            "key_quote": quotes[0] if quotes else None,
+            "evidence": quotes[:3],
+            "action_recommendation": _build_buyer_action(vendor, row.get("pain"), alternatives),
+            "buyer_role": row.get("role_level") or "",
+            "buyer_authority": bool(row.get("decision_maker")),
+        })
+        if len(results) >= limit:
+            break
+    return results
+
+
+def _build_deterministic_vendor_feed(
+    vendor_scores: list[dict[str, Any]],
+    *,
+    pain_lookup: dict[str, list[dict]],
+    competitor_lookup: dict[str, list[dict]],
+    feature_gap_lookup: dict[str, list[dict]],
+    quote_lookup: dict[str, list],
+    budget_lookup: dict[str, dict],
+    sentiment_lookup: dict[str, dict[str, int]],
+    buyer_auth_lookup: dict[str, dict],
+    dm_lookup: dict[str, float],
+    price_lookup: dict[str, float],
+    company_lookup: dict[str, list],
+    keyword_spike_lookup: dict[str, dict],
+    prior_reports: list[dict[str, Any]],
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+    temporal_lookup: dict[str, dict] | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Build vendor-level weekly churn feed from aggregated data.
+
+    Uses ALL enriched reviews (not just those with named companies).
+    Each entry represents one vendor's churn pressure profile.
+    """
+    # Build prior vendor metrics for trend comparison
+    prior_vendor_metrics: dict[str, dict[str, float]] = {}
+    for report in prior_reports:
+        if report.get("report_type") != "weekly_churn_feed":
+            continue
+        data = report.get("intelligence_data") or []
+        if not isinstance(data, list):
+            continue
+        for row in data:
+            vendor = row.get("vendor")
+            if vendor and vendor not in prior_vendor_metrics:
+                prior_vendor_metrics[vendor] = {
+                    "churn_signal_density": float(row.get("churn_signal_density") or row.get("churn_density") or 0),
+                    "avg_urgency": float(row.get("avg_urgency") or row.get("urgency") or 0),
+                }
+
+    # Aggregate (vendor_name, product_category) rows into one row per vendor.
+    # Sums reviews/churn_intent, weighted-averages urgency, picks dominant category.
+    merged: dict[str, dict[str, Any]] = {}
+    for row in vendor_scores:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        reviews = int(row.get("total_reviews") or 0)
+        churn = int(row.get("churn_intent") or 0)
+        urgency = float(row.get("avg_urgency") or 0)
+        category = row.get("product_category") or "Unknown"
+        sig_reviews = int(row.get("signal_reviews") or 0)
+        if vendor not in merged:
+            merged[vendor] = {
+                "total_reviews": reviews,
+                "signal_reviews": sig_reviews,
+                "churn_intent": churn,
+                "urgency_weighted_sum": urgency * reviews,
+                "category": category,
+                "category_reviews": reviews,
+            }
+        else:
+            m = merged[vendor]
+            m["total_reviews"] += reviews
+            m["signal_reviews"] = m.get("signal_reviews", 0) + sig_reviews
+            m["churn_intent"] += churn
+            m["urgency_weighted_sum"] += urgency * reviews
+            # Keep category with most reviews
+            if reviews > m["category_reviews"]:
+                m["category"] = category
+                m["category_reviews"] = reviews
+
+    candidates: list[dict[str, Any]] = []
+    fallback_candidates: list[dict[str, Any]] = []
+    for vendor, m in merged.items():
+        total_reviews = m["total_reviews"]
+        signal_reviews = int(m.get("signal_reviews") or 0) or total_reviews
+        churn_intent = m["churn_intent"]
+        churn_density = round((churn_intent * 100.0 / signal_reviews), 1) if signal_reviews else 0.0
+        avg_urgency = round(m["urgency_weighted_sum"] / total_reviews, 1) if total_reviews else 0.0
+        category = m["category"]
+        dm_rate = float(dm_lookup.get(vendor, 0))
+        price_rate = float(price_lookup.get(vendor, 0))
+        # Load reasoning once per vendor
+        _rc = _get_vendor_reasoning(vendor, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup)
+        reasoning_confidence = float(_rc.get("confidence", 0) or 0)
+
+        passes_primary_gate = not (
+            churn_density < 15 and avg_urgency < 6 and dm_rate < 0.3
+        )
+        passes_secondary_signal = (
+            reasoning_confidence >= 0.75
+            or price_rate >= 0.18
+            or dm_rate >= 0.08
+            or churn_density >= 5.0
+        )
+        if not passes_primary_gate and not (
+            total_reviews >= 50 and passes_secondary_signal
+        ):
+            continue
+
+        # Confidence label
+        if total_reviews >= 50:
+            confidence = "high"
+        elif total_reviews >= 20:
+            confidence = "medium"
+        else:
+            confidence = "low"
+
+        # Boost confidence when reasoning provides corroborating evidence
+        if reasoning_confidence >= 0.8 and confidence == "medium":
+            confidence = "high"
+
+        # Displacement mention total for this vendor
+        comp_entries = competitor_lookup.get(vendor, [])
+        displacement_mentions = sum(c.get("mentions", 0) for c in comp_entries)
+
+        _vendor_archetype = _rc.get("archetype")
+        score = _compute_churn_pressure_score(
+            churn_density=churn_density,
+            avg_urgency=avg_urgency,
+            dm_churn_rate=dm_rate,
+            displacement_mention_count=displacement_mentions,
+            price_complaint_rate=price_rate,
+            total_reviews=total_reviews,
+            archetype=_vendor_archetype,
+        )
+
+        # Pain breakdown (top 3)
+        pains = pain_lookup.get(vendor, [])
+        top_pain = pains[0]["category"] if pains else "unknown"
+        total_pain = sum(int(p.get("count") or 0) for p in pains)
+        pain_breakdown = [
+            {
+                "category": p["category"],
+                "count": p["count"],
+                "pct": round(int(p.get("count") or 0) / max(total_pain, 1), 3),
+            }
+            for p in pains[:3]
+        ]
+
+        # Feature gaps (top 3)
+        gaps = feature_gap_lookup.get(vendor, [])
+        top_feature_gaps = [g["feature"] for g in gaps[:3]]
+
+        # Displacement targets (top 3)
+        top_displacement = [{"competitor": c["name"], "mentions": c["mentions"]} for c in comp_entries[:3]]
+
+        # Quotes (items may be dicts with review_id or plain strings)
+        quotes = quote_lookup.get(vendor, [])
+        key_quote = _quote_text(quotes[0]) if quotes else None
+        evidence = quotes[:3]
+
+        # Dominant buyer role
+        ba = buyer_auth_lookup.get(vendor, {})
+        role_types = ba.get("role_types", {})
+        dominant_role = _dominant_segment_role(role_types)
+
+        # Sentiment direction
+        sentiment_counts = sentiment_lookup.get(vendor, {})
+        if total_reviews < 10 or not sentiment_counts:
+            sentiment_direction = "insufficient_history"
+        else:
+            sentiment_direction = max(sentiment_counts.items(), key=lambda x: x[1])[0]
+
+        # Trend from prior reports (z-score aware when temporal data available)
+        trend = _classify_trend(
+            vendor, churn_density, avg_urgency,
+            prior_vendor_metrics.get(vendor),
+            temporal_lookup=temporal_lookup,
+        )
+
+        # Named accounts (may be empty)
+        companies = company_lookup.get(vendor, [])
+        named_accounts = [
+            {"company": c.get("company", c) if isinstance(c, dict) else str(c),
+             "urgency": c.get("urgency", 0) if isinstance(c, dict) else 0,
+             "title": c.get("title") if isinstance(c, dict) else None,
+             "company_size": c.get("company_size") if isinstance(c, dict) else None,
+             "industry": c.get("industry") if isinstance(c, dict) else None,
+             "source": c.get("source") if isinstance(c, dict) else None,
+             "buying_stage": c.get("buying_stage") if isinstance(c, dict) else None,
+             "confidence_score": c.get("confidence_score") if isinstance(c, dict) else None,
+             "decision_maker": c.get("decision_maker") if isinstance(c, dict) else None,
+             "first_seen_at": c.get("first_seen_at") if isinstance(c, dict) else None,
+             "last_seen_at": c.get("last_seen_at") if isinstance(c, dict) else None}
+            for c in companies[:5]
+        ]
+
+        # Risk level -- prefer reasoning conclusion, fall back to deterministic
+        _rc_risk = _rc.get("risk_level", "")
+        if _rc_risk:
+            risk_level = _rc_risk
+        elif score >= 70:
+            risk_level = "high"
+        elif score >= 40:
+            risk_level = "medium"
+        else:
+            risk_level = "low"
+
+        # Affected segments (aggregate industry/size from churning companies)
+        _industry_counts: dict[str, int] = {}
+        _size_counts: dict[str, int] = {}
+        for c in companies:
+            if not isinstance(c, dict):
+                continue
+            ind = c.get("industry")
+            if ind and ind != "unknown":
+                _industry_counts[ind] = _industry_counts.get(ind, 0) + 1
+            sz = c.get("company_size")
+            if sz:
+                _size_counts[sz] = _size_counts.get(sz, 0) + 1
+        affected_segments = {
+            "industries": sorted(
+                [{"industry": k, "count": v} for k, v in _industry_counts.items()],
+                key=lambda x: -x["count"],
+            )[:5],
+            "company_sizes": sorted(
+                [{"size": k, "count": v} for k, v in _size_counts.items()],
+                key=lambda x: -x["count"],
+            )[:5],
+        }
+
+        # Alternatives for action recommendation
+        alt_names = [c["name"] for c in comp_entries[:2]] if comp_entries else []
+
+        entry = {
+            "vendor": vendor,
+            "category": category,
+            "total_reviews": total_reviews,
+            "churn_signal_density": churn_density,
+            "avg_urgency": avg_urgency,
+            "sample_size_confidence": confidence,
+            "churn_pressure_score": score,
+            "risk_level": risk_level,
+            "top_pain": top_pain,
+            "pain_breakdown": pain_breakdown,
+            "top_feature_gaps": top_feature_gaps,
+            "dm_churn_rate": round(dm_rate, 2),
+            "price_complaint_rate": round(price_rate, 2),
+            "dominant_buyer_role": dominant_role,
+            "top_displacement_targets": top_displacement,
+            "key_quote": key_quote,
+            "evidence": evidence,
+            "sentiment_direction": sentiment_direction,
+            "trend": trend,
+            "budget_context": budget_lookup.get(vendor, {}),
+            "action_recommendation": _build_buyer_action(vendor, top_pain, alt_names, archetype=_vendor_archetype),
+            "named_accounts": named_accounts,
+            "affected_segments": affected_segments,
+        }
+        if _rc:
+            entry["archetype"] = _rc.get("archetype", "")
+            entry["archetype_confidence"] = reasoning_confidence
+            entry["archetype_risk_level"] = _rc.get("risk_level", "")
+            entry["reasoning_mode"] = _rc.get("mode", "")
+            # Synthesis-native fields when available
+            if _rc.get("mode") == "synthesis":
+                entry["reasoning_source"] = "synthesis"
+                summary = _rc.get("executive_summary", "")
+                if summary:
+                    entry["reasoning_summary"] = summary
+        if passes_primary_gate:
+            candidates.append(entry)
+        else:
+            entry["selection_mode"] = "secondary_signal"
+            fallback_candidates.append(entry)
+
+    # Reasoning-weighted sort: vendors with high-confidence archetypes get a boost
+    def _sort_key(x: dict) -> tuple:
+        score = x["churn_pressure_score"]
+        conf = x.get("archetype_confidence", 0)
+        has_arch = bool(x.get("archetype"))
+        reasoning_boost = min(conf * 5, 5.0) if has_arch else 0
+        return (-(score + reasoning_boost),)
+    candidates.sort(key=_sort_key)
+    if not candidates and fallback_candidates:
+        fallback_candidates.sort(key=_sort_key)
+        return fallback_candidates[:limit]
+    return candidates[:limit]
+
+
+def _build_deterministic_displacement_map(
+    competitive_disp: list[dict[str, Any]],
+    competitor_reasons: list[dict[str, Any]],
+    quote_lookup: dict[str, list],
+    *,
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Build displacement report from evidence-quality-filtered aggregated flows.
+
+    Quality gate: only edges with at least one explicit_switch or active_evaluation
+    survive.  Pure implied_preference edges are market-pain data, not displacement.
+    """
+    reason_lookup = _build_reason_lookup(competitor_reasons)
+    def _rl_get(v: str) -> dict:
+        return _get_vendor_reasoning(v, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup)
+
+    def _source_vendor_wedge(vendor_name: str) -> str:
+        canon = _canonicalize_vendor(vendor_name)
+        if not canon:
+            return ""
+        if synthesis_views:
+            view = synthesis_views.get(canon)
+            if view is None:
+                for key, candidate in synthesis_views.items():
+                    if _canonicalize_vendor(key) == canon:
+                        view = candidate
+                        break
+            if view is not None:
+                wedge = getattr(view, "primary_wedge", None)
+                if wedge is not None:
+                    return str(getattr(wedge, "value", "") or "")
+                section = getattr(view, "section", None)
+                if callable(section):
+                    cn = section("causal_narrative")
+                    if isinstance(cn, dict):
+                        return str(cn.get("primary_wedge") or "")
+        return str(_rl_get(canon).get("archetype") or "")
+
+    results: list[dict[str, Any]] = []
+    for row in competitive_disp:
+        vendor = _canonicalize_vendor(row.get("vendor") or "")
+        competitor = _canonicalize_competitor(row.get("competitor") or "")
+        if not vendor or not competitor or vendor.lower() == competitor.lower():
+            continue
+        if not _battle_card_competitor_is_eligible(competitor):
+            continue
+
+        mention_count = int(row.get("mention_count") or 0)
+        explicit = int(row.get("explicit_switches") or 0)
+        active_eval = int(row.get("active_evaluations") or 0)
+        implied = int(row.get("implied_preferences") or 0)
+
+        # Quality gate: require at least one explicit switch or active evaluation
+        if explicit == 0 and active_eval == 0:
+            continue
+
+        # Primary driver: use structured reason_categories; fall back to keyword inference
+        reason_cats = row.get("reason_categories") or {}
+        if reason_cats:
+            normalized_reason_cats: dict[str, int] = {}
+            for key, count in reason_cats.items():
+                label = _normalize_displacement_driver_label(key)
+                if not label:
+                    continue
+                normalized_reason_cats[label] = normalized_reason_cats.get(label, 0) + int(count or 0)
+            if normalized_reason_cats:
+                canonical_priority = {
+                    "pricing": 9,
+                    "features": 8,
+                    "integration": 7,
+                    "ux": 6,
+                    "support": 5,
+                    "reliability": 4,
+                    "security": 3,
+                    "compliance": 2,
+                    "performance": 1,
+                    "migration": 1,
+                }
+                driver = max(
+                    normalized_reason_cats.items(),
+                    key=lambda x: (x[1], canonical_priority.get(x[0], 0)),
+                )[0]
+            else:
+                # All keys failed normalization -- try keyword inference on raw keys
+                driver = _infer_driver_from_reasons(list(reason_cats.keys()))
+        else:
+            reasons = reason_lookup.get((vendor, competitor), [])
+            driver = _infer_driver_from_reasons(reasons)
+
+        # Signal strength: weight evidence types (explicit 3x, active_eval 2x, implied 1x)
+        weighted_signal = explicit * 3 + active_eval * 2 + implied * 1
+        if weighted_signal >= 15 or explicit >= 3:
+            strength = "strong"
+        elif weighted_signal >= 6 or explicit >= 1:
+            strength = "moderate"
+        else:
+            strength = "emerging"
+        # Boost signal strength when source vendor has category_disruption or feature_gap archetype
+        src_arch = _source_vendor_wedge(vendor)
+        if src_arch in ("category_disruption", "feature_gap") and strength == "emerging":
+            strength = "moderate"
+
+        reasons_for_quote = reason_lookup.get((vendor, competitor), [])
+        edge_entry: dict[str, Any] = {
+            "from_vendor": vendor,
+            "to_vendor": competitor,
+            "mention_count": mention_count,
+            "primary_driver": driver,
+            "signal_strength": strength,
+            "evidence_breakdown": {
+                "explicit_switches": explicit,
+                "active_evaluations": active_eval,
+                "implied_preferences": implied,
+            },
+            "key_quote": _pick_displacement_quote(
+                vendor=vendor,
+                competitor=competitor,
+                reasons=reasons_for_quote,
+                quote_lookup=quote_lookup,
+            ),
+            "industries": row.get("industries", []),
+            "company_sizes": row.get("company_sizes", []),
+        }
+        _src_rc = _rl_get(vendor)
+        _tgt_rc = _rl_get(competitor)
+        if _src_rc.get("archetype"):
+            edge_entry["source_archetype"] = _src_rc["archetype"]
+            edge_entry["source_archetype_confidence"] = _src_rc.get("confidence", 0)
+        if _tgt_rc.get("archetype"):
+            edge_entry["target_archetype"] = _tgt_rc["archetype"]
+            edge_entry["target_archetype_confidence"] = _tgt_rc.get("confidence", 0)
+        results.append(edge_entry)
+    results.sort(key=lambda x: x["mention_count"], reverse=True)
+    return results[:limit]
+
+
+def _structure_displacement_report(flows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap the flat flow list into a narrative-first report structure.
+
+    Sections:
+      market_losers   -- vendors bleeding the most customers (net outbound)
+      market_winners  -- vendors gaining the most customers (net inbound)
+      top_battles     -- highest-signal flows, with battle_conclusion when available
+      driver_summary  -- what's driving displacement across all flows
+      meta            -- headline numbers
+      flows           -- full sorted list preserved for backward compat
+    """
+    if not flows:
+        return {
+            "market_losers": [],
+            "market_winners": [],
+            "top_battles": [],
+            "driver_summary": [],
+            "meta": {
+                "total_flows": 0,
+                "total_mentions": 0,
+                "dominant_driver": None,
+                "most_displaced_vendor": None,
+                "biggest_winner": None,
+            },
+            "flows": [],
+        }
+
+    # --- Compute per-vendor net flow ---
+    inbound: dict[str, int] = {}
+    outbound: dict[str, int] = {}
+    # top destination/source and driver per vendor
+    out_flows: dict[str, list[dict]] = {}
+    in_flows: dict[str, list[dict]] = {}
+    driver_mentions: dict[str, int] = {}
+    driver_flow_count: dict[str, int] = {}
+
+    for f in flows:
+        fv = f.get("from_vendor", "")
+        tv = f.get("to_vendor", "")
+        mc = int(f.get("mention_count") or 0)
+        drv = f.get("primary_driver") or "unspecified"
+
+        outbound[fv] = outbound.get(fv, 0) + mc
+        inbound[tv] = inbound.get(tv, 0) + mc
+        out_flows.setdefault(fv, []).append(f)
+        in_flows.setdefault(tv, []).append(f)
+        driver_mentions[drv] = driver_mentions.get(drv, 0) + mc
+        driver_flow_count[drv] = driver_flow_count.get(drv, 0) + 1
+
+    all_vendors = set(inbound) | set(outbound)
+    net = {v: inbound.get(v, 0) - outbound.get(v, 0) for v in all_vendors}
+    total_mentions = sum(f.get("mention_count", 0) for f in flows)
+
+    def _top_driver_for(flow_list: list[dict]) -> str | None:
+        counts: dict[str, int] = {}
+        for f in flow_list:
+            d = f.get("primary_driver") or "unspecified"
+            counts[d] = counts.get(d, 0) + int(f.get("mention_count") or 0)
+        return max(counts, key=lambda x: counts[x]) if counts else None
+
+    # --- Market losers (most net-negative vendors) ---
+    losers = sorted(
+        [(v, n) for v, n in net.items() if n < 0],
+        key=lambda x: x[1],
+    )[:10]
+    market_losers = []
+    for vendor, net_flow in losers:
+        vout = sorted(out_flows.get(vendor, []), key=lambda x: x.get("mention_count", 0), reverse=True)
+        market_losers.append({
+            "vendor": vendor,
+            "net_flow": net_flow,
+            "outbound_mentions": outbound.get(vendor, 0),
+            "inbound_mentions": inbound.get(vendor, 0),
+            "top_destination": vout[0]["to_vendor"] if vout else None,
+            "top_driver": _top_driver_for(out_flows.get(vendor, [])),
+        })
+
+    # --- Market winners (most net-positive vendors) ---
+    winners = sorted(
+        [(v, n) for v, n in net.items() if n > 0],
+        key=lambda x: -x[1],
+    )[:10]
+    market_winners = []
+    for vendor, net_flow in winners:
+        vin = sorted(in_flows.get(vendor, []), key=lambda x: x.get("mention_count", 0), reverse=True)
+        market_winners.append({
+            "vendor": vendor,
+            "net_flow": net_flow,
+            "outbound_mentions": outbound.get(vendor, 0),
+            "inbound_mentions": inbound.get(vendor, 0),
+            "top_source": vin[0]["from_vendor"] if vin else None,
+            "top_driver": _top_driver_for(in_flows.get(vendor, [])),
+        })
+
+    # --- Top battles: flows with battle_conclusion first, then high-signal remainder ---
+    with_battle = [f for f in flows if f.get("battle_conclusion")]
+    without_battle = [f for f in flows if not f.get("battle_conclusion")]
+    # Sort each group by signal quality: strong > moderate > emerging, then mention_count
+    _strength_rank = {"strong": 3, "moderate": 2, "emerging": 1}
+    def _battle_sort(f: dict) -> tuple:
+        return (
+            -_strength_rank.get(f.get("signal_strength", ""), 0),
+            -int(f.get("mention_count") or 0),
+        )
+    top_battles = sorted(with_battle, key=_battle_sort)[:8]
+    if len(top_battles) < 8:
+        needed = 8 - len(top_battles)
+        top_battles += sorted(without_battle, key=_battle_sort)[:needed]
+
+    # Keep only the fields useful for narrative display; drop raw ids
+    _battle_keep = {
+        "from_vendor", "to_vendor", "mention_count", "primary_driver",
+        "signal_strength", "confidence_score", "key_quote",
+        "battle_conclusion", "durability", "source_archetype", "target_archetype",
+        "reference_ids", "data_as_of_date", "reasoning_source",
+    }
+    top_battles = [{k: v for k, v in f.items() if k in _battle_keep} for f in top_battles]
+
+    # --- Driver summary ---
+    driver_summary = []
+    for drv, mentions in sorted(driver_mentions.items(), key=lambda x: -x[1]):
+        pct = round(mentions * 100 / total_mentions) if total_mentions else 0
+        driver_summary.append({
+            "driver": drv,
+            "mentions": mentions,
+            "pct": pct,
+            "flow_count": driver_flow_count.get(drv, 0),
+        })
+
+    dominant_driver = driver_summary[0]["driver"] if driver_summary else None
+    most_displaced = market_losers[0]["vendor"] if market_losers else None
+    biggest_winner = market_winners[0]["vendor"] if market_winners else None
+
+    return {
+        "market_losers": market_losers,
+        "market_winners": market_winners,
+        "top_battles": top_battles,
+        "driver_summary": driver_summary,
+        "meta": {
+            "total_flows": len(flows),
+            "total_mentions": total_mentions,
+            "dominant_driver": dominant_driver,
+            "pricing_pct": next(
+                (d["pct"] for d in driver_summary if d["driver"] == "pricing"), 0
+            ),
+            "most_displaced_vendor": most_displaced,
+            "biggest_winner": biggest_winner,
+        },
+        "flows": flows,
+    }
+
+
+def _build_deterministic_vendor_scorecards(
+    vendor_scores: list[dict[str, Any]],
+    *,
+    pain_lookup: dict[str, list[dict]],
+    competitor_lookup: dict[str, list[dict]],
+    feature_gap_lookup: dict[str, list[dict]],
+    quote_lookup: dict[str, list],
+    budget_lookup: dict[str, dict],
+    sentiment_lookup: dict[str, dict[str, int]],
+    buyer_auth_lookup: dict[str, dict],
+    dm_lookup: dict[str, float],
+    price_lookup: dict[str, float],
+    company_lookup: dict[str, list[dict]],
+    product_profile_lookup: dict[str, dict],
+    prior_reports: list[dict[str, Any]],
+    inbound_displacement_lookup: dict[str, int] | None = None,
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+    temporal_lookup: dict[str, dict] | None = None,
+    timeline_lookup: dict[str, list[dict]] | None = None,
+    use_case_lookup: dict[str, list[dict]] | None = None,
+    complaint_lookup: dict[str, list[dict]] | None = None,
+    positive_lookup: dict[str, list[dict]] | None = None,
+    department_lookup: dict[str, list[dict]] | None = None,
+    contract_value_lookup: dict[str, list[dict]] | None = None,
+    turning_point_lookup: dict[str, list[dict]] | None = None,
+    tenure_lookup: dict[str, list[dict]] | None = None,
+    evidence_vault_lookup: dict[str, dict[str, Any]] | None = None,
+    limit: int | None = 15,
+) -> list[dict[str, Any]]:
+    """Build vendor deep-dive scorecards from aggregated numeric data.
+
+    Merges multi-category rows into one entry per vendor, then enriches
+    with feature analysis, churn predictors, competitor overlap, and
+    customer profile data.
+    """
+    prior_vendor_metrics: dict[str, dict[str, float]] = {}
+    for report in prior_reports:
+        if report.get("report_type") != "vendor_scorecard":
+            continue
+        data = report.get("intelligence_data") or []
+        if not isinstance(data, list):
+            continue
+        for row in data:
+            vendor = row.get("vendor")
+            if vendor and vendor not in prior_vendor_metrics:
+                prior_vendor_metrics[vendor] = {
+                    "churn_signal_density": float(row.get("churn_signal_density") or 0),
+                    "avg_urgency": float(row.get("avg_urgency") or 0),
+                }
+
+    # -- Merge multi-category rows into one per vendor --------------
+    merged: dict[str, dict[str, Any]] = {}
+    for row in vendor_scores:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        reviews = int(row.get("total_reviews") or 0)
+        churn = int(row.get("churn_intent") or 0)
+        urgency = float(row.get("avg_urgency") or 0)
+        pos_pct = row.get("positive_review_pct")
+        rec_yes = int(row.get("recommend_yes") or 0)
+        rec_no = int(row.get("recommend_no") or 0)
+        rec_total = int(row.get("recommend_total") or 0)
+        category = row.get("product_category") or "Unknown"
+        sig_reviews = int(row.get("signal_reviews") or 0)
+        if vendor not in merged:
+            merged[vendor] = {
+                "total_reviews": reviews,
+                "signal_reviews": sig_reviews,
+                "churn_intent": churn,
+                "urgency_weighted_sum": urgency * reviews,
+                "recommend_yes": rec_yes,
+                "recommend_no": rec_no,
+                "recommend_total": rec_total,
+                "positive_pct_sum": (float(pos_pct) * reviews) if pos_pct is not None else 0,
+                "positive_pct_count": reviews if pos_pct is not None else 0,
+                "category": category,
+                "category_reviews": reviews,
+            }
+        else:
+            m = merged[vendor]
+            m["total_reviews"] += reviews
+            m["signal_reviews"] = m.get("signal_reviews", 0) + sig_reviews
+            m["churn_intent"] += churn
+            m["urgency_weighted_sum"] += urgency * reviews
+            m["recommend_yes"] += rec_yes
+            m["recommend_no"] += rec_no
+            m["recommend_total"] += rec_total
+            if pos_pct is not None:
+                m["positive_pct_sum"] += float(pos_pct) * reviews
+                m["positive_pct_count"] += reviews
+            if reviews > m["category_reviews"]:
+                m["category"] = category
+                m["category_reviews"] = reviews
+
+    # -- Build enriched scorecard per vendor -------------------------
+    results: list[dict[str, Any]] = []
+    for vendor, m in merged.items():
+        total_reviews = m["total_reviews"]
+        signal_reviews = int(m.get("signal_reviews") or 0) or total_reviews
+        churn_intent = m["churn_intent"]
+        churn_density = round((churn_intent * 100.0 / signal_reviews), 1) if signal_reviews else 0.0
+        avg_urgency = round(m["urgency_weighted_sum"] / total_reviews, 1) if total_reviews else 0.0
+        positive_pct = round(m["positive_pct_sum"] / m["positive_pct_count"], 1) if m["positive_pct_count"] else None
+        recommend_yes = m["recommend_yes"]
+        recommend_no = m["recommend_no"]
+        recommend_total = m.get("recommend_total", 0)
+        if recommend_total:
+            recommend_ratio = round(((recommend_yes - recommend_no) / recommend_total) * 100, 1)
+        else:
+            # Fall back to evidence vault metric_snapshot when signal table
+            # lacks recommend columns (the common path for reports).
+            vault = (evidence_vault_lookup or {}).get(vendor) or {}
+            ms = vault.get("metric_snapshot") or {}
+            vault_yes = int(ms.get("recommend_yes") or 0)
+            vault_no = int(ms.get("recommend_no") or 0)
+            vault_total = vault_yes + vault_no
+            if vault_total:
+                recommend_yes = vault_yes
+                recommend_no = vault_no
+                recommend_ratio = round(((vault_yes - vault_no) / vault_total) * 100, 1)
+            else:
+                recommend_ratio = 0.0
+
+        if total_reviews >= 50:
+            confidence = "high"
+        elif total_reviews >= 20:
+            confidence = "medium"
+        else:
+            confidence = "low"
+        # Boost confidence when reasoning provides corroborating evidence
+        _rc = _get_vendor_reasoning(vendor, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup)
+        if _rc.get("confidence", 0) >= 0.8 and confidence == "medium":
+            confidence = "high"
+
+        # Trend (z-score aware when temporal data available)
+        trend = _classify_trend(
+            vendor, churn_density, avg_urgency,
+            prior_vendor_metrics.get(vendor),
+            temporal_lookup=temporal_lookup,
+        )
+
+        sentiment_counts = sentiment_lookup.get(vendor, {})
+        if total_reviews < 10 or not sentiment_counts:
+            sentiment_direction = "insufficient_history"
+        else:
+            sentiment_direction = max(sentiment_counts.items(), key=lambda item: item[1])[0]
+
+        # Pain breakdown (top 5)
+        pains = pain_lookup.get(vendor, [])
+        top_pain = pains[0]["category"] if pains else "unknown"
+        total_pain = sum(int(p.get("count") or 0) for p in pains)
+        pain_breakdown = [
+            {
+                "category": p["category"],
+                "count": p["count"],
+                "pct": round(int(p.get("count") or 0) / max(total_pain, 1), 3),
+            }
+            for p in pains[:5]
+        ]
+
+        # Competitor overlap (top 5)
+        comp_entries = competitor_lookup.get(vendor, [])
+        top_competitor = comp_entries[:1]
+        if top_competitor:
+            comp = top_competitor[0]
+            top_competitor_text = f"{comp['name']} ({comp['mentions']} mentions)"
+        else:
+            top_competitor_text = "Insufficient displacement data"
+        competitor_overlap = [
+            {"competitor": c["name"], "mentions": c["mentions"]}
+            for c in comp_entries[:5]
+        ]
+
+        # Churn pressure score
+        dm_rate = float(dm_lookup.get(vendor, 0))
+        price_rate = float(price_lookup.get(vendor, 0))
+        displacement_mentions = sum(c.get("mentions", 0) for c in comp_entries)
+        _vendor_archetype = _rc.get("archetype")
+        churn_pressure_score = _compute_churn_pressure_score(
+            churn_density=churn_density,
+            avg_urgency=avg_urgency,
+            dm_churn_rate=dm_rate,
+            displacement_mention_count=displacement_mentions,
+            price_complaint_rate=price_rate,
+            total_reviews=total_reviews,
+            archetype=_vendor_archetype,
+        )
+
+        # Risk level
+        if churn_pressure_score >= 70:
+            risk_level = "high"
+        elif churn_pressure_score >= 40:
+            risk_level = "medium"
+        else:
+            risk_level = "low"
+
+        # Feature analysis (loved from product profile, hated from feature gaps)
+        profile = product_profile_lookup.get(vendor, {})
+        strengths_raw = profile.get("strengths") or []
+        if isinstance(strengths_raw, list):
+            loved = [
+                {"feature": s.get("area", s) if isinstance(s, dict) else str(s),
+                 "score": s.get("score") if isinstance(s, dict) else None,
+                 "source": "product_profile"}
+                for s in strengths_raw[:5]
+            ]
+        else:
+            loved = []
+        gaps = feature_gap_lookup.get(vendor, [])
+        hated = [
+            {"feature": g["feature"],
+             "mentions": g.get("count", g.get("mentions", 0)),
+             "source": "reviews"}
+            for g in gaps[:5]
+        ]
+        feature_analysis = {"loved": loved, "hated": hated}
+
+        # Churn predictors (high-urgency segment correlations)
+        companies = company_lookup.get(vendor, [])
+        high_urg_industries: dict[str, int] = {}
+        high_urg_sizes: dict[str, int] = {}
+        for c in companies:
+            if not isinstance(c, dict):
+                continue
+            urg = float(c.get("urgency", 0))
+            if urg >= 7:
+                ind = c.get("industry")
+                if ind and ind != "unknown":
+                    high_urg_industries[ind] = high_urg_industries.get(ind, 0) + 1
+                sz = c.get("company_size")
+                if sz:
+                    high_urg_sizes[sz] = high_urg_sizes.get(sz, 0) + 1
+        churn_predictors = {
+            "high_risk_industries": sorted(
+                [{"industry": k, "count": v} for k, v in high_urg_industries.items()],
+                key=lambda x: -x["count"],
+            )[:3],
+            "high_risk_sizes": sorted(
+                [{"size": k, "count": v} for k, v in high_urg_sizes.items()],
+                key=lambda x: -x["count"],
+            )[:3],
+            "dm_churn_rate": round(dm_rate, 2),
+            "price_complaint_rate": round(price_rate, 2),
+        }
+
+        # Evidence (top quotes)
+        quotes = quote_lookup.get(vendor, [])
+        evidence = quotes[:5]
+
+        # Named accounts
+        named_accounts = [
+            {"company": c.get("company", c) if isinstance(c, dict) else str(c),
+             "urgency": c.get("urgency", 0) if isinstance(c, dict) else 0,
+             "title": c.get("title") if isinstance(c, dict) else None,
+             "company_size": c.get("company_size") if isinstance(c, dict) else None,
+             "industry": c.get("industry") if isinstance(c, dict) else None,
+             "source": c.get("source") if isinstance(c, dict) else None,
+             "buying_stage": c.get("buying_stage") if isinstance(c, dict) else None,
+             "confidence_score": c.get("confidence_score") if isinstance(c, dict) else None,
+             "decision_maker": c.get("decision_maker") if isinstance(c, dict) else None,
+             "first_seen_at": c.get("first_seen_at") if isinstance(c, dict) else None,
+             "last_seen_at": c.get("last_seen_at") if isinstance(c, dict) else None}
+            for c in companies[:5]
+        ]
+
+        # Industry and company size distributions
+        industry_counts: dict[str, int] = {}
+        size_counts: dict[str, int] = {}
+        for c in companies:
+            ind = c.get("industry") if isinstance(c, dict) else None
+            if ind and ind != "unknown":
+                industry_counts[ind] = industry_counts.get(ind, 0) + 1
+            sz = c.get("company_size") if isinstance(c, dict) else None
+            if sz:
+                size_counts[sz] = size_counts.get(sz, 0) + 1
+        industry_dist = sorted(
+            [{"industry": k, "count": v} for k, v in industry_counts.items()],
+            key=lambda x: -x["count"],
+        )[:5]
+        size_dist = sorted(
+            [{"size": k, "count": v} for k, v in size_counts.items()],
+            key=lambda x: -x["count"],
+        )[:5]
+
+        # Customer profile (from product profile + company data)
+        customer_profile = {
+            "typical_industries": profile.get("typical_industries") or [],
+            "typical_company_size": profile.get("typical_company_size") or [],
+            "primary_use_cases": profile.get("primary_use_cases") or [],
+            "top_integrations": profile.get("top_integrations") or [],
+            "industry_distribution": industry_dist,
+            "company_size_distribution": size_dist,
+        }
+
+        # Buyer authority
+        ba = buyer_auth_lookup.get(vendor, {})
+        role_types = ba.get("role_types", {})
+        dominant_role = _dominant_segment_role(role_types)
+
+        # Net Flow calculation: Inbound Displacement - Outbound Churn
+        inbound_count = (inbound_displacement_lookup or {}).get(vendor, 0)
+        net_flow = inbound_count - churn_intent
+
+        sc_entry = {
+            "vendor": vendor,
+            "total_reviews": total_reviews,
+            "churn_signal_density": churn_density,
+            "inbound_displacement_count": inbound_count,
+            "net_flow": net_flow,
+            "positive_review_pct": float(positive_pct) if positive_pct is not None else None,
+            "avg_urgency": avg_urgency,
+            "recommend_ratio": recommend_ratio,
+            "sample_size_confidence": confidence,
+            "churn_pressure_score": churn_pressure_score,
+            "risk_level": risk_level,
+            "top_pain": top_pain,
+            "pain_breakdown": pain_breakdown,
+            "top_competitor_threat": top_competitor_text,
+            "competitor_overlap": competitor_overlap,
+            "trend": trend,
+            "budget_context": budget_lookup.get(vendor, {}),
+            "sentiment_direction": sentiment_direction,
+            "dm_churn_rate": round(dm_rate, 2),
+            "price_complaint_rate": round(price_rate, 2),
+            "feature_analysis": feature_analysis,
+            "churn_predictors": churn_predictors,
+            "evidence": evidence,
+            "named_accounts": named_accounts,
+            "customer_profile": customer_profile,
+            "dominant_buyer_role": dominant_role,
+            "industry_distribution": industry_dist,
+            "company_size_distribution": size_dist,
+        }
+        # Idle field enrichments (Tier 1: wired from existing lookups)
+        tl_entries = (timeline_lookup or {}).get(vendor, [])
+        eval_deadlines = [t for t in tl_entries if t.get("evaluation_deadline")]
+        if eval_deadlines:
+            sc_entry["upcoming_evaluation_deadlines"] = eval_deadlines[:5]
+        uc_entries = (use_case_lookup or {}).get(vendor, [])
+        if uc_entries:
+            sc_entry["product_depth"] = uc_entries[:10]
+        # Tier 3: new aggregation lookups
+        complaints = (complaint_lookup or {}).get(vendor, [])
+        if complaints:
+            sc_entry["top_complaints"] = complaints[:5]
+        positives = (positive_lookup or {}).get(vendor, [])
+        if positives:
+            sc_entry["retention_signals"] = positives[:5]
+        departments = (department_lookup or {}).get(vendor, [])
+        if departments:
+            sc_entry["department_distribution"] = departments[:5]
+        deal_sizes = (contract_value_lookup or {}).get(vendor, [])
+        if deal_sizes:
+            sc_entry["deal_size_distribution"] = deal_sizes
+        triggers = (turning_point_lookup or {}).get(vendor, [])
+        if triggers:
+            sc_entry["churn_triggers"] = triggers[:5]
+        tenures = (tenure_lookup or {}).get(vendor, [])
+        if tenures:
+            sc_entry["customer_tenure_profile"] = tenures[:5]
+
+        if _rc:
+            sc_entry["archetype"] = _rc.get("archetype", "")
+            sc_entry["archetype_confidence"] = _rc.get("confidence", 0)
+            sc_entry["reasoning_summary"] = _rc.get("executive_summary", "")
+            sc_entry["falsification_conditions"] = _rc.get("falsification_conditions", [])
+            sc_entry["uncertainty_sources"] = _rc.get("uncertainty_sources", [])
+            sc_entry["reasoning_mode"] = _rc.get("mode", "")
+            rc_risk = _rc.get("risk_level", "")
+            if rc_risk:
+                sc_entry["risk_level"] = rc_risk
+            if _rc.get("mode") == "synthesis":
+                sc_entry["reasoning_source"] = "synthesis"
+        results.append(sc_entry)
+    def _sc_sort_key(x: dict) -> tuple:
+        conf = x.get("archetype_confidence", 0)
+        has_arch = bool(x.get("archetype"))
+        reasoning_boost = min(conf * 5, 5.0) if has_arch else 0
+        return (-(x["avg_urgency"] + reasoning_boost), -(x["churn_signal_density"]), x["vendor"])
+    results.sort(key=_sc_sort_key)
+    if limit is None:
+        return results
+    return results[:limit]
+
+
+def _build_vendor_deep_dives(
+    vendor_scores: list[dict[str, Any]],
+    *,
+    pain_lookup: dict[str, list[dict]],
+    competitor_lookup: dict[str, list[dict]],
+    feature_gap_lookup: dict[str, list[dict]],
+    quote_lookup: dict[str, list],
+    company_lookup: dict[str, list[dict]],
+    dm_lookup: dict[str, float],
+    price_lookup: dict[str, float],
+    sentiment_lookup: dict[str, dict[str, int]],
+    buyer_auth_lookup: dict[str, dict] | None = None,
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+    limit: int = 60,
+) -> list[dict[str, Any]]:
+    """Build comprehensive per-vendor deep dive reports, sorted by churn pressure."""
+    def _rl_get(v: str) -> dict:
+        return _get_vendor_reasoning(v, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup)
+    _ba = buyer_auth_lookup or {}
+    results: list[dict[str, Any]] = []
+    _SENT_POS = {"stable_positive", "improving"}
+    _SENT_NEG = {"consistently_negative", "declining"}
+
+    for row in vendor_scores:
+        v = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not v:
+            continue
+
+        total_reviews = int(row.get("total_reviews") or 0)
+        signal_reviews = int(row.get("signal_reviews") or 0) or total_reviews
+        churn_intent = int(row.get("churn_intent") or 0)
+        churn_density = round((churn_intent * 100.0 / signal_reviews), 1) if signal_reviews else 0.0
+        avg_urgency = round(float(row.get("avg_urgency") or 0), 1)
+        dm_rate = float(dm_lookup.get(v, 0))
+        pr_rate = float(price_lookup.get(v, 0))
+        comp_entries = competitor_lookup.get(v, [])
+        disp_mentions = sum(int(c.get("mentions") or 0) for c in comp_entries)
+        _rc = _rl_get(v)
+
+        pressure = _compute_churn_pressure_score(
+            churn_density=churn_density,
+            avg_urgency=avg_urgency,
+            dm_churn_rate=dm_rate,
+            displacement_mention_count=disp_mentions,
+            price_complaint_rate=pr_rate,
+            total_reviews=total_reviews,
+            archetype=_rc.get("archetype"),
+        )
+        risk_level = _rc.get("risk_level") or (
+            "high" if pressure >= 70 else ("medium" if pressure >= 40 else "low")
+        )
+
+        # Pain breakdown
+        pains = pain_lookup.get(v, [])
+        total_pain = sum(int(p.get("count") or 0) for p in pains)
+        pain_breakdown = sorted(
+            [
+                {
+                    "category": p.get("category") or p.get("key") or "unknown",
+                    "count": int(p.get("count") or 0),
+                    "pct": round(int(p.get("count") or 0) / max(total_pain, 1), 3),
+                }
+                for p in pains
+                if p.get("category") or p.get("key")
+            ],
+            key=lambda x: -x["count"],
+        )[:10]
+
+        # Displacement targets
+        displacement_targets = sorted(
+            [
+                {
+                    "vendor": c.get("name", ""),
+                    "mention_count": int(c.get("mentions") or c.get("mention_count") or 0),
+                    "primary_driver": c.get("primary_driver"),
+                }
+                for c in comp_entries
+                if c.get("name")
+            ],
+            key=lambda x: -x["mention_count"],
+        )[:12]
+
+        # Feature gaps
+        feature_gaps = sorted(
+            [
+                {
+                    "feature": g.get("feature") or g.get("gap") or "",
+                    "mentions": int(g.get("count") or g.get("mentions") or 0),
+                }
+                for g in feature_gap_lookup.get(v, [])
+                if g.get("feature") or g.get("gap")
+            ],
+            key=lambda x: -x["mentions"],
+        )[:10]
+
+        # Customer profile
+        companies = company_lookup.get(v, [])
+        ind_counts: dict[str, int] = {}
+        size_counts: dict[str, int] = {}
+        for c in companies:
+            if not isinstance(c, dict):
+                continue
+            ind = c.get("industry")
+            if ind and ind != "unknown":
+                ind_counts[ind] = ind_counts.get(ind, 0) + 1
+            sz = c.get("company_size")
+            if sz:
+                size_counts[sz] = size_counts.get(sz, 0) + 1
+        industry_distribution = sorted(
+            [{"industry": k, "count": n} for k, n in ind_counts.items()],
+            key=lambda x: -x["count"],
+        )[:8]
+        size_distribution = sorted(
+            [{"size": k, "count": n} for k, n in size_counts.items()],
+            key=lambda x: -x["count"],
+        )[:6]
+
+        # Case studies
+        raw_quotes = quote_lookup.get(v, [])
+        case_studies: list[dict[str, Any]] = []
+        for q in raw_quotes:
+            if isinstance(q, dict):
+                case_studies.append({
+                    "quote": str(q.get("quote") or q.get("text") or "")[:300],
+                    "company": q.get("company", "Anonymous"),
+                    "urgency": float(q.get("urgency") or 0),
+                    "title": q.get("title"),
+                })
+            elif isinstance(q, str):
+                case_studies.append({
+                    "quote": q[:300],
+                    "company": "Anonymous",
+                    "urgency": 0.0,
+                    "title": None,
+                })
+        case_studies.sort(key=lambda x: -x["urgency"])
+
+        # Sentiment breakdown -- map direction strings to pos/neg/neutral buckets
+        sent = sentiment_lookup.get(v, {})
+        _sent_pos = sum(cnt for d, cnt in sent.items() if d in _SENT_POS)
+        _sent_neg = sum(cnt for d, cnt in sent.items() if d in _SENT_NEG)
+        _sent_neu = sum(cnt for d, cnt in sent.items() if d not in _SENT_POS and d not in _SENT_NEG)
+
+        # Buyer role -- skip "unknown" entries
+        ba = _ba.get(v, {})
+        if isinstance(ba, dict) and ba.get("role_types"):
+            _rt = {k: n for k, n in ba["role_types"].items() if k and k != "unknown"}
+            dominant_buyer_role = max(_rt, key=_rt.get, default=None) if _rt else None
+        else:
+            dominant_buyer_role = None
+
+        results.append({
+            "vendor": v,
+            "category": row.get("product_category") or "Unknown",
+            "total_reviews": total_reviews,
+            "churn_signal_density": churn_density,
+            "churn_pressure_score": round(pressure, 1),
+            "avg_urgency": avg_urgency,
+            "risk_level": risk_level,
+            "sentiment_direction": _rc.get("sentiment_direction") or "",
+            "trend": _rc.get("trend") or "",
+            "archetype": _rc.get("archetype"),
+            "archetype_confidence": _rc.get("confidence"),
+            "dm_churn_rate": round(dm_rate, 3),
+            "price_complaint_rate": round(pr_rate, 3),
+            "dominant_buyer_role": dominant_buyer_role,
+            "pain_breakdown": pain_breakdown,
+            "displacement_targets": displacement_targets,
+            "feature_gaps": feature_gaps,
+            "industry_distribution": industry_distribution,
+            "company_size_distribution": size_distribution,
+            "case_studies": case_studies[:5],
+            "sentiment_breakdown": {
+                "positive": _sent_pos,
+                "negative": _sent_neg,
+                "neutral": _sent_neu,
+            },
+        })
+
+    results.sort(key=lambda x: -x["churn_pressure_score"])
+    return results[:limit]
+
+
+def _build_deterministic_category_overview(
+    vendor_scores: list[dict[str, Any]],
+    *,
+    pain_lookup: dict[str, list[dict]],
+    competitive_disp: list[dict[str, Any]],
+    company_lookup: dict[str, list[dict]],
+    quote_lookup: dict[str, list],
+    feature_gap_lookup: dict[str, list[dict]],
+    dm_lookup: dict[str, float],
+    price_lookup: dict[str, float],
+    competitor_lookup: dict[str, list[dict]],
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+    limit: int = 12,
+) -> list[dict[str, Any]]:
+    """Build industry-specific category overview with vendor rankings and case studies."""
+    by_category: dict[str, list[dict[str, Any]]] = {}
+    for row in vendor_scores:
+        category = row.get("product_category") or "Unknown"
+        by_category.setdefault(category, []).append(row)
+
+    results: list[dict[str, Any]] = []
+    def _rl_get(v: str) -> dict:
+        return _get_vendor_reasoning(v, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup)
+    for category, rows in by_category.items():
+        ranked = sorted(
+            rows,
+            key=lambda r: (
+                -((r.get("churn_intent") or 0) / max((r.get("signal_reviews") or r.get("total_reviews") or 1), 1)),
+                -(r.get("avg_urgency") or 0),
+            ),
+        )
+        top_vendor = ranked[0]
+        highest_vendor = _canonicalize_vendor(top_vendor.get("vendor_name") or "")
+        dominant_pain = (pain_lookup.get(highest_vendor, [{}])[0] or {}).get("category", "unknown")
+
+        category_flows: dict[str, int] = {}
+        for flow in competitive_disp:
+            source_vendor = _canonicalize_vendor(flow.get("vendor") or "")
+            if any(_canonicalize_vendor(r.get("vendor_name") or "") == source_vendor for r in rows):
+                competitor = _canonicalize_competitor(flow.get("competitor") or "")
+                if competitor != highest_vendor:
+                    category_flows[competitor] = category_flows.get(competitor, 0) + int(flow.get("mention_count") or 0)
+        emerging = max(category_flows.items(), key=lambda item: item[1])[0] if category_flows else "Insufficient data"
+
+        total_reviews = int(top_vendor.get("total_reviews") or 0)
+        signal_reviews = int(top_vendor.get("signal_reviews") or 0) or total_reviews
+        churn_density = round((int(top_vendor.get("churn_intent") or 0) * 100.0 / signal_reviews), 1) if signal_reviews else 0.0
+
+        # Aggregate industry/size across all vendors in category
+        cat_industries: dict[str, int] = {}
+        cat_sizes: dict[str, int] = {}
+        for r in rows:
+            v = _canonicalize_vendor(r.get("vendor_name") or "")
+            for c in company_lookup.get(v, []):
+                if not isinstance(c, dict):
+                    continue
+                ind = c.get("industry")
+                if ind and ind != "unknown":
+                    cat_industries[ind] = cat_industries.get(ind, 0) + 1
+                sz = c.get("company_size")
+                if sz:
+                    cat_sizes[sz] = cat_sizes.get(sz, 0) + 1
+        top_industries = sorted(
+            [{"industry": k, "count": v} for k, v in cat_industries.items()],
+            key=lambda x: -x["count"],
+        )[:5]
+        top_sizes = sorted(
+            [{"size": k, "count": v} for k, v in cat_sizes.items()],
+            key=lambda x: -x["count"],
+        )[:5]
+
+        # -- Vendor rankings (all vendors in category ranked by churn pressure) --
+        vendor_rankings: list[dict[str, Any]] = []
+        for r in ranked[:8]:
+            v = _canonicalize_vendor(r.get("vendor_name") or "")
+            rev = int(r.get("total_reviews") or 0)
+            ci = int(r.get("churn_intent") or 0)
+            cd = round((ci * 100.0 / rev), 1) if rev else 0.0
+            urg = round(float(r.get("avg_urgency") or 0), 1)
+            dm_rate = float(dm_lookup.get(v, 0))
+            pr_rate = float(price_lookup.get(v, 0))
+            comp_ent = competitor_lookup.get(v, [])
+            disp_m = sum(c.get("mentions", 0) for c in comp_ent)
+            _v_arch = _rl_get(v).get("archetype")
+            vr_score = _compute_churn_pressure_score(
+                churn_density=cd, avg_urgency=urg, dm_churn_rate=dm_rate,
+                displacement_mention_count=disp_m, price_complaint_rate=pr_rate,
+                total_reviews=rev,
+                archetype=_v_arch,
+            )
+            # Use reasoning risk_level when available (Gap #26)
+            _rc_risk = _rl_get(v).get("risk_level", "")
+            _det_risk = "high" if vr_score >= 70 else ("medium" if vr_score >= 40 else "low")
+            vendor_rankings.append({
+                "vendor": v,
+                "churn_pressure_score": vr_score,
+                "churn_signal_density": cd,
+                "total_reviews": rev,
+                "risk_level": _rc_risk or _det_risk,
+            })
+        vendor_rankings.sort(key=lambda x: -x["churn_pressure_score"])
+
+        # -- Case studies (top quotes per category with company context) --
+        cat_quotes: list[dict[str, Any]] = []
+        for r in rows:
+            v = _canonicalize_vendor(r.get("vendor_name") or "")
+            for q in quote_lookup.get(v, [])[:2]:
+                if isinstance(q, dict):
+                    cat_quotes.append({
+                        "vendor": v,
+                        "quote": str(q.get("quote") or q.get("text") or "")[:200],
+                        "company": q.get("company", "Anonymous"),
+                        "urgency": q.get("urgency", 0),
+                        "title": q.get("title"),
+                    })
+                elif isinstance(q, str):
+                    cat_quotes.append({
+                        "vendor": v, "quote": q[:200],
+                        "company": "Anonymous", "urgency": 0,
+                    })
+        cat_quotes.sort(key=lambda x: -float(x.get("urgency", 0)))
+        case_studies = cat_quotes[:3]
+
+        # -- Top feature gaps (aggregated across category) --
+        cat_gaps: dict[str, int] = {}
+        for r in rows:
+            v = _canonicalize_vendor(r.get("vendor_name") or "")
+            for g in feature_gap_lookup.get(v, []):
+                feat = g.get("feature", "")
+                if feat:
+                    cat_gaps[feat] = cat_gaps.get(feat, 0) + g.get("count", g.get("mentions", 1))
+        top_gaps = sorted(
+            [{"feature": k, "mentions": v} for k, v in cat_gaps.items()],
+            key=lambda x: -x["mentions"],
+        )[:5]
+
+        # Archetype distribution: count + avg confidence per archetype in category
+        arch_counts: dict[str, int] = {}
+        arch_conf_sums: dict[str, float] = {}
+        for r in rows:
+            v = _canonicalize_vendor(r.get("vendor_name") or "")
+            _rc = _rl_get(v)
+            arch = _rc.get("archetype", "")
+            if arch:
+                arch_counts[arch] = arch_counts.get(arch, 0) + 1
+                arch_conf_sums[arch] = arch_conf_sums.get(arch, 0) + _rc.get("confidence", 0)
+        archetype_distribution = (
+            [
+                {"archetype": k, "count": v, "avg_confidence": round(arch_conf_sums.get(k, 0) / v, 2)}
+                for k, v in sorted(arch_counts.items(), key=lambda x: -x[1])
+            ]
+            if arch_counts else []
+        )
+
+        results.append({
+            "category": category,
+            "highest_churn_risk": highest_vendor,
+            "emerging_challenger": emerging,
+            "dominant_pain": dominant_pain,
+            "market_shift_signal": _build_market_shift_signal(
+                category, highest_vendor, churn_density, total_reviews, emerging,
+                reasoning_lookup or {},
+                synthesis_views=synthesis_views,
+            ),
+            "industry_distribution": top_industries,
+            "company_size_distribution": top_sizes,
+            "vendor_rankings": vendor_rankings,
+            "case_studies": case_studies,
+            "top_feature_gaps": top_gaps,
+            "archetype_distribution": archetype_distribution,
+        })
+    results.sort(key=lambda x: x["category"])
+    return results[:limit]
+
+
+def _get_battle_card_reasoning_state(
+    vendor: str,
+    *,
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+) -> dict[str, Any]:
+    """Unified reasoning state for battle card builders.
+
+    Resolves vendor reasoning through synthesis_views (preferred) or
+    reasoning_lookup (fallback).  No card mutation here.
+    """
+    rc = _get_vendor_reasoning(
+        vendor, synthesis_views=synthesis_views, reasoning_lookup=reasoning_lookup,
+    )
+    archetype = rc.get("archetype", "")
+    confidence = rc.get("confidence", 0)
+    risk_level = rc.get("risk_level", "")
+    key_signals = rc.get("key_signals", [])
+    falsification = rc.get("falsification_conditions", [])
+    uncertainty = rc.get("uncertainty_sources", [])
+    mode = rc.get("mode", "")
+    executive_summary = rc.get("executive_summary", "")
+
+    # Determine reasoning source
+    reasoning_source = "synthesis" if mode == "synthesis" else (
+        "synthesis_fallback" if mode == "synthesis_fallback" else "legacy"
+    )
+
+    # Confident reasoning: high-confidence archetype from unified helper,
+    # or confident synthesis view (wedge + medium/high confidence)
+    has_confident = bool(archetype) and confidence >= 0.7
+    if not has_confident and synthesis_views:
+        view = synthesis_views.get(vendor)
+        if view is None and vendor:
+            canon = vendor.strip().lower()
+            for vn, v in synthesis_views.items():
+                if vn.strip().lower() == canon:
+                    view = v
+                    break
+        if view is not None:
+            w = getattr(view, "primary_wedge", None)
+            score = (
+                view.confidence_score("causal_narrative")
+                if hasattr(view, "confidence_score")
+                else None
+            )
+            if score is not None:
+                has_confident = bool(w) and score >= 0.7
+            else:
+                c = view.confidence("causal_narrative") if hasattr(view, "confidence") else ""
+                has_confident = bool(w) and c in ("medium", "high")
+
+    return {
+        "archetype": archetype,
+        "confidence": confidence,
+        "risk_level": risk_level,
+        "key_signals": key_signals,
+        "falsification_conditions": falsification,
+        "uncertainty_sources": uncertainty,
+        "executive_summary": executive_summary,
+        "reasoning_source": reasoning_source,
+        "reasoning_mode": mode,
+        "has_confident_reasoning": has_confident,
+    }
+
+
+def _build_deterministic_battle_cards(
+    vendor_scores: list[dict[str, Any]],
+    *,
+    pain_lookup: dict[str, list[dict]],
+    competitor_lookup: dict[str, list[dict]],
+    feature_gap_lookup: dict[str, list[dict]],
+    quote_lookup: dict[str, list],
+    price_lookup: dict[str, float],
+    budget_lookup: dict[str, dict],
+    sentiment_lookup: dict[str, dict[str, int]],
+    dm_lookup: dict[str, float],
+    company_lookup: dict[str, list],
+    product_profile_lookup: dict[str, dict],
+    competitive_disp: list[dict[str, Any]],
+    competitor_reasons: list[dict[str, Any]],
+    synthesis_views: dict[str, Any] | None = None,
+    reasoning_lookup: dict[str, dict] | None = None,
+    timeline_lookup: dict[str, list[dict]] | None = None,
+    use_case_lookup: dict[str, list[dict]] | None = None,
+    positive_lookup: dict[str, list[dict]] | None = None,
+    department_lookup: dict[str, list[dict]] | None = None,
+    usage_duration_lookup: dict[str, list[dict]] | None = None,
+    buyer_auth_lookup: dict[str, dict] | None = None,
+    keyword_spike_lookup: dict[str, dict] | None = None,
+    evidence_vault_lookup: dict[str, dict[str, Any]] | None = None,
+    synthesis_requested_as_of: date | None = None,
+    category_dynamics_lookup: dict[str, dict[str, Any]] | None = None,
+    account_intel_lookup: dict[str, dict[str, Any]] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build per-vendor battle cards from aggregated data.
+
+    Each card is a concise, sales-oriented one-pager with:
+    - Top weaknesses (merged from product profile + pain categories)
+    - Customer pain quotes (verbatim, with provenance)
+    - Competitor differentiators (who they lose to, and why)
+    - Objection data (raw metrics for LLM-generated sales copy)
+    """
+    # Build reason lookup for inferring primary driver on differentiators
+    # (reuses _build_reason_lookup and _infer_driver_from_reasons from displacement map)
+    reason_lookup = _build_reason_lookup(competitor_reasons)
+
+    # Pick the primary category row per vendor (most reviews) instead of
+    # summing across categories, which inflates totals and averages.
+    merged: dict[str, dict[str, Any]] = {}
+    for row in vendor_scores:
+        vendor = _canonicalize_vendor(row.get("vendor_name") or "")
+        if not vendor:
+            continue
+        reviews = int(row.get("total_reviews") or 0)
+        churn = int(row.get("churn_intent") or 0)
+        urgency = float(row.get("avg_urgency") or 0)
+        category = row.get("product_category") or "Unknown"
+        if vendor not in merged or reviews > merged[vendor]["total_reviews"]:
+            merged[vendor] = {
+                "total_reviews": reviews,
+                "signal_reviews": int(row.get("signal_reviews") or 0),
+                "churn_intent": churn,
+                "avg_urgency": urgency,
+                "category": category,
+                "vendor_score": row,
+            }
+
+    cards: list[dict[str, Any]] = []
+    for vendor, m in merged.items():
+        vendor_vault = (evidence_vault_lookup or {}).get(vendor, {})
+        total_reviews = m["total_reviews"]
+        signal_reviews = int(m.get("signal_reviews") or 0) or total_reviews
+        churn_intent = m["churn_intent"]
+        churn_density = round(churn_intent * 100.0 / signal_reviews, 1) if signal_reviews else 0.0
+        avg_urgency = round(m["avg_urgency"], 1)
+        dm_rate = float(dm_lookup.get(vendor, 0))
+        price_rate = float(price_lookup.get(vendor, 0))
+        acct_intel = (account_intel_lookup or {}).get(vendor, {})
+        acct_summary = acct_intel.get("summary") or {} if isinstance(acct_intel, dict) else {}
+        acct_high_intent = int(acct_summary.get("high_intent_count") or 0)
+        acct_active_eval = int(acct_summary.get("active_eval_signal_count") or 0)
+        account_pressure_override = acct_high_intent >= 3 or acct_active_eval >= 2
+
+        # Resolve reasoning state once per vendor
+        reasoning_state = _get_battle_card_reasoning_state(
+            vendor,
+            synthesis_views=synthesis_views,
+            reasoning_lookup=reasoning_lookup,
+        )
+
+        # Qualification gate -- reasoning can lower thresholds
+        _has_reasoning = reasoning_state["has_confident_reasoning"]
+        _density_gate = 10 if _has_reasoning else 15
+        _urgency_gate = 2.5 if _has_reasoning else 3.0
+        _dm_gate = 0.2 if _has_reasoning else 0.3
+        if (
+            churn_density < _density_gate
+            and avg_urgency < _urgency_gate
+            and dm_rate < _dm_gate
+            and not account_pressure_override
+        ):
+            continue
+
+        # Confidence label
+        if total_reviews >= 50:
+            confidence = "high"
+        elif total_reviews >= 20:
+            confidence = "medium"
+        else:
+            confidence = "low"
+        if reasoning_state["confidence"] >= 0.8 and confidence == "medium":
+            confidence = "high"
+
+        comp_entries = competitor_lookup.get(vendor, [])
+        displacement_mentions = sum(c.get("mentions", 0) for c in comp_entries)
+
+        _vendor_archetype = reasoning_state["archetype"]
+        score = _compute_churn_pressure_score(
+            churn_density=churn_density,
+            avg_urgency=avg_urgency,
+            dm_churn_rate=dm_rate,
+            displacement_mention_count=displacement_mentions,
+            price_complaint_rate=price_rate,
+            total_reviews=total_reviews,
+            archetype=_vendor_archetype,
+        )
+
+        # -- Section 1: Vendor Weaknesses --
+        weaknesses = _battle_card_weaknesses_from_evidence_vault(vendor_vault, limit=5)
+        if not weaknesses:
+            weaknesses = []
+            seen_areas: set[str] = set()
+
+            profile = product_profile_lookup.get(vendor, {})
+            for w in (profile.get("weaknesses") or []):
+                if not isinstance(w, dict):
+                    continue
+                area = w.get("area", "")
+                if area and area not in seen_areas:
+                    seen_areas.add(area)
+                    evidence_count = int(w.get("evidence_count") or 0)
+                    weaknesses.append({
+                        "area": area,
+                        "score": w.get("score"),
+                        "evidence_count": evidence_count,
+                        "source": "product_profile",
+                    })
+
+            for p in pain_lookup.get(vendor, []):
+                area = p.get("category", "")
+                if area and area not in seen_areas:
+                    seen_areas.add(area)
+                    evidence_count = int(p.get("count") or 0)
+                    weaknesses.append({
+                        "area": area,
+                        "count": evidence_count,
+                        "evidence_count": evidence_count,
+                        "source": "pain_category",
+                    })
+
+            for g in feature_gap_lookup.get(vendor, []):
+                feature = g.get("feature", "")
+                if feature and feature not in seen_areas:
+                    seen_areas.add(feature)
+                    evidence_count = int(g.get("mentions") or 0)
+                    weaknesses.append({
+                        "area": feature,
+                        "count": evidence_count,
+                        "evidence_count": evidence_count,
+                        "source": "feature_gap",
+                    })
+
+            weaknesses.sort(
+                key=lambda w: -int(w.get("evidence_count") or 0),
+            )
+            weaknesses = weaknesses[:5]
+
+        # -- Section 2: Customer Pain Quotes (deduplicated by review + reviewer) --
+        quotes_raw = sorted(
+            quote_lookup.get(vendor, []),
+            key=_battle_card_quote_sort_key,
+            reverse=True,
+        )
+        pain_quotes: list[dict[str, Any]] = []
+        seen_review_ids: set[str] = set()
+        seen_reviewers: set[str] = set()
+        for q in quotes_raw:
+            if len(pain_quotes) >= 5:
+                break
+            if isinstance(q, dict):
+                if q.get("phrase_verbatim") is not True:
+                    continue
+                quote_text = str(q.get("quote") or "")
+                urgency = float(q.get("urgency") or 0)
+                if not _quote_has_pain_signal(
+                    quote_text,
+                    urgency=urgency,
+                    rating=q.get("rating"),
+                    rating_max=q.get("rating_max"),
+                ):
+                    continue
+                # Dedupe by review_id (exact same review)
+                rid = q.get("review_id", "")
+                if rid and rid in seen_review_ids:
+                    continue
+                # Dedupe by reviewer identity (same person, different reviews)
+                reviewer_key = (
+                    f"{(q.get('company') or '').lower().strip()}"
+                    f":{(q.get('title') or '').lower().strip()}"
+                )
+                if reviewer_key != ":" and reviewer_key in seen_reviewers:
+                    continue
+                if rid:
+                    seen_review_ids.add(rid)
+                if reviewer_key != ":":
+                    seen_reviewers.add(reviewer_key)
+                pain_quotes.append({
+                    "quote": quote_text,
+                    "urgency": urgency,
+                    "source_site": q.get("source_site") or q.get("source") or "",
+                    "company": q.get("company", ""),
+                    "title": q.get("title", ""),
+                    "company_size": q.get("company_size", ""),
+                    "industry": q.get("industry", ""),
+                    "rating": q.get("rating"),
+                    "rating_max": q.get("rating_max"),
+                    "review_id": q.get("review_id"),
+                    "field": q.get("field"),
+                    "phrase_verbatim": True,
+                    "quote_origin": str(q.get("quote_origin") or "review").strip() or "review",
+                })
+
+        # -- Section 3: Competitor Differentiators --
+        differentiators: list[dict[str, Any]] = []
+        for c in comp_entries[:5]:
+            comp_name = c.get("name", "")
+            if not comp_name:
+                continue
+            comp_profile = product_profile_lookup.get(
+                _canonicalize_vendor(comp_name), {},
+            )
+            # Find which of this vendor's weaknesses the competitor solves
+            solves = None
+            comp_pain_addressed = comp_profile.get("pain_addressed") or {}
+            if isinstance(comp_pain_addressed, dict) and weaknesses:
+                for w in weaknesses:
+                    area = w.get("area", "")
+                    if area in comp_pain_addressed and comp_pain_addressed[area] >= 0.6:
+                        solves = area
+                        break
+
+            # Switch count from competitor's commonly_switched_from
+            switch_count = 0
+            for sf in (comp_profile.get("commonly_switched_from") or []):
+                if isinstance(sf, dict):
+                    sf_vendor = _canonicalize_vendor(sf.get("vendor", ""))
+                    if sf_vendor == vendor:
+                        switch_count = sf.get("count", 0)
+                        break
+
+            # Infer primary driver from competitor reasons (same as displacement map)
+            reasons = reason_lookup.get((vendor, _canonicalize_competitor(comp_name)), [])
+            driver = _infer_driver_from_reasons(reasons)
+
+            differentiators.append({
+                "competitor": comp_name,
+                "mentions": c.get("mentions", 0),
+                "primary_driver": driver,
+                "solves_weakness": solves,
+                "switch_count": switch_count,
+            })
+
+        # -- Section 4: Objection Data (raw metrics for LLM) --
+        sentiment_counts = sentiment_lookup.get(vendor, {})
+        # Exclude "unknown" to find the dominant *known* sentiment direction
+        known_sentiment = {k: v for k, v in sentiment_counts.items() if k != "unknown"}
+        if total_reviews < 10 or not known_sentiment:
+            sentiment_dir = "insufficient_data"
+        else:
+            sentiment_dir = max(known_sentiment.items(), key=lambda x: x[1])[0]
+
+        top_gaps = [
+            {"feature": g.get("feature", ""), "mentions": g.get("mentions", 0)}
+            for g in feature_gap_lookup.get(vendor, [])[:5]
+        ]
+
+        vault_snapshot = vendor_vault.get("metric_snapshot") if isinstance(vendor_vault, dict) else None
+        vault_snapshot = vault_snapshot if isinstance(vault_snapshot, dict) else {}
+        objection_data: dict[str, Any] = {
+            "price_complaint_rate": round(price_rate, 3),
+            "dm_churn_rate": round(dm_rate, 3),
+            "sentiment_direction": sentiment_dir,
+            "top_feature_gaps": top_gaps,
+            "total_reviews": total_reviews,
+            "churn_signal_density": churn_density,
+            "avg_urgency": avg_urgency,
+            "budget_context": budget_lookup.get(vendor, {}),
+        }
+        _rr = vault_snapshot.get("recommend_ratio")
+        if _rr is not None:
+            try:
+                objection_data["recommend_ratio"] = round(float(_rr), 2)
+            except (TypeError, ValueError):
+                pass
+        _pp = vault_snapshot.get("positive_review_pct")
+        if _pp is not None:
+            try:
+                objection_data["positive_review_pct"] = round(float(_pp), 1)
+            except (TypeError, ValueError):
+                pass
+
+        integrations = (product_profile_lookup.get(vendor, {}).get("top_integrations") or [])[:8]
+        blocked_company_names = {
+            normalize_company_name(vendor),
+            *(
+                normalize_company_name(str(item.get("competitor") or ""))
+                for item in differentiators
+            ),
+            *(normalize_company_name(str(name)) for name in integrations),
+        }
+
+        # -- Section 5: High-intent companies --
+        # Priority: canonical account intelligence > evidence vault > churning_companies
+        canonical_accounts = (acct_intel.get("accounts") or []) if isinstance(acct_intel, dict) else []
+        hi_companies = _normalize_canonical_accounts_for_battle_card(
+            canonical_accounts,
+            current_vendor=vendor,
+            blocked_names=blocked_company_names,
+            limit=5,
+        ) if canonical_accounts else []
+        if not hi_companies:
+            has_vault_company_signals = isinstance(vendor_vault, dict) and "company_signals" in vendor_vault
+            hi_companies = _battle_card_companies_from_evidence_vault(
+                vendor_vault,
+                current_vendor=vendor,
+                blocked_names=blocked_company_names,
+                limit=5,
+            )
+            if not hi_companies and not has_vault_company_signals:
+                fallback_candidates = [
+                    item for item in (company_lookup.get(vendor, []))
+                    if _battle_card_company_is_display_safe(
+                        item.get("company"),
+                        current_vendor=vendor,
+                        blocked_names=blocked_company_names,
+                        role=item.get("role") or item.get("title"),
+                        company_size=item.get("company_size"),
+                        buying_stage=item.get("buying_stage"),
+                    )
+                ]
+                hi_companies = _rank_high_intent_companies(fallback_candidates)[:5]
+
+        # -- Section 6: Integration stack --
+
+        # -- Section 7: Buyer authority summary --
+        buyer_authority = (buyer_auth_lookup or {}).get(vendor, {})
+        keyword_spikes = (keyword_spike_lookup or {}).get(vendor, {})
+
+        # -- Budget: prefer median for "typical" size --
+        budget_ctx = budget_lookup.get(vendor, {})
+
+        card_entry = {
+            "vendor": vendor,
+            "category": m.get("category") or "",
+            "churn_pressure_score": score,
+            "total_reviews": total_reviews,
+            "confidence": confidence,
+            "vendor_weaknesses": weaknesses,
+            "customer_pain_quotes": pain_quotes,
+            "competitor_differentiators": differentiators,
+            "objection_data": objection_data,
+            "high_intent_companies": hi_companies,
+            "integration_stack": integrations,
+            "buyer_authority": buyer_authority or None,
+            # Populated by LLM pass in run():
+            "objection_handlers": [],
+            "recommended_plays": [],
+        }
+        # Idle field enrichments for battle cards
+        positives = (positive_lookup or {}).get(vendor, [])
+        if positives:
+            card_entry["retention_signals"] = positives[:5]
+        vault_strengths = _battle_card_strengths_from_evidence_vault(vendor_vault, limit=5)
+        if vault_strengths:
+            card_entry["incumbent_strengths"] = vault_strengths
+        if keyword_spikes.get("spike_count"):
+            card_entry["keyword_spikes"] = {
+                "spike_count": int(keyword_spikes.get("spike_count") or 0),
+                "keywords": list(keyword_spikes.get("spike_keywords") or [])[:10],
+                "trend_summary": keyword_spikes.get("trend_summary") or {},
+            }
+        tl_entries = (timeline_lookup or {}).get(vendor, [])
+        eval_deadlines = _build_active_evaluation_deadlines(
+            tl_entries,
+            limit=5,
+        )
+        # Merge canonical account contract_end dates into deadlines
+        # Use hi_companies (display-safe) not raw canonical_accounts
+        if hi_companies and len(eval_deadlines) < 5:
+            seen_companies = {(d.get("company") or "").lower() for d in eval_deadlines}
+            for hc in hi_companies:
+                if not isinstance(hc, dict) or len(eval_deadlines) >= 5:
+                    break
+                c_end = hc.get("contract_end")
+                if not c_end:
+                    continue
+                c_name = hc.get("company") or ""
+                if not c_name or c_name.lower() in seen_companies:
+                    continue
+                eval_deadlines.append({
+                    "company": c_name,
+                    "evaluation_deadline": None,
+                    "contract_end": str(c_end),
+                    "decision_timeline": None,
+                    "urgency": float(hc.get("urgency") or 0),
+                    "title": hc.get("role"),
+                    "company_size": hc.get("company_size"),
+                    "industry": hc.get("industry"),
+                    "trigger_type": "contract_end",
+                    "buying_stage": hc.get("buying_stage"),
+                    "role": hc.get("role"),
+                    "pain": hc.get("pain"),
+                    "source": hc.get("source") or "account_intelligence",
+                })
+                seen_companies.add(c_name.lower())
+            eval_deadlines.sort(
+                key=lambda d: (-float(d.get("urgency") or 0),),
+            )
+        if eval_deadlines:
+            card_entry["active_evaluation_deadlines"] = eval_deadlines[:5]
+        # Derive account pressure summary from canonical account intelligence
+        if canonical_accounts:
+            acct_summary = acct_intel.get("summary") or {} if isinstance(acct_intel, dict) else {}
+            hi_count = int(acct_summary.get("high_intent_count") or 0)
+            ae_count = int(acct_summary.get("active_eval_signal_count") or 0)
+            dm_ct = int(acct_summary.get("decision_maker_count") or 0)
+            pparts: list[str] = []
+            if hi_count:
+                pparts.append(f"{hi_count} high-intent account{'s' if hi_count != 1 else ''}")
+            if ae_count:
+                pparts.append(f"{ae_count} active evaluation signal{'s' if ae_count != 1 else ''}")
+            if dm_ct:
+                pparts.append(f"{dm_ct} decision-maker signal{'s' if dm_ct != 1 else ''}")
+            if pparts:
+                card_entry["account_pressure_summary"] = "Detected: " + ", ".join(pparts) + "."
+                card_entry["account_pressure_metrics"] = {
+                    "high_intent_count": hi_count,
+                    "active_eval_count": ae_count,
+                    "decision_maker_count": dm_ct,
+                    "total_accounts": int(acct_summary.get("total_accounts") or 0),
+                }
+            priority_names = [
+                ca.get("company_name") or ca.get("name") or ""
+                for ca in canonical_accounts
+                if isinstance(ca, dict) and (
+                    float(ca.get("urgency_score") or 0) >= 6.0
+                    or ca.get("decision_maker")
+                )
+            ][:5]
+            if priority_names:
+                card_entry["priority_account_names"] = [n for n in priority_names if n]
+        uc_entries = (use_case_lookup or {}).get(vendor, [])
+        if uc_entries:
+            card_entry["objection_data"]["product_depth"] = uc_entries[:5]
+        departments = (department_lookup or {}).get(vendor, [])
+        if departments:
+            card_entry["objection_data"]["department_context"] = departments[:3]
+        durations = (usage_duration_lookup or {}).get(vendor, [])
+        if durations:
+            card_entry["objection_data"]["tenure_churn_pattern"] = durations[:5]
+
+        if reasoning_state.get("archetype"):
+            card_entry["archetype"] = reasoning_state["archetype"]
+            card_entry["archetype_confidence"] = reasoning_state["confidence"]
+            card_entry["archetype_risk_level"] = reasoning_state["risk_level"]
+            card_entry["archetype_key_signals"] = reasoning_state["key_signals"]
+            card_entry["falsification_conditions"] = reasoning_state["falsification_conditions"]
+            card_entry["uncertainty_sources"] = reasoning_state["uncertainty_sources"]
+            card_entry["reasoning_source"] = reasoning_state["reasoning_source"]
+
+        # Inject category dynamics pool data for downstream council resolution
+        _cat_key = card_entry.get("category") or ""
+        _cat_dyn = (category_dynamics_lookup or {}).get(_cat_key)
+        if isinstance(_cat_dyn, dict):
+            card_entry["category_dynamics"] = _cat_dyn
+
+        vendor_evidence = _build_vendor_evidence(
+            m.get("vendor_score") or {},
+            pain_lookup=pain_lookup,
+            competitor_lookup=competitor_lookup,
+            feature_gap_lookup=feature_gap_lookup,
+            insider_lookup={},
+            keyword_spike_lookup=keyword_spike_lookup or {},
+            dm_lookup=dm_lookup,
+            price_lookup=price_lookup,
+            quote_lookup=quote_lookup,
+            budget_lookup=budget_lookup,
+            buyer_auth_lookup=buyer_auth_lookup,
+            use_case_lookup=use_case_lookup,
+        )
+
+        # Inject reasoning synthesis via typed reader contract
+        _synth_view = (synthesis_views or {}).get(vendor)
+        if _synth_view is None and vendor:
+            # Canonicalized fallback
+            canon = vendor.strip().lower()
+            for vn, v in (synthesis_views or {}).items():
+                if vn.strip().lower() == canon:
+                    _synth_view = v
+                    break
+        if _synth_view is not None:
+            from ._b2b_synthesis_reader import inject_synthesis_into_card
+            inject_synthesis_into_card(
+                card_entry,
+                _synth_view,
+                requested_as_of=synthesis_requested_as_of,
+                vendor_evidence=vendor_evidence,
+            )
+        segment_playbook = _battle_card_segment_playbook(card_entry)
+        if segment_playbook:
+            card_entry["segment_playbook"] = segment_playbook
+        timing_intelligence = _battle_card_timing_intelligence(card_entry)
+        if timing_intelligence:
+            card_entry["timing_intelligence"] = timing_intelligence
+            timing_summary, timing_metrics, priority_triggers = (
+                _timing_summary_payload(timing_intelligence)
+            )
+            if timing_summary:
+                card_entry["timing_summary"] = timing_summary
+            if timing_metrics:
+                card_entry["timing_metrics"] = timing_metrics
+            if priority_triggers:
+                card_entry["priority_timing_triggers"] = priority_triggers
+        if segment_playbook:
+            targeting_summary = _segment_targeting_summary(
+                segment_playbook,
+                timing_intelligence if timing_intelligence else None,
+            )
+            if targeting_summary:
+                card_entry["segment_targeting_summary"] = targeting_summary
+        cards.append(card_entry)
+
+    def _bc_sort_key(x: dict) -> tuple:
+        score = x["churn_pressure_score"]
+        conf = x.get("archetype_confidence", 0)
+        has_arch = bool(x.get("archetype"))
+        reasoning_boost = min(conf * 5, 5.0) if has_arch else 0
+        return (-(score + reasoning_boost),)
+    cards.sort(key=_bc_sort_key)
+    if limit is None:
+        return cards
+    return cards[:limit]
+
+
+def _build_exploratory_overview(
+    parsed: dict[str, Any],
+    *,
+    payload: dict[str, Any],
+    validation_warnings: list[str],
+    llm_model_id: str,
+) -> dict[str, Any]:
+    """Store exploratory LLM output separately from executive reports."""
+    return {
+        "scope": "exploratory",
+        "llm_model": llm_model_id,
+        "parse_fallback": bool(parsed.get("_parse_fallback")),
+        "model_analysis": parsed.get("analysis_text", ""),
+        "exploratory_summary": parsed.get("exploratory_summary", ""),
+        "executive_summary": parsed.get("executive_summary", ""),
+        "weekly_churn_feed": parsed.get("weekly_churn_feed", []),
+        "vendor_scorecards": parsed.get("vendor_scorecards", []),
+        "displacement_map": parsed.get("displacement_map", []),
+        "category_insights": parsed.get("category_insights", []),
+        "timeline_hot_list": parsed.get("timeline_hot_list", []),
+        "validation_warnings": validation_warnings,
+        "source_distribution": (payload.get("data_context") or {}).get("source_distribution", {}),
+    }
+
+
+def _trim_quote_bundles(
+    rows: list[dict[str, Any]],
+    *,
+    outer_limit: int,
+    quote_limit: int,
+    strip_ids: bool = False,
+) -> list[dict[str, Any]]:
+    """Trim quote bundles while preserving vendor labels.
+
+    When *strip_ids* is True, returns plain strings (for LLM payloads).
+    """
+    trimmed: list[dict[str, Any]] = []
+    for row in rows[:outer_limit]:
+        raw_quotes = list(row.get("quotes") or [])[:quote_limit]
+        trimmed.append({
+            "vendor": row.get("vendor"),
+            "quotes": _strip_quote_ids(raw_quotes) if strip_ids else raw_quotes,
+        })
+    return trimmed
+
+
+def _trim_company_bundles(
+    rows: list[dict[str, Any]],
+    *,
+    outer_limit: int,
+    company_limit: int,
+) -> list[dict[str, Any]]:
+    """Trim churning-company bundles while preserving vendor labels."""
+    trimmed: list[dict[str, Any]] = []
+    for row in rows[:outer_limit]:
+        trimmed.append({
+            "vendor": row.get("vendor"),
+            "companies": list(row.get("companies") or [])[:company_limit],
+        })
+    return trimmed
+
+
+def _trim_use_case_distribution(
+    rows: list[dict[str, Any]],
+    *,
+    inner_limit: int,
+) -> list[dict[str, Any]]:
+    """Trim nested use-case datasets without changing their structure."""
+    trimmed: list[dict[str, Any]] = []
+    for row in rows:
+        trimmed.append({
+            "type": row.get("type"),
+            "data": list(row.get("data") or [])[:inner_limit],
+        })
+    return trimmed
+
+
+def _build_exploratory_payload(
+    cfg,
+    *,
+    today: date,
+    window_days: int,
+    data_context: dict[str, Any],
+    vendor_scores: list[dict[str, Any]],
+    high_intent: list[dict[str, Any]],
+    competitive_disp: list[dict[str, Any]],
+    pain_dist: list[dict[str, Any]],
+    feature_gaps: list[dict[str, Any]],
+    negative_counts: list[dict[str, Any]],
+    price_rates: list[dict[str, Any]],
+    dm_rates: list[dict[str, Any]],
+    timeline_signals: list[dict[str, Any]],
+    competitor_reasons: list[dict[str, Any]],
+    prior_reports: list[dict[str, Any]],
+    quotable_evidence: list[dict[str, Any]],
+    budget_signals: list[dict[str, Any]],
+    use_case_dist: list[dict[str, Any]],
+    sentiment_traj: list[dict[str, Any]],
+    buyer_auth: list[dict[str, Any]],
+    churning_companies: list[dict[str, Any]],
+) -> tuple[dict[str, Any], int]:
+    """Build a trimmed exploratory payload that fits within the configured budget."""
+    generic_limit = max(1, cfg.intelligence_exploratory_generic_limit)
+    vendor_limit = max(1, cfg.intelligence_exploratory_vendor_limit)
+    high_intent_limit = max(1, cfg.intelligence_exploratory_high_intent_limit)
+    quote_vendor_limit = max(1, cfg.intelligence_exploratory_quote_vendor_limit)
+    quote_limit = max(1, cfg.intelligence_exploratory_quotes_per_vendor)
+    use_case_limit = max(1, cfg.intelligence_exploratory_use_case_limit)
+    company_limit = max(1, cfg.intelligence_exploratory_company_limit)
+    prior_limit = max(1, cfg.intelligence_exploratory_prior_report_limit)
+
+    def _make_payload() -> dict[str, Any]:
+        llm_vendors = [
+            {
+                "vendor": v["vendor_name"],
+                "category": v["product_category"],
+                "reviews": v["total_reviews"],
+                "churn": v["churn_intent"],
+                "urgency": round(v["avg_urgency"], 1),
+                "rating": round(v["avg_rating_normalized"], 2) if v["avg_rating_normalized"] else None,
+                "rec_yes": v["recommend_yes"],
+                "rec_no": v["recommend_no"],
+                "positive_pct": v.get("positive_review_pct"),
+            }
+            for v in vendor_scores[:vendor_limit]
+        ]
+        llm_high_intent = [
+            {
+                "company": h["company"],
+                "vendor": h["vendor"],
+                "urgency": h["urgency"],
+                "pain": h["pain"],
+                "dm": h.get("decision_maker"),
+                "role": h.get("role_level"),
+                "alts": [a.get("name", a) if isinstance(a, dict) else a for a in h.get("alternatives", [])[:3]],
+                "signal": h.get("contract_signal"),
+                "quotes": h.get("quotes", [])[:quote_limit],
+            }
+            for h in high_intent[:high_intent_limit]
+        ]
+        known_companies = [h["company"] for h in high_intent[:high_intent_limit] if h.get("company")]
+        llm_prior = [
+            {
+                "type": p["report_type"],
+                "date": p["report_date"],
+                "data": p.get("intelligence_data", {}),
+            }
+            for p in prior_reports[:prior_limit]
+        ]
+        return {
+            "date": str(today),
+            "data_context": data_context,
+            "analysis_window_days": window_days,
+            "vendor_churn_scores": llm_vendors,
+            "high_intent_companies": llm_high_intent,
+            "competitive_displacement": competitive_disp[:generic_limit],
+            "pain_distribution": pain_dist[:generic_limit],
+            "feature_gaps": feature_gaps[:generic_limit],
+            "negative_review_counts": negative_counts[:generic_limit],
+            "price_complaint_rates": price_rates[:generic_limit],
+            "decision_maker_churn_rates": dm_rates[:generic_limit],
+            "timeline_signals": timeline_signals[:generic_limit],
+            "competitor_reasons": competitor_reasons[:generic_limit],
+            "prior_reports": llm_prior,
+            "quotable_evidence": _trim_quote_bundles(
+                quotable_evidence,
+                outer_limit=quote_vendor_limit,
+                quote_limit=quote_limit,
+                strip_ids=True,
+            ),
+            "budget_signals": budget_signals[:generic_limit],
+            "use_case_distribution": _trim_use_case_distribution(
+                use_case_dist,
+                inner_limit=use_case_limit,
+            ),
+            "sentiment_trajectory": sentiment_traj[:generic_limit],
+            "buyer_authority": buyer_auth[:generic_limit],
+            "churning_companies": _trim_company_bundles(
+                churning_companies,
+                outer_limit=generic_limit,
+                company_limit=company_limit,
+            ),
+            "known_companies": known_companies,
+        }
+
+    payload = _make_payload()
+    payload_size = len(json.dumps(payload, default=str))
+
+    while payload_size > cfg.intelligence_exploratory_char_budget:
+        changed = False
+        if vendor_limit > 6:
+            vendor_limit -= 2
+            changed = True
+        if high_intent_limit > 4:
+            high_intent_limit -= 1
+            changed = True
+        if generic_limit > 6:
+            generic_limit -= 2
+            changed = True
+        if quote_vendor_limit > 6:
+            quote_vendor_limit -= 1
+            changed = True
+        if use_case_limit > 4:
+            use_case_limit -= 1
+            changed = True
+        if company_limit > 3:
+            company_limit -= 1
+            changed = True
+        if quote_limit > 1:
+            quote_limit -= 1
+            changed = True
+        if prior_limit > 1:
+            prior_limit -= 1
+            changed = True
+        if not changed:
+            break
+        payload = _make_payload()
+        payload_size = len(json.dumps(payload, default=str))
+
+    return payload, payload_size

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_specificity.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_specificity.py
@@ -1,0 +1,772 @@
+import copy
+import re
+from collections.abc import Callable
+from typing import Any
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_NUMERIC_TEXT_RE = re.compile(
+    r"(?:[$\u20ac\u00a3]?\d[\d,]*(?:\.\d+)?(?:\s*(?:%|k|m|b|x))?(?:/[a-z]+)?)",
+    re.IGNORECASE,
+)
+_TIMING_TEXT_RE = re.compile(
+    r"\b(?:renewal|deadline|contract|quarter|month|week|year|q[1-4]|fy\d{2,4}|today|tomorrow|immediate)\b",
+    re.IGNORECASE,
+)
+_REPORT_TIER_BANNED = re.compile(
+    r"\b(dashboard|live feed|free trial|software|platform)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalize_text(value: Any) -> str:
+    text = _HTML_TAG_RE.sub(" ", str(value or ""))
+    text = text.lower()
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _copy_json_dict(value: Any) -> dict[str, Any]:
+    return copy.deepcopy(value) if isinstance(value, dict) else {}
+
+
+def _copy_json_list(value: Any) -> list[Any]:
+    return copy.deepcopy(value) if isinstance(value, list) else []
+
+
+def _reference_id_counts(reference_ids: Any) -> dict[str, int]:
+    if not isinstance(reference_ids, dict):
+        return {}
+    counts: dict[str, int] = {}
+    for key, value in reference_ids.items():
+        if isinstance(value, list):
+            counts[str(key)] = len([item for item in value if str(item or "").strip()])
+        elif isinstance(value, dict):
+            counts[str(key)] = len(value)
+        elif value not in (None, "", [], {}):
+            counts[str(key)] = 1
+    return counts
+
+
+def _coerce_anchor_examples(value: Any) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(value, dict):
+        return {}
+    resolved: dict[str, list[dict[str, Any]]] = {}
+    for label, rows in value.items():
+        if not isinstance(rows, list):
+            continue
+        clean_rows = [dict(row) for row in rows if isinstance(row, dict)]
+        if clean_rows:
+            resolved[str(label)] = clean_rows
+    return resolved
+
+
+def _coerce_witness_highlights(value: Any) -> list[dict[str, Any]]:
+    return [dict(row) for row in value if isinstance(row, dict)] if isinstance(value, list) else []
+
+
+def _redact_company(text: str, company: str) -> str:
+    clean_text = str(text or "").strip()
+    clean_company = str(company or "").strip()
+    if not clean_text or not clean_company:
+        return clean_text
+    pattern = re.compile(re.escape(clean_company), re.IGNORECASE)
+    redacted = pattern.sub("a customer", clean_text)
+    return _WHITESPACE_RE.sub(" ", redacted).strip()
+
+
+def _sanitize_witness_row(
+    witness: dict[str, Any],
+    *,
+    allow_company_names: bool,
+) -> dict[str, Any]:
+    clean: dict[str, Any] = {}
+    for key in (
+        "witness_id",
+        "witness_type",
+        "time_anchor",
+        "competitor",
+        "pain_category",
+        "signal_type",
+        "replacement_mode",
+        "operating_model_shift",
+        "productivity_delta_claim",
+        "org_pressure_type",
+        "reviewer_title",
+        "company_size",
+        "industry",
+        "source",
+        "source_id",
+        "_sid",
+        "grounding_status",
+        "phrase_polarity",
+        "phrase_subject",
+        "phrase_role",
+        "phrase_verbatim",
+        "pain_confidence",
+    ):
+        value = witness.get(key)
+        if value in (None, "", [], {}):
+            continue
+        clean[key] = copy.deepcopy(value)
+
+    excerpt = str(witness.get("excerpt_text") or "").strip()
+    reviewer_company = str(witness.get("reviewer_company") or "").strip()
+    if excerpt:
+        clean["excerpt_text"] = (
+            excerpt if allow_company_names else _redact_company(excerpt, reviewer_company)
+        )
+    if allow_company_names and reviewer_company:
+        clean["reviewer_company"] = reviewer_company
+
+    numeric_literals = _copy_json_dict(witness.get("numeric_literals"))
+    if numeric_literals:
+        clean["numeric_literals"] = numeric_literals
+    signal_tags = _copy_json_list(witness.get("signal_tags"))
+    if signal_tags:
+        clean["signal_tags"] = signal_tags
+    return clean
+
+
+def surface_specificity_context(
+    source: dict[str, Any] | None,
+    *,
+    surface: str,
+    nested_keys: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    allow_company_names = surface not in {"blog", "campaign"}
+    sources: list[dict[str, Any]] = []
+    if isinstance(source, dict):
+        sources.append(source)
+        for key in nested_keys:
+            nested = source.get(key)
+            if isinstance(nested, dict):
+                sources.append(nested)
+
+    anchor_examples: dict[str, list[dict[str, Any]]] = {}
+    witness_highlights: list[dict[str, Any]] = []
+    reference_ids: dict[str, Any] = {}
+
+    for payload in sources:
+        if not anchor_examples:
+            anchor_examples = _coerce_anchor_examples(
+                payload.get("reasoning_anchor_examples") or payload.get("anchor_examples")
+            )
+        if not witness_highlights:
+            witness_highlights = _coerce_witness_highlights(
+                payload.get("reasoning_witness_highlights") or payload.get("witness_highlights")
+            )
+        if not reference_ids:
+            candidate_refs = payload.get("reasoning_reference_ids") or payload.get("reference_ids")
+            if isinstance(candidate_refs, dict):
+                reference_ids = _copy_json_dict(candidate_refs)
+
+    sanitized_anchors: dict[str, list[dict[str, Any]]] = {}
+    for label, rows in anchor_examples.items():
+        clean_rows = [
+            _sanitize_witness_row(row, allow_company_names=allow_company_names)
+            for row in rows
+        ]
+        clean_rows = [row for row in clean_rows if row]
+        if clean_rows:
+            sanitized_anchors[label] = clean_rows
+
+    sanitized_highlights = [
+        _sanitize_witness_row(row, allow_company_names=allow_company_names)
+        for row in witness_highlights
+    ]
+    sanitized_highlights = [row for row in sanitized_highlights if row]
+
+    context: dict[str, Any] = {}
+    if sanitized_anchors:
+        context["anchor_examples"] = sanitized_anchors
+    if sanitized_highlights:
+        context["witness_highlights"] = sanitized_highlights
+    if reference_ids:
+        context["reference_ids"] = reference_ids
+    return context
+
+
+def _witness_marker(witness: dict[str, Any]) -> str:
+    witness_id = str(witness.get("witness_id") or "").strip()
+    if witness_id:
+        return witness_id
+    excerpt = _normalize_text(witness.get("excerpt_text"))
+    if excerpt:
+        return excerpt
+    time_anchor = _normalize_text(witness.get("time_anchor"))
+    competitor = _normalize_text(witness.get("competitor"))
+    pain = _normalize_text(witness.get("pain_category"))
+    return "|".join(part for part in (time_anchor, competitor, pain) if part)
+
+
+def merge_specificity_contexts(*contexts: dict[str, Any] | None) -> dict[str, Any]:
+    anchor_examples: dict[str, list[dict[str, Any]]] = {}
+    witness_highlights: list[dict[str, Any]] = []
+    reference_ids: dict[str, Any] = {}
+    seen_highlights: set[str] = set()
+
+    for context in contexts:
+        if not isinstance(context, dict):
+            continue
+        for label, rows in _coerce_anchor_examples(context.get("anchor_examples")).items():
+            bucket = anchor_examples.setdefault(label, [])
+            seen_bucket = {_witness_marker(row) for row in bucket if _witness_marker(row)}
+            for row in rows:
+                marker = _witness_marker(row)
+                if marker and marker in seen_bucket:
+                    continue
+                bucket.append(copy.deepcopy(row))
+                if marker:
+                    seen_bucket.add(marker)
+        for row in _coerce_witness_highlights(context.get("witness_highlights")):
+            marker = _witness_marker(row)
+            if marker and marker in seen_highlights:
+                continue
+            witness_highlights.append(copy.deepcopy(row))
+            if marker:
+                seen_highlights.add(marker)
+        candidate_refs = context.get("reference_ids")
+        if isinstance(candidate_refs, dict):
+            for key, value in candidate_refs.items():
+                if key not in reference_ids:
+                    reference_ids[key] = copy.deepcopy(value)
+                    continue
+                if isinstance(reference_ids[key], list) and isinstance(value, list):
+                    seen_values = {str(item) for item in reference_ids[key]}
+                    for item in value:
+                        if str(item) in seen_values:
+                            continue
+                        reference_ids[key].append(copy.deepcopy(item))
+                        seen_values.add(str(item))
+
+    merged: dict[str, Any] = {}
+    if anchor_examples:
+        merged["anchor_examples"] = anchor_examples
+    if witness_highlights:
+        merged["witness_highlights"] = witness_highlights
+    if reference_ids:
+        merged["reference_ids"] = reference_ids
+    return merged
+
+
+def _numeric_terms_from_witness(witness: dict[str, Any]) -> set[str]:
+    terms: set[str] = set()
+    numeric_literals = witness.get("numeric_literals")
+    if isinstance(numeric_literals, dict):
+        for values in numeric_literals.values():
+            if isinstance(values, list):
+                for value in values:
+                    token = _normalize_text(value)
+                    if token and not (token.isdigit() and len(token) < 3):
+                        terms.add(token)
+            else:
+                token = _normalize_text(values)
+                if token and not (token.isdigit() and len(token) < 3):
+                    terms.add(token)
+    excerpt = str(witness.get("excerpt_text") or "")
+    for match in _NUMERIC_TEXT_RE.findall(excerpt):
+        token = _normalize_text(match)
+        if token and not (token.isdigit() and len(token) < 3):
+            terms.add(token)
+    return terms
+
+
+def _timing_terms_from_witness(witness: dict[str, Any]) -> set[str]:
+    terms: set[str] = set()
+    time_anchor = str(witness.get("time_anchor") or "").strip()
+    if time_anchor:
+        terms.add(_normalize_text(time_anchor))
+    excerpt = str(witness.get("excerpt_text") or "")
+    for match in _TIMING_TEXT_RE.findall(excerpt):
+        token = _normalize_text(match)
+        if token:
+            terms.add(token)
+    return terms
+
+
+def _list_terms(value: Any) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    terms: set[str] = set()
+    for item in value:
+        token = _normalize_text(item)
+        if token:
+            terms.add(token)
+    return terms
+
+
+def specificity_signal_terms(
+    *,
+    anchor_examples: dict[str, list[dict[str, Any]]] | None = None,
+    witness_highlights: list[dict[str, Any]] | None = None,
+    allow_company_names: bool,
+) -> dict[str, set[str]]:
+    companies: set[str] = set()
+    timing_terms: set[str] = set()
+    numeric_terms: set[str] = set()
+    competitor_terms: set[str] = set()
+    pain_terms: set[str] = set()
+    workflow_terms: set[str] = set()
+
+    rows: list[dict[str, Any]] = []
+    for group_rows in (anchor_examples or {}).values():
+        rows.extend(group_rows)
+    rows.extend(witness_highlights or [])
+
+    for witness in rows:
+        if allow_company_names:
+            reviewer_company = _normalize_text(witness.get("reviewer_company"))
+            if reviewer_company:
+                companies.add(reviewer_company)
+        competitor = _normalize_text(witness.get("competitor"))
+        if competitor:
+            competitor_terms.add(competitor)
+        timing_terms.update(_timing_terms_from_witness(witness))
+        numeric_terms.update(_numeric_terms_from_witness(witness))
+
+        for key in ("pain_category", "signal_type", "org_pressure_type"):
+            token = _normalize_text(witness.get(key))
+            if token:
+                pain_terms.add(token)
+        pain_terms.update(_list_terms(witness.get("signal_tags")))
+
+        for key in ("replacement_mode", "operating_model_shift", "productivity_delta_claim"):
+            token = _normalize_text(witness.get(key))
+            if token and token != "none" and token != "unknown":
+                workflow_terms.add(token)
+
+    return {
+        "companies": companies,
+        "timing_terms": timing_terms,
+        "numeric_terms": numeric_terms,
+        "competitor_terms": competitor_terms,
+        "pain_terms": pain_terms,
+        "workflow_terms": workflow_terms,
+    }
+
+
+def _contains_term(normalized_text: str, term: str) -> bool:
+    clean_term = _normalize_text(term)
+    if not normalized_text or not clean_term:
+        return False
+    pattern = re.compile(
+        r"(?<![a-z0-9])" + re.escape(clean_term) + r"(?![a-z0-9])"
+    )
+    return bool(pattern.search(normalized_text))
+
+
+def evaluate_specificity_support(
+    text: str,
+    *,
+    anchor_examples: dict[str, list[dict[str, Any]]] | None = None,
+    witness_highlights: list[dict[str, Any]] | None = None,
+    reference_ids: dict[str, Any] | None = None,
+    allow_company_names: bool,
+    min_anchor_hits: int = 1,
+    require_anchor_support: bool = True,
+    require_timing_or_numeric_when_available: bool = False,
+    include_competitor_terms: bool = True,
+    numeric_term_filter: Callable[[str], bool] | None = None,
+) -> dict[str, Any]:
+    normalized_text = _normalize_text(text)
+    blocking_issues: list[str] = []
+    warnings: list[str] = []
+
+    refs = reference_ids if isinstance(reference_ids, dict) else {}
+    witness_refs = [
+        str(value).strip()
+        for value in (refs.get("witness_ids") or [])
+        if str(value or "").strip()
+    ]
+    if witness_refs and not (anchor_examples or witness_highlights):
+        warnings.append("witness references exist but no anchor examples or witness highlights were surfaced")
+
+    terms = specificity_signal_terms(
+        anchor_examples=anchor_examples,
+        witness_highlights=witness_highlights,
+        allow_company_names=allow_company_names,
+    )
+    if numeric_term_filter is not None:
+        terms["numeric_terms"] = {
+            term for term in terms["numeric_terms"] if numeric_term_filter(term)
+        }
+    active_groups = {
+        "timing_terms": terms["timing_terms"],
+        "numeric_terms": terms["numeric_terms"],
+        "pain_terms": terms["pain_terms"],
+        "workflow_terms": terms["workflow_terms"],
+    }
+    if include_competitor_terms:
+        active_groups["competitor_terms"] = terms["competitor_terms"]
+    if allow_company_names:
+        active_groups["companies"] = terms["companies"]
+
+    matched_groups = [
+        group
+        for group, group_terms in active_groups.items()
+        if group_terms and any(_contains_term(normalized_text, term) for term in group_terms)
+    ]
+
+    anchors_available = bool(anchor_examples or witness_highlights)
+    structured_terms_available = any(group_terms for group_terms in active_groups.values())
+
+    if require_anchor_support and anchors_available and structured_terms_available:
+        if len(matched_groups) < max(1, int(min_anchor_hits)):
+            blocking_issues.append(
+                "content does not reference any witness-backed anchor despite anchors being available"
+            )
+    elif anchors_available and not structured_terms_available:
+        warnings.append(
+            "witness-backed anchors are available but do not expose concrete timing, numeric, competitor, or pain terms"
+        )
+
+    has_timing_or_numeric = bool(terms["timing_terms"] or terms["numeric_terms"])
+    matched_timing_or_numeric = any(
+        group in matched_groups for group in ("timing_terms", "numeric_terms")
+    )
+    if require_timing_or_numeric_when_available and has_timing_or_numeric and not matched_timing_or_numeric:
+        blocking_issues.append(
+            "content omits a concrete timing or numeric anchor even though one is available"
+        )
+
+    if allow_company_names and terms["companies"] and "companies" not in matched_groups:
+        warnings.append("named-account anchor exists but content does not mention a named example")
+    if terms["numeric_terms"] and "numeric_terms" not in matched_groups:
+        warnings.append("money-backed anchor exists but content does not mention the concrete spend signal")
+    if terms["timing_terms"] and "timing_terms" not in matched_groups:
+        warnings.append("timing anchor exists but content does not mention the live trigger window")
+    if include_competitor_terms and terms["competitor_terms"] and "competitor_terms" not in matched_groups:
+        warnings.append("competitor-backed anchor exists but content does not mention the competitive alternative")
+
+    return {
+        "blocking_issues": blocking_issues,
+        "warnings": warnings,
+        "matched_groups": matched_groups,
+        "signal_terms": terms,
+    }
+
+
+def specificity_audit_snapshot(
+    text: str,
+    *,
+    anchor_examples: dict[str, list[dict[str, Any]]] | None = None,
+    witness_highlights: list[dict[str, Any]] | None = None,
+    reference_ids: dict[str, Any] | None = None,
+    allow_company_names: bool,
+    min_anchor_hits: int = 1,
+    require_anchor_support: bool = True,
+    require_timing_or_numeric_when_available: bool = False,
+    include_competitor_terms: bool = True,
+) -> dict[str, Any]:
+    evaluation = evaluate_specificity_support(
+        text,
+        anchor_examples=anchor_examples,
+        witness_highlights=witness_highlights,
+        reference_ids=reference_ids,
+        allow_company_names=allow_company_names,
+        min_anchor_hits=min_anchor_hits,
+        require_anchor_support=require_anchor_support,
+        require_timing_or_numeric_when_available=require_timing_or_numeric_when_available,
+        include_competitor_terms=include_competitor_terms,
+    )
+    signal_terms = {
+        key: sorted(values)
+        for key, values in (evaluation.get("signal_terms") or {}).items()
+        if values
+    }
+    matched_groups = list(evaluation.get("matched_groups") or [])
+    available_groups = sorted(signal_terms.keys())
+    return {
+        "status": "fail" if evaluation.get("blocking_issues") else "pass",
+        "blocking_issues": list(evaluation.get("blocking_issues") or []),
+        "warnings": list(evaluation.get("warnings") or []),
+        "matched_groups": matched_groups,
+        "available_groups": available_groups,
+        "missing_groups": [
+            group for group in available_groups if group not in set(matched_groups)
+        ],
+        "signal_terms": signal_terms,
+        "anchor_count": sum(len(rows) for rows in (anchor_examples or {}).values()),
+        "anchor_labels": sorted((anchor_examples or {}).keys()),
+        "highlight_count": len(witness_highlights or []),
+        "reference_ids": _copy_json_dict(reference_ids),
+        "reference_id_counts": _reference_id_counts(reference_ids),
+    }
+
+
+def campaign_proof_terms_from_audit(
+    audit: dict[str, Any] | None,
+    *,
+    channel: str,
+    limit: int,
+) -> list[str]:
+    if not isinstance(audit, dict):
+        return []
+    signal_terms = audit.get("signal_terms")
+    if not isinstance(signal_terms, dict):
+        return []
+
+    blocking_issues = [
+        str(issue).strip().lower()
+        for issue in (audit.get("blocking_issues") or [])
+        if str(issue or "").strip()
+    ]
+    prefer_numeric_timing = any(
+        "timing or numeric anchor" in issue for issue in blocking_issues
+    )
+    group_order = ["numeric_terms", "timing_terms"]
+    if not prefer_numeric_timing:
+        if channel != "email_cold":
+            group_order.append("competitor_terms")
+        group_order.extend(["pain_terms", "workflow_terms"])
+
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for group_name in group_order:
+        values = signal_terms.get(group_name)
+        if not isinstance(values, list):
+            continue
+        ranked_values = sorted(
+            (str(value or "").strip() for value in values),
+            key=lambda token: (-len(token), token.lower()),
+        )
+        for token in ranked_values:
+            if not token:
+                continue
+            rendered = token.replace("_", " ")
+            marker = rendered.lower()
+            if marker in seen:
+                continue
+            resolved.append(rendered)
+            seen.add(marker)
+            if len(resolved) >= max(1, int(limit)):
+                return resolved
+    return resolved
+
+
+def _campaign_collection(payload: dict[str, Any], key: str) -> Any:
+    value = payload.get(key)
+    if value not in (None, "", [], {}):
+        return value
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    return None
+
+
+def _campaign_name_terms(value: Any) -> list[str]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    rows: list[Any] = []
+    if isinstance(value, list):
+        rows = list(value)
+    elif isinstance(value, dict):
+        rows = [value]
+
+    for row in rows:
+        name = ""
+        if isinstance(row, dict):
+            for key in ("name", "vendor_name", "incumbent_vendor", "alternative_vendor"):
+                candidate = str(row.get(key) or "").strip()
+                if candidate:
+                    name = candidate
+                    break
+        else:
+            name = str(row or "").strip()
+        marker = _normalize_text(name)
+        if not marker or marker in seen:
+            continue
+        seen.add(marker)
+        terms.append(name)
+    return terms
+
+
+def _campaign_private_company_terms(
+    anchor_examples: dict[str, list[dict[str, Any]]] | None,
+    witness_highlights: list[dict[str, Any]] | None,
+) -> list[str]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    for group_rows in (anchor_examples or {}).values():
+        rows.extend(group_rows)
+    rows.extend(witness_highlights or [])
+    for row in rows:
+        company = str(row.get("reviewer_company") or "").strip()
+        marker = _normalize_text(company)
+        if not marker or marker in seen:
+            continue
+        seen.add(marker)
+        terms.append(company)
+    return terms
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        marker = str(value or "").strip().lower()
+        if not marker or marker in seen:
+            continue
+        seen.add(marker)
+        resolved.append(str(value).strip())
+    return resolved
+
+
+def campaign_policy_audit_snapshot(
+    *,
+    subject: str,
+    body: str,
+    cta: str,
+    campaign: dict[str, Any] | None = None,
+    anchor_examples: dict[str, list[dict[str, Any]]] | None = None,
+    witness_highlights: list[dict[str, Any]] | None = None,
+    reference_ids: dict[str, Any] | None = None,
+    campaign_proof_terms: list[str] | None = None,
+    min_anchor_hits: int = 1,
+    require_anchor_support: bool = True,
+    require_timing_or_numeric_when_available: bool = False,
+    proof_term_limit: int = 3,
+) -> dict[str, Any]:
+    payload = campaign if isinstance(campaign, dict) else {}
+    channel = str(payload.get("channel") or "").strip()
+    target_mode = str(payload.get("target_mode") or "").strip()
+    tier = str(payload.get("tier") or "").strip()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        if not tier:
+            tier = str(metadata.get("tier") or "").strip()
+        if not target_mode:
+            target_mode = str(metadata.get("target_mode") or "").strip()
+
+    audit = specificity_audit_snapshot(
+        body,
+        anchor_examples=anchor_examples,
+        witness_highlights=witness_highlights,
+        reference_ids=reference_ids,
+        allow_company_names=False,
+        min_anchor_hits=min_anchor_hits,
+        require_anchor_support=require_anchor_support,
+        require_timing_or_numeric_when_available=require_timing_or_numeric_when_available,
+        include_competitor_terms=channel != "email_cold",
+    )
+    blocking_issues = list(audit.get("blocking_issues") or [])
+    warnings = list(audit.get("warnings") or [])
+
+    proof_terms = _dedupe_strings(
+        [str(term or "").strip() for term in (campaign_proof_terms or []) if str(term or "").strip()]
+    )
+    if not proof_terms:
+        proof_terms = _dedupe_strings(
+            [
+                str(term or "").strip()
+                for term in (_campaign_collection(payload, "campaign_proof_terms") or [])
+                if str(term or "").strip()
+            ]
+        )
+    if not proof_terms:
+        proof_terms = campaign_proof_terms_from_audit(
+            audit,
+            channel=channel,
+            limit=proof_term_limit,
+        )
+
+    normalized_body = _normalize_text(body)
+    normalized_message = _normalize_text(" ".join(part for part in (subject, body, cta) if part))
+    normalized_report = _normalize_text(" ".join(part for part in (body, cta) if part))
+    used_proof_terms = [
+        term for term in proof_terms if _contains_term(normalized_body, term)
+    ]
+
+    if proof_terms and require_anchor_support and (anchor_examples or witness_highlights):
+        if not used_proof_terms:
+            blocking_issues.append("missing_exact_proof_term")
+
+    if tier.lower() == "report":
+        report_match = _REPORT_TIER_BANNED.search(normalized_report)
+        if report_match:
+            blocking_issues.append(f"report_tier_language:{report_match.group(1)}")
+
+    forbidden_label = ""
+    forbidden_terms: list[str] = []
+    if channel == "email_cold":
+        if target_mode == "vendor_retention":
+            forbidden_label = "competitor_name_in_email_cold"
+            forbidden_terms.extend(
+                _campaign_name_terms(_campaign_collection(payload, "competitors_considering"))
+            )
+            signal_summary = payload.get("signal_summary")
+            if isinstance(signal_summary, dict):
+                forbidden_terms.extend(
+                    _campaign_name_terms(signal_summary.get("competitor_distribution"))
+                )
+        elif target_mode == "challenger_intel":
+            forbidden_label = "incumbent_name_in_email_cold"
+            forbidden_terms.extend(
+                _campaign_name_terms(_campaign_collection(payload, "competitors_considering"))
+            )
+            signal_summary = payload.get("signal_summary")
+            if isinstance(signal_summary, dict):
+                forbidden_terms.extend(
+                    _campaign_name_terms(signal_summary.get("incumbents_losing"))
+                )
+            incumbent_archetypes = payload.get("incumbent_archetypes")
+            if isinstance(incumbent_archetypes, dict):
+                for rows in incumbent_archetypes.values():
+                    forbidden_terms.extend(_campaign_name_terms(rows))
+    for term in _dedupe_strings(forbidden_terms):
+        if _contains_term(normalized_message, term):
+            blocking_issues.append(f"{forbidden_label}:{term}")
+
+    for company in _campaign_private_company_terms(anchor_examples, witness_highlights):
+        if _contains_term(normalized_message, company):
+            blocking_issues.append(f"private_account_name_leak:{company}")
+
+    deduped_blockers = _dedupe_strings(blocking_issues)
+    deduped_warnings = _dedupe_strings(warnings)
+    return {
+        **audit,
+        "status": "fail" if deduped_blockers else "pass",
+        "blocking_issues": deduped_blockers,
+        "warnings": deduped_warnings,
+        "campaign_proof_terms": proof_terms,
+        "required_proof_terms": proof_terms,
+        "used_proof_terms": used_proof_terms,
+        "unused_proof_terms": [term for term in proof_terms if term not in used_proof_terms],
+        "primary_blocker": deduped_blockers[0] if deduped_blockers else None,
+    }
+
+
+def latest_specificity_audit(metadata: Any) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        return {}
+    current = metadata.get("latest_specificity_audit")
+    if isinstance(current, dict):
+        return copy.deepcopy(current)
+    generation = metadata.get("generation_audit")
+    if not isinstance(generation, dict):
+        return {}
+    specificity = generation.get("specificity")
+    if isinstance(specificity, dict):
+        return copy.deepcopy(specificity)
+    if generation:
+        return {
+            "status": generation.get("status"),
+            "blocking_issues": [],
+            "warnings": [],
+            "matched_groups": [],
+        }
+    return {}
+
+
+def specificity_quality_summary(metadata: Any) -> dict[str, Any]:
+    audit = latest_specificity_audit(metadata)
+    blocking_issues = list(audit.get("blocking_issues") or [])
+    warnings = list(audit.get("warnings") or [])
+    return {
+        "quality_status": audit.get("status"),
+        "blocker_count": len(blocking_issues),
+        "warning_count": len(warnings),
+        "latest_error_summary": blocking_issues[0] if blocking_issues else None,
+    }

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_synthesis_reader.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_synthesis_reader.py
@@ -1,0 +1,1767 @@
+"""Read-only typed view over reasoning synthesis output.
+
+Provides a clean contract for downstream consumers (battle cards,
+challenger briefs, reports) instead of raw dict splatting.
+
+Handles both v1 and v2 schemas transparently.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from ...config import settings
+from ...reasoning.wedge_registry import Wedge, validate_wedge
+
+
+@dataclass(frozen=True, slots=True)
+class TracedNumber:
+    """A numeric value with its source provenance."""
+
+    value: Any
+    source_id: str
+
+    @property
+    def has_provenance(self) -> bool:
+        return bool(self.source_id)
+
+
+_CONFIDENCE_RANK = {
+    "high": 4,
+    "medium": 3,
+    "low": 2,
+    "insufficient": 1,
+}
+
+_CONFIDENCE_SCORE_BANDS = (
+    (0.75, "high"),
+    (0.45, "medium"),
+    (0.15, "low"),
+    (0.0, "insufficient"),
+)
+
+_REQUIRED_SECTIONS = (
+    "causal_narrative", "segment_playbook", "timing_intelligence",
+    "competitive_reframes", "migration_proof",
+)
+
+_EVIDENCE_SUMMARY_SECTIONS = (
+    "executive_summary",
+    "target_accounts",
+    "displacement_rankings",
+    "recommend_ratio",
+) + _REQUIRED_SECTIONS
+
+_SECTION_CONTRACT_PATHS = {
+    "causal_narrative": ("vendor_core_reasoning", "causal_narrative"),
+    "segment_playbook": ("vendor_core_reasoning", "segment_playbook"),
+    "timing_intelligence": ("vendor_core_reasoning", "timing_intelligence"),
+    "competitive_reframes": ("displacement_reasoning", "competitive_reframes"),
+    "migration_proof": ("displacement_reasoning", "migration_proof"),
+}
+
+_CONSUMER_REQUIRED_CONTRACTS = {
+    "battle_card": (
+        "vendor_core_reasoning",
+        "displacement_reasoning",
+        "category_reasoning",
+        "account_reasoning",
+    ),
+    "weekly_churn_feed": ("vendor_core_reasoning", "account_reasoning"),
+    "vendor_scorecard": (
+        "vendor_core_reasoning",
+        "displacement_reasoning",
+        "account_reasoning",
+    ),
+    "displacement_report": ("displacement_reasoning", "category_reasoning"),
+    "accounts_in_motion": (
+        "vendor_core_reasoning",
+        "displacement_reasoning",
+        "account_reasoning",
+    ),
+    "challenger_brief": (
+        "vendor_core_reasoning",
+        "displacement_reasoning",
+        "category_reasoning",
+        "account_reasoning",
+    ),
+    "campaign": (
+        "vendor_core_reasoning",
+        "displacement_reasoning",
+    ),
+    "blog_reranker": (
+        "vendor_core_reasoning",
+        "category_reasoning",
+    ),
+    "vendor_briefing": (
+        "vendor_core_reasoning",
+        "displacement_reasoning",
+        "account_reasoning",
+    ),
+}
+
+_PACKET_SCHEMA_VERSION = "witness_packet_v1"
+
+_ACCOUNT_REASONING_PREVIEW_CONSUMERS = frozenset({
+    "accounts_in_motion",
+    "battle_card",
+    "blog_reranker",
+    "campaign",
+    "challenger_brief",
+    "vendor_briefing",
+    "vendor_scorecard",
+    "weekly_churn_feed",
+})
+_ACCOUNT_REASONING_PREVIEW_DISCLAIMER = (
+    "Early account signal only: account reasoning is below the normal confidence "
+    "bar and should be treated as directional, not canonical."
+)
+
+
+def _coerce_json_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _coerce_confidence_score(value: Any) -> float | None:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if 0.0 <= score <= 1.0:
+        return score
+    return None
+
+
+def _confidence_numeric_to_label(confidence_score: float | None) -> str:
+    score = _coerce_confidence_score(confidence_score)
+    if score is None:
+        return "insufficient"
+    for floor, label in _CONFIDENCE_SCORE_BANDS:
+        if score >= floor:
+            return label
+    return "insufficient"
+
+
+def _collect_reference_source_ids(value: Any, sink: set[str]) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"source_id", "_sid"} and isinstance(item, str) and item.strip():
+                sink.add(item.strip())
+                continue
+            if key == "citations" and isinstance(item, list):
+                for citation in item:
+                    if isinstance(citation, str) and citation.strip():
+                        sink.add(citation.strip())
+                continue
+            _collect_reference_source_ids(item, sink)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_reference_source_ids(item, sink)
+
+
+def _packet_artifact_witness_from_payload(witness: dict[str, Any]) -> dict[str, Any]:
+    entry = dict(witness)
+    sid = str(entry.get("_sid") or entry.get("witness_id") or "").strip()
+    if sid:
+        entry.setdefault("_sid", sid)
+        entry.setdefault("witness_id", sid)
+    return entry
+
+
+def _packet_artifacts_from_payload(packet_payload: dict[str, Any]) -> dict[str, Any]:
+    witness_pack = packet_payload.get("witness_pack")
+    section_packets = packet_payload.get("section_packets")
+    artifacts: dict[str, Any] = {}
+    if isinstance(witness_pack, list) and witness_pack:
+        artifacts["witness_pack"] = [
+            _packet_artifact_witness_from_payload(item)
+            for item in witness_pack
+            if isinstance(item, dict)
+        ]
+    if isinstance(section_packets, dict) and section_packets:
+        artifacts["section_packets"] = dict(section_packets)
+    return artifacts
+
+
+def _reference_ids_from_contracts_and_packet(
+    raw: dict[str, Any],
+    packet_payload: dict[str, Any],
+) -> dict[str, list[str]]:
+    referenced_ids: set[str] = set()
+    contracts = raw.get("reasoning_contracts")
+    _collect_reference_source_ids(contracts if isinstance(contracts, dict) else raw, referenced_ids)
+
+    metric_source_ids: set[str] = set()
+    metric_ledger = packet_payload.get("metric_ledger")
+    if isinstance(metric_ledger, list):
+        for entry in metric_ledger:
+            if not isinstance(entry, dict):
+                continue
+            sid = str(entry.get("_sid") or "").strip()
+            if sid:
+                metric_source_ids.add(sid)
+    aggregates = packet_payload.get("precomputed_aggregates")
+    if isinstance(aggregates, dict):
+        for value in aggregates.values():
+            if not isinstance(value, dict):
+                continue
+            sid = str(value.get("_sid") or "").strip()
+            if sid:
+                metric_source_ids.add(sid)
+
+    witness_source_ids: set[str] = set()
+    witness_pack = packet_payload.get("witness_pack")
+    if isinstance(witness_pack, list):
+        for witness in witness_pack:
+            if not isinstance(witness, dict):
+                continue
+            sid = str(witness.get("_sid") or witness.get("witness_id") or "").strip()
+            if sid:
+                witness_source_ids.add(sid)
+
+    resolved: dict[str, list[str]] = {}
+    metric_ids = sorted(referenced_ids.intersection(metric_source_ids))
+    witness_ids = sorted(referenced_ids.intersection(witness_source_ids))
+    if metric_ids:
+        resolved["metric_ids"] = metric_ids
+    if witness_ids:
+        resolved["witness_ids"] = witness_ids
+    return resolved
+
+
+def _merge_packet_fallback(
+    raw: dict[str, Any],
+    packet_payload: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(raw)
+    packet_artifacts = merged.get("packet_artifacts")
+    if not isinstance(packet_artifacts, dict) or not packet_artifacts:
+        packet_artifacts = _packet_artifacts_from_payload(packet_payload)
+        if packet_artifacts:
+            merged["packet_artifacts"] = packet_artifacts
+
+    reference_ids = merged.get("reference_ids")
+    if not isinstance(reference_ids, dict) or not reference_ids:
+        resolved_refs = _reference_ids_from_contracts_and_packet(merged, packet_payload)
+        if resolved_refs:
+            merged["reference_ids"] = resolved_refs
+    return merged
+
+
+async def _load_packet_payload_for_vendor(
+    pool,
+    *,
+    vendor_name: str,
+    as_of_date: date,
+    analysis_window_days: int,
+) -> dict[str, Any]:
+    row = await pool.fetchrow(
+        """
+        SELECT packet
+        FROM b2b_vendor_reasoning_packets
+        WHERE LOWER(vendor_name) = LOWER($1)
+          AND as_of_date = $2
+          AND analysis_window_days = $3
+          AND schema_version = $4
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        vendor_name,
+        as_of_date,
+        analysis_window_days,
+        _PACKET_SCHEMA_VERSION,
+    )
+    packet = _coerce_json_dict(row.get("packet")) if row else {}
+    payload = packet.get("prompt_payload")
+    if not isinstance(payload, dict):
+        payload = packet.get("payload")
+    return dict(payload) if isinstance(payload, dict) else {}
+
+
+def _repair_stale_timing_support(contracts: dict[str, Any]) -> dict[str, Any]:
+    vendor_core = contracts.get("vendor_core_reasoning")
+    if not isinstance(vendor_core, dict):
+        return contracts
+    segment = vendor_core.get("segment_playbook")
+    timing = vendor_core.get("timing_intelligence")
+    if not isinstance(segment, dict) and (not isinstance(timing, dict) or not timing):
+        return contracts
+    from ._b2b_reasoning_contracts import (
+        _canonicalize_segment_playbook,
+        _canonicalize_timing_intelligence,
+        _merge_timing_signal_rows,
+        _timing_signal_fallback_rows,
+        _timing_signal_summary_rows,
+    )
+
+    repaired = dict(contracts)
+    repaired_vendor_core = dict(vendor_core)
+    changed = False
+
+    if isinstance(segment, dict) and segment:
+        repaired_segment = _canonicalize_segment_playbook(dict(segment))
+        if repaired_segment != segment:
+            repaired_vendor_core["segment_playbook"] = repaired_segment
+            changed = True
+
+    if isinstance(timing, dict) and timing:
+        repaired_timing = _canonicalize_timing_intelligence(dict(timing))
+        repaired_supporting = (
+            dict(repaired_timing.get("supporting_evidence"))
+            if isinstance(repaired_timing.get("supporting_evidence"), dict)
+            else {}
+        )
+        timing_rows = list(repaired_supporting.get("top_timing_signals") or [])
+        timing_rows = _merge_timing_signal_rows(
+            timing_rows,
+            _timing_signal_fallback_rows(repaired_timing),
+        )
+        timing_rows = _merge_timing_signal_rows(
+            timing_rows,
+            _timing_signal_summary_rows(repaired_supporting),
+        )
+        if timing_rows:
+            repaired_supporting["top_timing_signals"] = timing_rows
+            repaired_timing["supporting_evidence"] = repaired_supporting
+        if repaired_timing != timing:
+            repaired_vendor_core["timing_intelligence"] = repaired_timing
+            changed = True
+
+    if not changed:
+        return contracts
+    repaired["vendor_core_reasoning"] = repaired_vendor_core
+    return repaired
+
+
+class SynthesisView:
+    """Read-only view over a single vendor's reasoning synthesis.
+
+    Wraps the raw dict and provides typed accessors, confidence checks,
+    and source traceability.
+    """
+
+    __slots__ = ("vendor_name", "raw", "schema_version", "as_of_date")
+
+    def __init__(
+        self,
+        vendor_name: str,
+        raw: dict[str, Any],
+        schema_version: str = "v1",
+        as_of_date: date | None = None,
+    ) -> None:
+        self.vendor_name = vendor_name
+        self.raw = raw
+        self.schema_version = schema_version
+        self.as_of_date = as_of_date
+
+    @property
+    def is_v2(self) -> bool:
+        return self.schema_version.startswith("v2") or str(self.raw.get("schema_version") or "").startswith("2.")
+
+    @property
+    def has_explicit_contracts(self) -> bool:
+        return bool(self.reasoning_contracts)
+
+    @property
+    def as_of_date_iso(self) -> str:
+        if self.as_of_date is None:
+            return ""
+        return self.as_of_date.isoformat()
+
+    def is_stale(self, requested_as_of: date | None = None) -> bool:
+        if self.as_of_date is None:
+            return False
+        if requested_as_of is None:
+            return False
+        return self.as_of_date < requested_as_of
+
+    @property
+    def primary_wedge(self) -> Wedge | None:
+        cn = self.section("causal_narrative")
+        if not cn:
+            return None
+        return validate_wedge(cn.get("primary_wedge", ""))
+
+    @property
+    def wedge_label(self) -> str:
+        w = self.primary_wedge
+        if w is None:
+            return ""
+        return w.value.replace("_", " ").title()
+
+    def section(self, name: str) -> dict[str, Any]:
+        """Get a section dict, or empty dict if missing."""
+        contracts = self.reasoning_contracts
+        contract_path = _SECTION_CONTRACT_PATHS.get(name)
+        if contract_path:
+            contract_name, section_name = contract_path
+            contract = contracts.get(contract_name)
+            if isinstance(contract, dict):
+                nested = contract.get(section_name)
+                if isinstance(nested, dict):
+                    return nested
+            if self.has_explicit_contracts:
+                return {}
+        if name in ("category_reasoning", "account_reasoning", "evidence_governance"):
+            top_level = contracts.get(name)
+            if isinstance(top_level, dict):
+                return top_level
+            if self.has_explicit_contracts:
+                return {}
+        val = self.raw.get(name)
+        if isinstance(val, dict):
+            return val
+        return {}
+
+    def confidence(self, section: str) -> str:
+        """Get the confidence level for a section."""
+        sec = self.section(section)
+        conf = sec.get("confidence")
+        if isinstance(conf, str) and conf.strip():
+            return conf
+        score = self.confidence_score(section, fallback_to_label=False)
+        if score is not None:
+            return _confidence_numeric_to_label(score)
+        # Backward compatibility: older minimal contracts may omit an explicit
+        # confidence field. Treat non-empty sections as usable instead of
+        # suppressing them as "insufficient" by default.
+        if sec:
+            return "medium"
+        return "insufficient"
+
+    def confidence_score(self, section: str, *, fallback_to_label: bool = True) -> float | None:
+        """Get a numeric confidence score for a section when available."""
+        sec = self.section(section)
+        score = _coerce_confidence_score(sec.get("confidence_score"))
+        if score is None and section == "causal_narrative":
+            score = _coerce_confidence_score(self.confidence_posture.get("overall_score"))
+        if score is not None or not fallback_to_label:
+            return score
+        if sec:
+            return _confidence_label_to_numeric(self.confidence(section))
+        return 0.0
+
+    def should_suppress(self, section: str, vendor_evidence: dict[str, Any] | None = None) -> bool:
+        """True if section should not display.
+
+        Checks both synthesis confidence AND evidence-engine suppression rules
+        when vendor_evidence is provided.
+        """
+        conf = self.confidence(section)
+        if conf == "insufficient":
+            return True
+        if vendor_evidence is not None:
+            from ...reasoning.evidence_engine import get_evidence_engine
+            result = get_evidence_engine().evaluate_suppression(section, vendor_evidence)
+            if result.suppress:
+                return True
+        return False
+
+    def should_flag(self, section: str, vendor_evidence: dict[str, Any] | None = None) -> bool:
+        """True if section should display with a caveat/disclaimer.
+
+        Checks both synthesis confidence AND evidence-engine degrade rules.
+        """
+        conf = self.confidence(section)
+        if conf == "low":
+            return True
+        if vendor_evidence is not None:
+            from ...reasoning.evidence_engine import get_evidence_engine
+            result = get_evidence_engine().evaluate_suppression(section, vendor_evidence)
+            if result.degrade:
+                return True
+        return False
+
+    def get_disclaimer(self, section: str, vendor_evidence: dict[str, Any] | None = None) -> str | None:
+        """Get the disclaimer text for a degraded section, if any."""
+        if vendor_evidence is not None:
+            from ...reasoning.evidence_engine import get_evidence_engine
+            result = get_evidence_engine().evaluate_suppression(section, vendor_evidence)
+            if result.disclaimer:
+                return result.disclaimer
+        return None
+
+    def is_quotable(self, section: str) -> bool:
+        """True if section is safe for outbound material.
+
+        Requires confidence >= medium and no critical validation warnings.
+        """
+        conf = self.confidence(section)
+        if _CONFIDENCE_RANK.get(conf, 0) < _CONFIDENCE_RANK["medium"]:
+            return False
+        # Check for critical warnings on this section
+        warnings = self.raw.get("_validation_warnings") or []
+        for w in warnings:
+            if isinstance(w, dict) and w.get("path", "").startswith(section):
+                if w.get("code") in ("hallucinated_source_id", "value_mismatch"):
+                    return False
+        return True
+
+    def trace_number(self, section: str, field: str) -> TracedNumber:
+        """Extract a {value, source_id} wrapper from a section field.
+
+        Works with both v1 (bare values) and v2 (wrapped values).
+        """
+        sec = self.section(section)
+        val = sec.get(field)
+
+        if isinstance(val, dict) and "value" in val:
+            # v2 wrapped value
+            return TracedNumber(
+                value=val.get("value"),
+                source_id=val.get("source_id", ""),
+            )
+        # v1 bare value or missing
+        return TracedNumber(value=val, source_id="")
+
+    def citations(self, section: str) -> list[str]:
+        """Get the citations array for a section."""
+        sec = self.section(section)
+        cites = sec.get("citations")
+        return cites if isinstance(cites, list) else []
+
+    def falsification_conditions(self) -> list[dict[str, Any]]:
+        """Get structured falsification conditions from causal_narrative.
+
+        Returns list of {condition, signal_source, monitorable} dicts.
+        Falls back to bare strings wrapped in a dict for v1 compat.
+        """
+        cn = self.section("causal_narrative")
+        raw = cn.get("what_would_weaken_thesis") or []
+        if not isinstance(raw, list):
+            return []
+        result = []
+        for item in raw:
+            if isinstance(item, dict):
+                result.append(item)
+            elif isinstance(item, str):
+                result.append({
+                    "condition": item,
+                    "signal_source": "",
+                    "monitorable": False,
+                })
+        return result
+
+    def data_gaps(self, section: str) -> list[str]:
+        """Get data gaps for a section."""
+        sec = self.section(section)
+        gaps = sec.get("data_gaps")
+        return gaps if isinstance(gaps, list) else []
+
+    # --- Phase 3 accessors ------------------------------------------------
+
+    @property
+    def why_they_stay(self) -> dict[str, Any]:
+        """Get the why_they_stay block from vendor_core_reasoning."""
+        vc = self.contract("vendor_core_reasoning")
+        wts = vc.get("why_they_stay")
+        return wts if isinstance(wts, dict) else {}
+
+    @property
+    def confidence_posture(self) -> dict[str, Any]:
+        """Get the confidence_posture block from vendor_core_reasoning."""
+        vc = self.contract("vendor_core_reasoning")
+        cp = vc.get("confidence_posture")
+        return cp if isinstance(cp, dict) else {}
+
+    @property
+    def switch_triggers(self) -> list[dict[str, Any]]:
+        """Get switch_triggers from displacement_reasoning."""
+        dr = self.contract("displacement_reasoning")
+        st = dr.get("switch_triggers")
+        return st if isinstance(st, list) else []
+
+    @property
+    def evidence_governance(self) -> dict[str, Any]:
+        """Get the evidence_governance contract block."""
+        eg = self.contract("evidence_governance")
+        if eg:
+            return eg
+        # Also check top-level raw for older schemas
+        raw_eg = self.raw.get("evidence_governance")
+        return raw_eg if isinstance(raw_eg, dict) else {}
+
+    @property
+    def metric_ledger(self) -> list[dict[str, Any]]:
+        """Get metric_ledger from evidence_governance."""
+        ml = self.evidence_governance.get("metric_ledger")
+        return ml if isinstance(ml, list) else []
+
+    @property
+    def contradictions(self) -> list[dict[str, Any]]:
+        """Get contradictions from evidence_governance."""
+        c = self.evidence_governance.get("contradictions")
+        return c if isinstance(c, list) else []
+
+    @property
+    def coverage_gaps(self) -> list[dict[str, Any]]:
+        """Get coverage_gaps from evidence_governance."""
+        cg = self.evidence_governance.get("coverage_gaps")
+        return cg if isinstance(cg, list) else []
+
+    @property
+    def confidence_limits(self) -> list[str]:
+        """Get confidence limits from confidence_posture."""
+        return list(self.confidence_posture.get("limits") or [])
+
+    @property
+    def retention_strengths(self) -> list[dict[str, Any]]:
+        """Get strengths from why_they_stay."""
+        return list(self.why_they_stay.get("strengths") or [])
+
+    @property
+    def meta(self) -> dict[str, Any]:
+        m = self.raw.get("meta")
+        if isinstance(m, dict):
+            return m
+        # v1 fallback: build from evidence_window
+        ew = self.raw.get("evidence_window")
+        if isinstance(ew, dict):
+            return {
+                "evidence_window_start": ew.get("earliest"),
+                "evidence_window_end": ew.get("latest"),
+            }
+        return {}
+
+    @property
+    def validation_warnings(self) -> list[dict[str, Any]]:
+        w = self.raw.get("_validation_warnings")
+        return w if isinstance(w, list) else []
+
+    @property
+    def reasoning_contracts(self) -> dict[str, Any]:
+        rc = self.raw.get("reasoning_contracts")
+        return rc if isinstance(rc, dict) else {}
+
+    @property
+    def reference_ids(self) -> dict[str, list[str]]:
+        raw = self.raw.get("reference_ids")
+        if not isinstance(raw, dict):
+            return {}
+        resolved: dict[str, list[str]] = {}
+        for key in ("metric_ids", "witness_ids"):
+            values = raw.get(key)
+            if isinstance(values, list):
+                cleaned = [
+                    str(value).strip()
+                    for value in values
+                    if str(value or "").strip()
+                ]
+                if cleaned:
+                    resolved[key] = cleaned
+        return resolved
+
+    @property
+    def scope_manifest(self) -> dict[str, Any]:
+        raw = self.raw.get("scope_manifest")
+        return raw if isinstance(raw, dict) else {}
+
+    @property
+    def reasoning_atoms(self) -> dict[str, Any]:
+        raw = self.raw.get("reasoning_atoms")
+        return raw if isinstance(raw, dict) else {}
+
+    @property
+    def reasoning_delta(self) -> dict[str, Any]:
+        raw = self.raw.get("reasoning_delta")
+        return raw if isinstance(raw, dict) else {}
+
+    @property
+    def packet_artifacts(self) -> dict[str, Any]:
+        raw = self.raw.get("packet_artifacts")
+        return raw if isinstance(raw, dict) else {}
+
+    @property
+    def witness_pack(self) -> list[dict[str, Any]]:
+        raw = self.packet_artifacts.get("witness_pack")
+        return [dict(item) for item in raw if isinstance(item, dict)] if isinstance(raw, list) else []
+
+    @property
+    def section_packets(self) -> dict[str, Any]:
+        raw = self.packet_artifacts.get("section_packets")
+        return dict(raw) if isinstance(raw, dict) else {}
+
+    def contract(self, name: str) -> dict[str, Any]:
+        rc = self.reasoning_contracts.get(name)
+        return rc if isinstance(rc, dict) else {}
+
+    def account_reasoning_preview(self) -> dict[str, Any]:
+        account = self.contract("account_reasoning")
+        if not account:
+            raw_account = self.raw.get("account_reasoning")
+            if isinstance(raw_account, dict) and raw_account:
+                account = raw_account
+        return _build_account_reasoning_preview(account)
+
+    def witness(self, witness_id: str) -> dict[str, Any]:
+        target = str(witness_id or "").strip()
+        if not target:
+            return {}
+        for witness in self.witness_pack:
+            sid = str(witness.get("witness_id") or witness.get("_sid") or "").strip()
+            if sid == target:
+                return dict(witness)
+        return {}
+
+    def anchor_examples(self) -> dict[str, list[dict[str, Any]]]:
+        raw = self.section_packets.get("anchor_examples")
+        if not isinstance(raw, dict):
+            return {}
+        resolved: dict[str, list[dict[str, Any]]] = {}
+        for label, witness_ids in raw.items():
+            if not isinstance(witness_ids, list):
+                continue
+            matches: list[dict[str, Any]] = []
+            for witness_id in witness_ids:
+                witness = self.witness(str(witness_id or ""))
+                if witness:
+                    matches.append(witness)
+            if matches:
+                resolved[str(label)] = matches
+        return resolved
+
+    def witness_highlights(self, *, limit: int | None = None) -> list[dict[str, Any]]:
+        if limit is None:
+            limit = int(
+                getattr(settings.b2b_churn, "reasoning_witness_highlight_limit", 4),
+            )
+        if limit <= 0:
+            return []
+        highlights: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        def _add(witness: dict[str, Any]) -> None:
+            witness_id = str(witness.get("witness_id") or witness.get("_sid") or "").strip()
+            if not witness_id or witness_id in seen:
+                return
+            seen.add(witness_id)
+            highlights.append(dict(witness))
+
+        for rows in self.anchor_examples().values():
+            for witness in rows:
+                _add(witness)
+                if len(highlights) >= limit:
+                    return highlights
+
+        ranked = sorted(
+            self.witness_pack,
+            key=lambda item: (
+                -float(item.get("salience_score") or 0.0),
+                str(item.get("witness_id") or item.get("_sid") or ""),
+            ),
+        )
+        for witness in ranked:
+            _add(witness)
+            if len(highlights) >= limit:
+                break
+        return highlights
+
+    @property
+    def theses(self) -> list[dict[str, Any]]:
+        rows = self.reasoning_atoms.get("theses")
+        return [dict(item) for item in rows if isinstance(item, dict)] if isinstance(rows, list) else []
+
+    @property
+    def timing_windows(self) -> list[dict[str, Any]]:
+        rows = self.reasoning_atoms.get("timing_windows")
+        return [dict(item) for item in rows if isinstance(item, dict)] if isinstance(rows, list) else []
+
+    @property
+    def proof_points(self) -> list[dict[str, Any]]:
+        rows = self.reasoning_atoms.get("proof_points")
+        return [dict(item) for item in rows if isinstance(item, dict)] if isinstance(rows, list) else []
+
+    @property
+    def account_signals(self) -> list[dict[str, Any]]:
+        rows = self.reasoning_atoms.get("account_signals")
+        return [dict(item) for item in rows if isinstance(item, dict)] if isinstance(rows, list) else []
+
+    @property
+    def counterevidence(self) -> list[dict[str, Any]]:
+        rows = self.reasoning_atoms.get("counterevidence")
+        return [dict(item) for item in rows if isinstance(item, dict)] if isinstance(rows, list) else []
+
+    @property
+    def coverage_limits(self) -> list[dict[str, Any]]:
+        rows = self.reasoning_atoms.get("coverage_limits")
+        return [dict(item) for item in rows if isinstance(item, dict)] if isinstance(rows, list) else []
+
+    def reasoning_atom_summary(self) -> dict[str, Any]:
+        atoms = self.reasoning_atoms
+        if not atoms:
+            return {}
+
+        summary: dict[str, Any] = {
+            "schema_version": str(atoms.get("schema_version") or "v1"),
+        }
+
+        theses = [
+            {
+                "thesis_id": str(item.get("thesis_id") or ""),
+                "wedge": str(item.get("wedge") or ""),
+                "summary": str(item.get("summary") or ""),
+                "why_now": str(item.get("why_now") or ""),
+                "confidence": str(item.get("confidence") or ""),
+                "ui_priority": item.get("ui_priority"),
+            }
+            for item in self.theses[:2]
+        ]
+        theses = [item for item in theses if item["summary"] or item["why_now"]]
+        if theses:
+            summary["theses"] = theses
+
+        timing_windows = [
+            {
+                "window_type": str(item.get("window_type") or ""),
+                "start_or_anchor": str(item.get("start_or_anchor") or ""),
+                "urgency": str(item.get("urgency") or ""),
+                "recommended_action": str(item.get("recommended_action") or ""),
+            }
+            for item in self.timing_windows[:2]
+        ]
+        timing_windows = [item for item in timing_windows if item["start_or_anchor"]]
+        if timing_windows:
+            summary["timing_windows"] = timing_windows
+
+        proof_points = [
+            {
+                "label": str(item.get("label") or ""),
+                "claim_type": str(item.get("claim_type") or ""),
+                "value": item.get("value"),
+                "best_segment": str(item.get("best_segment") or ""),
+                "confidence": str(item.get("confidence") or ""),
+            }
+            for item in self.proof_points[:3]
+        ]
+        proof_points = [item for item in proof_points if item["label"]]
+        if proof_points:
+            summary["proof_points"] = proof_points
+
+        account_signals = [
+            {
+                "company": str(item.get("company") or ""),
+                "role_type": str(item.get("role_type") or ""),
+                "buying_stage": str(item.get("buying_stage") or ""),
+                "urgency": str(item.get("urgency") or ""),
+                "competitor_context": str(item.get("competitor_context") or ""),
+                "trust_tier": str(item.get("trust_tier") or ""),
+            }
+            for item in self.account_signals[:2]
+        ]
+        account_signals = [item for item in account_signals if item["company"]]
+        if account_signals:
+            summary["account_signals"] = account_signals
+
+        coverage_limits = [
+            {
+                "label": str(item.get("label") or item.get("gap") or ""),
+                "confidence_cap": str(item.get("confidence_cap") or ""),
+            }
+            for item in self.coverage_limits[:3]
+        ]
+        coverage_limits = [item for item in coverage_limits if item["label"]]
+        if coverage_limits:
+            summary["coverage_limits"] = coverage_limits
+
+        if self.counterevidence:
+            summary["counterevidence_count"] = len(self.counterevidence)
+
+        return summary
+
+    def consumer_context(self, consumer: str) -> dict[str, Any]:
+        contracts = self.materialized_contracts()
+        context: dict[str, Any] = {
+            "reasoning_contracts": contracts,
+            "vendor_core_reasoning": dict(contracts.get("vendor_core_reasoning") or {}),
+            "displacement_reasoning": dict(contracts.get("displacement_reasoning") or {}),
+            "category_reasoning": dict(contracts.get("category_reasoning") or {}),
+            "account_reasoning": dict(contracts.get("account_reasoning") or {}),
+            "reasoning_contract_gaps": contract_gaps_for_consumer(self, consumer),
+        }
+        anchors = self.anchor_examples()
+        if anchors:
+            context["anchor_examples"] = anchors
+        highlights = self.witness_highlights()
+        if highlights:
+            context["witness_highlights"] = highlights
+        refs = self.reference_ids
+        if refs:
+            context["reference_ids"] = refs
+        scope_manifest = self.scope_manifest
+        if scope_manifest:
+            context["scope_manifest"] = scope_manifest
+        atoms = self.reasoning_atoms
+        if atoms:
+            context["reasoning_atoms"] = atoms
+            if self.theses:
+                context["theses"] = self.theses
+            if self.timing_windows:
+                context["timing_windows"] = self.timing_windows
+            if self.proof_points:
+                context["proof_points"] = self.proof_points
+            if self.account_signals:
+                context["account_signals"] = self.account_signals
+            if self.counterevidence:
+                context["counterevidence"] = self.counterevidence
+            if self.coverage_limits:
+                context["coverage_limits"] = self.coverage_limits
+            atom_summary = self.reasoning_atom_summary()
+            if atom_summary:
+                context["reasoning_atom_summary"] = atom_summary
+        reasoning_delta = self.reasoning_delta
+        if reasoning_delta:
+            context["reasoning_delta"] = reasoning_delta
+        if self.packet_artifacts:
+            context["packet_artifacts"] = self.packet_artifacts
+        return context
+
+    def filtered_consumer_context(self, consumer: str) -> dict[str, Any]:
+        """Consumer context with suppression and flagging applied.
+
+        - Sections with confidence="insufficient" are removed entirely
+        - Sections with confidence="low" get surfaced in reasoning_section_disclaimers
+        - Gaps include both structural gaps and suppressed sections
+
+        Consumers should prefer this over raw consumer_context() for
+        any outbound/rendered content.
+        """
+        import copy
+        context = self.consumer_context(consumer)
+        # Deep copy contracts so suppression mutations don't affect
+        # the underlying SynthesisView or other consumer calls
+        contracts = copy.deepcopy(context.get("reasoning_contracts") or {})
+        context["reasoning_contracts"] = contracts
+        # Also deep copy the top-level contract shortcuts
+        for key in ("vendor_core_reasoning", "displacement_reasoning",
+                     "category_reasoning", "account_reasoning"):
+            if key in context:
+                context[key] = copy.deepcopy(context[key])
+        suppressed: list[str] = []
+        disclaimers: dict[str, str] = {}
+
+        # Sections that map to sub-keys of top-level contract blocks
+        _SECTION_MAP = {
+            "causal_narrative": ("vendor_core_reasoning", "causal_narrative"),
+            "segment_playbook": ("vendor_core_reasoning", "segment_playbook"),
+            "timing_intelligence": ("vendor_core_reasoning", "timing_intelligence"),
+            "competitive_reframes": ("displacement_reasoning", "competitive_reframes"),
+            "migration_proof": ("displacement_reasoning", "migration_proof"),
+            "category_reasoning": ("category_reasoning", None),
+            "account_reasoning": ("account_reasoning", None),
+        }
+
+        for section_name, (parent_key, child_key) in _SECTION_MAP.items():
+            if self.should_suppress(section_name):
+                suppressed.append(section_name)
+                # Remove from contracts
+                parent = contracts.get(parent_key)
+                if child_key and isinstance(parent, dict):
+                    parent.pop(child_key, None)
+                elif child_key is None:
+                    contracts.pop(parent_key, None)
+                    context.pop(parent_key, None)
+            elif self.should_flag(section_name):
+                disclaimer = self.get_disclaimer(section_name)
+                if disclaimer:
+                    disclaimers[section_name] = disclaimer
+                else:
+                    disclaimers[section_name] = (
+                        f"Low confidence: {section_name} is based on limited evidence"
+                    )
+
+        if suppressed:
+            gaps = context.get("reasoning_contract_gaps") or []
+            for s in suppressed:
+                gap_entry = f"{s}:suppressed"
+                if gap_entry not in gaps:
+                    gaps.append(gap_entry)
+            context["reasoning_contract_gaps"] = gaps
+            context["_suppressed_sections"] = suppressed
+
+        if consumer in _ACCOUNT_REASONING_PREVIEW_CONSUMERS:
+            preview = self.account_reasoning_preview()
+            if preview and not context.get("account_reasoning"):
+                context["account_reasoning_preview"] = preview
+                disclaimers.setdefault(
+                    "account_reasoning",
+                    str(
+                        preview.get("disclaimer")
+                        or _ACCOUNT_REASONING_PREVIEW_DISCLAIMER
+                    ),
+                )
+
+        if disclaimers:
+            context["reasoning_section_disclaimers"] = disclaimers
+            context["_section_disclaimers"] = disclaimers
+
+        return context
+
+    def materialized_contracts(self) -> dict[str, Any]:
+        """Return contract-first reasoning blocks with flat-section fallback.
+
+        New synthesis rows persist explicit ``reasoning_contracts``. Older rows may
+        only expose the flat battle-card-shaped sections. This view normalizes both
+        cases so downstream consumers can treat contract blocks as canonical.
+        """
+        contracts: dict[str, Any] = {}
+        allow_flat_fallback = not self.has_explicit_contracts
+
+        vendor_core = self.contract("vendor_core_reasoning")
+        if not vendor_core and allow_flat_fallback:
+            vendor_sections = {
+                section: self.section(section)
+                for section in (
+                    "causal_narrative",
+                    "segment_playbook",
+                    "timing_intelligence",
+                )
+                if self.section(section)
+            }
+            if vendor_sections:
+                vendor_core = {
+                    "schema_version": "v1",
+                    **vendor_sections,
+                }
+        if vendor_core:
+            contracts["vendor_core_reasoning"] = vendor_core
+
+        displacement = self.contract("displacement_reasoning")
+        if not displacement and allow_flat_fallback:
+            displacement_sections = {
+                section: self.section(section)
+                for section in (
+                    "competitive_reframes",
+                    "migration_proof",
+                )
+                if self.section(section)
+            }
+            if displacement_sections:
+                displacement = {
+                    "schema_version": "v1",
+                    **displacement_sections,
+                }
+        if displacement:
+            contracts["displacement_reasoning"] = displacement
+
+        category = self.contract("category_reasoning")
+        if not category:
+            raw_category = self.raw.get("category_reasoning")
+            if isinstance(raw_category, dict) and raw_category:
+                category = raw_category
+        if category:
+            contracts["category_reasoning"] = category
+
+        account = self.contract("account_reasoning")
+        if not account:
+            raw_account = self.raw.get("account_reasoning")
+            if isinstance(raw_account, dict) and raw_account:
+                account = raw_account
+        if account:
+            contracts["account_reasoning"] = account
+
+        evidence_gov = self.contract("evidence_governance")
+        if not evidence_gov:
+            raw_eg = self.raw.get("evidence_governance")
+            if isinstance(raw_eg, dict) and raw_eg:
+                evidence_gov = raw_eg
+        if evidence_gov:
+            contracts["evidence_governance"] = evidence_gov
+
+        contracts = _repair_stale_timing_support(contracts)
+
+        if contracts:
+            contracts["schema_version"] = (
+                str(self.reasoning_contracts.get("schema_version") or "v1")
+            )
+        return contracts
+
+
+def _coerce_iso_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return date.fromisoformat(text[:10])
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_reasoning_int(value: Any) -> int | None:
+    if isinstance(value, dict) and "value" in value:
+        value = value.get("value")
+    if value is None:
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_account_reasoning_preview(
+    account_reasoning: dict[str, Any] | None,
+    *,
+    limit: int = 5,
+) -> dict[str, Any]:
+    if not isinstance(account_reasoning, dict) or not account_reasoning:
+        return {}
+    confidence = str(account_reasoning.get("confidence") or "").strip().lower()
+    if confidence != "insufficient":
+        return {}
+
+    metrics: dict[str, int] = {}
+    for key in ("total_accounts", "high_intent_count", "active_eval_count"):
+        value = _coerce_reasoning_int(account_reasoning.get(key))
+        if value is not None:
+            metrics[key] = value
+
+    priority_names: list[str] = []
+    for item in account_reasoning.get("top_accounts") or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("company") or "").strip()
+        if name and name not in priority_names:
+            priority_names.append(name)
+        if len(priority_names) >= limit:
+            break
+
+    if not priority_names and not any(value > 0 for value in metrics.values()):
+        return {}
+
+    summary = str(account_reasoning.get("market_summary") or "").strip()
+    if not summary:
+        active_eval = metrics.get("active_eval_count")
+        high_intent = metrics.get("high_intent_count")
+        total_accounts = metrics.get("total_accounts")
+        if active_eval is not None and high_intent is not None:
+            summary = (
+                f"{active_eval} accounts are in active evaluation while "
+                f"{high_intent} accounts show high-intent churn signals."
+            )
+        elif high_intent is not None:
+            summary = f"{high_intent} accounts show high-intent churn signals."
+        elif total_accounts is not None:
+            summary = f"{total_accounts} accounts are currently in scope."
+
+    preview = {
+        "preview_mode": "early_account_signal",
+        "disclaimer": _ACCOUNT_REASONING_PREVIEW_DISCLAIMER,
+        "account_reasoning": dict(account_reasoning),
+    }
+    if summary:
+        preview["account_pressure_summary"] = summary
+    if metrics:
+        preview["account_pressure_metrics"] = metrics
+    if priority_names:
+        preview["priority_account_names"] = priority_names
+    return preview
+
+
+def required_contracts_for_consumer(consumer: str) -> tuple[str, ...]:
+    key = str(consumer or "").strip().lower()
+    return _CONSUMER_REQUIRED_CONTRACTS.get(key, ())
+
+
+def contract_gaps_for_consumer(view: SynthesisView | None, consumer: str) -> list[str]:
+    required = required_contracts_for_consumer(consumer)
+    if not required:
+        return []
+    if view is None:
+        return list(required)
+    materialized_contracts = getattr(view, "materialized_contracts", None)
+    if callable(materialized_contracts):
+        contracts = materialized_contracts() or {}
+    else:
+        contracts = {}
+        contract_getter = getattr(view, "contract", None)
+        if callable(contract_getter):
+            for name in required:
+                contract = contract_getter(name)
+                if isinstance(contract, dict) and contract:
+                    contracts[name] = contract
+    # Content arrays that indicate meaningful data per section
+    _SECTION_CONTENT_KEYS = {
+        "segment_playbook": "priority_segments",
+        "competitive_reframes": "reframes",
+        "migration_proof": "named_examples",
+        "account_reasoning": "top_accounts",
+    }
+
+    gaps: list[str] = []
+    for name in required:
+        section = contracts.get(name)
+        if not isinstance(section, dict) or not section:
+            gaps.append(name)
+            continue
+        # Confidence = insufficient means the section is structurally present
+        # but analytically empty; treat as a gap for consumers
+        conf = str(section.get("confidence") or "").strip().lower()
+        if conf == "insufficient":
+            gaps.append(f"{name}:insufficient")
+            continue
+        # Check for empty content arrays that consumers depend on
+        content_key = _SECTION_CONTENT_KEYS.get(name)
+        if content_key:
+            content = section.get(content_key)
+            if isinstance(content, list) and not content:
+                gaps.append(f"{name}:empty_{content_key}")
+    return gaps
+
+
+def inject_synthesis_freshness(
+    entry: dict[str, Any],
+    view: SynthesisView,
+    *,
+    requested_as_of: date | None = None,
+) -> None:
+    as_of_date = getattr(view, "as_of_date", None)
+    if as_of_date is not None:
+        entry["data_as_of_date"] = as_of_date.isoformat()
+    if requested_as_of is None:
+        return
+    is_stale = getattr(view, "is_stale", None)
+    if callable(is_stale):
+        entry["data_stale"] = bool(is_stale(requested_as_of))
+
+
+def load_synthesis_view(
+    raw: dict[str, Any],
+    vendor_name: str,
+    schema_version: str = "",
+    as_of_date: date | str | None = None,
+) -> SynthesisView:
+    """Construct a SynthesisView, handling v1 backward compatibility.
+
+    If ``schema_version`` is not provided, infers from the raw dict.
+    """
+    if not schema_version:
+        if str(raw.get("schema_version") or "").startswith("2.") or "meta" in raw:
+            schema_version = "v2"
+        else:
+            schema_version = "v1"
+    return SynthesisView(
+        vendor_name=vendor_name,
+        raw=raw,
+        schema_version=schema_version,
+        as_of_date=_coerce_iso_date(as_of_date),
+    )
+
+
+def inject_synthesis_into_card(
+    card_entry: dict[str, Any],
+    view: SynthesisView,
+    *,
+    materialize_flat_sections: bool = False,
+    requested_as_of: date | None = None,
+    vendor_evidence: dict[str, Any] | None = None,
+) -> None:
+    """Inject synthesis sections into a battle card entry.
+
+    When synthesis is present, the synthesis wedge becomes the authoritative
+    churn angle -- it overrides the archetype label so the card tells one
+    consistent story.
+
+    If ``vendor_evidence`` is provided, evidence-engine suppression and
+    conclusion gating rules are applied to sections and injected into the card.
+    """
+    context = view.filtered_consumer_context("battle_card")
+    if materialize_flat_sections:
+        for section in _REQUIRED_SECTIONS:
+            if not view.should_suppress(section, vendor_evidence):
+                card_entry[section] = view.section(section)
+
+    contracts = context.get("reasoning_contracts") or {}
+    if contracts:
+        card_entry["reasoning_contracts"] = contracts
+        card_entry["reasoning_source"] = "b2b_reasoning_synthesis"
+    account_preview = context.get("account_reasoning_preview")
+    if isinstance(account_preview, dict) and account_preview:
+        card_entry["account_reasoning_preview"] = account_preview
+    anchors = context.get("anchor_examples")
+    if isinstance(anchors, dict) and anchors:
+        card_entry["anchor_examples"] = anchors
+    highlights = context.get("witness_highlights")
+    if isinstance(highlights, list) and highlights:
+        card_entry["witness_highlights"] = highlights
+    reference_ids = context.get("reference_ids")
+    if isinstance(reference_ids, dict) and reference_ids:
+        card_entry["reference_ids"] = reference_ids
+    scope_manifest = context.get("scope_manifest")
+    if isinstance(scope_manifest, dict) and scope_manifest:
+        card_entry["scope_manifest"] = scope_manifest
+    reasoning_atom_summary = context.get("reasoning_atom_summary")
+    if isinstance(reasoning_atom_summary, dict) and reasoning_atom_summary:
+        card_entry["reasoning_atom_summary"] = reasoning_atom_summary
+    reasoning_delta = context.get("reasoning_delta")
+    if isinstance(reasoning_delta, dict) and reasoning_delta:
+        card_entry["reasoning_delta"] = reasoning_delta
+    inject_synthesis_freshness(
+        card_entry,
+        view,
+        requested_as_of=requested_as_of,
+    )
+    contract_gaps = context.get("reasoning_contract_gaps") or []
+    if contract_gaps:
+        card_entry["reasoning_contract_gaps"] = contract_gaps
+    suppressed = context.get("_suppressed_sections") or []
+    if suppressed:
+        card_entry["suppressed_sections"] = suppressed
+
+    # Always inject meta and wedge info
+    card_entry["evidence_window"] = view.meta
+    if view.primary_wedge:
+        card_entry["synthesis_wedge"] = view.primary_wedge.value
+        card_entry["synthesis_wedge_label"] = view.wedge_label
+        # Override archetype with synthesis wedge so the card has one story.
+        # Older archetype-style labels could come from a different producer;
+        # the synthesis wedge is derived from the same pool evidence the card
+        # displays.
+        card_entry["archetype"] = view.primary_wedge.value
+        card_entry["archetype_label"] = view.wedge_label
+
+    # Flag low-confidence sections
+    flagged = [s for s in _REQUIRED_SECTIONS if view.should_flag(s, vendor_evidence)]
+    if flagged:
+        card_entry["low_confidence_sections"] = flagged
+    # Inject disclaimers for degraded sections
+    disclaimers = {}
+    context_disclaimers = context.get("reasoning_section_disclaimers")
+    if isinstance(context_disclaimers, dict):
+        disclaimers.update(
+            {
+                str(key): str(value)
+                for key, value in context_disclaimers.items()
+                if str(key).strip() and str(value).strip()
+            },
+        )
+    for s in _REQUIRED_SECTIONS:
+        disc = view.get_disclaimer(s, vendor_evidence)
+        if disc:
+            disclaimers[s] = disc
+    if disclaimers:
+        card_entry["section_disclaimers"] = disclaimers
+
+    # Inject evidence-engine conclusion results when evidence is available
+    if vendor_evidence is not None:
+        card_entry["evidence_conclusions"] = evaluate_vendor_conclusions(vendor_evidence)
+
+    # Surface temporal depth warning in card header
+    meta = view.meta
+    ew_start = meta.get("evidence_window_start")
+    ew_end = meta.get("evidence_window_end")
+    if ew_start and ew_end:
+        try:
+            from datetime import date as _date
+            start = _date.fromisoformat(str(ew_start)[:10])
+            end = _date.fromisoformat(str(ew_end)[:10])
+            window_days = (end - start).days
+            card_entry["evidence_window_days"] = window_days
+            card_entry["evidence_window_label"] = f"{window_days}-day evidence window"
+            from ._b2b_pool_compression import MIN_EVIDENCE_WINDOW_DAYS
+            if window_days < MIN_EVIDENCE_WINDOW_DAYS:
+                card_entry["evidence_window_is_thin"] = True
+                card_entry["evidence_depth_warning"] = (
+                    f"Thin evidence window: {window_days} days. "
+                    f"Confidence may improve with more data."
+                )
+            else:
+                card_entry["evidence_window_is_thin"] = False
+        except (ValueError, TypeError):
+            pass
+
+    # Attach schema version for downstream branching
+    card_entry["synthesis_schema_version"] = view.schema_version
+
+
+def evaluate_vendor_conclusions(
+    vendor_evidence: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate evidence-engine conclusion gates for a vendor.
+
+    Call this at report generation time with aggregated vendor-level evidence
+    (total_reviews, pain_distribution, displacement_edge, indicator_counts, etc.).
+
+    Returns a dict suitable for merging into the report payload:
+    {
+        "conclusions": {
+            "pricing_crisis": {"met": True, "confidence": "high"},
+            "losing_market_share": {"met": False, "fallback_label": "Emerging..."},
+            ...
+        },
+        "suppressed_sections": ["target_accounts"],
+        "degraded_sections": {"executive_summary": "Based on limited..."},
+        "confidence_tier": "high",
+    }
+    """
+    from ...reasoning.evidence_engine import get_evidence_engine
+
+    engine = get_evidence_engine()
+
+    # Evaluate all conclusion gates
+    raw_conclusions = engine.evaluate_conclusions(vendor_evidence)
+    conclusions: dict[str, dict[str, Any]] = {}
+    for c in raw_conclusions:
+        entry: dict[str, Any] = {"met": c.met, "confidence": c.confidence}
+        if c.fallback_label:
+            entry["fallback_label"] = c.fallback_label
+        if c.fallback_action:
+            entry["fallback_action"] = c.fallback_action
+        conclusions[c.conclusion_id] = entry
+
+    # Evaluate section suppressions
+    suppressed: list[str] = []
+    degraded: dict[str, str] = {}
+    for section in _EVIDENCE_SUMMARY_SECTIONS:
+        result = engine.evaluate_suppression(section, vendor_evidence)
+        if result.suppress:
+            suppressed.append(section)
+        elif result.degrade and result.disclaimer:
+            degraded[section] = result.disclaimer
+
+    # Confidence tier
+    total_reviews = int(vendor_evidence.get("total_reviews", 0))
+    confidence_tier = engine.get_confidence_tier(total_reviews)
+
+    return {
+        "conclusions": conclusions,
+        "suppressed_sections": suppressed,
+        "degraded_sections": degraded,
+        "confidence_tier": confidence_tier,
+        "confidence_label": engine.get_confidence_label(total_reviews),
+    }
+
+
+# ---------------------------------------------------------------------------
+# SynthesisView -> reasoning_lookup entry (for shared builders)
+# ---------------------------------------------------------------------------
+
+def synthesis_view_to_reasoning_entry(view: SynthesisView) -> dict[str, Any]:
+    """Convert a SynthesisView into the dict shape that shared report builders expect.
+
+    This produces the same ``{archetype, confidence, executive_summary,
+    key_signals, ...}`` structure used by shared deterministic builders, so it
+    can be dropped into the same ``reasoning_lookup[vendor]`` slot.
+    """
+    cn = view.section("causal_narrative")
+    wedge = view.primary_wedge
+
+    # Prefer validated wedge, fall back to raw primary_wedge string
+    archetype = wedge.value if wedge else cn.get("primary_wedge", "")
+
+    confidence_str = view.confidence("causal_narrative")
+    confidence_num = view.confidence_score("causal_narrative")
+    if confidence_num is None:
+        confidence_num = _confidence_label_to_numeric(confidence_str)
+
+    # Build summary from available fields -- v2.3 uses trigger/why_now/causal_chain
+    executive_summary = cn.get("summary") or cn.get("executive_summary") or ""
+    if not executive_summary:
+        parts = [cn.get("trigger", ""), cn.get("why_now", "")]
+        chain = cn.get("causal_chain", "")
+        if chain:
+            parts.append(chain)
+        executive_summary = ". ".join(p for p in parts if p)
+
+    key_signals = cn.get("key_signals") or []
+    if not isinstance(key_signals, list):
+        key_signals = []
+    if not key_signals:
+        for field in ("trigger", "who_most_affected", "why_now"):
+            val = cn.get(field, "")
+            if val:
+                key_signals.append(val)
+
+    falsification = [
+        fc.get("condition", fc) if isinstance(fc, dict) else str(fc)
+        for fc in view.falsification_conditions()
+    ]
+
+    uncertainty = cn.get("data_gaps") or []
+    if not isinstance(uncertainty, list):
+        uncertainty = []
+
+    # risk_level from confidence
+    risk_level = "high" if confidence_str in ("high", "medium") else "low"
+
+    return {
+        "archetype": archetype,
+        "confidence": confidence_num,
+        "mode": "synthesis",
+        "risk_level": risk_level,
+        "executive_summary": executive_summary,
+        "key_signals": key_signals,
+        "falsification_conditions": falsification,
+        "uncertainty_sources": uncertainty,
+    }
+
+
+def build_reasoning_lookup_from_views(
+    synthesis_views: dict[str, SynthesisView],
+) -> dict[str, dict[str, Any]]:
+    """Build a reasoning_lookup dict from synthesis views.
+
+    Returns ``{vendor_name: reasoning_entry}`` in the shared deterministic
+    builder shape, while staying synthesis-only.
+    """
+    lookup: dict[str, dict[str, Any]] = {}
+    for vendor_name, view in synthesis_views.items():
+        lookup[vendor_name] = synthesis_view_to_reasoning_entry(view)
+    return lookup
+
+
+# ---------------------------------------------------------------------------
+# Shared DB loader: synthesis only
+# ---------------------------------------------------------------------------
+
+
+def _confidence_label_to_numeric(confidence_label: str) -> float:
+    return {
+        "high": 0.85,
+        "medium": 0.55,
+        "low": 0.25,
+        "insufficient": 0.0,
+    }.get(str(confidence_label or "").strip().lower(), 0.0)
+
+
+async def load_best_reasoning_view(
+    pool,
+    vendor_name: str,
+    *,
+    as_of: date | None = None,
+    analysis_window_days: int = 30,
+) -> SynthesisView | None:
+    """Load the best available synthesis reasoning for a vendor."""
+    # --- Try synthesis first -----------------------------------------------
+    if as_of is not None:
+        synth_row = await pool.fetchrow(
+            """
+            SELECT vendor_name, as_of_date, schema_version, synthesis
+            FROM b2b_reasoning_synthesis
+            WHERE LOWER(vendor_name) = LOWER($1)
+              AND as_of_date <= $2
+              AND analysis_window_days = $3
+            ORDER BY as_of_date DESC, created_at DESC
+            LIMIT 1
+            """,
+            vendor_name,
+            as_of,
+            analysis_window_days,
+        )
+    else:
+        synth_row = await pool.fetchrow(
+            """
+            SELECT vendor_name, as_of_date, schema_version, synthesis
+            FROM b2b_reasoning_synthesis
+            WHERE LOWER(vendor_name) = LOWER($1)
+              AND analysis_window_days = $2
+            ORDER BY as_of_date DESC, created_at DESC
+            LIMIT 1
+            """,
+            vendor_name,
+            analysis_window_days,
+        )
+
+    if synth_row:
+        raw = _coerce_json_dict(synth_row["synthesis"])
+        if raw:
+            if not raw.get("packet_artifacts") or not raw.get("reference_ids"):
+                packet_payload = await _load_packet_payload_for_vendor(
+                    pool,
+                    vendor_name=synth_row["vendor_name"],
+                    as_of_date=synth_row["as_of_date"],
+                    analysis_window_days=analysis_window_days,
+                )
+                if packet_payload:
+                    raw = _merge_packet_fallback(raw, packet_payload)
+            return load_synthesis_view(
+                raw,
+                vendor_name=synth_row["vendor_name"],
+                schema_version=str(synth_row.get("schema_version") or ""),
+                as_of_date=synth_row["as_of_date"],
+            )
+    return None
+
+
+async def discover_reasoning_vendor_names(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int = 90,
+) -> list[str]:
+    """Return vendor names with synthesis rows."""
+    synth_names = await pool.fetch(
+        "SELECT DISTINCT vendor_name FROM b2b_reasoning_synthesis "
+        "WHERE as_of_date <= $1 AND analysis_window_days = $2",
+        as_of, analysis_window_days,
+    )
+    return list({
+        r["vendor_name"] for r in synth_names
+        if r.get("vendor_name")
+    })
+
+
+async def load_best_reasoning_views(
+    pool,
+    vendor_names: list[str],
+    *,
+    as_of: date | None = None,
+    analysis_window_days: int = 30,
+) -> dict[str, SynthesisView]:
+    """Batch-load best reasoning for multiple vendors.
+
+    Returns a dict of vendor_name -> SynthesisView for each vendor that
+    has reasoning available.  Uses two bulk queries instead of N+1.
+    """
+    views: dict[str, SynthesisView] = {}
+    if not vendor_names:
+        return views
+
+    lower_names = [v.lower() for v in vendor_names]
+
+    # --- Bulk synthesis query ----------------------------------------------
+    if as_of is not None:
+        synth_rows = await pool.fetch(
+            """
+            SELECT DISTINCT ON (LOWER(vendor_name))
+                   vendor_name, as_of_date, schema_version, synthesis
+            FROM b2b_reasoning_synthesis
+            WHERE LOWER(vendor_name) = ANY($1)
+              AND as_of_date <= $2
+              AND analysis_window_days = $3
+            ORDER BY LOWER(vendor_name), as_of_date DESC, created_at DESC
+            """,
+            lower_names,
+            as_of,
+            analysis_window_days,
+        )
+    else:
+        synth_rows = await pool.fetch(
+            """
+            SELECT DISTINCT ON (LOWER(vendor_name))
+                   vendor_name, as_of_date, schema_version, synthesis
+            FROM b2b_reasoning_synthesis
+            WHERE LOWER(vendor_name) = ANY($1)
+              AND analysis_window_days = $2
+            ORDER BY LOWER(vendor_name), as_of_date DESC, created_at DESC
+            """,
+            lower_names,
+            analysis_window_days,
+        )
+
+    covered: set[str] = set()
+    for row in synth_rows:
+        raw = _coerce_json_dict(row.get("synthesis"))
+        if not raw:
+            continue
+        vname = row.get("vendor_name")
+        if not vname:
+            continue
+        if not raw.get("packet_artifacts") or not raw.get("reference_ids"):
+            packet_payload = await _load_packet_payload_for_vendor(
+                pool,
+                vendor_name=vname,
+                as_of_date=row["as_of_date"],
+                analysis_window_days=analysis_window_days,
+            )
+            if packet_payload:
+                raw = _merge_packet_fallback(raw, packet_payload)
+        views[vname] = load_synthesis_view(
+            raw,
+            vendor_name=vname,
+            schema_version=str(row.get("schema_version") or ""),
+            as_of_date=row["as_of_date"],
+        )
+        covered.add(vname.lower())
+    return views
+
+
+async def load_prior_reasoning_snapshots(
+    pool,
+    vendor_names: list[str],
+    *,
+    before_date: date | None = None,
+    analysis_window_days: int = 30,
+) -> dict[str, dict[str, Any]]:
+    """Load the most recent prior reasoning snapshot before a cutoff date."""
+    snapshots: dict[str, dict[str, Any]] = {}
+    if not vendor_names:
+        return snapshots
+
+    cutoff = before_date or date.today()
+    requested_by_lower: dict[str, str] = {}
+    lower_names: list[str] = []
+    for vendor_name in vendor_names:
+        raw_name = str(vendor_name or "").strip()
+        if not raw_name:
+            continue
+        lowered = raw_name.lower()
+        if lowered in requested_by_lower:
+            continue
+        requested_by_lower[lowered] = raw_name
+        lower_names.append(lowered)
+    if not lower_names:
+        return snapshots
+
+    synth_rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (LOWER(vendor_name))
+               vendor_name, as_of_date, schema_version, synthesis
+        FROM b2b_reasoning_synthesis
+        WHERE LOWER(vendor_name) = ANY($1)
+          AND as_of_date < $2
+          AND analysis_window_days = $3
+        ORDER BY LOWER(vendor_name), as_of_date DESC, created_at DESC
+        """,
+        lower_names,
+        cutoff,
+        analysis_window_days,
+    )
+    for row in synth_rows:
+        lowered = str(row.get("vendor_name") or "").strip().lower()
+        requested_name = requested_by_lower.get(lowered)
+        if not requested_name:
+            continue
+        raw = _coerce_json_dict(row["synthesis"])
+        if not raw:
+            continue
+        if not raw.get("packet_artifacts") or not raw.get("reference_ids"):
+            packet_payload = await _load_packet_payload_for_vendor(
+                pool,
+                vendor_name=row["vendor_name"],
+                as_of_date=row["as_of_date"],
+                analysis_window_days=analysis_window_days,
+            )
+            if packet_payload:
+                raw = _merge_packet_fallback(raw, packet_payload)
+        view = load_synthesis_view(
+            raw,
+            vendor_name=row["vendor_name"],
+            schema_version=str(row.get("schema_version") or ""),
+            as_of_date=row["as_of_date"],
+        )
+        snapshots[requested_name] = {
+            "archetype": view.primary_wedge.value if view.primary_wedge else "",
+            "confidence": (
+                view.confidence_score("causal_narrative")
+                if view.confidence_score("causal_narrative") is not None
+                else _confidence_label_to_numeric(view.confidence("causal_narrative"))
+            ),
+            "snapshot_date": view.as_of_date_iso,
+        }
+
+    return snapshots

--- a/extracted_content_pipeline/autonomous/tasks/_blog_deploy.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_deploy.py
@@ -1,0 +1,122 @@
+"""Auto-deploy blog posts: git commit + push + Vercel deploy hook."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+async def auto_deploy_blog(
+    ui_path: str,
+    slug: str,
+    *,
+    enabled: bool = False,
+    branch: str = "dev",
+    hook_url: str = "",
+) -> dict[str, str | bool | int]:
+    """Git-add the blog .ts files, commit, push, and fire deploy hook.
+
+    Parameters are explicit so callers pass the correct config
+    (consumer ExternalDataConfig or B2BChurnConfig).
+
+    Returns a status dict. Never raises -- all steps are wrapped in try/except.
+    """
+    result: dict[str, str | bool | int] = {"deployed": False}
+
+    if not enabled:
+        result["skipped"] = "auto_deploy disabled"
+        return result
+
+    # Resolve repo root (walk up from ui_path to find .git/)
+    repo_root = _find_repo_root(ui_path)
+    if not repo_root:
+        result["error"] = f"No .git/ found above {ui_path}"
+        logger.warning(result["error"])
+        return result
+
+    blog_dir = Path(ui_path)
+    ts_file = blog_dir / f"{slug}.ts"
+    index_file = blog_dir / "index.ts"
+
+    # Stage only the specific blog files
+    files_to_add = [str(f) for f in (ts_file, index_file) if f.exists()]
+    if not files_to_add:
+        result["skipped"] = "no files to stage"
+        return result
+
+    try:
+        subprocess.run(
+            ["git", "add"] + files_to_add,
+            cwd=str(repo_root), check=True, capture_output=True, timeout=30,
+        )
+    except Exception as exc:
+        result["error"] = f"git add failed: {exc}"
+        logger.warning(result["error"])
+        return result
+
+    # Check if there are staged changes
+    try:
+        cp = subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=str(repo_root), capture_output=True, timeout=10,
+        )
+        if cp.returncode == 0:
+            result["skipped"] = "no staged changes"
+            return result
+    except Exception as exc:
+        result["error"] = f"git diff check failed: {exc}"
+        logger.warning(result["error"])
+        return result
+
+    # Commit
+    try:
+        subprocess.run(
+            ["git", "commit", "-m", f"blog: auto-publish {slug}"],
+            cwd=str(repo_root), check=True, capture_output=True, timeout=30,
+        )
+    except Exception as exc:
+        result["error"] = f"git commit failed: {exc}"
+        logger.warning(result["error"])
+        return result
+
+    # Push current HEAD to the target branch (works even if local branch != target)
+    try:
+        subprocess.run(
+            ["git", "push", "origin", f"HEAD:{branch}"],
+            cwd=str(repo_root), check=True, capture_output=True, timeout=60,
+        )
+        result["pushed"] = True
+    except Exception as exc:
+        result["push_error"] = f"git push failed: {exc}"
+        logger.warning(result["push_error"])
+        # Continue -- deploy hook can still trigger a build from latest remote
+
+    # Fire Vercel deploy hook regardless of push outcome.
+    # Vercel may block git-triggered builds (unverified commits) but the
+    # hook always works and rebuilds from whatever is on the branch.
+    if hook_url:
+        try:
+            import httpx
+
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.post(hook_url)
+                result["hook_status"] = resp.status_code
+        except Exception as exc:
+            result["hook_error"] = str(exc)
+            logger.warning("Deploy hook failed: %s", exc)
+
+    result["deployed"] = bool(result.get("pushed") or result.get("hook_status"))
+    logger.info("Auto-deployed blog post: %s (deployed=%s)", slug, result["deployed"])
+    return result
+
+
+def _find_repo_root(start_path: str) -> Path | None:
+    """Walk up from start_path to find a directory containing .git/."""
+    p = Path(start_path).resolve()
+    for parent in [p] + list(p.parents):
+        if (parent / ".git").exists():
+            return parent
+    return None

--- a/extracted_content_pipeline/autonomous/tasks/_blog_matching.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_matching.py
@@ -1,0 +1,307 @@
+"""
+Shared blog post matching for campaign pipelines.
+
+Fetches published blog posts relevant to a vendor/category/brand,
+returning full URLs for injection into campaign selling context.
+
+Pipeline isolation ensures B2B and consumer blog posts never cross-match.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger("atlas.autonomous.tasks._blog_matching")
+
+# B2B blog topic types (b2b_blog_post_generation.py)
+_B2B_TOPIC_TYPES = (
+    "vendor_alternative",
+    "vendor_showdown",
+    "churn_report",
+    "migration_guide",
+    "vendor_deep_dive",
+    "market_landscape",
+    "pricing_reality_check",
+    "switching_story",
+    "pain_point_roundup",
+    "best_fit_guide",
+)
+
+# Consumer blog topic types (blog_post_generation.py)
+_CONSUMER_TOPIC_TYPES = (
+    "brand_showdown",
+    "complaint_roundup",
+    "migration_report",
+    "safety_spotlight",
+)
+
+_PIPELINE_TOPIC_TYPES = {
+    "b2b": _B2B_TOPIC_TYPES,
+    "consumer": _CONSUMER_TOPIC_TYPES,
+}
+
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+# Maps role keyword fragments → {topic_type: score_boost}.
+# Higher boost = stronger preference for that topic type for this role.
+_ROLE_TOPIC_BOOSTS: list[tuple[tuple[str, ...], dict[str, int]]] = [
+    # Finance, procurement, budget holders → pricing content resonates most
+    (("cfo", "finance", "controller", "procurement", "budget", "treasurer", "accounting"),
+     {"pricing_reality_check": 3, "churn_report": 1}),
+    # Technical buyers → migration feasibility is the key concern
+    (("cto", "engineer", "developer", "architect", "devops", "platform", "infrastructure", "technical"),
+     {"migration_guide": 3, "vendor_deep_dive": 1}),
+    # Operations/IT leadership → churn and market context
+    (("operations", "coo", "director of ops", "it director", "it manager"),
+     {"churn_report": 2, "market_landscape": 1}),
+    # Product/marketing → market landscape and best-fit content
+    (("cmo", "marketing", "product", "growth", "demand gen"),
+     {"market_landscape": 2, "best_fit_guide": 2}),
+    # Sales/BD → competitive comparison assets
+    (("sales", "business development", "bd", "revenue", "account executive", "ae"),
+     {"vendor_showdown": 2, "vendor_alternative": 2}),
+    # C-suite generalists → deep dives and landscape
+    (("ceo", "president", "founder", "owner", "vp", "vice president", "svp", "evp"),
+     {"vendor_deep_dive": 2, "market_landscape": 2}),
+]
+
+
+def _role_topic_boosts(contact_role: str | None) -> dict[str, int]:
+    """Return ``{topic_type: boost}`` for a contact role string."""
+    if not contact_role:
+        return {}
+    role_lower = contact_role.lower()
+    boosts: dict[str, int] = {}
+    for keywords, topic_boosts in _ROLE_TOPIC_BOOSTS:
+        if any(kw in role_lower for kw in keywords):
+            for topic, pts in topic_boosts.items():
+                boosts[topic] = max(boosts.get(topic, 0), pts)
+    return boosts
+
+
+def _tokenize_text(value: str) -> list[str]:
+    return _WORD_RE.findall((value or "").lower())
+
+
+def _contains_term_as_tokens(text: str, term: str) -> bool:
+    """Token-aware contains check to avoid substring false positives."""
+    hay = _tokenize_text(text)
+    needle = _tokenize_text(term)
+    if not hay or not needle:
+        return False
+    if len(needle) == 1:
+        return needle[0] in hay
+    for idx in range(0, len(hay) - len(needle) + 1):
+        if hay[idx:idx + len(needle)] == needle:
+            return True
+    return False
+
+
+def _normalized_post_dedupe_key(
+    row: dict[str, Any],
+    data_context: dict[str, Any],
+    topic_ctx: dict[str, Any],
+) -> str:
+    """Build a stable dedupe key so draft/published variants do not both surface."""
+    topic_type = str(row.get("topic_type") or "").lower()
+    if topic_type == "vendor_showdown":
+        vendor_a = str(topic_ctx.get("vendor_a") or data_context.get("vendor_a") or "").strip().lower()
+        vendor_b = str(topic_ctx.get("vendor_b") or data_context.get("vendor_b") or "").strip().lower()
+        if vendor_a and vendor_b:
+            ordered = "::".join(sorted((vendor_a, vendor_b)))
+            return f"{topic_type}:{ordered}"
+    slug = str(row.get("slug") or "").strip().lower()
+    slug = re.sub(r"-draft$", "", slug)
+    if slug:
+        return f"{topic_type}:{slug}"
+    return f"{topic_type}:{str(row.get('title') or '').strip().lower()}"
+
+
+async def fetch_relevant_blog_posts(
+    pool,
+    *,
+    pipeline: str,
+    vendor_name: str | None = None,
+    category: str | None = None,
+    brand_names: list[str] | None = None,
+    pain_categories: list[str] | None = None,
+    alternative_vendors: list[str] | None = None,
+    contact_role: str | None = None,
+    include_drafts: bool = False,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    """Fetch published blog posts relevant to a campaign target.
+
+    Args:
+        pool: asyncpg connection pool.
+        pipeline: ``"b2b"`` or ``"consumer"`` -- restricts to that pipeline's
+            topic types so B2B posts never appear in consumer emails and vice
+            versa.
+        vendor_name: Vendor/company name to match in title/slug.
+        category: Product category to match in ``tags->>0``.
+        brand_names: Additional brand names to match in title/slug.
+        pain_categories: Pain categories to match in data_context JSONB
+            (e.g. ``["pricing", "support"]``).  Highest-weight signal.
+        alternative_vendors: Alternative vendor names the target is
+            evaluating.  Matches against ``data_context.vendor_b`` in
+            showdown posts.
+        contact_role: Contact's job title/role.  Boosts topic types that
+            resonate with the buyer persona (e.g. CFO → pricing_reality_check).
+        include_drafts: When true, allow ``draft`` posts as a fallback when
+            no published matches exist.
+        limit: Max posts to return (default 3).
+
+    Returns:
+        List of ``{title, url, topic_type}`` sorted by relevance then recency.
+        Empty list on no matches or errors -- campaigns proceed without links.
+    """
+    topic_types = _PIPELINE_TOPIC_TYPES.get(pipeline)
+    if not topic_types:
+        logger.warning("Unknown pipeline %r, returning empty blog list", pipeline)
+        return []
+
+    # Resolve base URL from config
+    from ...config import settings
+
+    if pipeline == "b2b":
+        base_url = settings.b2b_churn.blog_base_url.rstrip("/")
+    else:
+        base_url = settings.external_data.blog_base_url.rstrip("/")
+
+    # Build search terms for name matching
+    search_terms: list[str] = []
+    if vendor_name:
+        search_terms.append(vendor_name.lower())
+    if brand_names:
+        search_terms.extend(b.lower() for b in brand_names if b)
+
+    try:
+        statuses = ["published", "draft"] if include_drafts else ["published"]
+        rows = await pool.fetch(
+            """
+            SELECT title, slug, topic_type, tags, data_context, status
+            FROM blog_posts
+            WHERE status = ANY($2::text[])
+              AND topic_type = ANY($1::text[])
+            ORDER BY COALESCE(published_at, created_at) DESC
+            LIMIT 50
+            """,
+            list(topic_types),
+            statuses,
+        )
+    except Exception:
+        logger.exception("Failed to fetch blog posts for matching")
+        return []
+
+    if not rows:
+        return []
+
+    # Prepare matching inputs
+    cat_lower = (category or "").lower()
+    pain_lower = [p.lower() for p in (pain_categories or []) if p]
+    alt_lower = [a.lower() for a in (alternative_vendors or []) if a]
+    role_boosts = _role_topic_boosts(contact_role)
+
+    # Score each post
+    allowed_statuses = set(statuses)
+    scored_rows: list[tuple[int, int, int, str, dict[str, Any]]] = []
+
+    for idx, row in enumerate(rows):
+        score = 0
+        slug = (row["slug"] or "").lower()
+        title = (row["title"] or "").lower()
+        status = str(row.get("status") or "published").lower()
+        if status not in allowed_statuses:
+            continue
+        tags = row["tags"] or []
+        if isinstance(tags, list):
+            tags_text = " ".join(str(tag).lower() for tag in tags if tag)
+        else:
+            tags_text = str(tags).lower()
+
+        # Parse data_context for deep matching
+        dc = row.get("data_context")
+        if isinstance(dc, str):
+            try:
+                dc = json.loads(dc)
+            except Exception:
+                dc = {}
+        if not isinstance(dc, dict):
+            dc = {}
+        tc = dc.get("topic_ctx") if isinstance(dc.get("topic_ctx"), dict) else {}
+
+        # Category match across tags, slug, and title (+2)
+        if cat_lower and (cat_lower in tags_text or cat_lower in slug or cat_lower in title):
+            score += 2
+
+        # Name match: vendor or brand name appears in tags, slug, or title (+3)
+        for term in search_terms:
+            if term in tags_text or term in slug or term in title:
+                score += 3
+                break  # one name match is enough
+
+        # Pain category match: post covers the same pain the campaign targets.
+        # Check topic_type, tags, title, slug, and pain-specific data_context
+        # fields -- NOT the entire data_context blob (avoids false positives
+        # from vendor names or categories containing pain keywords).
+        # Scoring: +4 first matched pain, +2 second, +1 each additional --
+        # rewards breadth while keeping top-priority pain as the dominant signal.
+        if pain_lower:
+            pain_haystack_parts = [title, slug, tags_text]
+            # Extract pain-specific fields from data_context
+            for pain_key in ("pain_distribution", "pain_breakdown",
+                             "pain_categories", "top_pain"):
+                pv = dc.get(pain_key) or tc.get(pain_key)
+                if pv is not None:
+                    pain_haystack_parts.append(str(pv).lower())
+            # topic_type itself is a pain signal (pricing_reality_check)
+            pain_haystack_parts.append(row["topic_type"] or "")
+            pain_haystack = " ".join(pain_haystack_parts)
+            pain_match_count = 0
+            for pain in pain_lower:
+                if len(pain) >= 3 and pain in pain_haystack:
+                    score += 4 if pain_match_count == 0 else (2 if pain_match_count == 1 else 1)
+                    pain_match_count += 1
+
+        # Alternative vendor match: post compares with the vendor being evaluated (+5)
+        if alt_lower:
+            # Check vendor_b in data_context (showdown posts store the second vendor here)
+            vendor_b = str(tc.get("vendor_b") or dc.get("vendor_b") or "").lower()
+            alt_haystack = " ".join(filter(None, [title, slug, tags_text]))
+            for alt in alt_lower:
+                if len(alt) < 3:
+                    continue  # skip very short names to avoid substring false positives
+                if alt == vendor_b or _contains_term_as_tokens(alt_haystack, alt):
+                    score += 5
+                    break
+
+        # Role-based topic boost: e.g. CFO contact → pricing_reality_check +3
+        if role_boosts:
+            topic_type = str(row.get("topic_type") or "").lower()
+            score += role_boosts.get(topic_type, 0)
+
+        if score > 0:
+            status_rank = 1 if status == "published" else 0
+            dedupe_key = _normalized_post_dedupe_key(row, dc, tc)
+            scored_rows.append((score, status_rank, -idx, dedupe_key, {
+                "title": row["title"],
+                "url": f"{base_url}/blog/{row['slug']}",
+                "topic_type": row["topic_type"],
+            }))
+
+    # Sort by relevance first, then prefer published over draft, then recency.
+    scored_rows.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
+    results: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for _, _, _, dedupe_key, item in scored_rows:
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        results.append(item)
+        if len(results) >= limit:
+            break
+    return results

--- a/extracted_content_pipeline/autonomous/tasks/_blog_ts.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_ts.py
@@ -1,0 +1,193 @@
+"""Shared helpers for writing blog .ts files and updating index.ts."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+import markdown as _md
+
+_md_converter = _md.Markdown(extensions=["tables", "fenced_code", "toc"])
+
+logger = logging.getLogger(__name__)
+
+
+def escape_js_single(text: str) -> str:
+    """Escape a string for use inside JS single quotes."""
+    return (
+        text
+        .replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def escape_template_literal(text: str) -> str:
+    """Escape a string for use inside JS template literals (backtick strings)."""
+    return (
+        text
+        .replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("${", "\\${")
+    )
+
+
+def slug_to_var_name(slug: str) -> str:
+    """Convert a blog slug to a valid camelCase JS variable name.
+
+    Examples:
+        'my-blog-post'       -> 'myBlogPost'
+        '2026-report'        -> 'post2026Report'
+        'vendor.comparison'  -> 'vendorComparison'
+    """
+    var_name = re.sub(r"[^a-zA-Z0-9]", "_", slug).strip("_")
+    parts = var_name.split("_")
+    var_name = parts[0] + "".join(p.capitalize() for p in parts[1:])
+    # JS identifiers cannot start with a digit
+    if var_name and var_name[0].isdigit():
+        var_name = "post" + var_name[0].upper() + var_name[1:]
+    return var_name
+
+
+def update_blog_index(index_path: Path, slug: str, var_name: str) -> bool:
+    """Add an import and POSTS entry to the blog index.ts file.
+
+    Returns True if the index was updated, False if skipped (already present
+    or file not found).
+    """
+    if not index_path.exists():
+        logger.warning("index.ts not found: %s", index_path)
+        return False
+
+    index_text = index_path.read_text(encoding="utf-8")
+
+    # Dynamic glob discovery -- posts are auto-discovered by filename pattern,
+    # so no static import or array entry is needed.
+    if "import.meta.glob" in index_text:
+        logger.debug("index.ts uses dynamic glob; skipping static registration for %s", slug)
+        return False
+
+    import_line = f"import {var_name} from './{slug}'"
+
+    # Already registered
+    if slug in index_text:
+        logger.debug("Post %s already in index.ts, skipping", slug)
+        return False
+
+    # Insert import after last existing import statement
+    lines = index_text.split("\n")
+    last_import_idx = -1
+    for i, line in enumerate(lines):
+        if line.startswith("import "):
+            last_import_idx = i
+
+    if last_import_idx >= 0:
+        lines.insert(last_import_idx + 1, import_line)
+    else:
+        lines.insert(0, import_line)
+
+    # Insert into POSTS array -- handle both `].sort(` and plain `]` endings
+    new_text = "\n".join(lines)
+    if re.search(r"].sort\(", new_text):
+        new_text = re.sub(
+            r"(].sort\()",
+            f"  {var_name},\n\\1",
+            new_text,
+            count=1,
+        )
+    else:
+        # Plain array ending: `]\n` or `]\n\n` at end of POSTS
+        new_text = re.sub(
+            r"(?m)^(\])\s*$",
+            f"  {var_name},\n\\1",
+            new_text,
+            count=1,
+        )
+
+    index_path.write_text(new_text, encoding="utf-8")
+    logger.info("Updated index.ts with %s", slug)
+    return True
+
+
+def build_post_ts(
+    slug: str,
+    title: str,
+    description: str,
+    date_str: str,
+    author: str,
+    tags: list[str],
+    topic_type: str,
+    charts_json: list[dict],
+    content: str,
+    data_context: dict | None = None,
+    seo_title: str = "",
+    seo_description: str = "",
+    target_keyword: str = "",
+    secondary_keywords: list[str] | None = None,
+    faq: list[dict] | None = None,
+    related_slugs: list[str] | None = None,
+    cta: dict | None = None,
+) -> tuple[str, str]:
+    """Build a complete .ts file for a blog post.
+
+    Returns (var_name, ts_content).
+    """
+    var_name = slug_to_var_name(slug)
+    charts_str = json.dumps(charts_json, indent=2, default=str)
+    # Render markdown to HTML at deploy time so the frontend never parses markdown
+    _md_converter.reset()
+    html_content = _md_converter.convert(content)
+    escaped_content = escape_template_literal(html_content)
+    escaped_title = escape_js_single(title)
+    escaped_desc = escape_js_single(description)
+
+    # Only include affiliate-relevant fields in data_context to keep .ts files lean
+    dc_output = {}
+    if data_context:
+        if data_context.get("affiliate_url"):
+            dc_output["affiliate_url"] = data_context["affiliate_url"]
+        if data_context.get("affiliate_partner"):
+            dc_output["affiliate_partner"] = data_context["affiliate_partner"]
+        if data_context.get("booking_url"):
+            dc_output["booking_url"] = data_context["booking_url"]
+    dc_str = json.dumps(dc_output, indent=2, default=str)
+
+    # Build optional SEO fields
+    seo_lines = ""
+    if seo_title:
+        seo_lines += f"  seo_title: '{escape_js_single(seo_title)}',\n"
+    if seo_description:
+        seo_lines += f"  seo_description: '{escape_js_single(seo_description)}',\n"
+    if target_keyword:
+        seo_lines += f"  target_keyword: '{escape_js_single(target_keyword)}',\n"
+    if secondary_keywords:
+        seo_lines += f"  secondary_keywords: {json.dumps(secondary_keywords)},\n"
+    if faq:
+        faq_str = json.dumps(faq, indent=2, default=str)
+        seo_lines += f"  faq: {faq_str},\n"
+    if related_slugs:
+        seo_lines += f"  related_slugs: {json.dumps(related_slugs)},\n"
+    if cta:
+        seo_lines += f"  cta: {json.dumps(cta, indent=2, default=str)},\n"
+
+    ts_content = f"""import type {{ BlogPost }} from './index'
+
+const post: BlogPost = {{
+  slug: '{slug}',
+  title: '{escaped_title}',
+  description: '{escaped_desc}',
+  date: '{date_str}',
+  author: '{escape_js_single(author)}',
+  tags: {json.dumps(tags)},
+  topic_type: '{topic_type}',
+  charts: {charts_str},
+  data_context: {dc_str},
+{seo_lines}  content: `{escaped_content}`,
+}}
+
+export default post
+"""
+    return var_name, ts_content

--- a/extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py
+++ b/extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py
@@ -1,0 +1,421 @@
+"""Shared compaction helpers for campaign sequence storage and prompt assembly."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from typing import Any
+
+from ...config import settings
+
+_STORAGE_DROP_COMPANY_CONTEXT_KEYS = frozenset({
+    "selling",
+    "comparison_asset",
+    "reasoning_contracts",
+    "qualification",
+    "partner",
+    "primary_blog_post",
+    "supporting_blog_posts",
+})
+_PROMPT_ONLY_DROP_COMPANY_CONTEXT_KEYS = frozenset({
+    "reasoning_anchor_examples",
+    "reasoning_witness_highlights",
+    "reasoning_reference_ids",
+})
+_SKIP = object()
+
+
+def prompt_max_tokens() -> int:
+    return int(settings.campaign_sequence.prompt_max_tokens)
+
+
+def prompt_email_body_preview_chars() -> int:
+    return int(settings.campaign_sequence.prompt_email_body_preview_chars)
+
+
+def _prompt_list_limit() -> int:
+    return int(settings.campaign_sequence.prompt_list_limit)
+
+
+def _prompt_quote_limit() -> int:
+    return int(settings.campaign_sequence.prompt_quote_limit)
+
+
+def _prompt_blog_post_limit() -> int:
+    return int(settings.campaign_sequence.prompt_blog_post_limit)
+
+
+def _has_context_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict, tuple, set)):
+        return bool(value)
+    return True
+
+
+def _parse_context_blob(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _compact_scalar_list(items: Any, *, max_items: int) -> list[str]:
+    compact: list[str] = []
+    for item in items or []:
+        if not isinstance(item, str):
+            continue
+        text = item.strip()
+        if text:
+            compact.append(text)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_object_list(items: Any, *, max_items: int) -> list[dict[str, Any]]:
+    compact: list[dict[str, Any]] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            key: value
+            for key, value in item.items()
+            if isinstance(value, (str, int, float, bool)) and _has_context_value(value)
+        }
+        if entry:
+            compact.append(entry)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_named_rows(
+    items: Any,
+    *,
+    keys: tuple[str, ...],
+    max_items: int,
+) -> list[dict[str, Any]]:
+    compact: list[dict[str, Any]] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        entry = {key: item[key] for key in keys if _has_context_value(item.get(key))}
+        if entry:
+            compact.append(entry)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_scalar_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: item
+        for key, item in value.items()
+        if isinstance(item, (str, int, float, bool)) and _has_context_value(item)
+    }
+
+
+def _compact_blog_posts(posts: Any) -> list[dict[str, str]]:
+    compact: list[dict[str, str]] = []
+    for post in posts or []:
+        if not isinstance(post, dict):
+            continue
+        entry = {
+            key: str(post.get(key) or "").strip()
+            for key in ("title", "url", "topic_type")
+            if str(post.get(key) or "").strip()
+        }
+        if entry:
+            compact.append(entry)
+        if len(compact) >= _prompt_blog_post_limit():
+            break
+    return compact
+
+
+def _compact_briefing_context(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for key, item in value.items():
+        if isinstance(item, (str, int, float, bool)) and _has_context_value(item):
+            compact[key] = item
+        elif isinstance(item, list):
+            compact_list = _compact_scalar_list(item, max_items=_prompt_list_limit())
+            if compact_list:
+                compact[key] = compact_list
+    return compact
+
+
+def _compact_reasoning_context(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for key in ("wedge", "confidence", "summary", "account_summary"):
+        item = value.get(key)
+        if _has_context_value(item):
+            compact[key] = item
+
+    key_signals = _compact_scalar_list(
+        value.get("key_signals"),
+        max_items=_prompt_quote_limit(),
+    )
+    if key_signals:
+        compact["key_signals"] = key_signals
+
+    why_they_stay = value.get("why_they_stay")
+    if isinstance(why_they_stay, dict):
+        summary = str(why_they_stay.get("summary") or "").strip()
+        if summary:
+            compact["why_they_stay"] = {"summary": summary}
+
+    timing = value.get("timing")
+    if isinstance(timing, dict):
+        timing_compact = {
+            key: timing[key]
+            for key in ("best_window", "trigger_count")
+            if _has_context_value(timing.get(key))
+        }
+        if timing_compact:
+            compact["timing"] = timing_compact
+
+    switch_triggers = _compact_object_list(
+        value.get("switch_triggers"),
+        max_items=_prompt_quote_limit(),
+    )
+    if switch_triggers:
+        compact["switch_triggers"] = switch_triggers
+
+    return compact
+
+
+def _compact_signal_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    row_keys = {
+        "pain_distribution": ("category", "count"),
+        "competitor_distribution": ("name", "count"),
+        "role_distribution": ("role", "count"),
+        "pain_driving_switch": ("category", "count"),
+        "incumbents_losing": ("name", "count"),
+    }
+    scalar_lists = {"feature_gaps", "feature_mentions"}
+
+    for key, item in value.items():
+        if key in row_keys:
+            rows = _compact_named_rows(
+                item,
+                keys=row_keys[key],
+                max_items=_prompt_list_limit(),
+            )
+            if rows:
+                compact[key] = rows
+        elif key in scalar_lists:
+            rows = _compact_scalar_list(item, max_items=_prompt_list_limit())
+            if rows:
+                compact[key] = rows
+        elif isinstance(item, dict):
+            nested = _compact_scalar_mapping(item)
+            if nested:
+                compact[key] = nested
+        elif _has_context_value(item):
+            compact[key] = item
+
+    return compact
+
+
+def _compact_incumbent_reasoning(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for vendor_name, item in value.items():
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            key: item[key]
+            for key in ("wedge", "summary", "why_they_stay")
+            if _has_context_value(item.get(key))
+        }
+        switch_triggers = _compact_scalar_list(
+            item.get("switch_triggers"),
+            max_items=_prompt_quote_limit(),
+        )
+        if switch_triggers:
+            entry["switch_triggers"] = switch_triggers
+        if entry:
+            compact[str(vendor_name)] = entry
+        if len(compact) >= _prompt_list_limit():
+            break
+    return compact
+
+
+def _compact_incumbent_archetypes(value: Any) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, list[str]] = {}
+    for group, items in value.items():
+        compact_items = _compact_scalar_list(items, max_items=_prompt_quote_limit())
+        if compact_items:
+            compact[str(group)] = compact_items
+    return compact
+
+
+def _compact_category_intelligence(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    stats = _compact_scalar_mapping(value.get("category_stats"))
+    if stats:
+        compact["category_stats"] = stats
+
+    for key in (
+        "top_pain_points",
+        "feature_gaps",
+        "competitive_flows",
+        "brand_health",
+        "safety_signals",
+        "top_root_causes",
+    ):
+        rows = _compact_object_list(value.get(key), max_items=_prompt_list_limit())
+        if rows:
+            compact[key] = rows
+
+    return compact
+
+
+def _company_context_drop_keys(*, prompt_safe: bool) -> frozenset[str]:
+    if prompt_safe:
+        return _STORAGE_DROP_COMPANY_CONTEXT_KEYS | _PROMPT_ONLY_DROP_COMPANY_CONTEXT_KEYS
+    return _STORAGE_DROP_COMPANY_CONTEXT_KEYS
+
+
+def _compact_company_context_value(key: str, value: Any, *, prompt_safe: bool) -> Any:
+    if key in _company_context_drop_keys(prompt_safe=prompt_safe):
+        return _SKIP
+    if key == "key_quotes":
+        return _compact_scalar_list(value, max_items=_prompt_quote_limit())
+    if key == "pain_categories":
+        return _compact_named_rows(
+            value,
+            keys=("category", "severity"),
+            max_items=_prompt_list_limit(),
+        )
+    if key == "competitors_considering":
+        return _compact_named_rows(
+            value,
+            keys=("name", "reason"),
+            max_items=_prompt_list_limit(),
+        )
+    if key in {"feature_gaps", "integration_stack"}:
+        return _compact_scalar_list(value, max_items=_prompt_list_limit())
+    if key == "signal_summary":
+        return _compact_signal_summary(value)
+    if key == "briefing_context":
+        return _compact_briefing_context(value)
+    if key == "reasoning_context":
+        return _compact_reasoning_context(value)
+    if key == "incumbent_reasoning":
+        return _compact_incumbent_reasoning(value)
+    if key == "incumbent_archetypes":
+        return _compact_incumbent_archetypes(value)
+    if key == "category_intelligence":
+        return _compact_category_intelligence(value)
+    return value
+
+
+def _compact_company_context(
+    company_context: dict[str, Any],
+    *,
+    prompt_safe: bool,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key, value in company_context.items():
+        compact_value = _compact_company_context_value(
+            key,
+            value,
+            prompt_safe=prompt_safe,
+        )
+        if compact_value is _SKIP or not _has_context_value(compact_value):
+            continue
+        compact[key] = compact_value
+    return compact
+
+
+def _compact_selling_context(selling_context: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key, value in selling_context.items():
+        if key in {"blog_posts", "primary_blog_post"}:
+            continue
+        if isinstance(value, (str, int, float, bool)) and _has_context_value(value):
+            compact[key] = value
+
+    blog_posts = selling_context.get("blog_posts")
+    if not blog_posts and isinstance(selling_context.get("primary_blog_post"), dict):
+        blog_posts = [selling_context["primary_blog_post"]]
+    compact_posts = _compact_blog_posts(blog_posts)
+    if compact_posts:
+        compact["blog_posts"] = compact_posts
+    return compact
+
+
+def compact_sequence_contexts(
+    company_context: Any,
+    selling_context: Any,
+    *,
+    prompt_safe: bool,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    parsed_company_context = _parse_context_blob(company_context)
+    parsed_selling_context = _parse_context_blob(selling_context)
+
+    legacy_selling = parsed_company_context.get("selling")
+    if not parsed_selling_context and isinstance(legacy_selling, dict):
+        parsed_selling_context = legacy_selling
+
+    return (
+        _compact_company_context(parsed_company_context, prompt_safe=prompt_safe),
+        _compact_selling_context(parsed_selling_context),
+    )
+
+
+def prepare_sequence_prompt_contexts(seq: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    return compact_sequence_contexts(
+        seq.get("company_context"),
+        seq.get("selling_context"),
+        prompt_safe=True,
+    )
+
+
+def prepare_sequence_storage_contexts(
+    company_context: Any,
+    selling_context: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    return compact_sequence_contexts(
+        company_context,
+        selling_context,
+        prompt_safe=False,
+    )
+
+
+def plain_text_preview(body: str, *, limit: int | None = None) -> str:
+    max_chars = int(limit or prompt_email_body_preview_chars())
+    text = re.sub(r"<[^>]+>", " ", body or "")
+    text = html.unescape(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars].rstrip()}..."

--- a/extracted_content_pipeline/autonomous/tasks/_execution_progress.py
+++ b/extracted_content_pipeline/autonomous/tasks/_execution_progress.py
@@ -1,0 +1,70 @@
+"""Shared helpers for reporting live autonomous task execution progress."""
+
+from typing import Any
+from uuid import UUID
+
+from ...storage.models import ScheduledTask
+
+
+def _task_execution_id(task: ScheduledTask) -> UUID | None:
+    """Return the current execution id injected by the scheduler, if present."""
+    raw = (task.metadata or {}).get("_execution_id")
+    if not raw:
+        return None
+    try:
+        return UUID(str(raw))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def task_run_id(task: ScheduledTask | Any) -> str | None:
+    """Return the best correlation id for a task execution.
+
+    Prefer the scheduler-injected execution id so one scheduled task can be
+    correlated across multiple runs. Fall back to explicit metadata keys and
+    finally the task id for ad-hoc/manual contexts that do not have an
+    execution row.
+    """
+    exec_id = _task_execution_id(task)
+    if exec_id is not None:
+        return str(exec_id)
+    metadata = getattr(task, "metadata", None)
+    if isinstance(metadata, dict):
+        for key in ("run_id", "task_id", "invocation_id"):
+            value = metadata.get(key)
+            if value:
+                return str(value)
+    task_id = getattr(task, "id", None)
+    if task_id:
+        return str(task_id)
+    return None
+
+
+async def _update_execution_progress(
+    task: ScheduledTask,
+    *,
+    stage: str,
+    progress_current: int | None = None,
+    progress_total: int | None = None,
+    progress_message: str | None = None,
+    **counters: Any,
+) -> None:
+    """Merge progress metadata into the current task execution row."""
+    exec_id = _task_execution_id(task)
+    if exec_id is None:
+        return
+    metadata: dict[str, Any] = {"stage": stage}
+    if progress_current is not None:
+        metadata["progress_current"] = int(progress_current)
+    if progress_total is not None:
+        metadata["progress_total"] = int(progress_total)
+    if progress_message:
+        metadata["progress_message"] = str(progress_message)
+    for key, value in counters.items():
+        if value is not None:
+            metadata[key] = value
+    try:
+        from ...storage.repositories.scheduled_task import get_scheduled_task_repo
+        await get_scheduled_task_repo().update_execution_metadata(exec_id, metadata)
+    except Exception:
+        return

--- a/extracted_content_pipeline/autonomous/tasks/_google_news.py
+++ b/extracted_content_pipeline/autonomous/tasks/_google_news.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunsplit, urlsplit
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger("atlas.autonomous.tasks.google_news")
+
+_GOOGLE_NEWS_HOST = "news.google.com"
+_GOOGLE_NEWS_PATH_PREFIX = "/rss/articles/"
+_GOOGLE_NEWS_RPC_ID = "Fbv4je"
+_GOOGLE_NEWS_DECODE_URL = (
+    "https://news.google.com/_/DotsSplashUi/data/batchexecute"
+    "?rpcids=Fbv4je"
+)
+_GOOGLE_NEWS_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; AtlasBot/1.0)",
+    "Accept": "text/html,application/xhtml+xml",
+}
+_GOOGLE_NEWS_FORM_HEADERS = {
+    **_GOOGLE_NEWS_HEADERS,
+    "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+    "Referer": "https://news.google.com/",
+}
+_GOOGLE_NEWS_FEATURE_FLAGS = ["FINANCE_TOP_INDICES", "WEB_TEST_1_0_0"]
+_GOOGLE_NEWS_REQUEST_BUILD = "655000234"
+_GARTURLRES_PATTERN = re.compile(r'\["garturlres","([^"]+)",\d+\]')
+
+
+def is_google_news_wrapper_url(url: str) -> bool:
+    """Return True when the URL points at a Google News RSS article wrapper."""
+    parsed = urlparse(url)
+    return (
+        parsed.scheme in {"http", "https"}
+        and parsed.netloc == _GOOGLE_NEWS_HOST
+        and parsed.path.startswith(_GOOGLE_NEWS_PATH_PREFIX)
+    )
+
+
+def _article_locale_context(url: str) -> tuple[str, str, str]:
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    locale = query.get("hl", ["en-US"])[0]
+    region = query.get("gl", ["US"])[0]
+    ceid = query.get("ceid", [f"{region}:{locale.split('-', 1)[0]}"])[0]
+    return locale, region, ceid
+
+
+def _extract_decode_inputs(html: str) -> tuple[str, int, str] | None:
+    soup = BeautifulSoup(html, "html.parser")
+    tag = soup.find(
+        attrs={
+            "data-n-a-id": True,
+            "data-n-a-ts": True,
+            "data-n-a-sg": True,
+        }
+    )
+    if not tag:
+        return None
+    try:
+        article_id = str(tag.get("data-n-a-id", "")).strip()
+        timestamp = int(str(tag.get("data-n-a-ts", "")).strip())
+        signature = str(tag.get("data-n-a-sg", "")).strip()
+    except (TypeError, ValueError):
+        return None
+    if not article_id or not signature:
+        return None
+    return article_id, timestamp, signature
+
+
+def _build_decode_payload(
+    article_id: str,
+    timestamp: int,
+    signature: str,
+    locale: str,
+    region: str,
+    ceid: str,
+) -> str:
+    request = [
+        "garturlreq",
+        [
+            [
+                locale,
+                region,
+                _GOOGLE_NEWS_FEATURE_FLAGS,
+                None,
+                None,
+                1,
+                1,
+                ceid,
+                None,
+                180,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0,
+                None,
+                None,
+                [1608992183, 723341000],
+            ],
+            locale,
+            region,
+            1,
+            [2, 3, 4, 8],
+            1,
+            0,
+            _GOOGLE_NEWS_REQUEST_BUILD,
+            0,
+            0,
+            None,
+            0,
+        ],
+        article_id,
+        timestamp,
+        signature,
+    ]
+    return json.dumps([[[_GOOGLE_NEWS_RPC_ID, json.dumps(request), None, "generic"]]])
+
+
+def _extract_resolved_url(payload_text: str) -> str | None:
+    for candidate in (payload_text, payload_text.replace('\\"', '"')):
+        match = _GARTURLRES_PATTERN.search(candidate)
+        if not match:
+            continue
+        try:
+            resolved = json.loads(f'"{match.group(1)}"')
+        except json.JSONDecodeError:
+            resolved = match.group(1).replace("\\/", "/").replace("\\u003d", "=")
+        if resolved.startswith(("http://", "https://")):
+            return _normalize_resolved_url(resolved)
+    return None
+
+
+def _normalize_resolved_url(url: str) -> str:
+    cleaned = (
+        url.replace("\\u003d", "=")
+        .replace("\\u0026", "&")
+        .replace("\\u002F", "/")
+        .replace("\\/", "/")
+    )
+    parsed = urlsplit(cleaned)
+    query = urlencode(
+        [(k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=True) if not k.startswith("gaa_")],
+        doseq=True,
+    )
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, ""))
+
+
+async def resolve_google_news_url(
+    wrapper_url: str,
+    timeout: float = 20.0,
+    client: Any | None = None,
+) -> str | None:
+    """Resolve a Google News wrapper URL to the publisher article URL."""
+    if not is_google_news_wrapper_url(wrapper_url):
+        return wrapper_url
+
+    import httpx
+
+    own_client = client is None
+    if own_client:
+        client = httpx.AsyncClient(follow_redirects=True, timeout=timeout)
+
+    try:
+        wrapper_response = await client.get(wrapper_url, headers=_GOOGLE_NEWS_HEADERS)
+        wrapper_response.raise_for_status()
+
+        inputs = _extract_decode_inputs(wrapper_response.text)
+        if not inputs:
+            return None
+
+        locale, region, ceid = _article_locale_context(str(wrapper_response.url))
+        payload = _build_decode_payload(*inputs, locale, region, ceid)
+        decode_response = await client.post(
+            _GOOGLE_NEWS_DECODE_URL,
+            data={"f.req": payload},
+            headers=_GOOGLE_NEWS_FORM_HEADERS,
+        )
+        decode_response.raise_for_status()
+        return _extract_resolved_url(decode_response.text)
+    except Exception:
+        logger.debug("Failed to resolve Google News wrapper URL: %s", wrapper_url, exc_info=True)
+        return None
+    finally:
+        if own_client:
+            await client.aclose()

--- a/extracted_content_pipeline/autonomous/tasks/article_enrichment.py
+++ b/extracted_content_pipeline/autonomous/tasks/article_enrichment.py
@@ -1,0 +1,431 @@
+"""
+Article enrichment pipeline: fetch full article content and classify
+via SORAM pressure channels using the local vLLM enrichment path.
+
+Two-phase pipeline per article:
+  Phase 1: httpx GET + trafilatura extract -> content column
+  Phase 2: Triage LLM with soram_classification skill -> SORAM + linguistic + entities
+
+Runs on an interval (default 10 min). Returns _skip_synthesis so the
+runner does not double-synthesize.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...services.scraping.universal.html_cleaner import html_to_text
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+from ._google_news import is_google_news_wrapper_url, resolve_google_news_url
+
+logger = logging.getLogger("atlas.autonomous.tasks.article_enrichment")
+
+_VALID_PRESSURE_DIRECTIONS = frozenset({"building", "steady", "releasing", "unclear"})
+_DEFAULT_ARTICLE_FAILURE_REASON = "unexpected_exception"
+_SORAM_CLASSIFICATION_JSON_SCHEMA: dict[str, Any] = {
+    "title": "soram_classification",
+    "type": "object",
+    "properties": {
+        "soram_channels": {
+            "type": "object",
+            "properties": {
+                "societal": {"type": "number"},
+                "operational": {"type": "number"},
+                "regulatory": {"type": "number"},
+                "alignment": {"type": "number"},
+                "media": {"type": "number"},
+            },
+            "required": ["societal", "operational", "regulatory", "alignment", "media"],
+            "additionalProperties": False,
+        },
+        "linguistic_indicators": {
+            "type": "object",
+            "properties": {
+                "permission_shift": {"type": "boolean"},
+                "certainty_spike": {"type": "boolean"},
+                "linguistic_dissociation": {"type": "boolean"},
+                "hedging_withdrawal": {"type": "boolean"},
+                "urgency_escalation": {"type": "boolean"},
+            },
+            "required": [
+                "permission_shift",
+                "certainty_spike",
+                "linguistic_dissociation",
+                "hedging_withdrawal",
+                "urgency_escalation",
+            ],
+            "additionalProperties": False,
+        },
+        "entities": {"type": "array", "items": {"type": "string"}},
+        "pressure_direction": {"type": "string", "enum": sorted(_VALID_PRESSURE_DIRECTIONS)},
+    },
+    "required": [
+        "soram_channels",
+        "linguistic_indicators",
+        "entities",
+        "pressure_direction",
+    ],
+    "additionalProperties": False,
+}
+
+
+def _normalize_failure_reason(reason: str | None) -> str:
+    """Normalize a nullable failure reason to a short stored tag."""
+    reason_text = str(reason or "").strip().lower()
+    return reason_text or _DEFAULT_ARTICLE_FAILURE_REASON
+
+
+def _record_failure_reason(counter: dict[str, int], reason: str | None) -> str:
+    """Increment a per-run failure-reason counter and return the stored tag."""
+    reason_text = _normalize_failure_reason(reason)
+    counter[reason_text] = counter.get(reason_text, 0) + 1
+    return reason_text
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: enrich pending news articles."""
+    cfg = settings.external_data
+    if not cfg.enabled or not cfg.enrichment_enabled:
+        return {"_skip_synthesis": "Article enrichment disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    max_batch = cfg.enrichment_max_per_batch
+    max_attempts = cfg.enrichment_max_attempts
+
+    # Fetch articles needing enrichment (pending or fetched but not classified)
+    rows = await pool.fetch(
+        """
+        SELECT id, title, url, summary, matched_keywords,
+               enrichment_status, enrichment_attempts, content
+        FROM news_articles
+        WHERE enrichment_status IN ('pending', 'fetched')
+          AND enrichment_attempts < $1
+          AND url != ''
+        ORDER BY created_at DESC
+        LIMIT $2
+        """,
+        max_attempts,
+        max_batch,
+    )
+
+    if not rows:
+        return {"_skip_synthesis": "No articles to enrich"}
+
+    fetched = 0
+    classified = 0
+    failed = 0
+    failure_reasons: dict[str, int] = {}
+
+    for row in rows:
+        article_id = row["id"]
+        status = row["enrichment_status"]
+        attempts = row["enrichment_attempts"]
+
+        fetched_content = None  # tracks content from Phase 1 for immediate Phase 2
+
+        try:
+            if status == "pending":
+                # Phase 1: fetch content
+                fetched_content, fetched_url, fetch_reason = await _fetch_article_content(
+                    row["url"],
+                    cfg,
+                )
+                if fetched_content:
+                    await pool.execute(
+                        """
+                        UPDATE news_articles
+                        SET content = $1,
+                            url = $2,
+                            enrichment_status = 'fetched',
+                            enrichment_attempts = $3,
+                            enrichment_failure_reason = NULL
+                        WHERE id = $4
+                        """,
+                        fetched_content[:cfg.enrichment_content_max_chars],
+                        fetched_url or row["url"],
+                        attempts + 1,
+                        article_id,
+                    )
+                    fetched += 1
+                    # Continue to phase 2 immediately
+                    status = "fetched"
+                else:
+                    stored_reason = _record_failure_reason(failure_reasons, fetch_reason)
+                    terminal = attempts + 1 >= max_attempts
+                    await pool.execute(
+                        """
+                        UPDATE news_articles
+                        SET url = $1,
+                            enrichment_attempts = $2,
+                            enrichment_failure_reason = $3,
+                            enrichment_status = $4
+                        WHERE id = $5
+                        """,
+                        fetched_url or row["url"],
+                        attempts + 1,
+                        stored_reason,
+                        "failed" if terminal else "pending",
+                        article_id,
+                    )
+                    if terminal:
+                        failed += 1
+                    continue
+
+            if status == "fetched":
+                # Phase 2: SORAM classification
+                article_content = fetched_content or row["content"]
+                if not article_content:
+                    article_content = row["summary"] or ""
+
+                classification, classify_reason = await _classify_soram(
+                    row["title"],
+                    article_content,
+                    row["matched_keywords"] or [],
+                )
+
+                if classification:
+                    soram = classification.get("soram_channels", {})
+                    ling = classification.get("linguistic_indicators", {})
+                    entities = classification.get("entities", [])
+                    direction = classification.get("pressure_direction")
+                    await pool.execute(
+                        """
+                        UPDATE news_articles
+                        SET soram_channels = $1::jsonb,
+                            linguistic_indicators = $2::jsonb,
+                            entities_detected = $3,
+                            pressure_direction = $4,
+                            enrichment_status = 'classified',
+                            enrichment_attempts = $5,
+                            enriched_at = $6,
+                            enrichment_failure_reason = NULL
+                        WHERE id = $7
+                        """,
+                        json.dumps(soram),
+                        json.dumps(ling),
+                        entities,
+                        direction,
+                        attempts + 1,
+                        datetime.now(timezone.utc),
+                        article_id,
+                    )
+                    classified += 1
+                else:
+                    stored_reason = _record_failure_reason(failure_reasons, classify_reason)
+                    terminal = attempts + 1 >= max_attempts
+                    await pool.execute(
+                        """
+                        UPDATE news_articles
+                        SET enrichment_attempts = $1,
+                            enrichment_failure_reason = $2,
+                            enrichment_status = $3
+                        WHERE id = $4
+                        """,
+                        attempts + 1,
+                        stored_reason,
+                        "failed" if terminal else "fetched",
+                        article_id,
+                    )
+                    if terminal:
+                        failed += 1
+
+        except Exception:
+            logger.exception("Failed to enrich article %s", article_id)
+            try:
+                stored_reason = _record_failure_reason(
+                    failure_reasons,
+                    _DEFAULT_ARTICLE_FAILURE_REASON,
+                )
+                terminal = attempts + 1 >= max_attempts
+                await pool.execute(
+                    """
+                    UPDATE news_articles
+                    SET enrichment_attempts = $1,
+                        enrichment_failure_reason = $2,
+                        enrichment_status = $3
+                    WHERE id = $4
+                    """,
+                    attempts + 1,
+                    stored_reason,
+                    "failed" if terminal else status,
+                    article_id,
+                )
+            except Exception:
+                pass
+            if terminal:
+                failed += 1
+
+    logger.info(
+        "Article enrichment: %d fetched, %d classified, %d failed (of %d)",
+        fetched, classified, failed, len(rows),
+    )
+
+    return {
+        "_skip_synthesis": "Article enrichment complete",
+        "total": len(rows),
+        "fetched": fetched,
+        "classified": classified,
+        "failed": failed,
+        "failure_reasons": failure_reasons,
+    }
+
+
+async def _fetch_article_content(url: str, cfg) -> tuple[str | None, str, str | None]:
+    """Fetch article HTML and extract main content from the publisher page."""
+    import httpx
+
+    fetch_url = url
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=cfg.enrichment_fetch_timeout,
+        ) as client:
+            if is_google_news_wrapper_url(url):
+                resolved = await resolve_google_news_url(
+                    url,
+                    timeout=cfg.enrichment_fetch_timeout,
+                    client=client,
+                )
+                if resolved:
+                    fetch_url = resolved
+                else:
+                    logger.debug("Could not resolve Google News wrapper URL %s", url)
+
+            resp = await client.get(
+                fetch_url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; AtlasBot/1.0)",
+                    "Accept": "text/html,application/xhtml+xml",
+                },
+            )
+            resp.raise_for_status()
+            html = resp.text
+
+        content = await asyncio.to_thread(
+            html_to_text,
+            html,
+            cfg.enrichment_content_max_chars,
+        )
+        if content and len(content.strip()) > 50:
+            return content.strip(), fetch_url, None
+
+        logger.debug("html extraction returned insufficient content for %s", fetch_url)
+        return None, fetch_url, "fetch_extraction_empty"
+
+    except httpx.TimeoutException as exc:
+        logger.debug("Timed out fetching article content from %s: %s", fetch_url, exc)
+        return None, fetch_url, "fetch_timeout"
+    except httpx.HTTPStatusError as exc:
+        logger.debug("HTTP error fetching article content from %s: %s", fetch_url, exc)
+        status_code = exc.response.status_code if exc.response is not None else None
+        if status_code in {401, 403, 429}:
+            return None, fetch_url, "fetch_blocked"
+        if status_code == 404:
+            return None, fetch_url, "fetch_not_found"
+        return None, fetch_url, "fetch_http_error"
+
+    except Exception as e:
+        logger.debug("Failed to fetch article content from %s: %s", fetch_url, e)
+        return None, fetch_url, "fetch_error"
+
+
+async def _classify_soram(
+    title: str,
+    content: str,
+    matched_keywords: list[str],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Classify article via local vLLM using soram_classification skill."""
+    from ...pipelines.llm import call_llm_with_skill, parse_json_response
+
+    truncated = content[:3000] if content else ""
+
+    payload = {
+        "title": title,
+        "content": truncated,
+        "matched_keywords": matched_keywords,
+    }
+
+    usage: dict[str, Any] = {}
+    max_output_tokens = max(
+        256,
+        int(getattr(settings.external_data, "enrichment_classification_max_tokens", 1200)),
+    )
+    try:
+        text = call_llm_with_skill(
+            "digest/soram_classification", payload,
+            max_tokens=max_output_tokens,
+            temperature=0.1,
+            workload="vllm",
+            response_format={"type": "json_object"},
+            guided_json=_SORAM_CLASSIFICATION_JSON_SCHEMA,
+            usage_out=usage,
+        )
+    except Exception:
+        logger.exception("SORAM classification LLM call failed")
+        return None, "classify_error"
+    if usage.get("input_tokens"):
+        logger.info("soram_classification LLM tokens: in=%d out=%d model=%s",
+                     usage["input_tokens"], usage["output_tokens"], usage.get("model", ""))
+    if not text:
+        return None, "classify_empty_response"
+
+    parsed = parse_json_response(text, recover_truncated=True)
+
+    # parse_json_response always returns a dict; check for required field
+    if "soram_channels" not in parsed:
+        logger.debug("SORAM classification missing soram_channels: %s", text[:200])
+        return None, "classify_invalid_json"
+
+    return _validate_classification(parsed), None
+
+
+def _validate_classification(raw: dict[str, Any]) -> dict[str, Any]:
+    """Validate and clamp SORAM classification values from LLM output."""
+    # Validate soram_channels: each value must be float 0.0-1.0
+    soram = raw.get("soram_channels", {})
+    if isinstance(soram, dict):
+        validated_soram = {}
+        for key in ("societal", "operational", "regulatory", "alignment", "media"):
+            val = soram.get(key, 0.0)
+            try:
+                validated_soram[key] = max(0.0, min(1.0, float(val)))
+            except (TypeError, ValueError):
+                validated_soram[key] = 0.0
+        raw["soram_channels"] = validated_soram
+    else:
+        raw["soram_channels"] = {k: 0.0 for k in ("societal", "operational", "regulatory", "alignment", "media")}
+
+    # Validate linguistic_indicators: each value must be bool
+    ling = raw.get("linguistic_indicators", {})
+    if isinstance(ling, dict):
+        validated_ling = {}
+        for key in ("permission_shift", "certainty_spike", "linguistic_dissociation",
+                     "hedging_withdrawal", "urgency_escalation"):
+            validated_ling[key] = bool(ling.get(key, False))
+        raw["linguistic_indicators"] = validated_ling
+    else:
+        raw["linguistic_indicators"] = {k: False for k in (
+            "permission_shift", "certainty_spike", "linguistic_dissociation",
+            "hedging_withdrawal", "urgency_escalation")}
+
+    # Validate entities: list of non-empty strings
+    entities = raw.get("entities", [])
+    if isinstance(entities, list):
+        raw["entities"] = [str(e) for e in entities[:5] if e and str(e).strip()]
+    else:
+        raw["entities"] = []
+
+    # Validate pressure_direction
+    direction = raw.get("pressure_direction", "unclear")
+    if direction not in _VALID_PRESSURE_DIRECTIONS:
+        direction = "unclear"
+    raw["pressure_direction"] = direction
+
+    return raw

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1,0 +1,9613 @@
+"""
+B2B blog post generation: picks the best data story each night from B2B
+churn signals, product profiles, and affiliate partners. Builds a
+deterministic blueprint, generates prose via LLM, and stores the
+assembled draft in blog_posts.
+
+Runs daily after b2b_product_profiles (default 11 PM).
+
+Pipeline stages:
+  1. Topic selection  -- score candidates from 4 B2B topic types
+  2. Data gathering   -- parallel SQL from b2b_* tables + affiliate_partners
+  3. Blueprint build  -- deterministic section/chart layout
+  4. Content gen      -- single LLM call with blueprint as input
+  5. Assembly/store   -- draft in blog_posts, affiliate link injection, ntfy
+
+Returns _skip_synthesis.
+"""
+
+import asyncio
+import copy
+import json
+import logging
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from ...config import settings
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+from ...services.scraping.sources import (
+    VERIFIED_SOURCES,
+    ReviewSource,
+    display_name as source_display_name,
+    filter_deprecated_sources,
+    parse_source_allowlist,
+    with_required_sources,
+)
+from ...reasoning.wedge_registry import Wedge, get_wedge_meta
+from ._execution_progress import task_run_id as _task_execution_run_id
+from ._b2b_shared import (
+    read_vendor_intelligence_map as _read_vendor_intelligence_map,
+    read_vendor_intelligence_records as _read_vendor_intelligence_records,
+    read_vendor_scorecard_details as _read_vendor_scorecard_details,
+    _align_vendor_intelligence_records_to_scorecards,
+    _segment_targeting_summary,
+    _timing_summary_payload,
+    fetch_all_pool_layers,
+)
+from ._b2b_specificity import (
+    evaluate_specificity_support,
+    specificity_signal_terms,
+    surface_specificity_context,
+)
+
+logger = logging.getLogger("atlas.autonomous.tasks.b2b_blog_post_generation")
+
+
+async def _fetch_latest_evidence_vault(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+    vendor_names: list[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Compatibility seam delegating canonical reads to the shared adapter."""
+    return await _read_vendor_intelligence_map(
+        pool,
+        as_of=as_of,
+        analysis_window_days=analysis_window_days,
+        vendor_names=vendor_names,
+    )
+
+
+async def _fetch_latest_evidence_vault_records(
+    pool,
+    *,
+    as_of: date,
+    analysis_window_days: int,
+    vendor_names: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Read canonical vendor-intelligence records with run metadata."""
+    return await _read_vendor_intelligence_records(
+        pool,
+        as_of=as_of,
+        analysis_window_days=analysis_window_days,
+        vendor_names=vendor_names,
+    )
+
+
+def _blog_vendor_lookup_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _blog_review_vendor_join(
+    review_alias: str = "r",
+    mention_alias: str = "vm",
+) -> str:
+    """Join canonical review-to-vendor mentions for vendor-scoped reads."""
+    return (
+        f"JOIN b2b_review_vendor_mentions {mention_alias} "
+        f"ON {mention_alias}.review_id = {review_alias}.id"
+    )
+
+
+def _blog_primary_vendor_join(
+    review_alias: str = "r",
+    mention_alias: str = "primary_vm",
+) -> str:
+    """Project one canonical vendor label per review for category-scoped reads."""
+    return (
+        "LEFT JOIN LATERAL ("
+        f" SELECT vm.vendor_name"
+        " FROM b2b_review_vendor_mentions vm"
+        f" WHERE vm.review_id = {review_alias}.id"
+        " ORDER BY vm.is_primary DESC, vm.id ASC"
+        f" LIMIT 1) AS {mention_alias} ON TRUE"
+    )
+
+
+async def _fetch_vendor_scorecard_details(
+    pool,
+    *,
+    vendor_names: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Read detailed scorecard rows keyed by requested vendor label."""
+    requested_vendors = [str(name or "").strip() for name in (vendor_names or []) if str(name or "").strip()]
+    if not requested_vendors:
+        return {}
+    rows = await _read_vendor_scorecard_details(
+        pool,
+        vendor_names=requested_vendors,
+    )
+    requested_by_key = {
+        _blog_vendor_lookup_key(name): name
+        for name in requested_vendors
+    }
+    detail_lookup: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        vendor_name = str(row.get("vendor_name") or "").strip()
+        if not vendor_name:
+            continue
+        detail_lookup[vendor_name] = row
+        requested_name = requested_by_key.get(_blog_vendor_lookup_key(vendor_name))
+        if requested_name:
+            detail_lookup[requested_name] = row
+    return detail_lookup
+
+_BLOG_GENERATION_CACHE_STAGE = "b2b_blog_post_generation.content"
+_BLOG_GENERATION_TRACE_SPAN = "task.b2b_blog_post_generation"
+_BLOG_BATCH_SELECTION_MULTIPLIER = 4
+_BLOG_BATCH_SELECTION_MIN_ATTEMPTS = 8
+
+_PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
+_BLOCKQUOTE_RE = re.compile(r"^\s*>\s*(.+?)\s*$")
+_ANSWER_PREFIX_RE = re.compile(r"(?im)^(\s*)answer:\s*")
+_CRITICAL_BLOG_WARNINGS = {
+    "review_period_not_explicitly_mentioned",
+    "methodology_disclaimer_missing_self_selected",
+    "unsupported_data_claim",
+    "chart_scope_ambiguity",
+    "migration_direction_drift",
+}
+_DATA_CLAIM_MARKERS = (
+    "most common",
+    "top migration",
+    "top source",
+    "primary source",
+    "primary driver",
+    "leading source",
+    "data shows",
+    "reviews mention",
+    "switched from",
+    "stories analyzed",
+)
+_DATA_CLAIM_PATTERN = re.compile(
+    r"\b(?:"
+    + "|".join(re.escape(m) for m in _DATA_CLAIM_MARKERS)
+    + r"|\d+\s*%|\d+\s+reviews?\b|\d+\s+stories?\b)",
+    re.IGNORECASE,
+)
+_VENDORISH_NAME_PATTERN = re.compile(
+    r"\b("
+    r"(?:[A-Z][a-z0-9]*[A-Z][A-Za-z0-9]*|[A-Z][a-z0-9]+|[A-Z]{2,}|[a-z]+[A-Z][A-Za-z0-9]*)"
+    r"(?:\s+(?:[A-Z][a-z0-9]*[A-Z][A-Za-z0-9]*|[A-Z][a-z0-9]+|[A-Z]{2,}|[a-z]+[A-Z][A-Za-z0-9]*)){0,3}"
+    r")\b"
+)
+_VENDORISH_SKIP_WORDS = frozenset(
+    " ".join(re.findall(r"[a-z0-9]+", w.lower())) for w in (
+        # Common English words that match the capitalized pattern
+        "The", "This", "That", "When", "What", "Where", "Which", "While",
+        "Most", "Top", "Data", "Teams", "Users", "Some", "Each", "Both",
+        "Many", "Other", "These", "Those", "After", "Before", "Between",
+        "About", "Since", "Until", "During", "However", "Although",
+        # Document structure words
+        "Introduction", "Conclusion", "Overview", "Analysis", "Guide",
+        "Report", "Summary", "Review", "Reviews", "Reviewers", "Reviewer",
+        "Section", "Chart", "Table", "Source", "Sources",
+        "Note", "Key", "Figure", "Methodology", "Decision",
+        "Rating", "Ratings", "Platform", "Platforms", "Price", "Pricing",
+        "Feature", "Features", "Support", "Integration", "Performance",
+        # Time/date words
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+        "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+        # Tech/domain terms that aren't vendors
+        "API", "SEO", "SaaS", "CRM", "ERP", "DNS", "SSL", "CSS",
+        "HTML", "REST", "SDK", "ROI", "KPI", "B2B", "SMB",
+    )
+)
+_BLOG_SKIP_SENTENCE_PREFIXES = (
+    "#",
+    "_methodology note:",
+    "methodology note:",
+    "analysis methodology:",
+    "*analysis methodology:",
+)
+_BLOG_SKIP_SENTENCE_CONTAINS = (
+    "this analysis draws on",
+    "this post draws on",
+    "analysis based on self-selected reviewer feedback",
+    "analysis reflects self-selected feedback from",
+)
+_SOURCE_NAME_ALIASES = {
+    "gartner peer insights",
+    "public b2b software review platforms",
+    "public software reviews",
+}
+_SOURCEISH_SKIP_WORDS = frozenset(
+    {
+        *(
+            " ".join(re.findall(r"[a-z0-9]+", source_display_name(source).lower()))
+            for source in ReviewSource
+        ),
+        *(
+            " ".join(re.findall(r"[a-z0-9]+", alias.lower()))
+            for alias in _SOURCE_NAME_ALIASES
+        ),
+    }
+)
+
+
+def _task_run_id(task: ScheduledTask | Any) -> str | None:
+    """Return a stable execution-aware run id for scheduled blog jobs."""
+    return _task_execution_run_id(task)
+
+
+def _blog_post_max_per_run(task: ScheduledTask | Any, cfg: Any) -> int:
+    """Resolve max posts per run from task metadata before config defaults."""
+    metadata = getattr(task, "metadata", None)
+    if isinstance(metadata, dict):
+        for key in ("blog_post_max_per_run", "max_posts_per_run", "max_per_run"):
+            value = metadata.get(key)
+            try:
+                if value is not None:
+                    return max(1, int(value))
+            except (TypeError, ValueError):
+                logger.warning("Ignoring invalid %s=%r on blog task metadata", key, value)
+    return max(1, int(cfg.blog_post_max_per_run))
+_WEDGEISH_SKIP_WORDS = frozenset(
+    " ".join(re.findall(r"[a-z0-9]+", phrase.lower()))
+    for phrase in {
+        *(wedge.value.replace("_", " ") for wedge in Wedge),
+        *(get_wedge_meta(wedge).label for wedge in Wedge),
+    }
+)
+_BLOG_NON_VENDOR_SKIP_WORDS = frozenset(
+    set(_VENDORISH_SKIP_WORDS) | set(_SOURCEISH_SKIP_WORDS) | set(_WEDGEISH_SKIP_WORDS)
+)
+
+
+def _build_grounded_vendor_set(blueprint: "PostBlueprint") -> set[str]:
+    """Build the set of vendor/product names supported by chart + context data."""
+    names: set[str] = set()
+    ctx = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+    # Topic vendors
+    for key in ("vendor", "vendor_a", "vendor_b", "from_vendor", "to_vendor"):
+        v = str(ctx.get(key) or "").strip()
+        nv = _normalized_vendor_text(v)
+        if nv and len(nv) > 1:
+            names.add(nv)
+    # Chart labels and series values
+    for chart in blueprint.charts:
+        for row in chart.data:
+            if not isinstance(row, dict):
+                continue
+            for val in row.values():
+                if isinstance(val, str):
+                    nv = _normalized_vendor_text(val)
+                    if nv and len(nv) > 1:
+                        names.add(nv)
+    # Explicit vendor lists in data_context
+    for key in ("displacement_targets", "competitors", "commonly_switched_from",
+                "top_displacement_targets", "vendor_profiles"):
+        items = ctx.get(key)
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict):
+                    for vk in ("vendor", "name", "competitor", "vendor_name"):
+                        v = str(item.get(vk) or "").strip()
+                        nv = _normalized_vendor_text(v)
+                        if nv and len(nv) > 1:
+                            names.add(nv)
+                elif isinstance(item, str):
+                    nv = _normalized_vendor_text(item)
+                    if nv and len(nv) > 1:
+                        names.add(nv)
+    return names
+
+
+def _find_unsupported_data_claims(
+    body: str,
+    grounded: set[str],
+    known_vendors: list[str] | None = None,
+) -> list[str]:
+    """Return sentences with data-claim markers that reference ungrounded vendors.
+
+    Uses two detection strategies:
+    1. Known-vendor lookup: check if any known vendor (from DB) appears in a
+       claim sentence but is NOT in the grounded set.
+    2. Regex fallback: extract capitalized name patterns for vendors not in
+       the known universe (catches novel names the LLM invented).
+    """
+    sentences = re.split(r'(?<=[.!?])\s+|\n+', body)
+    flagged: list[str] = []
+
+    # Build case-insensitive lookup for known vendors not in grounded set
+    ungrounded_known: list[tuple[str, re.Pattern[str]]] = []
+    for v in (known_vendors or []):
+        nv = _normalized_vendor_text(v)
+        if nv and nv not in grounded and len(v) > 2:
+            # Match the vendor name as a whole word, case-insensitive
+            pattern = re.compile(r"\b" + re.escape(v) + r"\b", re.IGNORECASE)
+            ungrounded_known.append((v, pattern))
+
+    for sentence in sentences:
+        if not _DATA_CLAIM_PATTERN.search(sentence):
+            continue
+        trimmed_sentence = sentence.strip()
+        trimmed_lower = trimmed_sentence.lower()
+        if any(trimmed_lower.startswith(prefix) for prefix in _BLOG_SKIP_SENTENCE_PREFIXES):
+            continue
+        if any(fragment in trimmed_lower for fragment in _BLOG_SKIP_SENTENCE_CONTAINS):
+            continue
+        # Strategy 1: known vendor lookup
+        found_known = False
+        for vendor_name, pattern in ungrounded_known:
+            if pattern.search(sentence):
+                flagged.append(f"{vendor_name}: {sentence.strip()[:120]}")
+                found_known = True
+                break
+        if found_known:
+            continue
+        # Strategy 2: regex fallback for multi-word names not in known universe.
+        # Single capitalized words are too noisy (Among, Outcome, Causal, etc.)
+        # -- those are only caught via the known-vendor DB path above.
+        candidates = _VENDORISH_NAME_PATTERN.findall(sentence)
+        for name in candidates:
+            if " " not in name.strip():
+                continue  # single words handled by known-vendor lookup only
+            normalized_name = _normalized_vendor_text(name)
+            if normalized_name not in grounded and len(normalized_name) > 2:
+                if normalized_name in _BLOG_NON_VENDOR_SKIP_WORDS:
+                    continue
+                flagged.append(f"{name}: {sentence.strip()[:120]}")
+                break
+    return flagged
+
+
+def _unsupported_claim_entries(report: dict[str, Any]) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    for warning in report.get("warnings", []) or []:
+        warning_text = str(warning)
+        if not warning_text.startswith("unsupported_data_claim:"):
+            continue
+        claim_text = warning_text[len("unsupported_data_claim:"):].strip()
+        vendor, _, snippet = claim_text.partition(":")
+        entries.append((vendor.strip(), snippet.strip()))
+    return entries
+
+
+def _line_contains_unsupported_claim(line: str, vendor: str, snippet: str) -> bool:
+    if not line.strip():
+        return False
+    if snippet and snippet in line:
+        return True
+    if vendor and re.search(r"\b" + re.escape(vendor) + r"\b", line, re.IGNORECASE):
+        return bool(_DATA_CLAIM_PATTERN.search(line))
+    return False
+
+
+def _remove_unsupported_claim_lines(body: str, report: dict[str, Any]) -> tuple[str, int]:
+    lines = body.splitlines()
+    if not lines:
+        return body, 0
+    removed = 0
+    for vendor, snippet in _unsupported_claim_entries(report):
+        if not vendor and not snippet:
+            continue
+        next_lines: list[str] = []
+        claim_removed = False
+        for line in lines:
+            if _line_contains_unsupported_claim(line, vendor, snippet):
+                removed += 1
+                claim_removed = True
+                continue
+            next_lines.append(line)
+        lines = next_lines
+        if claim_removed:
+            continue
+        text = "\n".join(lines)
+        sentences = re.split(r"(?<=[.!?])(\s+)", text)
+        kept: list[str] = []
+        for segment in sentences:
+            if _line_contains_unsupported_claim(segment, vendor, snippet):
+                removed += 1
+                continue
+            kept.append(segment)
+        lines = "".join(kept).splitlines()
+    return "\n".join(lines), removed
+
+
+def _strip_nonexistent_internal_links(
+    body: str,
+    *,
+    valid_slugs: set[str],
+    current_slug: str,
+) -> tuple[str, int]:
+    updated = str(body or "")
+    if not updated:
+        return updated, 0
+
+    removed = 0
+
+    markdown_pattern = re.compile(
+        r"\[([^\]]+)\]\(((?:https?://[^/)\s]+)?/blog/([a-z0-9\-]+))\)"
+    )
+
+    def _replace_markdown(match: re.Match[str]) -> str:
+        nonlocal removed
+        slug = str(match.group(3) or "")
+        if slug in valid_slugs or slug == current_slug:
+            return match.group(0)
+        removed += 1
+        return str(match.group(1) or "")
+
+    updated = markdown_pattern.sub(_replace_markdown, updated)
+
+    html_pattern = re.compile(
+        r"<a\s+[^>]*href=[\"']((?:https?://[^/\"']+)?/blog/([a-z0-9\-]+))[\"'][^>]*>(.*?)</a>",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    def _replace_html(match: re.Match[str]) -> str:
+        nonlocal removed
+        slug = str(match.group(2) or "")
+        if slug in valid_slugs or slug == current_slug:
+            return match.group(0)
+        removed += 1
+        return str(match.group(3) or "")
+
+    updated = html_pattern.sub(_replace_html, updated)
+
+    path_pattern = re.compile(r"(?<![A-Za-z0-9_-])/blog/([a-z0-9\-]+)")
+
+    def _replace_path(match: re.Match[str]) -> str:
+        nonlocal removed
+        slug = str(match.group(1) or "")
+        if slug in valid_slugs or slug == current_slug:
+            return match.group(0)
+        removed += 1
+        return slug.replace("-", " ")
+
+    updated = path_pattern.sub(_replace_path, updated)
+    return updated, removed
+
+
+def _blog_source_allowlist() -> list[str]:
+    """Return the configured source allowlist as a list for SQL ANY() binding."""
+    return filter_deprecated_sources(
+        with_required_sources(parse_source_allowlist(settings.b2b_churn.blog_source_allowlist)),
+        settings.b2b_churn.deprecated_review_sources,
+    )
+
+
+# -- dataclasses (same structure as consumer blog pipeline) --------
+
+@dataclass
+class ChartSpec:
+    chart_id: str
+    chart_type: str  # bar | horizontal_bar | radar | line
+    title: str
+    data: list[dict[str, Any]]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SectionSpec:
+    id: str
+    heading: str
+    goal: str
+    key_stats: dict[str, Any] = field(default_factory=dict)
+    chart_ids: list[str] = field(default_factory=list)
+    data_summary: str = ""
+
+
+@dataclass
+class PostBlueprint:
+    topic_type: str
+    slug: str
+    suggested_title: str
+    tags: list[str]
+    data_context: dict[str, Any]
+    sections: list[SectionSpec]
+    charts: list[ChartSpec]
+    quotable_phrases: list[dict[str, Any]] = field(default_factory=list)
+    cta: dict[str, Any] | None = None
+
+
+def _reasoning_scalar(value: Any) -> Any:
+    """Unwrap a traced reasoning value when present."""
+    if isinstance(value, dict) and "value" in value:
+        return value.get("value")
+    return value
+
+
+def _reasoning_int(value: Any) -> int | None:
+    """Unwrap a traced reasoning value into an integer when possible."""
+    raw = _reasoning_scalar(value)
+    if raw in (None, ""):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        try:
+            return int(float(raw))
+        except (TypeError, ValueError):
+            return None
+
+
+def _blog_account_reasoning_stats(
+    account_reasoning: dict[str, Any] | None,
+    account_preview: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build deterministic account-pressure stats for blog blueprints."""
+    if not isinstance(account_reasoning, dict):
+        account_reasoning = {}
+    if not isinstance(account_preview, dict):
+        account_preview = {}
+    stats: dict[str, Any] = {}
+    summary = str(account_reasoning.get("market_summary") or "").strip()
+    if not summary:
+        summary = str(account_preview.get("account_pressure_summary") or "").strip()
+    if summary:
+        stats["account_pressure_summary"] = summary
+    disclaimer = str(
+        account_reasoning.get("account_actionability_note")
+        or account_preview.get("account_actionability_note")
+        or account_preview.get("disclaimer")
+        or ""
+    ).strip()
+    if disclaimer:
+        stats["account_pressure_disclaimer"] = disclaimer
+    actionability_tier = str(
+        account_reasoning.get("account_actionability_tier")
+        or account_preview.get("account_actionability_tier")
+        or ""
+    ).strip()
+    if actionability_tier:
+        stats["account_actionability_tier"] = actionability_tier
+    for key in ("total_accounts", "high_intent_count", "active_eval_count"):
+        value = _reasoning_int(account_reasoning.get(key))
+        if value is None:
+            preview_metrics = account_preview.get("account_pressure_metrics") or {}
+            if isinstance(preview_metrics, dict):
+                value = _reasoning_int(preview_metrics.get(key))
+        if value is not None:
+            stats[key] = value
+    names: list[str] = []
+    for item in account_reasoning.get("top_accounts") or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if name and name not in names:
+            names.append(name)
+    if not names:
+        for item in account_preview.get("priority_account_names") or []:
+            name = str(item or "").strip()
+            if name and name not in names:
+                names.append(name)
+    if names:
+        stats["priority_accounts"] = names[:3]
+    return stats
+
+
+def _blog_timing_reasoning_stats(timing_intelligence: dict[str, Any] | None) -> dict[str, Any]:
+    """Build deterministic timing stats for blog blueprints."""
+    if not isinstance(timing_intelligence, dict):
+        return {}
+    summary, metrics, triggers = _timing_summary_payload(timing_intelligence)
+    stats: dict[str, Any] = {}
+    if summary:
+        stats["timing_summary"] = summary
+    if metrics:
+        stats.update(metrics)
+    if triggers:
+        stats["priority_timing_triggers"] = triggers[:3]
+    sentiment_direction = str(timing_intelligence.get("sentiment_direction") or "").strip()
+    if sentiment_direction:
+        stats["sentiment_direction"] = sentiment_direction
+    best_window = str(timing_intelligence.get("best_timing_window") or "").strip()
+    if best_window:
+        stats["best_timing_window"] = best_window
+    return stats
+
+
+def _blog_segment_reasoning_stats(
+    segment_playbook: dict[str, Any] | None,
+    timing_intelligence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build deterministic segment-targeting stats for blog blueprints."""
+    if not isinstance(segment_playbook, dict):
+        return {}
+    stats: dict[str, Any] = {}
+    summary = _segment_targeting_summary(segment_playbook, timing_intelligence)
+    if summary:
+        stats["segment_targeting_summary"] = summary
+    segments: list[dict[str, Any]] = []
+    for item in segment_playbook.get("priority_segments") or []:
+        if not isinstance(item, dict):
+            continue
+        segment = str(item.get("segment") or "").strip()
+        if not segment:
+            continue
+        row: dict[str, Any] = {"segment": segment}
+        reach = _reasoning_scalar(item.get("estimated_reach"))
+        if reach not in (None, ""):
+            row["estimated_reach"] = reach
+        angle = str(item.get("best_opening_angle") or "").strip()
+        if angle:
+            row["best_opening_angle"] = angle
+        segments.append(row)
+    if segments:
+        stats["priority_segments"] = segments[:3]
+    return stats
+
+
+def _blog_migration_proof_stats(displacement_reasoning: dict[str, Any] | None) -> dict[str, Any]:
+    """Build deterministic migration-proof stats for blog blueprints."""
+    if not isinstance(displacement_reasoning, dict):
+        return {}
+    proof = displacement_reasoning.get("migration_proof")
+    if not isinstance(proof, dict):
+        return {}
+    stats: dict[str, Any] = {}
+    if "switching_is_real" in proof:
+        stats["switching_is_real"] = bool(proof.get("switching_is_real"))
+    evidence_type = str(proof.get("evidence_type") or "").strip()
+    if evidence_type:
+        stats["evidence_type"] = evidence_type
+    for key in (
+        "switch_volume",
+        "active_evaluation_volume",
+        "displacement_mention_volume",
+        "top_destination",
+        "primary_switch_driver",
+    ):
+        value = _reasoning_scalar(proof.get(key))
+        if value not in (None, "", []):
+            stats[key] = value
+    examples: list[str] = []
+    for item in proof.get("named_examples") or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("company") or "").strip()
+        if name and name not in examples:
+            examples.append(name)
+    if examples:
+        stats["named_examples"] = examples[:3]
+    return stats
+
+
+def _blog_category_reasoning_stats(category_reasoning: dict[str, Any] | None) -> dict[str, Any]:
+    """Build deterministic category-reasoning stats for blog blueprints."""
+    if not isinstance(category_reasoning, dict):
+        return {}
+    stats: dict[str, Any] = {}
+    for key in ("market_regime", "narrative", "winner", "loser"):
+        value = str(category_reasoning.get(key) or "").strip()
+        if value:
+            stats[key] = value
+    return stats
+
+
+def _build_blog_claim_plan(
+    contracts: dict[str, Any] | None,
+    specificity_context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(contracts, dict):
+        return {}
+
+    plan: dict[str, Any] = {}
+    vendor_core = contracts.get("vendor_core_reasoning")
+    if isinstance(vendor_core, dict):
+        causal = vendor_core.get("causal_narrative")
+        if isinstance(causal, dict):
+            summary = str(causal.get("summary") or "").strip()
+            trigger = str(causal.get("trigger") or "").strip()
+            why_now = str(causal.get("why_now") or "").strip()
+            if summary:
+                plan["primary_thesis"] = summary
+            elif trigger or why_now:
+                parts = [part for part in (trigger, why_now) if part]
+                if parts:
+                    plan["primary_thesis"] = ". ".join(parts)
+
+        timing = vendor_core.get("timing_intelligence")
+        if isinstance(timing, dict):
+            best_window = str(timing.get("best_timing_window") or "").strip()
+            if best_window:
+                plan["timing_hook"] = best_window
+            else:
+                for trigger_row in timing.get("immediate_triggers") or []:
+                    if not isinstance(trigger_row, dict):
+                        continue
+                    trigger = str(
+                        trigger_row.get("trigger")
+                        or trigger_row.get("description")
+                        or ""
+                    ).strip()
+                    if trigger:
+                        plan["timing_hook"] = trigger
+                        break
+
+        retention = vendor_core.get("why_they_stay")
+        if isinstance(retention, dict):
+            summary = str(retention.get("summary") or "").strip()
+            if summary:
+                plan["counterevidence"] = summary
+
+    category_reasoning = contracts.get("category_reasoning")
+    if isinstance(category_reasoning, dict):
+        market_regime = str(category_reasoning.get("market_regime") or "").strip()
+        if market_regime:
+            plan["market_regime"] = market_regime
+
+    specificity = specificity_context if isinstance(specificity_context, dict) else {}
+    anchors = specificity.get("anchor_examples")
+    highlights = specificity.get("witness_highlights")
+    proof_anchors: list[dict[str, Any]] = []
+    preferred_labels = (
+        "outlier_or_named_account",
+        "common_pattern",
+        "counterevidence",
+    )
+    if isinstance(anchors, dict):
+        for label in preferred_labels:
+            rows = anchors.get(label) or []
+            if not isinstance(rows, list) or not rows:
+                continue
+            row = rows[0]
+            if not isinstance(row, dict):
+                continue
+            anchor = {"anchor_type": label}
+            for key in (
+                "excerpt_text",
+                "time_anchor",
+                "competitor",
+                "pain_category",
+                "signal_type",
+                "replacement_mode",
+                "operating_model_shift",
+                "productivity_delta_claim",
+                "org_pressure_type",
+                "reviewer_title",
+                "company_size",
+                "industry",
+                "numeric_literals",
+            ):
+                value = row.get(key)
+                if value not in (None, "", [], {}):
+                    anchor[key] = copy.deepcopy(value) if isinstance(value, (dict, list)) else value
+            if len(anchor) > 1:
+                proof_anchors.append(anchor)
+    if not proof_anchors and isinstance(highlights, list):
+        for row in highlights[:2]:
+            if not isinstance(row, dict):
+                continue
+            anchor: dict[str, Any] = {"anchor_type": "witness_highlight"}
+            for key in (
+                "excerpt_text",
+                "time_anchor",
+                "competitor",
+                "pain_category",
+                "signal_type",
+                "replacement_mode",
+                "operating_model_shift",
+                "productivity_delta_claim",
+                "org_pressure_type",
+                "numeric_literals",
+            ):
+                value = row.get(key)
+                if value not in (None, "", [], {}):
+                    anchor[key] = copy.deepcopy(value) if isinstance(value, (dict, list)) else value
+            if len(anchor) > 1:
+                proof_anchors.append(anchor)
+    if proof_anchors:
+        plan["proof_anchors"] = proof_anchors[:3]
+    return plan
+
+
+def _blog_scope_summary(scope_manifest: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(scope_manifest, dict):
+        return {}
+    summary: dict[str, Any] = {}
+    for key in (
+        "selection_strategy",
+        "reviews_considered_total",
+        "reviews_in_scope",
+        "witnesses_in_scope",
+        "witness_mix",
+    ):
+        value = scope_manifest.get(key)
+        if value not in (None, "", [], {}):
+            summary[key] = copy.deepcopy(value)
+    return summary
+
+
+def _blog_atom_context(consumer_context: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(consumer_context, dict):
+        return {}
+    context: dict[str, Any] = {}
+    theses = [
+        {
+            "wedge": str(item.get("wedge") or "").strip(),
+            "summary": str(item.get("summary") or "").strip(),
+            "why_now": str(item.get("why_now") or "").strip(),
+            "confidence": str(item.get("confidence") or "").strip(),
+        }
+        for item in (consumer_context.get("theses") or [])[:3]
+        if isinstance(item, dict)
+    ]
+    theses = [item for item in theses if item["summary"] or item["why_now"]]
+    if theses:
+        context["top_theses"] = theses
+    timing_windows = [
+        {
+            "window_type": str(item.get("window_type") or "").strip(),
+            "anchor": str(item.get("start_or_anchor") or "").strip(),
+            "urgency": str(item.get("urgency") or "").strip(),
+            "recommended_action": str(item.get("recommended_action") or "").strip(),
+        }
+        for item in (consumer_context.get("timing_windows") or [])[:3]
+        if isinstance(item, dict)
+    ]
+    timing_windows = [item for item in timing_windows if item["anchor"]]
+    if timing_windows:
+        context["timing_windows"] = timing_windows
+    proof_points = [
+        {
+            "label": str(item.get("label") or "").strip(),
+            "value": _reasoning_scalar(item.get("value")),
+            "interpretation": str(item.get("interpretation") or "").strip(),
+            "confidence": str(item.get("confidence") or "").strip(),
+        }
+        for item in (consumer_context.get("proof_points") or [])[:3]
+        if isinstance(item, dict)
+    ]
+    proof_points = [item for item in proof_points if item["label"]]
+    if proof_points:
+        context["proof_points"] = proof_points
+    account_signals = [
+        {
+            "company": str(item.get("company") or "").strip(),
+            "buying_stage": str(item.get("buying_stage") or "").strip(),
+            "competitor_context": str(item.get("competitor_context") or "").strip(),
+            "primary_pain": str(item.get("primary_pain") or "").strip(),
+            "quote": str(item.get("quote") or "").strip(),
+        }
+        for item in (consumer_context.get("account_signals") or [])[:3]
+        if isinstance(item, dict)
+    ]
+    account_signals = [
+        item for item in account_signals
+        if item["company"] or item["primary_pain"] or item["quote"]
+    ]
+    if account_signals:
+        context["account_signals"] = account_signals
+    coverage_limits = [
+        str(item.get("label") or "").strip()
+        for item in (consumer_context.get("coverage_limits") or [])[:4]
+        if isinstance(item, dict) and str(item.get("label") or "").strip()
+    ]
+    if coverage_limits:
+        context["coverage_limits"] = coverage_limits
+    counterevidence = [
+        str(item.get("statement") or "").strip()
+        for item in (consumer_context.get("counterevidence") or [])[:2]
+        if isinstance(item, dict) and str(item.get("statement") or "").strip()
+    ]
+    if counterevidence:
+        context["counterevidence"] = counterevidence
+    return context
+
+
+def _blog_delta_summary(reasoning_delta: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(reasoning_delta, dict):
+        return {}
+    summary: dict[str, Any] = {"changed": bool(reasoning_delta.get("changed"))}
+    for key in (
+        "wedge_changed",
+        "confidence_changed",
+        "top_destination_changed",
+    ):
+        if key in reasoning_delta:
+            summary[key] = bool(reasoning_delta.get(key))
+    for key in (
+        "theses_added",
+        "new_timing_windows",
+        "new_account_signals",
+        "coverage_worsened",
+    ):
+        value = reasoning_delta.get(key)
+        if isinstance(value, list) and value:
+            summary[key] = copy.deepcopy(value[:3])
+    return summary
+
+
+def _inject_blog_reasoning_specificity(
+    data: dict[str, Any],
+    *,
+    suffix: str,
+    view: Any,
+) -> None:
+    data_context = data.setdefault("data_context", {})
+    if not isinstance(data_context, dict):
+        data_context = {}
+        data["data_context"] = data_context
+
+    consumer_context = view.filtered_consumer_context("blog_reranker")
+    specificity = surface_specificity_context(consumer_context, surface="blog")
+    if specificity.get("anchor_examples"):
+        data[f"reasoning_anchor_examples{suffix}"] = specificity["anchor_examples"]
+        data_context[f"reasoning_anchor_examples{suffix}"] = copy.deepcopy(
+            specificity["anchor_examples"]
+        )
+    if specificity.get("witness_highlights"):
+        data[f"reasoning_witness_highlights{suffix}"] = specificity["witness_highlights"]
+        data_context[f"reasoning_witness_highlights{suffix}"] = copy.deepcopy(
+            specificity["witness_highlights"]
+        )
+    if specificity.get("reference_ids"):
+        data[f"reasoning_reference_ids{suffix}"] = specificity["reference_ids"]
+        data_context[f"reasoning_reference_ids{suffix}"] = copy.deepcopy(
+            specificity["reference_ids"]
+        )
+    disclaimers = consumer_context.get("reasoning_section_disclaimers")
+    if isinstance(disclaimers, dict) and disclaimers:
+        data[f"reasoning_section_disclaimers{suffix}"] = disclaimers
+        data_context[f"reasoning_section_disclaimers{suffix}"] = copy.deepcopy(
+            disclaimers
+        )
+
+    claim_plan = _build_blog_claim_plan(
+        consumer_context.get("reasoning_contracts") or view.materialized_contracts(),
+        specificity,
+    )
+    if claim_plan:
+        data[f"blog_claim_plan{suffix}"] = claim_plan
+        data_context[f"blog_claim_plan{suffix}"] = copy.deepcopy(claim_plan)
+    scope_summary = _blog_scope_summary(consumer_context.get("scope_manifest"))
+    if scope_summary:
+        data[f"reasoning_scope_summary{suffix}"] = scope_summary
+        data_context[f"reasoning_scope_summary{suffix}"] = copy.deepcopy(scope_summary)
+    atom_context = _blog_atom_context(consumer_context)
+    if atom_context:
+        data[f"reasoning_atom_context{suffix}"] = atom_context
+        data_context[f"reasoning_atom_context{suffix}"] = copy.deepcopy(atom_context)
+    delta_summary = _blog_delta_summary(consumer_context.get("reasoning_delta"))
+    if delta_summary:
+        data[f"reasoning_delta_summary{suffix}"] = delta_summary
+        data_context[f"reasoning_delta_summary{suffix}"] = copy.deepcopy(delta_summary)
+
+
+# -- Cross-vendor synthesis resolution helpers ----------------------
+
+def _resolve_blog_battle_summary(
+    vendor_a: str,
+    vendor_b: str,
+    xv_lookup: dict[str, Any],
+    fallback: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve a pairwise battle from cross-vendor synthesis or pool fallback.
+
+    Returns a blog-compatible summary dict with ``conclusion``, ``winner``,
+    ``loser``, ``confidence``, ``durability_assessment``, ``key_insights``.
+    """
+    battles = xv_lookup.get("battles") or {}
+    needle = tuple(sorted([
+        vendor_a.strip().lower(), vendor_b.strip().lower(),
+    ]))
+    # Try exact key first, then case-insensitive scan
+    entry = battles.get(needle)
+    if entry is None:
+        entry = battles.get(tuple(sorted([vendor_a.strip(), vendor_b.strip()])))
+    if entry is None:
+        for k, v in battles.items():
+            if tuple(sorted(s.lower() for s in k)) == needle:
+                entry = v
+                break
+    if entry is None:
+        return fallback or {}
+    conclusion = entry.get("conclusion") or {}
+    if not isinstance(conclusion, dict):
+        return fallback or {}
+    result = {
+        "conclusion": conclusion.get("conclusion") or "",
+        "winner": conclusion.get("winner") or "",
+        "loser": conclusion.get("loser") or "",
+        "confidence": conclusion.get("confidence"),
+        "durability_assessment": conclusion.get("durability_assessment") or "",
+        "key_insights": conclusion.get("key_insights") or [],
+        "source": "synthesis",
+    }
+    if not result["conclusion"]:
+        return fallback or {}
+    return result
+
+
+def _resolve_blog_council_summary(
+    category: str,
+    xv_lookup: dict[str, Any],
+    fallback: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve a category council from cross-vendor synthesis or pool fallback.
+
+    Returns a blog-compatible summary dict with ``conclusion``,
+    ``market_regime``, ``winner``, ``loser``, ``confidence``.
+    """
+    councils = xv_lookup.get("councils") or {}
+    cat_norm = (category or "").strip().lower()
+    entry = councils.get(category)
+    if entry is None:
+        # Try case-insensitive match
+        for k, v in councils.items():
+            if (k or "").strip().lower() == cat_norm:
+                entry = v
+                break
+    if entry is None:
+        return fallback or {}
+    conclusion = entry.get("conclusion") or {}
+    if not isinstance(conclusion, dict):
+        return fallback or {}
+    result = {
+        "conclusion": conclusion.get("conclusion") or "",
+        "market_regime": conclusion.get("market_regime") or "",
+        "winner": conclusion.get("winner"),
+        "loser": conclusion.get("loser"),
+        "confidence": conclusion.get("confidence"),
+        "durability_assessment": conclusion.get("durability_assessment") or "",
+        "key_insights": conclusion.get("key_insights") or [],
+        "source": "synthesis",
+    }
+    if not result["conclusion"] and not result["market_regime"]:
+        return fallback or {}
+    return result
+
+
+# -- CTA configuration --------------------------------------------
+
+_CTA_CONFIG: dict[str, dict[str, str]] = {
+    "vendor_showdown":       {"report_type": "vendor_comparison", "button_text": "Download the full benchmark report"},
+    "vendor_deep_dive":      {"report_type": "vendor_deep_dive",  "button_text": "Get the exclusive deep dive report"},
+    "churn_report":          {"report_type": "weekly_churn_feed", "button_text": "See which vendors are most at risk"},
+    "vendor_alternative":    {"report_type": "battle_card",       "button_text": "Compare alternatives side by side"},
+    "market_landscape":      {"report_type": "category_overview", "button_text": "Get the full industry report"},
+    "pricing_reality_check": {"report_type": "vendor_scorecard",  "button_text": "See the full pricing analysis"},
+    "switching_story":       {"report_type": "battle_card",       "button_text": "Get the switching playbook"},
+    "migration_guide":       {"report_type": "vendor_comparison", "button_text": "Download the migration comparison"},
+    "pain_point_roundup":    {"report_type": "category_overview", "button_text": "See the full category breakdown"},
+    "best_fit_guide":        {"report_type": "category_overview", "button_text": "Check your vendor's risk score"},
+}
+
+
+def _blog_length_policy(topic_type: str) -> dict[str, int]:
+    default_min_by_topic = {
+        "vendor_showdown": 2000,
+        "market_landscape": 1900,
+        "best_fit_guide": 1900,
+        "vendor_deep_dive": 1800,
+        "vendor_alternative": 1700,
+        "churn_report": 1700,
+        "pain_point_roundup": 1700,
+        "pricing_reality_check": 1600,
+        "migration_guide": 1500,
+        "switching_story": 1500,
+    }
+    default_target_by_topic = {
+        "vendor_showdown": 2600,
+        "market_landscape": 2600,
+        "best_fit_guide": 2500,
+        "vendor_deep_dive": 2400,
+        "vendor_alternative": 2300,
+        "churn_report": 2300,
+        "pain_point_roundup": 2300,
+        "pricing_reality_check": 2200,
+        "migration_guide": 2100,
+        "switching_story": 2100,
+    }
+
+    def _coerce_int_or_default(value: Any, default: int) -> int:
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            if value != value:
+                return default
+            return int(value)
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return default
+            try:
+                return int(text)
+            except ValueError:
+                try:
+                    return int(float(text))
+                except ValueError:
+                    return default
+        return default
+
+    cfg = settings.b2b_churn
+    normalized_topic = str(topic_type or "").strip().lower()
+    default_min = max(
+        1,
+        _coerce_int_or_default(getattr(cfg, "blog_post_min_words_default", 1800), 1800),
+    )
+    default_target = max(
+        default_min,
+        _coerce_int_or_default(getattr(cfg, "blog_post_target_words_default", default_min), default_min),
+    )
+    raw_min_by_topic = getattr(cfg, "blog_post_min_words_by_topic", default_min_by_topic) or default_min_by_topic
+    raw_target_by_topic = getattr(cfg, "blog_post_target_words_by_topic", default_target_by_topic) or default_target_by_topic
+    if not isinstance(raw_min_by_topic, dict):
+        raw_min_by_topic = default_min_by_topic
+    if not isinstance(raw_target_by_topic, dict):
+        raw_target_by_topic = default_target_by_topic
+    min_by_topic = {
+        str(key or "").strip().lower(): _coerce_int_or_default(value, default_min)
+        for key, value in raw_min_by_topic.items()
+        if str(key or "").strip()
+    }
+    target_by_topic = {
+        str(key or "").strip().lower(): _coerce_int_or_default(value, default_target)
+        for key, value in raw_target_by_topic.items()
+        if str(key or "").strip()
+    }
+    min_words = max(
+        1,
+        _coerce_int_or_default(min_by_topic.get(normalized_topic, default_min), default_min),
+    )
+    target_words = max(
+        min_words,
+        _coerce_int_or_default(target_by_topic.get(normalized_topic, default_target), default_target),
+    )
+    return {
+        "min_words": min_words,
+        "target_words": target_words,
+    }
+
+
+def _blog_topic_threshold(raw_map: Any, topic_type: str, *, default: int = 0) -> int:
+    if not isinstance(raw_map, dict):
+        return max(0, int(default))
+    normalized_topic = str(topic_type or "").strip().lower()
+    for key, value in raw_map.items():
+        if str(key or "").strip().lower() != normalized_topic:
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return max(0, int(default))
+    return max(0, int(default))
+
+
+def _blog_min_vendor_profiles(topic_type: str) -> int:
+    return _blog_topic_threshold(
+        getattr(settings.b2b_churn, "blog_min_vendor_profiles_by_topic", {}) or {},
+        topic_type,
+        default=2,
+    )
+
+
+def _blog_section_word_budget(blueprint: "PostBlueprint") -> dict[str, int]:
+    length_policy = _blog_length_policy(blueprint.topic_type)
+    section_count = max(1, len(blueprint.sections or []))
+    min_words = max(1, int(length_policy["min_words"]))
+    target_words = max(min_words, int(length_policy["target_words"]))
+    return {
+        "section_count": section_count,
+        "min_words_per_section": (min_words + section_count - 1) // section_count,
+        "target_words_per_section": (target_words + section_count - 1) // section_count,
+    }
+
+
+def _blog_sections_manifest(blueprint: "PostBlueprint") -> list[dict[str, Any]]:
+    return [
+        {
+            "id": section.id,
+            "heading": section.heading,
+            "goal": section.goal,
+            "chart_ids": list(section.chart_ids or []),
+        }
+        for section in (blueprint.sections or [])
+    ]
+
+
+def _attach_blog_blueprint_runtime_metadata(blueprint: "PostBlueprint") -> None:
+    if not isinstance(blueprint.data_context, dict):
+        blueprint.data_context = {}
+    blueprint.data_context["generation_length_policy"] = _blog_length_policy(
+        blueprint.topic_type
+    )
+    blueprint.data_context["section_word_budget"] = _blog_section_word_budget(
+        blueprint
+    )
+    blueprint.data_context["sections_manifest"] = _blog_sections_manifest(blueprint)
+
+
+def _build_cta(topic_type: str, data_context: dict[str, Any]) -> dict[str, Any] | None:
+    """Build structured CTA from topic type and data context."""
+    cfg = _CTA_CONFIG.get(topic_type)
+    if not cfg:
+        return None
+    tc = data_context.get("topic_ctx", {})
+    vendor = (
+        data_context.get("vendor")
+        or data_context.get("vendor_a")
+        or tc.get("vendor")
+        or tc.get("vendor_a")
+    )
+    category = data_context.get("category") or tc.get("category")
+    return {
+        "headline": "Want the full picture?",
+        "body": "",
+        "button_text": cfg["button_text"],
+        "report_type": cfg["report_type"],
+        "vendor_filter": vendor,
+        "category_filter": category,
+    }
+
+
+def _inject_affiliate_links(blueprint: PostBlueprint, content: dict[str, Any]) -> None:
+    """Inject affiliate placeholders/URLs into markdown as proper links."""
+    body = str(content.get("content") or "")
+    if not body:
+        return
+
+    affiliate_url = str(blueprint.data_context.get("affiliate_url") or "").strip()
+    affiliate_slug = str(blueprint.data_context.get("affiliate_slug") or "").strip()
+    partner_info = blueprint.data_context.get("affiliate_partner", {})
+    if not isinstance(partner_info, dict):
+        partner_info = {}
+    partner_name = str(partner_info.get("name") or partner_info.get("product_name") or "").strip()
+
+    if not (affiliate_slug and affiliate_url):
+        return
+
+    md_link = f"[{partner_name}]({affiliate_url})" if partner_name else affiliate_url
+    body = body.replace(f"{{{{affiliate:{affiliate_slug}}}}}", md_link)
+    if affiliate_url in body:
+        body = re.sub(
+            r'(?<!\]\()' + re.escape(affiliate_url) + r'(?!\))',
+            md_link,
+            body,
+        )
+    content["content"] = body
+
+
+def _normalize_quote_text(text: Any) -> str:
+    raw = str(text or "")
+    raw = raw.replace('\u201c', '"').replace('\u201d', '"').replace('\u2019', "'")
+    raw = raw.strip().strip('"').strip("'")
+    raw = re.sub(r"\s+", " ", raw)
+    raw = re.sub(r"[^a-z0-9 ]+", " ", raw.lower())
+    return re.sub(r"\s+", " ", raw).strip()
+
+
+def _extract_quote_body(line: str) -> str:
+    body = str(line or "").strip()
+    if "--" in body:
+        body = body.split("--", 1)[0].strip()
+    return body.strip().strip('"').strip("'").strip()
+
+
+def _extract_blockquote_quotes(markdown: str) -> list[str]:
+    quotes: list[str] = []
+    for line in str(markdown or "").splitlines():
+        match = _BLOCKQUOTE_RE.match(line)
+        if not match:
+            continue
+        quote = _extract_quote_body(match.group(1))
+        if len(quote) >= 12:
+            quotes.append(quote)
+    return quotes
+
+
+def _quote_grade_blueprint_phrases(
+    rows: list[dict[str, Any]],
+    *,
+    field: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build blueprint-shaped quote dicts from review rows.
+
+    Returns ONLY quote-grade phrases (subject_vendor + negative/mixed +
+    verbatim=True) per services.b2b.enrichment_contract.quote_grade_phrases.
+    Legacy v3 rows without phrase_metadata contribute nothing -- this
+    function is the gate that prevents non-verbatim text from reaching
+    the customer-facing quote pool.
+
+    Accepts either ``enrichment`` or ``enrichment_raw`` as the JSONB key
+    on each row -- recent producer migrations have used both names.
+
+    Output dicts include traceability so downstream consumers can audit
+    which review + source each phrase came from:
+        {
+            "phrase": <verbatim text>,
+            "vendor": <vendor_name or vendor>,
+            "urgency": <urgency_score>,
+            "role": <reviewer_title or role>,
+            "review_id": <id from row>,
+            "source": <source from row>,
+            "field": <phrase_metadata.field, e.g. 'pricing_phrases'>,
+        }
+    """
+    from ...services.b2b.enrichment_contract import quote_grade_phrases
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        enrichment_val = r.get("enrichment")
+        if enrichment_val is None:
+            enrichment_val = r.get("enrichment_raw")
+        if isinstance(enrichment_val, str) and enrichment_val:
+            try:
+                enrichment_val = json.loads(enrichment_val)
+            except (json.JSONDecodeError, TypeError):
+                enrichment_val = None
+        if not isinstance(enrichment_val, dict):
+            continue
+        phrases = quote_grade_phrases(enrichment_val, field=field)
+        for phrase in phrases:
+            text = str(phrase.get("text") or "").strip()
+            if not text:
+                continue
+            out.append({
+                "phrase": text,
+                "vendor": r.get("vendor_name") or r.get("vendor"),
+                "urgency": r.get("urgency"),
+                "role": r.get("reviewer_title") or r.get("role", ""),
+                "review_id": r.get("review_id") or r.get("id"),
+                "source": r.get("source"),
+                "field": phrase.get("field"),
+            })
+            if limit and len(out) >= limit:
+                return out
+    return out
+
+
+def _split_and_gate_blog_quotes(
+    rows: list[dict[str, Any]],
+    *,
+    field: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Split a mixed quote pool by explicit origin and route each path
+    through the appropriate quote-grade or legacy treatment.
+
+    Discriminator: every row MUST carry ``quote_origin`` to be kept.
+
+      - ``quote_origin == "review"`` -> route through
+        ``_quote_grade_blueprint_phrases`` (verbatim subject_vendor +
+        negative phrases). A row marked 'review' but missing
+        ``enrichment``/``enrichment_raw`` produces no quote-grade output
+        and is therefore dropped from the pool.
+      - ``quote_origin == "vault"`` -> route through the legacy
+        truncation path, but only when the row carries
+        ``phrase_verbatim=True`` (stamped by 4e-A's vault writer and
+        propagated through the blog vault mergers in 4i). Vault rows
+        without the marker are dropped, matching the policy that every
+        customer-rendered quote must trace back to a verbatim phrase.
+      - Anything else (no marker, unknown value) -> dropped.
+
+    The drop-by-default policy closes the prior 'no enrichment means
+    vault' loophole that would have let an unmarked SQL row sneak
+    through under a previous implementation.
+    """
+    review_rows: list[dict[str, Any]] = []
+    vault_rows: list[dict[str, Any]] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        origin = str(r.get("quote_origin") or "").strip().lower()
+        if origin == "review":
+            review_rows.append(r)
+        elif origin == "vault":
+            vault_rows.append(r)
+        # Unmarked / unknown origin: dropped on purpose.
+    review_quotes = _quote_grade_blueprint_phrases(
+        review_rows, field=field, limit=limit,
+    )
+    vault_quotes: list[dict[str, Any]] = []
+    for r in vault_rows:
+        # Phase 2.3 4i: vault rows must also carry phrase_verbatim=True.
+        # The blog vault mergers stamp it after 4e-A's writer
+        # propagation; missing markers fail closed here.
+        if r.get("phrase_verbatim") is not True:
+            continue
+        # Vault rows arrive in two shapes depending on the merger that
+        # produced them: ``phrase`` (from _merge_blog_quotes_with_evidence_vault)
+        # or ``text`` (from _build_specialized_blog_review_rows_from_evidence_vault).
+        # Either is acceptable for the legacy path -- the producer has
+        # already curated the surface text.
+        text = str(r.get("phrase") or r.get("text") or "").strip()
+        if not text:
+            continue
+        vault_quotes.append({
+            "phrase": text[:200],
+            "vendor": r.get("vendor"),
+            "urgency": r.get("urgency"),
+            "role": r.get("role", ""),
+            "phrase_verbatim": True,
+        })
+    combined = review_quotes + vault_quotes
+    if limit is not None:
+        return combined[:limit]
+    return combined
+
+
+def _source_quote_texts(blueprint: PostBlueprint) -> list[str]:
+    phrases = blueprint.quotable_phrases or []
+    expected_vendors = _expected_quote_vendors(blueprint)
+    candidate_vendors = {
+        str(item.get("vendor") or "").strip()
+        for item in phrases
+        if isinstance(item, dict) and str(item.get("vendor") or "").strip()
+    }
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in phrases:
+        if not isinstance(item, dict):
+            continue
+        item_vendor = str(item.get("vendor") or "").strip()
+        if expected_vendors and item_vendor and item_vendor.lower() not in expected_vendors:
+            continue
+        for key in ("phrase", "text", "quote", "best_quote"):
+            value = str(item.get(key) or "").strip()
+            if not value:
+                continue
+            if expected_vendors and _quote_mentions_unexpected_vendor(
+                value, expected_vendors, candidate_vendors,
+            ):
+                continue
+            marker = _normalize_quote_text(value)
+            if not marker or marker in seen:
+                continue
+            seen.add(marker)
+            out.append(value)
+            break
+    return out
+
+
+def _expected_quote_vendors(blueprint: PostBlueprint) -> set[str]:
+    data_context = blueprint.data_context or {}
+    expected: set[str] = set()
+    for key in ("vendor", "vendor_a", "vendor_b", "from_vendor", "to_vendor"):
+        value = str(data_context.get(key) or "").strip().lower()
+        if value:
+            expected.add(value)
+    return expected
+
+
+def _normalized_vendor_text(text: str) -> str:
+    return " ".join(re.findall(r"[a-z0-9]+", str(text or "").lower()))
+
+
+def _quote_mentions_unexpected_vendor(
+    quote_text: str,
+    expected_vendors: set[str],
+    candidate_vendors: set[str],
+) -> bool:
+    if not expected_vendors or not candidate_vendors:
+        return False
+    normalized_quote = f" {_normalized_vendor_text(quote_text)} "
+    if not normalized_quote.strip():
+        return False
+    for vendor in candidate_vendors:
+        if not vendor:
+            continue
+        normalized_vendor = _normalized_vendor_text(vendor)
+        if not normalized_vendor:
+            continue
+        if vendor.lower() in expected_vendors:
+            continue
+        if f" {normalized_vendor} " in normalized_quote:
+            return True
+    return False
+
+
+def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
+    normalized_quote = _normalize_quote_text(quote_text)
+    if not normalized_quote:
+        return True
+    quote_tokens = set(normalized_quote.split())
+    if not quote_tokens:
+        return True
+
+    for source_text in source_quotes:
+        normalized_source = _normalize_quote_text(source_text)
+        if not normalized_source:
+            continue
+        if normalized_quote in normalized_source or normalized_source in normalized_quote:
+            return True
+        source_tokens = set(normalized_source.split())
+        overlap = len(quote_tokens & source_tokens)
+        min_required = max(5, int(0.6 * min(len(quote_tokens), len(source_tokens))))
+        if overlap >= min_required:
+            return True
+    return False
+
+
+def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
+    """Strip LLM-generated blockquote lines that do not ground in a
+    quote-grade source pool.
+
+    Fails closed: when ``source_quotes`` is empty, ALL blockquote lines
+    are removed. The absence of a source pool is treated as 'no quote
+    material is grounded', not as 'everything passes' -- the latter was
+    the prior backdoor that allowed paraphrased LLM quotes to ship when
+    the producer hadn't supplied verbatim phrases.
+    """
+    removed = 0
+    output: list[str] = []
+    for line in str(markdown or "").splitlines():
+        match = _BLOCKQUOTE_RE.match(line)
+        if not match:
+            output.append(line)
+            continue
+        if not source_quotes:
+            removed += 1
+            continue
+        quote = _extract_quote_body(match.group(1))
+        if quote and not _quote_matches_source(quote, source_quotes):
+            removed += 1
+            continue
+        output.append(line)
+    return "\n".join(output), removed
+
+
+def _sanitize_blog_markdown(markdown: str) -> tuple[str, dict[str, int]]:
+    """Apply deterministic cleanup for common LLM artifacts."""
+    text = str(markdown or "")
+    answer_hits = len(_ANSWER_PREFIX_RE.findall(text))
+    if answer_hits:
+        text = _ANSWER_PREFIX_RE.sub(r"\1", text)
+    return text, {"answer_prefix_removed": answer_hits}
+
+
+def _required_vendor_mentions(blueprint: PostBlueprint, content_text: str) -> list[str]:
+    ctx = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+    required: list[str] = []
+    for key in ("vendor", "vendor_a", "vendor_b"):
+        value = str(ctx.get(key) or "").strip()
+        if value:
+            required.append(value)
+    if not required:
+        topic_ctx = ctx.get("topic_ctx")
+        if isinstance(topic_ctx, dict):
+            for key in ("vendor", "vendor_a", "vendor_b"):
+                value = str(topic_ctx.get(key) or "").strip()
+                if value:
+                    required.append(value)
+    missing: list[str] = []
+    haystack = str(content_text or "")
+    for vendor in required:
+        if not re.search(rf"\b{re.escape(vendor)}\b", haystack, re.IGNORECASE):
+            missing.append(vendor)
+    return missing
+
+
+def _apply_blog_quality_gate(
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Run deterministic quality checks and cleanup.
+
+    Returns (possibly cleaned content, quality report).
+    """
+    cleaned = dict(content or {})
+    body = str(cleaned.get("content") or "")
+    body, sanitize_counts = _sanitize_blog_markdown(body)
+
+    source_quotes = _source_quote_texts(blueprint)
+    body, removed_quotes = _remove_unmatched_quote_lines(body, source_quotes)
+    cleaned["content"] = body
+
+    blocking_issues: list[str] = []
+    warnings: list[str] = []
+    fixes_applied: list[str] = []
+
+    if sanitize_counts.get("answer_prefix_removed", 0) > 0:
+        fixes_applied.append(f"removed_answer_prefix:{sanitize_counts['answer_prefix_removed']}")
+    if removed_quotes > 0:
+        fixes_applied.append(f"removed_unmatched_quotes:{removed_quotes}")
+
+    length_policy = _blog_length_policy(blueprint.topic_type)
+    min_words = int(length_policy["min_words"])
+    target_words = int(length_policy["target_words"])
+    word_count = len(body.split())
+    if word_count < min_words:
+        blocking_issues.append(f"content_too_short:{word_count}_words_need_{min_words}")
+    elif word_count < target_words:
+        warnings.append(f"content_below_seo_target_{target_words}_words")
+
+    chart_ids = [c.chart_id for c in blueprint.charts]
+    chart_mentions = re.findall(r"\{\{chart:([a-zA-Z0-9\-_]+)\}\}", body)
+    chart_counts = {chart_id: chart_mentions.count(chart_id) for chart_id in chart_ids}
+    for chart_id in chart_ids:
+        count = chart_counts.get(chart_id, 0)
+        if count == 0:
+            blocking_issues.append(f"missing_chart_placeholder:{chart_id}")
+        elif count > 1:
+            blocking_issues.append(f"duplicate_chart_placeholder:{chart_id}")
+    unknown_chart_ids = sorted({cid for cid in chart_mentions if cid not in set(chart_ids)})
+    if unknown_chart_ids:
+        blocking_issues.append(f"unknown_chart_placeholders:{','.join(unknown_chart_ids)}")
+
+    unresolved_tokens: list[str] = []
+    for token in _PLACEHOLDER_RE.findall(body):
+        token = token.strip()
+        if token.startswith("chart:"):
+            continue
+        unresolved_tokens.append(token)
+    if unresolved_tokens:
+        blocking_issues.append(
+            f"unresolved_placeholders:{','.join(sorted(set(unresolved_tokens))[:6])}"
+        )
+
+    quoted = _extract_blockquote_quotes(body)
+    if source_quotes and len(quoted) < 2:
+        blocking_issues.append(f"too_few_sourced_quotes:{len(quoted)}")
+    if not source_quotes and len(quoted) == 0:
+        warnings.append("no_quotes_present")
+
+    review_period = str((blueprint.data_context or {}).get("review_period") or "").strip()
+    if review_period and review_period not in body:
+        warnings.append("review_period_not_explicitly_mentioned")
+    if "self-selected" not in body.lower():
+        warnings.append("methodology_disclaimer_missing_self_selected")
+
+    missing_vendors = _required_vendor_mentions(blueprint, body)
+    if missing_vendors:
+        blocking_issues.append(f"missing_vendor_mentions:{','.join(missing_vendors)}")
+
+    specificity_context = surface_specificity_context(
+        blueprint.data_context if isinstance(blueprint.data_context, dict) else {},
+        surface="blog",
+    )
+    if specificity_context:
+        specificity = evaluate_specificity_support(
+            body,
+            anchor_examples=specificity_context.get("anchor_examples"),
+            witness_highlights=specificity_context.get("witness_highlights"),
+            reference_ids=specificity_context.get("reference_ids"),
+            allow_company_names=False,
+            min_anchor_hits=int(settings.b2b_churn.blog_specificity_min_anchor_hits),
+            require_anchor_support=bool(
+                settings.b2b_churn.blog_specificity_require_anchor_support
+            ),
+            require_timing_or_numeric_when_available=bool(
+                settings.b2b_churn.blog_specificity_require_timing_or_numeric_when_available
+            ),
+            include_competitor_terms=True,
+            numeric_term_filter=_is_meaningful_numeric_anchor,
+        )
+        blocking_issues.extend(
+            f"witness_specificity:{issue}"
+            for issue in specificity.get("blocking_issues", []) or []
+        )
+        warnings.extend(
+            f"witness_specificity:{warning}"
+            for warning in specificity.get("warnings", []) or []
+        )
+
+    # Block placeholder links
+    if 'href="#"' in body or "href='#'" in body:
+        blocking_issues.append("placeholder_links_href_hash")
+
+    # Block nonexistent internal blog links
+    internal_links = re.findall(r'/blog/([a-z0-9\-]+)', body)
+    if internal_links:
+        known = set((blueprint.data_context or {}).get("_valid_internal_slugs") or [])
+        fake = [lk for lk in internal_links if lk not in known and lk != blueprint.slug]
+        if fake:
+            blocking_issues.append(f"nonexistent_internal_links:{','.join(fake[:4])}")
+
+    # Warn on title/slug mismatch
+    title_lower = str(content.get("title") or blueprint.suggested_title or "").lower()
+    for vk in ("vendor", "vendor_a", "vendor_b"):
+        v = str((blueprint.data_context or {}).get(vk) or "").strip()
+        if v and len(v) > 2 and v.lower() not in title_lower:
+            warnings.append(f"title_missing_expected_vendor:{v}")
+            break
+
+    body_lower = body.lower()
+    if "category winner" in body_lower or "category loser" in body_lower:
+        dc = blueprint.data_context or {}
+        if not (dc.get("category_winner") or dc.get("category_loser")):
+            blocking_issues.append("unsupported_category_outcome_assertion")
+
+    # Unsupported data claims: vendor names in claim-bearing sentences not in data
+    grounded = _build_grounded_vendor_set(blueprint)
+    ctx = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+    unsupported = _find_unsupported_data_claims(
+        body, grounded, known_vendors=ctx.get("_known_vendors"),
+    )
+    for claim in unsupported[:3]:
+        warnings.append(f"unsupported_data_claim:{claim}")
+
+    # Chart-scope ambiguity: strongest claim phrases must match chart data_labels
+    _CHART_SCOPE_PHRASES = (
+        "most common source", "top migration source", "top source",
+        "primary source", "where users come from", "where teams come from",
+        "most common migration",
+    )
+    chart_labels_lower: set[str] = set()
+    for chart in blueprint.charts:
+        for row in chart.data:
+            if isinstance(row, dict):
+                for vk in ("name", "label", "category"):
+                    v = str(row.get(vk) or "").strip()
+                    if v:
+                        chart_labels_lower.add(v.lower())
+    if chart_labels_lower:
+        sentences = re.split(r'(?<=[.!?])\s+|\n+', body)
+        for sentence in sentences:
+            s_lower = sentence.lower()
+            if not any(phrase in s_lower for phrase in _CHART_SCOPE_PHRASES):
+                continue
+            # Check if sentence names a vendor NOT in chart labels
+            for v in (ctx.get("_known_vendors") or []):
+                if len(v) > 2 and v.lower() not in chart_labels_lower and re.search(r"\b" + re.escape(v) + r"\b", sentence, re.IGNORECASE):
+                    warnings.append(
+                        f"chart_scope_ambiguity:{v}: {sentence.strip()[:100]}"
+                    )
+                    break
+
+    # Numeric consistency: check that sub-counts don't exceed headline counts
+    _COUNT_PATTERN = re.compile(
+        r"(\d[\d,]*)\s+(?:switching|churn|migration|displacement)\s+"
+        r"(?:signals?|stories|reviews?|mentions?)",
+        re.IGNORECASE,
+    )
+    count_values = [int(m.replace(",", "")) for m in _COUNT_PATTERN.findall(body)]
+    if len(count_values) >= 2:
+        headline = max(count_values)
+        sub_total = sum(v for v in count_values if v != headline)
+        if sub_total > headline and headline > 0:
+            warnings.append(
+                f"numeric_inconsistency:sub-counts ({sub_total}) exceed headline ({headline})"
+            )
+
+    # Direction guard: migration_guide should stay inbound-focused
+    if blueprint.topic_type == "migration_guide":
+        dc = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+        topic_vendor = str(dc.get("vendor") or dc.get("to_vendor") or "").strip()
+        if topic_vendor:
+            _OUTBOUND_PHRASES = (
+                f"switching from {topic_vendor}".lower(),
+                f"leaving {topic_vendor}".lower(),
+                f"moving away from {topic_vendor}".lower(),
+                f"migrating from {topic_vendor}".lower(),
+                f"abandoning {topic_vendor}".lower(),
+            )
+            outbound_count = sum(
+                1 for phrase in _OUTBOUND_PHRASES
+                if phrase in body_lower
+            )
+            if outbound_count >= 2:
+                warnings.append(
+                    f"migration_direction_drift:too much outbound prose about leaving {topic_vendor} "
+                    f"in a switch-to-{topic_vendor} article ({outbound_count} outbound phrases)"
+                )
+
+    threshold = int(settings.b2b_churn.blog_quality_pass_score)
+    score = max(0, 100 - (18 * len(blocking_issues)) - (6 * len(warnings)))
+    report = {
+        "score": score,
+        "threshold": threshold,
+        "status": "pass" if (not blocking_issues and score >= threshold) else "fail",
+        "blocking_issues": blocking_issues,
+        "warnings": warnings,
+        "fixes_applied": fixes_applied,
+        "quote_count": len(quoted),
+        "word_count": word_count,
+        "min_words_required": min_words,
+        "target_words": target_words,
+    }
+    return cleaned, report
+
+
+def _quality_feedback(report: dict[str, Any]) -> list[str]:
+    feedback: list[str] = []
+    for issue in report.get("blocking_issues", []) or []:
+        feedback.append(f"Fix: {issue}")
+    if (
+        report.get("status") == "fail"
+        and not (report.get("blocking_issues") or [])
+        and report.get("score") is not None
+        and report.get("threshold") is not None
+        and report.get("score") < report.get("threshold")
+    ):
+        feedback.append(
+            "Fix: Reduce warning-level quality issues so the final score "
+            f"meets the passing threshold of {report['threshold']}."
+        )
+    for warning in (report.get("warnings", []) or []):
+        if warning == "review_period_not_explicitly_mentioned":
+            feedback.append("Fix: Explicitly state the exact review period from data_context.review_period.")
+        elif warning == "methodology_disclaimer_missing_self_selected":
+            feedback.append("Fix: Include a plain-language methodology line that reviewers are self-selected and signals reflect perception.")
+        elif str(warning).startswith("chart_scope_ambiguity:"):
+            feedback.append(
+                "Fix: Differentiate charted source data from broader displacement/evaluation signals. "
+                "Use 'most common' and 'top sources' only for vendors visible in the chart's data_labels. "
+                "For vendors from broader data_context, use hedged language like 'broader displacement signals also mention' or 'evaluation alternatives include'."
+            )
+        elif str(warning).startswith("unsupported_data_claim:"):
+            feedback.append(
+                "Fix: A data claim references a vendor not present in any chart or data_context. "
+                "Either remove the claim or reword to cite the actual data source."
+            )
+        elif str(warning).startswith("migration_direction_drift:"):
+            feedback.append(
+                "Fix: This is a switch-TO article. Keep the primary narrative about inbound migration. "
+                "Outbound switching (people leaving the vendor) may be acknowledged in 1-2 sentences as a brief caveat, "
+                "but must not become a narrative thread. Remove or compress outbound-focused passages."
+            )
+        elif str(warning).startswith("witness_specificity:"):
+            feedback.append(
+                "Fix: Use the witness-backed proof anchors already provided. "
+                "Ground key claims in the concrete timing, numeric, competitor, or pain details instead of generic summary language."
+            )
+        else:
+            feedback.append(f"Improve: {warning}")
+    return feedback[:8]
+
+
+def _critical_quality_warnings(report: dict[str, Any]) -> list[str]:
+    return [
+        str(w)
+        for w in (report.get("warnings", []) or [])
+        if any(str(w) == cw or str(w).startswith(cw + ":") for cw in _CRITICAL_BLOG_WARNINGS)
+    ]
+
+
+def _with_unresolved_critical_warnings(report: dict[str, Any]) -> dict[str, Any]:
+    critical = _critical_quality_warnings(report)
+    if not critical:
+        return report
+    enriched = dict(report)
+    blocking = list(enriched.get("blocking_issues", []) or [])
+    for warning in critical:
+        marker = f"critical_warning_unresolved:{warning}"
+        if marker not in blocking:
+            blocking.append(marker)
+    enriched["blocking_issues"] = blocking
+    enriched["status"] = "fail"
+    return enriched
+
+
+def _insert_blog_note(body: str, note: str, *, marker: str) -> str:
+    text = str(body or "").strip()
+    note_text = str(note or "").strip()
+    if not text or not note_text:
+        return text
+
+    blocks = text.split("\n\n")
+    marker_prefix = marker.lower()
+    for idx, block in enumerate(blocks):
+        if block.strip().lower().startswith(marker_prefix):
+            if block.strip() == note_text:
+                return text
+            blocks[idx] = note_text
+            return "\n\n".join(blocks)
+    insert_at = 0
+    if blocks and blocks[0].lstrip().startswith("#"):
+        insert_at = 1
+        if len(blocks) > 1 and blocks[1].strip().lower().startswith("_methodology note:"):
+            insert_at = 2
+    blocks.insert(min(insert_at, len(blocks)), note_text)
+    return "\n\n".join(blocks)
+
+
+def _has_blog_note(body: str, *, marker: str) -> bool:
+    text = str(body or "").strip()
+    if not text:
+        return False
+    marker_prefix = str(marker or "").strip().lower()
+    if not marker_prefix:
+        return False
+    return any(
+        block.strip().lower().startswith(marker_prefix)
+        for block in text.split("\n\n")
+    )
+
+
+def _remove_blog_note(body: str, *, marker: str) -> str:
+    text = str(body or "").strip()
+    if not text:
+        return text
+    marker_prefix = str(marker or "").strip().lower()
+    if not marker_prefix:
+        return text
+    blocks = [
+        block
+        for block in text.split("\n\n")
+        if not block.strip().lower().startswith(marker_prefix)
+    ]
+    return "\n\n".join(blocks).strip()
+
+
+def _blog_specificity_context(blueprint: PostBlueprint) -> dict[str, Any]:
+    return surface_specificity_context(
+        blueprint.data_context if isinstance(blueprint.data_context, dict) else {},
+        surface="blog",
+    )
+
+
+def _specificity_rows(blueprint: PostBlueprint) -> list[dict[str, Any]]:
+    specificity = _blog_specificity_context(blueprint)
+    collected: list[dict[str, Any]] = []
+    anchors = specificity.get("anchor_examples")
+    preferred_labels = (
+        "outlier_or_named_account",
+        "common_pattern",
+        "counterevidence",
+    )
+    if isinstance(anchors, dict):
+        for label in preferred_labels:
+            group_rows = anchors.get(label) or []
+            if isinstance(group_rows, list):
+                for row in group_rows:
+                    if isinstance(row, dict):
+                        collected.append(row)
+        for group_rows in anchors.values():
+            if isinstance(group_rows, list):
+                for row in group_rows:
+                    if isinstance(row, dict):
+                        collected.append(row)
+    highlights = specificity.get("witness_highlights") or []
+    if isinstance(highlights, list):
+        for row in highlights:
+            if isinstance(row, dict):
+                collected.append(row)
+    return collected
+
+
+def _first_numeric_literal(witness: dict[str, Any]) -> str:
+    numeric_literals = witness.get("numeric_literals")
+    if not isinstance(numeric_literals, dict):
+        return ""
+    for values in numeric_literals.values():
+        if isinstance(values, list):
+            for value in values:
+                text = str(value or "").strip()
+                if _is_meaningful_numeric_anchor(text):
+                    return text
+            continue
+        text = str(values or "").strip()
+        if _is_meaningful_numeric_anchor(text):
+            return text
+    return ""
+
+
+def _first_term_from_rows(
+    rows: list[dict[str, Any]],
+    extractor,
+) -> str:
+    for row in rows:
+        value = str(extractor(row) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _preferred_signal_term(
+    values: set[str] | None,
+    *,
+    skip: set[str] | None = None,
+    predicate=None,
+) -> str:
+    candidates = [
+        str(value or "").strip()
+        for value in (values or set())
+        if str(value or "").strip()
+    ]
+    if skip:
+        lowered_skip = {str(value).strip().lower() for value in skip if str(value).strip()}
+        candidates = [value for value in candidates if value.lower() not in lowered_skip]
+    if predicate is not None:
+        candidates = [value for value in candidates if predicate(value)]
+    if not candidates:
+        return ""
+    candidates.sort(key=lambda token: (-len(token), token.lower()))
+    return candidates[0]
+
+
+def _is_meaningful_numeric_anchor(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    if "%" in text:
+        return True
+    if re.search(r"\b\d+(?:\.\d+)?\s*[kmbx]\b", text, re.IGNORECASE):
+        return True
+    if re.search(r"[$\u20ac\u00a3]\s*\d", text):
+        numeric_text = re.sub(r"[^0-9.]", "", text)
+        try:
+            return float(numeric_text) >= 1.0
+        except (TypeError, ValueError):
+            return False
+    numeric_groups = [
+        chunk.replace(",", "")
+        for chunk in re.findall(r"\d[\d,]*", text)
+    ]
+    return any(len(chunk) >= 3 for chunk in numeric_groups)
+
+
+def _blog_low_signal_anchor_labels() -> set[str]:
+    values = getattr(settings.b2b_churn, "blog_evidence_anchor_low_signal_labels", []) or []
+    labels: set[str] = set()
+    for value in values:
+        label = str(value or "").strip().lower().replace("_", " ")
+        if label:
+            labels.add(label)
+    return labels
+
+
+def _humanize_blog_anchor_label(value: Any) -> str:
+    return " ".join(str(value or "").strip().replace("_", " ").split())
+
+
+def _is_meaningful_blog_anchor_label(value: Any) -> bool:
+    label = _humanize_blog_anchor_label(value).lower()
+    if not label:
+        return False
+    if label in {"unknown", "none", "recommendation"}:
+        return False
+    if label in _blog_low_signal_anchor_labels():
+        return False
+    if any(pattern in label for pattern in (settings.b2b_churn.witness_specificity_generic_patterns or [])):
+        return False
+    condensed = re.sub(r"[^a-z0-9]", "", label)
+    if condensed.isalpha() and len(condensed) <= 2:
+        return False
+    return True
+
+
+def _meaningful_pain_label(witness: dict[str, Any]) -> str:
+    for key in ("pain_category", "signal_type", "org_pressure_type"):
+        value = _humanize_blog_anchor_label(witness.get(key))
+        if not _is_meaningful_blog_anchor_label(value):
+            continue
+        return value
+    return ""
+
+
+def _meaningful_workflow_label(witness: dict[str, Any]) -> str:
+    for key in ("replacement_mode", "operating_model_shift", "productivity_delta_claim"):
+        value = _humanize_blog_anchor_label(witness.get(key))
+        if not _is_meaningful_blog_anchor_label(value):
+            continue
+        return value
+    return ""
+
+
+def _needs_timing_or_numeric_anchor(report: dict[str, Any]) -> bool:
+    blockers = [str(issue) for issue in (report.get("blocking_issues") or [])]
+    return any(
+        issue.startswith("witness_specificity:")
+        and "timing or numeric anchor" in issue
+        for issue in blockers
+    )
+
+
+def _select_specificity_anchor_terms(
+    blueprint: PostBlueprint,
+    report: dict[str, Any],
+) -> dict[str, str]:
+    specificity = _blog_specificity_context(blueprint)
+    rows = _specificity_rows(blueprint)
+    if not rows:
+        return {}
+
+    needs_timing_numeric = _needs_timing_or_numeric_anchor(report)
+    timing_anchor = _first_term_from_rows(rows, lambda row: row.get("time_anchor"))
+    numeric_anchor = _first_term_from_rows(rows, _first_numeric_literal)
+    competitor = _first_term_from_rows(rows, lambda row: row.get("competitor"))
+    pain = _first_term_from_rows(rows, _meaningful_pain_label)
+    workflow = _first_term_from_rows(rows, _meaningful_workflow_label)
+
+    signal_terms = specificity_signal_terms(
+        anchor_examples=specificity.get("anchor_examples"),
+        witness_highlights=specificity.get("witness_highlights"),
+        allow_company_names=False,
+    )
+    if not timing_anchor:
+        timing_anchor = _preferred_signal_term(signal_terms.get("timing_terms"))
+    if not numeric_anchor:
+        numeric_anchor = _preferred_signal_term(
+            signal_terms.get("numeric_terms"),
+            predicate=_is_meaningful_numeric_anchor,
+        )
+    if not competitor:
+        competitor = _preferred_signal_term(signal_terms.get("competitor_terms"))
+    if not pain:
+        pain = _preferred_signal_term(
+            signal_terms.get("pain_terms"),
+            skip={
+                "recommendation",
+                "unknown",
+                "none",
+                *(_blog_low_signal_anchor_labels()),
+            },
+        )
+        if pain and not _is_meaningful_blog_anchor_label(pain):
+            pain = ""
+        else:
+            pain = _humanize_blog_anchor_label(pain)
+    if not workflow:
+        workflow = _preferred_signal_term(
+            signal_terms.get("workflow_terms"),
+            skip={"unknown", "none"},
+        )
+        if workflow and not _is_meaningful_blog_anchor_label(workflow):
+            workflow = ""
+        else:
+            workflow = _humanize_blog_anchor_label(workflow)
+
+    if needs_timing_numeric and not (timing_anchor or numeric_anchor):
+        return {}
+
+    return {
+        "time_anchor": timing_anchor,
+        "numeric_anchor": numeric_anchor,
+        "competitor": competitor,
+        "pain": pain,
+        "workflow": workflow,
+    }
+
+
+def _build_specificity_anchor_note(
+    blueprint: PostBlueprint,
+    report: dict[str, Any],
+) -> str:
+    terms = _select_specificity_anchor_terms(blueprint, report)
+    if not terms:
+        return ""
+
+    detail_bits: list[str] = []
+    time_anchor = terms["time_anchor"]
+    numeric_anchor = terms["numeric_anchor"]
+    competitor = terms["competitor"]
+    pain = terms["pain"]
+    workflow = terms["workflow"]
+
+    if time_anchor:
+        detail_bits.append(f"{time_anchor} is the live timing trigger")
+    if numeric_anchor:
+        detail_bits.append(f"{numeric_anchor} is the concrete spend anchor")
+    if competitor:
+        detail_bits.append(f"{competitor} is the competitive alternative in the witness-backed record")
+    if pain:
+        detail_bits.append(f"the core pressure showing up in the evidence is {pain}")
+    if workflow:
+        detail_bits.append(f"the workflow shift in play is {workflow}")
+
+    if not detail_bits:
+        return ""
+
+    note = "Evidence anchor: " + ", ".join(detail_bits[:-1])
+    if len(detail_bits) > 1:
+        note += f", and {detail_bits[-1]}."
+    else:
+        note += f"{detail_bits[-1]}."
+    if len(detail_bits) == 1:
+        note = "Evidence anchor: " + detail_bits[0] + "."
+    return note
+
+
+def _has_specificity_issues(report: dict[str, Any]) -> bool:
+    blockers = [str(issue) for issue in (report.get("blocking_issues") or [])]
+    warnings = [str(warning) for warning in (report.get("warnings") or [])]
+    return any(issue.startswith("witness_specificity:") for issue in blockers + warnings)
+
+
+def _apply_specificity_anchor_repair(
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    report: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    updated = dict(content or {})
+    body = str(updated.get("content") or "")
+    has_existing_note = _has_blog_note(body, marker="Evidence anchor:")
+    if not _has_specificity_issues(report) and not has_existing_note:
+        return updated, report, False
+
+    note = _build_specificity_anchor_note(blueprint, report)
+    if not note:
+        if not has_existing_note:
+            return updated, report, False
+        repaired_body = _remove_blog_note(body, marker="Evidence anchor:")
+        if repaired_body == body:
+            return updated, report, False
+        updated["content"] = repaired_body
+        updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
+        repaired_report = dict(repaired_report)
+        fixes = list(repaired_report.get("fixes_applied", []) or [])
+        fixes.append("removed_low_signal_witness_anchor_note")
+        repaired_report["fixes_applied"] = fixes
+        return updated, repaired_report, True
+
+    repaired_body = _insert_blog_note(body, note, marker="Evidence anchor:")
+    if repaired_body == body:
+        return updated, report, False
+
+    updated["content"] = repaired_body
+    updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
+    repaired_report = dict(repaired_report)
+    fixes = list(repaired_report.get("fixes_applied", []) or [])
+    fixes.append("added_witness_anchor_note")
+    repaired_report["fixes_applied"] = fixes
+    return updated, repaired_report, True
+
+
+def _only_content_too_short_blockers(report: dict[str, Any]) -> bool:
+    blockers = [str(issue) for issue in (report.get("blocking_issues") or [])]
+    return bool(blockers) and all(issue.startswith("content_too_short:") for issue in blockers)
+
+
+def _shortfall_words(report: dict[str, Any]) -> int:
+    try:
+        min_words = int(report.get("min_words_required") or 0)
+        word_count = int(report.get("word_count") or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min_words - word_count)
+
+
+def _top_source_summary(source_distribution: Any, *, limit: int = 3) -> str:
+    if not isinstance(source_distribution, dict):
+        return ""
+    ranked: list[tuple[str, int]] = []
+    for key, value in source_distribution.items():
+        name = str(key or "").strip()
+        if not name:
+            continue
+        try:
+            count = int(value or 0)
+        except (TypeError, ValueError):
+            continue
+        ranked.append((name, count))
+    if not ranked:
+        return ""
+    ranked.sort(key=lambda item: (-item[1], item[0].lower()))
+    parts = [f"{name} ({count})" for name, count in ranked[: max(1, int(limit))]]
+    if len(parts) == 1:
+        return parts[0]
+    return ", ".join(parts[:-1]) + f", and {parts[-1]}"
+
+
+def _build_coverage_snapshot_note(blueprint: PostBlueprint) -> str:
+    data_context = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+    enriched_count = int(data_context.get("enriched_count") or 0)
+    churn_intent_count = int(data_context.get("churn_intent_count") or 0)
+    review_period = str(data_context.get("review_period") or "").strip()
+    source_summary = _top_source_summary(data_context.get("source_distribution"))
+    data_quality = data_context.get("data_quality")
+    confidence = ""
+    if isinstance(data_quality, dict):
+        confidence = str(data_quality.get("confidence") or "").strip()
+    scope_summary = data_context.get("reasoning_scope_summary")
+    witnesses_in_scope = 0
+    if isinstance(scope_summary, dict):
+        try:
+            witnesses_in_scope = int(scope_summary.get("witnesses_in_scope") or 0)
+        except (TypeError, ValueError):
+            witnesses_in_scope = 0
+
+    details: list[str] = []
+    if enriched_count > 0:
+        details.append(f"this piece draws from {enriched_count} enriched reviews")
+    if churn_intent_count > 0:
+        details.append(f"including {churn_intent_count} churn-intent signals")
+    if witnesses_in_scope > 0:
+        details.append(f"with {witnesses_in_scope} witness-backed examples in scope")
+    if review_period:
+        details.append(f"collected between {review_period}")
+    if source_summary:
+        details.append(f"with the visible source mix led by {source_summary}")
+    if confidence:
+        details.append(f"and a current data-quality posture of {confidence} confidence")
+
+    if not details:
+        return ""
+
+    note = "Coverage snapshot: " + ", ".join(details[:-1])
+    if len(details) > 1:
+        note += f", and {details[-1]}."
+    else:
+        note += f"{details[-1]}."
+    if len(details) == 1:
+        note = "Coverage snapshot: " + details[0] + "."
+    note += " Treat the analysis as directional evidence rather than a full market census."
+    return note
+
+
+def _apply_borderline_shortfall_repair(
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    report: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    if not _only_content_too_short_blockers(report):
+        return dict(content or {}), report, False
+
+    shortfall = _shortfall_words(report)
+    threshold = int(getattr(settings.b2b_churn, "blog_post_borderline_shortfall_max_words", 0) or 0)
+    if shortfall <= 0 or shortfall > threshold:
+        return dict(content or {}), report, False
+
+    note = _build_coverage_snapshot_note(blueprint)
+    if not note:
+        return dict(content or {}), report, False
+
+    updated = dict(content or {})
+    body = str(updated.get("content") or "")
+    repaired_body = _insert_blog_note(body, note, marker="Coverage snapshot:")
+    if repaired_body == body:
+        return updated, report, False
+
+    updated["content"] = repaired_body
+    updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
+    repaired_report = dict(repaired_report)
+    fixes = list(repaired_report.get("fixes_applied", []) or [])
+    fixes.append("added_coverage_snapshot_note")
+    repaired_report["fixes_applied"] = fixes
+    return updated, repaired_report, True
+
+
+def _has_unsupported_category_outcome_issue(report: dict[str, Any]) -> bool:
+    return any(
+        str(issue) == "unsupported_category_outcome_assertion"
+        for issue in (report.get("blocking_issues") or [])
+    )
+
+
+def _line_contains_unsupported_category_outcome(line: str) -> bool:
+    return bool(re.search(r"\bcategory\s+(winner|loser)\b", str(line or ""), re.IGNORECASE))
+
+
+def _remove_unsupported_category_outcome_lines(body: str, report: dict[str, Any]) -> tuple[str, int]:
+    if not _has_unsupported_category_outcome_issue(report):
+        return str(body or ""), 0
+    lines = str(body or "").splitlines()
+    if not lines:
+        return str(body or ""), 0
+    removed = 0
+    next_lines: list[str] = []
+    for line in lines:
+        if _line_contains_unsupported_category_outcome(line):
+            removed += 1
+            continue
+        next_lines.append(line)
+    if removed > 0:
+        return "\n".join(next_lines), removed
+    text = "\n".join(lines)
+    sentences = re.split(r"(?<=[.!?])(\s+)", text)
+    kept: list[str] = []
+    for segment in sentences:
+        if _line_contains_unsupported_category_outcome(segment):
+            removed += 1
+            continue
+        kept.append(segment)
+    return "".join(kept), removed
+
+
+def _apply_blog_deterministic_repairs(
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    report: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    updated = dict(content or {})
+    body = str(updated.get("content") or "")
+    repaired_body, removed_claim_lines = _remove_unsupported_claim_lines(body, report)
+    repaired_body, removed_category_outcome_lines = _remove_unsupported_category_outcome_lines(
+        repaired_body,
+        report,
+    )
+    valid_slugs = {
+        str(slug).strip()
+        for slug in ((blueprint.data_context or {}).get("_valid_internal_slugs") or [])
+        if str(slug or "").strip()
+    }
+    repaired_body, removed_bad_links = _strip_nonexistent_internal_links(
+        repaired_body,
+        valid_slugs=valid_slugs,
+        current_slug=str(blueprint.slug or "").strip(),
+    )
+    repaired_report = dict(report or {})
+    if (
+        removed_claim_lines > 0
+        or removed_category_outcome_lines > 0
+        or removed_bad_links > 0
+    ) and repaired_body != body:
+        updated["content"] = repaired_body
+        updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
+        repaired_report = dict(repaired_report)
+        fixes = list(repaired_report.get("fixes_applied", []) or [])
+        if removed_claim_lines > 0:
+            fixes.append(f"removed_unsupported_claim_lines:{removed_claim_lines}")
+        if removed_category_outcome_lines > 0:
+            fixes.append(
+                f"removed_unsupported_category_outcome_lines:{removed_category_outcome_lines}"
+            )
+        if removed_bad_links > 0:
+            fixes.append(f"removed_nonexistent_internal_links:{removed_bad_links}")
+        repaired_report["fixes_applied"] = fixes
+
+    updated, repaired_report, _ = _apply_specificity_anchor_repair(
+        blueprint,
+        updated,
+        repaired_report,
+    )
+    updated, repaired_report, _ = _apply_borderline_shortfall_repair(
+        blueprint,
+        updated,
+        repaired_report,
+    )
+    return updated, repaired_report
+
+
+def _run_blog_quality_pass(
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    current = _ensure_methodology_context(blueprint, dict(content or {}))
+    _inject_affiliate_links(blueprint, current)
+    current, report = _apply_blog_quality_gate(blueprint, current)
+    current, report = _apply_blog_deterministic_repairs(blueprint, current, report)
+    return current, report
+
+
+def _with_first_pass_quality_metadata(
+    report: dict[str, Any],
+    *,
+    first_pass_report: dict[str, Any],
+    retry_requested: bool,
+) -> dict[str, Any]:
+    enriched = dict(report)
+    enriched["_first_pass_report"] = dict(first_pass_report)
+    enriched["_retry_requested"] = retry_requested
+    return enriched
+
+
+def _with_rejected_content_snapshot(
+    report: dict[str, Any],
+    *,
+    content_obj: dict[str, Any] | None,
+) -> dict[str, Any]:
+    enriched = dict(report)
+    finalized = _finalize_blog_generation_content(content_obj)
+    if isinstance(finalized, dict):
+        enriched["_rejected_content"] = finalized
+    return enriched
+
+
+def _ensure_methodology_context(
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+) -> dict[str, Any]:
+    """Inject a deterministic methodology note when the draft omits it."""
+    body = str((content or {}).get("content") or "").strip()
+    if not body:
+        return dict(content or {})
+
+    review_period = str((blueprint.data_context or {}).get("review_period") or "").strip()
+    if not review_period:
+        return dict(content or {})
+
+    has_review_period = review_period in body
+    has_self_selected = "self-selected" in body.lower()
+    if has_review_period and has_self_selected:
+        return dict(content or {})
+
+    source_label = str((blueprint.data_context or {}).get("data_source_label") or "").strip()
+    source_text = source_label or "public software reviews"
+    note = (
+        f"_Methodology note: This analysis reflects self-selected feedback from {source_text} "
+        f"collected between {review_period}. It captures reviewer perception, not a census of all users._"
+    )
+
+    updated = dict(content or {})
+    if body.startswith("# "):
+        head, _, remainder = body.partition("\n")
+        remainder = remainder.lstrip()
+        updated["content"] = f"{head}\n\n{note}\n\n{remainder}" if remainder else f"{head}\n\n{note}"
+    else:
+        updated["content"] = f"{note}\n\n{body}"
+    return updated
+
+
+def _finalize_blog_generation_content(
+    content_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Strip cache-only fields before returning assembled blog content."""
+    if content_obj is None:
+        return None
+    return {
+        key: value
+        for key, value in content_obj.items()
+        if not str(key).startswith("_cache_")
+    }
+
+
+async def _store_blog_generation_cache(
+    blueprint: PostBlueprint,
+    content_obj: dict[str, Any] | None,
+    *,
+    pool: Any | None = None,
+) -> None:
+    """Persist the final approved blog generation result in the exact cache."""
+    from ...services.b2b.cache_runner import (
+        bind_b2b_exact_stage_request,
+        store_b2b_exact_stage_text,
+    )
+
+    if not isinstance(content_obj, dict):
+        return
+    request_envelope = content_obj.get("_cache_request_envelope")
+    provider_name = str(content_obj.get("_cache_provider") or "")
+    model_name = str(content_obj.get("_cache_model") or "")
+    if not isinstance(request_envelope, dict) or not provider_name or not model_name:
+        return
+    request = bind_b2b_exact_stage_request(
+        "b2b_blog_post_generation.content",
+        provider=provider_name,
+        model=model_name,
+        request_envelope=request_envelope,
+    )
+    await store_b2b_exact_stage_text(
+        request,
+        response_text=json.dumps(
+            _finalize_blog_generation_content(content_obj),
+            separators=(",", ":"),
+            default=str,
+        ),
+        metadata={
+            "slug": blueprint.slug,
+            "topic_type": blueprint.topic_type,
+        },
+        pool=pool,
+    )
+
+
+async def _enforce_blog_quality_async(
+    llm,
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    max_tokens: int,
+    related_posts: list[dict[str, str]] | None = None,
+    run_id: str | None = None,
+    pool: Any | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Apply quality gate and perform one retry with feedback when needed."""
+    current, report = _run_blog_quality_pass(blueprint, content)
+    initial_critical = _critical_quality_warnings(report)
+    needs_retry = report.get("status") != "pass" or bool(initial_critical)
+    first_pass_report = dict(report)
+    if not needs_retry:
+        await _store_blog_generation_cache(blueprint, current, pool=pool)
+        return _finalize_blog_generation_content(current), _with_first_pass_quality_metadata(
+            report,
+            first_pass_report=first_pass_report,
+            retry_requested=False,
+        )
+
+    retry = await _generate_content_async(
+        llm,
+        blueprint,
+        max_tokens,
+        related_posts=related_posts,
+        quality_feedback=_quality_feedback(report),
+        run_id=run_id,
+        pool=pool,
+    )
+    if retry is None:
+        if initial_critical:
+            return None, _with_first_pass_quality_metadata(
+                _with_rejected_content_snapshot(
+                    _with_unresolved_critical_warnings(report),
+                    content_obj=current,
+                ),
+                first_pass_report=first_pass_report,
+                retry_requested=True,
+            )
+        return None, _with_first_pass_quality_metadata(
+            _with_rejected_content_snapshot(report, content_obj=current),
+            first_pass_report=first_pass_report,
+            retry_requested=True,
+        )
+
+    retry, retry_report = _run_blog_quality_pass(blueprint, retry)
+    retry_report = _with_unresolved_critical_warnings(retry_report)
+    if retry_report.get("status") != "pass":
+        return None, _with_first_pass_quality_metadata(
+            _with_rejected_content_snapshot(retry_report, content_obj=retry),
+            first_pass_report=first_pass_report,
+            retry_requested=True,
+        )
+    await _store_blog_generation_cache(blueprint, retry, pool=pool)
+    return _finalize_blog_generation_content(retry), _with_first_pass_quality_metadata(
+        retry_report,
+        first_pass_report=first_pass_report,
+        retry_requested=True,
+    )
+
+
+def _enforce_blog_quality(
+    llm,
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    max_tokens: int,
+    related_posts: list[dict[str, str]] | None = None,
+    run_id: str | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Sync wrapper retained for local/unit-test callers."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError("Use _enforce_blog_quality_async() from async contexts")
+
+    current, report = _run_blog_quality_pass(blueprint, content)
+    initial_critical = _critical_quality_warnings(report)
+    needs_retry = report.get("status") != "pass" or bool(initial_critical)
+    first_pass_report = dict(report)
+    if not needs_retry:
+        return _finalize_blog_generation_content(current), _with_first_pass_quality_metadata(
+            report,
+            first_pass_report=first_pass_report,
+            retry_requested=False,
+        )
+
+    retry = _generate_content(
+        llm,
+        blueprint,
+        max_tokens,
+        related_posts=related_posts,
+        quality_feedback=_quality_feedback(report),
+        run_id=run_id,
+    )
+    if retry is None:
+        if initial_critical:
+            return None, _with_first_pass_quality_metadata(
+                _with_rejected_content_snapshot(
+                    _with_unresolved_critical_warnings(report),
+                    content_obj=current,
+                ),
+                first_pass_report=first_pass_report,
+                retry_requested=True,
+            )
+        return None, _with_first_pass_quality_metadata(
+            _with_rejected_content_snapshot(report, content_obj=current),
+            first_pass_report=first_pass_report,
+            retry_requested=True,
+        )
+
+    retry, retry_report = _run_blog_quality_pass(blueprint, retry)
+    retry_report = _with_unresolved_critical_warnings(retry_report)
+    if retry_report.get("status") != "pass":
+        return None, _with_first_pass_quality_metadata(
+            _with_rejected_content_snapshot(retry_report, content_obj=retry),
+            first_pass_report=first_pass_report,
+            retry_requested=True,
+        )
+    return _finalize_blog_generation_content(retry), _with_first_pass_quality_metadata(
+        retry_report,
+        first_pass_report=first_pass_report,
+        retry_requested=True,
+    )
+
+
+def _canonicalize_blog_quality(
+    blueprint: PostBlueprint,
+    *,
+    content: dict[str, Any] | None,
+    report: dict[str, Any],
+    boundary: str,
+) -> dict[str, Any]:
+    from ...services.blog_quality import blog_quality_revalidation
+
+    result = blog_quality_revalidation(
+        blueprint=blueprint,
+        content=content,
+        boundary=boundary,
+        report=report,
+    )
+    blueprint.data_context = result["data_context"]
+    return result["audit"]
+
+
+def _persist_first_pass_blog_quality(
+    blueprint: PostBlueprint,
+    report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    from ...services.blog_quality import (
+        blog_quality_revalidation,
+        merge_blog_first_pass_quality_data_context,
+    )
+
+    first_pass_report = report.get("_first_pass_report") if isinstance(report, dict) else None
+    if not isinstance(first_pass_report, dict):
+        return {}
+
+    result = blog_quality_revalidation(
+        blueprint=blueprint,
+        content=None,
+        boundary="generation",
+        report=first_pass_report,
+    )
+    first_pass_audit = dict(result["audit"])
+    blueprint.data_context = merge_blog_first_pass_quality_data_context(
+        data_context=result["data_context"],
+        audit=first_pass_audit,
+    )
+    return first_pass_audit
+
+
+def _normalize_string_scope(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        values = raw.split(",")
+    elif isinstance(raw, (list, tuple, set)):
+        values = list(raw)
+    else:
+        values = [raw]
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(text)
+    return normalized
+
+
+# -- entry point --------------------------------------------------
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: generate B2B data-backed blog posts.
+
+    Loops up to ``max_per_run`` times, picking a fresh topic each iteration.
+    All posts are stored as drafts.
+    """
+    cfg = settings.b2b_churn
+    run_id = _task_run_id(task) or str(task.id)
+    maintenance_run = bool((task.metadata or {}).get("maintenance_run"))
+    if not cfg.blog_post_enabled and not maintenance_run:
+        return {"_skip_synthesis": "B2B blog post generation disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    from ...pipelines.llm import get_pipeline_llm
+    from ...pipelines.notify import send_pipeline_notification
+    from ...services.b2b.anthropic_batch import (
+        AnthropicBatchItem,
+        mark_batch_fallback_result,
+        run_anthropic_message_batch,
+    )
+    from ...services.b2b.cache_runner import lookup_b2b_exact_stage_text
+    from ...services.llm.anthropic import AnthropicLLM
+    from ...services.protocols import Message
+
+    llm = get_pipeline_llm(
+        workload="synthesis",
+        try_openrouter=True,
+        auto_activate_ollama=False,
+        openrouter_model=cfg.blog_post_openrouter_model,
+    )
+    if llm is None:
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    batch_requested = bool(
+        getattr(cfg, "anthropic_batch_enabled", False)
+        and getattr(cfg, "blog_post_anthropic_batch_enabled", True)
+    )
+    batch_llm = get_pipeline_llm(workload="anthropic") if batch_requested else None
+    if batch_llm is None and isinstance(llm, AnthropicLLM):
+        batch_llm = llm
+    generation_llm = batch_llm if isinstance(batch_llm, AnthropicLLM) else llm
+    blog_batch_enabled = isinstance(batch_llm, AnthropicLLM)
+
+    if generation_llm is None:
+        return {"_skip_synthesis": "No LLM available for B2B blog post generation"}
+
+    max_posts = _blog_post_max_per_run(task, cfg)
+    results: list[dict[str, Any]] = []
+    # Track vendors and topic types across iterations to prevent dominance
+    run_seen_vendors: set[str] = set()
+    run_seen_types: dict[str, int] = {}
+    attempted_slugs: set[str] = set()
+    blog_batch_metrics = {
+        "jobs": 0,
+        "submitted_items": 0,
+        "cache_prefiltered_items": 0,
+        "fallback_single_call_items": 0,
+        "completed_items": 0,
+        "failed_items": 0,
+    }
+
+    def _batch_payload() -> dict[str, int]:
+        return {
+            "blog_batch_jobs": int(blog_batch_metrics["jobs"]),
+            "blog_batch_items_submitted": int(blog_batch_metrics["submitted_items"]),
+            "blog_batch_cache_prefiltered": int(blog_batch_metrics["cache_prefiltered_items"]),
+            "blog_batch_fallback_single_call": int(blog_batch_metrics["fallback_single_call_items"]),
+            "blog_batch_completed_items": int(blog_batch_metrics["completed_items"]),
+            "blog_batch_failed_items": int(blog_batch_metrics["failed_items"]),
+        }
+
+    def _apply_topic_scope(
+        topic_type: str,
+        topic_ctx: dict[str, Any],
+        *,
+        seen_vendors: set[str],
+        seen_types: dict[str, int],
+    ) -> None:
+        for vendor_key in ("vendor", "vendor_a", "vendor_b", "from_vendor"):
+            vendor_value = str(topic_ctx.get(vendor_key) or "").lower().strip()
+            if vendor_value:
+                seen_vendors.add(vendor_value)
+        seen_types[topic_type] = seen_types.get(topic_type, 0) + 1
+
+    async def _prepare_post_candidate(
+        topic_type: str,
+        topic_ctx: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        topic_slug = str(topic_ctx.get("slug") or "").strip()
+        if topic_slug and topic_slug in attempted_slugs:
+            return None
+
+        data = await _gather_data(pool, topic_type, topic_ctx)
+        await _load_pool_layers_for_blog(pool, topic_type, topic_ctx, data)
+
+        sufficiency = _check_data_sufficiency(topic_type, data)
+        if not sufficiency["sufficient"]:
+            logger.warning(
+                "Data insufficiency for %s (%s): %s",
+                topic_ctx.get("slug", "?"), topic_type, sufficiency["reason"],
+            )
+            return None
+
+        blueprint = _build_blueprint(topic_type, topic_ctx, data)
+        if blueprint.slug in attempted_slugs:
+            return None
+        blueprint_sufficiency = _check_blueprint_sufficiency(blueprint)
+        if not blueprint_sufficiency["sufficient"]:
+            logger.warning(
+                "Blueprint insufficiency for %s (%s): %s",
+                blueprint.slug,
+                topic_type,
+                blueprint_sufficiency["reason"],
+            )
+            return None
+
+        link_posts = await _fetch_related_for_linking(
+            pool, blueprint.tags, blueprint.slug,
+        )
+        blueprint.data_context["_valid_internal_slugs"] = [
+            p["slug"] for p in (link_posts or []) if isinstance(p, dict) and p.get("slug")
+        ]
+        if "_known_vendors" not in blueprint.data_context:
+            try:
+                from ._b2b_shared import read_known_vendor_names
+
+                blueprint.data_context["_known_vendors"] = await read_known_vendor_names(pool)
+            except Exception:
+                blueprint.data_context["_known_vendors"] = []
+
+        return {
+            "topic_type": topic_type,
+            "topic_ctx": topic_ctx,
+            "blueprint": blueprint,
+            "link_posts": link_posts,
+        }
+
+    async def _generate_first_pass_batch(
+        candidates: list[dict[str, Any]],
+    ) -> dict[str, dict[str, Any] | None]:
+        prepared_entries: list[dict[str, Any]] = []
+        first_pass_by_slug: dict[str, dict[str, Any] | None] = {}
+
+        for index, candidate in enumerate(candidates):
+            blueprint = candidate["blueprint"]
+            prepared = _prepare_blog_generation_request(
+                generation_llm,
+                blueprint,
+                cfg.blog_post_max_tokens,
+                related_posts=candidate["link_posts"],
+            )
+            if prepared is None:
+                first_pass_by_slug[blueprint.slug] = None
+                continue
+
+            cached = await lookup_b2b_exact_stage_text(prepared["request"], pool=pool)
+            prepared_entries.append({
+                "custom_id": f"blog_post:{index}:{blueprint.slug}",
+                "candidate": candidate,
+                "prepared": prepared,
+                "cached_response_text": (
+                    str(cached["response_text"] or "")
+                    if cached is not None
+                    else None
+                ),
+                "cached_usage": (
+                    dict(cached.get("usage") or {})
+                    if cached is not None
+                    else {}
+                ),
+            })
+
+        if not prepared_entries:
+            return first_pass_by_slug
+
+        execution = await run_anthropic_message_batch(
+            llm=generation_llm,
+            stage_id=_BLOG_GENERATION_CACHE_STAGE,
+            task_name="b2b_blog_post_generation",
+            items=[
+                AnthropicBatchItem(
+                    custom_id=str(entry["custom_id"]),
+                    artifact_type="blog_post",
+                    artifact_id=str(entry["candidate"]["blueprint"].slug),
+                    vendor_name=(
+                        str(
+                            entry["candidate"]["blueprint"].data_context.get("vendor")
+                            or ""
+                        )
+                        or None
+                    ),
+                    messages=[
+                        Message(
+                            role=str(getattr(message, "role", "") or ""),
+                            content=str(getattr(message, "content", "") or ""),
+                        )
+                        for message in entry["prepared"]["messages"]
+                    ],
+                    max_tokens=cfg.blog_post_max_tokens,
+                    temperature=float(cfg.blog_post_temperature),
+                    trace_span_name=_BLOG_GENERATION_TRACE_SPAN,
+                    trace_metadata={
+                        **_blog_generation_trace_metadata(
+                            entry["candidate"]["blueprint"],
+                            run_id=run_id,
+                        ),
+                        "workload": "anthropic_batch",
+                    },
+                    request_metadata={
+                        "topic_type": entry["candidate"]["blueprint"].topic_type,
+                        "slug": entry["candidate"]["blueprint"].slug,
+                    },
+                    cached_response_text=entry["cached_response_text"],
+                    cached_usage=entry["cached_usage"],
+                )
+                for entry in prepared_entries
+            ],
+            run_id=run_id,
+            min_batch_size=int(getattr(cfg, "blog_post_anthropic_batch_min_items", 2)),
+            batch_metadata={
+                "report_type": "blog_post",
+            },
+            pool=pool,
+        )
+        blog_batch_metrics["jobs"] += 1 if execution.provider_batch_id else 0
+        blog_batch_metrics["submitted_items"] += execution.submitted_items
+        blog_batch_metrics["cache_prefiltered_items"] += execution.cache_prefiltered_items
+        blog_batch_metrics["fallback_single_call_items"] += execution.fallback_single_call_items
+        blog_batch_metrics["completed_items"] += execution.completed_items
+        blog_batch_metrics["failed_items"] += execution.failed_items
+
+        for entry in prepared_entries:
+            candidate = entry["candidate"]
+            blueprint = candidate["blueprint"]
+            prepared = entry["prepared"]
+            outcome = execution.results_by_custom_id.get(str(entry["custom_id"]))
+            parse_error_text: str | None = None
+            content: dict[str, Any] | None = None
+
+            if outcome is not None and outcome.response_text:
+                content = _parse_blog_generation_response_text(
+                    blueprint,
+                    outcome.response_text,
+                    request_envelope=prepared["request_envelope"],
+                    provider_name=str(prepared["provider_name"]),
+                    model_name=str(prepared["model_name"]),
+                )
+                if content is None:
+                    parse_error_text = "failed_to_parse_batch_response"
+
+            used_fallback_single_call = False
+            if content is None:
+                used_fallback_single_call = True
+                fallback_usage: dict[str, Any] = {}
+                content = await _generate_content_async(
+                    generation_llm,
+                    blueprint,
+                    cfg.blog_post_max_tokens,
+                    related_posts=candidate["link_posts"],
+                    run_id=run_id,
+                    pool=pool,
+                    usage_out=fallback_usage,
+                )
+                await mark_batch_fallback_result(
+                    batch_id=execution.local_batch_id,
+                    custom_id=str(entry["custom_id"]),
+                    succeeded=content is not None,
+                    error_text=(
+                        parse_error_text
+                        or (
+                            outcome.error_text
+                            if outcome is not None and outcome.error_text and content is None
+                            else None
+                        )
+                        or ("llm_returned_none" if content is None else None)
+                    ),
+                    response_text=(
+                        json.dumps(
+                            _finalize_blog_generation_content(content),
+                            separators=(",", ":"),
+                            default=str,
+                        )
+                        if content is not None
+                        else None
+                    ),
+                    usage=fallback_usage,
+                    provider=str(fallback_usage.get("provider") or "") or None,
+                    model=str(fallback_usage.get("model") or "") or None,
+                    provider_request_id=(
+                        str(fallback_usage.get("provider_request_id") or "") or None
+                    ),
+                    pool=pool,
+                )
+
+            if used_fallback_single_call:
+                logger.debug(
+                    "Blog batch fallback used for %s",
+                    blueprint.slug,
+                )
+            first_pass_by_slug[blueprint.slug] = content
+
+        return first_pass_by_slug
+
+    # Regeneration mode: re-process existing drafts through fixed pipeline
+    if cfg.blog_post_regenerate_mode or (
+        maintenance_run and bool((task.metadata or {}).get("regenerate_existing_posts"))
+    ):
+        return await _regenerate_existing_posts(pool, generation_llm, cfg, task, max_posts)
+
+    while len(results) < max_posts:
+        remaining_slots = max_posts - len(results)
+        candidate_entries: list[dict[str, Any]] = []
+        reserved_vendors = set(run_seen_vendors)
+        reserved_types = dict(run_seen_types)
+        selection_attempts = 0
+        selection_limit = max(
+            remaining_slots * _BLOG_BATCH_SELECTION_MULTIPLIER,
+            _BLOG_BATCH_SELECTION_MIN_ATTEMPTS,
+        )
+
+        while len(candidate_entries) < remaining_slots and selection_attempts < selection_limit:
+            selection_attempts += 1
+            topic = await _select_topic(
+                pool,
+                max_posts,
+                exclude_vendors=reserved_vendors,
+                exclude_types=reserved_types,
+            )
+            if topic is None:
+                break
+            topic_type, topic_ctx = topic
+            prepared_candidate = await _prepare_post_candidate(topic_type, topic_ctx)
+            _apply_topic_scope(
+                topic_type,
+                topic_ctx,
+                seen_vendors=reserved_vendors,
+                seen_types=reserved_types,
+            )
+            if prepared_candidate is None:
+                continue
+            attempted_slugs.add(prepared_candidate["blueprint"].slug)
+            candidate_entries.append(prepared_candidate)
+
+        if not candidate_entries:
+            logger.info("No more viable B2B topics after %d posts", len(results))
+            break
+
+        first_pass_by_slug: dict[str, dict[str, Any] | None] = {}
+        if blog_batch_enabled:
+            first_pass_by_slug = await _generate_first_pass_batch(candidate_entries)
+
+        for candidate in candidate_entries:
+            topic_type = candidate["topic_type"]
+            topic_ctx = candidate["topic_ctx"]
+            blueprint = candidate["blueprint"]
+            link_posts = candidate["link_posts"]
+            if blog_batch_enabled:
+                content = first_pass_by_slug.get(blueprint.slug)
+            else:
+                content = await _generate_content_async(
+                    generation_llm,
+                    blueprint,
+                    cfg.blog_post_max_tokens,
+                    related_posts=link_posts,
+                    run_id=run_id,
+                    pool=pool,
+                )
+
+            if content is None:
+                logger.warning("LLM failed for B2B topic %s, skipping", blueprint.slug)
+                from ..visibility import record_attempt, emit_event
+                await _upsert_blog_post_state(
+                    pool,
+                    blueprint,
+                    generation_llm,
+                    status="failed",
+                    run_id=run_id,
+                    attempt_no=1,
+                    failure_step="llm_call",
+                    error_code="llm_returned_none",
+                    error_summary="LLM returned None",
+                )
+                await record_attempt(
+                    pool, artifact_type="blog_post", artifact_id=blueprint.slug,
+                    run_id=run_id, attempt_no=1, stage="generation",
+                    status="failed", failure_step="llm_call",
+                    error_message="LLM returned None",
+                )
+                await emit_event(
+                    pool, stage="blog", event_type="generation_failure",
+                    entity_type="blog_post", entity_id=blueprint.slug,
+                    summary=f"LLM failed for {blueprint.slug} ({topic_type})",
+                    severity="error", actionable=True,
+                    artifact_type="blog_post", run_id=run_id,
+                    reason_code="llm_returned_none",
+                )
+                continue
+
+            content, quality_report = await _enforce_blog_quality_async(
+                generation_llm,
+                blueprint,
+                content,
+                cfg.blog_post_max_tokens,
+                related_posts=link_posts,
+                run_id=run_id,
+                pool=pool,
+            )
+            first_pass_audit = _persist_first_pass_blog_quality(blueprint, quality_report)
+            if quality_report.get("_retry_requested"):
+                from ..visibility import record_attempt
+                await record_attempt(
+                    pool,
+                    artifact_type="blog_post",
+                    artifact_id=blueprint.slug,
+                    run_id=run_id,
+                    attempt_no=1,
+                    stage="quality_gate_first_pass",
+                    status="retry_requested",
+                    score=first_pass_audit.get("score"),
+                    threshold=first_pass_audit.get("threshold"),
+                    blocker_count=len(first_pass_audit.get("blocking_issues", [])),
+                    warning_count=len(first_pass_audit.get("warnings", [])),
+                    blocking_issues=first_pass_audit.get("blocking_issues"),
+                    warnings=first_pass_audit.get("warnings"),
+                    failure_step="quality_gate_first_pass",
+                    error_message=", ".join(first_pass_audit.get("blocking_issues", [])[:3]) or None,
+                )
+            if content is None:
+                rejected_content = quality_report.get("_rejected_content") if isinstance(quality_report, dict) else None
+                quality_audit = _canonicalize_blog_quality(
+                    blueprint,
+                    content=rejected_content if isinstance(rejected_content, dict) else None,
+                    report=quality_report,
+                    boundary="generation",
+                )
+                logger.warning(
+                    "Quality gate failed for %s (%s): %s",
+                    blueprint.slug,
+                    blueprint.topic_type,
+                    ", ".join(quality_audit.get("blocking_issues", [])[:4]) or "unknown issues",
+                )
+                from ..visibility import record_attempt, emit_event
+                await _upsert_blog_post_state(
+                    pool,
+                    blueprint,
+                    generation_llm,
+                    status="rejected",
+                    run_id=run_id,
+                    attempt_no=1,
+                    score=quality_audit.get("score"),
+                    threshold=quality_audit.get("threshold"),
+                    blocker_count=len(quality_audit.get("blocking_issues", [])),
+                    warning_count=len(quality_audit.get("warnings", [])),
+                    failure_step="quality_gate",
+                    error_code="quality_gate_rejection",
+                    error_summary=", ".join(quality_audit.get("blocking_issues", [])[:3]),
+                    rejection_reason=", ".join(quality_audit.get("blocking_issues", [])[:3]),
+                    content=rejected_content if isinstance(rejected_content, dict) else None,
+                )
+                await record_attempt(
+                    pool, artifact_type="blog_post", artifact_id=blueprint.slug,
+                    run_id=run_id, attempt_no=1, stage="quality_gate",
+                    status="rejected",
+                    score=quality_audit.get("score"),
+                    threshold=quality_audit.get("threshold"),
+                    blocker_count=len(quality_audit.get("blocking_issues", [])),
+                    warning_count=len(quality_audit.get("warnings", [])),
+                    blocking_issues=quality_audit.get("blocking_issues"),
+                    warnings=quality_audit.get("warnings"),
+                    failure_step="quality_gate",
+                    error_message=", ".join(quality_audit.get("blocking_issues", [])[:3]),
+                )
+                await emit_event(
+                    pool, stage="blog", event_type="quality_gate_rejection",
+                    entity_type="blog_post", entity_id=blueprint.slug,
+                    summary=f"Quality gate rejected {blueprint.slug} ({topic_type})",
+                    severity="warning", actionable=True,
+                    artifact_type="blog_post", run_id=run_id,
+                    reason_code=quality_audit.get("blocking_issues", ["unknown"])[0][:80] if quality_audit.get("blocking_issues") else "unknown",
+                    decision="rejected",
+                    detail=quality_audit,
+                )
+                continue
+            quality_audit = _canonicalize_blog_quality(
+                blueprint,
+                content=content,
+                report=quality_report,
+                boundary="generation",
+            )
+
+            post_id = await _assemble_and_store(
+                pool,
+                blueprint,
+                content,
+                generation_llm,
+                run_id=run_id,
+                attempt_no=1,
+            )
+            if not post_id:
+                logger.info("Slug %s already published, skipping", blueprint.slug)
+                from ..visibility import record_dedup
+                await record_dedup(
+                    pool, stage="blog", entity_type="blog_post",
+                    entity_id=blueprint.slug, run_id=run_id,
+                    reason=f"Slug {blueprint.slug} already published",
+                )
+                continue
+
+            from ..visibility import record_attempt
+            await record_attempt(
+                pool, artifact_type="blog_post", artifact_id=blueprint.slug,
+                run_id=run_id, attempt_no=1, stage="quality_gate",
+                status="succeeded",
+                score=quality_audit.get("score"),
+                threshold=quality_audit.get("threshold"),
+                blocker_count=len(quality_audit.get("blocking_issues", [])),
+                warning_count=len(quality_audit.get("warnings", [])),
+                warnings=quality_audit.get("warnings"),
+            )
+
+            n_charts = len(blueprint.charts)
+            results.append({
+                "post_id": str(post_id),
+                "topic_type": blueprint.topic_type,
+                "slug": blueprint.slug,
+                "charts": n_charts,
+            })
+            _apply_topic_scope(
+                topic_type,
+                topic_ctx,
+                seen_vendors=run_seen_vendors,
+                seen_types=run_seen_types,
+            )
+
+            if len(results) >= max_posts:
+                break
+
+    if not results:
+        return {
+            "_skip_synthesis": "No B2B blog posts generated this run",
+            **_batch_payload(),
+        }
+
+    slugs = ", ".join(r["slug"] for r in results)
+    msg = f"B2B Blog: {len(results)} draft(s) created -- {slugs}"
+    await send_pipeline_notification(
+        msg, task, title="Atlas: B2B Blog Post Drafts",
+        default_tags="brain,newspaper",
+    )
+
+    return {
+        "_skip_synthesis": msg,
+        "posts": results,
+        "count": len(results),
+        **_batch_payload(),
+    }
+
+
+# -- Regeneration Mode ---------------------------------------------
+
+async def _regenerate_existing_posts(
+    pool, llm, cfg, task, max_posts: int
+) -> dict[str, Any]:
+    """Re-process existing draft posts through the fixed pipeline.
+
+    Queries blog_posts with status='draft' ordered by topic_type priority
+    (showdowns and deep dives first).  Uses the topic_ctx stored in
+    data_context to reconstruct blueprints.  Posts without stored topic_ctx
+    (legacy) are skipped.
+    """
+    from ...pipelines.notify import send_pipeline_notification
+    run_id = _task_run_id(task) or str(task.id)
+
+    scoped_vendors = [
+        value.lower()
+        for value in _normalize_string_scope((task.metadata or {}).get("test_vendors"))
+    ]
+    scoped_topic_types = _normalize_string_scope((task.metadata or {}).get("test_topic_types"))
+    scoped_slugs = _normalize_string_scope((task.metadata or {}).get("test_slugs"))
+
+    params: list[Any] = [list(_B2B_TOPIC_TYPES)]
+    where_clauses = [
+        "status = 'draft'",
+        f"topic_type = ANY(${len(params)}::text[])",
+    ]
+    if scoped_vendors:
+        params.append(scoped_vendors)
+        where_clauses.append(
+            "LOWER(COALESCE(data_context->>'vendor_name', data_context->>'vendor_a', "
+            f"data_context->>'vendor', '')) = ANY(${len(params)}::text[])"
+        )
+    if scoped_topic_types:
+        params.append(scoped_topic_types)
+        where_clauses.append(f"topic_type = ANY(${len(params)}::text[])")
+    if scoped_slugs:
+        params.append(scoped_slugs)
+        where_clauses.append(f"slug = ANY(${len(params)}::text[])")
+    params.append(max_posts)
+
+    rows = await pool.fetch(
+        f"""
+        SELECT id, slug, topic_type, data_context, created_at
+        FROM blog_posts
+        WHERE {' AND '.join(where_clauses)}
+        ORDER BY
+            CASE topic_type
+                WHEN 'vendor_showdown' THEN 1
+                WHEN 'vendor_deep_dive' THEN 2
+                WHEN 'churn_report' THEN 3
+                WHEN 'pricing_reality_check' THEN 4
+                WHEN 'vendor_alternative' THEN 5
+                WHEN 'switching_story' THEN 6
+                WHEN 'migration_guide' THEN 7
+                WHEN 'market_landscape' THEN 8
+                WHEN 'pain_point_roundup' THEN 9
+                WHEN 'best_fit_guide' THEN 10
+                ELSE 11
+            END,
+            created_at ASC
+        LIMIT ${len(params)}
+        """,
+        *params,
+    )
+
+    if not rows:
+        return {"_skip_synthesis": "No draft posts to regenerate"}
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        slug = row["slug"]
+        topic_type = row["topic_type"]
+        old_ctx = row["data_context"] or {}
+        if isinstance(old_ctx, str):
+            try:
+                old_ctx = json.loads(old_ctx)
+            except (json.JSONDecodeError, TypeError):
+                old_ctx = {}
+
+        try:
+            stored_ctx = old_ctx.get("topic_ctx")
+            if not stored_ctx or not isinstance(stored_ctx, dict):
+                logger.warning("Regen: no stored topic_ctx for %s, skipping", slug)
+                continue
+            topic_ctx = {**stored_ctx, "slug": slug}
+
+            data = await _gather_data(pool, topic_type, topic_ctx)
+            await _load_pool_layers_for_blog(pool, topic_type, topic_ctx, data)
+            sufficiency = _check_data_sufficiency(topic_type, data)
+            if not sufficiency["sufficient"]:
+                logger.warning("Regen: data insufficiency for %s: %s", slug, sufficiency["reason"])
+                continue
+            blueprint = _build_blueprint(topic_type, topic_ctx, data)
+            blueprint_sufficiency = _check_blueprint_sufficiency(blueprint)
+            if not blueprint_sufficiency["sufficient"]:
+                logger.warning(
+                    "Regen: blueprint insufficiency for %s: %s",
+                    slug,
+                    blueprint_sufficiency["reason"],
+                )
+                continue
+            link_posts = await _fetch_related_for_linking(
+                pool, blueprint.tags, blueprint.slug,
+            )
+            content = await _generate_content_async(
+                llm, blueprint, cfg.blog_post_max_tokens,
+                related_posts=link_posts,
+                run_id=run_id,
+            )
+            if content is None:
+                logger.warning("Regen: LLM failed for %s, skipping", slug)
+                await _upsert_blog_post_state(
+                    pool,
+                    blueprint,
+                    llm,
+                    status="failed",
+                    run_id=run_id,
+                    attempt_no=1,
+                    failure_step="llm_call",
+                    error_code="llm_returned_none",
+                    error_summary="LLM returned None",
+                )
+                continue
+
+            content, quality_report = await _enforce_blog_quality_async(
+                llm,
+                blueprint,
+                content,
+                cfg.blog_post_max_tokens,
+                related_posts=link_posts,
+                run_id=run_id,
+            )
+            _persist_first_pass_blog_quality(blueprint, quality_report)
+            if content is None:
+                rejected_content = quality_report.get("_rejected_content") if isinstance(quality_report, dict) else None
+                quality_audit = _canonicalize_blog_quality(
+                    blueprint,
+                    content=rejected_content if isinstance(rejected_content, dict) else None,
+                    report=quality_report,
+                    boundary="generation",
+                )
+                logger.warning(
+                    "Regen quality gate failed for %s: %s",
+                    slug,
+                    ", ".join(quality_audit.get("blocking_issues", [])[:4]) or "unknown issues",
+                )
+                await _upsert_blog_post_state(
+                    pool,
+                    blueprint,
+                    llm,
+                    status="rejected",
+                    run_id=run_id,
+                    attempt_no=1,
+                    score=quality_audit.get("score"),
+                    threshold=quality_audit.get("threshold"),
+                    blocker_count=len(quality_audit.get("blocking_issues", [])),
+                    warning_count=len(quality_audit.get("warnings", [])),
+                    failure_step="quality_gate",
+                    error_code="quality_gate_rejection",
+                    error_summary=", ".join(quality_audit.get("blocking_issues", [])[:3]),
+                    rejection_reason=", ".join(quality_audit.get("blocking_issues", [])[:3]),
+                    content=rejected_content if isinstance(rejected_content, dict) else None,
+                )
+                continue
+            _canonicalize_blog_quality(
+                blueprint,
+                content=content,
+                report=quality_report,
+                boundary="generation",
+            )
+
+            post_id = await _assemble_and_store(
+                pool,
+                blueprint,
+                content,
+                llm,
+                run_id=run_id,
+                attempt_no=1,
+            )
+            if post_id:
+                results.append({
+                    "post_id": str(post_id),
+                    "topic_type": topic_type,
+                    "slug": slug,
+                    "charts": len(blueprint.charts),
+                    "regenerated": True,
+                })
+                logger.info("Regenerated post: slug=%s", slug)
+        except Exception:
+            logger.exception("Regen failed for slug=%s", slug)
+
+    if not results:
+        return {"_skip_synthesis": "No posts regenerated this run"}
+
+    slugs = ", ".join(r["slug"] for r in results)
+    msg = f"B2B Blog Regen: {len(results)} post(s) regenerated -- {slugs}"
+    await send_pipeline_notification(
+        msg, task, title="Atlas: B2B Blog Regeneration",
+        default_tags="brain,recycle",
+    )
+
+    return {
+        "_skip_synthesis": msg,
+        "posts": results,
+        "count": len(results),
+        "regenerated": True,
+    }
+
+
+# -- Stage 1: Topic Selection -------------------------------------
+
+_CAMPAIGN_GAP_LOOKBACK_DAYS = 14
+_CAMPAIGN_GAP_BONUS_PCT = 0.30
+_OUTBOUND_SHOWDOWN_GAP_BONUS_PCT = 0.75
+_OUTBOUND_SHOWDOWN_CANDIDATE_LIMIT = 50
+_OUTBOUND_SHOWDOWN_MAX_SCORE = 100
+_B2B_TOPIC_TYPES = (
+    "vendor_alternative",
+    "vendor_showdown",
+    "churn_report",
+    "migration_guide",
+    "vendor_deep_dive",
+    "market_landscape",
+    "pricing_reality_check",
+    "switching_story",
+    "pain_point_roundup",
+    "best_fit_guide",
+)
+
+
+def _normalize_pain_label(value: Any) -> str:
+    """Normalize pain labels for deterministic overlap checks."""
+    text = re.sub(r"[^a-z0-9]+", " ", str(value or "").lower())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _collect_pain_labels(value: Any) -> set[str]:
+    """Collect normalized pain labels from nested payloads."""
+    labels: set[str] = set()
+    if value is None:
+        return labels
+    if isinstance(value, dict):
+        for key in ("category", "pain_category", "top_pain", "label", "name"):
+            norm = _normalize_pain_label(value.get(key))
+            if len(norm) >= 3:
+                labels.add(norm)
+        for inner in value.values():
+            labels |= _collect_pain_labels(inner)
+        return labels
+    if isinstance(value, list):
+        for item in value:
+            labels |= _collect_pain_labels(item)
+        return labels
+    norm = _normalize_pain_label(value)
+    if len(norm) >= 3:
+        labels.add(norm)
+    return labels
+
+
+def _extract_candidate_pain_labels(topic_type: str, ctx: dict[str, Any]) -> set[str]:
+    """Extract pain labels from candidate context without whole-object substring scans."""
+    labels: set[str] = set()
+    for key in ("pain_category", "top_pain", "pain_categories", "pain_distribution", "pain_breakdown"):
+        labels |= _collect_pain_labels(ctx.get(key))
+
+    # Topic-type inferred pain coverage for deterministic matching.
+    if topic_type == "pricing_reality_check":
+        labels |= {"pricing", "price", "billing", "cost"}
+    return labels
+
+
+def _candidate_overlaps_gap_pain(
+    topic_type: str,
+    ctx: dict[str, Any],
+    gap_pains: set[str],
+) -> bool:
+    """Return True when a candidate explicitly overlaps one of the gap pain labels."""
+    candidate_labels = _extract_candidate_pain_labels(topic_type, ctx)
+    if not candidate_labels:
+        return False
+    for pain in gap_pains:
+        norm = _normalize_pain_label(pain)
+        if len(norm) < 3:
+            continue
+        if norm in candidate_labels:
+            return True
+        if any(norm in cand or cand in norm for cand in candidate_labels):
+            return True
+    return False
+
+
+def _extract_blog_coverage_vendors(
+    data_context: dict[str, Any],
+    topic_ctx: dict[str, Any],
+) -> set[str]:
+    """Extract all vendor identities that a blog post covers."""
+    vendors: set[str] = set()
+    for key in ("vendor", "vendor_a", "vendor_b", "from_vendor", "to_vendor"):
+        for source in (data_context, topic_ctx):
+            value = str(source.get(key) or "").strip().lower()
+            if value:
+                vendors.add(value)
+    return vendors
+
+
+def _normalize_vendor_pair(
+    vendor_a: Any,
+    vendor_b: Any,
+) -> tuple[str, str] | None:
+    """Return a stable vendor pair ordering for deterministic showdown keys."""
+    left = str(vendor_a or "").strip()
+    right = str(vendor_b or "").strip()
+    if not left or not right:
+        return None
+    ordered = sorted((left, right), key=lambda item: item.lower())
+    if ordered[0].lower() == ordered[1].lower():
+        return None
+    return ordered[0], ordered[1]
+
+
+def _showdown_pair_key(vendor_a: Any, vendor_b: Any) -> str:
+    pair = _normalize_vendor_pair(vendor_a, vendor_b)
+    if not pair:
+        return ""
+    return f"{pair[0].lower()}::{pair[1].lower()}"
+
+
+def _normalized_text_contains_term(text: Any, term: Any) -> bool:
+    haystack = f" {_normalize_pain_label(text)} "
+    needle = _normalize_pain_label(term)
+    if len(needle) < 2:
+        return False
+    return f" {needle} " in haystack
+
+
+def _blog_post_covers_showdown_pair(
+    post: dict[str, Any],
+    vendor_a: Any,
+    vendor_b: Any,
+) -> bool:
+    """Return True when a blog post already covers a specific showdown pair."""
+    if str(post.get("topic_type") or "").strip() != "vendor_showdown":
+        return False
+
+    data_context = post.get("data_context")
+    if isinstance(data_context, str):
+        try:
+            data_context = json.loads(data_context)
+        except Exception:
+            data_context = {}
+    if not isinstance(data_context, dict):
+        data_context = {}
+    topic_ctx = data_context.get("topic_ctx") if isinstance(data_context.get("topic_ctx"), dict) else {}
+
+    pair_key = _showdown_pair_key(vendor_a, vendor_b)
+    covered_key = _showdown_pair_key(
+        topic_ctx.get("vendor_a") or data_context.get("vendor_a"),
+        topic_ctx.get("vendor_b") or data_context.get("vendor_b"),
+    )
+    if pair_key and pair_key == covered_key:
+        return True
+
+    text = " ".join(
+        str(post.get(field) or "").strip()
+        for field in ("title", "slug", "url")
+    )
+    return (
+        _normalized_text_contains_term(text, vendor_a)
+        and _normalized_text_contains_term(text, vendor_b)
+    )
+
+
+def _blog_post_showdown_pair_key(post: dict[str, Any]) -> str:
+    """Extract a normalized showdown pair key from stored blog post context."""
+    data_context = post.get("data_context")
+    if isinstance(data_context, str):
+        try:
+            data_context = json.loads(data_context)
+        except Exception:
+            data_context = {}
+    if not isinstance(data_context, dict):
+        data_context = {}
+    topic_ctx = data_context.get("topic_ctx") if isinstance(data_context.get("topic_ctx"), dict) else {}
+    return _showdown_pair_key(
+        topic_ctx.get("vendor_a") or data_context.get("vendor_a"),
+        topic_ctx.get("vendor_b") or data_context.get("vendor_b"),
+    )
+
+
+def _canonicalize_showdown_candidate(candidate: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize showdown pair ordering while keeping metrics attached to the right vendor."""
+    vendor_a = str(candidate.get("vendor_a") or "").strip()
+    vendor_b = str(candidate.get("vendor_b") or "").strip()
+    pair = _normalize_vendor_pair(vendor_a, vendor_b)
+    if not pair:
+        return None
+
+    normalized = dict(candidate)
+    if pair != (vendor_a, vendor_b):
+        normalized["vendor_a"], normalized["vendor_b"] = pair
+        normalized["reviews_a"], normalized["reviews_b"] = (
+            candidate.get("reviews_b"),
+            candidate.get("reviews_a"),
+        )
+        normalized["urgency_a"], normalized["urgency_b"] = (
+            candidate.get("urgency_b"),
+            candidate.get("urgency_a"),
+        )
+    else:
+        normalized["vendor_a"], normalized["vendor_b"] = pair
+    return normalized
+
+
+def _merge_showdown_candidates(
+    organic: list[dict[str, Any]],
+    outbound: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge organic showdown rows with outbound-driven pair demand."""
+    merged: dict[str, dict[str, Any]] = {}
+
+    for source_rows in (organic, outbound):
+        for row in source_rows:
+            normalized = _canonicalize_showdown_candidate(row)
+            if not normalized:
+                continue
+            key = _showdown_pair_key(normalized["vendor_a"], normalized["vendor_b"])
+            existing = merged.get(key)
+            if not existing:
+                merged[key] = normalized
+                continue
+
+            combined = dict(existing)
+            for field in ("category", "slug"):
+                if not combined.get(field) and normalized.get(field):
+                    combined[field] = normalized[field]
+            for field in ("reviews_a", "reviews_b", "total_reviews", "urgency_a", "urgency_b", "pain_diff"):
+                left = combined.get(field)
+                right = normalized.get(field)
+                if left in (None, ""):
+                    combined[field] = right
+                elif right not in (None, ""):
+                    combined[field] = max(left, right)
+            if normalized.get("outbound_gap_priority"):
+                combined["outbound_gap_priority"] = True
+            if normalized.get("outbound_gap_company_count"):
+                combined["outbound_gap_company_count"] = max(
+                    int(combined.get("outbound_gap_company_count") or 0),
+                    int(normalized.get("outbound_gap_company_count") or 0),
+                )
+            companies = [
+                str(name).strip()
+                for name in (combined.get("outbound_gap_companies") or [])
+                + (normalized.get("outbound_gap_companies") or [])
+                if str(name).strip()
+            ]
+            if companies:
+                combined["outbound_gap_companies"] = list(dict.fromkeys(companies))[:5]
+            merged[key] = combined
+
+    return list(merged.values())
+
+
+async def _fetch_existing_showdown_posts(pool) -> list[dict[str, Any]]:
+    """Return existing showdown posts so the selector can avoid duplicate pair coverage."""
+    return await pool.fetch(
+        """
+        SELECT title, slug, topic_type, data_context
+        FROM blog_posts
+        WHERE status = ANY($1::text[])
+          AND topic_type = 'vendor_showdown'
+        """,
+        ["draft", "published"],
+    )
+
+
+async def _fetch_outbound_review_queue_candidates(pool) -> list[dict[str, Any]]:
+    """Fetch active account-backed outbound candidates to identify missing comparison assets."""
+    from .b2b_campaign_generation import list_churning_company_review_candidates
+
+    result = await list_churning_company_review_candidates(
+        pool,
+        min_score=max(int(settings.b2b_campaign.review_queue_min_score), 1),
+        max_score=_OUTBOUND_SHOWDOWN_MAX_SCORE,
+        limit=_OUTBOUND_SHOWDOWN_CANDIDATE_LIMIT,
+        qualified_only=False,
+        ignore_recent_dedup=True,
+    )
+    return result.get("candidates") or []
+
+
+async def _build_outbound_showdown_candidate(
+    pool,
+    *,
+    vendor_a: str,
+    vendor_b: str,
+    category: str | None,
+) -> dict[str, Any] | None:
+    """Build a showdown candidate shape from outbound demand."""
+    stats_a, stats_b = await asyncio.gather(
+        _fetch_vendor_stats(pool, vendor_a),
+        _fetch_vendor_stats(pool, vendor_b),
+    )
+    if not stats_a or not stats_b:
+        return None
+
+    return {
+        "vendor_a": vendor_a,
+        "vendor_b": vendor_b,
+        "category": category or stats_a.get("category") or stats_b.get("category") or "software",
+        "reviews_a": int(stats_a.get("total") or 0),
+        "reviews_b": int(stats_b.get("total") or 0),
+        "total_reviews": int(stats_a.get("total") or 0) + int(stats_b.get("total") or 0),
+        "urgency_a": round(float(stats_a.get("avg_urgency") or 0), 1),
+        "urgency_b": round(float(stats_b.get("avg_urgency") or 0), 1),
+        "pain_diff": round(
+            abs(float(stats_a.get("avg_urgency") or 0) - float(stats_b.get("avg_urgency") or 0)),
+            1,
+        ),
+    }
+
+
+async def _find_outbound_showdown_gap_candidates(pool) -> list[dict[str, Any]]:
+    """Return missing incumbent-vs-alternative showdowns from the live outbound queue."""
+    existing_posts, review_candidates = await asyncio.gather(
+        _fetch_existing_showdown_posts(pool),
+        _fetch_outbound_review_queue_candidates(pool),
+    )
+    covered_pairs = {
+        _blog_post_showdown_pair_key(post)
+        for post in existing_posts
+        if _blog_post_showdown_pair_key(post)
+    }
+
+    pair_demand: dict[str, dict[str, Any]] = {}
+    for item in review_candidates:
+        comparison_asset = item.get("comparison_asset") or {}
+        incumbent = str(
+            comparison_asset.get("incumbent_vendor") or item.get("vendor_name") or ""
+        ).strip()
+        alternative = str(comparison_asset.get("alternative_vendor") or "").strip()
+        if not incumbent or not alternative:
+            continue
+        if not comparison_asset.get("company_safe"):
+            continue
+        if not comparison_asset.get("pain_categories"):
+            continue
+
+        pair_key = _showdown_pair_key(incumbent, alternative)
+        if not pair_key or pair_key in covered_pairs:
+            continue
+
+        primary_post = comparison_asset.get("primary_blog_post") or item.get("primary_blog_post") or {}
+        if isinstance(primary_post, dict) and _blog_post_covers_showdown_pair(primary_post, incumbent, alternative):
+            continue
+
+        company_name = str(item.get("company_name") or "").strip()
+        current = pair_demand.setdefault(
+            pair_key,
+            {
+                "vendor_a": incumbent,
+                "vendor_b": alternative,
+                "category": str(item.get("product_category") or "").strip(),
+                "companies": [],
+                "max_score": 0,
+            },
+        )
+        if company_name and company_name not in current["companies"]:
+            current["companies"].append(company_name)
+        current["max_score"] = max(current["max_score"], int(item.get("opportunity_score") or 0))
+
+    candidates: list[dict[str, Any]] = []
+    for demand in pair_demand.values():
+        built = await _build_outbound_showdown_candidate(
+            pool,
+            vendor_a=demand["vendor_a"],
+            vendor_b=demand["vendor_b"],
+            category=demand.get("category"),
+        )
+        if not built:
+            continue
+        built["outbound_gap_priority"] = True
+        built["outbound_gap_company_count"] = len(demand["companies"])
+        built["outbound_gap_companies"] = demand["companies"][:5]
+        built["outbound_gap_max_score"] = demand["max_score"]
+        candidates.append(built)
+
+    return candidates
+
+
+async def _detect_campaign_content_gaps(pool) -> dict[str, set[str]]:
+    """Find (vendor, pain) pairs with recent campaigns but no matching blog post.
+
+    Returns ``{vendor_lower: {pain_lower, ...}}`` for vendors that have
+    campaigns in the last N days but no draft/published blog post mentioning
+    both the vendor and that pain category.
+    """
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT LOWER(vendor_name) AS vendor,
+                   LOWER(
+                       COALESCE(p.value->>'category', p.value #>> '{}')
+                   ) AS pain
+            FROM b2b_campaigns,
+                 LATERAL jsonb_array_elements(
+                     CASE WHEN jsonb_typeof(pain_categories) = 'array'
+                          THEN pain_categories
+                          ELSE '[]'::jsonb END
+                 ) AS p(value)
+            WHERE created_at >= NOW() - make_interval(days => $1)
+              AND status NOT IN ('cancelled', 'failed')
+              AND vendor_name IS NOT NULL
+            GROUP BY 1, 2
+            HAVING count(*) >= 1
+            """,
+            _CAMPAIGN_GAP_LOOKBACK_DAYS,
+        )
+    except Exception:
+        logger.warning("Failed to query campaign content gaps", exc_info=True)
+        return {}
+
+    if not rows:
+        return {}
+
+    # Build campaign demand: {vendor: {pain, ...}}
+    demand: dict[str, set[str]] = {}
+    for r in rows:
+        vendor = (r["vendor"] or "").strip()
+        pain = (r["pain"] or "").strip()
+        if vendor and pain:
+            demand.setdefault(vendor, set()).add(pain)
+
+    if not demand:
+        return {}
+
+    # Check which (vendor, pain) pairs already have blog coverage
+    try:
+        covered_rows = await pool.fetch(
+            """
+            SELECT title, slug, topic_type, tags, data_context
+            FROM blog_posts
+            WHERE status = ANY($1::text[])
+              AND topic_type = ANY($2::text[])
+            """,
+            ["draft", "published"],
+            list(_B2B_TOPIC_TYPES),
+        )
+    except Exception:
+        logger.warning("Failed to query blog coverage for gap detection", exc_info=True)
+        return demand  # Assume no coverage -- treat all as gaps
+
+    # Remove covered pairs
+    for cr in covered_rows:
+        dc = cr.get("data_context")
+        if isinstance(dc, str):
+            try:
+                dc = json.loads(dc)
+            except Exception:
+                dc = {}
+        if not isinstance(dc, dict):
+            dc = {}
+        tc = dc.get("topic_ctx") if isinstance(dc.get("topic_ctx"), dict) else {}
+        covered_vendors = _extract_blog_coverage_vendors(dc, tc)
+        covered_candidates = covered_vendors & set(demand.keys())
+        if not covered_candidates:
+            continue
+        pain_labels: set[str] = set()
+        for key in ("pain_distribution", "pain_breakdown", "pain_categories", "top_pain"):
+            pain_labels |= _collect_pain_labels(dc.get(key))
+            pain_labels |= _collect_pain_labels(tc.get(key))
+        tags = cr.get("tags") or []
+        if isinstance(tags, list):
+            tags_text = " ".join(str(tag).lower() for tag in tags if tag)
+        else:
+            tags_text = str(tags).lower()
+        text_haystack = " ".join(
+            filter(
+                None,
+                [
+                    str(cr.get("title") or "").lower(),
+                    str(cr.get("slug") or "").lower(),
+                    str(cr.get("topic_type") or "").lower(),
+                    tags_text,
+                ],
+            )
+        )
+        for vendor in covered_candidates:
+            covered_pains: set[str] = set()
+            for pain in demand.get(vendor, set()):
+                norm = _normalize_pain_label(pain)
+                if len(norm) < 3:
+                    continue
+                if norm in pain_labels or norm in text_haystack:
+                    covered_pains.add(pain)
+            demand[vendor] -= covered_pains
+            if not demand[vendor]:
+                del demand[vendor]
+
+    return demand
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-aware topic reranker (Phase 7)
+# ---------------------------------------------------------------------------
+
+# Score adjustments for reasoning-backed reranking
+_REASONING_TIMING_BOOST = 10.0       # topic has active timing intelligence
+_REASONING_ACCOUNT_BOOST = 8.0       # topic has account-level intent signals
+_REASONING_SWITCH_TRIGGER_BOOST = 6.0  # displacement has switch triggers
+_REASONING_COVERAGE_GAP_PENALTY = -15.0  # evidence is thin
+_REASONING_RETENTION_BOOST = 3.0     # why_they_stay available (enables balanced copy)
+_REASONING_CONTRADICTION_PENALTY = -5.0  # contradictory evidence reduces confidence
+
+
+async def _rerank_topic_candidates_with_reasoning(
+    pool,
+    candidates: list[tuple[str, float, str, dict[str, Any]]],
+    *,
+    as_of: date | None = None,
+    analysis_window_days: int = 90,
+) -> list[tuple[str, float, str, dict[str, Any]]]:
+    """Rerank topic candidates using synthesis reasoning signals.
+
+    Adjusts normalized scores based on reasoning quality so topics backed
+    by strong synthesis outrank raw-volume topics, and thin-evidence topics
+    are deprioritized even when deterministic scores are high.
+    """
+    if not candidates:
+        return candidates
+
+    # Collect vendor names and category names from candidates
+    vendor_set: set[str] = set()
+    category_set: set[str] = set()
+    for _, _, _, ctx in candidates:
+        for key in ("vendor", "from_vendor", "vendor_a", "vendor_b"):
+            v = str(ctx.get(key) or "").strip()
+            if v:
+                vendor_set.add(v)
+        cat = str(ctx.get("category") or "").strip()
+        if cat:
+            category_set.add(cat)
+
+    from ._b2b_synthesis_reader import load_best_reasoning_views
+
+    # For category-only candidates, resolve categories to vendor names
+    vendor_to_category: dict[str, str] = {}
+    if category_set:
+        cat_vendors_needed = category_set - {v.lower() for v in vendor_set}
+        if cat_vendors_needed:
+            try:
+                from ._b2b_shared import read_category_vendor_rows
+
+                _as_of_filter = as_of or date.today()
+                cat_vendor_rows = await read_category_vendor_rows(
+                    pool,
+                    category_names=cat_vendors_needed,
+                )
+                for row in cat_vendor_rows:
+                    vn = row.get("vendor_name")
+                    pc = row.get("product_category")
+                    if vn:
+                        vendor_set.add(vn)
+                        if pc:
+                            vendor_to_category[vn] = pc.lower().strip()
+            except Exception:
+                logger.debug("Category vendor resolution failed", exc_info=True)
+
+    views: dict = {}
+    if vendor_set:
+        try:
+            views = await load_best_reasoning_views(
+                pool, list(vendor_set),
+                as_of=as_of,
+                analysis_window_days=analysis_window_days,
+            )
+        except Exception:
+            logger.debug("Reasoning reranker: synthesis lookup failed, skipping", exc_info=True)
+            return candidates
+
+    # Build category index from loaded views
+    category_views: dict[str, list] = {}
+    for vname, view in views.items():
+        cat_name = ""
+        # Source 1: DB-resolved category from vendor resolution query
+        cat_name = vendor_to_category.get(vname, "")
+        # Source 2: evidence_vault product_category
+        if not cat_name:
+            ev = view.raw.get("evidence_vault") or {}
+            if isinstance(ev, dict):
+                cat_name = str(ev.get("product_category") or "").strip()
+        # Source 3: category_reasoning fields
+        if not cat_name:
+            cat_contract = view.contract("category_reasoning")
+            if isinstance(cat_contract, dict):
+                for cat_key in ("category", "product_category"):
+                    cat_name = str(cat_contract.get(cat_key) or "").strip()
+                    if cat_name:
+                        break
+        if cat_name:
+            category_views.setdefault(cat_name.lower().strip(), []).append(view)
+
+    if not views and not category_views:
+        return candidates
+
+    reranked: list[tuple[str, float, str, dict[str, Any]]] = []
+    for slug, score, topic_type, ctx in candidates:
+        adjustment = 0.0
+        reasons: list[str] = []
+
+        # Get primary vendor's reasoning view
+        primary = (
+            str(ctx.get("vendor") or ctx.get("from_vendor") or "").strip()
+            or str(ctx.get("vendor_a") or "").strip()
+        )
+        view = views.get(primary) if primary else None
+
+        if view is not None:
+            # Timing intelligence boost
+            timing = view.section("timing_intelligence")
+            if timing and timing.get("best_timing_window"):
+                triggers = timing.get("immediate_triggers") or []
+                if triggers:
+                    adjustment += _REASONING_TIMING_BOOST
+                    reasons.append("timing_boost")
+
+            # Account-level intent boost
+            acct = view.contract("account_reasoning")
+            if acct and acct.get("market_summary"):
+                high_intent = acct.get("high_intent_count")
+                if isinstance(high_intent, dict):
+                    high_intent = high_intent.get("value")
+                if high_intent and int(high_intent or 0) > 0:
+                    adjustment += _REASONING_ACCOUNT_BOOST
+                    reasons.append("account_intent_boost")
+
+            # Switch trigger boost
+            triggers = view.switch_triggers
+            if triggers:
+                adjustment += _REASONING_SWITCH_TRIGGER_BOOST
+                reasons.append("switch_trigger_boost")
+
+            # Why they stay boost (enables balanced copy)
+            if view.why_they_stay:
+                adjustment += _REASONING_RETENTION_BOOST
+                reasons.append("retention_context")
+
+            # Coverage gap penalty
+            gaps = view.coverage_gaps
+            if gaps:
+                # Scale penalty by number of gaps
+                gap_penalty = _REASONING_COVERAGE_GAP_PENALTY * min(len(gaps), 3) / 3
+                adjustment += gap_penalty
+                reasons.append(f"coverage_gap_penalty({len(gaps)})")
+
+            # Contradiction penalty
+            contradictions = view.contradictions
+            if contradictions:
+                adjustment += _REASONING_CONTRADICTION_PENALTY
+                reasons.append("contradiction_penalty")
+
+        # For showdowns, apply symmetric reasoning for vendor_b at half weight
+        vendor_b = str(ctx.get("vendor_b") or "").strip()
+        view_b = views.get(vendor_b) if vendor_b else None
+        if view_b is not None:
+            _SECONDARY_WEIGHT = 0.5
+            timing_b = view_b.section("timing_intelligence")
+            if timing_b and (timing_b.get("immediate_triggers") or []):
+                adjustment += _REASONING_TIMING_BOOST * _SECONDARY_WEIGHT
+                reasons.append("vendor_b_timing_boost")
+            if view_b.switch_triggers:
+                adjustment += _REASONING_SWITCH_TRIGGER_BOOST * _SECONDARY_WEIGHT
+                reasons.append("vendor_b_trigger_boost")
+            if view_b.why_they_stay:
+                adjustment += _REASONING_RETENTION_BOOST * _SECONDARY_WEIGHT
+                reasons.append("vendor_b_retention_context")
+            gaps_b = view_b.coverage_gaps
+            if gaps_b:
+                adjustment += _REASONING_COVERAGE_GAP_PENALTY * min(len(gaps_b), 3) / 6
+                reasons.append(f"vendor_b_gap_penalty({len(gaps_b)})")
+            if view_b.contradictions:
+                adjustment += _REASONING_CONTRADICTION_PENALTY * _SECONDARY_WEIGHT
+                reasons.append("vendor_b_contradiction_penalty")
+
+        # Category-level reasoning for topics without vendor keys
+        if view is None and view_b is None:
+            cat_name = str(ctx.get("category") or "").lower().strip()
+            cat_matches = category_views.get(cat_name, [])
+            if cat_matches:
+                # Use the best-informed category view
+                best_cat_view = cat_matches[0]
+                cat_contract = best_cat_view.contract("category_reasoning")
+                if isinstance(cat_contract, dict):
+                    regime = cat_contract.get("market_regime", "")
+                    if regime:
+                        adjustment += 4.0  # category has regime context
+                        reasons.append("category_regime_boost")
+                    cat_confidence = cat_contract.get("confidence_score")
+                    if cat_confidence is not None:
+                        try:
+                            if float(cat_confidence) < 0.3:
+                                adjustment += _REASONING_COVERAGE_GAP_PENALTY / 3
+                                reasons.append("category_low_confidence_penalty")
+                        except (TypeError, ValueError):
+                            pass
+                cat_gaps = best_cat_view.coverage_gaps
+                if cat_gaps:
+                    adjustment += _REASONING_COVERAGE_GAP_PENALTY * min(len(cat_gaps), 3) / 6
+                    reasons.append(f"category_gap_penalty({len(cat_gaps)})")
+
+        new_score = max(0.0, score + adjustment)
+        if reasons:
+            ctx = {**ctx, "_reasoning_adjustments": reasons}
+        reranked.append((slug, new_score, topic_type, ctx))
+
+    reranked.sort(key=lambda x: x[1], reverse=True)
+    boosted = sum(1 for _, _, _, c in reranked if c.get("_reasoning_adjustments"))
+    if boosted:
+        logger.info(
+            "Reasoning reranker adjusted %d/%d candidates", boosted, len(reranked),
+        )
+    return reranked
+
+
+async def _select_topic(
+    pool,
+    max_per_run: int = 1,
+    *,
+    exclude_vendors: set[str] | None = None,
+    exclude_types: dict[str, int] | None = None,
+) -> tuple[str, dict[str, Any]] | None:
+    """Score candidates and pick the best unwritten B2B topic."""
+    today = date.today()
+    month_suffix = today.strftime("%Y-%m")
+
+    (alternatives, showdowns, outbound_showdowns, churn_reports, migrations,
+     deep_dives, landscapes,
+     pricing_checks, switching_stories, pain_roundups, fit_guides,
+    ) = await asyncio.gather(
+        _find_vendor_alternative_candidates(pool),
+        _find_vendor_showdown_candidates(pool),
+        _find_outbound_showdown_gap_candidates(pool),
+        _find_churn_report_candidates(pool),
+        _find_migration_guide_candidates(pool),
+        _find_vendor_deep_dive_candidates(pool),
+        _find_market_landscape_candidates(pool),
+        _find_pricing_reality_check_candidates(pool),
+        _find_switching_story_candidates(pool),
+        _find_pain_point_roundup_candidates(pool),
+        _find_best_fit_guide_candidates(pool),
+        return_exceptions=True,
+    )
+    alternatives = alternatives if not isinstance(alternatives, Exception) else []
+    showdowns = showdowns if not isinstance(showdowns, Exception) else []
+    outbound_showdowns = outbound_showdowns if not isinstance(outbound_showdowns, Exception) else []
+    churn_reports = churn_reports if not isinstance(churn_reports, Exception) else []
+    migrations = migrations if not isinstance(migrations, Exception) else []
+    deep_dives = deep_dives if not isinstance(deep_dives, Exception) else []
+    landscapes = landscapes if not isinstance(landscapes, Exception) else []
+    pricing_checks = pricing_checks if not isinstance(pricing_checks, Exception) else []
+    switching_stories = switching_stories if not isinstance(switching_stories, Exception) else []
+    pain_roundups = pain_roundups if not isinstance(pain_roundups, Exception) else []
+    fit_guides = fit_guides if not isinstance(fit_guides, Exception) else []
+    showdowns = _merge_showdown_candidates(showdowns, outbound_showdowns)
+
+    raw_candidates: list[tuple[str, float, str, dict[str, Any]]] = []
+
+    for alt in alternatives:
+        slug = f"{_slugify(alt['vendor'])}-alternatives-{month_suffix}"
+        score = alt["urgency"] * alt["review_count"]
+        raw_candidates.append((slug, score, "vendor_alternative", {**alt, "slug": slug}))
+
+    for pair in showdowns:
+        slug = f"{_slugify(pair['vendor_a'])}-vs-{_slugify(pair['vendor_b'])}-{month_suffix}"
+        # Weight reviews heavily -- popular pairs are most interesting to readers.
+        # pain_diff is a bonus, not the primary driver.
+        score = (pair["total_reviews"] + pair["pain_diff"] * 50) * 1.5
+        raw_candidates.append((slug, score, "vendor_showdown", {**pair, "slug": slug}))
+
+    for cr in churn_reports:
+        slug = f"{_slugify(cr['vendor'])}-churn-report-{month_suffix}"
+        score = cr["negative_reviews"] * cr["avg_urgency"]
+        raw_candidates.append((slug, score, "churn_report", {**cr, "slug": slug}))
+
+    for mig in migrations:
+        slug = f"switch-to-{_slugify(mig['vendor'])}-{month_suffix}"
+        score = mig["switch_count"] * mig["review_total"] * 1.5
+        raw_candidates.append((slug, score, "migration_guide", {**mig, "slug": slug}))
+
+    for dd in deep_dives:
+        slug = f"{_slugify(dd['vendor'])}-deep-dive-{month_suffix}"
+        score = dd["review_count"] * 1.5 + dd["profile_richness"] * 5
+        raw_candidates.append((slug, score, "vendor_deep_dive", {**dd, "slug": slug}))
+
+    for ml in landscapes:
+        slug = f"{_slugify(ml['category'])}-landscape-{month_suffix}"
+        score = ml["vendor_count"] * ml["total_reviews"] * 0.5
+        raw_candidates.append((slug, score, "market_landscape", {**ml, "slug": slug}))
+
+    for pc in pricing_checks:
+        slug = f"real-cost-of-{_slugify(pc['vendor'])}-{month_suffix}"
+        score = pc["pricing_complaints"] * 10 + pc["total_reviews"] * 0.5
+        raw_candidates.append((slug, score, "pricing_reality_check", {**pc, "slug": slug}))
+
+    for ss in switching_stories:
+        slug = f"why-teams-leave-{_slugify(ss['from_vendor'])}-{month_suffix}"
+        score = ss["switch_mentions"] * 8 + ss["avg_urgency"] * 2
+        raw_candidates.append((slug, score, "switching_story", {**ss, "slug": slug}))
+
+    for pr in pain_roundups:
+        slug = f"top-complaint-every-{_slugify(pr['category'])}-{month_suffix}"
+        score = pr["vendor_count"] * pr["total_complaints"] * 0.3
+        raw_candidates.append((slug, score, "pain_point_roundup", {**pr, "slug": slug}))
+
+    for fg in fit_guides:
+        slug = f"best-{_slugify(fg['category'])}-for-{_slugify(fg['company_size'])}-{month_suffix}"
+        score = fg["vendor_count"] * fg["total_reviews"] * 0.8
+        raw_candidates.append((slug, score, "best_fit_guide", {**fg, "slug": slug}))
+
+    if not raw_candidates:
+        return None
+
+    # --- Normalize scores within each topic type (0-100 scale) ---
+    # Without normalization, deep_dives (score ~900) always beat showdowns (~400).
+    # Normalizing ensures the *best* candidate of each type competes fairly.
+    by_type: dict[str, list[tuple[str, float, str, dict]]] = {}
+    for slug, score, topic_type, ctx in raw_candidates:
+        by_type.setdefault(topic_type, []).append((slug, score, topic_type, ctx))
+
+    normalized: list[tuple[str, float, str, dict]] = []
+    for topic_type, entries in by_type.items():
+        max_score = max(e[1] for e in entries) or 1.0
+        for slug, score, tt, ctx in entries:
+            norm = (score / max_score) * 100.0
+            normalized.append((slug, norm, tt, ctx))
+
+    raw_candidates = normalized
+
+    # --- Campaign content gap bonus: boost topics filling campaign demand ---
+    content_gaps = await _detect_campaign_content_gaps(pool)
+    if content_gaps:
+        boosted: list[tuple[str, float, str, dict]] = []
+        gap_boost_count = 0
+        for slug, score, topic_type, ctx in raw_candidates:
+            vendor_keys = {
+                str(ctx.get(key) or "").lower().strip()
+                for key in ("vendor", "from_vendor", "vendor_a", "vendor_b")
+                if str(ctx.get(key) or "").strip()
+            }
+            should_boost = False
+            for vendor_key in vendor_keys:
+                gap_pains = content_gaps.get(vendor_key)
+                if gap_pains and _candidate_overlaps_gap_pain(topic_type, ctx, gap_pains):
+                    should_boost = True
+                    break
+            if should_boost:
+                score *= (1.0 + _CAMPAIGN_GAP_BONUS_PCT)
+                gap_boost_count += 1
+            boosted.append((slug, score, topic_type, ctx))
+        raw_candidates = boosted
+        if gap_boost_count:
+            logger.info(
+                "Campaign gap bonus applied to %d/%d candidates",
+                gap_boost_count, len(raw_candidates),
+            )
+
+    boosted_showdowns: list[tuple[str, float, str, dict]] = []
+    showdown_gap_boost_count = 0
+    for slug, score, topic_type, ctx in raw_candidates:
+        if topic_type == "vendor_showdown" and ctx.get("outbound_gap_priority"):
+            score *= (1.0 + _OUTBOUND_SHOWDOWN_GAP_BONUS_PCT)
+            showdown_gap_boost_count += 1
+        boosted_showdowns.append((slug, score, topic_type, ctx))
+    raw_candidates = boosted_showdowns
+    if showdown_gap_boost_count:
+        logger.info(
+            "Outbound showdown gap bonus applied to %d candidate(s)",
+            showdown_gap_boost_count,
+        )
+
+    # --- Reasoning-aware reranking (Phase 7) ---
+    raw_candidates = await _rerank_topic_candidates_with_reasoning(
+        pool, raw_candidates, as_of=today,
+    )
+
+    # --- Data sufficiency gate: filter candidates below minimum review counts ---
+    sources = _blog_source_allowlist()
+    vendor_counts = await _batch_vendor_review_counts(pool, raw_candidates, sources)
+    _MIN_REVIEWS_BY_TYPE = {
+        "vendor_showdown": 10,
+        "vendor_deep_dive": 8,
+        "churn_report": 8,
+        "best_fit_guide": 8,
+    }
+    _DEFAULT_MIN_REVIEWS = 5
+    before_sufficiency = len(raw_candidates)
+    sufficient: list[tuple[str, float, str, dict]] = []
+    for slug, score, topic_type, ctx in raw_candidates:
+        min_required = _MIN_REVIEWS_BY_TYPE.get(topic_type, _DEFAULT_MIN_REVIEWS)
+        # For showdowns, check both vendors
+        if topic_type == "vendor_showdown":
+            va = (ctx.get("vendor_a") or "").lower().strip()
+            vb = (ctx.get("vendor_b") or "").lower().strip()
+            if vendor_counts.get(va, 0) < min_required or vendor_counts.get(vb, 0) < min_required:
+                logger.debug(
+                    "Sufficiency gate: %s skipped (%s=%d, %s=%d, need %d)",
+                    slug, va, vendor_counts.get(va, 0), vb, vendor_counts.get(vb, 0), min_required,
+                )
+                continue
+        else:
+            vk = (ctx.get("vendor") or ctx.get("from_vendor") or "").lower().strip()
+            if vk and vendor_counts.get(vk, 0) < min_required:
+                logger.debug(
+                    "Sufficiency gate: %s skipped (vendor=%s, count=%d, need %d)",
+                    slug, vk, vendor_counts.get(vk, 0), min_required,
+                )
+                continue
+        sufficient.append((slug, score, topic_type, ctx))
+    raw_candidates = sufficient
+    if before_sufficiency != len(raw_candidates):
+        logger.info(
+            "Sufficiency gate filtered %d -> %d candidates",
+            before_sufficiency, len(raw_candidates),
+        )
+
+    if not raw_candidates:
+        return None
+
+    # --- Dedup layer 1: exact slug match (same topic+vendor+month) ---
+    all_slugs = list({c[0] for c in raw_candidates})
+    existing_slugs = await _batch_slug_check(pool, all_slugs)
+
+    # --- Dedup layer 2: vendor-level cooldown (any topic type, 7 days) ---
+    # A vendor needs 3+ posts within the window to be considered "covered",
+    # allowing a deep-dive and a showdown without triggering cooldown.
+    covered_vendors = await _recently_covered_vendors(pool, days=7)
+
+    def _vendor_keys(ctx: dict) -> set[str]:
+        """Return all vendor names from a candidate (normalized for dedup).
+
+        Showdowns have vendor_a + vendor_b; others have vendor.
+        """
+        keys = set()
+        for k in ("vendor", "vendor_a", "vendor_b", "from_vendor"):
+            v = ctx.get(k, "")
+            if v:
+                keys.add(v.lower().strip())
+        return keys
+
+    candidates = [
+        (score, topic_type, ctx)
+        for slug, score, topic_type, ctx in raw_candidates
+        if slug not in existing_slugs
+        and (
+            ctx.get("outbound_gap_priority")
+            or not _vendor_keys(ctx) & covered_vendors
+        )
+    ]
+
+    if not candidates:
+        logger.info(
+            "No candidates survived filters. raw=%d, slug_dupes=%d, covered_vendors=%d",
+            len(raw_candidates), len(existing_slugs), len(covered_vendors),
+        )
+        return None
+
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    logger.info(
+        "Topic candidates after filtering: %d (top: %s)",
+        len(candidates),
+        [(c[1], c[2].get("slug", "?"), f"{c[0]:.0f}") for c in candidates[:5]],
+    )
+
+    # --- Dedup layer 3: cross-iteration vendor + type diversity ---
+    _max_per_type = 2
+    _exclude_vendors = exclude_vendors or set()
+    _exclude_types = exclude_types or {}
+    best = None
+    for score, topic_type, ctx in candidates:
+        # Skip vendors already used in this run
+        vks = _vendor_keys(ctx)
+        if vks & _exclude_vendors:
+            continue
+        # Skip topic types that hit the per-run cap
+        if _exclude_types.get(topic_type, 0) >= _max_per_type:
+            continue
+        best = (score, topic_type, ctx)
+        break
+
+    if best is None:
+        return None
+    logger.info(
+        "Selected B2B topic: %s (score=%.1f, slug=%s)",
+        best[1], best[0], best[2].get("slug"),
+    )
+    return best[1], best[2]
+
+
+async def _find_vendor_alternative_candidates(pool) -> list[dict[str, Any]]:
+    """Vendors with high churn + affiliate partner covering the category."""
+    from ._b2b_shared import read_vendor_alternative_candidates
+
+    return await read_vendor_alternative_candidates(pool)
+
+
+async def _find_vendor_showdown_candidates(pool) -> list[dict[str, Any]]:
+    """Pairs of vendors in the same category with contrasting pain profiles."""
+    from ._b2b_shared import read_vendor_showdown_candidates
+
+    return await read_vendor_showdown_candidates(pool)
+
+
+async def _find_churn_report_candidates(pool) -> list[dict[str, Any]]:
+    """Single vendor with high urgency + many negative reviews."""
+    from ._b2b_shared import read_churn_report_candidates
+
+    return await read_churn_report_candidates(pool)
+
+
+async def _find_migration_guide_candidates(pool) -> list[dict[str, Any]]:
+    """Vendors with high switched_from counts in product profiles."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            pp.vendor_name AS vendor,
+            pp.product_category AS category,
+            COALESCE(jsonb_array_length(pp.commonly_switched_from), 0) AS switch_count,
+            (
+                SELECT COUNT(DISTINCT br.id)
+                FROM b2b_reviews br
+                JOIN b2b_review_vendor_mentions vm ON vm.review_id = br.id
+                WHERE vm.vendor_name = pp.vendor_name
+                  AND br.duplicate_of_review_id IS NULL
+            ) AS review_total
+        FROM b2b_product_profiles pp
+        WHERE jsonb_array_length(COALESCE(pp.commonly_switched_from, '[]'::jsonb)) >= 2
+        ORDER BY jsonb_array_length(pp.commonly_switched_from) DESC
+        LIMIT 10
+        """
+    )
+    return [
+        {
+            "vendor": r["vendor"],
+            "category": r["category"],
+            "switch_count": r["switch_count"],
+            "review_total": r["review_total"],
+        }
+        for r in rows
+    ]
+
+
+async def _find_pricing_reality_check_candidates(pool) -> list[dict[str, Any]]:
+    """Vendors where users complain about pricing -- bait-and-switch, hidden costs, etc."""
+    # APPROVED-ENRICHMENT-READ: pain_categories, urgency_score
+    # Reason: inline aggregate query, structurally coupled to product output
+    sources = _blog_source_allowlist()
+    rows = await pool.fetch(
+        """
+        SELECT
+            vm.vendor_name AS vendor,
+            r.product_category AS category,
+            COUNT(DISTINCT r.id) AS total_reviews,
+            COUNT(DISTINCT r.id) FILTER (
+                WHERE r.enrichment->>'pain_categories' ILIKE '%pricing%'
+            ) AS pricing_complaints,
+            ROUND(AVG(
+                CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]'
+                     THEN (r.enrichment->>'urgency_score')::numeric ELSE NULL END
+            )::numeric, 1) AS avg_urgency
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE r.enrichment_status = 'enriched'
+          AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($1)
+        GROUP BY vm.vendor_name, r.product_category
+        HAVING COUNT(DISTINCT r.id) FILTER (
+            WHERE r.enrichment->>'pain_categories' ILIKE '%pricing%'
+        ) >= 2
+        ORDER BY COUNT(DISTINCT r.id) FILTER (
+            WHERE r.enrichment->>'pain_categories' ILIKE '%pricing%'
+        ) DESC
+        LIMIT 10
+        """,
+        sources,
+    )
+    return [
+        {
+            "vendor": r["vendor"],
+            "category": r["category"],
+            "total_reviews": r["total_reviews"],
+            "pricing_complaints": r["pricing_complaints"],
+            "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _find_switching_story_candidates(pool) -> list[dict[str, Any]]:
+    """Vendors users are actively leaving -- real switching stories from reviews."""
+    # APPROVED-ENRICHMENT-READ: urgency_score
+    # Reason: inline aggregate query, structurally coupled to product output
+    sources = _blog_source_allowlist()
+    rows = await pool.fetch(
+        """
+        SELECT
+            vm.vendor_name AS from_vendor,
+            r.product_category AS category,
+            COUNT(DISTINCT r.id) AS total_reviews,
+            COUNT(DISTINCT r.id) FILTER (
+                WHERE (r.enrichment->>'urgency_score')::numeric >= 7
+            ) AS high_urgency_count,
+            COUNT(DISTINCT r.id) FILTER (
+                WHERE r.review_text ILIKE '%switch%' OR r.review_text ILIKE '%migrat%'
+                   OR r.review_text ILIKE '%moved to%' OR r.review_text ILIKE '%moving to%'
+                   OR r.review_text ILIKE '%left for%' OR r.review_text ILIKE '%leaving for%'
+            ) AS switch_mentions,
+            ROUND(AVG(
+                CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]'
+                     THEN (r.enrichment->>'urgency_score')::numeric ELSE NULL END
+            )::numeric, 1) AS avg_urgency
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE r.enrichment_status = 'enriched'
+          AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($1)
+        GROUP BY vm.vendor_name, r.product_category
+        HAVING COUNT(DISTINCT r.id) FILTER (
+            WHERE r.review_text ILIKE '%switch%' OR r.review_text ILIKE '%migrat%'
+               OR r.review_text ILIKE '%moved to%' OR r.review_text ILIKE '%moving to%'
+               OR r.review_text ILIKE '%left for%' OR r.review_text ILIKE '%leaving for%'
+        ) >= 2
+        ORDER BY switch_mentions DESC
+        LIMIT 10
+        """,
+        sources,
+    )
+    return [
+        {
+            "from_vendor": r["from_vendor"],
+            "category": r["category"],
+            "total_reviews": r["total_reviews"],
+            "high_urgency_count": r["high_urgency_count"],
+            "switch_mentions": r["switch_mentions"],
+            "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _find_pain_point_roundup_candidates(pool) -> list[dict[str, Any]]:
+    """Categories with enough vendors to do a cross-vendor complaint comparison."""
+    # APPROVED-ENRICHMENT-READ: urgency_score
+    # Reason: inline aggregate query, structurally coupled to product output
+    sources = _blog_source_allowlist()
+    rows = await pool.fetch(
+        """
+        SELECT
+            r.product_category AS category,
+            COUNT(DISTINCT vm.vendor_name) AS vendor_count,
+            COUNT(DISTINCT r.id) AS total_complaints,
+            ROUND(AVG(
+                CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]'
+                     THEN (r.enrichment->>'urgency_score')::numeric ELSE NULL END
+            )::numeric, 1) AS avg_urgency
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE r.enrichment_status = 'enriched'
+          AND r.duplicate_of_review_id IS NULL
+          AND r.product_category IS NOT NULL AND r.product_category != ''
+          AND r.source = ANY($1)
+        GROUP BY r.product_category
+        HAVING COUNT(DISTINCT vm.vendor_name) >= 3
+        ORDER BY COUNT(DISTINCT vm.vendor_name) DESC
+        LIMIT 10
+        """,
+        sources,
+    )
+    return [
+        {
+            "category": r["category"],
+            "vendor_count": r["vendor_count"],
+            "total_complaints": r["total_complaints"],
+            "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+        }
+        for r in rows
+    ]
+
+
+async def _find_best_fit_guide_candidates(pool) -> list[dict[str, Any]]:
+    """Categories with vendors serving different company sizes -- recommend by fit."""
+    min_vendor_profiles = _blog_min_vendor_profiles("best_fit_guide")
+    rows = await pool.fetch(
+        """
+        SELECT
+            pp.product_category AS category,
+            COUNT(DISTINCT pp.vendor_name) AS vendor_count,
+            (SELECT COUNT(*) FROM b2b_reviews br
+             WHERE br.product_category = pp.product_category
+               AND br.enrichment_status = 'enriched'
+               AND br.duplicate_of_review_id IS NULL) AS total_reviews,
+            MODE() WITHIN GROUP (
+                ORDER BY COALESCE(
+                    (
+                        SELECT key
+                        FROM jsonb_each_text(COALESCE(pp.typical_company_size, '{}'::jsonb))
+                        ORDER BY value::numeric DESC
+                        LIMIT 1
+                    ),
+                    'unknown'
+                )
+            ) AS dominant_size
+        FROM b2b_product_profiles pp
+        WHERE pp.product_category IS NOT NULL AND pp.product_category != ''
+        GROUP BY pp.product_category
+        HAVING COUNT(DISTINCT pp.vendor_name) >= $1
+        ORDER BY COUNT(DISTINCT pp.vendor_name) DESC
+        LIMIT 10
+        """,
+        min_vendor_profiles,
+    )
+    return [
+        {
+            "category": r["category"],
+            "vendor_count": r["vendor_count"],
+            "total_reviews": r["total_reviews"],
+            "company_size": r["dominant_size"] or "small-teams",
+        }
+        for r in rows
+    ]
+
+
+async def _find_vendor_deep_dive_candidates(pool) -> list[dict[str, Any]]:
+    """Any vendor with a product profile -- showcase what we know about them."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            pp.vendor_name AS vendor,
+            pp.product_category AS category,
+            (
+                SELECT COUNT(DISTINCT br.id)
+                FROM b2b_reviews br
+                JOIN b2b_review_vendor_mentions vm ON vm.review_id = br.id
+                WHERE vm.vendor_name = pp.vendor_name
+                  AND br.duplicate_of_review_id IS NULL
+            ) AS review_count,
+            (CASE
+                WHEN pp.strengths IS NOT NULL AND jsonb_array_length(COALESCE(pp.strengths, '[]'::jsonb)) > 0 THEN 1 ELSE 0
+            END +
+            CASE
+                WHEN pp.weaknesses IS NOT NULL AND jsonb_array_length(COALESCE(pp.weaknesses, '[]'::jsonb)) > 0 THEN 1 ELSE 0
+            END +
+            CASE
+                WHEN pp.top_integrations IS NOT NULL AND jsonb_array_length(COALESCE(pp.top_integrations, '[]'::jsonb)) > 0 THEN 1 ELSE 0
+            END +
+            CASE
+                WHEN pp.commonly_compared_to IS NOT NULL AND jsonb_array_length(COALESCE(pp.commonly_compared_to, '[]'::jsonb)) > 0 THEN 1 ELSE 0
+            END +
+            CASE
+                WHEN pp.commonly_switched_from IS NOT NULL AND jsonb_array_length(COALESCE(pp.commonly_switched_from, '[]'::jsonb)) > 0 THEN 1 ELSE 0
+            END) AS profile_richness
+        FROM b2b_product_profiles pp
+        ORDER BY profile_richness DESC, review_count DESC
+        LIMIT 60
+        """
+    )
+    return [
+        {
+            "vendor": r["vendor"],
+            "category": r["category"],
+            "review_count": r["review_count"],
+            "profile_richness": r["profile_richness"],
+        }
+        for r in rows
+    ]
+
+
+async def _find_market_landscape_candidates(pool) -> list[dict[str, Any]]:
+    """Categories with multiple vendors -- write a landscape overview."""
+    from ._b2b_shared import read_market_landscape_candidates
+
+    min_vendor_profiles = _blog_min_vendor_profiles("market_landscape")
+    return await read_market_landscape_candidates(
+        pool,
+        min_vendor_profiles=min_vendor_profiles,
+    )
+
+
+async def _batch_vendor_review_counts(
+    pool, candidates: list[tuple[str, float, str, dict]], sources: list[str]
+) -> dict[str, int]:
+    """Single SQL query counting blog-eligible reviews per vendor.
+
+    Returns {vendor_name_lower: count}.
+    """
+    vendor_set: set[str] = set()
+    for _, _, _, ctx in candidates:
+        for k in ("vendor", "vendor_a", "vendor_b", "from_vendor"):
+            v = ctx.get(k, "")
+            if v:
+                vendor_set.add(v)
+    if not vendor_set:
+        return {}
+    rows = await pool.fetch(
+        """
+        SELECT LOWER(vm.vendor_name) AS vn, COUNT(DISTINCT r.id) AS cnt
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE vm.vendor_name = ANY($1)
+          AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($2)
+        GROUP BY LOWER(vm.vendor_name)
+        """,
+        list(vendor_set), sources,
+    )
+    return {r["vn"]: r["cnt"] for r in rows}
+
+
+def _blog_slug_block_reason(
+    row: dict[str, Any] | Any,
+    *,
+    now: datetime | None = None,
+) -> str | None:
+    """Return the reason a blog slug should be blocked from regeneration."""
+    def _coerce_int_or_default(value: Any, default: int) -> int:
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            if value != value:
+                return default
+            return int(value)
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return default
+            try:
+                return int(text)
+            except ValueError:
+                try:
+                    return int(float(text))
+                except ValueError:
+                    return default
+        return default
+
+    if not row:
+        return None
+    status = str(row.get("status") or "").strip().lower()
+    slug = str(row.get("slug") or "").strip()
+    if not slug or not status:
+        return None
+    if status == "failed":
+        return None
+    if status != "rejected":
+        return f"status:{status}"
+
+    max_retries = _coerce_int_or_default(
+        getattr(settings.b2b_churn, "blog_post_max_rejection_retries", 1),
+        1,
+    )
+    rejection_count = int(row.get("rejection_count") or 0)
+    if rejection_count > max_retries:
+        return "retry_limit"
+
+    cooldown_hours = _coerce_int_or_default(
+        getattr(settings.b2b_churn, "blog_post_rejection_cooldown_hours", 24),
+        24,
+    )
+    rejected_at = row.get("rejected_at")
+    if (
+        cooldown_hours > 0
+        and isinstance(rejected_at, datetime)
+        and rejected_at >= (now or datetime.now(rejected_at.tzinfo)) - timedelta(hours=cooldown_hours)
+    ):
+        return "rejection_cooldown"
+    return None
+
+
+async def _get_blog_slug_block_reason(pool, slug: str) -> str | None:
+    """Return the current block reason for a single blog slug, if any."""
+    row = await pool.fetchrow(
+        """
+        SELECT slug, status, COALESCE(rejection_count, 0) AS rejection_count, rejected_at
+        FROM blog_posts
+        WHERE slug = $1
+        """,
+        slug,
+    )
+    return _blog_slug_block_reason(row)
+
+
+async def _batch_slug_check(pool, slugs: list[str]) -> set[str]:
+    """Return slugs that should NOT be regenerated."""
+    if not slugs:
+        return set()
+    rows = await pool.fetch(
+        """
+        SELECT slug, status, COALESCE(rejection_count, 0) AS rejection_count, rejected_at
+        FROM blog_posts
+        WHERE slug = ANY($1)
+        """,
+        slugs,
+    )
+    blocked: set[str] = set()
+    for row in rows:
+        reason = _blog_slug_block_reason(row)
+        if not reason:
+            continue
+        blocked.add(str(row["slug"]))
+        if reason == "retry_limit":
+            logger.info(
+                "Permanently blocked slug %s after %d rejections",
+                row["slug"],
+                int(row.get("rejection_count") or 0),
+            )
+        elif reason == "rejection_cooldown":
+            logger.info("Cooling down rejected slug %s before another retry", row["slug"])
+    return blocked
+
+
+async def _recently_covered_vendors(pool, days: int = 90) -> set[str]:
+    """Return vendor names that already have *multiple* B2B blog posts recently.
+
+    A vendor is considered "covered" when it appears in 2+ posts within the
+    cooldown window.  This allows a single deep-dive to coexist with a showdown
+    or pricing check for the same vendor, while still preventing one vendor
+    from dominating the blog.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT LOWER(vendor) AS vendor, COUNT(*) AS cnt FROM (
+            SELECT data_context->>'vendor' AS vendor
+            FROM blog_posts
+            WHERE created_at > NOW() - make_interval(days => $1)
+              AND data_context->>'vendor' IS NOT NULL
+            UNION ALL
+            SELECT data_context->>'vendor_a' AS vendor
+            FROM blog_posts
+            WHERE created_at > NOW() - make_interval(days => $1)
+              AND data_context->>'vendor_a' IS NOT NULL
+            UNION ALL
+            SELECT data_context->>'vendor_b' AS vendor
+            FROM blog_posts
+            WHERE created_at > NOW() - make_interval(days => $1)
+              AND data_context->>'vendor_b' IS NOT NULL
+        ) sub
+        WHERE vendor != ''
+        GROUP BY LOWER(vendor)
+        HAVING COUNT(*) >= 3
+        """,
+        days,
+    )
+    return {r["vendor"] for r in rows if r["vendor"]}
+
+
+def _slugify(text: str) -> str:
+    """Convert text to URL-safe slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    return re.sub(r"-+", "-", text).strip("-")[:60]
+
+
+def _merge_blog_signals_with_evidence_vault(
+    raw_signals: list[dict[str, Any]],
+    vault: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Prefer canonical vault pain rows while preserving raw fallback rows."""
+    if not isinstance(vault, dict):
+        return raw_signals
+    weakness_rows = vault.get("weakness_evidence") or []
+    gap_labels = [
+        str(item.get("label") or item.get("key") or "").strip()
+        for item in weakness_rows
+        if isinstance(item, dict) and str(item.get("evidence_type") or "") == "feature_gap"
+    ]
+    vault_rows = [
+        item for item in weakness_rows
+        if isinstance(item, dict) and str(item.get("evidence_type") or "") == "pain_category"
+    ]
+    if not vault_rows:
+        vault_rows = [
+            item for item in weakness_rows
+            if isinstance(item, dict) and str(item.get("evidence_type") or "") != "feature_gap"
+        ]
+    raw_by_key = {
+        str(item.get("pain_category") or "").strip().lower(): item
+        for item in (raw_signals or [])
+        if isinstance(item, dict) and str(item.get("pain_category") or "").strip()
+    }
+    merged: list[dict[str, Any]] = []
+    for item in vault_rows:
+        match_key = str(item.get("key") or item.get("label") or "").strip().lower()
+        raw = raw_by_key.pop(match_key, {})
+        metrics = item.get("supporting_metrics") if isinstance(item.get("supporting_metrics"), dict) else {}
+        merged.append({
+            "pain_category": str(item.get("label") or item.get("key") or "").strip(),
+            "signal_count": int(item.get("mention_count_total") or raw.get("signal_count") or 0),
+            "avg_urgency": metrics.get("avg_urgency_when_mentioned") or raw.get("avg_urgency") or 0,
+            "feature_gaps": gap_labels[:5] or list(raw.get("feature_gaps") or []),
+        })
+    merged.extend(raw_by_key.values())
+    merged.sort(key=lambda item: (int(item.get("signal_count") or 0), float(item.get("avg_urgency") or 0)), reverse=True)
+    return merged
+
+
+def _merge_blog_quotes_with_evidence_vault(
+    raw_quotes: list[dict[str, Any]],
+    vault: dict[str, Any] | None,
+    *,
+    limit: int = 15,
+) -> list[dict[str, Any]]:
+    """Prefer canonical vault quotes while preserving raw quote fallback."""
+    if not isinstance(vault, dict):
+        return raw_quotes
+    candidates: list[dict[str, Any]] = []
+    for section, sentiment in (("weakness_evidence", "negative"), ("strength_evidence", "positive")):
+        for item in vault.get(section) or []:
+            if not isinstance(item, dict):
+                continue
+            # Phase 2.3 4i: vault rows must carry phrase_verbatim=True
+            # (stamped by 4e-A's _rollup_quote_metadata). Unmarked vault
+            # rows are dropped at the merger so the downstream blog
+            # gate can require the marker on every emitted vault row.
+            if item.get("phrase_verbatim") is not True:
+                continue
+            phrase = str(item.get("best_quote") or "").strip()
+            if not phrase:
+                continue
+            source = item.get("quote_source") if isinstance(item.get("quote_source"), dict) else {}
+            metrics = item.get("supporting_metrics") if isinstance(item.get("supporting_metrics"), dict) else {}
+            candidates.append({
+                "phrase": phrase,
+                "vendor": vault.get("vendor_name") or "",
+                "urgency": metrics.get("avg_urgency_when_mentioned") or 0,
+                "role": source.get("reviewer_title") or "",
+                "company": source.get("company") or "",
+                "company_size": source.get("company_size") or "",
+                "industry": source.get("industry") or "",
+                "source_name": source.get("source") or "",
+                "sentiment": sentiment,
+                # Phase 2.3 origin marker (vault portion of merger) +
+                # phrase_verbatim propagation so downstream consumers
+                # can enforce the policy uniformly.
+                "quote_origin": "vault",
+                "phrase_verbatim": True,
+                "_priority": int(item.get("mention_count_total") or 0),
+            })
+    ordered = sorted(candidates, key=lambda item: (item["_priority"], len(str(item.get("phrase") or ""))), reverse=True)
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in ordered + list(raw_quotes or []):
+        phrase = " ".join(str(item.get("phrase") or "").lower().split())
+        if not phrase or phrase in seen:
+            continue
+        seen.add(phrase)
+        merged.append({k: v for k, v in item.items() if k != "_priority"})
+        if len(merged) >= limit:
+            break
+    return merged
+
+
+def _merge_specialized_blog_review_rows(
+    raw_rows: list[dict[str, Any]],
+    vault_rows: list[dict[str, Any]],
+    *,
+    limit: int,
+    prefer_raw: bool,
+) -> list[dict[str, Any]]:
+    """Merge specialized review-row payloads with exact-text dedupe."""
+    ordered = (list(raw_rows or []) + list(vault_rows or [])) if prefer_raw else (list(vault_rows or []) + list(raw_rows or []))
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in ordered:
+        text = " ".join(str(item.get("text") or "").lower().split())
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        merged.append(item)
+        if len(merged) >= limit:
+            break
+    return merged
+
+
+def _build_specialized_blog_review_rows_from_evidence_vault(
+    vault: dict[str, Any] | None,
+    *,
+    mode: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Build pricing/positive/switching review rows from canonical vault quotes."""
+    if not isinstance(vault, dict):
+        return []
+
+    def _matches_pricing(item: dict[str, Any]) -> bool:
+        text = " ".join(
+            [
+                str(item.get("key") or "").lower(),
+                str(item.get("label") or "").lower(),
+                str(item.get("evidence_type") or "").lower(),
+            ]
+        )
+        return any(token in text for token in ("pricing", "price", "billing", "cost", "seat", "contract", "fee"))
+
+    section = "strength_evidence" if mode == "positive" else "weakness_evidence"
+    candidates: list[dict[str, Any]] = []
+    for item in vault.get(section) or []:
+        if not isinstance(item, dict):
+            continue
+        if mode == "pricing" and not _matches_pricing(item):
+            continue
+        # Phase 2.3 4i: same fail-closed gate as the merger. Vault rows
+        # must carry phrase_verbatim=True (stamped by 4e-A) before their
+        # best_quote is allowed onto a customer-visible blog surface.
+        if item.get("phrase_verbatim") is not True:
+            continue
+        quote = str(item.get("best_quote") or "").strip()
+        if not quote:
+            continue
+        source = item.get("quote_source") if isinstance(item.get("quote_source"), dict) else {}
+        metrics = item.get("supporting_metrics") if isinstance(item.get("supporting_metrics"), dict) else {}
+        candidates.append({
+            "text": quote[:400],
+            "vendor": vault.get("vendor_name") or "",
+            "role": source.get("reviewer_title") or "",
+            "rating": source.get("rating"),
+            "urgency": metrics.get("avg_urgency_when_mentioned") or 0,
+            "source_name": source.get("source") or "",
+            "company": source.get("company") or "",
+            # Phase 2.3 quote-grade migration: explicit origin marker so
+            # _split_and_gate_blog_quotes can route vault rows to the
+            # legacy truncation path while SQL/review rows go through
+            # the contract gate. Unmarked rows are dropped, not
+            # silently preserved.
+            "quote_origin": "vault",
+            "phrase_verbatim": True,
+            "_priority": (
+                int(item.get("mention_count_total") or 0),
+                int(item.get("mention_count_recent") or 0),
+                str(source.get("reviewed_at") or ""),
+            ),
+        })
+    candidates.sort(key=lambda item: (item["_priority"], len(str(item.get("text") or ""))), reverse=True)
+    return [{k: v for k, v in item.items() if k != "_priority"} for item in candidates[:limit]]
+
+
+# -- Stage 1b: Reasoning Pool Loading --------------------------------
+
+
+async def _load_pool_layers_for_blog(
+    pool,
+    topic_type: str,
+    topic_ctx: dict[str, Any],
+    data: dict[str, Any],
+) -> None:
+    """Inject reasoning pool data into the blog data dict.
+
+    Loads the 6 reasoning pools via ``fetch_all_pool_layers`` and extracts
+    vendor-specific layers based on the topic context.  Also loads reasoning
+    synthesis views when available for causal narrative injection.
+
+    Mutates *data* in place -- adds keys like ``pool_layers``,
+    ``synthesis_views``, and topic-specific shortcuts (``displacement_a_to_b``,
+    ``category_regime``, etc.) that blueprint functions can reference.
+    """
+    vendor_keys = [
+        str(topic_ctx.get(k) or "").strip()
+        for k in ("vendor", "vendor_a", "vendor_b", "from_vendor", "to_vendor")
+    ]
+    vendor_names = [v for v in vendor_keys if v]
+    category_name = str(topic_ctx.get("category") or "").strip()
+    if not vendor_names and not category_name:
+        return
+
+    window_days = settings.b2b_churn.intelligence_window_days
+    today = date.today()
+
+    try:
+        all_layers = await fetch_all_pool_layers(
+            pool, as_of=today, analysis_window_days=window_days,
+        )
+    except Exception:
+        logger.warning("Failed to load pool layers for blog generation", exc_info=True)
+        all_layers = {}
+
+    if not all_layers:
+        return
+
+    data["pool_layers"] = all_layers
+
+    # Load reasoning views (synthesis-first, legacy fallback)
+    from ._b2b_synthesis_reader import load_best_reasoning_views
+
+    view_names = [v.strip() for v in vendor_names if v and v.strip()]
+
+    # For category-only topics, resolve category to vendors
+    if not view_names:
+        category_name = str(
+            topic_ctx.get("category") or ""
+        ).strip()
+        if category_name:
+            try:
+                from ._b2b_shared import read_category_vendor_rows
+
+                cat_rows = await read_category_vendor_rows(
+                    pool,
+                    category_names=[category_name],
+                    limit=10,
+                )
+                view_names = [r["vendor_name"] for r in cat_rows if r.get("vendor_name")]
+            except Exception:
+                logger.debug("Category vendor resolution for blog render failed", exc_info=True)
+
+    if view_names:
+        try:
+            synth_views = await load_best_reasoning_views(
+                pool, view_names,
+                as_of=today,
+                analysis_window_days=window_days,
+            )
+            data["synthesis_views"] = synth_views
+        except Exception:
+            logger.warning("Failed to load synthesis views for blog generation", exc_info=True)
+            data["synthesis_views"] = {}
+    else:
+        data["synthesis_views"] = {}
+
+    # Load cross-vendor synthesis (battles, councils, asymmetries)
+    try:
+        from ._b2b_cross_vendor_synthesis import load_cross_vendor_synthesis_lookup
+        xv_synth = await load_cross_vendor_synthesis_lookup(
+            pool, as_of=today, analysis_window_days=window_days,
+        )
+        data["xv_synthesis_lookup"] = xv_synth
+    except Exception:
+        logger.debug("Cross-vendor synthesis load failed, using pool fallback")
+        data["xv_synthesis_lookup"] = {"battles": {}, "councils": {}, "asymmetries": {}}
+
+    # Extract topic-specific shortcuts for blueprint convenience
+    vendor = str(
+        topic_ctx.get("vendor") or topic_ctx.get("from_vendor") or ""
+    ).strip()
+    vendor_a = str(topic_ctx.get("vendor_a") or "").strip()
+    vendor_b = str(topic_ctx.get("vendor_b") or "").strip()
+
+    if vendor:
+        vl = all_layers.get(vendor) or {}
+        data["pool_segment"] = vl.get("segment")
+        data["pool_temporal"] = vl.get("temporal")
+        data["pool_accounts"] = vl.get("accounts")
+        data["pool_category"] = vl.get("category")
+        data["pool_displacement"] = vl.get("displacement") or []
+
+    if vendor_a and vendor_b:
+        vl_a = all_layers.get(vendor_a) or {}
+        vl_b = all_layers.get(vendor_b) or {}
+        data["pool_segment_a"] = vl_a.get("segment")
+        data["pool_segment_b"] = vl_b.get("segment")
+        data["pool_temporal_a"] = vl_a.get("temporal")
+        data["pool_temporal_b"] = vl_b.get("temporal")
+
+        # Find the displacement edge A->B
+        for edge in vl_a.get("displacement") or []:
+            if isinstance(edge, dict):
+                to = str(edge.get("to_vendor") or "").strip().lower()
+                if to == vendor_b.lower():
+                    data["displacement_a_to_b"] = edge
+                    break
+
+        # Find the displacement edge B->A
+        for edge in vl_b.get("displacement") or []:
+            if isinstance(edge, dict):
+                to = str(edge.get("to_vendor") or "").strip().lower()
+                if to == vendor_a.lower():
+                    data["displacement_b_to_a"] = edge
+                    break
+
+        # Category dynamics (shared by vendors in same category)
+        data["pool_category"] = vl_a.get("category") or vl_b.get("category")
+
+    if category_name and not data.get("pool_category"):
+        category_lower = _normalize_pain_label(category_name)
+        for layers in all_layers.values():
+            if not isinstance(layers, dict):
+                continue
+            cat_layer = layers.get("category")
+            if not isinstance(cat_layer, dict):
+                continue
+            layer_category = _normalize_pain_label(cat_layer.get("category"))
+            evidence_category = _normalize_pain_label(
+                (layers.get("evidence_vault") or {}).get("product_category"),
+            )
+            if category_lower == layer_category or category_lower == evidence_category:
+                data["pool_category"] = cat_layer
+                break
+
+    # Extract synthesis contracts for primary vendor(s)
+    synth = data.get("synthesis_views") or {}
+    primary = vendor or vendor_a
+    # For category-only topics, pick the best-informed view from loaded views
+    if not primary and synth:
+        # Prefer view with category_reasoning.market_regime
+        for vn, v in synth.items():
+            cat_c = v.contract("category_reasoning")
+            if isinstance(cat_c, dict) and cat_c.get("market_regime"):
+                primary = vn
+                break
+        # Fallback: first view with any contracts
+        if not primary:
+            primary = next(iter(synth), "")
+    if primary and synth.get(primary):
+        view = synth[primary]
+        consumer_context = view.filtered_consumer_context("blog_reranker")
+        contracts = consumer_context.get("reasoning_contracts") or view.materialized_contracts()
+        if contracts:
+            data["synthesis_contracts"] = contracts
+            data["synthesis_wedge"] = (
+                view.primary_wedge.value if view.primary_wedge else None
+            )
+            data["synthesis_wedge_label"] = view.wedge_label
+        account_preview = consumer_context.get("account_reasoning_preview") or {}
+        if isinstance(account_preview, dict) and account_preview:
+            data["account_reasoning_preview"] = copy.deepcopy(account_preview)
+        # Phase 3 governance sections for blueprint context
+        if view.why_they_stay:
+            data["why_they_stay"] = view.why_they_stay
+        if view.confidence_posture:
+            data["confidence_posture"] = view.confidence_posture
+        eg = view.evidence_governance
+        if eg:
+            data["evidence_governance"] = eg
+        _inject_blog_reasoning_specificity(data, suffix="", view=view)
+
+    # Balanced multi-vendor synthesis for showdown/comparison topics
+    if vendor_a and vendor_b:
+        view_b = synth.get(vendor_b)
+        if view_b:
+            consumer_context_b = view_b.filtered_consumer_context("blog_reranker")
+            contracts_b = (
+                consumer_context_b.get("reasoning_contracts")
+                or view_b.materialized_contracts()
+            )
+            if contracts_b:
+                data["synthesis_contracts_b"] = contracts_b
+                data["synthesis_wedge_b"] = (
+                    view_b.primary_wedge.value if view_b.primary_wedge else None
+                )
+                data["synthesis_wedge_label_b"] = view_b.wedge_label
+            account_preview_b = consumer_context_b.get("account_reasoning_preview") or {}
+            if isinstance(account_preview_b, dict) and account_preview_b:
+                data["account_reasoning_preview_b"] = copy.deepcopy(account_preview_b)
+            if view_b.why_they_stay:
+                data["why_they_stay_b"] = view_b.why_they_stay
+            if view_b.confidence_posture:
+                data["confidence_posture_b"] = view_b.confidence_posture
+            _inject_blog_reasoning_specificity(data, suffix="_b", view=view_b)
+
+
+# -- Stage 2: Data Gathering --------------------------------------
+
+async def _gather_data(
+    pool, topic_type: str, topic_ctx: dict[str, Any]
+) -> dict[str, Any]:
+    """Fetch data needed for the blueprint from B2B tables."""
+    data: dict[str, Any] = {}
+    vendor_names = [
+        str(topic_ctx.get(key) or "").strip()
+        for key in ("vendor", "vendor_a", "vendor_b", "from_vendor")
+        if str(topic_ctx.get(key) or "").strip()
+    ]
+    scorecard_detail_lookup: dict[str, dict[str, Any]] = {}
+    try:
+        if vendor_names:
+            evidence_vault_records, scorecard_detail_lookup = await asyncio.gather(
+                _fetch_latest_evidence_vault_records(
+                    pool,
+                    as_of=date.today(),
+                    analysis_window_days=settings.b2b_churn.intelligence_window_days,
+                    vendor_names=vendor_names,
+                ),
+                _fetch_vendor_scorecard_details(
+                    pool,
+                    vendor_names=vendor_names,
+                ),
+            )
+            evidence_vault_lookup, vault_alignment = (
+                _align_vendor_intelligence_records_to_scorecards(
+                    list(scorecard_detail_lookup.values()),
+                    evidence_vault_records,
+                )
+            )
+            if vault_alignment["mismatched_vendor_count"] > 0:
+                logger.info(
+                    "Suppressed stale blog evidence-vault overlays for %s",
+                    ", ".join(vault_alignment["mismatched_vendors"]),
+                )
+        else:
+            evidence_vault_lookup = {}
+    except Exception:
+        logger.warning("Failed to load evidence vault for blog data gathering", exc_info=True)
+        evidence_vault_lookup = {}
+        scorecard_detail_lookup = {}
+
+    if topic_type == "vendor_alternative":
+        vendor = topic_ctx["vendor"]
+        category = topic_ctx["category"]
+        profile, signals, reviews, partner, extended_ctx = await asyncio.gather(
+            _fetch_product_profile(pool, vendor),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor,
+                detail_row=scorecard_detail_lookup.get(vendor),
+            ),
+            _fetch_quotable_reviews(pool, vendor_name=vendor),
+            _fetch_affiliate_partner(pool, topic_ctx.get("affiliate_id")),
+            _fetch_vendor_extended_context(pool, vendor),
+            return_exceptions=True,
+        )
+        data["profile"] = profile if not isinstance(profile, Exception) else {}
+        data["signals"] = _merge_blog_signals_with_evidence_vault(
+            signals if not isinstance(signals, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["quotes"] = _merge_blog_quotes_with_evidence_vault(
+            reviews if not isinstance(reviews, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["partner"] = partner if not isinstance(partner, Exception) else None
+        data["extended_ctx"] = extended_ctx if not isinstance(extended_ctx, Exception) else {}
+
+    elif topic_type == "vendor_showdown":
+        vendor_a, vendor_b = topic_ctx["vendor_a"], topic_ctx["vendor_b"]
+        prof_a, prof_b, sigs_a, sigs_b, quotes = await asyncio.gather(
+            _fetch_product_profile(pool, vendor_a),
+            _fetch_product_profile(pool, vendor_b),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor_a,
+                detail_row=scorecard_detail_lookup.get(vendor_a),
+            ),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor_b,
+                detail_row=scorecard_detail_lookup.get(vendor_b),
+            ),
+            _fetch_quotable_reviews(pool, category=topic_ctx["category"]),
+            return_exceptions=True,
+        )
+        data["profile_a"] = prof_a if not isinstance(prof_a, Exception) else {}
+        data["profile_b"] = prof_b if not isinstance(prof_b, Exception) else {}
+        data["signals_a"] = _merge_blog_signals_with_evidence_vault(
+            sigs_a if not isinstance(sigs_a, Exception) else [],
+            evidence_vault_lookup.get(vendor_a),
+        )
+        data["signals_b"] = _merge_blog_signals_with_evidence_vault(
+            sigs_b if not isinstance(sigs_b, Exception) else [],
+            evidence_vault_lookup.get(vendor_b),
+        )
+        data["quotes"] = quotes if not isinstance(quotes, Exception) else []
+
+    elif topic_type == "churn_report":
+        vendor = topic_ctx["vendor"]
+        profile, signals, quotes = await asyncio.gather(
+            _fetch_product_profile(pool, vendor),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor,
+                detail_row=scorecard_detail_lookup.get(vendor),
+            ),
+            _fetch_quotable_reviews(pool, vendor_name=vendor),
+            return_exceptions=True,
+        )
+        data["profile"] = profile if not isinstance(profile, Exception) else {}
+        data["signals"] = _merge_blog_signals_with_evidence_vault(
+            signals if not isinstance(signals, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["quotes"] = _merge_blog_quotes_with_evidence_vault(
+            quotes if not isinstance(quotes, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+
+    elif topic_type == "migration_guide":
+        vendor = topic_ctx["vendor"]
+        profile, signals, quotes, extended_ctx = await asyncio.gather(
+            _fetch_product_profile(pool, vendor),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor,
+                detail_row=scorecard_detail_lookup.get(vendor),
+            ),
+            _fetch_quotable_reviews(pool, vendor_name=vendor),
+            _fetch_vendor_extended_context(pool, vendor),
+            return_exceptions=True,
+        )
+        data["profile"] = profile if not isinstance(profile, Exception) else {}
+        data["signals"] = _merge_blog_signals_with_evidence_vault(
+            signals if not isinstance(signals, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["quotes"] = _merge_blog_quotes_with_evidence_vault(
+            quotes if not isinstance(quotes, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["extended_ctx"] = extended_ctx if not isinstance(extended_ctx, Exception) else {}
+
+    elif topic_type == "pricing_reality_check":
+        vendor = topic_ctx["vendor"]
+        profile, signals = await asyncio.gather(
+            _fetch_product_profile(pool, vendor),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor,
+                detail_row=scorecard_detail_lookup.get(vendor),
+            ),
+            return_exceptions=True,
+        )
+        data["profile"] = profile if not isinstance(profile, Exception) else {}
+        data["signals"] = _merge_blog_signals_with_evidence_vault(
+            signals if not isinstance(signals, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        # Pull actual pricing complaint reviews directly
+        from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
+        sources = _blog_source_allowlist()
+        pricing_rows = await read_vendor_quote_evidence(
+            pool,
+            vendor_name=vendor,
+            window_days=3650,
+            min_urgency=0,
+            limit=10,
+            sources=sources,
+            pain_filter="pricing",
+        )
+        raw_pricing_reviews = [
+            {
+                "text": (r["review_text"] or "")[:300],
+                "vendor": r["vendor_name"],
+                "role": r["reviewer_title"],
+                "rating": r["rating"],
+                "urgency": r["urgency"] or 0,
+                "source_name": r["source"],
+                # Phase 2.3 quote-grade migration: carry v4 enrichment +
+                # review_id forward and stamp explicit origin so
+                # _split_and_gate_blog_quotes can route this row through
+                # the contract gate (verbatim-only). Vault rows below
+                # carry quote_origin="vault" from their builder and stay
+                # on the legacy truncation path. Unmarked rows are
+                # dropped at the wrapper, never silently preserved.
+                "review_id": r.get("review_id"),
+                "source": r.get("source"),
+                "reviewer_title": r.get("reviewer_title"),
+                "vendor_name": r.get("vendor_name"),
+                "enrichment_raw": r.get("enrichment_raw"),
+                "quote_origin": "review",
+            }
+            for r in pricing_rows
+        ]
+        vault_pricing_reviews = _build_specialized_blog_review_rows_from_evidence_vault(
+            evidence_vault_lookup.get(vendor),
+            mode="pricing",
+            limit=10,
+        )
+        data["pricing_reviews"] = _merge_specialized_blog_review_rows(
+            raw_pricing_reviews,
+            vault_pricing_reviews,
+            limit=10,
+            prefer_raw=False,
+        )
+        # Also pull positive reviews for balance
+        positive_reviews = await pool.fetch(
+            """
+            SELECT
+                r.review_text,
+                r.reviewer_title,
+                r.rating,
+                vm.vendor_name AS vendor_name
+            FROM b2b_reviews r
+            JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+            WHERE vm.vendor_name = $1 AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND rating >= 4
+              AND r.source = ANY($2)
+            ORDER BY rating DESC
+            LIMIT 5
+            """,
+            vendor, sources,
+        )
+        raw_positive_reviews = [
+            {"text": r["review_text"][:300], "role": r["reviewer_title"], "rating": float(r["rating"]) if r["rating"] else None}
+            for r in positive_reviews
+        ]
+        vault_positive_reviews = _build_specialized_blog_review_rows_from_evidence_vault(
+            evidence_vault_lookup.get(vendor),
+            mode="positive",
+            limit=5,
+        )
+        data["positive_reviews"] = _merge_specialized_blog_review_rows(
+            raw_positive_reviews,
+            vault_positive_reviews,
+            limit=5,
+            prefer_raw=False,
+        )
+
+    elif topic_type == "switching_story":
+        vendor = topic_ctx["from_vendor"]
+        profile, signals = await asyncio.gather(
+            _fetch_product_profile(pool, vendor),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor,
+                detail_row=scorecard_detail_lookup.get(vendor),
+            ),
+            return_exceptions=True,
+        )
+        data["profile"] = profile if not isinstance(profile, Exception) else {}
+        data["signals"] = _merge_blog_signals_with_evidence_vault(
+            signals if not isinstance(signals, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        # Pull actual switching reviews
+        # APPROVED-ENRICHMENT-READ: urgency_score
+        # Reason: review_text ILIKE filter is domain-specific, only urgency in ORDER BY
+        sources = _blog_source_allowlist()
+        switch_reviews = await pool.fetch(
+            """
+            SELECT
+                r.id AS review_id,
+                r.review_text,
+                vm.vendor_name AS vendor_name,
+                r.reviewer_title,
+                r.rating,
+                r.source,
+                r.enrichment->>'urgency_score' AS urgency,
+                r.enrichment AS enrichment_raw
+            FROM b2b_reviews r
+            JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+            WHERE vm.vendor_name = $1 AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND (r.review_text ILIKE '%switch%' OR r.review_text ILIKE '%migrat%'
+                   OR r.review_text ILIKE '%moved to%' OR r.review_text ILIKE '%moving to%'
+                   OR r.review_text ILIKE '%left for%' OR r.review_text ILIKE '%leaving for%')
+              AND r.source = ANY($2)
+            ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
+            LIMIT 10
+            """,
+            vendor, sources,
+        )
+        raw_switch_reviews = [
+            {
+                "text": r["review_text"][:400],
+                "vendor": r["vendor_name"],
+                "role": r["reviewer_title"],
+                "rating": float(r["rating"]) if r["rating"] else None,
+                "urgency": float(r["urgency"]) if r["urgency"] else 0,
+                "source_name": r["source"],
+                # Phase 2.3 quote-grade migration markers (mirror pricing path).
+                "review_id": str(r["review_id"]) if r["review_id"] is not None else None,
+                "source": r["source"],
+                "reviewer_title": r["reviewer_title"],
+                "vendor_name": r["vendor_name"],
+                "enrichment_raw": r["enrichment_raw"],
+                "quote_origin": "review",
+            }
+            for r in switch_reviews
+        ]
+        vault_switch_reviews = _build_specialized_blog_review_rows_from_evidence_vault(
+            evidence_vault_lookup.get(vendor),
+            mode="switching",
+            limit=10,
+        )
+        data["switch_reviews"] = _merge_specialized_blog_review_rows(
+            raw_switch_reviews,
+            vault_switch_reviews,
+            limit=10,
+            prefer_raw=True,
+        )
+        data["quotes"] = data["switch_reviews"]
+
+    elif topic_type == "pain_point_roundup":
+        category = topic_ctx["category"]
+        # Per-vendor pain breakdown from raw reviews
+        # APPROVED-ENRICHMENT-READ: pain_categories, urgency_score
+        # Reason: inline aggregate query, structurally coupled to product output
+        sources = _blog_source_allowlist()
+        vendor_pains = await pool.fetch(
+            """
+            SELECT
+                vm.vendor_name AS vendor_name,
+                COUNT(DISTINCT r.id) AS review_count,
+                r.enrichment->>'pain_categories' AS pains,
+                ROUND(AVG(
+                    CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]'
+                         THEN (r.enrichment->>'urgency_score')::numeric ELSE NULL END
+                )::numeric, 1) AS avg_urgency
+            FROM b2b_reviews r
+            JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+            WHERE r.product_category = $1 AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            GROUP BY vm.vendor_name, r.enrichment->>'pain_categories'
+            ORDER BY review_count DESC
+            LIMIT 30
+            """,
+            category, sources,
+        )
+        # Aggregate top pain per vendor
+        vendor_pain_map: dict[str, dict] = {}
+        for r in vendor_pains:
+            vn = r["vendor_name"]
+            if vn not in vendor_pain_map:
+                vendor_pain_map[vn] = {
+                    "vendor": vn, "review_count": 0, "top_pain": "overall_dissatisfaction",
+                    "avg_urgency": float(r["avg_urgency"]) if r["avg_urgency"] else 0,
+                }
+            vendor_pain_map[vn]["review_count"] += r["review_count"]
+            pain_str = r["pains"] or ""
+            if "pricing" in pain_str:
+                vendor_pain_map[vn]["top_pain"] = "pricing"
+            elif "ux" in pain_str:
+                vendor_pain_map[vn]["top_pain"] = "ux"
+            elif "support" in pain_str:
+                vendor_pain_map[vn]["top_pain"] = "support"
+            elif "reliability" in pain_str:
+                vendor_pain_map[vn]["top_pain"] = "reliability"
+            elif "features" in pain_str:
+                vendor_pain_map[vn]["top_pain"] = "features"
+        data["vendor_pains"] = list(vendor_pain_map.values())
+        # Pull quotable reviews across the category
+        quotes = await _fetch_quotable_reviews(pool, category=category)
+        data["quotes"] = quotes if not isinstance(quotes, Exception) else []
+
+    elif topic_type == "best_fit_guide":
+        category = topic_ctx["category"]
+        sources = _blog_source_allowlist()
+        # Fetch all profiles in category
+        from ._b2b_shared import read_category_vendor_rows
+
+        vendor_rows = await read_category_vendor_rows(
+            pool,
+            category_names=[category],
+        )
+        profiles = []
+        vendor_signals = []
+        for vr in vendor_rows[:10]:
+            vn = vr["vendor_name"]
+            p = await _fetch_product_profile(pool, vn)
+            s = await _fetch_blog_signal_rows(
+                pool,
+                vn,
+                detail_row=scorecard_detail_lookup.get(vn),
+            )
+            if p:
+                # Also pull avg rating from raw reviews
+                rating_row = await pool.fetchrow(
+                    "SELECT ROUND(AVG(r.rating)::numeric, 1) AS avg_rating, COUNT(*) AS cnt "
+                    "FROM b2b_reviews r "
+                    "JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id "
+                    "WHERE vm.vendor_name = $1 AND r.rating IS NOT NULL "
+                    "AND r.duplicate_of_review_id IS NULL AND r.source = ANY($2)",
+                    vn, sources,
+                )
+                profiles.append({
+                    "vendor": vn,
+                    "profile": p,
+                    "avg_rating": float(rating_row["avg_rating"]) if rating_row and rating_row["avg_rating"] else None,
+                    "review_count": rating_row["cnt"] if rating_row else 0,
+                })
+                vendor_signals.append(
+                    {
+                        "vendor": vn,
+                        "signals": _merge_blog_signals_with_evidence_vault(
+                            s,
+                            evidence_vault_lookup.get(vn),
+                        ),
+                    }
+                )
+        data["vendor_profiles"] = profiles
+        data["vendor_signals"] = vendor_signals
+        quotes = await _fetch_quotable_reviews(pool, category=category)
+        data["quotes"] = quotes if not isinstance(quotes, Exception) else []
+
+    elif topic_type == "vendor_deep_dive":
+        vendor = topic_ctx["vendor"]
+        profile, signals, quotes, extended_ctx = await asyncio.gather(
+            _fetch_product_profile(pool, vendor),
+            _fetch_blog_signal_rows(
+                pool,
+                vendor,
+                detail_row=scorecard_detail_lookup.get(vendor),
+            ),
+            _fetch_quotable_reviews(pool, vendor_name=vendor),
+            _fetch_vendor_extended_context(pool, vendor),
+            return_exceptions=True,
+        )
+        data["profile"] = profile if not isinstance(profile, Exception) else {}
+        data["signals"] = _merge_blog_signals_with_evidence_vault(
+            signals if not isinstance(signals, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["quotes"] = _merge_blog_quotes_with_evidence_vault(
+            quotes if not isinstance(quotes, Exception) else [],
+            evidence_vault_lookup.get(vendor),
+        )
+        data["extended_ctx"] = extended_ctx if not isinstance(extended_ctx, Exception) else {}
+        # Fetch competitors for context
+        compared = (data["profile"].get("commonly_compared_to") or [])[:5]
+        competitor_profiles = []
+        for comp in compared:
+            comp_name = comp.get("vendor", comp) if isinstance(comp, dict) else str(comp)
+            try:
+                cp = await _fetch_product_profile(pool, comp_name)
+                if cp:
+                    competitor_profiles.append(cp)
+            except Exception:
+                pass
+        data["competitor_profiles"] = competitor_profiles
+
+    elif topic_type == "market_landscape":
+        category = topic_ctx["category"]
+        sources = _blog_source_allowlist()
+        # Fetch all vendors in this category
+        from ._b2b_shared import read_category_vendor_rows
+
+        vendor_rows = await read_category_vendor_rows(
+            pool,
+            category_names=[category],
+            require_scorecard_match=True,
+        )
+        vendor_names = [r["vendor_name"] for r in vendor_rows]
+        profiles = []
+        signals_list = []
+        for vn in vendor_names[:10]:
+            try:
+                p = await _fetch_product_profile(pool, vn)
+                s = await _fetch_blog_signal_rows(
+                    pool,
+                    vn,
+                    detail_row=scorecard_detail_lookup.get(vn),
+                )
+                rating_row = await pool.fetchrow(
+                    "SELECT ROUND(AVG(r.rating)::numeric, 1) AS avg_rating, COUNT(*) AS cnt "
+                    "FROM b2b_reviews r "
+                    "JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id "
+                    "WHERE vm.vendor_name = $1 AND r.rating IS NOT NULL "
+                    "AND r.duplicate_of_review_id IS NULL AND r.source = ANY($2)",
+                    vn, sources,
+                )
+                profiles.append({
+                    "vendor": vn,
+                    "profile": p,
+                    "avg_rating": float(rating_row["avg_rating"]) if rating_row and rating_row["avg_rating"] else None,
+                    "review_count": rating_row["cnt"] if rating_row else 0,
+                })
+                signals_list.append({
+                    "vendor": vn,
+                    "signals": _merge_blog_signals_with_evidence_vault(
+                        s,
+                        evidence_vault_lookup.get(vn),
+                    ),
+                })
+            except Exception:
+                pass
+        data["vendor_profiles"] = profiles
+        data["vendor_signals"] = signals_list
+        quotes = await _fetch_quotable_reviews(pool, category=category)
+        data["quotes"] = quotes if not isinstance(quotes, Exception) else []
+
+    # Data context metadata -- scoped to vendor(s) from this topic
+    ctx_sources = _blog_source_allowlist()
+    vendor_names: list[str] = []
+    if topic_ctx.get("vendor"):
+        vendor_names.append(topic_ctx["vendor"])
+    if topic_ctx.get("vendor_a"):
+        vendor_names.append(topic_ctx["vendor_a"])
+    if topic_ctx.get("vendor_b"):
+        vendor_names.append(topic_ctx["vendor_b"])
+    if topic_ctx.get("from_vendor"):
+        vendor_names.append(topic_ctx["from_vendor"])
+    # For category-level topics, pull all vendors in the category
+    if not vendor_names and topic_ctx.get("category"):
+        cat_rows = await pool.fetch(
+            "SELECT DISTINCT vm.vendor_name "
+            "FROM b2b_reviews r "
+            "JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id "
+            "WHERE r.product_category = $1 AND r.duplicate_of_review_id IS NULL AND r.source = ANY($2)",
+            topic_ctx["category"], ctx_sources,
+        )
+        vendor_names = [r["vendor_name"] for r in cat_rows]
+
+    # APPROVED-ENRICHMENT-READ: churn_signals.intent_to_leave
+    # Reason: inline aggregate query, structurally coupled to product output
+    if vendor_names:
+        ctx_row = await pool.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS total_reviews,
+                COUNT(*) FILTER (WHERE enrichment_status = 'enriched') AS enriched,
+                COUNT(*) FILTER (WHERE (enrichment->'churn_signals'->>'intent_to_leave')::boolean = true) AS churn_intent,
+                MIN(imported_at)::date AS earliest,
+                MAX(imported_at)::date AS latest
+            FROM b2b_reviews
+            WHERE EXISTS (
+                SELECT 1
+                FROM b2b_review_vendor_mentions vm
+                WHERE vm.review_id = b2b_reviews.id
+                  AND vm.vendor_name = ANY($1)
+            )
+              AND duplicate_of_review_id IS NULL
+              AND source = ANY($2)
+            """,
+            vendor_names, ctx_sources,
+        )
+    else:
+        # APPROVED-ENRICHMENT-READ: churn_signals.intent_to_leave
+        # Reason: inline aggregate query, structurally coupled to product output
+        ctx_row = await pool.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS total_reviews,
+                COUNT(*) FILTER (WHERE enrichment_status = 'enriched') AS enriched,
+                COUNT(*) FILTER (WHERE (enrichment->'churn_signals'->>'intent_to_leave')::boolean = true) AS churn_intent,
+                MIN(imported_at)::date AS earliest,
+                MAX(imported_at)::date AS latest
+            FROM b2b_reviews
+            WHERE source = ANY($1)
+              AND duplicate_of_review_id IS NULL
+            """,
+            ctx_sources,
+        )
+    data["data_context"] = {
+        "total_reviews_analyzed": ctx_row["total_reviews"] if ctx_row else 0,
+        "enriched_count": ctx_row["enriched"] if ctx_row else 0,
+        "churn_intent_count": ctx_row["churn_intent"] if ctx_row else 0,
+        "review_period": (
+            f"{ctx_row['earliest']} to {ctx_row['latest']}"
+            if ctx_row and ctx_row["earliest"]
+            else "dates unavailable"
+        ),
+        "report_date": str(date.today()),
+        "booking_url": settings.b2b_campaign.default_booking_url,
+    }
+
+    # Store the full topic_ctx so regeneration can reconstruct blueprints
+    # without re-deriving scoring stats from the DB.
+    data["data_context"]["topic_ctx"] = {
+        k: v for k, v in topic_ctx.items()
+        if v is not None and k != "slug"
+    }
+
+    # Keep vendor names as top-level keys for the dedup SQL in
+    # _recently_covered_vendors() which queries data_context->>'vendor' etc.
+    for vk in ("vendor", "vendor_a", "vendor_b"):
+        if topic_ctx.get(vk):
+            data["data_context"][vk] = topic_ctx[vk]
+
+    # Source distribution and data quality metadata
+    source_dist = await _fetch_source_distribution(pool, vendor_names)
+    data["data_context"]["source_distribution"] = source_dist
+    data["data_context"]["data_source_label"] = "Public B2B software review platforms"
+    data["data_context"]["data_disclaimer"] = (
+        "Analysis based on self-selected reviewer feedback. "
+        "Results reflect reviewer perception, not product capability."
+    )
+    review_count = data["data_context"]["enriched_count"]
+    data["data_context"]["data_quality"] = {
+        "sample_size": review_count,
+        "confidence": "high" if review_count >= 50 else "moderate" if review_count >= 20 else "low",
+        "note": f"Based on {review_count} enriched reviews" + (
+            " (small sample)" if review_count < 20 else ""
+        ),
+    }
+    vault_vendors = [vn for vn in vendor_names if evidence_vault_lookup.get(vn)]
+    data["data_context"]["evidence_vault_used"] = bool(vault_vendors)
+    if vault_vendors:
+        data["data_context"]["evidence_vault_vendors"] = vault_vendors
+
+    category = (
+        topic_ctx.get("category")
+        or topic_ctx.get("product_category")
+        or data.get("profile", {}).get("product_category")
+    )
+    if category:
+        overview = await _fetch_category_overview_entry(pool, str(category))
+        if overview:
+            data["category_overview"] = overview
+            regime = (overview.get("cross_vendor_analysis") or {}).get("market_regime")
+            if regime:
+                data["data_context"]["market_regime"] = regime
+
+    # Attach affiliate info to data_context if available.
+    # For topic types that don't explicitly fetch a partner (everything except
+    # vendor_alternative), look up a matching partner by product category so
+    # comparison/landscape/deep-dive posts can include the affiliate link.
+    partner = data.get("partner")
+    if not partner:
+        category = topic_ctx.get("category") or topic_ctx.get("product_category")
+        if category:
+            partner = await _fetch_affiliate_partner_by_category(pool, category)
+            if partner:
+                data["partner"] = partner
+    if partner:
+        data["data_context"]["affiliate_partner"] = {
+            "name": partner["name"],
+            "product_name": partner["product_name"],
+            "slug": _slugify(partner["product_name"]),
+        }
+        data["data_context"]["affiliate_url"] = partner["affiliate_url"]
+        data["data_context"]["affiliate_slug"] = _slugify(partner["product_name"])
+
+    return data
+
+
+async def _fetch_product_profile(pool, vendor_name: str) -> dict[str, Any]:
+    """Fetch the product profile for a vendor."""
+    row = await pool.fetchrow(
+        "SELECT * FROM b2b_product_profiles WHERE vendor_name = $1 ORDER BY last_computed_at DESC LIMIT 1",
+        vendor_name,
+    )
+    if not row:
+        return {}
+    result = dict(row)
+    for key in ("strengths", "weaknesses", "pain_addressed", "primary_use_cases",
+                "top_integrations", "commonly_compared_to", "commonly_switched_from",
+                "typical_company_size", "typical_industries"):
+        if key in result and isinstance(result[key], str):
+            try:
+                result[key] = json.loads(result[key])
+            except (json.JSONDecodeError, TypeError):
+                pass
+    # Normalize field names for blueprint compatibility
+    result["integrations"] = result.get("top_integrations", [])
+    result["use_cases"] = result.get("primary_use_cases", [])
+    return result
+
+
+async def _fetch_vendor_extended_context(pool, vendor_name: str) -> dict[str, Any]:
+    """Fetch extended vendor context from use case, integration, and buyer profile tables.
+
+    Returns ``{"use_cases": [...], "integrations": [...], "buyer_profiles": [...]}``.
+    Each list entry includes mention counts and confidence scores from aggregated review data.
+    Empty dicts on missing tables or errors -- callers use profile fallbacks.
+    """
+    try:
+        use_case_rows, integration_rows, buyer_rows = await asyncio.gather(
+            pool.fetch(
+                "SELECT use_case_name, mention_count, avg_urgency, confidence_score "
+                "FROM b2b_vendor_use_cases WHERE vendor_name = $1 "
+                "ORDER BY mention_count DESC LIMIT 8",
+                vendor_name,
+            ),
+            pool.fetch(
+                "SELECT integration_name, mention_count, confidence_score "
+                "FROM b2b_vendor_integrations WHERE vendor_name = $1 "
+                "ORDER BY mention_count DESC LIMIT 10",
+                vendor_name,
+            ),
+            pool.fetch(
+                "SELECT role_type, buying_stage, review_count, dm_count, avg_urgency "
+                "FROM b2b_vendor_buyer_profiles WHERE vendor_name = $1 "
+                "ORDER BY review_count DESC LIMIT 8",
+                vendor_name,
+            ),
+        )
+        return {
+            "use_cases": [dict(r) for r in use_case_rows],
+            "integrations": [dict(r) for r in integration_rows],
+            "buyer_profiles": [dict(r) for r in buyer_rows],
+        }
+    except Exception:
+        logger.debug("Extended context unavailable for %s", vendor_name)
+        return {}
+
+
+async def _fetch_pain_category_urgency(pool, vendor_name: str) -> dict[str, float]:
+    """Query per-category average urgency directly from b2b_reviews."""
+    # APPROVED-ENRICHMENT-READ: pain_category, urgency_score
+    # Reason: inline aggregate query, structurally coupled to product output
+    rows = await pool.fetch(
+        """
+        SELECT r.enrichment->>'pain_category' AS pain_cat,
+               AVG((r.enrichment->>'urgency_score')::numeric) AS avg_urg,
+               COUNT(*) AS cnt
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE vm.vendor_name = $1 AND r.enrichment_status = 'enriched'
+          AND r.duplicate_of_review_id IS NULL
+          AND r.enrichment->>'pain_category' IS NOT NULL
+        GROUP BY r.enrichment->>'pain_category'
+        """,
+        vendor_name,
+    )
+    return {
+        r["pain_cat"]: round(float(r["avg_urg"]), 1)
+        for r in rows
+        if r["pain_cat"] and r["avg_urg"] is not None
+    }
+
+
+def _build_blog_signal_rows_from_scorecard_detail(
+    row: dict[str, Any],
+    *,
+    per_cat_urgency: dict[str, float],
+) -> list[dict[str, Any]]:
+    """Project one scorecard-detail row into blog signal rows."""
+    if not row:
+        return []
+    vendor_avg = round(float(row["avg_urgency_score"]), 1)
+
+    # Unpack JSONB pain categories into structured list
+    pain_cats = row["top_pain_categories"] or []
+    if isinstance(pain_cats, str):
+        try:
+            pain_cats = json.loads(pain_cats)
+        except (json.JSONDecodeError, TypeError):
+            pain_cats = []
+
+    feature_gaps = row["top_feature_gaps"] or []
+    if isinstance(feature_gaps, str):
+        try:
+            feature_gaps = json.loads(feature_gaps)
+        except (json.JSONDecodeError, TypeError):
+            feature_gaps = []
+
+    results = []
+    seen_cats: set[str] = set()
+    for pc in pain_cats[:10]:
+        raw_cat = pc.get("category", pc) if isinstance(pc, dict) else str(pc)
+        # Handle double-encoded JSON (e.g. '{"category": "features", "severity": "primary"}')
+        if isinstance(raw_cat, str) and raw_cat.startswith("{"):
+            try:
+                inner = json.loads(raw_cat)
+                raw_cat = inner.get("category", raw_cat) if isinstance(inner, dict) else raw_cat
+            except (json.JSONDecodeError, TypeError):
+                pass
+        cat_name = str(raw_cat)
+        # Skip null/None/empty categories
+        if not cat_name or cat_name in ("None", "null", "none", ""):
+            continue
+        count = pc.get("count", 1) if isinstance(pc, dict) else 1
+        # Use per-category urgency when available, fall back to vendor average
+        cat_urgency = per_cat_urgency.get(cat_name, vendor_avg)
+        results.append({
+            "pain_category": cat_name,
+            "signal_count": count,
+            "avg_urgency": cat_urgency,
+            "feature_gaps": [
+                fg.get("feature", fg) if isinstance(fg, dict) else str(fg)
+                for fg in feature_gaps[:5]
+            ],
+        })
+        seen_cats.add(cat_name)
+
+    # Supplement with categories from enriched reviews not in the aggregate
+    for cat_name, urgency in per_cat_urgency.items():
+        if cat_name in seen_cats or not cat_name or cat_name in ("None", "null", "none"):
+            continue
+        results.append({
+            "pain_category": cat_name,
+            "signal_count": 1,
+            "avg_urgency": urgency,
+            "feature_gaps": [],
+        })
+    return results
+
+
+async def _fetch_blog_signal_rows(
+    pool,
+    vendor_name: str,
+    *,
+    detail_row: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch blog signal rows for one vendor from scorecard detail."""
+    row = detail_row
+    if row is None:
+        from ._b2b_shared import read_vendor_scorecard_detail
+
+        row = await read_vendor_scorecard_detail(
+            pool,
+            vendor_name,
+        )
+    if not row:
+        return []
+
+    # Fetch per-category urgency from raw reviews so category charts reflect
+    # the actual category average, not the rolled-up vendor average.
+    per_cat_urgency = await _fetch_pain_category_urgency(pool, vendor_name)
+    return _build_blog_signal_rows_from_scorecard_detail(
+        row,
+        per_cat_urgency=per_cat_urgency,
+    )
+
+
+async def _fetch_churn_signals(pool, vendor_name: str) -> list[dict[str, Any]]:
+    """Compatibility seam for callers that still fetch one vendor at a time."""
+    return await _fetch_blog_signal_rows(pool, vendor_name)
+
+
+async def _fetch_quotable_reviews(
+    pool, vendor_name: str | None = None, category: str | None = None
+) -> list[dict[str, Any]]:
+    """Pull balanced positive + negative review excerpts for the topic.
+
+    Returns up to 15 quotes interleaved with a ``sentiment`` field so the
+    LLM skill prompt can place them in the right sections.
+    """
+    sources = _blog_source_allowlist()
+    negative = await _fetch_negative_quotes(pool, vendor_name, category, sources, limit=9)
+    positive = await _fetch_positive_quotes(pool, vendor_name, category, sources, limit=6)
+
+    # Interleave: negative, positive, negative, positive, ...
+    merged: list[dict[str, Any]] = []
+    ni, pi = 0, 0
+    while ni < len(negative) or pi < len(positive):
+        if ni < len(negative):
+            merged.append(negative[ni])
+            ni += 1
+        if pi < len(positive):
+            merged.append(positive[pi])
+            pi += 1
+    return merged[:15]
+
+
+def _extract_phrase(text: str) -> str:
+    """Extract the most impactful sentence from review text."""
+    sentences = [s.strip() for s in re.split(r'[.!?]+', text) if len(s.strip()) > 20]
+    return (sentences[0] if sentences else text[:150])[:200]
+
+
+async def _fetch_negative_quotes(
+    pool, vendor_name: str | None, category: str | None,
+    sources: list[str], limit: int = 9,
+) -> list[dict[str, Any]]:
+    """High-urgency enriched reviews (negative signal)."""
+    # APPROVED-ENRICHMENT-READ: urgency_score
+    # Reason: urgency used only in ORDER BY; query is structurally tied to account_resolution + prospect_org_cache JOINs
+    vendor_projection = (
+        "matched_vm.vendor_name AS matched_vendor_name"
+        if vendor_name
+        else "COALESCE(primary_vm.vendor_name, r.vendor_name) AS matched_vendor_name"
+    )
+    vendor_join = (
+        _blog_review_vendor_join("r", "matched_vm")
+        if vendor_name
+        else _blog_primary_vendor_join("r", "primary_vm")
+    )
+    _quote_cols = f"""
+        r.id AS review_id,
+        r.review_text, {vendor_projection}, r.reviewer_title, r.rating,
+        r.enrichment->>'urgency_score' AS urgency,
+        r.source,
+        r.enrichment AS enrichment_raw,
+        COALESCE(
+            CASE
+                WHEN ar.confidence_label IN ('high', 'medium')
+                THEN ar.resolved_company_name
+                ELSE NULL
+            END,
+            r.reviewer_company
+        ) AS company,
+        r.company_size_raw,
+        COALESCE(poc.industry, r.reviewer_industry) AS industry,
+        poc.employee_count AS verified_employee_count,
+        poc.country AS company_country
+    """
+    _quote_joins = f"""
+        {vendor_join}
+        LEFT JOIN b2b_account_resolution ar
+            ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
+        LEFT JOIN prospect_org_cache poc
+            ON poc.company_name_norm = CASE
+                WHEN ar.confidence_label IN ('high', 'medium')
+                THEN ar.normalized_company_name
+                ELSE NULL
+            END
+    """
+    if vendor_name:
+        rows = await pool.fetch(
+            f"""
+            SELECT {_quote_cols}
+            FROM b2b_reviews r {_quote_joins}
+            WHERE matched_vm.vendor_name = $1
+              AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
+            LIMIT $3
+            """,
+            vendor_name, sources, limit,
+        )
+    elif category:
+        rows = await pool.fetch(
+            f"""
+            SELECT {_quote_cols}
+            FROM b2b_reviews r {_quote_joins}
+            WHERE r.product_category = $1
+              AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            ORDER BY (r.enrichment->>'urgency_score')::numeric DESC NULLS LAST
+            LIMIT $3
+            """,
+            category, sources, limit,
+        )
+    else:
+        return []
+
+    results = []
+    for r in rows:
+        urg = 0.0
+        try:
+            urg = float(r["urgency"]) if r["urgency"] else 0.0
+        except (ValueError, TypeError):
+            pass
+        results.append({
+            "phrase": _extract_phrase(r["review_text"] or ""),
+            "vendor": r["matched_vendor_name"],
+            "urgency": urg,
+            "role": r["reviewer_title"],
+            "company": r["company"],
+            "company_size": r["company_size_raw"],
+            "industry": r["industry"],
+            "verified_employee_count": r["verified_employee_count"],
+            "company_country": r["company_country"],
+            "source_name": r["source"],
+            "sentiment": "negative",
+            # Phase 2.3 quote-grade migration markers. quote_origin lets
+            # _split_and_gate_blog_quotes route this row through the
+            # contract gate (verbatim-only) rather than legacy truncation.
+            "review_id": str(r["review_id"]) if r["review_id"] is not None else None,
+            "source": r["source"],
+            "enrichment_raw": r["enrichment_raw"],
+            "quote_origin": "review",
+        })
+    return results
+
+
+async def _fetch_positive_quotes(
+    pool, vendor_name: str | None, category: str | None,
+    sources: list[str], limit: int = 6,
+) -> list[dict[str, Any]]:
+    """High-rated reviews from raw columns (no enrichment required)."""
+    vendor_projection = (
+        "matched_vm.vendor_name AS matched_vendor_name"
+        if vendor_name
+        else "COALESCE(primary_vm.vendor_name, r.vendor_name) AS matched_vendor_name"
+    )
+    vendor_join = (
+        _blog_review_vendor_join("r", "matched_vm")
+        if vendor_name
+        else _blog_primary_vendor_join("r", "primary_vm")
+    )
+    _pos_cols = f"""
+        r.id AS review_id,
+        COALESCE(r.pros, r.review_text) AS text, {vendor_projection},
+        r.reviewer_title, r.rating, r.source,
+        r.enrichment AS enrichment_raw,
+        COALESCE(
+            CASE
+                WHEN ar.confidence_label IN ('high', 'medium')
+                THEN ar.resolved_company_name
+                ELSE NULL
+            END,
+            r.reviewer_company
+        ) AS company,
+        r.company_size_raw,
+        COALESCE(poc.industry, r.reviewer_industry) AS industry,
+        poc.employee_count AS verified_employee_count,
+        poc.country AS company_country
+    """
+    _pos_joins = f"""
+        {vendor_join}
+        LEFT JOIN b2b_account_resolution ar
+            ON ar.review_id = r.id AND ar.resolution_status = 'resolved'
+        LEFT JOIN prospect_org_cache poc
+            ON poc.company_name_norm = CASE
+                WHEN ar.confidence_label IN ('high', 'medium')
+                THEN ar.normalized_company_name
+                ELSE NULL
+            END
+    """
+    if vendor_name:
+        rows = await pool.fetch(
+            f"""
+            SELECT {_pos_cols}
+            FROM b2b_reviews r {_pos_joins}
+            WHERE matched_vm.vendor_name = $1
+              AND r.duplicate_of_review_id IS NULL
+              AND r.rating >= 4
+              AND r.source = ANY($2)
+              AND COALESCE(r.pros, r.review_text) IS NOT NULL
+              AND LENGTH(COALESCE(r.pros, r.review_text)) > 20
+            ORDER BY r.rating DESC, r.imported_at DESC
+            LIMIT $3
+            """,
+            vendor_name, sources, limit,
+        )
+    elif category:
+        rows = await pool.fetch(
+            f"""
+            SELECT {_pos_cols}
+            FROM b2b_reviews r {_pos_joins}
+            WHERE r.product_category = $1
+              AND r.duplicate_of_review_id IS NULL
+              AND r.rating >= 4
+              AND r.source = ANY($2)
+              AND COALESCE(r.pros, r.review_text) IS NOT NULL
+              AND LENGTH(COALESCE(r.pros, r.review_text)) > 20
+            ORDER BY r.rating DESC, r.imported_at DESC
+            LIMIT $3
+            """,
+            category, sources, limit,
+        )
+    else:
+        return []
+
+    results = []
+    for r in rows:
+        results.append({
+            "phrase": _extract_phrase(r["text"] or ""),
+            "vendor": r["matched_vendor_name"],
+            "urgency": 0.0,
+            "role": r["reviewer_title"],
+            "company": r["company"],
+            "company_size": r["company_size_raw"],
+            "industry": r["industry"],
+            "verified_employee_count": r["verified_employee_count"],
+            "company_country": r["company_country"],
+            "source_name": r["source"],
+            "sentiment": "positive",
+            # Phase 2.3 quote-grade migration markers (mirror negative path).
+            "review_id": str(r["review_id"]) if r["review_id"] is not None else None,
+            "source": r["source"],
+            "enrichment_raw": r["enrichment_raw"],
+            "quote_origin": "review",
+        })
+    return results
+
+
+async def _fetch_affiliate_partner(pool, partner_id: str | None) -> dict[str, Any] | None:
+    """Fetch affiliate partner details."""
+    if not partner_id:
+        return None
+    import uuid as _uuid
+    pid = _uuid.UUID(partner_id) if isinstance(partner_id, str) else partner_id
+    row = await pool.fetchrow(
+        "SELECT id, name, product_name, affiliate_url, category FROM affiliate_partners WHERE id = $1",
+        pid,
+    )
+    if not row:
+        return None
+    return dict(row)
+
+
+async def _fetch_affiliate_partner_by_category(pool, category: str) -> dict[str, Any] | None:
+    """Fetch the first enabled affiliate partner matching a product category."""
+    row = await pool.fetchrow(
+        "SELECT id, name, product_name, affiliate_url, category "
+        "FROM affiliate_partners WHERE enabled = true AND LOWER(category) = LOWER($1) "
+        "LIMIT 1",
+        category,
+    )
+    if not row:
+        return None
+    return dict(row)
+
+
+
+async def _fetch_category_overview_entry(pool, category: str) -> dict[str, Any] | None:
+    """Fetch the latest persisted category overview entry for a category."""
+    if not category:
+        return None
+
+    row = await pool.fetchrow(
+        """
+        SELECT intelligence_data
+        FROM b2b_intelligence
+        WHERE report_type = 'category_overview'
+        ORDER BY report_date DESC, created_at DESC
+        LIMIT 1
+        """,
+    )
+    if not row:
+        return None
+
+    data = row["intelligence_data"]
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    entries = data if isinstance(data, list) else data.get("category_overview", data)
+    if not isinstance(entries, list):
+        return None
+
+    wanted = category.strip().lower()
+    for entry in entries:
+        if isinstance(entry, dict) and str(entry.get("category", "")).strip().lower() == wanted:
+            return entry
+    return None
+
+
+async def _fetch_source_distribution(pool, vendor_names: list[str]) -> dict[str, Any]:
+    """Return review counts by source platform for the given vendors."""
+    if not vendor_names:
+        return {"sources": [], "verified_count": 0, "community_count": 0}
+    allowed = _blog_source_allowlist()
+    rows = await pool.fetch(
+        """
+        SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE vm.vendor_name = ANY($1) AND r.enrichment_status = 'enriched'
+          AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($2)
+        GROUP BY r.source
+        ORDER BY cnt DESC
+        """,
+        vendor_names, allowed,
+    )
+    sources = [{"name": r["src"], "count": r["cnt"]} for r in rows]
+    verified = sum(r["cnt"] for r in rows if r["src"].lower().replace(" ", "_") in VERIFIED_SOURCES)
+    community = sum(r["cnt"] for r in rows if r["src"].lower().replace(" ", "_") not in VERIFIED_SOURCES)
+    return {"sources": sources, "verified_count": verified, "community_count": community}
+
+
+# -- Data Sufficiency Check ----------------------------------------
+
+# Topic types that focus on a single vendor
+_SINGLE_VENDOR_TYPES = {
+    "vendor_alternative", "vendor_deep_dive", "churn_report",
+    "migration_guide", "pricing_reality_check", "switching_story",
+}
+# Topic types that need multiple vendor profiles
+_MULTI_VENDOR_TYPES = {"market_landscape", "best_fit_guide"}
+
+
+def _check_data_sufficiency(topic_type: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate gathered data meets minimum requirements for a quality post.
+
+    Returns {"sufficient": bool, "reason": str}.
+    """
+    quotes = data.get("quotes", [])
+    min_quotes = _blog_topic_threshold(
+        getattr(settings.b2b_churn, "blog_min_quotes_by_topic", {}) or {},
+        topic_type,
+        default=2,
+    )
+
+    # Universal: at least 2 quotable reviews
+    # (pricing_reality_check builds quotes from pricing_reviews in the blueprint)
+    if topic_type != "pricing_reality_check" and len(quotes) < min_quotes:
+        return {
+            "sufficient": False,
+            "reason": f"Only {len(quotes)} quotable reviews (need {min_quotes}+)",
+        }
+
+    # Single-vendor types: product profile must exist
+    if topic_type in _SINGLE_VENDOR_TYPES:
+        profile = data.get("profile", {})
+        if not profile:
+            return {"sufficient": False, "reason": "No product profile found"}
+
+    # Churn-focused types: at least 1 signal category
+    if topic_type in ("churn_report", "vendor_alternative", "migration_guide"):
+        signals = data.get("signals", [])
+        if not signals:
+            return {"sufficient": False, "reason": "No churn signal categories found"}
+
+    # Pricing / switching story need their specific reviews
+    if topic_type == "pricing_reality_check":
+        if not data.get("pricing_reviews"):
+            return {"sufficient": False, "reason": "No pricing complaint reviews found"}
+
+    if topic_type == "switching_story":
+        if not data.get("switch_reviews"):
+            return {"sufficient": False, "reason": "No switching reviews found"}
+
+    # Showdowns: both vendor profiles must exist
+    if topic_type == "vendor_showdown":
+        if not data.get("profile_a"):
+            return {"sufficient": False, "reason": "No product profile for vendor A"}
+        if not data.get("profile_b"):
+            return {"sufficient": False, "reason": "No product profile for vendor B"}
+
+    # Multi-vendor types: at least 2 vendor profiles
+    if topic_type in _MULTI_VENDOR_TYPES:
+        vendor_profiles = data.get("vendor_profiles", [])
+        min_vendor_profiles = _blog_min_vendor_profiles(topic_type)
+        if len(vendor_profiles) < min_vendor_profiles:
+            return {
+                "sufficient": False,
+                "reason": (
+                    f"Only {len(vendor_profiles)} vendor profiles "
+                    f"(need {min_vendor_profiles}+)"
+                ),
+            }
+
+    return {"sufficient": True, "reason": ""}
+
+
+def _check_blueprint_sufficiency(blueprint: PostBlueprint) -> dict[str, Any]:
+    min_sections = _blog_topic_threshold(
+        getattr(settings.b2b_churn, "blog_min_sections_by_topic", {}) or {},
+        blueprint.topic_type,
+        default=0,
+    )
+    section_count = len(blueprint.sections or [])
+    if section_count < min_sections:
+        return {
+            "sufficient": False,
+            "reason": f"Only {section_count} blueprint sections (need {min_sections}+)",
+        }
+    return {"sufficient": True, "reason": ""}
+
+
+# -- Stage 3: Blueprint Construction ------------------------------
+
+def _build_blueprint(
+    topic_type: str, topic_ctx: dict[str, Any], data: dict[str, Any]
+) -> PostBlueprint:
+    """Build a structured post blueprint deterministically from data."""
+    builder = {
+        "vendor_alternative": _blueprint_vendor_alternative,
+        "vendor_showdown": _blueprint_vendor_showdown,
+        "churn_report": _blueprint_churn_report,
+        "migration_guide": _blueprint_migration_guide,
+        "vendor_deep_dive": _blueprint_vendor_deep_dive,
+        "market_landscape": _blueprint_market_landscape,
+        "pricing_reality_check": _blueprint_pricing_reality_check,
+        "switching_story": _blueprint_switching_story,
+        "pain_point_roundup": _blueprint_pain_point_roundup,
+        "best_fit_guide": _blueprint_best_fit_guide,
+    }[topic_type]
+    bp = builder(topic_ctx, data)
+    bp.cta = _build_cta(bp.topic_type, bp.data_context)
+    return bp
+
+
+def _blog_quote_highlights(
+    quotes: list[dict[str, Any]] | None,
+    *,
+    limit: int = 4,
+    vendors: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    allowed_vendors = {
+        str(value or "").strip().lower()
+        for value in (vendors or [])
+        if str(value or "").strip()
+    }
+    seen: set[str] = set()
+    highlights: list[dict[str, Any]] = []
+    gated_quotes = _split_and_gate_blog_quotes(list(quotes or []), limit=None)
+    for item in gated_quotes:
+        if not isinstance(item, dict):
+            continue
+        vendor = str(item.get("vendor") or "").strip()
+        if allowed_vendors and vendor.lower() not in allowed_vendors:
+            continue
+        phrase = " ".join(str(item.get("phrase") or "").split())
+        if not phrase:
+            continue
+        marker = phrase.lower()
+        if marker in seen:
+            continue
+        seen.add(marker)
+        row: dict[str, Any] = {
+            "vendor": vendor,
+            "phrase": phrase[:220],
+            "sentiment": str(item.get("sentiment") or "").strip(),
+        }
+        for key in ("role", "company", "source_name"):
+            value = str(item.get(key) or "").strip()
+            if value:
+                row[key] = value[:120]
+        highlights.append(row)
+        if len(highlights) >= max(1, int(limit)):
+            break
+    return highlights
+
+
+def _aggregate_category_pain_rows(
+    vendor_signals: list[dict[str, Any]] | None,
+    *,
+    limit: int = 6,
+) -> list[dict[str, Any]]:
+    aggregated: dict[str, dict[str, Any]] = {}
+    for vendor_row in vendor_signals or []:
+        if not isinstance(vendor_row, dict):
+            continue
+        vendor = str(vendor_row.get("vendor") or "").strip()
+        for signal in vendor_row.get("signals") or []:
+            if not isinstance(signal, dict):
+                continue
+            pain = str(signal.get("pain_category") or "").strip()
+            if not pain or pain.lower() in {"none", "null"}:
+                continue
+            bucket = aggregated.setdefault(
+                pain,
+                {
+                    "name": pain,
+                    "vendor_count": 0,
+                    "signal_count": 0,
+                    "avg_urgency_total": 0.0,
+                    "_vendors": set(),
+                },
+            )
+            vendors = bucket["_vendors"]
+            if vendor and vendor not in vendors:
+                vendors.add(vendor)
+                bucket["vendor_count"] += 1
+            try:
+                bucket["signal_count"] += int(signal.get("signal_count") or 0)
+            except (TypeError, ValueError):
+                pass
+            try:
+                bucket["avg_urgency_total"] += float(signal.get("avg_urgency") or 0.0)
+            except (TypeError, ValueError):
+                pass
+    rows: list[dict[str, Any]] = []
+    for bucket in aggregated.values():
+        vendor_count = int(bucket.get("vendor_count") or 0)
+        avg_total = float(bucket.get("avg_urgency_total") or 0.0)
+        rows.append(
+            {
+                "name": bucket["name"],
+                "vendor_count": vendor_count,
+                "signal_count": int(bucket.get("signal_count") or 0),
+                "avg_urgency": round(avg_total / max(vendor_count, 1), 1),
+            }
+        )
+    rows.sort(
+        key=lambda item: (
+            -int(item.get("vendor_count") or 0),
+            -int(item.get("signal_count") or 0),
+            -float(item.get("avg_urgency") or 0.0),
+            str(item.get("name") or "").lower(),
+        )
+    )
+    return rows[: max(1, int(limit))]
+
+
+def _blueprint_vendor_alternative(ctx: dict, data: dict) -> PostBlueprint:
+    vendor = ctx["vendor"]
+    category = ctx.get("category", "software")
+    profile = data.get("profile", {})
+    signals = data.get("signals", [])
+    partner = data.get("partner")
+
+    # Pain radar chart
+    pain_data = [
+        {"name": s["pain_category"] or "Other", vendor: s["avg_urgency"]}
+        for s in signals[:6]
+    ]
+    pain_chart = ChartSpec(
+        chart_id="pain-radar",
+        chart_type="radar",
+        title=f"Pain Distribution: {vendor}",
+        data=pain_data,
+        config={
+            "x_key": "name",
+            "bars": [{"dataKey": vendor, "color": "#f87171"}],
+        },
+    )
+
+    # Feature gaps chart
+    all_gaps: dict[str, int] = {}
+    for s in signals:
+        for gap in s.get("feature_gaps", []):
+            if gap:
+                all_gaps[gap] = all_gaps.get(gap, 0) + s["signal_count"]
+    top_gaps = sorted(all_gaps.items(), key=lambda x: x[1], reverse=True)[:6]
+    gap_chart_data = [{"name": g[:30], "mentions": c} for g, c in top_gaps]
+
+    charts = [pain_chart]
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Hook with the scale of churn signals for {vendor}",
+            key_stats={
+                "vendor": vendor,
+                "category": category,
+                "urgency": ctx["urgency"],
+                "review_count": ctx["review_count"],
+            },
+            data_summary=(
+                f"{vendor} has {ctx['review_count']} reviews with churn signals "
+                f"(avg urgency {ctx['urgency']}/10) in the {category} category."
+            ),
+        ),
+        SectionSpec(
+            id="pain_analysis",
+            heading=f"What's Driving Users Away from {vendor}?",
+            goal="Break down the pain categories causing churn",
+            chart_ids=["pain-radar"],
+            data_summary=f"Top pain areas: {', '.join(s['pain_category'] for s in signals[:3] if s['pain_category'])}.",
+        ),
+    ]
+
+    if gap_chart_data:
+        gap_chart = ChartSpec(
+            chart_id="gaps-bar",
+            chart_type="horizontal_bar",
+            title=f"Most Requested Features Missing from {vendor}",
+            data=gap_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "mentions", "color": "#a78bfa"}],
+            },
+        )
+        charts.append(gap_chart)
+        sections.append(SectionSpec(
+            id="feature_gaps",
+            heading="What Users Wish They Had",
+            goal="List the most requested missing features",
+            chart_ids=["gaps-bar"],
+            data_summary=f"Top {len(gap_chart_data)} feature gaps users mention.",
+        ))
+
+    # Alternative spotlight
+    alt_name = partner["product_name"] if partner else f"alternatives in {category}"
+    sections.append(SectionSpec(
+        id="alternative",
+        heading=f"The Alternative: {alt_name}" if partner else f"Alternatives in {category}",
+        goal="Present the alternative with data-backed strengths",
+        key_stats={
+            "alternative": alt_name,
+            "vendor": vendor,
+            **({"affiliate_slug": _slugify(partner["product_name"])} if partner else {}),
+        },
+        data_summary=(
+            f"Profile strengths for {alt_name}: "
+            f"{', '.join(s.get('area', str(s)) if isinstance(s, dict) else str(s) for s in profile.get('strengths', [])[:3]) or 'N/A'}."
+        ),
+    ))
+
+    # Displacement and temporal context (from reasoning pools)
+    pool_disp = data.get("pool_displacement") or []
+    pool_temporal = data.get("pool_temporal") or {}
+    pool_segment = data.get("pool_segment") or {}
+    synth_contracts = data.get("synthesis_contracts") or {}
+    account_preview = data.get("account_reasoning_preview") or {}
+    vendor_core = synth_contracts.get("vendor_core_reasoning") or {}
+    displacement_reasoning = synth_contracts.get("displacement_reasoning") or {}
+    category_reasoning = synth_contracts.get("category_reasoning") or {}
+    account_reasoning = synth_contracts.get("account_reasoning") or {}
+    segment_playbook = vendor_core.get("segment_playbook") if isinstance(vendor_core, dict) else {}
+    timing_intelligence = vendor_core.get("timing_intelligence") if isinstance(vendor_core, dict) else {}
+    causal = vendor_core if isinstance(vendor_core, dict) else {}
+    contract_disp = _blog_migration_proof_stats(displacement_reasoning)
+    contract_timing = _blog_timing_reasoning_stats(timing_intelligence)
+    contract_segment = _blog_segment_reasoning_stats(segment_playbook, timing_intelligence)
+    contract_account = _blog_account_reasoning_stats(
+        account_reasoning,
+        account_preview,
+    )
+    contract_category = _blog_category_reasoning_stats(category_reasoning)
+
+    has_pool_context = bool(
+        pool_disp or pool_temporal or causal or contract_disp or contract_timing
+        or contract_segment or contract_account or contract_category
+    )
+    if has_pool_context:
+        context_stats: dict[str, Any] = {"vendor": vendor}
+        # Top displacement targets
+        if pool_disp:
+            top_targets = sorted(
+                pool_disp,
+                key=lambda e: (e.get("edge_metrics") or {}).get("mention_count") or 0,
+                reverse=True,
+            )[:3]
+            context_stats["displacement_targets"] = [
+                {
+                    "to_vendor": e.get("to_vendor"),
+                    "mentions": (e.get("edge_metrics") or {}).get("mention_count") or 0,
+                    "primary_driver": (e.get("edge_metrics") or {}).get("primary_driver"),
+                }
+                for e in top_targets
+            ]
+        # Temporal triggers
+        tl_summary = pool_temporal.get("timeline_signal_summary") or {}
+        if tl_summary.get("renewal_signals") or tl_summary.get("evaluation_deadline_signals"):
+            context_stats["renewal_signals"] = tl_summary.get("renewal_signals") or 0
+            context_stats["evaluation_deadlines"] = tl_summary.get("evaluation_deadline_signals") or 0
+        # Keyword spikes
+        spikes = pool_temporal.get("keyword_spikes") or {}
+        if spikes.get("spike_count"):
+            context_stats["keyword_spike_count"] = spikes["spike_count"]
+            context_stats["spike_keywords"] = (spikes.get("spike_keywords") or [])[:5]
+        # Segment: decision maker churn
+        budget = pool_segment.get("budget_pressure") or {}
+        if budget.get("dm_churn_rate") is not None:
+            context_stats["dm_churn_rate"] = budget["dm_churn_rate"]
+        # Causal narrative
+        cn = causal.get("causal_narrative")
+        if isinstance(cn, dict) and cn.get("trigger"):
+            context_stats["causal_trigger"] = cn["trigger"]
+            context_stats["causal_why_now"] = cn.get("why_now")
+        context_stats.update(contract_disp)
+        context_stats.update(contract_timing)
+        context_stats.update(contract_segment)
+        context_stats.update(contract_account)
+        if contract_category.get("market_regime"):
+            context_stats["category_market_regime"] = contract_category["market_regime"]
+        if contract_category.get("winner"):
+            context_stats["category_winner"] = contract_category["winner"]
+        if contract_category.get("loser"):
+            context_stats["category_loser"] = contract_category["loser"]
+        # Buyer persona distribution from extended context
+        _ext_alt = data.get("extended_ctx") or {}
+        _buyer_profiles_alt = _ext_alt.get("buyer_profiles") or []
+        if _buyer_profiles_alt:
+            context_stats["top_buyer_personas"] = [
+                {"role": p["role_type"], "stage": p["buying_stage"], "reviews": p["review_count"]}
+                for p in _buyer_profiles_alt[:3]
+            ]
+
+        sections.append(SectionSpec(
+            id="market_context",
+            heading=f"Why Users Are Leaving {vendor} Right Now",
+            goal="Show displacement patterns, temporal triggers, and buyer context",
+            key_stats=context_stats,
+        ))
+
+    verdict_stats: dict[str, Any] = {"vendor": vendor, "urgency": ctx["urgency"]}
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        verdict_stats["synthesis_wedge"] = wedge
+        verdict_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    if contract_category.get("market_regime"):
+        verdict_stats["market_regime"] = contract_category["market_regime"]
+    if contract_account.get("account_pressure_summary"):
+        verdict_stats["account_pressure_summary"] = contract_account["account_pressure_summary"]
+    if contract_account.get("account_pressure_disclaimer"):
+        verdict_stats["account_pressure_disclaimer"] = contract_account["account_pressure_disclaimer"]
+    if contract_account.get("account_actionability_tier"):
+        verdict_stats["account_actionability_tier"] = contract_account["account_actionability_tier"]
+
+    sections.append(SectionSpec(
+        id="verdict",
+        heading="The Verdict",
+        goal="Summarize findings and recommend action",
+        key_stats=verdict_stats,
+    ))
+
+    # Build affiliate context
+    data_context = {**data["data_context"]}
+    if partner:
+        data_context["affiliate_url"] = partner["affiliate_url"]
+        data_context["affiliate_slug"] = _slugify(partner["product_name"])
+
+    return PostBlueprint(
+        topic_type="vendor_alternative",
+        slug=ctx["slug"],
+        suggested_title=f"{vendor} Alternatives: {ctx['review_count']} Churn Signals Analyzed",
+        tags=[category, vendor.lower(), "alternatives", "churn-analysis"],
+        data_context=data_context,
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_vendor_showdown(ctx: dict, data: dict) -> PostBlueprint:
+    vendor_a, vendor_b = ctx["vendor_a"], ctx["vendor_b"]
+    category = ctx.get("category", "software")
+    quote_highlights = _blog_quote_highlights(
+        data.get("quotes", []),
+        limit=4,
+        vendors=[vendor_a, vendor_b],
+    )
+
+    # Head-to-head comparison chart
+    h2h_data = [
+        {"name": "Avg Urgency", vendor_a: ctx["urgency_a"], vendor_b: ctx["urgency_b"]},
+        {"name": "Review Count", vendor_a: ctx["reviews_a"], vendor_b: ctx["reviews_b"]},
+    ]
+
+    # Add pain category comparison from signals
+    signals_a = {s["pain_category"]: s["avg_urgency"] for s in data.get("signals_a", [])}
+    signals_b = {s["pain_category"]: s["avg_urgency"] for s in data.get("signals_b", [])}
+    all_cats = set(signals_a.keys()) | set(signals_b.keys())
+    pain_comparison = [
+        {"name": cat, vendor_a: signals_a.get(cat, 0), vendor_b: signals_b.get(cat, 0)}
+        for cat in sorted(all_cats)
+    ][:6]
+
+    h2h_chart = ChartSpec(
+        chart_id="head2head-bar",
+        chart_type="horizontal_bar",
+        title=f"{vendor_a} vs {vendor_b}: Key Metrics",
+        data=h2h_data,
+        config={
+            "x_key": "name",
+            "bars": [
+                {"dataKey": vendor_a, "color": "#22d3ee"},
+                {"dataKey": vendor_b, "color": "#f472b6"},
+            ],
+        },
+    )
+
+    charts = [h2h_chart]
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal="Hook with the contrast between the two vendors",
+            key_stats={
+                "vendor_a": vendor_a,
+                "vendor_b": vendor_b,
+                "category": category,
+                "reviews_a": ctx["reviews_a"],
+                "reviews_b": ctx["reviews_b"],
+                "urgency_a": ctx["urgency_a"],
+                "urgency_b": ctx["urgency_b"],
+                "pain_diff": ctx["pain_diff"],
+            },
+            data_summary=(
+                f"{vendor_a} ({ctx['reviews_a']} signals, urgency {ctx['urgency_a']}) "
+                f"vs {vendor_b} ({ctx['reviews_b']} signals, urgency {ctx['urgency_b']}). "
+                f"Urgency difference: {ctx['pain_diff']}."
+            ),
+        ),
+        SectionSpec(
+            id="head2head",
+            heading=f"{vendor_a} vs {vendor_b}: By the Numbers",
+            goal="Present core metrics side by side",
+            chart_ids=["head2head-bar"],
+            data_summary=f"Comparing churn signals and urgency across both vendors.",
+        ),
+    ]
+
+    if pain_comparison:
+        pain_chart = ChartSpec(
+            chart_id="pain-comparison-bar",
+            chart_type="bar",
+            title=f"Pain Categories: {vendor_a} vs {vendor_b}",
+            data=pain_comparison,
+            config={
+                "x_key": "name",
+                "bars": [
+                    {"dataKey": vendor_a, "color": "#22d3ee"},
+                    {"dataKey": vendor_b, "color": "#f472b6"},
+                ],
+            },
+        )
+        charts.append(pain_chart)
+        sections.append(SectionSpec(
+            id="pain_breakdown",
+            heading="Where Each Vendor Falls Short",
+            goal="Compare pain categories between both vendors",
+            chart_ids=["pain-comparison-bar"],
+            data_summary=f"Pain category comparison across {len(pain_comparison)} categories.",
+        ))
+
+    # Displacement dynamics section (from reasoning pools)
+    disp_a_to_b = data.get("displacement_a_to_b") or {}
+    disp_b_to_a = data.get("displacement_b_to_a") or {}
+    edge_a = disp_a_to_b.get("edge_metrics") or {}
+    edge_b = disp_b_to_a.get("edge_metrics") or {}
+    xv_lookup = data.get("xv_synthesis_lookup") or {}
+    battle_a = _resolve_blog_battle_summary(
+        vendor_a, vendor_b, xv_lookup,
+        disp_a_to_b.get("battle_summary") or {},
+    )
+    flow_a = disp_a_to_b.get("flow_summary") or {}
+    switch_reasons = disp_a_to_b.get("switch_reasons") or []
+
+    has_displacement = bool(edge_a.get("mention_count") or edge_b.get("mention_count"))
+    if has_displacement:
+        disp_stats: dict[str, Any] = {
+            "a_to_b_mentions": edge_a.get("mention_count") or 0,
+            "b_to_a_mentions": edge_b.get("mention_count") or 0,
+            "a_to_b_signal_strength": edge_a.get("signal_strength"),
+            "a_to_b_primary_driver": edge_a.get("primary_driver"),
+            "explicit_switches": flow_a.get("explicit_switch_count") or 0,
+            "active_evaluations": flow_a.get("active_evaluation_count") or 0,
+        }
+        if switch_reasons:
+            disp_stats["top_switch_reasons"] = [
+                {"reason": r.get("reason_category") or r.get("reason"), "count": r.get("mention_count", 0)}
+                for r in switch_reasons[:5]
+            ]
+        if battle_a.get("conclusion"):
+            disp_stats["battle_conclusion"] = battle_a["conclusion"]
+            disp_stats["battle_winner"] = battle_a.get("winner")
+            disp_stats["battle_confidence"] = battle_a.get("confidence")
+            disp_stats["battle_durability"] = battle_a.get("durability_assessment")
+        sections.append(SectionSpec(
+            id="displacement",
+            heading="Who Is Actually Switching?",
+            goal="Show displacement patterns: who leaves whom, why, and how fast",
+            key_stats=disp_stats,
+            data_summary=(
+                f"{edge_a.get('mention_count') or 0} displacement signals from {vendor_a} to {vendor_b}, "
+                f"{edge_b.get('mention_count') or 0} from {vendor_b} to {vendor_a}."
+            ),
+        ))
+
+    # Segment intelligence (from reasoning pools)
+    seg_a = data.get("pool_segment_a") or {}
+    seg_b = data.get("pool_segment_b") or {}
+    roles_a = seg_a.get("affected_roles") or []
+    roles_b = seg_b.get("affected_roles") or []
+    has_segments = bool(roles_a or roles_b)
+    if has_segments:
+        seg_stats: dict[str, Any] = {}
+        if roles_a:
+            seg_stats["roles_a"] = [
+                {"role": r.get("role_type"), "count": r.get("review_count", 0), "churn_rate": r.get("churn_rate")}
+                for r in roles_a[:5]
+            ]
+        if roles_b:
+            seg_stats["roles_b"] = [
+                {"role": r.get("role_type"), "count": r.get("review_count", 0), "churn_rate": r.get("churn_rate")}
+                for r in roles_b[:5]
+            ]
+        budget_a = seg_a.get("budget_pressure") or {}
+        budget_b = seg_b.get("budget_pressure") or {}
+        if budget_a.get("dm_churn_rate") is not None:
+            seg_stats["dm_churn_rate_a"] = budget_a["dm_churn_rate"]
+        if budget_b.get("dm_churn_rate") is not None:
+            seg_stats["dm_churn_rate_b"] = budget_b["dm_churn_rate"]
+        sections.append(SectionSpec(
+            id="buyer_segments",
+            heading="Who Is Churning? Buyer Profile Breakdown",
+            goal="Show which buyer roles and segments are most affected",
+            key_stats=seg_stats,
+        ))
+
+    # Category dynamics + synthesis (from reasoning pools + cross-vendor synthesis)
+    cat_dyn = data.get("pool_category") or {}
+    regime = cat_dyn.get("market_regime") or {}
+    council = _resolve_blog_council_summary(
+        category, xv_lookup, cat_dyn.get("council_summary") or {},
+    )
+    synth_contracts = data.get("synthesis_contracts") or {}
+    vendor_core = synth_contracts.get("vendor_core_reasoning") or {}
+    category_reasoning = synth_contracts.get("category_reasoning") or {}
+    contract_category = _blog_category_reasoning_stats(category_reasoning)
+    causal = vendor_core if isinstance(vendor_core, dict) else {}
+
+    verdict_stats: dict[str, Any] = {
+        "vendor_a": vendor_a,
+        "vendor_b": vendor_b,
+        "urgency_a": ctx["urgency_a"],
+        "urgency_b": ctx["urgency_b"],
+    }
+    if regime.get("regime_type"):
+        verdict_stats["market_regime"] = regime["regime_type"]
+    if council.get("conclusion"):
+        verdict_stats["category_conclusion"] = council["conclusion"]
+    elif contract_category.get("narrative"):
+        verdict_stats["category_conclusion"] = contract_category["narrative"]
+    if battle_a.get("winner"):
+        verdict_stats["displacement_winner"] = battle_a["winner"]
+        verdict_stats["displacement_confidence"] = battle_a.get("confidence")
+    if causal.get("causal_narrative"):
+        cn = causal["causal_narrative"]
+        if isinstance(cn, dict):
+            verdict_stats["causal_trigger"] = cn.get("trigger")
+            verdict_stats["causal_why_now"] = cn.get("why_now")
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        verdict_stats["synthesis_wedge"] = wedge
+        verdict_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    if contract_category.get("market_regime"):
+        verdict_stats["category_market_regime"] = contract_category["market_regime"]
+    if contract_category.get("winner"):
+        verdict_stats["category_winner"] = contract_category["winner"]
+    if contract_category.get("loser"):
+        verdict_stats["category_loser"] = contract_category["loser"]
+
+    sections.append(SectionSpec(
+        id="verdict",
+        heading="The Verdict",
+        goal="Declare which vendor fares better and the decisive factor",
+        key_stats=verdict_stats,
+        data_summary=f"Final comparison of urgency, displacement, and buyer-fit signals for {vendor_a} and {vendor_b}.",
+    ))
+
+    if quote_highlights:
+        sections.append(SectionSpec(
+            id="reviewer_voice",
+            heading=f"What Reviewers Say About {vendor_a} and {vendor_b}",
+            goal="Keep the comparison grounded in direct reviewer language from both vendors",
+            key_stats={"quote_highlights": quote_highlights},
+            data_summary=f"{len(quote_highlights)} quote-backed snippets comparing {vendor_a} and {vendor_b}.",
+        ))
+
+    return PostBlueprint(
+        topic_type="vendor_showdown",
+        slug=ctx["slug"],
+        suggested_title=f"{vendor_a} vs {vendor_b}: Comparing Reviewer Complaints Across {ctx['total_reviews']} Reviews",
+        tags=[category, vendor_a.lower(), vendor_b.lower(), "comparison", "churn-analysis"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_churn_report(ctx: dict, data: dict) -> PostBlueprint:
+    vendor = ctx["vendor"]
+    category = ctx.get("category", "software")
+    signals = data.get("signals", [])
+    profile = data.get("profile", {})
+    market_regime = (data.get("category_overview", {}).get("cross_vendor_analysis") or {}).get("market_regime")
+    synth_contracts = data.get("synthesis_contracts") or {}
+    account_preview = data.get("account_reasoning_preview") or {}
+    vendor_core = synth_contracts.get("vendor_core_reasoning") or {}
+    displacement_reasoning = synth_contracts.get("displacement_reasoning") or {}
+    category_reasoning = synth_contracts.get("category_reasoning") or {}
+    account_reasoning = synth_contracts.get("account_reasoning") or {}
+    segment_playbook = vendor_core.get("segment_playbook") if isinstance(vendor_core, dict) else {}
+    timing_intelligence = vendor_core.get("timing_intelligence") if isinstance(vendor_core, dict) else {}
+    contract_disp = _blog_migration_proof_stats(displacement_reasoning)
+    contract_segment = _blog_segment_reasoning_stats(segment_playbook, timing_intelligence)
+    contract_timing = _blog_timing_reasoning_stats(timing_intelligence)
+    contract_category = _blog_category_reasoning_stats(category_reasoning)
+    contract_account = _blog_account_reasoning_stats(
+        account_reasoning,
+        account_preview,
+    )
+    if not market_regime:
+        market_regime = contract_category.get("market_regime")
+
+    # Pain distribution chart
+    pain_data = [
+        {"name": s["pain_category"] or "Other", "signals": s["signal_count"], "urgency": s["avg_urgency"]}
+        for s in signals[:8]
+    ]
+    pain_chart = ChartSpec(
+        chart_id="pain-bar",
+        chart_type="bar",
+        title=f"Churn Pain Categories: {vendor}",
+        data=pain_data,
+        config={
+            "x_key": "name",
+            "bars": [
+                {"dataKey": "signals", "color": "#f87171"},
+                {"dataKey": "urgency", "color": "#fbbf24"},
+            ],
+        },
+    )
+
+    # Feature gaps
+    all_gaps: dict[str, int] = {}
+    for s in signals:
+        for gap in s.get("feature_gaps", []):
+            if gap:
+                all_gaps[gap] = all_gaps.get(gap, 0) + 1
+    top_gaps = sorted(all_gaps.items(), key=lambda x: x[1], reverse=True)[:6]
+    gap_data = [{"name": g[:30], "mentions": c} for g, c in top_gaps]
+
+    charts = [pain_chart]
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Lead with the scale of churn signals for {vendor}",
+            key_stats={
+                "vendor": vendor,
+                "category": category,
+                "negative_reviews": ctx["negative_reviews"],
+                "avg_urgency": ctx["avg_urgency"],
+                "total_reviews": ctx["total_reviews"],
+                "market_regime": market_regime,
+            },
+            data_summary=(
+                f"{vendor} has {ctx['negative_reviews']} negative reviews out of "
+                f"{ctx['total_reviews']} total (avg urgency {ctx['avg_urgency']}/10)."
+            ),
+        ),
+        SectionSpec(
+            id="pain_breakdown",
+            heading="What's Causing the Churn?",
+            goal="Group pain points by category",
+            chart_ids=["pain-bar"],
+            data_summary=f"Top pain categories: {', '.join(s['pain_category'] for s in signals[:3] if s['pain_category'])}.",
+        ),
+    ]
+    if market_regime:
+        sections.append(SectionSpec(
+            id="market_context",
+            heading=f"Market Context for {category}",
+            goal="Explain how the broader category regime changes the interpretation of this vendor's churn signals",
+            key_stats={"market_regime": market_regime},
+            data_summary=f"Current market regime: {market_regime}.",
+        ))
+
+    if gap_data:
+        gap_chart = ChartSpec(
+            chart_id="gaps-bar",
+            chart_type="horizontal_bar",
+            title=f"Feature Gaps Driving Churn: {vendor}",
+            data=gap_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "mentions", "color": "#a78bfa"}],
+            },
+        )
+        charts.append(gap_chart)
+        sections.append(SectionSpec(
+            id="feature_gaps",
+            heading="What's Missing?",
+            goal="List the feature gaps driving users away",
+            chart_ids=["gaps-bar"],
+            data_summary=f"Top {len(gap_data)} missing features.",
+        ))
+
+    # Reasoning pool enrichment: displacement, segment, temporal
+    pool_disp = data.get("pool_displacement") or []
+    pool_segment = data.get("pool_segment") or {}
+    pool_temporal = data.get("pool_temporal") or {}
+    if pool_disp:
+        top_targets = sorted(
+            pool_disp,
+            key=lambda e: (e.get("edge_metrics") or {}).get("mention_count") or 0,
+            reverse=True,
+        )[:5]
+        disp_stats: dict[str, Any] = {
+            "targets": [
+                {
+                    "to_vendor": e.get("to_vendor"),
+                    "mentions": (e.get("edge_metrics") or {}).get("mention_count") or 0,
+                    "primary_driver": (e.get("edge_metrics") or {}).get("primary_driver"),
+                    "signal_strength": (e.get("edge_metrics") or {}).get("signal_strength"),
+                }
+                for e in top_targets
+            ],
+        }
+        sections.append(SectionSpec(
+            id="displacement",
+            heading=f"Where {vendor} Users Are Going",
+            goal="Show which alternatives are gaining traction and why",
+            key_stats=disp_stats,
+        ))
+    elif contract_disp:
+        sections.append(SectionSpec(
+            id="displacement",
+            heading=f"Where {vendor} Users Are Going",
+            goal="Show which alternatives are gaining traction and why",
+            key_stats=contract_disp,
+        ))
+
+    # Buyer segment breakdown
+    roles = pool_segment.get("affected_roles") or []
+    if roles:
+        seg_stats: dict[str, Any] = {
+            "roles": [
+                {"role": r.get("role_type"), "count": r.get("review_count", 0), "churn_rate": r.get("churn_rate")}
+                for r in roles[:5]
+            ],
+        }
+        budget = pool_segment.get("budget_pressure") or {}
+        if budget.get("dm_churn_rate") is not None:
+            seg_stats["dm_churn_rate"] = budget["dm_churn_rate"]
+        sections.append(SectionSpec(
+            id="buyer_segments",
+            heading="Who Is Churning?",
+            goal="Break down churn by buyer role and seniority",
+            key_stats=seg_stats,
+        ))
+    elif contract_segment:
+        sections.append(SectionSpec(
+            id="buyer_segments",
+            heading="Who Is Churning?",
+            goal="Break down churn by buyer role and seniority",
+            key_stats=contract_segment,
+        ))
+
+    # Temporal context
+    tl_summary = pool_temporal.get("timeline_signal_summary") or {}
+    sentiment = pool_temporal.get("sentiment_trajectory") or {}
+    has_temporal = tl_summary.get("renewal_signals") or sentiment.get("declining_pct")
+    if has_temporal:
+        temporal_stats: dict[str, Any] = {}
+        if tl_summary.get("renewal_signals"):
+            temporal_stats["renewal_signals"] = tl_summary["renewal_signals"]
+        if tl_summary.get("evaluation_deadline_signals"):
+            temporal_stats["evaluation_deadlines"] = tl_summary["evaluation_deadline_signals"]
+        if sentiment.get("declining_pct") is not None:
+            temporal_stats["declining_pct"] = sentiment["declining_pct"]
+            temporal_stats["improving_pct"] = sentiment.get("improving_pct")
+        sections.append(SectionSpec(
+            id="timing",
+            heading="Timing Signals: When to Act",
+            goal="Show contract renewal windows and sentiment trajectory",
+            key_stats=temporal_stats,
+        ))
+    elif contract_timing:
+        sections.append(SectionSpec(
+            id="timing",
+            heading="Timing Signals: When to Act",
+            goal="Show contract renewal windows and sentiment trajectory",
+            key_stats=contract_timing,
+        ))
+
+    outlook_stats: dict[str, Any] = {"vendor": vendor, "avg_urgency": ctx["avg_urgency"]}
+    causal = vendor_core.get("causal_narrative") if isinstance(vendor_core, dict) else {}
+    if isinstance(causal, dict) and causal.get("trigger"):
+        outlook_stats["causal_trigger"] = causal["trigger"]
+        outlook_stats["causal_why_now"] = causal.get("why_now")
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        outlook_stats["synthesis_wedge"] = wedge
+    if contract_account.get("account_pressure_summary"):
+        outlook_stats["account_pressure_summary"] = contract_account["account_pressure_summary"]
+    if contract_account.get("account_pressure_disclaimer"):
+        outlook_stats["account_pressure_disclaimer"] = contract_account["account_pressure_disclaimer"]
+    if contract_account.get("account_actionability_tier"):
+        outlook_stats["account_actionability_tier"] = contract_account["account_actionability_tier"]
+    if contract_category.get("narrative"):
+        outlook_stats["category_narrative"] = contract_category["narrative"]
+
+    sections.append(SectionSpec(
+        id="outlook",
+        heading="What This Means for Teams Using " + vendor,
+        goal="Provide actionable guidance for current users",
+        key_stats=outlook_stats,
+    ))
+
+    return PostBlueprint(
+        topic_type="churn_report",
+        slug=ctx["slug"],
+        suggested_title=f"{vendor} Churn Report: {ctx['negative_reviews']} Negative Reviews Analyzed",
+        tags=[category, vendor.lower(), "churn-report", "enterprise-software"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_migration_guide(ctx: dict, data: dict) -> PostBlueprint:
+    vendor = ctx["vendor"]
+    category = ctx.get("category", "software")
+    profile = data.get("profile", {})
+    signals = data.get("signals", [])
+    synth_contracts = data.get("synthesis_contracts") or {}
+    account_preview = data.get("account_reasoning_preview") or {}
+    vendor_core = synth_contracts.get("vendor_core_reasoning") or {}
+    displacement_reasoning = synth_contracts.get("displacement_reasoning") or {}
+    category_reasoning = synth_contracts.get("category_reasoning") or {}
+    account_reasoning = synth_contracts.get("account_reasoning") or {}
+    timing_intelligence = vendor_core.get("timing_intelligence") if isinstance(vendor_core, dict) else {}
+    # contract_disp intentionally omitted: migration_proof is outbound-oriented,
+    # wrong direction for a switch-to guide.
+    contract_category = _blog_category_reasoning_stats(category_reasoning)
+
+    # Migration sources chart
+    switched_from = profile.get("commonly_switched_from", [])
+    if isinstance(switched_from, str):
+        try:
+            switched_from = json.loads(switched_from)
+        except (json.JSONDecodeError, TypeError):
+            switched_from = []
+
+    source_data = [
+        {
+            "name": (src.get("vendor", "Unknown") if isinstance(src, dict) else str(src))[:25],
+            "migrations": src.get("count", 1) if isinstance(src, dict) else 1,
+        }
+        for src in switched_from[:8]
+        if (src.get("vendor", "") if isinstance(src, dict) else str(src)).lower().strip() != vendor.lower().strip()
+    ]
+
+    inbound_source_count = len(source_data)
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Highlight the volume of inbound migrations to {vendor}",
+            key_stats={
+                "vendor": vendor,
+                "category": category,
+                "inbound_source_count": inbound_source_count,
+                "review_total": ctx["review_total"],
+            },
+            data_summary=(
+                f"{vendor} attracts users from {inbound_source_count} documented competitor platforms "
+                f"based on analysis of {ctx['review_total']} total reviews."
+            ),
+        ),
+    ]
+
+    if source_data:
+        source_chart = ChartSpec(
+            chart_id="sources-bar",
+            chart_type="horizontal_bar",
+            title=f"Where {vendor} Users Come From",
+            data=source_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "migrations", "color": "#34d399"}],
+            },
+        )
+        charts.append(source_chart)
+        sections.append(SectionSpec(
+            id="sources",
+            heading=f"Where Are {vendor} Users Coming From?",
+            goal="Show the top migration sources",
+            chart_ids=["sources-bar"],
+            data_summary=f"Top {len(source_data)} competitors users are leaving for {vendor}.",
+        ))
+
+    # Pain of origin chart (what drove them away from competitors)
+    if signals:
+        pain_data = [
+            {"name": s["pain_category"] or "Other", "signals": s["signal_count"]}
+            for s in signals[:6]
+        ]
+        pain_chart = ChartSpec(
+            chart_id="pain-bar",
+            chart_type="bar",
+            title=f"Pain Categories That Drive Migration to {vendor}",
+            data=pain_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "signals", "color": "#f87171"}],
+            },
+        )
+        charts.append(pain_chart)
+        sections.append(SectionSpec(
+            id="triggers",
+            heading="What Triggers the Switch?",
+            goal="Explain the common pain categories behind migration",
+            chart_ids=["pain-bar"],
+            data_summary=f"Top pain categories driving migration.",
+        ))
+
+    # Use mention-counted integrations from extended context when available
+    _ext_ctx = data.get("extended_ctx") or {}
+    _ext_ints = _ext_ctx.get("integrations") or []
+    _migration_integrations = (
+        [{"name": r["integration_name"], "mentions": r["mention_count"]} for r in _ext_ints[:5]]
+        if _ext_ints
+        else (profile.get("integrations", [])[:5] if isinstance(profile.get("integrations"), list) else [])
+    )
+    sections.append(SectionSpec(
+        id="practical",
+        heading="Making the Switch: What to Expect",
+        goal="Practical migration considerations (integrations, learning curve)",
+        key_stats={
+            "vendor": vendor,
+            "integrations": _migration_integrations,
+        },
+    ))
+
+    # Inbound migration count from commonly_switched_from
+    inbound_migration_count = sum(
+        (src.get("count", 1) if isinstance(src, dict) else 1)
+        for src in switched_from
+        if (src.get("vendor", "") if isinstance(src, dict) else str(src)).lower().strip() != vendor.lower().strip()
+    )
+    takeaway_stats: dict[str, Any] = {
+        "vendor": vendor,
+        "inbound_source_count": len(source_data),
+        "inbound_migration_mentions": inbound_migration_count,
+    }
+
+    # Pool displacement: filter to INBOUND edges only (to_vendor = this vendor)
+    pool_disp = data.get("pool_displacement") or []
+    inbound_disp = [
+        e for e in pool_disp
+        if str(e.get("to_vendor") or "").lower().strip() == vendor.lower().strip()
+    ]
+    if inbound_disp:
+        top = sorted(inbound_disp, key=lambda e: (e.get("edge_metrics") or {}).get("mention_count") or 0, reverse=True)
+        if top:
+            em = top[0].get("edge_metrics") or {}
+            takeaway_stats["top_inbound_driver"] = em.get("primary_driver")
+
+    # Drop outbound-oriented contract_disp (migration_proof describes why
+    # customers LEAVE, not why they JOIN -- wrong direction for this article).
+    # Only inject inbound-safe fields from reasoning.
+    causal = (data.get("synthesis_contracts") or {}).get("vendor_core_reasoning") or {}
+
+    # --- Reasoning wedge injection (AEO authority) ---
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        takeaway_stats["synthesis_wedge"] = wedge
+        takeaway_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    cn = causal.get("causal_narrative")
+    if isinstance(cn, dict) and cn.get("trigger"):
+        takeaway_stats["causal_trigger"] = cn["trigger"]
+        takeaway_stats["causal_why_now"] = cn.get("why_now")
+    if contract_category.get("market_regime"):
+        takeaway_stats["market_regime"] = contract_category["market_regime"]
+
+    sections.append(SectionSpec(
+        id="takeaway",
+        heading="Key Takeaways",
+        goal="Summary and recommendations",
+        key_stats=takeaway_stats,
+    ))
+
+    return PostBlueprint(
+        topic_type="migration_guide",
+        slug=ctx["slug"],
+        suggested_title=f"Migration Guide: Why Teams Are Switching to {vendor}",
+        tags=[category, vendor.lower(), "migration", "switching-guide"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
+    """In-depth profile of a single vendor -- showcase data gathering capabilities."""
+    vendor = ctx["vendor"]
+    category = ctx.get("category", "software")
+    profile = data.get("profile", {})
+    signals = data.get("signals", [])
+    competitor_profiles = data.get("competitor_profiles", [])
+    synth_contracts = data.get("synthesis_contracts") or {}
+    account_preview = data.get("account_reasoning_preview") or {}
+    vendor_core = synth_contracts.get("vendor_core_reasoning") or {}
+    category_reasoning = synth_contracts.get("category_reasoning") or {}
+    account_reasoning = synth_contracts.get("account_reasoning") or {}
+    segment_playbook = vendor_core.get("segment_playbook") if isinstance(vendor_core, dict) else {}
+    timing_intelligence = vendor_core.get("timing_intelligence") if isinstance(vendor_core, dict) else {}
+    contract_segment = _blog_segment_reasoning_stats(segment_playbook, timing_intelligence)
+    contract_timing = _blog_timing_reasoning_stats(timing_intelligence)
+    contract_account = _blog_account_reasoning_stats(
+        account_reasoning,
+        account_preview,
+    )
+    contract_category = _blog_category_reasoning_stats(category_reasoning)
+    quote_highlights = _blog_quote_highlights(
+        data.get("quotes", []),
+        limit=4,
+        vendors=[vendor],
+    )
+
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Position this as a comprehensive, data-driven look at {vendor}",
+            key_stats={
+                "vendor": vendor,
+                "category": category,
+                "review_count": ctx["review_count"],
+                "profile_richness": ctx["profile_richness"],
+            },
+            data_summary=(
+                f"A deep dive into {vendor} based on {ctx['review_count']} reviews "
+                f"and cross-referenced data from multiple B2B intelligence sources."
+            ),
+        ),
+    ]
+
+    # Strengths vs weaknesses chart
+    strengths = profile.get("strengths", [])
+    weaknesses = profile.get("weaknesses", [])
+    # When the product profile is too thin, build from review sentiment
+    if len(strengths) + len(weaknesses) < 3 and signals:
+        area_map: dict[str, dict] = {}
+        for s in signals:
+            cat = s.get("pain_category", "")
+            if not cat or cat in ("None", "null", "none"):
+                continue
+            urg = float(s.get("avg_urgency", 0))
+            cnt = int(s.get("signal_count", 1))
+            area_map.setdefault(cat, {"name": cat, "strengths": 0, "weaknesses": 0})
+            if urg >= 3.0:
+                area_map[cat]["weaknesses"] += cnt
+            else:
+                area_map[cat]["strengths"] += cnt
+        sw_data = sorted(area_map.values(), key=lambda x: x["strengths"] + x["weaknesses"], reverse=True)[:8]
+    elif strengths or weaknesses:
+        # Merge by area so each bar shows strength vs weakness evidence
+        area_map: dict[str, dict] = {}
+        for s in strengths[:8]:
+            name = str(s.get("area", s) if isinstance(s, dict) else s)[:30]
+            count = int(s.get("evidence_count", 1)) if isinstance(s, dict) else 1
+            area_map.setdefault(name, {"name": name, "strengths": 0, "weaknesses": 0})
+            area_map[name]["strengths"] += count
+        for w in weaknesses[:8]:
+            name = str(w.get("area", w) if isinstance(w, dict) else w)[:30]
+            count = int(w.get("evidence_count", 1)) if isinstance(w, dict) else 1
+            area_map.setdefault(name, {"name": name, "strengths": 0, "weaknesses": 0})
+            area_map[name]["weaknesses"] += count
+        sw_data = sorted(area_map.values(), key=lambda x: x["strengths"] + x["weaknesses"], reverse=True)[:8]
+    else:
+        sw_data = []
+    if sw_data:
+        sw_chart = ChartSpec(
+            chart_id="strengths-weaknesses",
+            chart_type="horizontal_bar",
+            title=f"{vendor}: Strengths vs Weaknesses",
+            data=sw_data,
+            config={
+                "x_key": "name",
+                "bars": [
+                    {"dataKey": "strengths", "color": "#34d399"},
+                    {"dataKey": "weaknesses", "color": "#f87171"},
+                ],
+            },
+        )
+        charts.append(sw_chart)
+        sections.append(SectionSpec(
+            id="strengths_weaknesses",
+            heading=f"What {vendor} Does Well -- and Where It Falls Short",
+            goal="Present strengths and weaknesses from real user data",
+            chart_ids=["strengths-weaknesses"],
+            data_summary=f"{len(strengths)} strengths and {len(weaknesses)} weaknesses identified.",
+        ))
+
+    # Pain signals chart
+    if signals:
+        pain_data = [
+            {"name": s["pain_category"] or "Other", "urgency": s["avg_urgency"]}
+            for s in signals[:6]
+        ]
+        pain_chart = ChartSpec(
+            chart_id="pain-radar",
+            chart_type="radar",
+            title=f"User Pain Areas: {vendor}",
+            data=pain_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "urgency", "color": "#f87171"}],
+            },
+        )
+        charts.append(pain_chart)
+        sections.append(SectionSpec(
+            id="pain_analysis",
+            heading=f"Where {vendor} Users Feel the Most Pain",
+            goal="Break down the top pain categories from review analysis",
+            chart_ids=["pain-radar"],
+        ))
+
+    # Integrations and use cases -- prefer mention-counted extended context over flat profile arrays
+    extended_ctx = data.get("extended_ctx") or {}
+    ext_integrations = extended_ctx.get("integrations") or []
+    ext_use_cases = extended_ctx.get("use_cases") or []
+    ext_buyer_profiles = extended_ctx.get("buyer_profiles") or []
+    integrations = profile.get("integrations", [])
+    use_cases = profile.get("use_cases", [])
+    if ext_integrations or ext_use_cases or integrations or use_cases:
+        ecosystem_integrations = (
+            [{"name": r["integration_name"], "mentions": r["mention_count"]}
+             for r in ext_integrations[:8]]
+            if ext_integrations
+            else [str(i)[:30] for i in integrations[:8]] if isinstance(integrations, list) else []
+        )
+        ecosystem_use_cases = (
+            [{"name": r["use_case_name"], "mentions": r["mention_count"],
+              "urgency": round(float(r.get("avg_urgency") or 0), 1)}
+             for r in ext_use_cases[:6]]
+            if ext_use_cases
+            else [str(u)[:40] for u in use_cases[:6]] if isinstance(use_cases, list) else []
+        )
+        effective_int_count = len(ext_integrations) if ext_integrations else len(integrations) if isinstance(integrations, list) else 0
+        effective_uc_count = len(ext_use_cases) if ext_use_cases else len(use_cases) if isinstance(use_cases, list) else 0
+        sections.append(SectionSpec(
+            id="ecosystem",
+            heading=f"The {vendor} Ecosystem: Integrations & Use Cases",
+            goal="Show the product ecosystem and typical deployment scenarios",
+            key_stats={
+                "integrations": ecosystem_integrations,
+                "use_cases": ecosystem_use_cases,
+            },
+            data_summary=f"{effective_int_count} integrations and {effective_uc_count} primary use cases.",
+        ))
+
+    if ext_buyer_profiles:
+        sections.append(SectionSpec(
+            id="buyer_profiles",
+            heading=f"Who Reviews {vendor}: Buyer Personas",
+            goal="Show the distribution of buyer roles and purchase stages to anchor persona targeting",
+            key_stats={
+                "top_buyer_roles": [
+                    {"role": p["role_type"], "stage": p["buying_stage"],
+                     "reviews": p["review_count"]}
+                    for p in ext_buyer_profiles[:5]
+                ],
+            },
+            data_summary=f"Top buyer roles: {', '.join(p['role_type'] for p in ext_buyer_profiles[:3] if p.get('role_type'))}.",
+        ))
+
+    if contract_segment:
+        sections.append(SectionSpec(
+            id="segment_timing",
+            heading=f"Which Teams Feel {vendor} Pain First",
+            goal="Translate segment targeting and timing intelligence into who feels the pressure first and why",
+            key_stats=contract_segment,
+            data_summary=(
+                str(contract_segment.get("segment_targeting_summary") or "").strip()
+                or f"Priority segments surfaced from reasoning for {vendor}."
+            ),
+        ))
+
+    if contract_timing:
+        sections.append(SectionSpec(
+            id="timing_signals",
+            heading=f"When {vendor} Friction Turns Into Action",
+            goal="Show renewal windows, sentiment direction, and timing triggers that make dissatisfaction operational",
+            key_stats=contract_timing,
+            data_summary=(
+                str(contract_timing.get("timing_summary") or "").strip()
+                or f"Timing intelligence surfaced for {vendor}."
+            ),
+        ))
+
+    if contract_account:
+        sections.append(SectionSpec(
+            id="account_pressure",
+            heading=f"Where {vendor} Pressure Shows Up in Accounts",
+            goal="Surface named-account and account-pattern pressure without overstating certainty",
+            key_stats=contract_account,
+            data_summary=(
+                str(contract_account.get("account_pressure_summary") or "").strip()
+                or f"Account-pressure patterns were surfaced for {vendor}."
+            ),
+        ))
+
+    # Competitive landscape
+    compared = profile.get("commonly_compared_to", [])
+    if compared:
+        comp_names = [
+            (c.get("vendor", c) if isinstance(c, dict) else str(c))[:25]
+            for c in compared[:6]
+        ]
+        sections.append(SectionSpec(
+            id="competitive_landscape",
+            heading=f"How {vendor} Stacks Up Against Competitors",
+            goal="Position the vendor relative to frequently compared alternatives",
+            key_stats={"competitors": comp_names},
+            data_summary=f"Commonly compared to: {', '.join(comp_names)}.",
+        ))
+
+    market_position_stats: dict[str, Any] = {}
+    if contract_category:
+        market_position_stats.update(contract_category)
+    if competitor_profiles:
+        market_position_stats["competitor_snapshots"] = [
+            {
+                "vendor": str(profile_row.get("vendor_name") or profile_row.get("vendor") or "").strip(),
+                "strengths": [
+                    str(item.get("area", item)) if isinstance(item, dict) else str(item)
+                    for item in (profile_row.get("strengths") or [])[:2]
+                ],
+                "weaknesses": [
+                    str(item.get("area", item)) if isinstance(item, dict) else str(item)
+                    for item in (profile_row.get("weaknesses") or [])[:2]
+                ],
+            }
+            for profile_row in competitor_profiles[:3]
+            if str(profile_row.get("vendor_name") or profile_row.get("vendor") or "").strip()
+        ]
+    if market_position_stats:
+        sections.append(SectionSpec(
+            id="market_position",
+            heading=f"Where {vendor} Sits in the {category} Market",
+            goal="Connect the vendor profile to broader category dynamics and the nearest competitive alternatives",
+            key_stats=market_position_stats,
+            data_summary=(
+                str(contract_category.get("narrative") or "").strip()
+                or f"Competitive context for {vendor} in the {category} market."
+            ),
+        ))
+
+    if quote_highlights:
+        sections.append(SectionSpec(
+            id="reviewer_voice",
+            heading=f"What Reviewers Actually Say About {vendor}",
+            goal="Anchor the analysis in direct review language so the conclusions stay evidence-backed",
+            key_stats={"quote_highlights": quote_highlights},
+            data_summary=f"{len(quote_highlights)} representative quote-backed snippets for {vendor}.",
+        ))
+
+    verdict_stats: dict[str, Any] = {"vendor": vendor, "review_count": ctx["review_count"]}
+    pool_segment = data.get("pool_segment") or {}
+    pool_temporal = data.get("pool_temporal") or {}
+    roles = pool_segment.get("affected_roles") or []
+    if roles:
+        verdict_stats["top_churning_role"] = roles[0].get("role_type")
+        verdict_stats["top_role_churn_rate"] = roles[0].get("churn_rate")
+    sentiment = pool_temporal.get("sentiment_trajectory") or {}
+    if sentiment.get("declining_pct") is not None:
+        verdict_stats["declining_pct"] = sentiment["declining_pct"]
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        verdict_stats["synthesis_wedge"] = wedge
+    if contract_segment.get("segment_targeting_summary"):
+        verdict_stats["segment_targeting_summary"] = contract_segment["segment_targeting_summary"]
+    if contract_timing.get("timing_summary"):
+        verdict_stats["timing_summary"] = contract_timing["timing_summary"]
+    if contract_account.get("account_pressure_summary"):
+        verdict_stats["account_pressure_summary"] = contract_account["account_pressure_summary"]
+    if contract_account.get("account_pressure_disclaimer"):
+        verdict_stats["account_pressure_disclaimer"] = contract_account["account_pressure_disclaimer"]
+    if contract_account.get("account_actionability_tier"):
+        verdict_stats["account_actionability_tier"] = contract_account["account_actionability_tier"]
+    if contract_category.get("market_regime"):
+        verdict_stats["market_regime"] = contract_category["market_regime"]
+
+    sections.append(SectionSpec(
+        id="verdict",
+        heading=f"The Bottom Line on {vendor}",
+        goal="Synthesize all data into actionable guidance for potential buyers",
+        key_stats=verdict_stats,
+        data_summary=f"Final synthesis of category position, buyer pressure, and timing risk for {vendor}.",
+    ))
+
+    return PostBlueprint(
+        topic_type="vendor_deep_dive",
+        slug=ctx["slug"],
+        suggested_title=f"{vendor} Deep Dive: Reviewer Sentiment Across {ctx['review_count']} Reviews",
+        tags=[category, vendor.lower(), "deep-dive", "vendor-profile", "b2b-intelligence"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
+    """Category-wide overview comparing all vendors in a space."""
+    category = ctx["category"]
+    vendor_count = ctx["vendor_count"]
+    vendor_profiles = data.get("vendor_profiles", [])
+    vendor_signals = data.get("vendor_signals", [])
+    market_regime = (data.get("category_overview", {}).get("cross_vendor_analysis") or {}).get("market_regime")
+    pain_rows = _aggregate_category_pain_rows(vendor_signals, limit=6)
+    quote_highlights = _blog_quote_highlights(data.get("quotes", []), limit=4)
+    signals_by_vendor = {
+        str(item.get("vendor") or "").strip(): item.get("signals") or []
+        for item in vendor_signals
+        if isinstance(item, dict)
+    }
+
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Frame this as a comprehensive market overview of the {category} space",
+            key_stats={
+                "category": category,
+                "vendor_count": vendor_count,
+                "total_reviews": ctx["total_reviews"],
+                "avg_urgency": ctx["avg_urgency"],
+                "market_regime": market_regime,
+            },
+            data_summary=(
+                f"The {category} landscape has {vendor_count} major vendors "
+                f"with {ctx['total_reviews']} total churn signals analyzed."
+            ),
+        ),
+    ]
+    if market_regime:
+        sections.append(SectionSpec(
+            id="market_regime",
+            heading="What Market Regime Are We In?",
+            goal="Anchor the landscape analysis in the current category regime before comparing vendors",
+            key_stats={"market_regime": market_regime},
+            data_summary=f"Current market regime: {market_regime}.",
+        ))
+
+    # Urgency comparison chart across vendors
+    urgency_data = []
+    for vs in vendor_signals:
+        vendor = vs["vendor"]
+        sigs = vs.get("signals", [])
+        if sigs:
+            avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
+            urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
+    if urgency_data:
+        urgency_chart = ChartSpec(
+            chart_id="vendor-urgency",
+            chart_type="horizontal_bar",
+            title=f"Churn Urgency by Vendor: {category}",
+            data=sorted(urgency_data, key=lambda x: x["urgency"], reverse=True),
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "urgency", "color": "#f87171"}],
+            },
+        )
+        charts.append(urgency_chart)
+        sections.append(SectionSpec(
+            id="urgency_ranking",
+            heading="Which Vendors Face the Highest Churn Risk?",
+            goal="Rank vendors by churn urgency",
+            chart_ids=["vendor-urgency"],
+            data_summary=f"Urgency scores across {len(urgency_data)} vendors.",
+        ))
+
+    if pain_rows:
+        pain_chart = ChartSpec(
+            chart_id="category-pain-map",
+            chart_type="horizontal_bar",
+            title=f"Common Pain Patterns Across {category}",
+            data=pain_rows,
+            config={
+                "x_key": "name",
+                "bars": [
+                    {"dataKey": "vendor_count", "color": "#f87171"},
+                    {"dataKey": "avg_urgency", "color": "#fbbf24"},
+                ],
+            },
+        )
+        charts.append(pain_chart)
+        sections.append(SectionSpec(
+            id="category_pain_patterns",
+            heading=f"What Keeps Coming Up Across {category} Vendors",
+            goal="Show the pain categories that recur across vendors, not just inside one product",
+            chart_ids=["category-pain-map"],
+            data_summary=(
+                f"Recurring pain patterns across {len(pain_rows)} category themes, "
+                f"led by {', '.join(row['name'] for row in pain_rows[:3])}."
+            ),
+        ))
+
+    # Per-vendor breakdowns
+    for vp in vendor_profiles[:5]:
+        vendor = vp["vendor"]
+        profile = vp.get("profile", {})
+        strengths = profile.get("strengths", [])
+        weaknesses = profile.get("weaknesses", [])
+        vendor_signal_rows = signals_by_vendor.get(vendor, [])
+        top_pains = [
+            str(item.get("pain_category") or "").strip()
+            for item in vendor_signal_rows[:3]
+            if str(item.get("pain_category") or "").strip()
+        ]
+        avg_rating = vp.get("avg_rating")
+        review_count = vp.get("review_count")
+        if strengths or weaknesses:
+            sections.append(SectionSpec(
+                id=f"vendor-{_slugify(vendor)}",
+                heading=f"{vendor}: Strengths & Weaknesses",
+                goal=f"Brief profile of {vendor} in the {category} space",
+                key_stats={
+                    "vendor": vendor,
+                    "avg_rating": avg_rating,
+                    "review_count": review_count,
+                    "top_pains": top_pains,
+                    "strengths": [str(s.get("area", s)) if isinstance(s, dict) else str(s) for s in strengths[:3]],
+                    "weaknesses": [str(w.get("area", w)) if isinstance(w, dict) else str(w) for w in weaknesses[:3]],
+                },
+                data_summary=(
+                    f"{vendor} has {review_count or 0} reviews in scope"
+                    + (f", rating {avg_rating}" if avg_rating is not None else "")
+                    + (
+                        f", with pain pressure concentrated in {', '.join(top_pains)}."
+                        if top_pains
+                        else "."
+                    )
+                ),
+            ))
+
+    takeaway_stats: dict[str, Any] = {"category": category, "vendor_count": vendor_count}
+    cat_dyn = data.get("pool_category") or {}
+    regime = cat_dyn.get("market_regime") or {}
+    xv_lookup_ml = data.get("xv_synthesis_lookup") or {}
+    council = _resolve_blog_council_summary(
+        category, xv_lookup_ml, cat_dyn.get("council_summary") or {},
+    )
+    if regime.get("regime_type"):
+        takeaway_stats["market_regime"] = regime["regime_type"]
+    if council.get("conclusion"):
+        takeaway_stats["category_conclusion"] = council["conclusion"]
+    if council.get("winner"):
+        takeaway_stats["category_winner"] = council["winner"]
+
+    # --- Reasoning wedge injection (AEO authority) ---
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        takeaway_stats["synthesis_wedge"] = wedge
+        takeaway_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    causal = (data.get("synthesis_contracts") or {}).get("vendor_core_reasoning") or {}
+    cn = causal.get("causal_narrative")
+    if isinstance(cn, dict) and cn.get("trigger"):
+        takeaway_stats["causal_trigger"] = cn["trigger"]
+        takeaway_stats["causal_why_now"] = cn.get("why_now")
+    _seg = data.get("pool_segment") or {}
+    _budget = _seg.get("budget_pressure") or {}
+    if _budget.get("dm_churn_rate") is not None and "dm_churn_rate" not in takeaway_stats:
+        takeaway_stats["dm_churn_rate"] = _budget["dm_churn_rate"]
+
+        takeaway_stats["category_winner"] = council["winner"]
+
+    sections.append(SectionSpec(
+        id="takeaway",
+        heading=f"Choosing the Right {category} Platform",
+        goal="Synthesize the landscape and help readers pick the right tool",
+        key_stats=takeaway_stats,
+        data_summary=f"Decision framework across vendor breadth, churn urgency, and category-level pressure in {category}.",
+    ))
+
+    if quote_highlights:
+        sections.append(SectionSpec(
+            id="reviewer_voice",
+            heading=f"What Reviewers Say Across the {category} Market",
+            goal="Use direct reviewer snippets to keep the market overview grounded in visible evidence",
+            key_stats={"quote_highlights": quote_highlights},
+            data_summary=f"{len(quote_highlights)} quote-backed examples spanning the {category} market.",
+        ))
+
+    vendor_names = [vp["vendor"] for vp in vendor_profiles[:5]]
+    return PostBlueprint(
+        topic_type="market_landscape",
+        slug=ctx["slug"],
+        suggested_title=f"{category} Landscape {date.today().year}: {vendor_count} Vendors Compared by Real User Data",
+        tags=[category.lower(), "market-landscape", "comparison", "b2b-intelligence"],
+        data_context={**data["data_context"], "category": category},
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_pricing_reality_check(ctx: dict, data: dict) -> PostBlueprint:
+    """Honest breakdown of a vendor's pricing -- the good, the bad, and the bait-and-switch."""
+    vendor = ctx["vendor"]
+    category = ctx.get("category", "software")
+    pricing_reviews = data.get("pricing_reviews", [])
+    positive_reviews = data.get("positive_reviews", [])
+    profile = data.get("profile", {})
+
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Lead with the pricing pain -- how many users flagged pricing as a problem with {vendor}",
+            key_stats={
+                "vendor": vendor,
+                "category": category,
+                "pricing_complaints": ctx["pricing_complaints"],
+                "total_reviews": ctx["total_reviews"],
+                "avg_urgency": ctx["avg_urgency"],
+            },
+            data_summary=(
+                f"{ctx['pricing_complaints']} out of {ctx['total_reviews']} {vendor} reviews "
+                f"flag pricing as a pain point (avg urgency {ctx['avg_urgency']}/10)."
+            ),
+        ),
+        SectionSpec(
+            id="what_users_say",
+            heading=f"What {vendor} Users Actually Say About Pricing",
+            goal="Present real quotes from users who got hit by price increases, hidden costs, or bait-and-switch tactics",
+            key_stats={"pricing_review_count": len(pricing_reviews)},
+            data_summary=f"{len(pricing_reviews)} reviews specifically mention pricing frustrations.",
+        ),
+    ]
+
+    # Pricing complaint urgency distribution
+    if pricing_reviews:
+        urgency_buckets = {"Critical (8-10)": 0, "High (6-7)": 0, "Moderate (4-5)": 0, "Low (1-3)": 0}
+        for pr in pricing_reviews:
+            u = pr.get("urgency", 0)
+            if u >= 8: urgency_buckets["Critical (8-10)"] += 1
+            elif u >= 6: urgency_buckets["High (6-7)"] += 1
+            elif u >= 4: urgency_buckets["Moderate (4-5)"] += 1
+            else: urgency_buckets["Low (1-3)"] += 1
+        urgency_data = [{"name": k, "count": v} for k, v in urgency_buckets.items() if v > 0]
+        if urgency_data:
+            charts.append(ChartSpec(
+                chart_id="pricing-urgency",
+                chart_type="bar",
+                title=f"Pricing Complaint Severity: {vendor}",
+                data=urgency_data,
+                config={"x_key": "name", "bars": [{"dataKey": "count", "color": "#f87171"}]},
+            ))
+            sections.append(SectionSpec(
+                id="severity",
+                heading="How Bad Is It?",
+                goal="Show the severity distribution of pricing complaints",
+                chart_ids=["pricing-urgency"],
+            ))
+
+    # Credit where it's due
+    if positive_reviews:
+        sections.append(SectionSpec(
+            id="credit_where_due",
+            heading=f"Where {vendor} Genuinely Delivers",
+            goal="Be fair -- highlight what users love about the product despite pricing concerns",
+            key_stats={"positive_count": len(positive_reviews)},
+            data_summary=f"{len(positive_reviews)} positive reviews highlight genuine strengths.",
+        ))
+
+    bl_stats: dict[str, Any] = {"vendor": vendor, "pricing_complaints": ctx["pricing_complaints"]}
+    pool_segment = data.get("pool_segment") or {}
+    budget = pool_segment.get("budget_pressure") or {}
+    if budget.get("price_increase_rate") is not None:
+        bl_stats["price_increase_rate"] = budget["price_increase_rate"]
+    if budget.get("dm_churn_rate") is not None:
+        bl_stats["dm_churn_rate"] = budget["dm_churn_rate"]
+    roles = pool_segment.get("affected_roles") or []
+
+    # --- Reasoning wedge injection (AEO authority) ---
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        bl_stats["synthesis_wedge"] = wedge
+        bl_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    causal = (data.get("synthesis_contracts") or {}).get("vendor_core_reasoning") or {}
+    cn = causal.get("causal_narrative")
+    if isinstance(cn, dict) and cn.get("trigger"):
+        bl_stats["causal_trigger"] = cn["trigger"]
+        bl_stats["causal_why_now"] = cn.get("why_now")
+    _seg = data.get("pool_segment") or {}
+    _budget = _seg.get("budget_pressure") or {}
+    if _budget.get("dm_churn_rate") is not None and "dm_churn_rate" not in bl_stats:
+        bl_stats["dm_churn_rate"] = _budget["dm_churn_rate"]
+
+    if roles:
+        bl_stats["top_churning_role"] = roles[0].get("role_type")
+
+    sections.append(SectionSpec(
+        id="bottom_line",
+        heading="The Bottom Line: Is It Worth the Price?",
+        goal="Honest verdict -- who should pay for it and who should look elsewhere",
+        key_stats=bl_stats,
+    ))
+
+    # Quotable phrases from pricing reviews. Routes SQL-fetched rows
+    # (quote_origin="review") through the contract gate (verbatim-only)
+    # and vault rows (quote_origin="vault") through the legacy
+    # truncation path. Unmarked rows are dropped at the wrapper, never
+    # silently preserved -- closes the prior 'no enrichment means
+    # vault' loophole.
+    quotes = _split_and_gate_blog_quotes(
+        pricing_reviews, field="pricing_phrases", limit=5,
+    )
+
+    return PostBlueprint(
+        topic_type="pricing_reality_check",
+        slug=ctx["slug"],
+        suggested_title=f"The Real Cost of {vendor}: Pricing Complaints in {ctx['pricing_complaints']} Reviews",
+        tags=[category, vendor.lower(), "pricing", "honest-review", "cost-analysis"],
+        data_context={**data.get("data_context", {}), "vendor": vendor},
+        sections=sections,
+        charts=charts,
+        quotable_phrases=quotes,
+    )
+
+
+def _blueprint_switching_story(ctx: dict, data: dict) -> PostBlueprint:
+    """Real stories of teams leaving a vendor -- why they left and where they went."""
+    vendor = ctx["from_vendor"]
+    category = ctx.get("category", "software")
+    switch_reviews = data.get("switch_reviews", [])
+    profile = data.get("profile", {})
+
+    compared_to = profile.get("commonly_compared_to", [])
+    comp_names = [
+        (c.get("vendor", c) if isinstance(c, dict) else str(c))[:25]
+        for c in compared_to[:6]
+    ]
+
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Lead with the switching volume -- real teams actively leaving {vendor}",
+            key_stats={
+                "vendor": vendor,
+                "category": category,
+                "switch_mentions": ctx["switch_mentions"],
+                "total_reviews": ctx["total_reviews"],
+                "avg_urgency": ctx["avg_urgency"],
+            },
+            data_summary=(
+                f"{ctx['switch_mentions']} reviewers mention switching away from {vendor}. "
+                f"Avg urgency among all reviews: {ctx['avg_urgency']}/10."
+            ),
+        ),
+        SectionSpec(
+            id="breaking_points",
+            heading=f"The Breaking Points: Why Teams Leave {vendor}",
+            goal="Present the real reasons from actual reviews -- be specific and honest",
+            key_stats={"switch_review_count": len(switch_reviews)},
+            data_summary=f"{len(switch_reviews)} reviews describe their switching experience.",
+        ),
+    ]
+
+    if comp_names:
+        sections.append(SectionSpec(
+            id="where_they_go",
+            heading="Where Are They Going?",
+            goal="Show the alternatives teams are choosing and why",
+            key_stats={"alternatives": comp_names},
+            data_summary=f"Commonly compared to: {', '.join(comp_names)}.",
+        ))
+
+    # Strengths they're giving up
+    strengths = profile.get("strengths", [])
+    if strengths:
+        sections.append(SectionSpec(
+            id="what_youll_miss",
+            heading=f"What You'll Miss: {vendor}'s Genuine Strengths",
+            goal="Be honest about what the vendor does well -- switching has trade-offs",
+            key_stats={
+                "strengths": [str(s.get("area", s)) if isinstance(s, dict) else str(s) for s in strengths[:4]],
+            },
+        ))
+
+    sv_stats: dict[str, Any] = {"vendor": vendor, "avg_urgency": ctx["avg_urgency"]}
+    pool_disp = data.get("pool_displacement") or []
+    if pool_disp:
+        top_edge = max(pool_disp, key=lambda e: (e.get("edge_metrics") or {}).get("mention_count") or 0)
+        em = top_edge.get("edge_metrics") or {}
+        sv_stats["top_destination"] = top_edge.get("to_vendor")
+        sv_stats["displacement_driver"] = em.get("primary_driver")
+        switch_reasons = top_edge.get("switch_reasons") or []
+
+    # --- Reasoning wedge injection (AEO authority) ---
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        sv_stats["synthesis_wedge"] = wedge
+        sv_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    causal = (data.get("synthesis_contracts") or {}).get("vendor_core_reasoning") or {}
+    cn = causal.get("causal_narrative")
+    if isinstance(cn, dict) and cn.get("trigger"):
+        sv_stats["causal_trigger"] = cn["trigger"]
+        sv_stats["causal_why_now"] = cn.get("why_now")
+    _seg = data.get("pool_segment") or {}
+    _budget = _seg.get("budget_pressure") or {}
+    if _budget.get("dm_churn_rate") is not None and "dm_churn_rate" not in sv_stats:
+        sv_stats["dm_churn_rate"] = _budget["dm_churn_rate"]
+
+        if switch_reasons:
+            sv_stats["top_switch_reasons"] = [r.get("reason_category") or r.get("reason") for r in switch_reasons[:3]]
+
+    sections.append(SectionSpec(
+        id="verdict",
+        heading="Should You Stay or Switch?",
+        goal="Honest framework for making the decision -- not everyone should switch",
+        key_stats=sv_stats,
+    ))
+
+    # Phase 2.3 quote-grade migration: route SQL switch reviews
+    # (quote_origin="review") through the contract gate; vault switch
+    # rows (quote_origin="vault") stay on the legacy truncation path.
+    # Unmarked rows dropped at the wrapper.
+    quotes = _split_and_gate_blog_quotes(
+        switch_reviews, field=None, limit=5,
+    )
+
+    return PostBlueprint(
+        topic_type="switching_story",
+        slug=ctx["slug"],
+        suggested_title=f"Why Teams Are Leaving {vendor}: {ctx['switch_mentions']} Switching Stories Analyzed",
+        tags=[category, vendor.lower(), "switching", "migration", "honest-review"],
+        data_context={**data.get("data_context", {}), "vendor": vendor},
+        sections=sections,
+        charts=charts,
+        quotable_phrases=quotes,
+    )
+
+
+def _blueprint_pain_point_roundup(ctx: dict, data: dict) -> PostBlueprint:
+    """Cross-vendor pain comparison -- the #1 complaint about every vendor in a category."""
+    category = ctx["category"]
+    vendor_pains = data.get("vendor_pains", [])
+
+    # Chart: top pain per vendor
+    pain_chart_data = [
+        {"name": vp["vendor"][:20], "reviews": vp["review_count"], "urgency": vp["avg_urgency"]}
+        for vp in sorted(vendor_pains, key=lambda x: x["review_count"], reverse=True)[:8]
+    ]
+
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Frame as a no-BS comparison -- every {category} tool has flaws, here they are",
+            key_stats={
+                "category": category,
+                "vendor_count": ctx["vendor_count"],
+                "total_complaints": ctx["total_complaints"],
+            },
+            data_summary=(
+                f"We analyzed {ctx['total_complaints']} reviews across {ctx['vendor_count']} "
+                f"{category} vendors. Every single one has a #1 complaint."
+            ),
+        ),
+    ]
+
+    if pain_chart_data:
+        charts.append(ChartSpec(
+            chart_id="vendor-urgency",
+            chart_type="horizontal_bar",
+            title=f"Review Volume & Urgency by Vendor: {category}",
+            data=pain_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [
+                    {"dataKey": "reviews", "color": "#22d3ee"},
+                    {"dataKey": "urgency", "color": "#f87171"},
+                ],
+            },
+        ))
+        sections.append(SectionSpec(
+            id="overview",
+            heading="The Landscape at a Glance",
+            goal="Show which vendors have the most complaints and highest urgency",
+            chart_ids=["vendor-urgency"],
+        ))
+
+    # Per-vendor sections
+    for vp in vendor_pains[:6]:
+        sections.append(SectionSpec(
+            id=f"vendor-{_slugify(vp['vendor'])}",
+            heading=f"{vp['vendor']}: The #1 Complaint Is {vp['top_pain'].title()}",
+            goal=f"Honest breakdown of {vp['vendor']}'s biggest weakness AND what it does well",
+            key_stats={
+                "vendor": vp["vendor"],
+                "top_pain": vp["top_pain"],
+                "review_count": vp["review_count"],
+                "avg_urgency": vp["avg_urgency"],
+            },
+        ))
+
+    pp_stats: dict[str, Any] = {"category": category, "vendor_count": ctx["vendor_count"]}
+    cat_dyn = data.get("pool_category") or {}
+    regime = cat_dyn.get("market_regime") or {}
+    if regime.get("regime_type"):
+        pp_stats["market_regime"] = regime["regime_type"]
+    if regime.get("outlier_vendors"):
+        pp_stats["outlier_vendors"] = regime["outlier_vendors"][:3]
+
+
+    # --- Reasoning wedge injection (AEO authority) ---
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        pp_stats["synthesis_wedge"] = wedge
+        pp_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    causal = (data.get("synthesis_contracts") or {}).get("vendor_core_reasoning") or {}
+    cn = causal.get("causal_narrative")
+    if isinstance(cn, dict) and cn.get("trigger"):
+        pp_stats["causal_trigger"] = cn["trigger"]
+        pp_stats["causal_why_now"] = cn.get("why_now")
+    _seg = data.get("pool_segment") or {}
+    _budget = _seg.get("budget_pressure") or {}
+    if _budget.get("dm_churn_rate") is not None and "dm_churn_rate" not in pp_stats:
+        pp_stats["dm_churn_rate"] = _budget["dm_churn_rate"]
+
+    sections.append(SectionSpec(
+        id="takeaway",
+        heading="Every Tool Has a Flaw -- Pick the One You Can Live With",
+        goal="Honest summary -- there's no perfect tool, help readers pick the right trade-off",
+        key_stats=pp_stats,
+    ))
+
+    return PostBlueprint(
+        topic_type="pain_point_roundup",
+        slug=ctx["slug"],
+        suggested_title=f"The #1 Complaint About Every Major {category} Tool in {date.today().year}",
+        tags=[category.lower(), "complaints", "comparison", "honest-review", "b2b-intelligence"],
+        data_context={**data.get("data_context", {}), "category": category},
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+def _blueprint_best_fit_guide(ctx: dict, data: dict) -> PostBlueprint:
+    """Recommend the right tool based on team size, needs, and budget -- not commissions."""
+    category = ctx["category"]
+    vendor_profiles = data.get("vendor_profiles", [])
+    vendor_signals = data.get("vendor_signals", [])
+    pain_rows = _aggregate_category_pain_rows(vendor_signals, limit=6)
+    quote_highlights = _blog_quote_highlights(data.get("quotes", []), limit=4)
+    signals_by_vendor = {
+        str(item.get("vendor") or "").strip(): item.get("signals") or []
+        for item in vendor_signals
+        if isinstance(item, dict)
+    }
+
+    charts = []
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal=f"Position as an honest buyer's guide for {category} -- based on real user data, not marketing",
+            key_stats={
+                "category": category,
+                "vendor_count": ctx["vendor_count"],
+                "total_reviews": ctx["total_reviews"],
+            },
+            data_summary=(
+                f"We analyzed {ctx['total_reviews']} real user reviews across "
+                f"{ctx['vendor_count']} {category} tools to find who's actually best for what."
+            ),
+        ),
+    ]
+
+    # Rating comparison chart
+    rated_vendors = [vp for vp in vendor_profiles if vp.get("avg_rating") is not None]
+    if rated_vendors:
+        rating_data = sorted(
+            [{"name": vp["vendor"][:20], "rating": vp["avg_rating"], "reviews": vp["review_count"]}
+             for vp in rated_vendors],
+            key=lambda x: x["rating"], reverse=True,
+        )
+        charts.append(ChartSpec(
+            chart_id="ratings",
+            chart_type="horizontal_bar",
+            title=f"Average Rating by Vendor: {category}",
+            data=rating_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "rating", "color": "#34d399"}],
+            },
+        ))
+        sections.append(SectionSpec(
+            id="ratings_overview",
+            heading="Ratings at a Glance (But Don't Stop Here)",
+            goal="Show ratings but warn that averages hide important nuances",
+            chart_ids=["ratings"],
+            data_summary=f"Ratings and review volume across {len(rating_data)} vendors in the {category} set.",
+        ))
+
+    if pain_rows:
+        charts.append(ChartSpec(
+            chart_id="category-pain-fit-map",
+            chart_type="horizontal_bar",
+            title=f"Common Pain Patterns in {category}",
+            data=pain_rows,
+            config={
+                "x_key": "name",
+                "bars": [
+                    {"dataKey": "vendor_count", "color": "#f87171"},
+                    {"dataKey": "avg_urgency", "color": "#fbbf24"},
+                ],
+            },
+        ))
+        sections.append(SectionSpec(
+            id="category_tradeoffs",
+            heading=f"What Teams Consistently Struggle With in {category}",
+            goal="Explain the tradeoffs that keep showing up across vendors before recommending specific fits",
+            chart_ids=["category-pain-fit-map"],
+            data_summary=(
+                f"Category-wide pain patterns led by {', '.join(row['name'] for row in pain_rows[:3])}."
+            ),
+        ))
+
+    # Per-vendor recommendation sections
+    for vp in vendor_profiles[:6]:
+        profile = vp.get("profile", {})
+        company_size = profile.get("typical_company_size", {})
+        size_str = ", ".join(f"{k}" for k, v in sorted(company_size.items(), key=lambda x: x[1], reverse=True)[:2]) if isinstance(company_size, dict) and company_size else "all sizes"
+        strengths = profile.get("strengths", [])
+        weaknesses = profile.get("weaknesses", [])
+        vendor_signal_rows = signals_by_vendor.get(vp["vendor"], [])
+        top_pains = [
+            str(item.get("pain_category") or "").strip()
+            for item in vendor_signal_rows[:3]
+            if str(item.get("pain_category") or "").strip()
+        ]
+        sections.append(SectionSpec(
+            id=f"vendor-{_slugify(vp['vendor'])}",
+            heading=f"{vp['vendor']}: Best For {size_str} Teams",
+            goal=f"Honest recommendation -- who should use {vp['vendor']} and who shouldn't",
+            key_stats={
+                "vendor": vp["vendor"],
+                "company_size": size_str,
+                "avg_rating": vp.get("avg_rating"),
+                "review_count": vp.get("review_count"),
+                "top_pains": top_pains,
+                "strengths": [str(s.get("area", s)) if isinstance(s, dict) else str(s) for s in strengths[:3]],
+                "weaknesses": [str(w.get("area", w)) if isinstance(w, dict) else str(w) for w in weaknesses[:3]],
+            },
+            data_summary=(
+                f"{vp['vendor']} is strongest for {size_str} teams"
+                + (f", with rating {vp.get('avg_rating')}" if vp.get("avg_rating") is not None else "")
+                + (
+                    f", but recurring pain shows up around {', '.join(top_pains)}."
+                    if top_pains
+                    else "."
+                )
+            ),
+        ))
+
+    bf_stats: dict[str, Any] = {"category": category, "vendor_count": ctx["vendor_count"]}
+    cat_dyn = data.get("pool_category") or {}
+    xv_lookup_bf = data.get("xv_synthesis_lookup") or {}
+    council = _resolve_blog_council_summary(
+        category, xv_lookup_bf, cat_dyn.get("council_summary") or {},
+    )
+    if council.get("winner"):
+        bf_stats["category_winner"] = council["winner"]
+    if council.get("conclusion"):
+        bf_stats["category_conclusion"] = council["conclusion"]
+
+
+    # --- Reasoning wedge injection (AEO authority) ---
+    wedge = data.get("synthesis_wedge")
+    if wedge:
+        bf_stats["synthesis_wedge"] = wedge
+        bf_stats["synthesis_wedge_label"] = data.get("synthesis_wedge_label") or ""
+    causal = (data.get("synthesis_contracts") or {}).get("vendor_core_reasoning") or {}
+    cn = causal.get("causal_narrative")
+    if isinstance(cn, dict) and cn.get("trigger"):
+        bf_stats["causal_trigger"] = cn["trigger"]
+        bf_stats["causal_why_now"] = cn.get("why_now")
+    _seg = data.get("pool_segment") or {}
+    _budget = _seg.get("budget_pressure") or {}
+    if _budget.get("dm_churn_rate") is not None and "dm_churn_rate" not in bf_stats:
+        bf_stats["dm_churn_rate"] = _budget["dm_churn_rate"]
+
+    sections.append(SectionSpec(
+        id="decision_framework",
+        heading="How to Actually Choose",
+        goal="Give a clear decision framework based on budget, team size, and must-have features",
+        key_stats=bf_stats,
+        data_summary=f"Decision framework for narrowing {category} options by fit, tradeoffs, and current market pressure.",
+    ))
+
+    if quote_highlights:
+        sections.append(SectionSpec(
+            id="reviewer_voice",
+            heading=f"What Reviewers Actually Say in {category}",
+            goal="Ground the buyer's guide in direct reviewer evidence, not just rating averages",
+            key_stats={"quote_highlights": quote_highlights},
+            data_summary=f"{len(quote_highlights)} quote-backed snippets from the {category} review set.",
+        ))
+
+    company_size = ctx.get("company_size") or ctx.get("dominant_size") or ""
+    size_label = company_size.replace("_", " ").replace("-", " ").strip() if company_size else ""
+    size_suffix = f" for {size_label} Teams" if size_label and size_label != "unknown" else ""
+    return PostBlueprint(
+        topic_type="best_fit_guide",
+        slug=ctx["slug"],
+        suggested_title=f"Best {category} Tools{size_suffix}: {ctx['vendor_count']} Vendors Compared Across {ctx['total_reviews']} Reviews",
+        tags=[category.lower(), "buyers-guide", "comparison", "honest-review", *(["team-size"] if size_label else [])],
+        data_context={**data.get("data_context", {}), "category": category, "company_size": company_size},
+        sections=sections,
+        charts=charts,
+        quotable_phrases=_split_and_gate_blog_quotes(data.get("quotes", []), limit=15),
+    )
+
+
+# -- Stage 4: Content Generation ----------------------------------
+
+def _blog_generation_trace_metadata(
+    blueprint: PostBlueprint,
+    *,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "workflow": "b2b_blog_post_generation",
+        "report_type": blueprint.topic_type,
+        "topic_type": blueprint.topic_type,
+        "slug": blueprint.slug,
+        "source_name": "b2b_blog_post_generation",
+        "event_type": "llm_overlay",
+        "entity_type": "blog_post",
+        "entity_id": blueprint.slug,
+        "suggested_title": blueprint.suggested_title[:200],
+        "tags": blueprint.tags[:10],
+    }
+    if run_id:
+        metadata["run_id"] = run_id
+    data_context = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+    if data_context.get("vendor"):
+        metadata["vendor_name"] = str(data_context["vendor"])[:200]
+    if data_context.get("vendor_a"):
+        metadata["vendor_a"] = str(data_context["vendor_a"])[:200]
+    if data_context.get("vendor_b"):
+        metadata["vendor_b"] = str(data_context["vendor_b"])[:200]
+    if data_context.get("category"):
+        metadata["category"] = str(data_context["category"])[:200]
+    return metadata
+
+
+def _build_blog_generation_payload(
+    blueprint: PostBlueprint,
+    *,
+    related_posts: list[dict[str, str]] | None = None,
+    quality_feedback: list[str] | None = None,
+) -> dict[str, Any]:
+    _attach_blog_blueprint_runtime_metadata(blueprint)
+    length_policy = _blog_length_policy(blueprint.topic_type)
+    section_word_budget = _blog_section_word_budget(blueprint)
+    payload: dict[str, Any] = {
+        "topic_type": blueprint.topic_type,
+        "suggested_title": blueprint.suggested_title,
+        "data_context": blueprint.data_context,
+        "length_policy": length_policy,
+        "section_word_budget": section_word_budget,
+        "sections": [
+            {
+                "id": section.id,
+                "heading": section.heading,
+                "goal": section.goal,
+                "key_stats": section.key_stats,
+                "chart_ids": section.chart_ids,
+                "data_summary": section.data_summary,
+            }
+            for section in blueprint.sections
+        ],
+        "available_charts": [
+            {
+                "chart_id": chart.chart_id,
+                "chart_type": chart.chart_type,
+                "title": chart.title,
+                "data_labels": [
+                    str(row.get("name") or row.get("label") or row.get("category") or "")
+                    for row in chart.data
+                    if isinstance(row, dict)
+                ][:10],
+            }
+            for chart in blueprint.charts
+        ],
+        "quotable_phrases": blueprint.quotable_phrases[:5],
+    }
+    data_context = blueprint.data_context if isinstance(blueprint.data_context, dict) else {}
+    for src_key, dest_key in (
+        ("reasoning_anchor_examples", "anchor_examples"),
+        ("reasoning_witness_highlights", "witness_highlights"),
+        ("reasoning_reference_ids", "reference_ids"),
+        ("blog_claim_plan", "claim_plan"),
+        ("reasoning_anchor_examples_b", "anchor_examples_b"),
+        ("reasoning_witness_highlights_b", "witness_highlights_b"),
+        ("reasoning_reference_ids_b", "reference_ids_b"),
+        ("blog_claim_plan_b", "claim_plan_b"),
+    ):
+        value = data_context.get(src_key)
+        if value not in (None, "", [], {}):
+            payload[dest_key] = value
+    if blueprint.cta:
+        payload["cta_context"] = {
+            "button_text": blueprint.cta["button_text"],
+            "report_type": blueprint.cta["report_type"],
+            "vendor": blueprint.cta.get("vendor_filter"),
+        }
+    if related_posts:
+        payload["related_posts"] = related_posts
+    if quality_feedback:
+        payload["quality_feedback"] = quality_feedback[:10]
+    return payload
+
+
+def _prepare_blog_generation_request(
+    llm,
+    blueprint: PostBlueprint,
+    max_tokens: int,
+    *,
+    related_posts: list[dict[str, str]] | None = None,
+    quality_feedback: list[str] | None = None,
+) -> dict[str, Any] | None:
+    from ...services.b2b.cache_runner import prepare_b2b_exact_stage_request
+    from ...services.protocols import Message
+    from ...skills.registry import get_skill_registry
+
+    skill = get_skill_registry().get("digest/b2b_blog_post_generation")
+    if skill is None:
+        logger.error("Skill digest/b2b_blog_post_generation not found")
+        return None
+
+    payload = _build_blog_generation_payload(
+        blueprint,
+        related_posts=related_posts,
+        quality_feedback=quality_feedback,
+    )
+    messages = [
+        Message(role="system", content=skill.content),
+        Message(
+            role="user",
+            content=json.dumps(payload, separators=(",", ":"), default=str),
+        ),
+    ]
+    request = prepare_b2b_exact_stage_request(
+        _BLOG_GENERATION_CACHE_STAGE,
+        llm=llm,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=float(settings.b2b_churn.blog_post_temperature),
+    )
+    return {
+        "payload": payload,
+        "messages": messages,
+        "request": request,
+        "provider_name": request.provider,
+        "model_name": request.model,
+        "request_envelope": request.request_envelope,
+    }
+
+
+def _trace_blog_generation_call(
+    llm,
+    blueprint: PostBlueprint,
+    *,
+    messages: list[Any],
+    result: Any,
+    run_id: str | None = None,
+) -> None:
+    usage = result.get("usage", {}) if isinstance(result, dict) else {}
+    if not usage.get("input_tokens"):
+        return
+
+    logger.info(
+        "b2b_blog_post_generation LLM tokens: in=%d out=%d",
+        usage["input_tokens"],
+        usage.get("output_tokens", 0),
+    )
+    from ...pipelines.llm import trace_llm_call
+
+    trace_meta = result.get("_trace_meta", {}) if isinstance(result, dict) else {}
+    response_text = (result.get("response", "") if isinstance(result, dict) else str(result)) or ""
+    trace_llm_call(
+        _BLOG_GENERATION_TRACE_SPAN,
+        input_tokens=usage["input_tokens"],
+        output_tokens=usage.get("output_tokens", 0),
+        cached_tokens=trace_meta.get("cached_tokens") or trace_meta.get("cache_read_tokens"),
+        cache_write_tokens=trace_meta.get("cache_write_tokens") or trace_meta.get("cache_creation_tokens"),
+        billable_input_tokens=trace_meta.get("billable_input_tokens"),
+        model=getattr(llm, "model", ""),
+        provider=getattr(llm, "name", ""),
+        input_data={
+            "messages": [
+                {
+                    "role": getattr(message, "role", ""),
+                    "content": str(getattr(message, "content", "") or "")[:500],
+                }
+                for message in messages
+            ]
+        },
+        output_data={"response": response_text[:2000]},
+        api_endpoint=trace_meta.get("api_endpoint"),
+        provider_request_id=trace_meta.get("provider_request_id"),
+        ttft_ms=trace_meta.get("ttft_ms"),
+        inference_time_ms=trace_meta.get("inference_time_ms"),
+        queue_time_ms=trace_meta.get("queue_time_ms"),
+        metadata=_blog_generation_trace_metadata(
+            blueprint,
+            run_id=run_id,
+        ),
+    )
+
+
+def _parse_blog_generation_response_text(
+    blueprint: PostBlueprint,
+    text: str | None,
+    *,
+    request_envelope: dict[str, Any],
+    provider_name: str,
+    model_name: str,
+    debug_result: Any | None = None,
+) -> dict[str, Any] | None:
+    from ...pipelines.llm import clean_llm_output, parse_json_response
+
+    logger.info("Blog LLM raw response length: %d chars", len(text or ""))
+    if not text:
+        logger.error("Blog LLM returned empty response for %s", blueprint.slug)
+        if debug_result is not None:
+            try:
+                with open("/tmp/blog_empty_response.txt", "w") as handle:
+                    handle.write(json.dumps(debug_result, indent=2, default=str)[:5000])
+            except Exception:
+                pass
+        return None
+
+    cleaned_text = clean_llm_output(text)
+    parsed = parse_json_response(cleaned_text, recover_truncated=True)
+    if parsed.get("_parse_fallback"):
+        logger.error(
+            "Failed to parse LLM response as JSON (text[:500]=%s)",
+            cleaned_text[:500],
+        )
+        try:
+            with open("/tmp/blog_llm_fail.txt", "w") as handle:
+                handle.write(
+                    f"PARSE FALLBACK\ntext_len={len(cleaned_text)}\ntext[:2000]={cleaned_text[:2000]}\n"
+                )
+        except Exception:
+            pass
+        return None
+
+    if not all(key in parsed for key in ("title", "description", "content")):
+        logger.error(
+            "LLM response missing required keys: %s (text[:300]=%s)",
+            list(parsed.keys()),
+            cleaned_text[:300],
+        )
+        return None
+
+    if "seo_title" not in parsed or not parsed["seo_title"]:
+        parsed["seo_title"] = parsed["title"][:60]
+    if "seo_description" not in parsed or not parsed["seo_description"]:
+        parsed["seo_description"] = parsed["description"][:155]
+    if "target_keyword" not in parsed:
+        parsed["target_keyword"] = ""
+    if "secondary_keywords" not in parsed:
+        parsed["secondary_keywords"] = []
+    if "faq" not in parsed or not isinstance(parsed["faq"], list):
+        parsed["faq"] = []
+
+    if blueprint.cta and parsed.get("cta_body"):
+        blueprint.cta["body"] = str(parsed["cta_body"])[:200]
+
+    parsed["_cache_request_envelope"] = request_envelope
+    parsed["_cache_provider"] = provider_name
+    parsed["_cache_model"] = model_name
+    return parsed
+
+
+async def _generate_content_async(
+    llm, blueprint: PostBlueprint, max_tokens: int,
+    related_posts: list[dict[str, str]] | None = None,
+    quality_feedback: list[str] | None = None,
+    run_id: str | None = None,
+    pool: Any | None = None,
+    usage_out: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Single LLM call: blueprint in, {title, description, content} out."""
+    from ...services.b2b.cache_runner import lookup_b2b_exact_stage_text
+
+    prepared = _prepare_blog_generation_request(
+        llm,
+        blueprint,
+        max_tokens,
+        related_posts=related_posts,
+        quality_feedback=quality_feedback,
+    )
+    if prepared is None:
+        return None
+
+    request = prepared["request"]
+    messages = prepared["messages"]
+
+    try:
+        cached = await lookup_b2b_exact_stage_text(request, pool=pool)
+        if cached is not None:
+            if usage_out is not None:
+                usage_out.clear()
+                usage_out.update(
+                    {
+                        "input_tokens": 0,
+                        "billable_input_tokens": 0,
+                        "cached_tokens": 0,
+                        "cache_write_tokens": 0,
+                        "output_tokens": 0,
+                        "provider": str(cached.get("provider") or prepared["provider_name"]),
+                        "model": str(cached.get("model") or prepared["model_name"]),
+                    }
+                )
+            return _parse_blog_generation_response_text(
+                blueprint,
+                str(cached["response_text"] or ""),
+                request_envelope=prepared["request_envelope"],
+                provider_name=str(prepared["provider_name"]),
+                model_name=str(prepared["model_name"]),
+            )
+
+        result = await asyncio.to_thread(
+            llm.chat,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=float(settings.b2b_churn.blog_post_temperature),
+        )
+        if usage_out is not None:
+            usage = result.get("usage", {}) if isinstance(result, dict) else {}
+            trace_meta = result.get("_trace_meta", {}) if isinstance(result, dict) else {}
+            usage_out.clear()
+            usage_out.update(
+                {
+                    "input_tokens": int((usage or {}).get("input_tokens") or 0),
+                    "billable_input_tokens": int(
+                        (trace_meta or {}).get("billable_input_tokens")
+                        or (usage or {}).get("input_tokens")
+                        or 0
+                    ),
+                    "cached_tokens": int(
+                        (trace_meta or {}).get("cached_tokens")
+                        or (trace_meta or {}).get("cache_read_tokens")
+                        or 0
+                    ),
+                    "cache_write_tokens": int(
+                        (trace_meta or {}).get("cache_write_tokens")
+                        or (trace_meta or {}).get("cache_creation_tokens")
+                        or 0
+                    ),
+                    "output_tokens": int((usage or {}).get("output_tokens") or 0),
+                    "provider": str(getattr(llm, "name", "") or ""),
+                    "model": str(getattr(llm, "model", "") or ""),
+                    "provider_request_id": (
+                        str((trace_meta or {}).get("provider_request_id") or "") or None
+                    ),
+                }
+            )
+        _trace_blog_generation_call(
+            llm,
+            blueprint,
+            messages=messages,
+            result=result,
+            run_id=run_id,
+        )
+        text = result.get("response", "") if isinstance(result, dict) else str(result)
+        return _parse_blog_generation_response_text(
+            blueprint,
+            text,
+            request_envelope=prepared["request_envelope"],
+            provider_name=str(prepared["provider_name"]),
+            model_name=str(prepared["model_name"]),
+            debug_result=result,
+        )
+    except Exception:
+        logger.exception("LLM content generation failed")
+        return None
+
+
+def _generate_content(
+    llm, blueprint: PostBlueprint, max_tokens: int,
+    related_posts: list[dict[str, str]] | None = None,
+    quality_feedback: list[str] | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Sync wrapper retained for local/unit-test callers."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            _generate_content_async(
+                llm,
+                blueprint,
+                max_tokens,
+                related_posts=related_posts,
+                quality_feedback=quality_feedback,
+                run_id=run_id,
+            )
+        )
+    raise RuntimeError("Use _generate_content_async() from async contexts")
+
+
+# -- Stage 5: Assembly & Storage ----------------------------------
+
+
+async def _compute_related_slugs(
+    pool, current_slug: str, tags: list[str], limit: int = 4
+) -> list[str]:
+    """Find related blog posts by overlapping tags/category."""
+    if not tags:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT slug FROM blog_posts
+        WHERE slug != $1
+          AND status IN ('draft', 'published')
+          AND tags::jsonb ?| $2
+        ORDER BY created_at DESC
+        LIMIT $3
+        """,
+        current_slug, tags[:3], limit,
+    )
+    return [r["slug"] for r in rows]
+
+
+async def _fetch_related_for_linking(
+    pool, tags: list[str], current_slug: str = "", limit: int = 6
+) -> list[dict[str, str]]:
+    """Fetch published/draft posts with overlapping tags for internal linking."""
+    if not tags:
+        return []
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT slug, title FROM blog_posts
+            WHERE slug != $1
+              AND status IN ('draft', 'published')
+              AND tags::jsonb ?| $2
+            ORDER BY created_at DESC
+            LIMIT $3
+            """,
+            current_slug, tags[:3], limit,
+        )
+        return [{"slug": r["slug"], "title": r["title"]} for r in rows]
+    except Exception:
+        logger.debug("Failed to fetch related posts for linking", exc_info=True)
+        return []
+
+
+def _fallback_target_keyword(blueprint: PostBlueprint) -> str:
+    """Generate a deterministic target keyword when the LLM omits it."""
+    ctx = blueprint.data_context.get("topic_ctx") or blueprint.data_context
+    tt = blueprint.topic_type
+    vendor = str(ctx.get("vendor") or ctx.get("vendor_a") or ctx.get("from_vendor") or "").strip()
+    vendor_b = str(ctx.get("vendor_b") or "").strip()
+    category = str(ctx.get("category") or "").strip()
+    kw_map = {
+        "vendor_showdown": f"{vendor} vs {vendor_b}".strip(),
+        "vendor_alternative": f"{vendor} alternatives".strip(),
+        "churn_report": f"{vendor} churn rate".strip(),
+        "pricing_reality_check": f"{vendor} pricing".strip(),
+        "migration_guide": f"switch to {vendor}".strip(),
+        "switching_story": f"why teams leave {vendor}".strip(),
+        "vendor_deep_dive": f"{vendor} reviews".strip(),
+        "market_landscape": f"{category} software comparison".strip(),
+        "pain_point_roundup": f"{category} software complaints".strip(),
+        "best_fit_guide": (
+            f"best {category} tools for {ctx.get('company_size', '').replace('_', ' ')}".strip()
+            if ctx.get("company_size") and ctx["company_size"] != "unknown"
+            else f"best {category} tools".strip()
+        ),
+    }
+    return kw_map.get(tt, vendor).lower() or blueprint.slug.replace("-", " ")[:50]
+
+
+def _fallback_seo_title(display_title: str, blueprint: PostBlueprint) -> str:
+    """Generate a deterministic SEO title when the LLM omits it."""
+    kw = _fallback_target_keyword(blueprint)
+    year = date.today().year
+    candidate = f"{kw.title()} {year}"
+    if len(candidate) <= 60:
+        return candidate
+    return display_title[:60]
+
+
+async def _upsert_blog_post_state(
+    pool,
+    blueprint: PostBlueprint,
+    llm,
+    *,
+    status: str,
+    run_id: str | None = None,
+    attempt_no: int | None = None,
+    score: int | None = None,
+    threshold: int | None = None,
+    blocker_count: int = 0,
+    warning_count: int = 0,
+    failure_step: str | None = None,
+    error_code: str | None = None,
+    error_summary: str | None = None,
+    rejection_reason: str | None = None,
+    content: dict[str, Any] | None = None,
+) -> str:
+    """Upsert the canonical blog row so failures/rejections do not vanish."""
+    _attach_blog_blueprint_runtime_metadata(blueprint)
+    charts_json = [asdict(c) for c in blueprint.charts]
+    model_name = getattr(llm, "model_name", None) or getattr(llm, "model", "unknown")
+    title = (content or {}).get("title") or blueprint.suggested_title
+    description = (content or {}).get("description", "")
+    body = (content or {}).get("content", "")
+    source_report_date = blueprint.data_context.get("source_report_date") or date.today()
+    row = await pool.fetchrow(
+        """
+        INSERT INTO blog_posts (
+            slug, title, description, topic_type, tags,
+            content, charts, data_context, status, llm_model, source_report_date,
+            seo_title, seo_description, target_keyword,
+            secondary_keywords, faq, cta,
+            latest_run_id, latest_attempt_no, latest_failure_step,
+            latest_error_code, latest_error_summary,
+            quality_score, quality_threshold, blocker_count, warning_count,
+            rejected_at, rejection_reason
+        ) VALUES (
+            $1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8::jsonb, $9, $10, $11,
+            $12, $13, $14, $15::jsonb, $16::jsonb, $17::jsonb,
+            $18, $19, $20, $21, $22, $23, $24, $25, $26,
+            CASE WHEN $9 = 'rejected' THEN NOW() ELSE NULL END,
+            CASE WHEN $9 = 'rejected' THEN $27 ELSE NULL END
+        )
+        ON CONFLICT (slug) DO UPDATE SET
+            title = EXCLUDED.title,
+            description = EXCLUDED.description,
+            topic_type = EXCLUDED.topic_type,
+            tags = EXCLUDED.tags,
+            content = EXCLUDED.content,
+            charts = EXCLUDED.charts,
+            data_context = EXCLUDED.data_context,
+            status = EXCLUDED.status,
+            llm_model = EXCLUDED.llm_model,
+            source_report_date = EXCLUDED.source_report_date,
+            seo_title = EXCLUDED.seo_title,
+            seo_description = EXCLUDED.seo_description,
+            target_keyword = EXCLUDED.target_keyword,
+            secondary_keywords = EXCLUDED.secondary_keywords,
+            faq = EXCLUDED.faq,
+            cta = EXCLUDED.cta,
+            latest_run_id = EXCLUDED.latest_run_id,
+            latest_attempt_no = EXCLUDED.latest_attempt_no,
+            latest_failure_step = EXCLUDED.latest_failure_step,
+            latest_error_code = EXCLUDED.latest_error_code,
+            latest_error_summary = EXCLUDED.latest_error_summary,
+            quality_score = EXCLUDED.quality_score,
+            quality_threshold = EXCLUDED.quality_threshold,
+            blocker_count = EXCLUDED.blocker_count,
+            warning_count = EXCLUDED.warning_count,
+            rejected_at = EXCLUDED.rejected_at,
+            rejection_reason = EXCLUDED.rejection_reason,
+            rejection_count = CASE
+                WHEN EXCLUDED.status = 'rejected'
+                THEN COALESCE(blog_posts.rejection_count, 0) + 1
+                ELSE 0
+            END,
+            published_at = CASE
+                WHEN EXCLUDED.status = 'published' THEN COALESCE(blog_posts.published_at, NOW())
+                ELSE blog_posts.published_at
+            END
+        WHERE blog_posts.status != 'published'
+        RETURNING id
+        """,
+        blueprint.slug,
+        title,
+        description,
+        blueprint.topic_type,
+        json.dumps(blueprint.tags),
+        body,
+        json.dumps(charts_json, default=str),
+        json.dumps(blueprint.data_context, default=str),
+        status,
+        str(model_name),
+        source_report_date,
+        (content or {}).get("seo_title") or _fallback_seo_title(title, blueprint),
+        (content or {}).get("seo_description") or description[:155],
+        (content or {}).get("target_keyword") or _fallback_target_keyword(blueprint),
+        json.dumps((content or {}).get("secondary_keywords", []), default=str),
+        json.dumps((content or {}).get("faq", []), default=str),
+        json.dumps(blueprint.cta, default=str) if blueprint.cta else None,
+        run_id,
+        attempt_no,
+        failure_step,
+        error_code,
+        error_summary,
+        score,
+        threshold,
+        blocker_count,
+        warning_count,
+        rejection_reason,
+    )
+    return str(row["id"]) if row else ""
+
+
+async def _assemble_and_store(
+    pool,
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    llm,
+    *,
+    run_id: str | None = None,
+    attempt_no: int | None = None,
+) -> str:
+    """Store the assembled post as a draft in blog_posts."""
+    from ...services.blog_quality import blog_quality_summary
+
+    charts_json = [asdict(c) for c in blueprint.charts]
+    quality = blog_quality_summary(blueprint.data_context)
+    post_id = await _upsert_blog_post_state(
+        pool,
+        blueprint,
+        llm,
+        status="draft",
+        run_id=run_id,
+        attempt_no=attempt_no,
+        score=quality.get("score"),
+        threshold=quality.get("threshold"),
+        blocker_count=len(quality.get("blocking_issues", []) or []),
+        warning_count=len(quality.get("warnings", []) or []),
+        content=content,
+    )
+    if not post_id:
+        logger.warning(
+            "Skipped overwrite of published post: slug=%s", blueprint.slug
+        )
+        return ""
+    logger.info("Stored B2B blog draft: slug=%s, id=%s", blueprint.slug, post_id)
+
+    # Compute related posts (same category/vendor overlap)
+    related: list[str] = []
+    try:
+        related = await _compute_related_slugs(pool, blueprint.slug, blueprint.tags)
+        if related:
+            await pool.execute(
+                "UPDATE blog_posts SET related_slugs = $1 WHERE id = $2",
+                json.dumps(related), post_id,
+            )
+    except Exception:
+        logger.debug("Related slug computation skipped", exc_info=True)
+
+    # Write .ts file for the frontend if ui_path is configured
+    cfg = settings.b2b_churn
+    if cfg.blog_post_ui_path:
+        try:
+            _write_ui_post(
+                cfg.blog_post_ui_path,
+                blueprint,
+                content,
+                charts_json,
+                related_slugs=related,
+            )
+        except Exception:
+            logger.warning("Failed to write B2B blog UI file", exc_info=True)
+        else:
+            try:
+                from ._blog_deploy import auto_deploy_blog
+                await auto_deploy_blog(
+                    cfg.blog_post_ui_path,
+                    blueprint.slug,
+                    enabled=cfg.blog_auto_deploy_enabled,
+                    branch=cfg.blog_auto_deploy_branch,
+                    hook_url=cfg.blog_auto_deploy_hook_url,
+                )
+            except Exception:
+                logger.warning("B2B blog auto-deploy failed", exc_info=True)
+
+    return post_id
+
+
+def _write_ui_post(
+    ui_path: str,
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    charts_json: list[dict[str, Any]],
+    related_slugs: list[str] | None = None,
+) -> None:
+    """Write a .ts post file and register it in index.ts."""
+    from pathlib import Path
+    from ._blog_ts import build_post_ts, update_blog_index
+
+    blog_dir = Path(ui_path)
+    if not blog_dir.is_dir():
+        logger.warning("blog_post_ui_path does not exist: %s", ui_path)
+        return
+
+    slug = blueprint.slug
+    var_name, ts_content = build_post_ts(
+        slug=slug,
+        title=content["title"],
+        description=content.get("description", ""),
+        date_str=date.today().isoformat(),
+        author="Churn Signals Team",
+        tags=blueprint.tags,
+        topic_type=blueprint.topic_type,
+        charts_json=charts_json,
+        content=content["content"],
+        data_context=blueprint.data_context,
+        seo_title=content.get("seo_title", ""),
+        seo_description=content.get("seo_description", ""),
+        target_keyword=content.get("target_keyword", ""),
+        secondary_keywords=content.get("secondary_keywords"),
+        faq=content.get("faq"),
+        related_slugs=related_slugs,
+        cta=blueprint.cta,
+    )
+
+    post_path = blog_dir / (slug + ".ts")
+    post_path.write_text(ts_content, encoding="utf-8")
+    logger.info("Wrote B2B blog UI file: %s", post_path)
+
+    update_blog_index(blog_dir / "index.ts", slug, var_name)
+
+
+# -- Manual generation helpers ------------------------------------
+
+_KNOWN_TOPIC_TYPES = {
+    "vendor_alternative", "vendor_showdown", "churn_report",
+    "migration_guide", "vendor_deep_dive", "market_landscape",
+    "pricing_reality_check", "switching_story", "pain_point_roundup",
+    "best_fit_guide",
+}
+
+
+async def _fetch_vendor_stats(pool, vendor_name: str) -> dict[str, Any]:
+    """Return review counts and urgency for a single vendor."""
+    # APPROVED-ENRICHMENT-READ: urgency_score
+    # Reason: inline aggregate query, structurally coupled to product output
+    row = await pool.fetchrow(
+        """
+        SELECT
+            COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE r.enrichment_status = 'enriched') AS enriched,
+            COUNT(*) FILTER (WHERE r.rating IS NOT NULL AND r.rating < 3) AS negative,
+            ROUND(AVG(
+                CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]'
+                     THEN (r.enrichment->>'urgency_score')::numeric ELSE NULL END
+            )::numeric, 1) AS avg_urgency,
+            MODE() WITHIN GROUP (ORDER BY r.product_category) AS category
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE LOWER(vm.vendor_name) = LOWER($1)
+          AND r.duplicate_of_review_id IS NULL
+        """,
+        vendor_name,
+    )
+    if not row or row["total"] == 0:
+        return {}
+    return {
+        "total": row["total"],
+        "enriched": row["enriched"],
+        "negative": row["negative"],
+        "avg_urgency": float(row["avg_urgency"]) if row["avg_urgency"] else 0,
+        "category": row["category"] or "",
+    }
+
+
+async def _fetch_category_topic_stats(pool, category: str) -> dict[str, Any]:
+    sources = _blog_source_allowlist()
+    row = await pool.fetchrow(
+        """
+        SELECT
+            COUNT(DISTINCT vm.vendor_name) AS vendor_count,
+            COUNT(DISTINCT r.id) FILTER (WHERE r.enrichment_status = 'enriched') AS enriched_reviews,
+            ROUND(AVG(
+                CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]'
+                     THEN (r.enrichment->>'urgency_score')::numeric ELSE NULL END
+            )::numeric, 1) AS avg_urgency
+        FROM b2b_reviews r
+        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+        WHERE r.product_category = $1
+          AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($2)
+        """,
+        category,
+        sources,
+    )
+    dominant_size = await pool.fetchval(
+        """
+        SELECT MODE() WITHIN GROUP (
+            ORDER BY COALESCE(
+                (
+                    SELECT key
+                    FROM jsonb_each_text(COALESCE(pp.typical_company_size, '{}'::jsonb))
+                    ORDER BY value::numeric DESC
+                    LIMIT 1
+                ),
+                'unknown'
+            )
+        ) AS dominant_size
+        FROM b2b_product_profiles pp
+        WHERE pp.product_category = $1
+        """,
+        category,
+    )
+    return {
+        "vendor_count": int(row["vendor_count"] or 0) if row else 0,
+        "enriched_reviews": int(row["enriched_reviews"] or 0) if row else 0,
+        "avg_urgency": float(row["avg_urgency"]) if row and row["avg_urgency"] else 0.0,
+        "dominant_size": str(dominant_size or "unknown"),
+    }
+
+
+async def build_manual_topic_ctx(
+    pool,
+    vendor_name: str,
+    topic_type: str,
+    vendor_b: str | None = None,
+    category: str | None = None,
+    company_size: str | None = None,
+) -> dict[str, Any]:
+    """Construct topic_ctx for a manually requested blog post.
+
+    Bypasses _select_topic() dedup -- always builds context even if a post
+    for this vendor+month already exists.
+    """
+    month_suffix = date.today().strftime("%Y-%m")
+    stats = await _fetch_vendor_stats(pool, vendor_name)
+    if not category:
+        category = stats.get("category", "software") or "software"
+    category_stats = await _fetch_category_topic_stats(pool, category)
+
+    ctx: dict[str, Any] = {
+        "category": category,
+    }
+
+    if topic_type == "vendor_showdown":
+        if not vendor_b:
+            raise ValueError("vendor_showdown requires vendor_b")
+        stats_b = await _fetch_vendor_stats(pool, vendor_b)
+        slug = f"{_slugify(vendor_name)}-vs-{_slugify(vendor_b)}-{month_suffix}"
+        ctx.update({
+            "vendor_a": vendor_name,
+            "vendor_b": vendor_b,
+            "reviews_a": stats.get("total", 0),
+            "reviews_b": stats_b.get("total", 0),
+            "total_reviews": stats.get("total", 0) + stats_b.get("total", 0),
+            "urgency_a": stats.get("avg_urgency", 0),
+            "urgency_b": stats_b.get("avg_urgency", 0),
+            "pain_diff": abs(stats.get("avg_urgency", 0) - stats_b.get("avg_urgency", 0)),
+            "slug": slug,
+        })
+    elif topic_type == "switching_story":
+        slug = f"why-teams-leave-{_slugify(vendor_name)}-{month_suffix}"
+        ctx.update({
+            "from_vendor": vendor_name,
+            "total_reviews": stats.get("total", 0),
+            "high_urgency_count": stats.get("negative", 0),
+            "switch_mentions": 0,
+            "avg_urgency": stats.get("avg_urgency", 0),
+            "slug": slug,
+        })
+    elif topic_type == "market_landscape":
+        slug = f"{_slugify(category)}-landscape-{month_suffix}"
+        ctx.update({
+            "vendor_count": category_stats.get("vendor_count", 0),
+            "total_reviews": category_stats.get("enriched_reviews", 0),
+            "avg_urgency": category_stats.get("avg_urgency", 0),
+            "slug": slug,
+        })
+    elif topic_type == "pain_point_roundup":
+        slug = f"top-complaint-every-{_slugify(category)}-{month_suffix}"
+        ctx.update({
+            "vendor_count": category_stats.get("vendor_count", 0),
+            "total_complaints": category_stats.get("enriched_reviews", 0),
+            "avg_urgency": category_stats.get("avg_urgency", 0),
+            "slug": slug,
+        })
+    elif topic_type == "best_fit_guide":
+        size = (
+            company_size
+            or category_stats.get("dominant_size")
+            or ctx.get("company_size")
+            or "teams"
+        )
+        slug = f"best-{_slugify(category)}-for-{_slugify(size)}-{month_suffix}"
+        ctx.update({
+            "vendor_count": category_stats.get("vendor_count", 0),
+            "total_reviews": category_stats.get("enriched_reviews", 0),
+            "company_size": size,
+            "slug": slug,
+        })
+    elif topic_type == "pricing_reality_check":
+        slug = f"real-cost-of-{_slugify(vendor_name)}-{month_suffix}"
+        ctx.update({
+            "vendor": vendor_name,
+            "total_reviews": stats.get("total", 0),
+            "pricing_complaints": stats.get("negative", 0),
+            "avg_urgency": stats.get("avg_urgency", 0),
+            "slug": slug,
+        })
+    elif topic_type == "migration_guide":
+        slug = f"switch-to-{_slugify(vendor_name)}-{month_suffix}"
+        ctx.update({
+            "vendor": vendor_name,
+            "switch_count": 0,
+            "review_total": stats.get("total", 0),
+            "slug": slug,
+        })
+    elif topic_type == "vendor_alternative":
+        slug = f"{_slugify(vendor_name)}-alternatives-{month_suffix}"
+        ctx.update({
+            "vendor": vendor_name,
+            "urgency": stats.get("avg_urgency", 0),
+            "review_count": stats.get("total", 0),
+            "has_affiliate": False,
+            "affiliate_id": None,
+            "affiliate_name": None,
+            "affiliate_product": None,
+            "affiliate_url": None,
+            "slug": slug,
+        })
+    elif topic_type == "churn_report":
+        slug = f"{_slugify(vendor_name)}-churn-report-{month_suffix}"
+        ctx.update({
+            "vendor": vendor_name,
+            "negative_reviews": stats.get("negative", 0),
+            "avg_urgency": stats.get("avg_urgency", 0),
+            "total_reviews": stats.get("total", 0),
+            "slug": slug,
+        })
+    elif topic_type == "vendor_deep_dive":
+        slug = f"{_slugify(vendor_name)}-deep-dive-{month_suffix}"
+        ctx.update({
+            "vendor": vendor_name,
+            "review_count": stats.get("total", 0),
+            "profile_richness": 0,
+            "slug": slug,
+        })
+    else:
+        raise ValueError(f"Unknown topic_type: {topic_type}")
+
+    return ctx

--- a/extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py
@@ -1,0 +1,5979 @@
+"""
+B2B ABM Campaign Generation: uses Claude (draft LLM) to produce personalized
+outreach content -- cold emails, LinkedIn messages, follow-up emails -- from
+the highest-scoring churn intelligence opportunities.
+
+Runs daily after b2b_churn_intelligence. Reads enriched b2b_reviews, scores
+opportunities, groups by company, and generates multi-channel campaigns.
+
+Returns _skip_synthesis.
+"""
+
+import asyncio
+import json
+import logging
+import re
+import uuid as _uuid
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...services.b2b.account_opportunity_claims import (
+    account_opportunity_source_review_count,
+    build_account_opportunity_claim,
+    serialize_product_claim,
+)
+from ...services.campaign_reasoning_context import (
+    campaign_reasoning_atom_context as _shared_campaign_reasoning_atom_context,
+    campaign_reasoning_delta_summary as _shared_campaign_reasoning_delta_summary,
+    campaign_reasoning_scope_summary as _shared_campaign_reasoning_scope_summary,
+)
+from ...services.campaign_quality import campaign_quality_revalidation
+from ...services.vendor_target_selection import dedupe_vendor_target_rows
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+from ..visibility import emit_event, record_attempt
+from ._execution_progress import task_run_id as _task_run_id
+from ._campaign_sequence_context import prepare_sequence_storage_contexts
+from ._b2b_specificity import (
+    campaign_proof_terms_from_audit,
+    merge_specificity_contexts,
+    specificity_audit_snapshot,
+    surface_specificity_context,
+)
+from ._b2b_shared import (
+    _battle_card_company_is_display_safe,
+    _review_vendor_association_join,
+)
+from .b2b_vendor_briefing import build_gate_url
+from .campaign_audit import log_campaign_event
+
+logger = logging.getLogger("atlas.autonomous.tasks.b2b_campaign_generation")
+
+# ---------------------------------------------------------------------------
+# Input sanitization
+# ---------------------------------------------------------------------------
+
+_PLACEHOLDER_NAMES = frozenset({
+    "john smith", "jane doe", "john doe", "jane smith",
+    "test user", "test contact", "sample contact",
+    "first last", "name here",
+})
+
+
+def _sanitize_contact_name(name: str | None) -> str | None:
+    """Return None for placeholder/seed contact names."""
+    if not name:
+        return None
+    if name.strip().lower() in _PLACEHOLDER_NAMES:
+        return None
+    return name.strip()
+
+
+def _build_selling_context(
+    *,
+    sender_name: str,
+    sender_title: str,
+    sender_company: str,
+    booking_url: str = "",
+    product_name: str = "",
+    affiliate_url: str = "",
+    primary_blog_post: dict[str, Any] | None = None,
+    blog_posts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build selling context without hard-coded fallbacks."""
+    selling = {
+        "sender_name": sender_name,
+        "sender_title": sender_title,
+        "sender_company": sender_company,
+    }
+    if booking_url:
+        selling["booking_url"] = booking_url
+    if product_name:
+        selling["product_name"] = product_name
+    if affiliate_url:
+        selling["affiliate_url"] = affiliate_url
+    if primary_blog_post:
+        selling["primary_blog_post"] = primary_blog_post
+    if blog_posts:
+        selling["blog_posts"] = blog_posts
+    return selling
+
+
+# ---------------------------------------------------------------------------
+# Post-generation validation
+# ---------------------------------------------------------------------------
+
+_MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_MD_ITALIC_RE = re.compile(r"(?<!\w)\*([^*]+)\*(?!\w)")
+_MD_HEADING_RE = re.compile(r"^#{1,3}\s+", re.MULTILINE)
+_MD_LIST_RE = re.compile(r"^[-*]\s+", re.MULTILINE)
+_PLACEHOLDER_RE = re.compile(r"\[(?:Name|Company|Your Name|First Name|Title)\]|\{\{.+?\}\}")
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_REPORT_TIER_BANNED = re.compile(
+    r"\b(dashboard|live feed|free trial|software|platform)\b", re.IGNORECASE,
+)
+# Words that trigger spam filters when used in subject lines.
+_SUBJECT_SPAM_TRIGGERS = re.compile(
+    r"\b(urgent|urgency|high.urgency|act now|limited time|don't miss"
+    r"|last chance|exclusive offer|free|risk.free|guaranteed"
+    r"|congratulations|winner|alert|warning|immediate)\b",
+    re.IGNORECASE,
+)
+_SIGNOFF_RE = re.compile(r"<p>\s*(best|thanks|regards|sincerely|cheers)\s*,?\s*(<br>|</p>)", re.IGNORECASE)
+
+
+def _ensure_html(body: str) -> str:
+    """Convert markdown artifacts to minimal HTML."""
+    # Bold: **text** -> <strong>text</strong>
+    body = _MD_BOLD_RE.sub(r"<strong>\1</strong>", body)
+    # Italic: *text* -> <em>text</em>
+    body = _MD_ITALIC_RE.sub(r"<em>\1</em>", body)
+    # Strip markdown headings
+    body = _MD_HEADING_RE.sub("", body)
+    # Strip markdown list markers
+    body = _MD_LIST_RE.sub("", body)
+
+    # Wrap in <p> tags if missing
+    if "<p>" not in body.lower():
+        paragraphs = [p.strip() for p in body.split("\n\n") if p.strip()]
+        if not paragraphs:
+            # Single block -- split on double newline or treat as one paragraph
+            lines = [ln.strip() for ln in body.strip().splitlines() if ln.strip()]
+            if len(lines) > 1:
+                paragraphs = lines
+            else:
+                paragraphs = [body.strip()]
+        body = "".join(f"<p>{p}</p>" for p in paragraphs)
+
+    return body
+
+
+def _truncate_to_limit(body: str, max_words: int) -> str:
+    """Truncate body to max_words at the nearest sentence/paragraph boundary."""
+    plain = _HTML_TAG_RE.sub(" ", body)
+    words = plain.split()
+    if len(words) <= max_words:
+        return body
+
+    # Strategy 1: split on </p>, accumulate whole paragraphs
+    parts = re.split(r"(</p>)", body)
+    result = []
+    word_count = 0
+    for part in parts:
+        part_plain = _HTML_TAG_RE.sub(" ", part).strip()
+        part_words = len(part_plain.split()) if part_plain else 0
+        if word_count + part_words > max_words and result:
+            break
+        result.append(part)
+        word_count += part_words
+
+    truncated = "".join(result)
+
+    # Strategy 2: if still over (single giant paragraph), hard-truncate
+    truncated_plain = _HTML_TAG_RE.sub(" ", truncated)
+    if len(truncated_plain.split()) > max_words:
+        # Take first max_words from the plain text, find last sentence end
+        kept_words = plain.split()[:max_words]
+        kept_text = " ".join(kept_words)
+        # Try to cut at last period
+        last_period = kept_text.rfind(". ")
+        if last_period > len(kept_text) // 2:
+            kept_text = kept_text[: last_period + 1]
+        truncated = f"<p>{kept_text}</p>"
+
+    # Ensure we close any open <p> tag
+    if truncated.count("<p>") > truncated.count("</p>"):
+        truncated += "</p>"
+    return truncated if truncated.strip() else body
+
+
+def _campaign_word_limits(
+    *,
+    channel: str,
+    target_mode: str | None,
+) -> tuple[int, int] | None:
+    raw_limits = settings.b2b_campaign.word_limits
+    if not isinstance(raw_limits, dict):
+        return None
+    normalized_mode = str(target_mode or "").strip().lower()
+    mode_limits = raw_limits.get(normalized_mode)
+    if not isinstance(mode_limits, dict):
+        mode_limits = raw_limits.get("default")
+    if not isinstance(mode_limits, dict):
+        return None
+    resolved = mode_limits.get(str(channel or "").strip())
+    if not isinstance(resolved, list) or len(resolved) != 2:
+        return None
+    try:
+        min_words = int(resolved[0])
+        max_words = int(resolved[1])
+    except (TypeError, ValueError):
+        return None
+    if min_words < 0 or max_words < min_words:
+        return None
+    return min_words, max_words
+
+
+def _append_signoff(body: str, payload: dict[str, Any]) -> str:
+    """Append a deterministic sender sign-off when the model omits one."""
+    if _SIGNOFF_RE.search(body):
+        return body
+    selling = payload.get("selling") or {}
+    sender_name = str(selling.get("sender_name") or "").strip()
+    sender_title = str(selling.get("sender_title") or "").strip()
+    sender_company = str(selling.get("sender_company") or "").strip()
+    if not sender_name and not sender_company:
+        return body
+    if not sender_name and sender_company:
+        sender_name = f"{sender_company} team"
+    lines = ["Best,", sender_name]
+    if sender_title and sender_company:
+        lines.append(f"{sender_title}, {sender_company}")
+    elif sender_title:
+        lines.append(sender_title)
+    elif sender_company and sender_company.lower() not in sender_name.lower():
+        lines.append(sender_company)
+    return f"{body}<p>{'<br>'.join(lines)}</p>"
+
+
+def _validate_campaign_content(
+    parsed: dict[str, Any],
+    channel: str,
+    tier: str = "",
+    target_mode: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Validate and fix campaign content. Returns (fixed_content, issues_dict)."""
+    issues: dict[str, Any] = {}
+
+    # Required fields
+    for field in ("subject", "body", "cta"):
+        if not parsed.get(field) or not isinstance(parsed[field], str):
+            issues["missing_field"] = field
+            return parsed, issues
+
+    subject = parsed["subject"].strip()
+    body = parsed["body"].strip()
+    cta = parsed["cta"].strip()
+
+    # Subject spam trigger words: flag for LLM retry
+    spam_match = _SUBJECT_SPAM_TRIGGERS.search(subject)
+    if spam_match:
+        issues["subject_spam_trigger"] = spam_match.group()
+
+    # Subject length: truncate at word boundary if over 60 chars
+    if len(subject) > 60:
+        words = subject.split()
+        truncated = []
+        for w in words:
+            candidate = " ".join(truncated + [w])
+            if len(candidate) > 57:
+                break
+            truncated.append(w)
+        subject = " ".join(truncated)
+
+    # HTML enforcement
+    body = _ensure_html(body)
+
+    # Placeholder detection
+    if _PLACEHOLDER_RE.search(body):
+        issues["placeholders"] = True
+        return parsed, issues
+
+    # Word count
+    limits = _campaign_word_limits(channel=channel, target_mode=target_mode)
+    if limits:
+        plain = _HTML_TAG_RE.sub(" ", body)
+        wc = len(plain.split())
+        min_words, max_words = limits
+        if wc < min_words:
+            issues["word_count"] = wc
+            issues["min_words"] = min_words
+        elif wc > max_words:
+            issues["word_count"] = wc
+            issues["max_words"] = max_words
+            # Apply truncation as fallback (caller may retry first)
+            body = _truncate_to_limit(body, max_words)
+
+    # Report-tier banned words: strip from body + cta
+    if tier == "report":
+        for text_field in (body, cta):
+            if _REPORT_TIER_BANNED.search(text_field):
+                issues["report_tier_violation"] = True
+                break
+        # Auto-fix: replace banned phrases
+        body = _REPORT_TIER_BANNED.sub("intelligence brief", body)
+        cta = _REPORT_TIER_BANNED.sub("brief", cta)
+
+    parsed = {**parsed, "subject": subject, "body": body, "cta": cta}
+    return parsed, issues
+
+
+def _campaign_artifact_key(
+    *,
+    company_name: str,
+    batch_id: str | None,
+    channel: str,
+) -> str:
+    company = str(company_name or "").strip() or "unknown_company"
+    batch = str(batch_id or "").strip() or "no_batch"
+    ch = str(channel or "").strip() or "unknown_channel"
+    return f"{batch}:{company}:{ch}"
+
+
+def _campaign_specificity_context(payload: dict[str, Any]) -> dict[str, Any]:
+    direct = surface_specificity_context(
+        payload,
+        surface="campaign",
+        nested_keys=("briefing_context",),
+    )
+    company_context = payload.get("company_context")
+    nested = surface_specificity_context(
+        company_context,
+        surface="campaign",
+        nested_keys=("briefing_context",),
+    ) if isinstance(company_context, dict) else {}
+    return merge_specificity_contexts(direct, nested)
+
+
+def _inject_reasoning_campaign_context(
+    target: dict[str, Any],
+    consumer_context: dict[str, Any] | None,
+) -> None:
+    if not isinstance(target, dict) or not isinstance(consumer_context, dict):
+        return
+    anchors = consumer_context.get("anchor_examples")
+    if isinstance(anchors, dict) and anchors:
+        target["reasoning_anchor_examples"] = anchors
+    highlights = consumer_context.get("witness_highlights")
+    if isinstance(highlights, list) and highlights:
+        target["reasoning_witness_highlights"] = highlights
+    reference_ids = consumer_context.get("reference_ids")
+    if isinstance(reference_ids, dict) and reference_ids:
+        target["reasoning_reference_ids"] = reference_ids
+    scope_summary = _campaign_reasoning_scope_summary(
+        consumer_context.get("scope_manifest"),
+    )
+    if scope_summary:
+        target["reasoning_scope_summary"] = scope_summary
+    atom_context = _campaign_reasoning_atom_context(consumer_context)
+    if atom_context:
+        target["reasoning_atom_context"] = atom_context
+    delta_summary = _campaign_reasoning_delta_summary(
+        consumer_context.get("reasoning_delta"),
+    )
+    if delta_summary:
+        target["reasoning_delta_summary"] = delta_summary
+    disclaimers = consumer_context.get("reasoning_section_disclaimers")
+    if isinstance(disclaimers, dict) and disclaimers:
+        target["reasoning_section_disclaimers"] = disclaimers
+
+
+def _campaign_reasoning_scope_summary(scope_manifest: dict[str, Any] | None) -> dict[str, Any]:
+    return _shared_campaign_reasoning_scope_summary(scope_manifest)
+
+
+def _campaign_reasoning_atom_context(consumer_context: dict[str, Any] | None) -> dict[str, Any]:
+    return _shared_campaign_reasoning_atom_context(consumer_context)
+
+
+def _campaign_reasoning_delta_summary(reasoning_delta: dict[str, Any] | None) -> dict[str, Any]:
+    return _shared_campaign_reasoning_delta_summary(reasoning_delta)
+
+
+def _campaign_specificity_audit(
+    *,
+    body: str,
+    channel: str,
+    specificity_context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    context = specificity_context if isinstance(specificity_context, dict) else {}
+    return specificity_audit_snapshot(
+        body,
+        anchor_examples=context.get("anchor_examples"),
+        witness_highlights=context.get("witness_highlights"),
+        reference_ids=context.get("reference_ids"),
+        allow_company_names=False,
+        min_anchor_hits=int(settings.b2b_campaign.specificity_min_anchor_hits),
+        require_anchor_support=bool(
+            settings.b2b_campaign.specificity_require_anchor_support
+        ),
+        require_timing_or_numeric_when_available=bool(
+            settings.b2b_campaign.specificity_require_timing_or_numeric_when_available
+        ),
+        include_competitor_terms=channel != "email_cold",
+    )
+
+
+def _campaign_specificity_terms(
+    specificity: dict[str, Any] | None,
+    *,
+    channel: str,
+) -> list[str]:
+    return campaign_proof_terms_from_audit(
+        specificity,
+        channel=channel,
+        limit=int(settings.b2b_campaign.specificity_revision_term_limit),
+    )
+
+
+def _campaign_specificity_revision(
+    *,
+    channel: str,
+    specificity: dict[str, Any] | None,
+) -> str:
+    lines = [
+        "REVISION REQUIRED: The previous body failed the witness-backed specificity gate.",
+    ]
+    exact_terms = _campaign_specificity_terms(specificity, channel=channel)
+    blocking_issues = [
+        str(issue).strip().lower()
+        for issue in (specificity or {}).get("blocking_issues", [])
+        if str(issue or "").strip()
+    ]
+    if any("timing or numeric anchor" in issue for issue in blocking_issues):
+        if exact_terms:
+            lines.append(
+                "Rewrite the body so it explicitly mentions at least one of these exact numeric or timing details: "
+                + "; ".join(exact_terms)
+                + "."
+            )
+        else:
+            lines.append(
+                "Rewrite the body so it explicitly mentions a concrete numeric or timing anchor from the provided witness-backed context."
+            )
+    elif exact_terms:
+        lines.append(
+            "Rewrite the body so it explicitly uses at least one of these exact witness-backed proof terms: "
+            + "; ".join(exact_terms)
+            + "."
+        )
+    else:
+        lines.append(
+            "Rewrite the body so it explicitly uses a concrete witness-backed proof anchor instead of aggregate summary language."
+        )
+    if any(issue.startswith("report_tier_language:") for issue in blocking_issues):
+        lines.append(
+            "Remove dashboard, live feed, free trial, software, and platform language from report-tier copy."
+        )
+    if channel == "email_cold":
+        if any(issue.startswith("incumbent_name_in_email_cold:") for issue in blocking_issues):
+            lines.append("Do not name incumbents in the cold email.")
+        else:
+            lines.append("Do not name competitors in the cold email.")
+    lines.append("Do not reveal private account names or review sources.")
+    return " ".join(lines)
+
+
+def _campaign_storage_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    revalidation = payload.get("_campaign_revalidation")
+    if isinstance(revalidation, dict):
+        merged_metadata = revalidation.get("metadata")
+        if isinstance(merged_metadata, dict):
+            metadata.update(merged_metadata)
+    if not metadata:
+        tier = str(payload.get("tier") or "").strip()
+        if tier:
+            metadata["tier"] = tier
+        specificity_context = payload.get("_campaign_specificity_context")
+        if isinstance(specificity_context, dict):
+            if specificity_context.get("anchor_examples"):
+                metadata["reasoning_anchor_examples"] = specificity_context["anchor_examples"]
+            if specificity_context.get("witness_highlights"):
+                metadata["reasoning_witness_highlights"] = specificity_context["witness_highlights"]
+            if specificity_context.get("reference_ids"):
+                metadata["reasoning_reference_ids"] = specificity_context["reference_ids"]
+        proof_terms = payload.get("campaign_proof_terms")
+        if isinstance(proof_terms, list) and proof_terms:
+            metadata["campaign_proof_terms"] = [
+                str(term or "").strip()
+                for term in proof_terms
+                if str(term or "").strip()
+            ]
+    opportunity_claim = payload.get("opportunity_claim")
+    if isinstance(opportunity_claim, dict) and opportunity_claim:
+        metadata["opportunity_claim"] = opportunity_claim
+        metadata["opportunity_claim_gate"] = {
+            "claim_id": opportunity_claim.get("claim_id"),
+            "render_allowed": opportunity_claim.get("render_allowed"),
+            "report_allowed": opportunity_claim.get("report_allowed"),
+            "confidence": opportunity_claim.get("confidence"),
+            "evidence_posture": opportunity_claim.get("evidence_posture"),
+            "suppression_reason": opportunity_claim.get("suppression_reason"),
+        }
+    opportunity_claims = [
+        claim
+        for claim in payload.get("opportunity_claims") or []
+        if isinstance(claim, dict) and claim
+    ]
+    if opportunity_claims:
+        metadata["opportunity_claims"] = opportunity_claims[:20]
+    generation_audit = payload.get("_generation_audit")
+    if isinstance(generation_audit, dict) and generation_audit:
+        metadata["generation_audit"] = generation_audit
+        specificity = generation_audit.get("specificity")
+        if isinstance(specificity, dict) and specificity:
+            metadata["latest_specificity_audit"] = {
+                **specificity,
+                "boundary": "generation",
+            }
+    return metadata
+
+
+def _campaign_payload_has_report_safe_product_claim(payload: dict[str, Any]) -> bool:
+    """Replay/persistence guard for already-fetched campaign payloads."""
+    saw_claim_context = False
+
+    claim = payload.get("opportunity_claim")
+    if isinstance(claim, dict):
+        saw_claim_context = True
+        if claim.get("report_allowed") is not True:
+            return False
+
+    claims = [
+        item
+        for item in payload.get("opportunity_claims") or []
+        if isinstance(item, dict)
+    ]
+    if claims:
+        saw_claim_context = True
+        if not all(item.get("report_allowed") is True for item in claims):
+            return False
+
+    gate = payload.get("opportunity_claim_gate")
+    if isinstance(gate, dict):
+        saw_claim_context = True
+        if gate.get("report_allowed") is not True:
+            return False
+
+    return saw_claim_context
+
+
+async def _record_campaign_generation_failure(
+    pool,
+    *,
+    artifact_id: str,
+    company_name: str,
+    channel: str,
+    generation_audit: dict[str, Any] | None,
+) -> None:
+    audit = generation_audit if isinstance(generation_audit, dict) else {}
+    specificity = audit.get("specificity") if isinstance(audit.get("specificity"), dict) else {}
+    blocking_issues = list(specificity.get("blocking_issues") or [])
+    warnings = list(specificity.get("warnings") or [])
+    failure_reason = str(audit.get("failure_reason") or "generation_failed")
+    await record_attempt(
+        pool,
+        artifact_type="campaign",
+        artifact_id=artifact_id,
+        attempt_no=1,
+        stage="generation",
+        status="failed",
+        blocker_count=len(blocking_issues),
+        warning_count=len(warnings),
+        blocking_issues=blocking_issues,
+        warnings=warnings,
+        failure_step="generation",
+        error_message=failure_reason,
+    )
+    await emit_event(
+        pool,
+        stage="campaign_generation",
+        event_type="generation_failure",
+        entity_type="campaign",
+        entity_id=artifact_id,
+        summary=f"Campaign generation failed for {company_name} / {channel}",
+        severity="warning",
+        actionable=True,
+        artifact_type="campaign",
+        reason_code=failure_reason[:80],
+        detail=audit,
+    )
+
+# Reuse scoring constants from b2b_affiliates
+_ROLE_SCORES = {
+    "decision_maker": 20,
+    "economic_buyer": 15,
+    "champion": 15,
+    "evaluator": 10,
+}
+
+_STAGE_SCORES = {
+    "active_purchase": 25,
+    "evaluation": 20,
+    "renewal_decision": 15,
+    "post_purchase": 5,
+}
+
+_CONTEXT_SCORES = {
+    "considering": 10,
+    "switched_to": 8,
+    "compared": 6,
+    "switched_from": 2,
+}
+
+
+def _safe_float(val, default=None):
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _parse_json_object_field(val: Any) -> dict[str, Any]:
+    """Safely parse a JSONB field that may be a str, dict, or None."""
+    if isinstance(val, dict):
+        return val
+    if isinstance(val, str):
+        try:
+            parsed = json.loads(val)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _dedupe_texts(values: list[str], max_items: int) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        marker = text.lower()
+        if marker in seen:
+            continue
+        seen.add(marker)
+        deduped.append(text)
+        if len(deduped) >= max_items:
+            break
+    return deduped
+
+
+_CAMPAIGN_PAIN_SEVERITY_RANK = {
+    "critical": 5,
+    "high": 4,
+    "primary": 4,
+    "medium": 3,
+    "secondary": 3,
+    "low": 2,
+    "minor": 2,
+    "mentioned": 1,
+    "": 0,
+}
+
+
+def _campaign_stable_row_order(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        rows,
+        key=lambda row: (
+            str(row.get("review_id") or ""),
+            json.dumps(row, sort_keys=True, separators=(",", ":"), default=str),
+        ),
+    )
+
+
+def _campaign_sorted_count_rows(
+    counts: dict[str, int],
+    *,
+    field_name: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    return [
+        {field_name: key, "count": value}
+        for key, value in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], str(item[0]).lower(), str(item[0])),
+        )[:limit]
+    ]
+
+
+def _campaign_sorted_count_keys(counts: dict[str, int], *, limit: int) -> list[str]:
+    return [
+        key
+        for key, _value in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], str(item[0]).lower(), str(item[0])),
+        )[:limit]
+    ]
+
+
+def _campaign_merge_pain_severity(existing: str, incoming: str) -> str:
+    current = str(existing or "").strip().lower()
+    candidate = str(incoming or "").strip().lower()
+    if _CAMPAIGN_PAIN_SEVERITY_RANK.get(candidate, 0) >= _CAMPAIGN_PAIN_SEVERITY_RANK.get(current, 0):
+        return candidate or current
+    return current
+
+
+def _briefing_text_list(
+    items: Any, *, keys: tuple[str, ...], max_items: int = 5,
+) -> list[str]:
+    values: list[str] = []
+    if not isinstance(items, list):
+        return values
+    for item in items:
+        if isinstance(item, str):
+            values.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        for key in keys:
+            text = str(item.get(key) or "").strip()
+            if text:
+                values.append(text)
+                break
+    return _dedupe_texts(values, max_items)
+
+
+def _briefing_context_from_data(briefing_data: Any) -> dict[str, Any]:
+    """Extract a compact campaign-safe summary from persisted vendor briefings."""
+    briefing = _parse_json_object_field(briefing_data)
+    if not briefing:
+        return {}
+
+    context: dict[str, Any] = {}
+    for field in (
+        "account_pressure_summary",
+        "timing_summary",
+        "segment_targeting_summary",
+        "trend",
+        "category",
+    ):
+        text = str(briefing.get(field) or "").strip()
+        if text:
+            context[field] = text
+
+    summary = str(
+        briefing.get("executive_summary")
+        or briefing.get("headline")
+        or briefing.get("profile_summary")
+        or ""
+    ).strip()
+    if summary:
+        context["executive_summary"] = summary
+
+    account_names = _briefing_text_list(
+        briefing.get("priority_account_names") or briefing.get("named_accounts"),
+        keys=("account_name", "company_name", "name", "company"),
+    )
+    if account_names:
+        context["priority_account_names"] = account_names
+
+    displacement = _briefing_text_list(
+        briefing.get("top_displacement_targets"),
+        keys=("name", "vendor", "opponent"),
+    )
+    if displacement:
+        context["top_displacement_targets"] = displacement
+
+    feature_gaps = _briefing_text_list(
+        briefing.get("top_feature_gaps"),
+        keys=("feature", "name", "gap"),
+    )
+    if feature_gaps:
+        context["top_feature_gaps"] = feature_gaps
+
+    pain_labels = _briefing_text_list(
+        briefing.get("pain_labels") or briefing.get("pain_breakdown"),
+        keys=("label", "category", "pain_category"),
+    )
+    if pain_labels:
+        context["pain_labels"] = pain_labels
+
+    # account pressure metrics from b2b_account_intelligence
+    acct_metrics = briefing.get("account_pressure_metrics")
+    if isinstance(acct_metrics, dict):
+        high_intent = int(acct_metrics.get("high_intent_count") or 0)
+        active_eval = int(acct_metrics.get("active_eval_signal_count") or 0)
+        if high_intent:
+            context["account_high_intent_count"] = high_intent
+        if active_eval:
+            context["account_active_eval_count"] = active_eval
+
+    # timing triggers from b2b_temporal_intelligence
+    triggers = _briefing_text_list(
+        briefing.get("priority_timing_triggers"),
+        keys=("trigger", "label", "text"),
+        max_items=3,
+    )
+    if triggers:
+        context["priority_timing_triggers"] = triggers
+
+    # top buyer profiles (role + stage + urgency)
+    raw_profiles = [
+        p for p in (briefing.get("buyer_profiles") or []) if isinstance(p, dict)
+    ]
+    if raw_profiles:
+        context["top_buyer_profiles"] = [
+            {
+                "role_type": str(p.get("role_type") or ""),
+                "buying_stage": str(p.get("buying_stage") or ""),
+                "avg_urgency": float(p.get("avg_urgency") or 0),
+            }
+            for p in raw_profiles[:2]
+        ]
+
+    # competitive dynamics from b2b_displacement_dynamics
+    comp_dyn = briefing.get("competitive_dynamics")
+    if isinstance(comp_dyn, dict):
+        raw_pairs = [
+            p for p in (comp_dyn.get("pairs") or []) if isinstance(p, dict)
+        ]
+        if raw_pairs:
+            context["competitive_dynamics"] = [
+                {
+                    "challenger": str(p.get("challenger") or ""),
+                    "battle_summary": str(p.get("battle_summary") or "")[:300],
+                    "switch_reasons": [
+                        r.get("reason") or r.get("reason_category") or str(r)
+                        if isinstance(r, dict)
+                        else str(r)
+                        for r in (p.get("switch_reasons") or [])[:3]
+                        if r
+                    ],
+                }
+                for p in raw_pairs[:2]
+            ]
+
+    # pain urgency enrichment from pain_points overlay
+    pain_with_urgency = [
+        p for p in (briefing.get("pain_breakdown") or [])
+        if isinstance(p, dict) and p.get("avg_urgency")
+    ]
+    if pain_with_urgency:
+        context["pain_urgency"] = [
+            {
+                "category": str(
+                    p.get("category") or p.get("pain_category") or ""
+                ),
+                "avg_urgency": float(p.get("avg_urgency") or 0),
+            }
+            for p in pain_with_urgency[:4]
+        ]
+
+    specificity = surface_specificity_context(briefing, surface="campaign")
+    if specificity.get("anchor_examples"):
+        context["reasoning_anchor_examples"] = specificity["anchor_examples"]
+    if specificity.get("witness_highlights"):
+        context["reasoning_witness_highlights"] = specificity["witness_highlights"]
+    if specificity.get("reference_ids"):
+        context["reasoning_reference_ids"] = specificity["reference_ids"]
+
+    return context
+
+
+def _campaign_account_summary_from_consumer_context(
+    consumer_context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(consumer_context, dict):
+        return {}
+
+    contracts = consumer_context.get("reasoning_contracts") or {}
+    if isinstance(contracts, dict):
+        account_reasoning = contracts.get("account_reasoning") or {}
+        if isinstance(account_reasoning, dict):
+            summary = str(account_reasoning.get("market_summary") or "").strip()
+            if summary:
+                payload = {
+                    "account_summary": summary,
+                    "account_summary_source": "account_reasoning",
+                }
+                disclaimer = str(
+                    account_reasoning.get("account_actionability_note")
+                    or account_reasoning.get("disclaimer")
+                    or ""
+                ).strip()
+                if disclaimer:
+                    payload["account_summary_disclaimer"] = disclaimer
+                actionability_tier = str(
+                    account_reasoning.get("account_actionability_tier") or ""
+                ).strip()
+                if actionability_tier:
+                    payload["account_actionability_tier"] = actionability_tier
+                return payload
+
+    preview = consumer_context.get("account_reasoning_preview") or {}
+    if not isinstance(preview, dict):
+        return {}
+
+    summary = str(preview.get("account_pressure_summary") or "").strip()
+    if not summary:
+        return {}
+
+    payload = {
+        "account_summary": summary,
+        "account_summary_source": "account_reasoning_preview",
+    }
+    disclaimer = str(preview.get("disclaimer") or "").strip()
+    if disclaimer:
+        payload["account_summary_disclaimer"] = disclaimer
+    actionability_tier = str(preview.get("account_actionability_tier") or "").strip()
+    if actionability_tier:
+        payload["account_actionability_tier"] = actionability_tier
+
+    priority_names = preview.get("priority_account_names") or []
+    if isinstance(priority_names, list):
+        cleaned = [str(item or "").strip() for item in priority_names if str(item or "").strip()]
+        if cleaned:
+            payload["priority_account_names"] = cleaned[:3]
+    return payload
+
+
+_CAMPAIGN_WORD_RE = re.compile(r"[a-z0-9]+")
+_COMPARISON_TOPIC_TYPES = {
+    "vendor_showdown",
+    "vendor_alternative",
+    "migration_guide",
+    "switching_story",
+    "best_fit_guide",
+    "vendor_deep_dive",
+}
+
+
+def _campaign_tokenize_text(value: str) -> list[str]:
+    return _CAMPAIGN_WORD_RE.findall((value or "").lower())
+
+
+def _campaign_text_matches_term(text: str, term: str) -> bool:
+    hay = _campaign_tokenize_text(text)
+    needle = _campaign_tokenize_text(term)
+    if not hay or not needle:
+        return False
+    if len(needle) == 1:
+        return needle[0] in hay
+    for idx in range(0, len(hay) - len(needle) + 1):
+        if hay[idx:idx + len(needle)] == needle:
+            return True
+    return False
+
+
+def _comparison_candidates_from_context(context: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for item in context.get("recommended_alternatives") or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("vendor_name") or "").strip()
+        if not name or name.lower() in seen:
+            continue
+        seen.add(name.lower())
+        candidates.append({
+            "vendor_name": name,
+            "source": "recommended_alternative",
+            "selection_reason": str(item.get("reasoning") or item.get("profile_summary") or "").strip(),
+        })
+
+    for item in context.get("competitors_considering") or []:
+        if isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            reason = str(item.get("reason") or "").strip()
+        else:
+            name = str(item or "").strip()
+            reason = ""
+        if not name or name.lower() in seen:
+            continue
+        seen.add(name.lower())
+        candidates.append({
+            "vendor_name": name,
+            "source": "competitor_considering",
+            "selection_reason": reason,
+        })
+
+    return candidates
+
+
+def _prioritize_blog_posts_for_context(
+    blog_posts: list[dict[str, Any]],
+    *,
+    incumbent_vendor: str,
+    candidates: list[dict[str, Any]],
+    pain_terms: list[str],
+) -> list[dict[str, Any]]:
+    scored: list[tuple[int, int, dict[str, Any]]] = []
+    primary_vendor = str((candidates[0] or {}).get("vendor_name") or "").strip() if candidates else ""
+
+    for idx, post in enumerate(blog_posts or []):
+        if not isinstance(post, dict):
+            continue
+        text = " ".join(
+            str(post.get(field) or "").strip()
+            for field in ("title", "url", "topic_type")
+        )
+        score = 0
+        primary_vendor_match = bool(primary_vendor and _campaign_text_matches_term(text, primary_vendor))
+        incumbent_vendor_match = bool(incumbent_vendor and _campaign_text_matches_term(text, incumbent_vendor))
+        pain_match = any(_campaign_text_matches_term(text, term) for term in pain_terms)
+        if primary_vendor_match:
+            score += 6
+        if incumbent_vendor_match:
+            score += 4
+        if (
+            str(post.get("topic_type") or "").strip() in _COMPARISON_TOPIC_TYPES
+            and (primary_vendor_match or incumbent_vendor_match or pain_match)
+        ):
+            score += 3
+        if pain_match:
+            score += 2
+        if score <= 0:
+            continue
+        scored.append((score, -idx, post))
+
+    scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [post for _, _, post in scored]
+
+
+def _build_comparison_asset(
+    context: dict[str, Any],
+    blog_posts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    company_name = str(context.get("company") or "").strip()
+    incumbent_vendor = str(context.get("churning_from") or "").strip()
+    pain_terms = [
+        str(item.get("category") or "").strip()
+        for item in context.get("pain_categories") or []
+        if isinstance(item, dict) and str(item.get("category") or "").strip()
+    ]
+    candidates = _comparison_candidates_from_context(context)
+    ranked_posts = _prioritize_blog_posts_for_context(
+        blog_posts,
+        incumbent_vendor=incumbent_vendor,
+        candidates=candidates,
+        pain_terms=pain_terms,
+    )
+    primary_candidate = candidates[0] if candidates else {}
+    primary_post = ranked_posts[0] if ranked_posts else None
+    company_safe = _battle_card_company_is_display_safe(
+        company_name,
+        current_vendor=incumbent_vendor,
+        role=context.get("role_type") or context.get("reviewer_title"),
+        company_size=context.get("company_size") or context.get("seat_count"),
+        buying_stage=context.get("buying_stage") or context.get("decision_timeline"),
+    )
+    reasons = []
+    if company_safe:
+        reasons.append("named_company")
+    if pain_terms:
+        reasons.append("pain_signal")
+    if primary_candidate.get("vendor_name"):
+        reasons.append("comparison_vendor")
+    if primary_post:
+        reasons.append("blog_asset")
+
+    return {
+        "qualified": bool(company_safe and pain_terms and primary_candidate.get("vendor_name") and primary_post),
+        "qualification_reasons": reasons,
+        "company_safe": company_safe,
+        "incumbent_vendor": incumbent_vendor,
+        "alternative_vendor": primary_candidate.get("vendor_name"),
+        "selection_source": primary_candidate.get("source"),
+        "selection_reason": primary_candidate.get("selection_reason"),
+        "pain_categories": pain_terms[:3],
+        "primary_blog_post": primary_post,
+        "supporting_blog_posts": ranked_posts[:3],
+    }
+
+
+def _evaluate_outbound_qualification(
+    comparison_asset: dict[str, Any],
+    *,
+    require_display_safe_company: bool,
+    require_primary_blog_post: bool,
+    min_pain_categories: int,
+) -> dict[str, Any]:
+    pain_categories = [
+        str(item).strip()
+        for item in comparison_asset.get("pain_categories") or []
+        if str(item).strip()
+    ]
+    checks = [
+        ("display_safe_company", (not require_display_safe_company) or bool(comparison_asset.get("company_safe"))),
+        ("pain_categories", len(pain_categories) >= min_pain_categories),
+        ("alternative_vendor", bool(comparison_asset.get("alternative_vendor"))),
+        ("primary_blog_post", (not require_primary_blog_post) or bool(comparison_asset.get("primary_blog_post"))),
+    ]
+    passed_checks = [name for name, passed in checks if passed]
+    missing_checks = [name for name, passed in checks if not passed]
+    return {
+        "qualified": not missing_checks,
+        "passed_checks": passed_checks,
+        "missing_checks": missing_checks,
+        "pain_category_count": len(pain_categories),
+    }
+
+
+async def _prepare_churning_company_context(
+    pool,
+    *,
+    best: dict[str, Any],
+    opps: list[dict[str, Any]],
+    partner_index: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    cfg = settings.b2b_campaign
+    base_context = _build_company_context(best, opps)
+    base_context["opportunity_source"] = best.get("opportunity_source")
+
+    try:
+        from ...services.b2b.product_matching import match_products
+
+        matches = await match_products(
+            churning_from=best["vendor_name"],
+            pain_categories=base_context["pain_categories"],
+            company_size=best.get("seat_count"),
+            industry=best.get("industry"),
+            pool=pool,
+            limit=3,
+        )
+        if matches:
+            has_explicit_alternatives = bool(base_context.get("competitors_considering"))
+            if best.get("opportunity_source") == "accounts_in_motion" and has_explicit_alternatives:
+                base_context["supplemental_recommended_alternatives"] = matches
+            else:
+                base_context["recommended_alternatives"] = matches
+    except Exception:
+        logger.debug("Product matching unavailable, continuing without recommendations")
+
+    pains = [
+        item["category"]
+        for item in base_context.get("pain_categories", [])
+        if item.get("category")
+    ]
+    alternatives = [
+        item.get("vendor_name")
+        for item in base_context.get("recommended_alternatives", [])
+        if isinstance(item, dict) and item.get("vendor_name")
+    ]
+    if not alternatives:
+        alternatives = [
+            item.get("name") or item
+            for item in base_context.get("competitors_considering", [])
+            if (item.get("name") if isinstance(item, dict) else item)
+        ]
+
+    blog_posts = await _fetch_blog_posts(
+        pool,
+        pipeline="b2b",
+        vendor_name=base_context.get("churning_from"),
+        category=base_context.get("category"),
+        pain_categories=pains or None,
+        alternative_vendors=alternatives[:3] or None,
+        include_drafts=True,
+    )
+    comparison_asset = _build_comparison_asset(base_context, blog_posts)
+    qualification = _evaluate_outbound_qualification(
+        comparison_asset,
+        require_display_safe_company=cfg.require_display_safe_company,
+        require_primary_blog_post=cfg.require_primary_blog_post,
+        min_pain_categories=cfg.min_pain_categories,
+    )
+    comparison_asset["qualified"] = qualification["qualified"]
+    comparison_asset["qualification_reasons"] = qualification["passed_checks"]
+    comparison_asset["missing_requirements"] = qualification["missing_checks"]
+    comparison_asset["qualification_details"] = qualification
+    base_context["comparison_asset"] = comparison_asset
+
+    ordered_blog_posts = comparison_asset.get("supporting_blog_posts") or blog_posts
+    primary_blog_post = comparison_asset.get("primary_blog_post")
+    partner = _match_partner(base_context, partner_index) if partner_index else None
+    return {
+        "base_context": base_context,
+        "qualification": qualification,
+        "primary_blog_post": primary_blog_post,
+        "ordered_blog_posts": ordered_blog_posts,
+        "partner": partner,
+    }
+
+
+from ._blog_matching import fetch_relevant_blog_posts as _fetch_blog_posts
+
+
+# ---------------------------------------------------------------------------
+# Calibration weight cache
+# ---------------------------------------------------------------------------
+
+import time as _time
+
+_calibration_cache: dict[str, dict[str, float]] = {}
+_calibration_cache_ts: float = 0.0
+_CALIBRATION_CACHE_TTL = 3600  # 1 hour
+
+
+def _get_calibration_adjustments() -> dict[str, dict[str, float]]:
+    """Return cached calibration adjustments {dimension: {value: adjustment}}.
+
+    Returns empty dict if cache is stale or not loaded (caller uses static defaults).
+    Cache is populated by _load_calibration_weights() which must be awaited separately.
+    """
+    global _calibration_cache, _calibration_cache_ts
+    if _time.monotonic() - _calibration_cache_ts > _CALIBRATION_CACHE_TTL:
+        return {}
+    return _calibration_cache
+
+
+async def load_calibration_weights() -> bool:
+    """Load latest calibration weights from DB into module cache.
+
+    Called at the start of generate_campaigns(). Returns True if weights were loaded.
+    """
+    global _calibration_cache, _calibration_cache_ts
+    try:
+        pool = get_db_pool()
+        if not pool.is_initialized:
+            return False
+
+        latest_version = await pool.fetchval(
+            "SELECT MAX(model_version) FROM score_calibration_weights"
+        )
+        if latest_version is None:
+            return False
+
+        rows = await pool.fetch(
+            """
+            SELECT dimension, dimension_value, weight_adjustment
+            FROM score_calibration_weights
+            WHERE model_version = $1
+            """,
+            latest_version,
+        )
+
+        cache: dict[str, dict[str, float]] = {}
+        for r in rows:
+            dim = r["dimension"]
+            if dim not in cache:
+                cache[dim] = {}
+            cache[dim][r["dimension_value"]] = float(r["weight_adjustment"])
+
+        _calibration_cache = cache
+        _calibration_cache_ts = _time.monotonic()
+        return True
+    except Exception:
+        logger.debug("Could not load calibration weights", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _compute_score(row: dict) -> tuple[int, dict]:
+    """Compute opportunity score (0-100) from enrichment signals.
+
+    Blends static defaults with calibration adjustments when available.
+    Calibration adjustments are additive point shifts derived from observed
+    outcome conversion rates (see b2b_score_calibration.py).
+
+    Returns (final_score, components_dict) so callers can persist the breakdown.
+    """
+    cal = _get_calibration_adjustments()
+    score = 0.0
+
+    # Urgency component (max 30 pts)
+    urgency = _safe_float(row.get("urgency"), 0)
+    urgency_pts = max(0, min(30, (urgency - 5) * 6))
+    if cal.get("urgency_bucket"):
+        bucket = "high" if urgency >= 8 else ("medium" if urgency >= 5 else "low")
+        urgency_pts += cal["urgency_bucket"].get(bucket, 0)
+    urgency_final = max(0, min(30, urgency_pts))
+    score += urgency_final
+
+    # Role component (max ~20 pts)
+    role_pts = 0.0
+    role_label = None
+    if row.get("is_dm"):
+        role_pts = 20
+        role_label = "decision_maker"
+        if cal.get("role_type"):
+            role_pts += cal["role_type"].get("decision_maker", 0)
+    elif row.get("role_type") in _ROLE_SCORES:
+        role_label = row["role_type"]
+        role_pts = _ROLE_SCORES[role_label]
+        if cal.get("role_type"):
+            role_pts += cal["role_type"].get(role_label, 0)
+    role_final = max(0, role_pts)
+    score += role_final
+
+    # Buying stage component (max ~25 pts)
+    buying_stage = row.get("buying_stage") or ""
+    stage_pts = _STAGE_SCORES.get(buying_stage, 0)
+    if cal.get("buying_stage"):
+        stage_pts += cal["buying_stage"].get(buying_stage, 0)
+    stage_final = max(0, stage_pts)
+    score += stage_final
+
+    # Seat count component (max ~15 pts)
+    seat_count = row.get("seat_count")
+    seat_pts = 0.0
+    seat_bucket = None
+    if seat_count is not None:
+        if seat_count >= 500:
+            seat_pts = 15
+            seat_bucket = "500+"
+        elif seat_count >= 100:
+            seat_pts = 10
+            seat_bucket = "100-499"
+        elif seat_count >= 20:
+            seat_pts = 5
+            seat_bucket = "20-99"
+        else:
+            seat_bucket = "small"
+        if cal.get("seat_bucket"):
+            seat_pts += cal["seat_bucket"].get(seat_bucket, 0)
+    seat_final = max(0, seat_pts)
+    score += seat_final
+
+    # Mention context component (max ~10 pts)
+    mention_context = (row.get("mention_context") or "").lower()
+    context_final = 0.0
+    context_keyword = None
+    for keyword, pts in _CONTEXT_SCORES.items():
+        if keyword in mention_context:
+            context_pts = pts
+            if cal.get("context_keyword"):
+                context_pts += cal["context_keyword"].get(keyword, 0)
+            context_final = max(0, context_pts)
+            context_keyword = keyword
+            break
+    score += context_final
+
+    final = int(min(100, max(0, score)))
+    components = {
+        "urgency": {"pts": round(urgency_final, 1), "raw": round(urgency, 1), "max": 30},
+        "role": {"pts": round(role_final, 1), "label": role_label, "max": 20},
+        "stage": {"pts": round(stage_final, 1), "label": buying_stage or None, "max": 25},
+        "seats": {"pts": round(seat_final, 1), "bucket": seat_bucket, "max": 15},
+        "context": {"pts": round(context_final, 1), "keyword": context_keyword, "max": 10},
+    }
+    return final, components
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: generate ABM campaigns from churn intelligence."""
+    cfg = settings.b2b_campaign
+    if not cfg.enabled:
+        return {"_skip_synthesis": "B2B campaign generation disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    result = await generate_campaigns(
+        pool=pool,
+        min_score=cfg.min_opportunity_score,
+        limit=cfg.max_campaigns_per_run,
+        target_mode=cfg.target_mode,
+        run_id=_task_run_id(task),
+        task=task,
+    )
+
+    # Send notification
+    if result.get("generated", 0) > 0:
+        from ...pipelines.notify import send_pipeline_notification
+
+        mode_label = result.get("target_mode", cfg.target_mode).replace("_", " ").title()
+        msg = (
+            f"[{mode_label}] Generated {result['generated']} campaign(s) for "
+            f"{result['companies']} company/companies. "
+            f"Review drafts in the lead engagement pipeline."
+        )
+        await send_pipeline_notification(
+            msg, task, title="Atlas: ABM Campaigns",
+            default_tags="briefcase,campaign",
+        )
+
+    return {"_skip_synthesis": "Campaign generation complete", **result}
+
+
+async def _create_sequence_for_cold_email(
+    pool,
+    *,
+    company_name: str,
+    batch_id: str,
+    partner_id: str | None,
+    context: dict[str, Any],
+    cold_email_subject: str,
+    cold_email_body: str,
+) -> _uuid.UUID | None:
+    """Create a campaign_sequences row and link the cold email to it.
+
+    Returns the sequence ID if created, None on conflict (already exists).
+    """
+    cfg = settings.campaign_sequence
+    compact_company_context, compact_selling_context = prepare_sequence_storage_contexts(
+        context,
+        context.get("selling", {}),
+    )
+
+    seq_id = await pool.fetchval(
+        """
+        INSERT INTO campaign_sequences (
+            company_name, batch_id, partner_id,
+            company_context, selling_context, max_steps
+        ) VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT ((LOWER(company_name)), batch_id) DO NOTHING
+        RETURNING id
+        """,
+        company_name,
+        batch_id,
+        _uuid.UUID(partner_id) if partner_id else None,
+        json.dumps(compact_company_context, default=str),
+        json.dumps(compact_selling_context, default=str),
+        cfg.max_steps,
+    )
+
+    if not seq_id:
+        logger.debug("Sequence already exists for %s / %s", company_name, batch_id)
+        return None
+
+    # Link the cold email campaign row to this sequence
+    await pool.execute(
+        """
+        UPDATE b2b_campaigns
+        SET sequence_id = $1, step_number = 1
+        WHERE company_name = $2 AND batch_id = $3 AND channel = 'email_cold'
+        """,
+        seq_id,
+        company_name,
+        batch_id,
+    )
+
+    # Audit log
+    await log_campaign_event(
+        pool,
+        event_type="generated",
+        sequence_id=seq_id,
+        step_number=1,
+        source="system",
+        subject=cold_email_subject,
+        body=cold_email_body,
+    )
+
+    # Best-effort CRM recipient lookup (only for churning_company mode where
+    # company_name is a person/company name; vendor/challenger modes set
+    # recipient_email from the target contact directly after this function).
+    # Skip when target_persona is set -- persona sequences rely on the
+    # prospect_matching task for differentiated recipient assignment.
+    has_persona = context.get("target_persona") is not None
+    if partner_id and not has_persona:
+        try:
+            contact_email = await pool.fetchval(
+                """
+                SELECT email FROM contacts
+                WHERE LOWER(full_name) LIKE '%' || LOWER($1) || '%'
+                  AND email IS NOT NULL
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                company_name,
+            )
+            if contact_email:
+                await pool.execute(
+                    "UPDATE campaign_sequences SET recipient_email = $1 WHERE id = $2",
+                    contact_email,
+                    seq_id,
+                )
+                logger.info(
+                    "Auto-populated recipient %s for sequence %s (%s)",
+                    contact_email, seq_id, company_name,
+                )
+        except Exception:
+            logger.warning("CRM recipient lookup failed for %s, skipping", company_name)
+
+    logger.info("Created campaign sequence %s for %s (batch %s)", seq_id, company_name, batch_id)
+    return seq_id
+
+
+async def generate_campaigns(
+    pool,
+    min_score: int = 70,
+    limit: int = 20,
+    vendor_filter: str | None = None,
+    company_filter: str | None = None,
+    target_mode: str | None = None,
+    force: bool = False,
+    ignore_recent_dedup: bool = False,
+    ignore_briefing_gate: bool = False,
+    run_id: str | None = None,
+    task: ScheduledTask | Any | None = None,
+) -> dict[str, Any]:
+    """Core generation logic, shared by autonomous task and manual API trigger.
+
+    Dispatches to the appropriate generation path based on target_mode:
+      - churning_company: original behavior (outreach to the churning company)
+      - vendor_retention: sell churn intelligence to the vendor losing customers
+      - challenger_intel: sell intent leads to the challenger gaining customers
+    """
+    cfg = settings.b2b_campaign
+    mode = target_mode or cfg.target_mode
+    bypass_recent_dedup = force or ignore_recent_dedup
+    bypass_briefing_gate = force or ignore_briefing_gate
+
+    # Load calibration weights into cache (best-effort, falls back to static defaults)
+    await load_calibration_weights()
+
+    if mode == "vendor_retention":
+        return await _generate_vendor_campaigns(
+            pool, min_score, limit, vendor_filter, company_filter,
+            bypass_briefing_gate=bypass_briefing_gate,
+            bypass_recent_dedup=bypass_recent_dedup,
+            run_id=run_id,
+            task=task,
+        )
+    elif mode == "challenger_intel":
+        return await _generate_challenger_campaigns(
+            pool, min_score, limit, vendor_filter, company_filter,
+            bypass_briefing_gate=bypass_briefing_gate,
+            bypass_recent_dedup=bypass_recent_dedup,
+            run_id=run_id,
+            task=task,
+        )
+
+    # Default: churning_company (original behavior)
+    return await _generate_churning_company_campaigns(
+        pool, min_score, limit, vendor_filter, company_filter,
+        bypass_recent_dedup=bypass_recent_dedup,
+        run_id=run_id,
+        task=task,
+    )
+
+
+async def list_churning_company_review_candidates(
+    pool,
+    *,
+    min_score: int,
+    max_score: int,
+    limit: int,
+    vendor_filter: str | None = None,
+    company_filter: str | None = None,
+    qualified_only: bool = True,
+    ignore_recent_dedup: bool = False,
+) -> dict[str, Any]:
+    cfg = settings.b2b_campaign
+    fetched = await _fetch_accounts_in_motion_opportunities(
+        pool,
+        min_score=min_score,
+        limit=min(max(limit * 5, limit), 500),
+        vendor_filter=vendor_filter,
+        company_filter=company_filter,
+    )
+    by_company: dict[str, list[dict[str, Any]]] = {}
+    for row in fetched:
+        score = int(row.get("opportunity_score") or 0)
+        if score > max_score:
+            continue
+        company = str(row.get("reviewer_company") or "").strip()
+        if not company:
+            continue
+        by_company.setdefault(company.lower(), []).append(row)
+
+    partner_index = await _fetch_affiliate_partners(pool)
+    candidates: list[dict[str, Any]] = []
+    missing_requirements: dict[str, int] = {}
+    dedup_blocked = 0
+    evaluated = 0
+
+    for company_key, opps in by_company.items():
+        company_name = opps[0].get("reviewer_company") or opps[0]["vendor_name"]
+        recent_campaign_count = 0
+        if not ignore_recent_dedup:
+            recent_campaign_count = int(await pool.fetchval(
+                """
+                SELECT COUNT(*) FROM b2b_campaigns
+                WHERE LOWER(company_name) = $1
+                  AND created_at > NOW() - make_interval(days => $2)
+                """,
+                company_key, cfg.dedup_days,
+            ) or 0)
+        if recent_campaign_count > 0 and qualified_only:
+            dedup_blocked += 1
+            continue
+
+        best = max(opps, key=lambda item: item["opportunity_score"])
+        prepared = await _prepare_churning_company_context(
+            pool,
+            best=best,
+            opps=opps,
+            partner_index=partner_index,
+        )
+        evaluated += 1
+        qualification = prepared["qualification"]
+        for reason in qualification["missing_checks"]:
+            missing_requirements[reason] = missing_requirements.get(reason, 0) + 1
+        if qualified_only and not qualification["qualified"]:
+            continue
+
+        base_context = prepared["base_context"]
+        partner = prepared["partner"]
+        comparison_asset = base_context.get("comparison_asset") or {}
+        candidate = {
+            "company_name": company_name,
+            "vendor_name": best["vendor_name"],
+            "product_category": best.get("product_category"),
+            "opportunity_score": best["opportunity_score"],
+            "urgency_score": float(best.get("urgency") or 0),
+            "role_type": base_context.get("role_type"),
+            "reviewer_title": base_context.get("reviewer_title"),
+            "industry": base_context.get("industry"),
+            "company_size": base_context.get("company_size"),
+            "seat_count": best.get("seat_count"),
+            "buying_stage": best.get("buying_stage"),
+            "pain_categories": base_context.get("pain_categories") or [],
+            "key_quotes": base_context.get("key_quotes") or [],
+            "competitors_considering": base_context.get("competitors_considering") or [],
+            "reasoning_anchor_examples": base_context.get("reasoning_anchor_examples") or {},
+            "reasoning_witness_highlights": base_context.get("reasoning_witness_highlights") or [],
+            "reasoning_reference_ids": base_context.get("reasoning_reference_ids") or {},
+            "comparison_asset": comparison_asset,
+            "primary_blog_post": prepared["primary_blog_post"],
+            "supporting_blog_posts": prepared["ordered_blog_posts"],
+            "partner": (
+                {
+                    "id": partner["id"],
+                    "product_name": partner.get("product_name"),
+                    "affiliate_url": partner.get("affiliate_url"),
+                }
+                if partner else None
+            ),
+            "qualification": qualification,
+            "recent_campaign_count": recent_campaign_count,
+            "dedup_blocked": recent_campaign_count > 0,
+            "opportunity_source": best.get("opportunity_source") or "accounts_in_motion",
+            "generate_request": {
+                "target_mode": "churning_company",
+                "company_name": company_name,
+                "vendor_name": best["vendor_name"],
+                "min_score": best["opportunity_score"],
+                "limit": 1,
+                "force": False,
+            },
+        }
+        candidates.append(candidate)
+
+    candidates.sort(
+        key=lambda item: (item["opportunity_score"], item["urgency_score"]),
+        reverse=True,
+    )
+    visible = candidates[:limit]
+    return {
+        "count": len(visible),
+        "candidates": visible,
+        "summary": {
+            "min_score": min_score,
+            "max_score": max_score,
+            "qualified_only": qualified_only,
+            "ignore_recent_dedup": ignore_recent_dedup,
+            "evaluated": evaluated,
+            "qualified": sum(1 for item in candidates if item["qualification"]["qualified"]),
+            "unqualified": max(evaluated - sum(1 for item in candidates if item["qualification"]["qualified"]), 0),
+            "dedup_blocked": dedup_blocked,
+            "missing_requirements": missing_requirements,
+        },
+    }
+
+
+async def _generate_churning_company_campaigns(
+    pool,
+    min_score: int,
+    limit: int,
+    vendor_filter: str | None,
+    company_filter: str | None,
+    bypass_recent_dedup: bool = False,
+    run_id: str | None = None,
+    task: ScheduledTask | Any | None = None,
+) -> dict[str, Any]:
+    """Original generation path: outreach to the churning company."""
+    cfg = settings.b2b_campaign
+
+    # 1. Prefer named account opportunities, then fall back to review rows.
+    opportunities = await _fetch_accounts_in_motion_opportunities(
+        pool, min_score, limit,
+        vendor_filter=vendor_filter,
+        company_filter=company_filter,
+    )
+    opportunity_source = "accounts_in_motion"
+    if not opportunities:
+        opportunities = await _fetch_opportunities(
+            pool, min_score, limit,
+            vendor_filter=vendor_filter,
+            company_filter=company_filter,
+            dm_only=cfg.require_decision_maker,
+        )
+        opportunity_source = "reviews"
+
+    if not opportunities:
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0}
+
+    # 2. Group by company (one campaign set per company)
+    #    Skip opportunities with no reviewer_company -- we need a real target
+    by_company: dict[str, list[dict]] = {}
+    skipped_no_company = 0
+    for opp in opportunities:
+        company = opp.get("reviewer_company")
+        if not company:
+            skipped_no_company += 1
+            continue
+        key = company.lower()
+        if key not in by_company:
+            by_company[key] = []
+        by_company[key].append(opp)
+    if not by_company:
+        return {
+            "generated": 0,
+            "skipped": skipped_no_company,
+            "failed": 0,
+            "companies": 0,
+            "candidate_companies": 0,
+            "opportunity_source": opportunity_source,
+        }
+
+    # 3. Dedup: skip companies with recent campaigns
+    companies_to_process = []
+    for company_key, opps in by_company.items():
+        company_name = opps[0].get("reviewer_company") or opps[0]["vendor_name"]
+        if bypass_recent_dedup:
+            companies_to_process.append((company_name, opps))
+            continue
+        existing = await pool.fetchval(
+            """
+            SELECT COUNT(*) FROM b2b_campaigns
+            WHERE LOWER(company_name) = $1
+              AND created_at > NOW() - make_interval(days => $2)
+            """,
+            company_key, cfg.dedup_days,
+        )
+        if existing == 0:
+            companies_to_process.append((company_name, opps))
+
+    if not companies_to_process:
+        return {"generated": 0, "skipped": len(by_company), "failed": 0, "companies": 0}
+
+    # 4. Get LLM
+    from ...services.llm_router import get_llm
+    llm = get_llm("campaign")
+    if llm is None:
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    if llm is None:
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0, "error": "No LLM available"}
+
+    # 5. Load skill prompt
+    from ...skills import get_skill_registry
+    from ...services.protocols import Message
+
+    skill = get_skill_registry().get("digest/b2b_campaign_generation")
+    if not skill:
+        logger.warning("Skill 'digest/b2b_campaign_generation' not found")
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0, "error": "Skill not found"}
+
+    llm_model_name = getattr(llm, "model_id", None) or getattr(llm, "model", "unknown")
+    claimer = f"reconcile:{run_id or 'adhoc'}:{_uuid.uuid4().hex[:10]}"
+    batch_id = f"batch_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    generated = 0
+    failed = 0
+    deferred = 0
+    skipped_unqualified = 0
+    generated_without_partner = 0
+    sequences_created = 0
+    qualified_companies = 0
+    qualification_summary: dict[str, int] = {}
+
+    # Fetch affiliate partners for sender identity matching
+    partner_index = await _fetch_affiliate_partners(pool)
+
+    personas_skipped = 0
+    batch_metrics = {
+        "jobs": 0,
+        "submitted_items": 0,
+        "cache_prefiltered_items": 0,
+        "fallback_single_call_items": 0,
+        "completed_items": 0,
+        "failed_items": 0,
+    }
+
+    # --- Pre-qualification pass (sequential, fast) ---
+    qualified_units: list[dict[str, Any]] = []
+    for company_name, opps in companies_to_process:
+        best = max(opps, key=lambda o: o["opportunity_score"])
+        prepared = await _prepare_churning_company_context(
+            pool, best=best, opps=opps, partner_index=partner_index,
+        )
+        base_context = prepared["base_context"]
+        qualification = prepared["qualification"]
+        primary_blog_post = prepared["primary_blog_post"]
+        ordered_blog_posts = prepared["ordered_blog_posts"]
+        if not qualification["qualified"]:
+            skipped_unqualified += 1
+            for reason in qualification["missing_checks"]:
+                qualification_summary[reason] = qualification_summary.get(reason, 0) + 1
+            continue
+        qualified_companies += 1
+        partner = prepared["partner"]
+        partner_id: str | None = None
+        if partner:
+            base_context["selling"] = _build_selling_context(
+                sender_name=cfg.default_sender_name, sender_title=cfg.default_sender_title,
+                sender_company=cfg.default_sender_company,
+                product_name=partner["product_name"], affiliate_url=partner["affiliate_url"],
+                primary_blog_post=primary_blog_post, blog_posts=ordered_blog_posts,
+            )
+            partner_id = partner["id"]
+        else:
+            generated_without_partner += 1
+            base_context["selling"] = _build_selling_context(
+                sender_name=cfg.default_sender_name, sender_title=cfg.default_sender_title,
+                sender_company=cfg.default_sender_company,
+                primary_blog_post=primary_blog_post, blog_posts=ordered_blog_posts,
+            )
+        for persona in cfg.personas:
+            persona_context = _build_persona_context(base_context, persona)
+            if persona_context is None:
+                personas_skipped += 1
+                continue
+            qualified_units.append({
+                "company_name": company_name, "opps": opps, "best": best,
+                "persona": persona, "persona_context": persona_context,
+                "persona_batch_id": f"{batch_id}_{persona}", "partner_id": partner_id,
+            })
+
+    phase_one_entries: list[dict[str, Any]] = []
+    phase_one_channels = [channel for channel in cfg.channels if channel != "email_followup"]
+    for unit in qualified_units:
+        for channel in phase_one_channels:
+            payload = {
+                **unit["persona_context"],
+                "channel": channel,
+                "target_mode": "churning_company",
+            }
+            artifact_id = _campaign_artifact_key(
+                company_name=unit["company_name"],
+                batch_id=unit["persona_batch_id"],
+                channel=channel,
+            )
+            phase_one_entries.append(
+                {
+                    "custom_id": artifact_id,
+                    "artifact_id": artifact_id,
+                    "campaign_batch_id": unit["persona_batch_id"],
+                    "phase": "cold",
+                    "payload": payload,
+                    "channel": channel,
+                    "company_name": unit["company_name"],
+                    "persona": unit["persona"],
+                    "persona_batch_id": unit["persona_batch_id"],
+                    "persona_context": unit["persona_context"],
+                    "best": unit["best"],
+                    "review_ids": [o["review_id"] for o in unit["opps"] if o.get("review_id")][:20] or None,
+                    "partner_id": unit["partner_id"],
+                    "max_tokens": cfg.max_tokens,
+                    "temperature": cfg.temperature,
+                    "trace_metadata": _campaign_trace_metadata(
+                        payload,
+                        run_id=run_id,
+                        stage_id="b2b_campaign_generation.content",
+                    ),
+                }
+            )
+
+    phase_one_results, phase_one_batch = await _run_campaign_batch(
+        llm,
+        skill.content,
+        phase_one_entries,
+        run_id=run_id,
+        task=task,
+    )
+    _merge_batch_metrics(batch_metrics, phase_one_batch)
+
+    cold_email_by_unit: dict[tuple[str, str], dict[str, str]] = {}
+    for entry in phase_one_entries:
+        company_name = entry["company_name"]
+        persona = entry["persona"]
+        channel = entry["channel"]
+        payload = entry["payload"]
+        artifact_id = entry["artifact_id"]
+        content = phase_one_results.get(entry["custom_id"])
+        if _is_deferred_campaign_content(content):
+            await record_attempt(
+                pool,
+                artifact_type="campaign",
+                artifact_id=artifact_id,
+                attempt_no=1,
+                stage="generation",
+                status="queued",
+            )
+            deferred += 1
+            continue
+        if content:
+            metadata = _campaign_storage_metadata(payload)
+            generation_audit = (
+                payload.get("_generation_audit")
+                if isinstance(payload.get("_generation_audit"), dict)
+                else {}
+            )
+            specificity = (
+                generation_audit.get("specificity")
+                if isinstance(generation_audit.get("specificity"), dict)
+                else {}
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_campaigns (
+                        company_name, vendor_name, product_category,
+                        opportunity_score, urgency_score, pain_categories,
+                        competitors_considering, seat_count, contract_end,
+                        decision_timeline, buying_stage, role_type,
+                        key_quotes, source_review_ids,
+                        channel, subject, body, cta,
+                        status, batch_id, llm_model,
+                        partner_id, industry, target_mode, metadata,
+                        score_components
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23, $24, $25::jsonb,
+                        $26::jsonb
+                    )
+                    """,
+                    company_name,
+                    entry["best"]["vendor_name"],
+                    entry["best"].get("product_category"),
+                    entry["best"]["opportunity_score"],
+                    entry["best"].get("urgency"),
+                    json.dumps(entry["persona_context"].get("pain_categories", [])),
+                    json.dumps(entry["persona_context"].get("competitors_considering", [])),
+                    entry["best"].get("seat_count"),
+                    entry["best"].get("contract_end"),
+                    entry["best"].get("decision_timeline"),
+                    entry["best"].get("buying_stage"),
+                    entry["persona_context"].get("role_type"),
+                    json.dumps(entry["persona_context"].get("key_quotes", [])),
+                    entry["review_ids"],
+                    channel,
+                    content.get("subject", ""),
+                    content.get("body", ""),
+                    content.get("cta", ""),
+                    "draft",
+                    entry["persona_batch_id"],
+                    llm_model_name,
+                    _uuid.UUID(entry["partner_id"]) if entry["partner_id"] else None,
+                    entry["persona_context"].get("industry"),
+                    "churning_company",
+                    json.dumps(metadata, default=str),
+                    json.dumps(entry["best"].get("score_components")),
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="generation",
+                    status="succeeded",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                )
+                generated += 1
+                if channel == "email_cold":
+                    cold_email_by_unit[(company_name, persona)] = {
+                        "subject": content.get("subject", ""),
+                        "body": content.get("body", ""),
+                    }
+            except Exception:
+                logger.exception("Failed to store campaign for %s/%s/%s", company_name, persona, channel)
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="storage",
+                    status="failed",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    blocking_issues=list(specificity.get("blocking_issues") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                    failure_step="storage",
+                    error_message="campaign_storage_failed",
+                )
+                failed += 1
+        else:
+            await _record_campaign_generation_failure(
+                pool,
+                artifact_id=artifact_id,
+                company_name=company_name,
+                channel=channel,
+                generation_audit=payload.get("_generation_audit"),
+            )
+            failed += 1
+
+    if settings.campaign_sequence.enabled:
+        for unit in qualified_units:
+            cold = cold_email_by_unit.get((unit["company_name"], unit["persona"]))
+            if not cold:
+                continue
+            try:
+                seq_id = await _create_sequence_for_cold_email(
+                    pool,
+                    company_name=unit["company_name"],
+                    batch_id=unit["persona_batch_id"],
+                    partner_id=unit["partner_id"],
+                    context=unit["persona_context"],
+                    cold_email_subject=cold.get("subject", ""),
+                    cold_email_body=cold.get("body", ""),
+                )
+                if seq_id:
+                    sequences_created += 1
+            except Exception as exc:
+                logger.warning(
+                    "Failed to create sequence for %s/%s: %s",
+                    unit["company_name"],
+                    unit["persona"],
+                    exc,
+                )
+
+    followup_entries: list[dict[str, Any]] = []
+    if "email_followup" in cfg.channels:
+        for unit in qualified_units:
+            cold_context = cold_email_by_unit.get((unit["company_name"], unit["persona"]))
+            if not cold_context:
+                continue
+            payload = {
+                **unit["persona_context"],
+                "channel": "email_followup",
+                "target_mode": "churning_company",
+                "cold_email_context": cold_context,
+            }
+            artifact_id = _campaign_artifact_key(
+                company_name=unit["company_name"],
+                batch_id=unit["persona_batch_id"],
+                channel="email_followup",
+            )
+            followup_entries.append(
+                {
+                    "custom_id": artifact_id,
+                    "artifact_id": artifact_id,
+                    "campaign_batch_id": unit["persona_batch_id"],
+                    "phase": "followup",
+                    "payload": payload,
+                    "channel": "email_followup",
+                    "company_name": unit["company_name"],
+                    "persona": unit["persona"],
+                    "persona_batch_id": unit["persona_batch_id"],
+                    "persona_context": unit["persona_context"],
+                    "best": unit["best"],
+                    "review_ids": [o["review_id"] for o in unit["opps"] if o.get("review_id")][:20] or None,
+                    "partner_id": unit["partner_id"],
+                    "max_tokens": cfg.max_tokens,
+                    "temperature": cfg.temperature,
+                    "trace_metadata": _campaign_trace_metadata(
+                        payload,
+                        run_id=run_id,
+                        stage_id="b2b_campaign_generation.content",
+                    ),
+                }
+            )
+
+    followup_results, phase_two_batch = await _run_campaign_batch(
+        llm,
+        skill.content,
+        followup_entries,
+        run_id=run_id,
+        task=task,
+    )
+    _merge_batch_metrics(batch_metrics, phase_two_batch)
+
+    for entry in followup_entries:
+        company_name = entry["company_name"]
+        persona = entry["persona"]
+        payload = entry["payload"]
+        artifact_id = entry["artifact_id"]
+        content = followup_results.get(entry["custom_id"])
+        if _is_deferred_campaign_content(content):
+            await record_attempt(
+                pool,
+                artifact_type="campaign",
+                artifact_id=artifact_id,
+                attempt_no=1,
+                stage="generation",
+                status="queued",
+            )
+            deferred += 1
+            continue
+        if content:
+            metadata = _campaign_storage_metadata(payload)
+            generation_audit = (
+                payload.get("_generation_audit")
+                if isinstance(payload.get("_generation_audit"), dict)
+                else {}
+            )
+            specificity = (
+                generation_audit.get("specificity")
+                if isinstance(generation_audit.get("specificity"), dict)
+                else {}
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_campaigns (
+                        company_name, vendor_name, product_category,
+                        opportunity_score, urgency_score, pain_categories,
+                        competitors_considering, seat_count, contract_end,
+                        decision_timeline, buying_stage, role_type,
+                        key_quotes, source_review_ids,
+                        channel, subject, body, cta,
+                        status, batch_id, llm_model,
+                        partner_id, industry, target_mode, metadata,
+                        score_components
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23, $24, $25::jsonb,
+                        $26::jsonb
+                    )
+                    """,
+                    company_name,
+                    entry["best"]["vendor_name"],
+                    entry["best"].get("product_category"),
+                    entry["best"]["opportunity_score"],
+                    entry["best"].get("urgency"),
+                    json.dumps(entry["persona_context"].get("pain_categories", [])),
+                    json.dumps(entry["persona_context"].get("competitors_considering", [])),
+                    entry["best"].get("seat_count"),
+                    entry["best"].get("contract_end"),
+                    entry["best"].get("decision_timeline"),
+                    entry["best"].get("buying_stage"),
+                    entry["persona_context"].get("role_type"),
+                    json.dumps(entry["persona_context"].get("key_quotes", [])),
+                    entry["review_ids"],
+                    "email_followup",
+                    content.get("subject", ""),
+                    content.get("body", ""),
+                    content.get("cta", ""),
+                    "draft",
+                    entry["persona_batch_id"],
+                    llm_model_name,
+                    _uuid.UUID(entry["partner_id"]) if entry["partner_id"] else None,
+                    entry["persona_context"].get("industry"),
+                    "churning_company",
+                    json.dumps(metadata, default=str),
+                    json.dumps(entry["best"].get("score_components")),
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="generation",
+                    status="succeeded",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                )
+                generated += 1
+            except Exception:
+                logger.exception(
+                    "Failed to store campaign for %s/%s/%s",
+                    company_name,
+                    persona,
+                    "email_followup",
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="storage",
+                    status="failed",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    blocking_issues=list(specificity.get("blocking_issues") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                    failure_step="storage",
+                    error_message="campaign_storage_failed",
+                )
+                failed += 1
+        else:
+            await _record_campaign_generation_failure(
+                pool,
+                artifact_id=artifact_id,
+                company_name=company_name,
+                channel="email_followup",
+                generation_audit=payload.get("_generation_audit"),
+            )
+            failed += 1
+
+    logger.info(
+        "Campaign generation (churning_company): %d generated, %d failed, %d generated without partner, "
+        "%d personas skipped, %d sequences from %d companies",
+        generated, failed, generated_without_partner, personas_skipped, sequences_created, len(companies_to_process),
+    )
+
+    return {
+        "generated": generated,
+        "failed": failed,
+        "skipped": (len(by_company) - len(companies_to_process)) + skipped_no_company + skipped_unqualified,
+        "skipped_dedup": len(by_company) - len(companies_to_process),
+        "skipped_no_company": skipped_no_company,
+        "skipped_unqualified": skipped_unqualified,
+        "skipped_no_partner": 0,
+        "generated_without_partner": generated_without_partner,
+        "deferred": deferred,
+        "personas_skipped": personas_skipped,
+        "sequences_created": sequences_created,
+        "companies": qualified_companies,
+        "candidate_companies": len(companies_to_process),
+        "qualification_summary": qualification_summary,
+        "batch_id": batch_id,
+        "target_mode": "churning_company",
+        "opportunity_source": opportunity_source,
+        "anthropic_batch_jobs": batch_metrics["jobs"],
+        "anthropic_batch_items_submitted": batch_metrics["submitted_items"],
+        "anthropic_batch_cache_prefiltered": batch_metrics["cache_prefiltered_items"],
+        "anthropic_batch_fallback_single_call": batch_metrics["fallback_single_call_items"],
+        "anthropic_batch_completed_items": batch_metrics["completed_items"],
+        "anthropic_batch_failed_items": batch_metrics["failed_items"],
+    }
+
+
+# ------------------------------------------------------------------
+# Vendor retention campaign generation (P1)
+# ------------------------------------------------------------------
+
+
+async def _fetch_vendor_targets(pool, vendor_name: str | None = None) -> list[dict]:
+    """Fetch active vendor targets, optionally filtered by vendor name."""
+    if vendor_name:
+        rows = await pool.fetch(
+            """
+            SELECT id, company_name, target_mode, contact_name, contact_email,
+                   contact_role, products_tracked, competitors_tracked, tier, status,
+                   notes, account_id, created_at, updated_at
+            FROM vendor_targets
+            WHERE status = 'active' AND target_mode = 'vendor_retention'
+              AND company_name ILIKE '%' || $1 || '%'
+            """,
+            vendor_name,
+        )
+    else:
+        rows = await pool.fetch(
+            """
+            SELECT id, company_name, target_mode, contact_name, contact_email,
+                   contact_role, products_tracked, competitors_tracked, tier, status,
+                   notes, account_id, created_at, updated_at
+            FROM vendor_targets
+            WHERE status = 'active' AND target_mode = 'vendor_retention'
+            """
+        )
+    return dedupe_vendor_target_rows(rows)
+
+
+def _build_vendor_context(vendor_name: str, signals: list[dict]) -> dict[str, Any]:
+    """Aggregate churn signals into a vendor-scoped intelligence summary."""
+    ordered_signals = _campaign_stable_row_order(signals)
+    total = len(ordered_signals)
+    high_urgency = sum(1 for s in ordered_signals if _safe_float(s.get("urgency"), 0) >= 8)
+    medium_urgency = sum(1 for s in ordered_signals if 5 <= _safe_float(s.get("urgency"), 0) < 8)
+
+    # Pain distribution
+    pain_counts: dict[str, int] = {}
+    for s in ordered_signals:
+        pain = _parse_json_field(s.get("pain_json"))
+        for p in pain:
+            if isinstance(p, dict) and p.get("category"):
+                pain_counts[p["category"]] = pain_counts.get(p["category"], 0) + 1
+
+    # Competitor distribution (who they're losing to)
+    comp_counts: dict[str, int] = {}
+    for s in ordered_signals:
+        comps = s.get("competitors", [])
+        for c in comps:
+            if isinstance(c, dict) and c.get("name"):
+                name = c["name"]
+                comp_counts[name] = comp_counts.get(name, 0) + 1
+
+    # Feature gaps
+    gap_counts: dict[str, int] = {}
+    for s in ordered_signals:
+        gaps = _parse_json_field(s.get("feature_gaps"))
+        for g in gaps:
+            label = g if isinstance(g, str) else (g.get("feature", "") if isinstance(g, dict) else "")
+            if label:
+                gap_counts[label] = gap_counts.get(label, 0) + 1
+
+    # Quote-grade phrases from enrichment
+    quote_list: list[str] = []
+    for s in ordered_signals:
+        for text in _campaign_quote_texts(s.get("quotable_phrases")):
+            if text not in quote_list:
+                quote_list.append(text)
+
+    # Timeline signals
+    timeline_count = sum(1 for s in signals if s.get("contract_end"))
+
+    opportunity_claims = [
+        s["opportunity_claim"]
+        for s in ordered_signals
+        if isinstance(s.get("opportunity_claim"), dict)
+    ]
+
+    context = {
+        "vendor_name": vendor_name,
+        "key_quotes": quote_list[:8],
+        "signal_summary": {
+            "total_signals": total,
+            "high_urgency_count": high_urgency,
+            "medium_urgency_count": medium_urgency,
+            "pain_distribution": _campaign_sorted_count_rows(
+                pain_counts,
+                field_name="category",
+                limit=10,
+            ),
+            "competitor_distribution": _campaign_sorted_count_rows(
+                comp_counts,
+                field_name="name",
+                limit=10,
+            ),
+            "feature_gaps": _campaign_sorted_count_keys(gap_counts, limit=10),
+            "timeline_signals": timeline_count,
+            "trend_vs_last_month": None,  # overridden by caller with _compute_vendor_trend()
+        },
+    }
+    if opportunity_claims:
+        context["opportunity_claims"] = opportunity_claims[:20]
+    return context
+
+
+async def _compute_vendor_trend(
+    pool,
+    vendor_name: str,
+    products: list[str] | None = None,
+) -> str | None:
+    """Compare signal count in last 30d vs previous 30d for a vendor.
+
+    Returns 'increasing', 'stable', 'decreasing', or None on error.
+    """
+    # APPROVED-ENRICHMENT-READ: urgency_score
+    # Reason: COUNT-only aggregation with urgency threshold, not a row-level extraction
+    try:
+        # Count distinct reviews through canonical vendor mentions so alias/product
+        # matching follows the same scope as the rest of the vendor readers.
+        names = [vendor_name]
+        if products:
+            names.extend(products)
+        name_conditions = " OR ".join(
+            f"vm.vendor_name ILIKE '%' || ${i + 1} || '%'" for i in range(len(names))
+        )
+        base_idx = len(names) + 1
+        vendor_join = _review_vendor_association_join(review_alias="r", output_alias="vm")
+
+        current = await pool.fetchval(
+            f"""
+            SELECT COUNT(DISTINCT r.id) FROM b2b_reviews r
+            {vendor_join}
+            WHERE r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.enriched_at > NOW() - INTERVAL '30 days'
+              AND (r.enrichment->>'urgency_score')::numeric >= ${base_idx}
+              AND ({name_conditions})
+            """,
+            *names, 3.0,
+        )
+        previous = await pool.fetchval(
+            f"""
+            SELECT COUNT(DISTINCT r.id) FROM b2b_reviews r
+            {vendor_join}
+            WHERE r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.enriched_at BETWEEN NOW() - INTERVAL '60 days' AND NOW() - INTERVAL '30 days'
+              AND (r.enrichment->>'urgency_score')::numeric >= ${base_idx}
+              AND ({name_conditions})
+            """,
+            *names, 3.0,
+        )
+        if previous == 0 and current == 0:
+            return None
+        if previous == 0:
+            return "increasing"
+        ratio = current / previous
+        if ratio >= 1.2:
+            return "increasing"
+        elif ratio <= 0.8:
+            return "decreasing"
+        return "stable"
+    except Exception:
+        logger.debug("Failed to compute trend for %s", vendor_name)
+        return None
+
+
+_CONTACT_ROLE_MAP: dict[str, str] = {
+    "vp customer success": "economic_buyer",
+    "head of customer success": "economic_buyer",
+    "vp cs": "economic_buyer",
+    "chief customer officer": "economic_buyer",
+    "head of product": "decision_maker",
+    "vp product": "decision_maker",
+    "cpo": "decision_maker",
+    "vp sales": "economic_buyer",
+    "head of sales": "economic_buyer",
+    "cro": "economic_buyer",
+    "head of competitive intelligence": "evaluator",
+    "vp marketing": "decision_maker",
+}
+
+
+def _map_role_type(contact_role: str | None) -> str:
+    """Map a raw contact title to an enum role_type value."""
+    if not contact_role:
+        return "economic_buyer"
+    return _CONTACT_ROLE_MAP.get(contact_role.lower(), "economic_buyer")
+
+
+async def _generate_vendor_campaigns(
+    pool,
+    min_score: int,
+    limit: int,
+    vendor_filter: str | None,
+    company_filter: str | None = None,
+    bypass_briefing_gate: bool = False,
+    bypass_recent_dedup: bool = False,
+    run_id: str | None = None,
+    task: ScheduledTask | Any | None = None,
+) -> dict[str, Any]:
+    """Generate campaigns targeting vendor CS/Product leaders with churn intelligence."""
+    cfg = settings.b2b_campaign
+
+    # 1. Fetch vendor targets (our customers)
+    targets = await _fetch_vendor_targets(pool, vendor_filter)
+    if not targets:
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0,
+                "target_mode": "vendor_retention", "error": "No active vendor targets"}
+
+    # 2. Fetch all enriched opportunities (company_filter narrows the signal pool)
+    opportunities = await _fetch_opportunities(
+        pool, min_score, limit * 5, company_filter=company_filter, dm_only=False,
+    )
+
+    # 3. Get LLM + skill
+    from ...services.llm_router import get_llm
+    llm = get_llm("campaign")
+    if llm is None:
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    if llm is None:
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0,
+                "target_mode": "vendor_retention", "error": "No LLM available"}
+
+    from ...skills import get_skill_registry
+    skill = get_skill_registry().get("digest/b2b_vendor_outreach")
+    if not skill:
+        logger.warning("Skill 'digest/b2b_vendor_outreach' not found")
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0,
+                "target_mode": "vendor_retention", "error": "Skill not found"}
+
+    llm_model_name = getattr(llm, "model_id", None) or getattr(llm, "model", "unknown")
+    batch_id = f"batch_vr_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    generated = 0
+    failed = 0
+    skipped = 0
+    deferred = 0
+    deferred = 0
+    sequences_created = 0
+    batch_metrics = {
+        "jobs": 0,
+        "submitted_items": 0,
+        "cache_prefiltered_items": 0,
+        "fallback_single_call_items": 0,
+        "completed_items": 0,
+        "failed_items": 0,
+    }
+    phase_one_entries: list[dict[str, Any]] = []
+
+    for target in targets[:limit]:
+        vendor_name = target["company_name"]
+
+        # B->A sequencing: require a briefing before campaign generation
+        briefing_row = await pool.fetchrow(
+            """SELECT id, created_at, briefing_data FROM b2b_vendor_briefings
+               WHERE LOWER(vendor_name) = LOWER($1)
+                 AND target_mode = $2
+                 AND status = 'sent'
+               ORDER BY created_at DESC LIMIT 1""",
+            vendor_name,
+            "vendor_retention",
+        )
+        if not briefing_row and not bypass_briefing_gate:
+            skipped += 1
+            continue
+        if briefing_row and not bypass_briefing_gate:
+            days_since_briefing = (
+                datetime.now(timezone.utc) - briefing_row["created_at"]
+            ).days
+            if days_since_briefing < 7:
+                skipped += 1
+                continue
+
+        # Dedup: skip vendor if campaign sent within dedup_days
+        if not bypass_recent_dedup:
+            existing = await pool.fetchval(
+                """
+                SELECT COUNT(*) FROM b2b_campaigns
+                WHERE company_name ILIKE $1
+                  AND target_mode = 'vendor_retention'
+                  AND created_at > NOW() - make_interval(days => $2)
+                """,
+                vendor_name, cfg.dedup_days,
+            )
+            if existing > 0:
+                skipped += 1
+                continue
+
+        # Group signals: opportunities where vendor_name matches this target
+        products = target.get("products_tracked") or []
+        vendor_signals = [
+            opp for opp in opportunities
+            if opp["vendor_name"].lower() == vendor_name.lower()
+            or (products and opp["vendor_name"].lower() in [p.lower() for p in products])
+        ]
+
+        if not vendor_signals:
+            logger.debug("No churn signals found for vendor %s, skipping", vendor_name)
+            skipped += 1
+            continue
+
+        # Build vendor-scoped context
+        vendor_ctx = _build_vendor_context(vendor_name, vendor_signals)
+        briefing_context = _briefing_context_from_data(
+            briefing_row.get("briefing_data") if briefing_row else None,
+        )
+        if briefing_context:
+            vendor_ctx["briefing_context"] = briefing_context
+        vendor_ctx["signal_summary"]["trend_vs_last_month"] = await _compute_vendor_trend(
+            pool, vendor_name, products,
+        )
+
+        # Load reasoning context (synthesis-first, legacy fallback)
+        from ._b2b_synthesis_reader import load_best_reasoning_view
+
+        vendor_reasoning = await load_best_reasoning_view(
+            pool,
+            vendor_name,
+        )
+        if vendor_reasoning is not None:
+            _inject_reasoning_campaign_context(
+                vendor_ctx,
+                vendor_reasoning.filtered_consumer_context("campaign"),
+            )
+            cn = vendor_reasoning.section("causal_narrative")
+            wedge = vendor_reasoning.primary_wedge
+            wedge_label = wedge.value if wedge else cn.get("primary_wedge", "")
+            falsification = [
+                fc.get("condition", fc) if isinstance(fc, dict) else fc
+                for fc in vendor_reasoning.falsification_conditions()
+            ]
+            # Build summary from available fields -- v2.3 schema uses
+            # trigger/why_now/causal_chain instead of summary/key_signals
+            summary = cn.get("summary") or cn.get("executive_summary") or ""
+            if not summary:
+                parts = [cn.get("trigger", ""), cn.get("why_now", "")]
+                chain = cn.get("causal_chain", "")
+                if chain:
+                    parts.append(chain)
+                summary = ". ".join(p for p in parts if p)
+            key_signals = cn.get("key_signals") or []
+            if not key_signals:
+                # Derive from v2.3 fields
+                for field in ("trigger", "who_most_affected", "why_now"):
+                    val = cn.get(field, "")
+                    if val:
+                        key_signals.append(val)
+            reasoning_ctx: dict[str, Any] = {
+                "wedge": wedge_label,
+                "confidence": vendor_reasoning.confidence("causal_narrative"),
+                "summary": summary,
+                "key_signals": key_signals,
+                "falsification": falsification,
+            }
+            # Phase 3 sections: why_they_stay, timing, switch_triggers, accounts
+            wts = vendor_reasoning.why_they_stay
+            if wts:
+                reasoning_ctx["why_they_stay"] = {
+                    "summary": wts.get("summary", ""),
+                    "strengths": [
+                        {"area": s.get("area", ""), "evidence": s.get("evidence", "")}
+                        for s in wts.get("strengths", [])
+                        if isinstance(s, dict)
+                    ][:5],
+                }
+            timing = vendor_reasoning.section("timing_intelligence")
+            if timing:
+                reasoning_ctx["timing"] = {
+                    "best_window": timing.get("best_timing_window", ""),
+                    "trigger_count": len(timing.get("immediate_triggers") or []),
+                }
+            triggers = vendor_reasoning.switch_triggers
+            if triggers:
+                reasoning_ctx["switch_triggers"] = [
+                    {"type": t.get("type", ""), "description": t.get("description", "")}
+                    for t in triggers[:3]
+                ]
+            cp = vendor_reasoning.confidence_posture
+            if cp and cp.get("limits"):
+                reasoning_ctx["confidence_limits"] = cp["limits"]
+            consumer_context = vendor_reasoning.filtered_consumer_context("campaign")
+            account_summary = _campaign_account_summary_from_consumer_context(
+                consumer_context,
+            )
+            if account_summary:
+                reasoning_ctx.update(account_summary)
+            atom_context = _campaign_reasoning_atom_context(
+                consumer_context,
+            )
+            if atom_context:
+                reasoning_ctx["atom_context"] = atom_context
+            delta_summary = _campaign_reasoning_delta_summary(
+                vendor_reasoning.reasoning_delta,
+            )
+            if delta_summary:
+                reasoning_ctx["delta_summary"] = delta_summary
+            scope_summary = _campaign_reasoning_scope_summary(
+                vendor_reasoning.scope_manifest,
+            )
+            if scope_summary:
+                reasoning_ctx["scope_summary"] = scope_summary
+
+            vendor_ctx["reasoning_context"] = reasoning_ctx
+            contracts = vendor_reasoning.materialized_contracts()
+            if contracts:
+                vendor_ctx["reasoning_contracts"] = contracts
+        best = max(vendor_signals, key=lambda o: o["opportunity_score"])
+        review_ids = [o["review_id"] for o in vendor_signals if o.get("review_id")]
+
+        # Generate for email_cold and email_followup
+        _vpains = [p["category"] for p in (vendor_ctx.get("signal_summary") or {}).get("pain_distribution", []) if p.get("category")]
+        _vcomps = [c["name"] for c in (vendor_ctx.get("signal_summary") or {}).get("competitor_distribution", []) if c.get("name")]
+        vendor_blog_urls = await _fetch_blog_posts(
+            pool, pipeline="b2b", vendor_name=vendor_name, category=vendor_ctx.get("category"),
+            pain_categories=_vpains or None,
+            alternative_vendors=_vcomps[:3] or None,
+            contact_role=target.get("contact_role"),
+            include_drafts=True,
+        )
+        # Gate URL for vendor-specific report (instead of generic booking page)
+        vendor_gate_url = build_gate_url(vendor_name)
+        selling_context = _build_selling_context(
+            sender_name=cfg.default_sender_name,
+            sender_title=cfg.default_sender_title,
+            sender_company=cfg.default_sender_company,
+            booking_url=vendor_gate_url,
+            blog_posts=vendor_blog_urls,
+        )
+        cold_payload = {
+            **vendor_ctx,
+            "contact_name": _sanitize_contact_name(target.get("contact_name")),
+            "contact_role": target.get("contact_role"),
+            "tier": target.get("tier", "report"),
+            "selling": selling_context,
+            "channel": "email_cold",
+            "target_mode": "vendor_retention",
+        }
+        cold_artifact_id = _campaign_artifact_key(
+            company_name=vendor_name,
+            batch_id=batch_id,
+            channel="email_cold",
+        )
+        phase_one_entries.append(
+            {
+                "custom_id": cold_artifact_id,
+                "artifact_id": cold_artifact_id,
+                "campaign_batch_id": batch_id,
+                "phase": "cold",
+                "payload": cold_payload,
+                "channel": "email_cold",
+                "company_name": vendor_name,
+                "best": best,
+                "vendor_ctx": vendor_ctx,
+                "review_ids": review_ids[:20] or None,
+                "target": target,
+                "followup_payload": {
+                    **vendor_ctx,
+                    "contact_name": _sanitize_contact_name(target.get("contact_name")),
+                    "contact_role": target.get("contact_role"),
+                    "tier": target.get("tier", "report"),
+                    "selling": selling_context,
+                    "channel": "email_followup",
+                    "target_mode": "vendor_retention",
+                },
+                "sequence_context": {
+                    **vendor_ctx,
+                    "contact_name": _sanitize_contact_name(target.get("contact_name")),
+                    "contact_role": target.get("contact_role"),
+                    "tier": target.get("tier", "report"),
+                    "recipient_type": "vendor_retention",
+                    "selling": selling_context,
+                },
+                "max_tokens": cfg.max_tokens,
+                "temperature": cfg.temperature,
+                "trace_metadata": _campaign_trace_metadata(
+                    cold_payload,
+                    run_id=run_id,
+                    stage_id="b2b_campaign_generation.content",
+                ),
+            }
+        )
+
+    phase_one_results, phase_one_batch = await _run_campaign_batch(
+        llm,
+        skill.content,
+        phase_one_entries,
+        run_id=run_id,
+        task=task,
+    )
+    _merge_batch_metrics(batch_metrics, phase_one_batch)
+
+    followup_entries: list[dict[str, Any]] = []
+    for entry in phase_one_entries:
+        vendor_name = entry["company_name"]
+        payload = entry["payload"]
+        artifact_id = entry["artifact_id"]
+        content = phase_one_results.get(entry["custom_id"])
+        if _is_deferred_campaign_content(content):
+            await record_attempt(
+                pool,
+                artifact_type="campaign",
+                artifact_id=artifact_id,
+                attempt_no=1,
+                stage="generation",
+                status="queued",
+            )
+            deferred += 1
+            continue
+        if content:
+            metadata = _campaign_storage_metadata(payload)
+            generation_audit = (
+                payload.get("_generation_audit")
+                if isinstance(payload.get("_generation_audit"), dict)
+                else {}
+            )
+            specificity = (
+                generation_audit.get("specificity")
+                if isinstance(generation_audit.get("specificity"), dict)
+                else {}
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_campaigns (
+                        company_name, vendor_name, product_category,
+                        opportunity_score, urgency_score, pain_categories,
+                        competitors_considering, seat_count, contract_end,
+                        decision_timeline, buying_stage, role_type,
+                        key_quotes, source_review_ids,
+                        channel, subject, body, cta,
+                        status, batch_id, llm_model, industry, target_mode, metadata,
+                        recipient_email, score_components
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23, $24::jsonb,
+                        $25, $26::jsonb
+                    )
+                    """,
+                    vendor_name,
+                    vendor_name,
+                    entry["best"].get("product_category"),
+                    entry["best"]["opportunity_score"],
+                    entry["best"].get("urgency"),
+                    json.dumps(entry["vendor_ctx"]["signal_summary"]["pain_distribution"]),
+                    json.dumps(entry["vendor_ctx"]["signal_summary"]["competitor_distribution"]),
+                    entry["best"].get("seat_count"),
+                    entry["best"].get("contract_end"),
+                    entry["best"].get("decision_timeline"),
+                    entry["best"].get("buying_stage"),
+                    _map_role_type(entry["target"].get("contact_role")),
+                    json.dumps(entry["vendor_ctx"].get("key_quotes", [])),
+                    entry["review_ids"],
+                    "email_cold",
+                    content.get("subject", ""),
+                    content.get("body", ""),
+                    content.get("cta", ""),
+                    "draft",
+                    batch_id,
+                    llm_model_name,
+                    entry["best"].get("industry"),
+                    "vendor_retention",
+                    json.dumps(metadata, default=str),
+                    entry["target"].get("contact_email"),
+                    json.dumps(entry["best"].get("score_components")),
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="generation",
+                    status="succeeded",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                )
+                generated += 1
+                cold_email_content = {
+                    "subject": content.get("subject", ""),
+                    "body": content.get("body", ""),
+                }
+                if settings.campaign_sequence.enabled:
+                    try:
+                        seq_id = await _create_sequence_for_cold_email(
+                            pool,
+                            company_name=vendor_name,
+                            batch_id=batch_id,
+                            partner_id=None,
+                            context=entry["sequence_context"],
+                            cold_email_subject=cold_email_content.get("subject", ""),
+                            cold_email_body=cold_email_content.get("body", ""),
+                        )
+                        if seq_id:
+                            sequences_created += 1
+                            contact_email = entry["target"].get("contact_email")
+                            if contact_email:
+                                await pool.execute(
+                                    "UPDATE campaign_sequences SET recipient_email = $1 WHERE id = $2",
+                                    contact_email,
+                                    seq_id,
+                                )
+                    except Exception as exc:
+                        logger.warning("Failed to create vendor sequence for %s: %s", vendor_name, exc)
+
+                followup_payload = dict(entry["followup_payload"])
+                followup_payload["cold_email_context"] = cold_email_content
+                followup_artifact_id = _campaign_artifact_key(
+                    company_name=vendor_name,
+                    batch_id=batch_id,
+                    channel="email_followup",
+                )
+                followup_entries.append(
+                    {
+                        "custom_id": followup_artifact_id,
+                        "artifact_id": followup_artifact_id,
+                        "campaign_batch_id": batch_id,
+                        "phase": "followup",
+                        "payload": followup_payload,
+                        "channel": "email_followup",
+                        "company_name": vendor_name,
+                        "best": entry["best"],
+                        "vendor_ctx": entry["vendor_ctx"],
+                        "review_ids": entry["review_ids"],
+                        "target": entry["target"],
+                        "max_tokens": cfg.max_tokens,
+                        "temperature": cfg.temperature,
+                        "trace_metadata": _campaign_trace_metadata(
+                            followup_payload,
+                            run_id=run_id,
+                            stage_id="b2b_campaign_generation.content",
+                        ),
+                    }
+                )
+            except Exception:
+                logger.exception("Failed to store vendor campaign for %s/%s", vendor_name, "email_cold")
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="storage",
+                    status="failed",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    blocking_issues=list(specificity.get("blocking_issues") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                    failure_step="storage",
+                    error_message="campaign_storage_failed",
+                )
+                failed += 1
+        else:
+            await _record_campaign_generation_failure(
+                pool,
+                artifact_id=artifact_id,
+                company_name=vendor_name,
+                channel="email_cold",
+                generation_audit=payload.get("_generation_audit"),
+            )
+            failed += 1
+
+    followup_results, phase_two_batch = await _run_campaign_batch(
+        llm,
+        skill.content,
+        followup_entries,
+        run_id=run_id,
+        task=task,
+    )
+    _merge_batch_metrics(batch_metrics, phase_two_batch)
+
+    for entry in followup_entries:
+        vendor_name = entry["company_name"]
+        payload = entry["payload"]
+        artifact_id = entry["artifact_id"]
+        content = followup_results.get(entry["custom_id"])
+        if _is_deferred_campaign_content(content):
+            await record_attempt(
+                pool,
+                artifact_type="campaign",
+                artifact_id=artifact_id,
+                attempt_no=1,
+                stage="generation",
+                status="queued",
+            )
+            deferred += 1
+            continue
+        if content:
+            metadata = _campaign_storage_metadata(payload)
+            generation_audit = (
+                payload.get("_generation_audit")
+                if isinstance(payload.get("_generation_audit"), dict)
+                else {}
+            )
+            specificity = (
+                generation_audit.get("specificity")
+                if isinstance(generation_audit.get("specificity"), dict)
+                else {}
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_campaigns (
+                        company_name, vendor_name, product_category,
+                        opportunity_score, urgency_score, pain_categories,
+                        competitors_considering, seat_count, contract_end,
+                        decision_timeline, buying_stage, role_type,
+                        key_quotes, source_review_ids,
+                        channel, subject, body, cta,
+                        status, batch_id, llm_model, industry, target_mode, metadata,
+                        recipient_email, score_components
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23, $24::jsonb,
+                        $25, $26::jsonb
+                    )
+                    """,
+                    vendor_name,
+                    vendor_name,
+                    entry["best"].get("product_category"),
+                    entry["best"]["opportunity_score"],
+                    entry["best"].get("urgency"),
+                    json.dumps(entry["vendor_ctx"]["signal_summary"]["pain_distribution"]),
+                    json.dumps(entry["vendor_ctx"]["signal_summary"]["competitor_distribution"]),
+                    entry["best"].get("seat_count"),
+                    entry["best"].get("contract_end"),
+                    entry["best"].get("decision_timeline"),
+                    entry["best"].get("buying_stage"),
+                    _map_role_type(entry["target"].get("contact_role")),
+                    json.dumps(entry["vendor_ctx"].get("key_quotes", [])),
+                    entry["review_ids"],
+                    "email_followup",
+                    content.get("subject", ""),
+                    content.get("body", ""),
+                    content.get("cta", ""),
+                    "draft",
+                    batch_id,
+                    llm_model_name,
+                    entry["best"].get("industry"),
+                    "vendor_retention",
+                    json.dumps(metadata, default=str),
+                    entry["target"].get("contact_email"),
+                    json.dumps(entry["best"].get("score_components")),
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="generation",
+                    status="succeeded",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                )
+                generated += 1
+            except Exception:
+                logger.exception("Failed to store vendor campaign for %s/%s", vendor_name, "email_followup")
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="storage",
+                    status="failed",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    blocking_issues=list(specificity.get("blocking_issues") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                    failure_step="storage",
+                    error_message="campaign_storage_failed",
+                )
+                failed += 1
+        else:
+            await _record_campaign_generation_failure(
+                pool,
+                artifact_id=artifact_id,
+                company_name=vendor_name,
+                channel="email_followup",
+                generation_audit=payload.get("_generation_audit"),
+            )
+            failed += 1
+
+    logger.info(
+        "Campaign generation (vendor_retention): %d generated, %d failed, %d skipped, %d sequences from %d targets",
+        generated, failed, skipped, sequences_created, len(targets),
+    )
+
+    return {
+        "generated": generated,
+        "failed": failed,
+        "deferred": deferred,
+        "skipped": skipped,
+        "sequences_created": sequences_created,
+        "companies": len(targets) - skipped,
+        "batch_id": batch_id,
+        "target_mode": "vendor_retention",
+        "anthropic_batch_jobs": batch_metrics["jobs"],
+        "anthropic_batch_items_submitted": batch_metrics["submitted_items"],
+        "anthropic_batch_cache_prefiltered": batch_metrics["cache_prefiltered_items"],
+        "anthropic_batch_fallback_single_call": batch_metrics["fallback_single_call_items"],
+        "anthropic_batch_completed_items": batch_metrics["completed_items"],
+        "anthropic_batch_failed_items": batch_metrics["failed_items"],
+    }
+
+
+# ------------------------------------------------------------------
+# Challenger intel campaign generation (P2)
+# ------------------------------------------------------------------
+
+
+async def _fetch_challenger_targets(pool, vendor_filter: str | None = None) -> list[dict]:
+    """Fetch active challenger targets."""
+    if vendor_filter:
+        rows = await pool.fetch(
+            """
+            SELECT id, company_name, target_mode, contact_name, contact_email,
+                   contact_role, products_tracked, competitors_tracked, tier, status,
+                   notes, account_id, created_at, updated_at
+            FROM vendor_targets
+            WHERE status = 'active' AND target_mode = 'challenger_intel'
+              AND company_name ILIKE '%' || $1 || '%'
+            """,
+            vendor_filter,
+        )
+    else:
+        rows = await pool.fetch(
+            """
+            SELECT id, company_name, target_mode, contact_name, contact_email,
+                   contact_role, products_tracked, competitors_tracked, tier, status,
+                   notes, account_id, created_at, updated_at
+            FROM vendor_targets
+            WHERE status = 'active' AND target_mode = 'challenger_intel'
+            """
+        )
+    return dedupe_vendor_target_rows(rows)
+
+
+def _build_challenger_context(challenger_name: str, signals: list[dict]) -> dict[str, Any]:
+    """Aggregate signals where a specific product is mentioned as the alternative."""
+    total = len(signals)
+
+    # Buying stage distribution
+    by_stage: dict[str, int] = {}
+    ordered_signals = _campaign_stable_row_order(signals)
+
+    for s in ordered_signals:
+        stage = s.get("buying_stage") or "unknown"
+        by_stage[stage] = by_stage.get(stage, 0) + 1
+
+    # Role distribution
+    role_counts: dict[str, int] = {}
+    for s in ordered_signals:
+        role = s.get("role_type") or "unknown"
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    # Pain categories driving the switch (from incumbent)
+    pain_counts: dict[str, int] = {}
+    for s in ordered_signals:
+        pain = _parse_json_field(s.get("pain_json"))
+        for p in pain:
+            if isinstance(p, dict) and p.get("category"):
+                pain_counts[p["category"]] = pain_counts.get(p["category"], 0) + 1
+
+    # Incumbents losing customers
+    incumbent_counts: dict[str, int] = {}
+    for s in ordered_signals:
+        vendor = s.get("vendor_name", "")
+        if vendor:
+            incumbent_counts[vendor] = incumbent_counts.get(vendor, 0) + 1
+
+    # Seat count buckets
+    large = sum(1 for s in ordered_signals if (s.get("seat_count") or 0) >= 500)
+    mid = sum(1 for s in ordered_signals if 100 <= (s.get("seat_count") or 0) < 500)
+    small = sum(1 for s in ordered_signals if 0 < (s.get("seat_count") or 0) < 100)
+
+    # Feature mentions (positive mentions of challenger from competitor context)
+    feature_mentions: list[str] = []
+    for s in ordered_signals:
+        comps = s.get("competitors", [])
+        for c in comps:
+            if isinstance(c, dict) and c.get("name", "").lower() == challenger_name.lower():
+                reason = c.get("reason", "")
+                if reason and reason not in feature_mentions:
+                    feature_mentions.append(reason)
+
+    # Quote-grade phrases from enrichment
+    quote_list: list[str] = []
+    for s in ordered_signals:
+        for text in _campaign_quote_texts(s.get("quotable_phrases")):
+            if text not in quote_list:
+                quote_list.append(text)
+
+    opportunity_claims = [
+        s["opportunity_claim"]
+        for s in ordered_signals
+        if isinstance(s.get("opportunity_claim"), dict)
+    ]
+
+    context = {
+        "challenger_name": challenger_name,
+        "key_quotes": quote_list[:8],
+        "signal_summary": {
+            "total_leads": total,
+            "by_buying_stage": {
+                "active_purchase": by_stage.get("active_purchase", 0),
+                "evaluation": by_stage.get("evaluation", 0),
+                "renewal_decision": by_stage.get("renewal_decision", 0),
+            },
+            "role_distribution": _campaign_sorted_count_rows(
+                role_counts,
+                field_name="role",
+                limit=5,
+            ),
+            "pain_driving_switch": _campaign_sorted_count_rows(
+                pain_counts,
+                field_name="category",
+                limit=10,
+            ),
+            "incumbents_losing": _campaign_sorted_count_rows(
+                incumbent_counts,
+                field_name="name",
+                limit=10,
+            ),
+            "seat_count_signals": {
+                "large_500plus": large,
+                "mid_100_499": mid,
+                "small_under_100": small,
+            },
+            "feature_mentions": feature_mentions[:10],
+        },
+    }
+    if opportunity_claims:
+        context["opportunity_claims"] = opportunity_claims[:20]
+    return context
+
+
+async def _generate_challenger_campaigns(
+    pool,
+    min_score: int,
+    limit: int,
+    vendor_filter: str | None,
+    company_filter: str | None = None,
+    bypass_briefing_gate: bool = False,
+    bypass_recent_dedup: bool = False,
+    run_id: str | None = None,
+    task: ScheduledTask | Any | None = None,
+) -> dict[str, Any]:
+    """Generate campaigns targeting challenger Sales/Competitive Intel leaders."""
+    cfg = settings.b2b_campaign
+
+    # 1. Fetch challenger targets
+    targets = await _fetch_challenger_targets(pool, vendor_filter)
+    if not targets:
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0,
+                "target_mode": "challenger_intel", "error": "No active challenger targets"}
+
+    # 2. Fetch all enriched opportunities (company_filter narrows the signal pool)
+    opportunities = await _fetch_opportunities(
+        pool, min_score, limit * 5, company_filter=company_filter, dm_only=False,
+    )
+
+    # 3. Get LLM + skill
+    from ...services.llm_router import get_llm
+    llm = get_llm("campaign")
+    if llm is None:
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    if llm is None:
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0,
+                "target_mode": "challenger_intel", "error": "No LLM available"}
+
+    from ...skills import get_skill_registry
+    skill = get_skill_registry().get("digest/b2b_challenger_outreach")
+    if not skill:
+        logger.warning("Skill 'digest/b2b_challenger_outreach' not found")
+        return {"generated": 0, "skipped": 0, "failed": 0, "companies": 0,
+                "target_mode": "challenger_intel", "error": "Skill not found"}
+
+    llm_model_name = getattr(llm, "model_id", None) or getattr(llm, "model", "unknown")
+    batch_id = f"batch_ci_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    generated = 0
+    failed = 0
+    skipped = 0
+    deferred = 0
+    sequences_created = 0
+    batch_metrics = {
+        "jobs": 0,
+        "submitted_items": 0,
+        "cache_prefiltered_items": 0,
+        "fallback_single_call_items": 0,
+        "completed_items": 0,
+        "failed_items": 0,
+    }
+    phase_one_entries: list[dict[str, Any]] = []
+
+    for target in targets[:limit]:
+        challenger_name = target["company_name"]
+
+        # B->A sequencing: require a briefing before campaign generation
+        briefing_row = await pool.fetchrow(
+            """SELECT id, created_at, briefing_data FROM b2b_vendor_briefings
+               WHERE LOWER(vendor_name) = LOWER($1)
+                 AND target_mode = $2
+                 AND status = 'sent'
+               ORDER BY created_at DESC LIMIT 1""",
+            challenger_name,
+            "challenger_intel",
+        )
+        if not briefing_row and not bypass_briefing_gate:
+            skipped += 1
+            continue
+        if briefing_row and not bypass_briefing_gate:
+            days_since_briefing = (
+                datetime.now(timezone.utc) - briefing_row["created_at"]
+            ).days
+            if days_since_briefing < 7:
+                skipped += 1
+                continue
+
+        # Dedup
+        if not bypass_recent_dedup:
+            existing = await pool.fetchval(
+                """
+                SELECT COUNT(*) FROM b2b_campaigns
+                WHERE company_name ILIKE $1
+                  AND target_mode = 'challenger_intel'
+                  AND created_at > NOW() - make_interval(days => $2)
+                """,
+                challenger_name, cfg.dedup_days,
+            )
+            if existing > 0:
+                skipped += 1
+                continue
+
+        # Find signals where this challenger is mentioned as a competitor being considered
+        challenger_signals = []
+        seen_ids: set[str] = set()
+        tracked_vendors = {p.lower() for p in (target.get("competitors_tracked") or [])}
+        for opp in opportunities:
+            opp_id = opp.get("review_id", id(opp))
+            if opp_id in seen_ids:
+                continue
+            matched = False
+            comps = opp.get("competitors", [])
+            for c in comps:
+                if isinstance(c, dict) and c.get("name", "").lower() == challenger_name.lower():
+                    matched = True
+                    break
+            # Also match against competitors_tracked (incumbents the challenger cares about)
+            if not matched and opp["vendor_name"].lower() in tracked_vendors:
+                matched = True
+            if matched:
+                challenger_signals.append(opp)
+                seen_ids.add(opp_id)
+
+        if not challenger_signals:
+            logger.debug("No intent signals found for challenger %s, skipping", challenger_name)
+            skipped += 1
+            continue
+
+        # Build challenger-scoped context
+        challenger_ctx = _build_challenger_context(challenger_name, challenger_signals)
+        briefing_context = _briefing_context_from_data(
+            briefing_row.get("briefing_data") if briefing_row else None,
+        )
+        if briefing_context:
+            challenger_ctx["briefing_context"] = briefing_context
+
+        # Fetch incumbent reasoning (synthesis-first, legacy fallback)
+        incumbent_names = [
+            inc["name"]
+            for inc in challenger_ctx.get("signal_summary", {}).get("incumbents_losing", [])
+            if inc.get("name")
+        ]
+        if incumbent_names:
+            from ._b2b_synthesis_reader import load_best_reasoning_views
+
+            inc_views = await load_best_reasoning_views(
+                pool,
+                incumbent_names,
+            )
+            if inc_views:
+                by_archetype: dict[str, list[str]] = {}
+                incumbent_reasoning: dict[str, dict[str, Any]] = {}
+                for vname, view in inc_views.items():
+                    wedge = view.primary_wedge
+                    label = wedge.value if wedge else (
+                        view.section("causal_narrative").get("primary_wedge", "")
+                    )
+                    if label:
+                        by_archetype.setdefault(label, []).append(vname)
+                    # Extract incumbent reasoning summary for challenger context
+                    cn = view.section("causal_narrative")
+                    inc_summary: dict[str, Any] = {
+                        "wedge": label,
+                        "summary": cn.get("summary") or cn.get("executive_summary", ""),
+                    }
+                    wts = view.why_they_stay
+                    if wts:
+                        inc_summary["why_they_stay"] = wts.get("summary", "")
+                    triggers = view.switch_triggers
+                    if triggers:
+                        inc_summary["switch_triggers"] = [
+                            t.get("type", "") for t in triggers[:3]
+                        ]
+                    if inc_summary.get("summary"):
+                        incumbent_reasoning[vname] = inc_summary
+                if by_archetype:
+                    challenger_ctx["incumbent_archetypes"] = by_archetype
+                if incumbent_reasoning:
+                    challenger_ctx["incumbent_reasoning"] = incumbent_reasoning
+
+        best = max(challenger_signals, key=lambda o: o["opportunity_score"])
+        review_ids = [o["review_id"] for o in challenger_signals if o.get("review_id")]
+
+        _cpains = [p["category"] for p in (challenger_ctx.get("signal_summary") or {}).get("pain_driving_switch", []) if p.get("category")]
+        _cincumbents = [c["name"] for c in (challenger_ctx.get("signal_summary") or {}).get("incumbents_losing", []) if c.get("name")]
+        challenger_blog_urls = await _fetch_blog_posts(
+            pool, pipeline="b2b", vendor_name=challenger_name, category=challenger_ctx.get("category"),
+            pain_categories=_cpains or None,
+            alternative_vendors=_cincumbents[:3] or None,
+            contact_role=target.get("contact_role"),
+            include_drafts=True,
+        )
+        # Gate URL for challenger-specific report
+        challenger_gate_url = build_gate_url(challenger_name)
+        selling_context = _build_selling_context(
+            sender_name=cfg.default_sender_name,
+            sender_title=cfg.default_sender_title,
+            sender_company=cfg.default_sender_company,
+            booking_url=challenger_gate_url,
+            blog_posts=challenger_blog_urls,
+        )
+        cold_payload = {
+            **challenger_ctx,
+            "contact_name": _sanitize_contact_name(target.get("contact_name")),
+            "contact_role": target.get("contact_role"),
+            "tier": target.get("tier", "report"),
+            "selling": selling_context,
+            "channel": "email_cold",
+            "target_mode": "challenger_intel",
+        }
+        cold_artifact_id = _campaign_artifact_key(
+            company_name=challenger_name,
+            batch_id=batch_id,
+            channel="email_cold",
+        )
+        phase_one_entries.append(
+            {
+                "custom_id": cold_artifact_id,
+                "artifact_id": cold_artifact_id,
+                "campaign_batch_id": batch_id,
+                "phase": "cold",
+                "payload": cold_payload,
+                "channel": "email_cold",
+                "company_name": challenger_name,
+                "best": best,
+                "challenger_ctx": challenger_ctx,
+                "review_ids": review_ids[:20] or None,
+                "target": target,
+                "followup_payload": {
+                    **challenger_ctx,
+                    "contact_name": _sanitize_contact_name(target.get("contact_name")),
+                    "contact_role": target.get("contact_role"),
+                    "tier": target.get("tier", "report"),
+                    "selling": selling_context,
+                    "channel": "email_followup",
+                    "target_mode": "challenger_intel",
+                },
+                "sequence_context": {
+                    **challenger_ctx,
+                    "contact_name": _sanitize_contact_name(target.get("contact_name")),
+                    "contact_role": target.get("contact_role"),
+                    "tier": target.get("tier", "report"),
+                    "recipient_type": "challenger_intel",
+                    "selling": selling_context,
+                },
+                "max_tokens": cfg.max_tokens,
+                "temperature": cfg.temperature,
+                "trace_metadata": _campaign_trace_metadata(
+                    cold_payload,
+                    run_id=run_id,
+                    stage_id="b2b_campaign_generation.content",
+                ),
+            }
+        )
+
+    phase_one_results, phase_one_batch = await _run_campaign_batch(
+        llm,
+        skill.content,
+        phase_one_entries,
+        run_id=run_id,
+        task=task,
+    )
+    _merge_batch_metrics(batch_metrics, phase_one_batch)
+
+    followup_entries: list[dict[str, Any]] = []
+    for entry in phase_one_entries:
+        challenger_name = entry["company_name"]
+        payload = entry["payload"]
+        artifact_id = entry["artifact_id"]
+        content = phase_one_results.get(entry["custom_id"])
+        if _is_deferred_campaign_content(content):
+            await record_attempt(
+                pool,
+                artifact_type="campaign",
+                artifact_id=artifact_id,
+                attempt_no=1,
+                stage="generation",
+                status="queued",
+            )
+            deferred += 1
+            continue
+        if content:
+            metadata = _campaign_storage_metadata(payload)
+            generation_audit = (
+                payload.get("_generation_audit")
+                if isinstance(payload.get("_generation_audit"), dict)
+                else {}
+            )
+            specificity = (
+                generation_audit.get("specificity")
+                if isinstance(generation_audit.get("specificity"), dict)
+                else {}
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_campaigns (
+                        company_name, vendor_name, product_category,
+                        opportunity_score, urgency_score, pain_categories,
+                        competitors_considering, seat_count, contract_end,
+                        decision_timeline, buying_stage, role_type,
+                        key_quotes, source_review_ids,
+                        channel, subject, body, cta,
+                        status, batch_id, llm_model, industry, target_mode, metadata,
+                        recipient_email, score_components
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23, $24::jsonb,
+                        $25, $26::jsonb
+                    )
+                    """,
+                    challenger_name,
+                    entry["best"]["vendor_name"],
+                    entry["best"].get("product_category"),
+                    entry["best"]["opportunity_score"],
+                    entry["best"].get("urgency"),
+                    json.dumps(entry["challenger_ctx"]["signal_summary"]["pain_driving_switch"]),
+                    json.dumps(entry["challenger_ctx"]["signal_summary"]["incumbents_losing"]),
+                    entry["best"].get("seat_count"),
+                    entry["best"].get("contract_end"),
+                    entry["best"].get("decision_timeline"),
+                    entry["best"].get("buying_stage"),
+                    _map_role_type(entry["target"].get("contact_role")),
+                    json.dumps(entry["challenger_ctx"].get("key_quotes", [])),
+                    entry["review_ids"],
+                    "email_cold",
+                    content.get("subject", ""),
+                    content.get("body", ""),
+                    content.get("cta", ""),
+                    "draft",
+                    batch_id,
+                    llm_model_name,
+                    entry["best"].get("industry"),
+                    "challenger_intel",
+                    json.dumps(metadata, default=str),
+                    entry["target"].get("contact_email"),
+                    json.dumps(entry["best"].get("score_components")),
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="generation",
+                    status="succeeded",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                )
+                generated += 1
+                cold_email_content = {
+                    "subject": content.get("subject", ""),
+                    "body": content.get("body", ""),
+                }
+                if settings.campaign_sequence.enabled:
+                    try:
+                        seq_id = await _create_sequence_for_cold_email(
+                            pool,
+                            company_name=challenger_name,
+                            batch_id=batch_id,
+                            partner_id=None,
+                            context=entry["sequence_context"],
+                            cold_email_subject=cold_email_content.get("subject", ""),
+                            cold_email_body=cold_email_content.get("body", ""),
+                        )
+                        if seq_id:
+                            sequences_created += 1
+                            contact_email = entry["target"].get("contact_email")
+                            if contact_email:
+                                await pool.execute(
+                                    "UPDATE campaign_sequences SET recipient_email = $1 WHERE id = $2",
+                                    contact_email,
+                                    seq_id,
+                                )
+                    except Exception as exc:
+                        logger.warning("Failed to create challenger sequence for %s: %s", challenger_name, exc)
+
+                followup_payload = dict(entry["followup_payload"])
+                followup_payload["cold_email_context"] = cold_email_content
+                followup_artifact_id = _campaign_artifact_key(
+                    company_name=challenger_name,
+                    batch_id=batch_id,
+                    channel="email_followup",
+                )
+                followup_entries.append(
+                    {
+                        "custom_id": followup_artifact_id,
+                        "artifact_id": followup_artifact_id,
+                        "campaign_batch_id": batch_id,
+                        "phase": "followup",
+                        "payload": followup_payload,
+                        "channel": "email_followup",
+                        "company_name": challenger_name,
+                        "best": entry["best"],
+                        "challenger_ctx": entry["challenger_ctx"],
+                        "review_ids": entry["review_ids"],
+                        "target": entry["target"],
+                        "max_tokens": cfg.max_tokens,
+                        "temperature": cfg.temperature,
+                        "trace_metadata": _campaign_trace_metadata(
+                            followup_payload,
+                            run_id=run_id,
+                            stage_id="b2b_campaign_generation.content",
+                        ),
+                    }
+                )
+            except Exception:
+                logger.exception("Failed to store challenger campaign for %s/%s", challenger_name, "email_cold")
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="storage",
+                    status="failed",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    blocking_issues=list(specificity.get("blocking_issues") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                    failure_step="storage",
+                    error_message="campaign_storage_failed",
+                )
+                failed += 1
+        else:
+            await _record_campaign_generation_failure(
+                pool,
+                artifact_id=artifact_id,
+                company_name=challenger_name,
+                channel="email_cold",
+                generation_audit=payload.get("_generation_audit"),
+            )
+            failed += 1
+
+    followup_results, phase_two_batch = await _run_campaign_batch(
+        llm,
+        skill.content,
+        followup_entries,
+        run_id=run_id,
+        task=task,
+    )
+    _merge_batch_metrics(batch_metrics, phase_two_batch)
+
+    for entry in followup_entries:
+        challenger_name = entry["company_name"]
+        payload = entry["payload"]
+        artifact_id = entry["artifact_id"]
+        content = followup_results.get(entry["custom_id"])
+        if _is_deferred_campaign_content(content):
+            await record_attempt(
+                pool,
+                artifact_type="campaign",
+                artifact_id=artifact_id,
+                attempt_no=1,
+                stage="generation",
+                status="queued",
+            )
+            deferred += 1
+            continue
+        if content:
+            metadata = _campaign_storage_metadata(payload)
+            generation_audit = (
+                payload.get("_generation_audit")
+                if isinstance(payload.get("_generation_audit"), dict)
+                else {}
+            )
+            specificity = (
+                generation_audit.get("specificity")
+                if isinstance(generation_audit.get("specificity"), dict)
+                else {}
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_campaigns (
+                        company_name, vendor_name, product_category,
+                        opportunity_score, urgency_score, pain_categories,
+                        competitors_considering, seat_count, contract_end,
+                        decision_timeline, buying_stage, role_type,
+                        key_quotes, source_review_ids,
+                        channel, subject, body, cta,
+                        status, batch_id, llm_model, industry, target_mode, metadata,
+                        recipient_email, score_components
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23, $24::jsonb,
+                        $25, $26::jsonb
+                    )
+                    """,
+                    challenger_name,
+                    entry["best"]["vendor_name"],
+                    entry["best"].get("product_category"),
+                    entry["best"]["opportunity_score"],
+                    entry["best"].get("urgency"),
+                    json.dumps(entry["challenger_ctx"]["signal_summary"]["pain_driving_switch"]),
+                    json.dumps(entry["challenger_ctx"]["signal_summary"]["incumbents_losing"]),
+                    entry["best"].get("seat_count"),
+                    entry["best"].get("contract_end"),
+                    entry["best"].get("decision_timeline"),
+                    entry["best"].get("buying_stage"),
+                    _map_role_type(entry["target"].get("contact_role")),
+                    json.dumps(entry["challenger_ctx"].get("key_quotes", [])),
+                    entry["review_ids"],
+                    "email_followup",
+                    content.get("subject", ""),
+                    content.get("body", ""),
+                    content.get("cta", ""),
+                    "draft",
+                    batch_id,
+                    llm_model_name,
+                    entry["best"].get("industry"),
+                    "challenger_intel",
+                    json.dumps(metadata, default=str),
+                    entry["target"].get("contact_email"),
+                    json.dumps(entry["best"].get("score_components")),
+                )
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="generation",
+                    status="succeeded",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                )
+                generated += 1
+            except Exception:
+                logger.exception("Failed to store challenger campaign for %s/%s", challenger_name, "email_followup")
+                await record_attempt(
+                    pool,
+                    artifact_type="campaign",
+                    artifact_id=artifact_id,
+                    attempt_no=1,
+                    stage="storage",
+                    status="failed",
+                    blocker_count=len(specificity.get("blocking_issues") or []),
+                    warning_count=len(specificity.get("warnings") or []),
+                    blocking_issues=list(specificity.get("blocking_issues") or []),
+                    warnings=list(specificity.get("warnings") or []),
+                    failure_step="storage",
+                    error_message="campaign_storage_failed",
+                )
+                failed += 1
+        else:
+            await _record_campaign_generation_failure(
+                pool,
+                artifact_id=artifact_id,
+                company_name=challenger_name,
+                channel="email_followup",
+                generation_audit=payload.get("_generation_audit"),
+            )
+            failed += 1
+
+    logger.info(
+        "Campaign generation (challenger_intel): %d generated, %d failed, %d skipped, %d sequences from %d targets",
+        generated, failed, skipped, sequences_created, len(targets),
+    )
+
+    return {
+        "generated": generated,
+        "failed": failed,
+        "deferred": deferred,
+        "skipped": skipped,
+        "sequences_created": sequences_created,
+        "companies": len(targets) - skipped,
+        "batch_id": batch_id,
+        "target_mode": "challenger_intel",
+        "anthropic_batch_jobs": batch_metrics["jobs"],
+        "anthropic_batch_items_submitted": batch_metrics["submitted_items"],
+        "anthropic_batch_cache_prefiltered": batch_metrics["cache_prefiltered_items"],
+        "anthropic_batch_fallback_single_call": batch_metrics["fallback_single_call_items"],
+        "anthropic_batch_completed_items": batch_metrics["completed_items"],
+        "anthropic_batch_failed_items": batch_metrics["failed_items"],
+    }
+
+
+# ------------------------------------------------------------------
+# Data fetchers
+# ------------------------------------------------------------------
+
+
+async def _fetch_opportunities(
+    pool,
+    min_score: int,
+    limit: int,
+    vendor_filter: str | None = None,
+    company_filter: str | None = None,
+    dm_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Fetch and score top opportunities from enriched b2b_reviews."""
+    from atlas_brain.autonomous.tasks._b2b_shared import read_campaign_opportunities
+
+    rows = await read_campaign_opportunities(
+        pool,
+        window_days=90,
+        min_urgency=5.0,
+        vendor_name=vendor_filter,
+        company=company_filter,
+        dm_only=dm_only,
+        limit=min(limit * 3, 500),
+    )
+
+    # Fetch prior engagement speed for scoring tie-breaker
+    avg_open_cache: dict[str, float | None] = {}
+    vendor_names = {r["vendor_name"] for r in rows if r.get("vendor_name")}
+    if vendor_names:
+        eng_rows = await pool.fetch(
+            """
+            SELECT vendor_name, AVG(hours_to_first_open) AS avg_open_hours
+            FROM b2b_campaigns
+            WHERE vendor_name = ANY($1::text[])
+              AND hours_to_first_open IS NOT NULL
+              AND sent_at > NOW() - INTERVAL '90 days'
+            GROUP BY vendor_name
+            """,
+            list(vendor_names),
+        )
+        for er in eng_rows:
+            avg_open_cache[er["vendor_name"]] = (
+                float(er["avg_open_hours"]) if er["avg_open_hours"] is not None else None
+            )
+
+    opportunities = []
+    claim_as_of_date = date.today()
+    for r in rows:
+        row_dict = dict(r)
+        competitors = row_dict.get("competitors", [])
+
+        mention_context = ""
+        if competitors and isinstance(competitors[0], dict):
+            mention_context = competitors[0].get("context", "")
+
+        row_dict["mention_context"] = mention_context
+        row_dict["urgency"] = _safe_float(row_dict.get("urgency"), 0)
+        row_dict["avg_open_hours"] = avg_open_cache.get(row_dict.get("vendor_name"))
+        opp_score, score_components = _compute_score(row_dict)
+
+        if opp_score < min_score:
+            continue
+
+        row_dict["opportunity_score"] = opp_score
+        row_dict["score_components"] = score_components
+        claim = _attach_campaign_opportunity_claim(
+            row_dict,
+            as_of_date=claim_as_of_date,
+            analysis_window_days=90,
+        )
+        if not claim.report_allowed:
+            continue
+        opportunities.append(row_dict)
+
+    # Sort by score, then by prior engagement speed as tie-breaker (lower open hours = better)
+    opportunities.sort(
+        key=lambda o: (o["opportunity_score"], -(o.get("avg_open_hours") or 999)),
+        reverse=True,
+    )
+    return opportunities[:limit]
+
+
+async def _fetch_accounts_in_motion_opportunities(
+    pool,
+    min_score: int,
+    limit: int,
+    vendor_filter: str | None = None,
+    company_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch named company targets from the latest accounts-in-motion reports."""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT ON (LOWER(vendor_filter))
+               vendor_filter, intelligence_data
+        FROM b2b_intelligence
+        WHERE report_type = 'accounts_in_motion'
+          AND vendor_filter IS NOT NULL
+        ORDER BY LOWER(vendor_filter), report_date DESC, created_at DESC
+        """
+    )
+    results: list[dict[str, Any]] = []
+    vendor_filter_lc = str(vendor_filter or "").lower()
+    company_filter_lc = str(company_filter or "").lower()
+    claim_as_of_date = date.today()
+
+    for row in rows:
+        vendor_name = str(row.get("vendor_filter") or "").strip()
+        if vendor_filter_lc and vendor_filter_lc not in vendor_name.lower():
+            continue
+        report = row.get("intelligence_data")
+        if isinstance(report, str):
+            try:
+                report = json.loads(report)
+            except (json.JSONDecodeError, TypeError):
+                report = {}
+        if not isinstance(report, dict):
+            continue
+        feature_gaps = _parse_json_field(report.get("feature_gaps"))
+        category = report.get("category")
+        for account in report.get("accounts") or []:
+            if not isinstance(account, dict):
+                continue
+            company = str(account.get("company") or "").strip()
+            if not company:
+                continue
+            if company_filter_lc and company_filter_lc not in company.lower():
+                continue
+            score = int(account.get("opportunity_score") or 0)
+            if score < min_score:
+                continue
+            quote = str(account.get("top_quote") or "").strip()
+            review_ids = account.get("source_reviews") or []
+            review_id = review_ids[0] if review_ids else None
+            alternatives = [
+                {"name": str(name).strip(), "reason": ""}
+                for name in (account.get("alternatives_considering") or [])
+                if str(name).strip()
+            ]
+            candidate = {
+                "review_id": review_id,
+                "source_review_ids": review_ids,
+                "vendor_name": vendor_name or str(report.get("vendor") or "").strip(),
+                "reviewer_company": company,
+                "product_category": category,
+                "opportunity_score": score,
+                "urgency": account.get("urgency"),
+                "pain_json": (
+                    [{"category": account.get("pain_category"), "severity": "primary"}]
+                    if account.get("pain_category") else []
+                ),
+                "competitors": alternatives,
+                "quotable_phrases": [{
+                    "text": quote,
+                    "phrase_verbatim": True,
+                    "quote_origin": "accounts_in_motion",
+                    "review_id": review_id,
+                }] if quote else [],
+                "feature_gaps": feature_gaps,
+                "integration_stack": [],
+                "seat_count": account.get("seat_count"),
+                "contract_end": account.get("contract_end"),
+                "decision_timeline": account.get("decision_timeline"),
+                "buying_stage": account.get("buying_stage"),
+                "role_type": account.get("role_level"),
+                "industry": account.get("industry"),
+                "reviewer_title": account.get("title"),
+                "company_size_raw": account.get("company_size"),
+                "score_components": account.get("score_components") or {},
+                "opportunity_source": "accounts_in_motion",
+            }
+            claim = _attach_campaign_opportunity_claim(
+                candidate,
+                as_of_date=claim_as_of_date,
+                analysis_window_days=90,
+            )
+            if not claim.report_allowed:
+                continue
+            results.append(candidate)
+
+    results.sort(
+        key=lambda row: (
+            int(row.get("opportunity_score") or 0),
+            float(row.get("urgency") or 0),
+        ),
+        reverse=True,
+    )
+    return results[:limit]
+
+
+def _campaign_opportunity_claim_input(row: dict[str, Any]) -> dict[str, Any]:
+    """Map campaign candidate rows into the ACCOUNT ProductClaim row shape."""
+    return {
+        "company": row.get("reviewer_company") or row.get("company"),
+        "vendor": row.get("vendor_name") or row.get("vendor"),
+        "review_id": row.get("review_id"),
+        "source_review_ids": row.get("source_review_ids"),
+        "quotes": row.get("quotable_phrases") or row.get("quotes") or [],
+        "alternatives": row.get("competitors") or row.get("alternatives") or [],
+        "buying_stage": row.get("buying_stage"),
+        "contract_signal": (
+            row.get("decision_timeline")
+            or row.get("contract_signal")
+            or row.get("contract_end")
+        ),
+        "intent_signals": row.get("intent_signals"),
+    }
+
+
+def _attach_campaign_opportunity_claim(
+    row: dict[str, Any],
+    *,
+    as_of_date: date,
+    analysis_window_days: int,
+):
+    claim_input = _campaign_opportunity_claim_input(row)
+    claim = build_account_opportunity_claim(
+        claim_input,
+        as_of_date=as_of_date,
+        analysis_window_days=analysis_window_days,
+    )
+    row["opportunity_claim"] = serialize_product_claim(
+        claim,
+        source_review_count=account_opportunity_source_review_count(claim_input),
+    )
+    return claim
+
+
+def _parse_json_field(val) -> list:
+    """Safely parse a JSONB field that may be a str, list, or None."""
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return val
+    if isinstance(val, str):
+        try:
+            parsed = json.loads(val)
+            return parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, TypeError):
+            return []
+    return []
+
+
+def _campaign_quote_texts(value: Any) -> list[str]:
+    phrases = _parse_json_field(value)
+    texts: list[str] = []
+    for phrase in phrases:
+        if isinstance(phrase, dict) and phrase.get("phrase_verbatim") is True:
+            text = str(
+                phrase.get("text")
+                or phrase.get("phrase")
+                or phrase.get("quote")
+                or phrase.get("best_quote")
+                or ""
+            ).strip()
+        else:
+            text = ""
+        if text and text not in texts:
+            texts.append(text)
+    return texts
+
+
+def _campaign_primary_pain_category(opp: dict[str, Any]) -> str:
+    for item in _parse_json_field(opp.get("pain_json")):
+        if not isinstance(item, dict):
+            continue
+        category = str(item.get("category") or "").strip()
+        if category:
+            return category
+    return ""
+
+
+def _campaign_numeric_literals(opp: dict[str, Any]) -> dict[str, list[str]]:
+    literals: dict[str, list[str]] = {}
+    seat_count = opp.get("seat_count")
+    try:
+        seats = int(seat_count) if seat_count not in (None, "") else 0
+    except (TypeError, ValueError):
+        seats = 0
+    if seats > 0:
+        literals["seat_count"] = [str(seats)]
+    return literals
+
+
+def _build_churning_company_anchor_context(
+    best: dict[str, Any],
+    all_opps: list[dict[str, Any]],
+) -> dict[str, Any]:
+    pain_counts: dict[str, int] = {}
+    for opp in all_opps:
+        category = _campaign_primary_pain_category(opp)
+        if category:
+            pain_counts[category.lower()] = pain_counts.get(category.lower(), 0) + 1
+    dominant_pain = ""
+    if pain_counts:
+        dominant_pain = max(
+            pain_counts.items(),
+            key=lambda item: (item[1], item[0]),
+        )[0]
+
+    candidates: list[dict[str, Any]] = []
+    for opp in all_opps:
+        review_id = str(opp.get("review_id") or "").strip()
+        quote_texts = _campaign_quote_texts(opp.get("quotable_phrases"))
+        excerpt = quote_texts[0] if quote_texts else ""
+        if not excerpt:
+            continue
+
+        competitor = ""
+        competitors = opp.get("competitors") or []
+        if isinstance(competitors, list):
+            for item in competitors:
+                if isinstance(item, dict):
+                    competitor = str(item.get("name") or "").strip()
+                else:
+                    competitor = str(item or "").strip()
+                if competitor:
+                    break
+
+        feature_gaps: list[str] = []
+        for gap in _parse_json_field(opp.get("feature_gaps")):
+            if isinstance(gap, dict):
+                label = str(
+                    gap.get("feature") or gap.get("name") or gap.get("gap") or ""
+                ).strip()
+            else:
+                label = str(gap or "").strip()
+            if label and label not in feature_gaps:
+                feature_gaps.append(label)
+
+        numeric_literals = _campaign_numeric_literals(opp)
+        pain_category = _campaign_primary_pain_category(opp)
+        time_anchor = str(
+            opp.get("contract_end") or opp.get("decision_timeline") or ""
+        ).strip()
+        witness_id = (
+            f"campaign_witness:{review_id}:0"
+            if review_id
+            else f"campaign_witness:{str(best.get('vendor_name') or '').lower()}:{len(candidates)}"
+        )
+        candidates.append({
+            "witness_id": witness_id,
+            "excerpt_text": excerpt,
+            "reviewer_company": str(opp.get("reviewer_company") or "").strip(),
+            "time_anchor": time_anchor,
+            "competitor": competitor,
+            "pain_category": pain_category,
+            "phrase_verbatim": True,
+            "signal_tags": feature_gaps[:3],
+            "numeric_literals": numeric_literals,
+            "_urgency": _safe_float(opp.get("urgency"), 0),
+            "_has_numeric": bool(numeric_literals),
+            "_has_time": bool(time_anchor),
+            "_has_competitor": bool(competitor),
+            "_is_common_pattern": bool(
+                dominant_pain and pain_category and pain_category.lower() == dominant_pain
+            ),
+        })
+
+    if not candidates:
+        return {}
+
+    candidates.sort(
+        key=lambda item: (
+            item["_has_numeric"],
+            item["_has_time"],
+            item["_has_competitor"],
+            item["_is_common_pattern"],
+            item["_urgency"],
+            len(str(item.get("excerpt_text") or "")),
+            str(item.get("witness_id") or ""),
+        ),
+        reverse=True,
+    )
+
+    anchor_examples: dict[str, list[dict[str, Any]]] = {}
+    used_ids: set[str] = set()
+    for label, predicate in (
+        ("outlier_or_named_account", lambda item: True),
+        ("common_pattern", lambda item: bool(item.get("_is_common_pattern"))),
+    ):
+        for candidate in candidates:
+            witness_id = str(candidate.get("witness_id") or "")
+            if witness_id in used_ids or not predicate(candidate):
+                continue
+            anchor_examples[label] = [
+                {
+                    key: value
+                    for key, value in candidate.items()
+                    if not key.startswith("_")
+                },
+            ]
+            used_ids.add(witness_id)
+            break
+
+    limit = max(1, int(settings.b2b_churn.reasoning_witness_highlight_limit))
+    witness_highlights = [
+        {
+            key: value
+            for key, value in candidate.items()
+            if not key.startswith("_")
+        }
+        for candidate in candidates[:limit]
+    ]
+    reference_ids = {
+        "witness_ids": [
+            str(item.get("witness_id") or "").strip()
+            for item in witness_highlights
+            if str(item.get("witness_id") or "").strip()
+        ],
+    }
+
+    return {
+        "reasoning_anchor_examples": anchor_examples,
+        "reasoning_witness_highlights": witness_highlights,
+        "reasoning_reference_ids": reference_ids,
+    }
+
+
+def _build_company_context(best: dict, all_opps: list[dict]) -> dict[str, Any]:
+    """Build rich context dict for LLM from grouped opportunities."""
+    ordered_opps = _campaign_stable_row_order(all_opps)
+    pain_cats: dict[str, str] = {}
+    competitors_considering: list[dict] = []
+    key_quotes: list[str] = []
+    all_feature_gaps: list[str] = []
+    all_integrations: list[str] = []
+
+    for opp in ordered_opps:
+        # Pain categories
+        pain = _parse_json_field(opp.get("pain_json"))
+        for p in pain:
+            if isinstance(p, dict) and p.get("category"):
+                category = str(p.get("category") or "").strip()
+                if not category:
+                    continue
+                pain_cats[category] = _campaign_merge_pain_severity(
+                    pain_cats.get(category, ""),
+                    str(p.get("severity") or "mentioned"),
+                )
+
+        # Competitors
+        comps = opp.get("competitors", [])
+        for c in comps:
+            if isinstance(c, dict) and c.get("name"):
+                if not any(x["name"].lower() == c["name"].lower() for x in competitors_considering):
+                    competitors_considering.append({
+                        "name": c["name"],
+                        "reason": c.get("reason", ""),
+                    })
+
+        # Quote-grade phrases from enrichment (replaces raw review_text truncation)
+        for text in _campaign_quote_texts(opp.get("quotable_phrases")):
+            if text not in key_quotes:
+                key_quotes.append(text)
+
+        # Feature gaps
+        gaps = _parse_json_field(opp.get("feature_gaps"))
+        for g in gaps:
+            label = g if isinstance(g, str) else (g.get("feature", "") if isinstance(g, dict) else "")
+            if label and label not in all_feature_gaps:
+                all_feature_gaps.append(label)
+
+        # Integration stack
+        stacks = _parse_json_field(opp.get("integration_stack"))
+        for s in stacks:
+            if isinstance(s, str) and s not in all_integrations:
+                all_integrations.append(s)
+
+    context = {
+        "company": best.get("reviewer_company") or best["vendor_name"],
+        "churning_from": best["vendor_name"],
+        "category": best.get("product_category", ""),
+        "pain_categories": [
+            {"category": key, "severity": pain_cats[key]}
+            for key in sorted(pain_cats, key=lambda item: item.lower())
+        ],
+        "competitors_considering": competitors_considering[:5],
+        "urgency": best.get("urgency", 0),
+        "seat_count": best.get("seat_count"),
+        "contract_end": best.get("contract_end"),
+        "decision_timeline": best.get("decision_timeline"),
+        "buying_stage": best.get("buying_stage"),
+        "role_type": best.get("role_type"),
+        "industry": best.get("industry"),
+        "reviewer_title": best.get("reviewer_title"),
+        "company_size": best.get("company_size_raw"),
+        "key_quotes": key_quotes[:5],
+        "feature_gaps": all_feature_gaps[:5],
+        "primary_workflow": best.get("primary_workflow"),
+        "integration_stack": all_integrations[:5],
+        "sentiment_direction": best.get("sentiment_direction"),
+    }
+    if isinstance(best.get("opportunity_claim"), dict):
+        context["opportunity_claim"] = best["opportunity_claim"]
+    context.update(_build_churning_company_anchor_context(best, all_opps))
+    return context
+
+
+# ------------------------------------------------------------------
+# Persona-specific context filtering
+# ------------------------------------------------------------------
+
+# Pain categories relevant to each persona
+_PERSONA_PAIN_FILTER: dict[str, set[str]] = {
+    "executive": {"pricing", "cost", "scalability", "reliability"},
+    "technical": {"features", "ux", "integration", "security", "performance"},
+    "operations": {"support", "reliability", "usability", "service"},
+    "evaluator": {"features", "ux", "integration", "usability", "performance", "pricing"},
+    "champion": {"support", "usability", "reliability", "features", "service"},
+}
+
+# Quote keywords for filtering key_quotes per persona
+_PERSONA_QUOTE_KEYWORDS: dict[str, list[str]] = {
+    "executive": ["cost", "price", "budget", "roi", "renewal", "money", "expensive", "contract", "spend"],
+    "technical": ["feature", "bug", "api", "migration", "workaround", "integration", "missing", "broken", "limitation"],
+    "operations": ["support", "ticket", "downtime", "complaint", "productivity", "team", "workflow", "response time", "sla"],
+    "evaluator": ["evaluate", "compare", "alternative", "demo", "trial", "requirement", "criteria", "shortlist", "selection", "vendor"],
+    "champion": ["team", "adoption", "rollout", "training", "onboarding", "user", "daily", "workflow", "productivity", "frustrat"],
+}
+
+# Persona -> role_type mapping (controls tone via existing skill Rule #3)
+_PERSONA_ROLE_TYPE: dict[str, str] = {
+    "executive": "economic_buyer",
+    "technical": "evaluator",
+    "operations": "champion",
+    "evaluator": "evaluator",
+    "champion": "champion",
+}
+
+# Context fields to emphasize per persona
+_PERSONA_EMPHASIS: dict[str, list[str]] = {
+    "executive": ["urgency", "seat_count", "contract_end", "decision_timeline"],
+    "technical": ["feature_gaps", "integration_stack", "competitors_considering"],
+    "operations": ["pain_categories", "key_quotes"],
+    "evaluator": ["feature_gaps", "competitors_considering", "integration_stack", "pain_categories"],
+    "champion": ["pain_categories", "key_quotes", "urgency"],
+}
+
+
+def _build_persona_context(base_context: dict[str, Any], persona: str) -> dict[str, Any] | None:
+    """Filter base company context for a specific persona.
+
+    Returns a persona-tailored copy of the context, or None if the persona has
+    no relevant pain categories (skip rule).
+    """
+    pain_filter = _PERSONA_PAIN_FILTER.get(persona, set())
+    quote_keywords = _PERSONA_QUOTE_KEYWORDS.get(persona, [])
+
+    # Filter pain categories
+    filtered_pains = []
+    for p in base_context.get("pain_categories", []):
+        cat = (p.get("category") or "").lower()
+        if any(f in cat for f in pain_filter):
+            filtered_pains.append(p)
+
+    # Skip rule: no relevant pain categories -> skip this persona
+    if not filtered_pains:
+        return None
+
+    # Filter key quotes by persona-relevant keywords
+    filtered_quotes = []
+    for q in base_context.get("key_quotes", []):
+        q_lower = q.lower()
+        if any(kw in q_lower for kw in quote_keywords):
+            filtered_quotes.append(q)
+    # If no quotes matched keywords, keep top 2 from base (better than empty)
+    if not filtered_quotes:
+        filtered_quotes = base_context.get("key_quotes", [])[:2]
+
+    ctx = {
+        **base_context,
+        "pain_categories": filtered_pains,
+        "key_quotes": filtered_quotes[:5],
+        "role_type": _PERSONA_ROLE_TYPE.get(persona, base_context.get("role_type")),
+        "target_persona": persona,
+        "emphasized_fields": _PERSONA_EMPHASIS.get(persona, []),
+    }
+
+    return ctx
+
+
+# ------------------------------------------------------------------
+# Partner matching
+# ------------------------------------------------------------------
+
+
+async def _fetch_affiliate_partners(pool) -> dict[str, Any]:
+    """Fetch enabled affiliate partners, indexed by product name and category."""
+    rows = await pool.fetch(
+        "SELECT id, name, product_name, product_aliases, category, affiliate_url "
+        "FROM affiliate_partners WHERE enabled = true"
+    )
+    by_product: dict[str, dict] = {}
+    by_category: dict[str, list[dict]] = {}
+
+    for r in rows:
+        partner = dict(r)
+        partner["id"] = str(partner["id"])
+        # Index by lowercase product name + aliases
+        by_product[partner["product_name"].lower()] = partner
+        for alias in (partner.get("product_aliases") or []):
+            by_product[alias.lower()] = partner
+        # Index by lowercase category
+        cat = (partner.get("category") or "").lower()
+        if cat:
+            by_category.setdefault(cat, []).append(partner)
+
+    return {"by_product": by_product, "by_category": by_category}
+
+
+def _match_partner(
+    context: dict,
+    partner_index: dict[str, Any],
+) -> dict | None:
+    """Match a company context to the best affiliate partner.
+
+    Priority: (1) exact product match against competitors, (2) category fallback.
+    """
+    by_product = partner_index["by_product"]
+    by_category = partner_index["by_category"]
+
+    comparison_asset = context.get("comparison_asset") or {}
+    comparison_vendor = str(comparison_asset.get("alternative_vendor") or "").lower()
+    if comparison_vendor and comparison_vendor in by_product:
+        return by_product[comparison_vendor]
+
+    for alt in context.get("recommended_alternatives") or []:
+        if not isinstance(alt, dict):
+            continue
+        name = str(alt.get("vendor_name") or "").lower()
+        if name and name in by_product:
+            return by_product[name]
+
+    # Try exact match on competitor names
+    for comp in context.get("competitors_considering", []):
+        name = (comp.get("name") or "").lower()
+        if name and name in by_product:
+            return by_product[name]
+
+    # Fallback: match by product category
+    category = (context.get("category") or "").lower()
+    if category and category in by_category:
+        return by_category[category][0]
+
+    return None
+
+
+# ------------------------------------------------------------------
+# LLM generation
+# ------------------------------------------------------------------
+
+
+async def _call_llm(
+    llm,
+    system_prompt: str,
+    user_content: str,
+    max_tokens: int,
+    temperature: float,
+    *,
+    trace_span_name: str | None = None,
+    trace_metadata: dict[str, Any] | None = None,
+    usage_out: dict[str, Any] | None = None,
+) -> str | None:
+    """Low-level LLM call. Returns raw text or None."""
+    import asyncio
+    import time
+
+    from ...pipelines.llm import _trace_cache_metrics, trace_llm_call
+    from ...services.protocols import Message
+
+    messages = [
+        Message(role="system", content=system_prompt),
+        Message(role="user", content=user_content),
+    ]
+    t0 = time.monotonic()
+
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(
+                llm.chat,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ),
+            timeout=float(settings.b2b_campaign.llm_timeout_seconds),
+        )
+        text = str(result.get("response", "") or "").strip()
+        usage = result.get("usage", {})
+        trace_meta = result.get("_trace_meta", {})
+        cached_tokens, cache_write_tokens, billable_input_tokens = _trace_cache_metrics(
+            usage if isinstance(usage, dict) else {},
+            trace_meta if isinstance(trace_meta, dict) else {},
+        )
+        trace_llm_call(
+            span_name=trace_span_name or "task.b2b_campaign_generation",
+            input_tokens=int((usage or {}).get("input_tokens") or 0),
+            output_tokens=int((usage or {}).get("output_tokens") or 0),
+            cached_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+            billable_input_tokens=billable_input_tokens,
+            model=str(getattr(llm, "model", "") or getattr(llm, "model_id", "") or ""),
+            provider=str(getattr(llm, "name", "") or ""),
+            duration_ms=(time.monotonic() - t0) * 1000,
+            metadata=trace_metadata or {},
+            input_data={
+                "messages": [
+                    {"role": message.role, "content": message.content[:500]}
+                    for message in messages
+                ]
+            },
+            output_data={"response": text[:2000]} if text else None,
+            api_endpoint=(trace_meta or {}).get("api_endpoint"),
+            provider_request_id=(trace_meta or {}).get("provider_request_id"),
+            ttft_ms=(trace_meta or {}).get("ttft_ms"),
+            inference_time_ms=(trace_meta or {}).get("inference_time_ms"),
+            queue_time_ms=(trace_meta or {}).get("queue_time_ms"),
+        )
+        if usage_out is not None:
+            usage_out.clear()
+            usage_out.update(
+                {
+                    "input_tokens": int((usage or {}).get("input_tokens") or 0),
+                    "output_tokens": int((usage or {}).get("output_tokens") or 0),
+                    "cached_tokens": int(cached_tokens or 0),
+                    "cache_write_tokens": int(cache_write_tokens or 0),
+                    "billable_input_tokens": int(
+                        billable_input_tokens
+                        if billable_input_tokens is not None
+                        else int((usage or {}).get("input_tokens") or 0)
+                    ),
+                    "model": str(getattr(llm, "model", "") or getattr(llm, "model_id", "") or ""),
+                    "provider": str(getattr(llm, "name", "") or ""),
+                    "provider_request_id": (
+                        str((trace_meta or {}).get("provider_request_id") or "") or None
+                    ),
+                }
+            )
+        return text or None
+    except Exception as exc:
+        trace_llm_call(
+            span_name=trace_span_name or "task.b2b_campaign_generation",
+            model=str(getattr(llm, "model", "") or getattr(llm, "model_id", "") or ""),
+            provider=str(getattr(llm, "name", "") or ""),
+            duration_ms=(time.monotonic() - t0) * 1000,
+            status="failed",
+            metadata=trace_metadata or {},
+            input_data={
+                "messages": [
+                    {"role": message.role, "content": message.content[:500]}
+                    for message in messages
+                ]
+            },
+            error_message=str(exc)[:500],
+            error_type=type(exc).__name__,
+        )
+        logger.exception("Campaign generation LLM call failed")
+        return None
+
+
+def _prepare_campaign_request_payload(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Mutate payload with specificity context and return the first-pass request body."""
+    request_payload = payload
+    working_payload = dict(payload)
+    channel = str(payload.get("channel") or "")
+    specificity_context = _campaign_specificity_context(request_payload)
+    if specificity_context:
+        request_payload["_campaign_specificity_context"] = specificity_context
+        proof_terms = _campaign_specificity_terms(
+            _campaign_specificity_audit(
+                body="",
+                channel=channel,
+                specificity_context=specificity_context,
+            ),
+            channel=channel,
+        )
+        if proof_terms:
+            request_payload["campaign_proof_terms"] = proof_terms
+            working_payload["campaign_proof_terms"] = proof_terms
+    return working_payload, specificity_context
+
+
+def _campaign_trace_metadata(
+    payload: dict[str, Any],
+    *,
+    run_id: str | None,
+    stage_id: str,
+) -> dict[str, Any]:
+    vendor_name = (
+        str(payload.get("vendor_name") or "").strip()
+        or str(payload.get("challenger_name") or "").strip()
+        or str(payload.get("company") or "").strip()
+        or str(payload.get("churning_from") or "").strip()
+    )
+    metadata: dict[str, Any] = {
+        "stage_id": stage_id,
+        "workflow": "b2b_campaign_generation",
+        "channel": str(payload.get("channel") or ""),
+        "target_mode": str(payload.get("target_mode") or ""),
+        "tier": str(payload.get("tier") or ""),
+    }
+    if vendor_name:
+        metadata["vendor_name"] = vendor_name
+    if run_id:
+        metadata["run_id"] = run_id
+    return metadata
+
+
+def _merge_batch_metrics(
+    target: dict[str, int],
+    delta: dict[str, int | str],
+) -> None:
+    for key in (
+        "jobs",
+        "submitted_items",
+        "cache_prefiltered_items",
+        "fallback_single_call_items",
+        "completed_items",
+        "failed_items",
+    ):
+        target[key] = int(target.get(key, 0)) + int(delta.get(key, 0) or 0)
+
+
+def _is_deferred_campaign_content(content: dict[str, Any] | None) -> bool:
+    return isinstance(content, dict) and bool(content.get("_deferred"))
+
+
+def _json_safe(value: Any) -> Any:
+    try:
+        return json.loads(json.dumps(value, default=str))
+    except Exception:
+        return value
+
+
+_CAMPAIGN_BATCH_REPLAY_CONTRACT_VERSION = 1
+
+
+def _safe_replay_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_replay_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_campaign_batch_replay_entry(entry: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(entry, dict):
+        return None
+    payload = entry.get("payload")
+    best = entry.get("best")
+    review_ids = entry.get("review_ids")
+    if not isinstance(payload, dict) or not isinstance(best, dict) or not isinstance(review_ids, list):
+        return None
+
+    artifact_id = str(entry.get("artifact_id") or "").strip()
+    campaign_batch_id = str(entry.get("campaign_batch_id") or "").strip()
+    company_name = str(entry.get("company_name") or "").strip()
+    target_mode = str(payload.get("target_mode") or "").strip()
+    if not artifact_id or not campaign_batch_id or not company_name or not target_mode:
+        return None
+
+    replay_entry: dict[str, Any] = {
+        "artifact_id": artifact_id,
+        "campaign_batch_id": campaign_batch_id,
+        "company_name": company_name,
+        "payload": _json_safe(payload),
+        "best": _json_safe(best),
+        "review_ids": _json_safe(review_ids),
+    }
+
+    if target_mode == "churning_company":
+        persona_context = entry.get("persona_context")
+        if not isinstance(persona_context, dict):
+            return None
+        replay_entry["persona_context"] = _json_safe(persona_context)
+        persona = str(entry.get("persona") or "").strip()
+        if persona:
+            replay_entry["persona"] = persona
+        partner_id = str(entry.get("partner_id") or "").strip()
+        if partner_id:
+            replay_entry["partner_id"] = partner_id
+    elif target_mode == "vendor_retention":
+        vendor_ctx = entry.get("vendor_ctx")
+        target = entry.get("target")
+        followup_payload = entry.get("followup_payload")
+        sequence_context = entry.get("sequence_context")
+        if not all(isinstance(value, dict) for value in (vendor_ctx, target, followup_payload, sequence_context)):
+            return None
+        replay_entry["vendor_ctx"] = _json_safe(vendor_ctx)
+        replay_entry["target"] = _json_safe(target)
+        replay_entry["followup_payload"] = _json_safe(followup_payload)
+        replay_entry["sequence_context"] = _json_safe(sequence_context)
+    elif target_mode == "challenger_intel":
+        challenger_ctx = entry.get("challenger_ctx")
+        target = entry.get("target")
+        followup_payload = entry.get("followup_payload")
+        sequence_context = entry.get("sequence_context")
+        if not all(isinstance(value, dict) for value in (challenger_ctx, target, followup_payload, sequence_context)):
+            return None
+        replay_entry["challenger_ctx"] = _json_safe(challenger_ctx)
+        replay_entry["target"] = _json_safe(target)
+        replay_entry["followup_payload"] = _json_safe(followup_payload)
+        replay_entry["sequence_context"] = _json_safe(sequence_context)
+    else:
+        return None
+
+    return replay_entry
+
+
+def _normalize_campaign_batch_replay_entry(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    raw = metadata.get("replay_entry")
+    if not isinstance(raw, dict):
+        return None
+
+    candidate = raw
+    if _safe_replay_int(raw.get("contract_version")) == _CAMPAIGN_BATCH_REPLAY_CONTRACT_VERSION:
+        nested = raw.get("entry")
+        if not isinstance(nested, dict):
+            return None
+        candidate = nested
+
+    replay_entry = _build_campaign_batch_replay_entry(candidate)
+    if replay_entry is None:
+        return None
+
+    max_tokens = _safe_replay_int(metadata.get("_max_tokens"))
+    if max_tokens is None:
+        max_tokens = _safe_replay_int(candidate.get("max_tokens"))
+    if max_tokens is not None:
+        replay_entry["max_tokens"] = max_tokens
+
+    temperature = _safe_replay_float(metadata.get("_temperature"))
+    if temperature is None:
+        temperature = _safe_replay_float(candidate.get("temperature"))
+    if temperature is not None:
+        replay_entry["temperature"] = temperature
+
+    trace_metadata = metadata.get("_trace_metadata")
+    if not isinstance(trace_metadata, dict):
+        trace_metadata = candidate.get("trace_metadata")
+    if isinstance(trace_metadata, dict) and trace_metadata:
+        replay_entry["trace_metadata"] = _json_safe(trace_metadata)
+
+    return replay_entry
+
+
+def _campaign_batch_request_metadata(entry: dict[str, Any]) -> dict[str, Any]:
+    payload = entry.get("payload") or {}
+    replay_entry = _build_campaign_batch_replay_entry(entry)
+    metadata: dict[str, Any] = {
+        "channel": payload.get("channel"),
+        "target_mode": payload.get("target_mode"),
+        "tier": payload.get("tier"),
+        "replay_handler": "campaign_generation",
+    }
+    if replay_entry is not None:
+        metadata["replay_entry"] = {
+            "contract_version": _CAMPAIGN_BATCH_REPLAY_CONTRACT_VERSION,
+            "entry": replay_entry,
+        }
+    return metadata
+
+
+async def _run_campaign_batch(
+    llm,
+    system_prompt: str,
+    entries: list[dict[str, Any]],
+    *,
+    run_id: str | None,
+    task: ScheduledTask | Any | None = None,
+) -> tuple[dict[str, dict[str, Any] | None], dict[str, int | str]]:
+    """Run the first campaign attempt through Anthropic batching when eligible."""
+    from ...services.b2b.anthropic_batch import (
+        AnthropicBatchItem,
+        mark_batch_fallback_result,
+        submit_anthropic_message_batch,
+        run_anthropic_message_batch,
+    )
+    from ...services.b2b.cache_runner import (
+        lookup_b2b_exact_stage_text,
+        prepare_b2b_exact_stage_request,
+    )
+    from ...services.b2b.llm_exact_cache import llm_identity
+    from ...services.protocols import Message
+    import inspect
+    from ._b2b_batch_utils import (
+        anthropic_batch_min_items,
+        anthropic_batch_requested,
+        is_anthropic_llm,
+        resolve_anthropic_batch_llm,
+    )
+
+    async def _invoke_generate_content(
+        entry: dict[str, Any],
+        *,
+        first_attempt_text: str | None = None,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        params = inspect.signature(_generate_content).parameters
+        supports_kwargs = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in params.values()
+        )
+        kwargs: dict[str, Any] = {}
+        generation_usage: dict[str, Any] = {}
+        if first_attempt_text is not None and ("first_attempt_text" in params or supports_kwargs):
+            kwargs["first_attempt_text"] = first_attempt_text
+        if "trace_span_name" in params or supports_kwargs:
+            kwargs["trace_span_name"] = "task.b2b_campaign_generation"
+        if "trace_metadata" in params or supports_kwargs:
+            kwargs["trace_metadata"] = entry["trace_metadata"]
+        if "usage_out" in params or supports_kwargs:
+            kwargs["usage_out"] = generation_usage
+        content = await _generate_content(
+            llm,
+            system_prompt,
+            entry["payload"],
+            entry["max_tokens"],
+            entry["temperature"],
+            **kwargs,
+        )
+        return content, generation_usage
+
+    if not entries:
+        return {}, {
+            "jobs": 0,
+            "submitted_items": 0,
+            "cache_prefiltered_items": 0,
+            "fallback_single_call_items": 0,
+            "completed_items": 0,
+            "failed_items": 0,
+        }
+
+    batch_requested = anthropic_batch_requested(
+        task,
+        global_default=bool(getattr(settings.b2b_churn, "anthropic_batch_enabled", False)),
+        task_default=bool(getattr(settings.b2b_campaign, "anthropic_batch_enabled", True)),
+        task_keys=("campaign_anthropic_batch_enabled",),
+    )
+    batch_llm = resolve_anthropic_batch_llm(current_llm=llm) if batch_requested else None
+    if not is_anthropic_llm(batch_llm):
+        results: dict[str, dict[str, Any] | None] = {}
+        for entry in entries:
+            content, _ = await _invoke_generate_content(entry)
+            results[entry["custom_id"]] = content
+        return results, {
+            "jobs": 0,
+            "submitted_items": 0,
+            "cache_prefiltered_items": 0,
+            "fallback_single_call_items": 0,
+            "completed_items": 0,
+            "failed_items": 0,
+        }
+
+    provider_name, model_name = llm_identity(batch_llm)
+    batch_items: list[AnthropicBatchItem] = []
+    for entry in entries:
+        payload = entry["payload"]
+        working_payload, _ = _prepare_campaign_request_payload(payload)
+        user_content = json.dumps(working_payload, separators=(",", ":"), default=str)
+        request = prepare_b2b_exact_stage_request(
+            "b2b_campaign_generation.content",
+            provider=provider_name,
+            model=model_name,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+            max_tokens=entry["max_tokens"],
+            temperature=entry["temperature"],
+        )
+        cached = await lookup_b2b_exact_stage_text(request)
+        cached_response_text = str(cached["response_text"]) if cached is not None else None
+        cached_usage = dict(cached.get("usage") or {}) if cached is not None else {}
+        batch_items.append(
+            AnthropicBatchItem(
+                custom_id=entry["custom_id"],
+                artifact_type="campaign",
+                artifact_id=entry["artifact_id"],
+                vendor_name=entry["trace_metadata"].get("vendor_name"),
+                messages=[
+                    Message(role="system", content=system_prompt),
+                    Message(role="user", content=user_content),
+                ],
+                max_tokens=entry["max_tokens"],
+                temperature=entry["temperature"],
+                trace_span_name="task.b2b_campaign_generation",
+                trace_metadata=entry["trace_metadata"],
+                request_metadata=_campaign_batch_request_metadata(entry),
+                cached_response_text=cached_response_text,
+                cached_usage=cached_usage,
+            )
+        )
+
+    if settings.b2b_campaign.anthropic_batch_detached_enabled:
+        execution = await submit_anthropic_message_batch(
+            llm=batch_llm,
+            stage_id="b2b_campaign_generation.content",
+            task_name="b2b_campaign_generation",
+            items=batch_items,
+            run_id=run_id,
+            min_batch_size=anthropic_batch_min_items(
+                task,
+                default=int(getattr(settings.b2b_campaign, "anthropic_batch_min_items", 2)),
+                keys=("campaign_anthropic_batch_min_items",),
+            ),
+            batch_metadata={"phase_channels": sorted({str(entry["channel"]) for entry in entries})},
+        )
+        if execution.provider_batch_id:
+            results: dict[str, dict[str, Any] | None] = {}
+            for entry in entries:
+                results[entry["custom_id"]] = {"_deferred": True}
+            return results, {
+                "jobs": 1,
+                "submitted_items": execution.submitted_items,
+                "cache_prefiltered_items": execution.cache_prefiltered_items,
+                "fallback_single_call_items": execution.fallback_single_call_items,
+                "completed_items": execution.completed_items,
+                "failed_items": execution.failed_items,
+            }
+        results: dict[str, dict[str, Any] | None] = {}
+        for entry in entries:
+            outcome = execution.results_by_custom_id.get(entry["custom_id"])
+            if outcome is not None and outcome.response_text is not None:
+                content, _ = await _invoke_generate_content(
+                    entry,
+                    first_attempt_text=outcome.response_text,
+                )
+                results[entry["custom_id"]] = content
+                continue
+            content, fallback_usage = await _invoke_generate_content(entry)
+            results[entry["custom_id"]] = content
+            if outcome is not None and outcome.fallback_required:
+                await mark_batch_fallback_result(
+                    batch_id=execution.local_batch_id,
+                    custom_id=entry["custom_id"],
+                    succeeded=content is not None,
+                    error_text=outcome.error_text if content is None else None,
+                    response_text=json.dumps(content, separators=(",", ":"), default=str) if content else None,
+                    usage=fallback_usage,
+                    provider=str(fallback_usage.get("provider") or "") or None,
+                    model=str(fallback_usage.get("model") or "") or None,
+                    provider_request_id=(
+                        str(fallback_usage.get("provider_request_id") or "") or None
+                    ),
+                )
+        return results, {
+            "jobs": 0,
+            "submitted_items": execution.submitted_items,
+            "cache_prefiltered_items": execution.cache_prefiltered_items,
+            "fallback_single_call_items": execution.fallback_single_call_items,
+            "completed_items": execution.completed_items,
+            "failed_items": execution.failed_items,
+        }
+
+    execution = await run_anthropic_message_batch(
+        llm=batch_llm,
+        stage_id="b2b_campaign_generation.content",
+        task_name="b2b_campaign_generation",
+        items=batch_items,
+        run_id=run_id,
+        min_batch_size=anthropic_batch_min_items(
+            task,
+            default=int(getattr(settings.b2b_campaign, "anthropic_batch_min_items", 2)),
+            keys=("campaign_anthropic_batch_min_items",),
+        ),
+        batch_metadata={"phase_channels": sorted({str(entry["channel"]) for entry in entries})},
+    )
+
+    results: dict[str, dict[str, Any] | None] = {}
+    for entry in entries:
+        outcome = execution.results_by_custom_id.get(entry["custom_id"])
+        if outcome is None:
+            content, fallback_usage = await _invoke_generate_content(entry)
+            results[entry["custom_id"]] = content
+            await mark_batch_fallback_result(
+                batch_id=execution.local_batch_id,
+                custom_id=entry["custom_id"],
+                succeeded=content is not None,
+                error_text="missing_batch_outcome" if content is None else None,
+                response_text=json.dumps(content, separators=(",", ":"), default=str) if content else None,
+                usage=fallback_usage,
+                provider=str(fallback_usage.get("provider") or "") or None,
+                model=str(fallback_usage.get("model") or "") or None,
+                provider_request_id=(
+                    str(fallback_usage.get("provider_request_id") or "") or None
+                ),
+            )
+            continue
+
+        if outcome.response_text is not None:
+            content, _ = await _invoke_generate_content(
+                entry,
+                first_attempt_text=outcome.response_text,
+            )
+            results[entry["custom_id"]] = content
+            continue
+
+        content, fallback_usage = await _invoke_generate_content(entry)
+        results[entry["custom_id"]] = content
+        await mark_batch_fallback_result(
+            batch_id=execution.local_batch_id,
+            custom_id=entry["custom_id"],
+            succeeded=content is not None,
+            error_text=outcome.error_text if content is None else None,
+            response_text=json.dumps(content, separators=(",", ":"), default=str) if content else None,
+            usage=fallback_usage,
+            provider=str(fallback_usage.get("provider") or "") or None,
+            model=str(fallback_usage.get("model") or "") or None,
+            provider_request_id=(
+                str(fallback_usage.get("provider_request_id") or "") or None
+            ),
+        )
+
+    return results, {
+        "jobs": 1 if execution.provider_batch_id else 0,
+        "submitted_items": execution.submitted_items,
+        "cache_prefiltered_items": execution.cache_prefiltered_items,
+        "fallback_single_call_items": execution.fallback_single_call_items,
+        "completed_items": execution.completed_items,
+        "failed_items": execution.failed_items,
+    }
+
+
+def _normalized_batch_item_metadata(row: Any) -> dict[str, Any]:
+    metadata = row.get("request_metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except Exception:
+            metadata = {}
+    return metadata if isinstance(metadata, dict) else {}
+
+
+async def _mark_campaign_batch_item_applied(
+    pool,
+    *,
+    item_id: str,
+    applied_status: str,
+    error: str | None = None,
+) -> None:
+    patch = {
+        "applied_at": datetime.now(timezone.utc).isoformat(),
+        "applied_status": applied_status,
+    }
+    if error:
+        patch["applied_error"] = error[:500]
+    await pool.execute(
+        """
+        UPDATE anthropic_message_batch_items
+        SET request_metadata = ((COALESCE(request_metadata, '{}'::jsonb) - 'applying_at' - 'applying_by') || $2::jsonb)
+        WHERE id = $1::uuid
+        """,
+        item_id,
+        json.dumps(patch, default=str),
+    )
+
+
+async def _claim_campaign_batch_item_for_apply(
+    pool,
+    *,
+    item_id: str,
+    claimer: str,
+    stale_after_minutes: int = 30,
+) -> bool:
+    patch = {
+        "applying_at": datetime.now(timezone.utc).isoformat(),
+        "applying_by": claimer[:120],
+    }
+    row = await pool.fetchrow(
+        f"""
+        UPDATE anthropic_message_batch_items
+        SET request_metadata = ((COALESCE(request_metadata, '{{}}'::jsonb) - 'applying_at' - 'applying_by') || $2::jsonb)
+        WHERE id = $1::uuid
+          AND COALESCE(request_metadata->>'applied_at', '') = ''
+          AND (
+                COALESCE(request_metadata->>'applying_at', '') = ''
+                OR NULLIF(request_metadata->>'applying_at', '')::timestamptz < NOW() - INTERVAL '{int(stale_after_minutes)} minutes'
+              )
+        RETURNING id
+        """,
+        item_id,
+        json.dumps(patch, default=str),
+    )
+    return row is not None
+
+
+def _campaign_generation_specificity(payload: dict[str, Any]) -> dict[str, Any]:
+    generation_audit = (
+        payload.get("_generation_audit")
+        if isinstance(payload.get("_generation_audit"), dict)
+        else {}
+    )
+    specificity = (
+        generation_audit.get("specificity")
+        if isinstance(generation_audit.get("specificity"), dict)
+        else {}
+    )
+    return specificity
+
+
+async def _resolve_campaign_batch_item_content(
+    row: Any,
+    *,
+    llm,
+    system_prompt: str,
+    entry: dict[str, Any],
+) -> dict[str, Any] | None:
+    payload = entry.get("payload") or {}
+    trace_metadata = entry.get("trace_metadata")
+    if not isinstance(trace_metadata, dict):
+        trace_metadata = _campaign_trace_metadata(
+            payload,
+            run_id=str((payload.get("run_id") or "")).strip() or None,
+            stage_id="b2b_campaign_generation.content",
+        )
+    status = str(row.get("status") or "")
+    response_text = str(row.get("response_text") or "") or None
+    if status in {"batch_succeeded", "cache_hit"} and response_text:
+        return await _generate_content(
+            llm,
+            system_prompt,
+            payload,
+            int(entry.get("max_tokens") or settings.b2b_campaign.max_tokens),
+            float(entry.get("temperature") or settings.b2b_campaign.temperature),
+            first_attempt_text=response_text,
+            trace_span_name="task.b2b_campaign_generation",
+            trace_metadata=trace_metadata,
+        )
+    if status == "fallback_pending":
+        content = await _generate_content(
+            llm,
+            system_prompt,
+            payload,
+            int(entry.get("max_tokens") or settings.b2b_campaign.max_tokens),
+            float(entry.get("temperature") or settings.b2b_campaign.temperature),
+            trace_span_name="task.b2b_campaign_generation",
+            trace_metadata=trace_metadata,
+        )
+        from ...services.b2b.anthropic_batch import mark_batch_fallback_result
+
+        await mark_batch_fallback_result(
+            batch_id=str(row.get("batch_id")),
+            custom_id=str(row.get("custom_id")),
+            succeeded=content is not None,
+            error_text=None if content is not None else str(row.get("error_text") or "") or "single_call_failed",
+            response_text=json.dumps(content, separators=(",", ":"), default=str) if content else None,
+        )
+        return content
+    if status == "fallback_succeeded" and response_text:
+        try:
+            parsed = json.loads(response_text)
+            if isinstance(parsed, dict) and parsed.get("body"):
+                payload["_generation_audit"] = payload.get("_generation_audit") or {"status": "succeeded", "attempts": 1}
+                return parsed
+        except Exception:
+            pass
+    return None
+
+
+async def _store_churning_replayed_campaign(
+    pool,
+    *,
+    entry: dict[str, Any],
+    content: dict[str, Any],
+    llm_model_name: str,
+) -> dict[str, Any] | None:
+    payload = entry["payload"]
+    company_name = entry["company_name"]
+    artifact_id = entry["artifact_id"]
+    metadata = _campaign_storage_metadata(payload)
+    specificity = _campaign_generation_specificity(payload)
+    if str(payload.get("channel") or "") == "email_followup":
+        await pool.execute(
+            """
+            INSERT INTO b2b_campaigns (
+                company_name, vendor_name, product_category,
+                opportunity_score, urgency_score, pain_categories,
+                competitors_considering, seat_count, contract_end,
+                decision_timeline, buying_stage, role_type,
+                key_quotes, source_review_ids,
+                channel, subject, body, cta,
+                status, batch_id, llm_model,
+                partner_id, industry, target_mode, metadata,
+                score_components
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                $11, $12, $13, $14, $15, $16, $17, $18,
+                $19, $20, $21, $22, $23, $24, $25::jsonb,
+                $26::jsonb
+            )
+            """,
+            company_name,
+            entry["best"]["vendor_name"],
+            entry["best"].get("product_category"),
+            entry["best"]["opportunity_score"],
+            entry["best"].get("urgency"),
+            json.dumps(entry["persona_context"].get("pain_categories", [])),
+            json.dumps(entry["persona_context"].get("competitors_considering", [])),
+            entry["best"].get("seat_count"),
+            entry["best"].get("contract_end"),
+            entry["best"].get("decision_timeline"),
+            entry["best"].get("buying_stage"),
+            entry["persona_context"].get("role_type"),
+            json.dumps(entry["persona_context"].get("key_quotes", [])),
+            entry["review_ids"],
+            "email_followup",
+            content.get("subject", ""),
+            content.get("body", ""),
+            content.get("cta", ""),
+            "draft",
+            entry["campaign_batch_id"],
+            llm_model_name,
+            _uuid.UUID(entry["partner_id"]) if entry.get("partner_id") else None,
+            entry["persona_context"].get("industry"),
+            "churning_company",
+            json.dumps(metadata, default=str),
+            json.dumps(entry["best"].get("score_components")),
+        )
+        await record_attempt(pool, artifact_type="campaign", artifact_id=artifact_id, attempt_no=1, stage="generation", status="succeeded", blocker_count=len(specificity.get("blocking_issues") or []), warning_count=len(specificity.get("warnings") or []), warnings=list(specificity.get("warnings") or []))
+        return None
+
+    await pool.execute(
+        """
+        INSERT INTO b2b_campaigns (
+            company_name, vendor_name, product_category,
+            opportunity_score, urgency_score, pain_categories,
+            competitors_considering, seat_count, contract_end,
+            decision_timeline, buying_stage, role_type,
+            key_quotes, source_review_ids,
+            channel, subject, body, cta,
+            status, batch_id, llm_model,
+            partner_id, industry, target_mode, metadata,
+            score_components
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+            $11, $12, $13, $14, $15, $16, $17, $18,
+            $19, $20, $21, $22, $23, $24, $25::jsonb,
+            $26::jsonb
+        )
+        """,
+        company_name,
+        entry["best"]["vendor_name"],
+        entry["best"].get("product_category"),
+        entry["best"]["opportunity_score"],
+        entry["best"].get("urgency"),
+        json.dumps(entry["persona_context"].get("pain_categories", [])),
+        json.dumps(entry["persona_context"].get("competitors_considering", [])),
+        entry["best"].get("seat_count"),
+        entry["best"].get("contract_end"),
+        entry["best"].get("decision_timeline"),
+        entry["best"].get("buying_stage"),
+        entry["persona_context"].get("role_type"),
+        json.dumps(entry["persona_context"].get("key_quotes", [])),
+        entry["review_ids"],
+        str(payload.get("channel") or "email_cold"),
+        content.get("subject", ""),
+        content.get("body", ""),
+        content.get("cta", ""),
+        "draft",
+        entry["campaign_batch_id"],
+        llm_model_name,
+        _uuid.UUID(entry["partner_id"]) if entry.get("partner_id") else None,
+        entry["persona_context"].get("industry"),
+        "churning_company",
+        json.dumps(metadata, default=str),
+        json.dumps(entry["best"].get("score_components")),
+    )
+    await record_attempt(pool, artifact_type="campaign", artifact_id=artifact_id, attempt_no=1, stage="generation", status="succeeded", blocker_count=len(specificity.get("blocking_issues") or []), warning_count=len(specificity.get("warnings") or []), warnings=list(specificity.get("warnings") or []))
+    if settings.campaign_sequence.enabled:
+        try:
+            await _create_sequence_for_cold_email(
+                pool,
+                company_name=company_name,
+                batch_id=entry["campaign_batch_id"],
+                partner_id=entry.get("partner_id"),
+                context=entry["persona_context"],
+                cold_email_subject=content.get("subject", ""),
+                cold_email_body=content.get("body", ""),
+            )
+        except Exception as exc:
+            logger.warning("Failed to create sequence for replayed campaign %s/%s: %s", company_name, entry.get("persona"), exc)
+    followup_payload = {
+        **entry["persona_context"],
+        "channel": "email_followup",
+        "target_mode": "churning_company",
+        "cold_email_context": {
+            "subject": content.get("subject", ""),
+            "body": content.get("body", ""),
+        },
+    }
+    return {
+        "custom_id": _campaign_artifact_key(company_name=company_name, batch_id=entry["campaign_batch_id"], channel="email_followup"),
+        "artifact_id": _campaign_artifact_key(company_name=company_name, batch_id=entry["campaign_batch_id"], channel="email_followup"),
+        "campaign_batch_id": entry["campaign_batch_id"],
+        "phase": "followup",
+        "payload": followup_payload,
+        "channel": "email_followup",
+        "company_name": company_name,
+        "persona": entry.get("persona"),
+        "persona_batch_id": entry["campaign_batch_id"],
+        "persona_context": entry["persona_context"],
+        "best": entry["best"],
+        "review_ids": entry["review_ids"],
+        "partner_id": entry.get("partner_id"),
+        "max_tokens": entry.get("max_tokens") or settings.b2b_campaign.max_tokens,
+        "temperature": entry.get("temperature") or settings.b2b_campaign.temperature,
+        "trace_metadata": _campaign_trace_metadata(
+            followup_payload,
+            run_id=str((entry.get("trace_metadata") or {}).get("run_id") or "").strip() or None,
+            stage_id="b2b_campaign_generation.content",
+        ),
+    }
+
+
+async def _store_vendor_retention_replayed_campaign(
+    pool,
+    *,
+    entry: dict[str, Any],
+    content: dict[str, Any],
+    llm_model_name: str,
+) -> dict[str, Any] | None:
+    payload = entry["payload"]
+    vendor_name = entry["company_name"]
+    artifact_id = entry["artifact_id"]
+    metadata = _campaign_storage_metadata(payload)
+    specificity = _campaign_generation_specificity(payload)
+    channel = str(payload.get("channel") or "email_cold")
+    await pool.execute(
+        """
+        INSERT INTO b2b_campaigns (
+            company_name, vendor_name, product_category,
+            opportunity_score, urgency_score, pain_categories,
+            competitors_considering, seat_count, contract_end,
+            decision_timeline, buying_stage, role_type,
+            key_quotes, source_review_ids,
+            channel, subject, body, cta,
+            status, batch_id, llm_model, industry, target_mode, metadata,
+            recipient_email, score_components
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+            $11, $12, $13, $14, $15, $16, $17, $18,
+            $19, $20, $21, $22, $23, $24::jsonb,
+            $25, $26::jsonb
+        )
+        """,
+        vendor_name,
+        vendor_name,
+        entry["best"].get("product_category"),
+        entry["best"]["opportunity_score"],
+        entry["best"].get("urgency"),
+        json.dumps(entry["vendor_ctx"]["signal_summary"]["pain_distribution"]),
+        json.dumps(entry["vendor_ctx"]["signal_summary"]["competitor_distribution"]),
+        entry["best"].get("seat_count"),
+        entry["best"].get("contract_end"),
+        entry["best"].get("decision_timeline"),
+        entry["best"].get("buying_stage"),
+        _map_role_type(entry["target"].get("contact_role")),
+        json.dumps(entry["vendor_ctx"].get("key_quotes", [])),
+        entry["review_ids"],
+        channel,
+        content.get("subject", ""),
+        content.get("body", ""),
+        content.get("cta", ""),
+        "draft",
+        entry["campaign_batch_id"],
+        llm_model_name,
+        entry["best"].get("industry"),
+        "vendor_retention",
+        json.dumps(metadata, default=str),
+        entry["target"].get("contact_email"),
+        json.dumps(entry["best"].get("score_components")),
+    )
+    await record_attempt(pool, artifact_type="campaign", artifact_id=artifact_id, attempt_no=1, stage="generation", status="succeeded", blocker_count=len(specificity.get("blocking_issues") or []), warning_count=len(specificity.get("warnings") or []), warnings=list(specificity.get("warnings") or []))
+    if channel == "email_followup":
+        return None
+    if settings.campaign_sequence.enabled:
+        try:
+            seq_id = await _create_sequence_for_cold_email(
+                pool,
+                company_name=vendor_name,
+                batch_id=entry["campaign_batch_id"],
+                partner_id=None,
+                context=entry["sequence_context"],
+                cold_email_subject=content.get("subject", ""),
+                cold_email_body=content.get("body", ""),
+            )
+            if seq_id and entry["target"].get("contact_email"):
+                await pool.execute(
+                    "UPDATE campaign_sequences SET recipient_email = $1 WHERE id = $2",
+                    entry["target"].get("contact_email"),
+                    seq_id,
+                )
+        except Exception as exc:
+            logger.warning("Failed to create replayed vendor sequence for %s: %s", vendor_name, exc)
+    followup_payload = dict(entry["followup_payload"])
+    followup_payload["cold_email_context"] = {"subject": content.get("subject", ""), "body": content.get("body", "")}
+    return {
+        "custom_id": _campaign_artifact_key(company_name=vendor_name, batch_id=entry["campaign_batch_id"], channel="email_followup"),
+        "artifact_id": _campaign_artifact_key(company_name=vendor_name, batch_id=entry["campaign_batch_id"], channel="email_followup"),
+        "campaign_batch_id": entry["campaign_batch_id"],
+        "phase": "followup",
+        "payload": followup_payload,
+        "channel": "email_followup",
+        "company_name": vendor_name,
+        "best": entry["best"],
+        "vendor_ctx": entry["vendor_ctx"],
+        "review_ids": entry["review_ids"],
+        "target": entry["target"],
+        "max_tokens": entry.get("max_tokens") or settings.b2b_campaign.max_tokens,
+        "temperature": entry.get("temperature") or settings.b2b_campaign.temperature,
+        "trace_metadata": _campaign_trace_metadata(
+            followup_payload,
+            run_id=str((entry.get("trace_metadata") or {}).get("run_id") or "").strip() or None,
+            stage_id="b2b_campaign_generation.content",
+        ),
+    }
+
+
+async def _store_challenger_replayed_campaign(
+    pool,
+    *,
+    entry: dict[str, Any],
+    content: dict[str, Any],
+    llm_model_name: str,
+) -> dict[str, Any] | None:
+    payload = entry["payload"]
+    challenger_name = entry["company_name"]
+    artifact_id = entry["artifact_id"]
+    metadata = _campaign_storage_metadata(payload)
+    specificity = _campaign_generation_specificity(payload)
+    channel = str(payload.get("channel") or "email_cold")
+    await pool.execute(
+        """
+        INSERT INTO b2b_campaigns (
+            company_name, vendor_name, product_category,
+            opportunity_score, urgency_score, pain_categories,
+            competitors_considering, seat_count, contract_end,
+            decision_timeline, buying_stage, role_type,
+            key_quotes, source_review_ids,
+            channel, subject, body, cta,
+            status, batch_id, llm_model, industry, target_mode, metadata,
+            recipient_email, score_components
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+            $11, $12, $13, $14, $15, $16, $17, $18,
+            $19, $20, $21, $22, $23, $24::jsonb,
+            $25, $26::jsonb
+        )
+        """,
+        challenger_name,
+        entry["best"]["vendor_name"],
+        entry["best"].get("product_category"),
+        entry["best"]["opportunity_score"],
+        entry["best"].get("urgency"),
+        json.dumps(entry["challenger_ctx"]["signal_summary"]["pain_driving_switch"]),
+        json.dumps(entry["challenger_ctx"]["signal_summary"]["incumbents_losing"]),
+        entry["best"].get("seat_count"),
+        entry["best"].get("contract_end"),
+        entry["best"].get("decision_timeline"),
+        entry["best"].get("buying_stage"),
+        _map_role_type(entry["target"].get("contact_role")),
+        json.dumps(entry["challenger_ctx"].get("key_quotes", [])),
+        entry["review_ids"],
+        channel,
+        content.get("subject", ""),
+        content.get("body", ""),
+        content.get("cta", ""),
+        "draft",
+        entry["campaign_batch_id"],
+        llm_model_name,
+        entry["best"].get("industry"),
+        "challenger_intel",
+        json.dumps(metadata, default=str),
+        entry["target"].get("contact_email"),
+        json.dumps(entry["best"].get("score_components")),
+    )
+    await record_attempt(pool, artifact_type="campaign", artifact_id=artifact_id, attempt_no=1, stage="generation", status="succeeded", blocker_count=len(specificity.get("blocking_issues") or []), warning_count=len(specificity.get("warnings") or []), warnings=list(specificity.get("warnings") or []))
+    if channel == "email_followup":
+        return None
+    if settings.campaign_sequence.enabled:
+        try:
+            seq_id = await _create_sequence_for_cold_email(
+                pool,
+                company_name=challenger_name,
+                batch_id=entry["campaign_batch_id"],
+                partner_id=None,
+                context=entry["sequence_context"],
+                cold_email_subject=content.get("subject", ""),
+                cold_email_body=content.get("body", ""),
+            )
+            if seq_id and entry["target"].get("contact_email"):
+                await pool.execute(
+                    "UPDATE campaign_sequences SET recipient_email = $1 WHERE id = $2",
+                    entry["target"].get("contact_email"),
+                    seq_id,
+                )
+        except Exception as exc:
+            logger.warning("Failed to create replayed challenger sequence for %s: %s", challenger_name, exc)
+    followup_payload = dict(entry["followup_payload"])
+    followup_payload["cold_email_context"] = {"subject": content.get("subject", ""), "body": content.get("body", "")}
+    return {
+        "custom_id": _campaign_artifact_key(company_name=challenger_name, batch_id=entry["campaign_batch_id"], channel="email_followup"),
+        "artifact_id": _campaign_artifact_key(company_name=challenger_name, batch_id=entry["campaign_batch_id"], channel="email_followup"),
+        "campaign_batch_id": entry["campaign_batch_id"],
+        "phase": "followup",
+        "payload": followup_payload,
+        "channel": "email_followup",
+        "company_name": challenger_name,
+        "best": entry["best"],
+        "challenger_ctx": entry["challenger_ctx"],
+        "review_ids": entry["review_ids"],
+        "target": entry["target"],
+        "max_tokens": entry.get("max_tokens") or settings.b2b_campaign.max_tokens,
+        "temperature": entry.get("temperature") or settings.b2b_campaign.temperature,
+        "trace_metadata": _campaign_trace_metadata(
+            followup_payload,
+            run_id=str((entry.get("trace_metadata") or {}).get("run_id") or "").strip() or None,
+            stage_id="b2b_campaign_generation.content",
+        ),
+    }
+
+
+async def _store_replayed_campaign_entry(
+    pool,
+    *,
+    entry: dict[str, Any],
+    content: dict[str, Any],
+    llm_model_name: str,
+) -> dict[str, Any] | None:
+    payload = entry.get("payload")
+    if not isinstance(payload, dict) or not _campaign_payload_has_report_safe_product_claim(payload):
+        raise ValueError("campaign replay missing report-safe ProductClaim gate")
+    target_mode = str(((entry.get("payload") or {}).get("target_mode")) or "")
+    if target_mode == "churning_company":
+        return await _store_churning_replayed_campaign(pool, entry=entry, content=content, llm_model_name=llm_model_name)
+    if target_mode == "vendor_retention":
+        return await _store_vendor_retention_replayed_campaign(pool, entry=entry, content=content, llm_model_name=llm_model_name)
+    if target_mode == "challenger_intel":
+        return await _store_challenger_replayed_campaign(pool, entry=entry, content=content, llm_model_name=llm_model_name)
+    raise ValueError(f"Unsupported campaign replay target mode: {target_mode}")
+
+
+async def reconcile_batches(task: ScheduledTask) -> dict[str, Any]:
+    cfg = settings.b2b_campaign
+    if not cfg.enabled or not cfg.anthropic_batch_detached_enabled:
+        return {"_skip_synthesis": "Detached campaign batch reconciliation disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    from ...services.llm_router import get_llm
+    from ...skills import get_skill_registry
+    from ...services.b2b.anthropic_batch import reconcile_anthropic_message_batch
+
+    llm = get_llm("campaign")
+    skill = get_skill_registry().get("digest/b2b_campaign_generation")
+    if llm is None or skill is None:
+        return {"reconciled_batches": 0, "applied_items": 0, "submitted_followups": 0, "error": "campaign_llm_or_skill_missing"}
+    llm_model_name = getattr(llm, "model_id", None) or getattr(llm, "model", "unknown")
+    claimer = f"reconcile:{getattr(task, 'id', None) or 'adhoc'}:{_uuid.uuid4().hex[:10]}"
+
+    batch_rows = await pool.fetch(
+        """
+        SELECT DISTINCT b.id, b.run_id, b.status
+        FROM anthropic_message_batches b
+        JOIN anthropic_message_batch_items i ON i.batch_id = b.id
+        WHERE b.task_name = 'b2b_campaign_generation'
+          AND b.provider_batch_id IS NOT NULL
+          AND COALESCE(i.request_metadata->>'replay_handler', '') = 'campaign_generation'
+          AND COALESCE(i.request_metadata->>'applied_at', '') = ''
+        ORDER BY b.created_at ASC
+        LIMIT 25
+        """
+    )
+
+    reconciled_batches = 0
+    applied_items = 0
+    submitted_followups = 0
+    failed_items = 0
+
+    for batch_row in batch_rows:
+        execution = await reconcile_anthropic_message_batch(
+            llm=llm,
+            local_batch_id=str(batch_row["id"]),
+            pool=pool,
+        )
+        reconciled_batches += 1
+
+        item_rows = await pool.fetch(
+            """
+            SELECT *
+            FROM anthropic_message_batch_items
+            WHERE batch_id = $1::uuid
+            ORDER BY created_at ASC
+            """,
+            batch_row["id"],
+        )
+
+        followup_entries: list[dict[str, Any]] = []
+        for item_row in item_rows:
+            metadata = _normalized_batch_item_metadata(item_row)
+            if metadata.get("replay_handler") != "campaign_generation":
+                continue
+            if metadata.get("applied_at"):
+                continue
+            entry = _normalize_campaign_batch_replay_entry(metadata)
+            if not isinstance(entry, dict):
+                await _mark_campaign_batch_item_applied(
+                    pool,
+                    item_id=str(item_row["id"]),
+                    applied_status="failed",
+                    error="invalid_replay_entry",
+                )
+                failed_items += 1
+                continue
+
+            status = str(item_row.get("status") or "")
+            if status == "pending":
+                continue
+            claimed = await _claim_campaign_batch_item_for_apply(
+                pool,
+                item_id=str(item_row["id"]),
+                claimer=claimer,
+                stale_after_minutes=int(getattr(cfg, "anthropic_batch_stale_minutes", 30) or 30),
+            )
+            if not claimed:
+                continue
+
+            content = await _resolve_campaign_batch_item_content(
+                item_row,
+                llm=llm,
+                system_prompt=skill.content,
+                entry=entry,
+            )
+            if content is None:
+                if status in {"batch_errored", "batch_expired", "batch_canceled", "fallback_failed"}:
+                    await _record_campaign_generation_failure(
+                        pool,
+                        artifact_id=str(entry.get("artifact_id") or item_row.get("artifact_id") or ""),
+                        company_name=str(entry.get("company_name") or ""),
+                        channel=str(((entry.get("payload") or {}).get("channel")) or ""),
+                        generation_audit={
+                            "status": "failed",
+                            "failure_reason": status,
+                        },
+                    )
+                await _mark_campaign_batch_item_applied(
+                    pool,
+                    item_id=str(item_row["id"]),
+                    applied_status="failed",
+                    error=status or "no_content",
+                )
+                failed_items += 1
+                continue
+
+            try:
+                next_entry = await _store_replayed_campaign_entry(
+                    pool,
+                    entry=entry,
+                    content=content,
+                    llm_model_name=llm_model_name,
+                )
+                await _mark_campaign_batch_item_applied(
+                    pool,
+                    item_id=str(item_row["id"]),
+                    applied_status="succeeded",
+                )
+                applied_items += 1
+                if next_entry is not None:
+                    followup_entries.append(next_entry)
+            except Exception as exc:
+                logger.exception("Failed to apply replayed campaign batch item %s", item_row.get("custom_id"))
+                await _mark_campaign_batch_item_applied(
+                    pool,
+                    item_id=str(item_row["id"]),
+                    applied_status="failed",
+                    error=str(exc),
+                )
+                failed_items += 1
+
+        if followup_entries:
+            _, followup_metrics = await _run_campaign_batch(
+                llm,
+                skill.content,
+                followup_entries,
+                run_id=str(batch_row.get("run_id") or "") or None,
+            )
+            submitted_followups += int(followup_metrics.get("submitted_items") or 0)
+
+    return {
+        "_skip_synthesis": "Campaign batch reconciliation complete",
+        "reconciled_batches": reconciled_batches,
+        "applied_items": applied_items,
+        "submitted_followups": submitted_followups,
+        "failed_items": failed_items,
+    }
+
+
+async def _generate_content(
+    llm,
+    system_prompt: str,
+    payload: dict[str, Any],
+    max_tokens: int,
+    temperature: float,
+    *,
+    first_attempt_text: str | None = None,
+    trace_span_name: str | None = None,
+    trace_metadata: dict[str, Any] | None = None,
+    usage_out: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Call LLM, validate output, retry once if word count exceeded."""
+    import inspect
+
+    from ...pipelines.llm import clean_llm_output
+    from ...services.b2b.cache_runner import (
+        lookup_b2b_exact_stage_text,
+        prepare_b2b_exact_stage_request,
+        store_b2b_exact_stage_text,
+    )
+    from ...services.b2b.llm_exact_cache import llm_identity
+
+    request_payload = payload
+    channel = payload.get("channel", "")
+    tier = payload.get("tier", "")
+    target_mode = payload.get("target_mode")
+    last_wc = 0
+    last_min = 0
+    last_max = 0
+    retry_reasons: list[str] = []
+    working_payload, specificity_context = _prepare_campaign_request_payload(request_payload)
+    provider_name, model_name = llm_identity(llm)
+    cache_namespace = "b2b_campaign_generation.content"
+    usage_total: dict[str, Any] = {}
+    call_llm_params = inspect.signature(_call_llm).parameters
+    call_llm_supports_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in call_llm_params.values()
+    )
+
+    def _accumulate_usage(sample: dict[str, Any] | None) -> None:
+        if not sample:
+            return
+        usage_total["input_tokens"] = int(usage_total.get("input_tokens") or 0) + int(sample.get("input_tokens") or 0)
+        usage_total["billable_input_tokens"] = int(usage_total.get("billable_input_tokens") or 0) + int(
+            sample.get("billable_input_tokens")
+            if sample.get("billable_input_tokens") is not None
+            else sample.get("input_tokens") or 0
+        )
+        usage_total["cached_tokens"] = int(usage_total.get("cached_tokens") or 0) + int(sample.get("cached_tokens") or 0)
+        usage_total["cache_write_tokens"] = int(usage_total.get("cache_write_tokens") or 0) + int(sample.get("cache_write_tokens") or 0)
+        usage_total["output_tokens"] = int(usage_total.get("output_tokens") or 0) + int(sample.get("output_tokens") or 0)
+        if sample.get("provider"):
+            usage_total["provider"] = sample.get("provider")
+        if sample.get("model"):
+            usage_total["model"] = sample.get("model")
+        if sample.get("provider_request_id"):
+            usage_total["provider_request_id"] = sample.get("provider_request_id")
+
+    def _write_usage_out() -> None:
+        if usage_out is not None:
+            usage_out.clear()
+            usage_out.update(usage_total)
+
+    for attempt in range(2):
+        user_content = json.dumps(working_payload, separators=(",", ":"), default=str)
+
+        # On retry, prepend a revision instruction
+        if attempt == 1:
+            revision = working_payload.pop("_revision", None)
+            if revision:
+                user_content = f"{revision}\n\n{user_content}"
+            elif last_wc:
+                if last_min and last_wc < last_min:
+                    user_content = (
+                        f"REVISION REQUIRED: The previous body was {last_wc} words "
+                        f"but MUST be at least {last_min} words. Add one or two "
+                        f"concrete sentences using the provided evidence. Return "
+                        f"the same JSON format.\n\n{user_content}"
+                    )
+                elif last_max:
+                    user_content = (
+                        f"REVISION REQUIRED: The previous body was {last_wc} words "
+                        f"but MUST be under {last_max} words. Rewrite the body "
+                        f"shorter -- cut sentences, not words. Return the same JSON "
+                        f"format.\n\n{user_content}"
+                    )
+
+        request = prepare_b2b_exact_stage_request(
+            cache_namespace,
+            provider=provider_name,
+            model=model_name,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        cached = await lookup_b2b_exact_stage_text(request)
+        text = cached["response_text"] if cached is not None else None
+        if cached is not None and usage_out is not None:
+            _write_usage_out()
+        if text is None and attempt == 0 and first_attempt_text is not None:
+            text = first_attempt_text
+        if text is None:
+            call_kwargs: dict[str, Any] = {}
+            call_usage: dict[str, Any] = {}
+            if "trace_span_name" in call_llm_params or call_llm_supports_kwargs:
+                call_kwargs["trace_span_name"] = trace_span_name
+            if "trace_metadata" in call_llm_params or call_llm_supports_kwargs:
+                call_kwargs["trace_metadata"] = trace_metadata
+            if "usage_out" in call_llm_params or call_llm_supports_kwargs:
+                call_kwargs["usage_out"] = call_usage
+            text = await _call_llm(
+                llm,
+                system_prompt,
+                user_content,
+                max_tokens,
+                temperature,
+                **call_kwargs,
+            )
+            _accumulate_usage(call_usage)
+            _write_usage_out()
+        if not text:
+            _write_usage_out()
+            request_payload["_generation_audit"] = {
+                "status": "failed",
+                "attempts": attempt + 1,
+                "retry_reasons": retry_reasons,
+                "failure_reason": "llm_returned_empty",
+            }
+            return None
+
+        try:
+            text = clean_llm_output(text)
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse campaign generation JSON: %.200s", text)
+            _write_usage_out()
+            request_payload["_generation_audit"] = {
+                "status": "failed",
+                "attempts": attempt + 1,
+                "retry_reasons": retry_reasons,
+                "failure_reason": "invalid_json",
+            }
+            return None
+
+        if not isinstance(parsed, dict) or "body" not in parsed:
+            logger.warning("Campaign generation missing 'body' field")
+            _write_usage_out()
+            request_payload["_generation_audit"] = {
+                "status": "failed",
+                "attempts": attempt + 1,
+                "retry_reasons": retry_reasons,
+                "failure_reason": "missing_body",
+            }
+            return None
+
+        # Validate and fix
+        validated, issues = _validate_campaign_content(
+            parsed,
+            channel,
+            tier=tier,
+            target_mode=target_mode,
+        )
+
+        if issues.get("missing_field"):
+            logger.warning("Campaign missing required field: %s", issues["missing_field"])
+            _write_usage_out()
+            request_payload["_generation_audit"] = {
+                "status": "failed",
+                "attempts": attempt + 1,
+                "retry_reasons": retry_reasons,
+                "failure_reason": f"missing_field:{issues['missing_field']}",
+                "validation_issues": issues,
+            }
+            return None
+
+        if issues.get("placeholders"):
+            logger.warning("Campaign body contains placeholder brackets, rejecting")
+            _write_usage_out()
+            request_payload["_generation_audit"] = {
+                "status": "failed",
+                "attempts": attempt + 1,
+                "retry_reasons": retry_reasons,
+                "failure_reason": "placeholders",
+                "validation_issues": issues,
+            }
+            return None
+
+        # Retry on spam trigger in subject line
+        if issues.get("subject_spam_trigger") and attempt == 0:
+            logger.info(
+                "Subject contains spam trigger %r, retrying",
+                issues["subject_spam_trigger"],
+            )
+            retry_reasons.append("subject_spam_trigger")
+            working_payload = {**working_payload, "_revision": (
+                f"REVISION REQUIRED: The subject line contains the spam "
+                f"trigger word '{issues['subject_spam_trigger']}'. Rewrite "
+                f"the subject line without urgency/alarm language. Use "
+                f"curiosity or data-driven phrasing instead."
+            )}
+            continue
+
+        if issues.get("word_count") and attempt == 0:
+            # Retry with correction prompt
+            last_wc = issues["word_count"]
+            last_min = int(issues.get("min_words") or 0)
+            last_max = int(issues.get("max_words") or 0)
+            if last_min and last_wc < last_min:
+                logger.info(
+                    "Campaign body %d words (min %d), retrying with correction",
+                    last_wc, last_min,
+                )
+            else:
+                logger.info(
+                    "Campaign body %d words (max %d), retrying with correction",
+                    last_wc, last_max,
+                )
+            retry_reasons.append("word_count")
+            continue
+
+        if issues.get("word_count"):
+            if issues.get("min_words"):
+                logger.warning(
+                    "Campaign body still %d words after retry, below min %d",
+                    issues["word_count"], issues["min_words"],
+                )
+                request_payload["_generation_audit"] = {
+                    "status": "failed",
+                    "attempts": attempt + 1,
+                    "retry_reasons": retry_reasons,
+                    "failure_reason": "word_count_too_short",
+                    "validation_issues": issues,
+                }
+                return None
+            logger.warning(
+                "Campaign body still %d words after retry, truncated to %d",
+                issues["word_count"], issues["max_words"],
+            )
+
+        revalidation = campaign_quality_revalidation(
+            campaign={
+                **request_payload,
+                "subject": validated.get("subject") or "",
+                "body": validated.get("body") or "",
+                "cta": validated.get("cta") or "",
+            },
+            boundary="generation",
+            specificity_context=specificity_context,
+        )
+        request_payload["_campaign_revalidation"] = revalidation
+        specificity = revalidation["audit"]
+        if specificity.get("campaign_proof_terms") and not request_payload.get("campaign_proof_terms"):
+            request_payload["campaign_proof_terms"] = list(specificity["campaign_proof_terms"])
+            working_payload["campaign_proof_terms"] = list(specificity["campaign_proof_terms"])
+        if specificity.get("blocking_issues"):
+            if attempt == 0:
+                retry_reasons.append("specificity")
+                working_payload = {
+                    **working_payload,
+                    "_revision": _campaign_specificity_revision(
+                        channel=channel,
+                        specificity=specificity,
+                    ),
+                }
+                continue
+            logger.warning(
+                "Campaign specificity gate failed: %s",
+                "; ".join(specificity["blocking_issues"]),
+            )
+            _write_usage_out()
+            request_payload["_generation_audit"] = {
+                "status": "failed",
+                "attempts": attempt + 1,
+                "retry_reasons": retry_reasons,
+                "failure_reason": "specificity_gate",
+                "validation_issues": issues,
+                "specificity": specificity,
+            }
+            return None
+
+        validated["body"] = _append_signoff(validated["body"], request_payload)
+        request_payload["_generation_audit"] = {
+            "status": "succeeded",
+            "attempts": attempt + 1,
+            "retry_reasons": retry_reasons,
+            "validation_issues": issues,
+            "specificity": specificity,
+        }
+        await store_b2b_exact_stage_text(
+            request,
+            response_text=json.dumps(validated, separators=(",", ":"), default=str),
+            metadata={
+                "channel": channel,
+                "tier": tier,
+                "target_mode": target_mode,
+            },
+        )
+        _write_usage_out()
+        return validated
+
+    _write_usage_out()
+    request_payload["_generation_audit"] = {
+        "status": "failed",
+        "attempts": 2,
+        "retry_reasons": retry_reasons,
+        "failure_reason": "exhausted_retries",
+    }
+    return None

--- a/extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py
@@ -1,0 +1,3222 @@
+"""
+Vendor Intelligence Briefing -- build, render, and send.
+
+Assembles a deterministic vendor churn briefing from existing DB tables
+(no LLM calls) and sends it via Resend.
+
+Data sources (in priority order):
+1. b2b_intelligence (weekly_churn_feed) -- richest, pre-aggregated
+2. b2b_churn_signals -- fallback aggregated metrics
+3. b2b_evidence_vault -- canonical weakness, quote, and company-signal evidence
+4. b2b_product_profiles -- enrichment (profile summary, competitive context)
+5. b2b_reasoning_synthesis -- reasoning contracts fallback when feed absent (sets reasoning_synthesis flag)
+6. b2b_segment_intelligence -- buyer segment breakdown (role, stage, pain)
+7. b2b_temporal_intelligence -- renewal windows, budget cycles, keyword spikes
+8. b2b_cross_vendor_reasoning_synthesis -- pairwise battle + category council outcomes
+9. b2b_vendor_buyer_profiles -- role/stage distribution with urgency signals
+10. b2b_reviews -- high-urgency quotes if evidence is still insufficient
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+import jwt as pyjwt
+
+from ...config import settings
+from ...services.campaign_sender import get_campaign_sender
+from ...services.vendor_target_selection import dedupe_vendor_target_rows
+from ...services.vendor_registry import resolve_vendor_name
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+from ...templates.email.vendor_briefing import render_vendor_briefing_html
+from ._b2b_shared import (
+    _align_vendor_intelligence_record_to_scorecard,
+    _timing_summary_payload,
+    _reasoning_int,
+    read_vendor_company_signal_review_queue,
+    read_vendor_intelligence_record,
+    read_vendor_intelligence,
+    read_vendor_scorecard_detail,
+)
+from .campaign_suppression import is_suppressed
+
+logger = logging.getLogger("atlas.b2b.vendor_briefing")
+
+_ACCOUNT_CARD_SYSTEM_PROMPT = (
+    "You are a B2B sales intelligence analyst. "
+    "Generate concise, data-grounded intelligence cards. "
+    "Every claim must be supported by the provided data. "
+    "Return only valid JSON."
+)
+
+
+def _apply_synthesis_view_to_briefing(
+    briefing: dict[str, Any],
+    view: Any,
+    *,
+    requested_as_of: date | None = None,
+) -> bool:
+    """Overlay normalized synthesis-view fields onto a briefing payload."""
+    if view is None:
+        return False
+
+    from ._b2b_synthesis_reader import inject_synthesis_freshness
+
+    context = view.filtered_consumer_context("vendor_briefing")
+    contracts = context.get("reasoning_contracts") or {}
+    vendor_core = context.get("vendor_core_reasoning") or {}
+    displacement = context.get("displacement_reasoning") or {}
+    account_reasoning = context.get("account_reasoning") or {}
+    used = False
+
+    if isinstance(vendor_core, dict) and vendor_core:
+        briefing["vendor_core_reasoning"] = vendor_core
+        timing_intelligence = vendor_core.get("timing_intelligence")
+        if isinstance(timing_intelligence, dict) and timing_intelligence:
+            briefing["timing_intelligence"] = timing_intelligence
+            timing_summary, timing_metrics, priority_triggers = _timing_summary_payload(
+                timing_intelligence,
+            )
+            if timing_summary:
+                briefing["timing_summary"] = timing_summary
+            if timing_metrics:
+                briefing["timing_metrics"] = timing_metrics
+            if priority_triggers:
+                briefing["priority_timing_triggers"] = priority_triggers
+        wts = view.why_they_stay
+        if wts:
+            briefing["why_they_stay"] = wts
+        cp = view.confidence_posture
+        if cp:
+            briefing["confidence_posture"] = cp
+            limits = cp.get("limits")
+            if limits:
+                briefing["confidence_limits"] = limits
+        used = True
+
+    if isinstance(displacement, dict) and displacement:
+        briefing["displacement_reasoning"] = displacement
+        switch_triggers = view.switch_triggers
+        if switch_triggers:
+            briefing["switch_triggers"] = switch_triggers
+        used = True
+
+    if isinstance(account_reasoning, dict) and account_reasoning:
+        briefing["account_reasoning"] = account_reasoning
+        summary_payload = _account_reasoning_summary_payload(account_reasoning)
+        for key, value in summary_payload.items():
+            if value not in ("", [], {}, None):
+                briefing[key] = value
+        merged_accounts = _merge_named_accounts_with_account_reasoning(
+            briefing.get("named_accounts") or [],
+            account_reasoning,
+        )
+        if merged_accounts:
+            briefing["named_accounts"] = merged_accounts
+        used = True
+    else:
+        preview = context.get("account_reasoning_preview")
+        if isinstance(preview, dict) and preview:
+            preview_reasoning = preview.get("account_reasoning")
+            if isinstance(preview_reasoning, dict) and preview_reasoning:
+                briefing["account_reasoning_preview"] = preview_reasoning
+                briefing["account_reasoning_preview_only"] = True
+                for key in (
+                    "account_pressure_summary",
+                    "account_pressure_metrics",
+                    "priority_account_names",
+                ):
+                    value = preview.get(key)
+                    if value not in ("", [], {}, None):
+                        briefing[key] = value
+                merged_accounts = _merge_named_accounts_with_account_reasoning(
+                    briefing.get("named_accounts") or [],
+                    preview_reasoning,
+                )
+                if merged_accounts:
+                    briefing["named_accounts"] = merged_accounts
+                used = True
+
+    if contracts:
+        briefing["reasoning_contracts"] = contracts
+        briefing["reasoning_source"] = "b2b_reasoning_synthesis"
+        used = True
+
+    evidence_window = view.meta
+    if evidence_window:
+        briefing["evidence_window"] = evidence_window
+        ew_start = evidence_window.get("evidence_window_start")
+        ew_end = evidence_window.get("evidence_window_end")
+        if ew_start and ew_end:
+            try:
+                briefing["evidence_window_days"] = (
+                    date.fromisoformat(str(ew_end)[:10])
+                    - date.fromisoformat(str(ew_start)[:10])
+                ).days
+            except (TypeError, ValueError):
+                pass
+        used = True
+
+    if view.primary_wedge:
+        briefing["synthesis_wedge"] = view.primary_wedge.value
+        briefing["synthesis_wedge_label"] = view.wedge_label
+        used = True
+    if getattr(view, "schema_version", ""):
+        briefing["synthesis_schema_version"] = view.schema_version
+        used = True
+
+    coverage_gaps = view.coverage_gaps
+    if coverage_gaps:
+        briefing["coverage_gaps"] = coverage_gaps
+        used = True
+
+    anchors = context.get("anchor_examples")
+    if isinstance(anchors, dict) and anchors:
+        briefing["reasoning_anchor_examples"] = anchors
+        used = True
+    highlights = context.get("witness_highlights")
+    if isinstance(highlights, list) and highlights:
+        briefing["reasoning_witness_highlights"] = highlights
+        used = True
+    reference_ids = context.get("reference_ids")
+    if isinstance(reference_ids, dict) and reference_ids:
+        briefing["reasoning_reference_ids"] = reference_ids
+        used = True
+    scope_manifest = context.get("scope_manifest")
+    if isinstance(scope_manifest, dict) and scope_manifest:
+        briefing["scope_manifest"] = scope_manifest
+        used = True
+    atom_summary = context.get("reasoning_atom_summary")
+    if isinstance(atom_summary, dict) and atom_summary:
+        briefing["reasoning_atom_summary"] = atom_summary
+        used = True
+    delta = context.get("reasoning_delta")
+    if isinstance(delta, dict) and delta:
+        briefing["reasoning_delta"] = delta
+        used = True
+
+    contract_gaps = context.get("reasoning_contract_gaps") or []
+    if contract_gaps:
+        briefing["reasoning_contract_gaps"] = contract_gaps
+        used = True
+    section_disclaimers = context.get("reasoning_section_disclaimers")
+    if isinstance(section_disclaimers, dict) and section_disclaimers:
+        briefing["reasoning_section_disclaimers"] = section_disclaimers
+        used = True
+
+    inject_synthesis_freshness(
+        briefing,
+        view,
+        requested_as_of=requested_as_of,
+    )
+    return used
+
+
+async def _attach_company_signal_review_queue_to_briefing(
+    pool,
+    briefing: dict[str, Any],
+    *,
+    vendor_name: str,
+) -> bool:
+    try:
+        queue = await read_vendor_company_signal_review_queue(
+            pool,
+            vendor_name=vendor_name,
+        )
+    except Exception:
+        logger.debug("Company signal review queue load failed for %s", vendor_name, exc_info=True)
+        return False
+    if not queue:
+        return False
+    briefing["company_signal_review_queue"] = queue
+    return True
+
+
+def _apply_reasoning_synthesis_to_briefing(
+    briefing: dict[str, Any],
+    feed_entry: dict[str, Any] | None,
+) -> bool:
+    """Overlay contract-backed reasoning fields from weekly feed entries."""
+    if not isinstance(feed_entry, dict):
+        return False
+
+    from ._b2b_synthesis_reader import load_synthesis_view
+
+    vendor_name = str(feed_entry.get("vendor") or briefing.get("vendor") or "").strip()
+    view = load_synthesis_view(
+        feed_entry,
+        vendor_name,
+        schema_version=str(
+            feed_entry.get("synthesis_schema_version")
+            or feed_entry.get("schema_version")
+            or ""
+        ),
+        as_of_date=feed_entry.get("data_as_of_date"),
+    )
+    used = _apply_synthesis_view_to_briefing(briefing, view)
+
+    for field in (
+        "synthesis_wedge",
+        "synthesis_wedge_label",
+        "synthesis_schema_version",
+        "evidence_window",
+        "evidence_window_days",
+        "data_as_of_date",
+        "data_stale",
+        "account_pressure_summary",
+        "account_pressure_metrics",
+        "priority_account_names",
+        "timing_summary",
+        "timing_metrics",
+        "priority_timing_triggers",
+        "reasoning_anchor_examples",
+        "reasoning_witness_highlights",
+        "reasoning_reference_ids",
+        "reasoning_contract_gaps",
+        "reasoning_section_disclaimers",
+        "reasoning_source",
+        "category_council",
+    ):
+        value = feed_entry.get(field)
+        if value is not None:
+            briefing[field] = value
+            used = True
+
+    return used
+
+
+def _account_reasoning_named_accounts(
+    account_reasoning: dict[str, Any] | None,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Convert account reasoning top_accounts into briefing account rows."""
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    if not isinstance(account_reasoning, dict):
+        return rows
+    for item in account_reasoning.get("top_accounts") or []:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("company") or "").strip()
+        if not name or name.casefold() in seen:
+            continue
+        seen.add(name.casefold())
+        try:
+            urgency = round(max(0.0, min(float(item.get("intent_score") or 0), 1.0)) * 10, 1)
+        except (TypeError, ValueError):
+            urgency = 0.0
+        rows.append({
+            "company": name,
+            "urgency": urgency,
+            "source": "account_reasoning",
+            "confidence_score": item.get("intent_score"),
+            "reasoning_backed": True,
+            "source_id": item.get("source_id"),
+        })
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _merge_named_accounts_with_account_reasoning(
+    named_accounts: list[dict[str, Any]] | Any,
+    account_reasoning: dict[str, Any] | None,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Preserve richer named-account rows and supplement from account reasoning."""
+    merged = [item for item in (named_accounts or []) if isinstance(item, dict)]
+    seen = {
+        str(item.get("company") or "").strip().casefold()
+        for item in merged
+        if str(item.get("company") or "").strip()
+    }
+    for row in _account_reasoning_named_accounts(account_reasoning, limit=limit):
+        key = str(row.get("company") or "").strip().casefold()
+        if key and key not in seen:
+            merged.append(row)
+            seen.add(key)
+        if len(merged) >= limit:
+            break
+    return merged[:limit]
+
+
+def _account_reasoning_summary_payload(
+    account_reasoning: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build visible account-pressure fields from account reasoning."""
+    if not isinstance(account_reasoning, dict):
+        return {}
+    metrics: dict[str, int] = {}
+    for key in ("total_accounts", "high_intent_count", "active_eval_count"):
+        value = _reasoning_int(account_reasoning.get(key))
+        if value is not None:
+            metrics[key] = value
+    summary = str(account_reasoning.get("market_summary") or "").strip()
+    if not summary:
+        active_eval = metrics.get("active_eval_count")
+        high_intent = metrics.get("high_intent_count")
+        total_accounts = metrics.get("total_accounts")
+        if active_eval is not None and high_intent is not None:
+            summary = (
+                f"{active_eval} accounts are in active evaluation while "
+                f"{high_intent} accounts show high-intent churn signals."
+            )
+        elif high_intent is not None:
+            summary = f"{high_intent} accounts show high-intent churn signals."
+        elif total_accounts is not None:
+            summary = f"{total_accounts} accounts are currently in scope."
+    priority_names = [
+        row["company"] for row in _account_reasoning_named_accounts(account_reasoning)
+    ]
+    payload: dict[str, Any] = {}
+    if summary:
+        payload["account_pressure_summary"] = summary
+    if metrics:
+        payload["account_pressure_metrics"] = metrics
+    if priority_names:
+        payload["priority_account_names"] = priority_names
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Gate token helpers
+# ---------------------------------------------------------------------------
+
+def create_gate_token(vendor_name: str) -> str:
+    """Create a signed JWT for the briefing email gate."""
+    jwt_cfg = settings.saas_auth
+    now = datetime.now(timezone.utc)
+    expiry_days = settings.b2b_churn.vendor_briefing_gate_expiry_days
+    payload = {
+        "vendor_name": vendor_name,
+        "type": "briefing_gate",
+        "iat": now,
+        "exp": now + timedelta(days=expiry_days),
+    }
+    return pyjwt.encode(payload, jwt_cfg.jwt_secret, algorithm=jwt_cfg.jwt_algorithm)
+
+
+def build_gate_url(vendor_name: str) -> str:
+    """Build the full gate URL for a vendor briefing."""
+    base = settings.b2b_churn.vendor_briefing_gate_base_url.rstrip("/")
+    token = create_gate_token(vendor_name)
+    return f"{base}?vendor={quote(vendor_name)}&ref={token}"
+
+
+async def _is_first_briefing(pool: Any, vendor_name: str) -> bool:
+    """Return True if no successful briefing has ever been sent for this vendor."""
+    count = await pool.fetchval(
+        """
+        SELECT COUNT(*) FROM b2b_vendor_briefings
+        WHERE LOWER(vendor_name) = LOWER($1)
+          AND status NOT IN ('failed', 'suppressed', 'rejected')
+        """,
+        vendor_name,
+    )
+    return (count or 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Analyst enrichment (Kimi K2.5 via OpenRouter)
+# ---------------------------------------------------------------------------
+
+_ANALYST_SYSTEM_PROMPT = """\
+You are a B2B churn intelligence analyst writing for VP-level readers. Given \
+raw churn data about a software vendor, produce a JSON object with:
+
+1. executive_summary: 2-3 sentences for a VP of Customer Success.
+2. pain_labels: Object mapping raw category codes to professional labels \
+(e.g. "ux" -> "User Experience Complexity").
+3. headline: Under 10 words. Bloomberg-style, not clickbait.
+4. cta_hook: One sentence tying the CTA to the specific risk found \
+(e.g. "Review the pricing-driven churn cluster behind this alert").
+5. displacement_qualifier: If quotes mention competitors not in the \
+displacement table, return a short qualifier (e.g. "Other alternatives \
+appear in qualitative evidence but at lower measured frequency"). \
+Return empty string if no mismatch.
+6. account_persona_context: If named_account_personas are provided, note \
+the seniority distribution and industries represented. This informs \
+urgency calibration -- VP-level signals from enterprise accounts carry \
+more weight than end-user signals from SMBs.
+
+CRITICAL RULES:
+
+TONE MUST MATCH THE METRICS. The input includes a `tone_band` field:
+- "watchlist": Score 0-29, urgency <4. Use language like "meaningful \
+retention risk", "monitor closely", "targeted intervention recommended". \
+Do NOT say "immediate", "urgent", "systemic", or "acute".
+- "active_risk": Score 30-59 OR urgency 4-7. Use "material risk", \
+"active intervention warranted", "accelerating concern".
+- "critical": Score 60+ OR urgency 8+. Use "immediate action required", \
+"acute churn pressure", "executive escalation needed".
+
+If the tone_band says "watchlist" but the data has high-urgency quotes, \
+acknowledge the tension: "While aggregate urgency remains moderate, \
+individual high-risk accounts warrant targeted attention."
+
+STRENGTH CALIBRATION:
+- If `retention_strengths` is present, acknowledge what the vendor does well \
+before stating the risk in the executive_summary. Example: "Despite strong \
+customer satisfaction in [area], [vendor] faces material churn pressure \
+driven by [weakness]." This prevents overstatement and builds credibility \
+with prospects who value parts of the incumbent. Do not fabricate strengths \
+not in the list.
+
+ATTRIBUTION RULES:
+- NEVER make direct attribution claims about named accounts. Do NOT write \
+"Meridian Technologies citing $180K as unsustainable."
+- Instead write: "High-risk accounts including Meridian Technologies show \
+pricing-related churn signals, including references to $180K+ annual \
+contract fatigue."
+- Named accounts show signals. They did not make statements to us.
+- Quotes are market intelligence observations, not verified direct \
+attribution from named accounts.
+
+Return ONLY valid JSON. No markdown fences, no explanation."""
+
+_PAIN_LABEL_FALLBACKS = {
+    "pricing": "Pricing and Contract Value Fatigue",
+    "support": "Support Experience Issues",
+    "reliability": "Reliability Concerns",
+    "usability": "User Experience Complexity",
+    "ux": "User Experience Complexity",
+    "features": "Feature Gap Concerns",
+    "performance": "Performance Limitations",
+    "integration": "Integration Friction",
+    "security": "Security and Compliance Concerns",
+    "onboarding": "Onboarding Friction",
+    "migration": "Migration Complexity",
+    "other": "Overall Dissatisfaction",
+    "general_dissatisfaction": "Overall Dissatisfaction",
+    "overall_dissatisfaction": "Overall Dissatisfaction",
+}
+
+
+def _tone_band(score: float, urgency: float) -> str:
+    """Determine tone band from churn pressure score and urgency."""
+    if score >= 60 or urgency >= 8:
+        return "critical"
+    if score >= 30 or urgency >= 4:
+        return "active_risk"
+    return "watchlist"
+
+
+def _default_pain_label(category: Any) -> str | None:
+    """Return a readable pain label, or None if the category is missing.
+
+    No synthetic 'Overall Dissatisfaction' default. Empty / whitespace /
+    None inputs return None so callers can decide whether to suppress
+    the surface or render an explicit no-pain fallback. A real category
+    of 'overall_dissatisfaction' still maps to its display label via
+    _PAIN_LABEL_FALLBACKS -- the helper only refuses to invent one.
+    """
+    if category is None:
+        return None
+    raw = str(category).strip().lower()
+    if not raw:
+        return None
+    return _PAIN_LABEL_FALLBACKS.get(raw, raw.replace("_", " ").title())
+
+
+def _build_default_cta_hook(briefing: dict[str, Any]) -> str:
+    """Build a specific CTA hook from the strongest measured signal.
+
+    Branches on ``pain_label`` rather than the raw ``top_pain`` category
+    string. This catches whitespace-only categories (which were truthy
+    enough to enter a pain branch under the old code) and avoids
+    rendering an empty or synthetic 'overall dissatisfaction' phrase
+    when no real pain signal is present.
+    """
+    challenger_mode = briefing.get("challenger_mode", False)
+    vendor = briefing.get("vendor_name", "the vendor")
+    pains = briefing.get("pain_breakdown") or []
+    top_pain = pains[0].get("category") if pains and isinstance(pains[0], dict) else ""
+    pain_label_raw = _default_pain_label(top_pain) if top_pain else None
+    pain_label = pain_label_raw.lower() if pain_label_raw else None
+
+    targets = briefing.get("top_displacement_targets") or []
+    top_target = ""
+    if targets and isinstance(targets[0], dict):
+        top_target = str(targets[0].get("competitor") or "").strip()
+
+    if challenger_mode:
+        if top_target and pain_label:
+            return (
+                f"See which accounts are leaving {top_target} due to "
+                f"{pain_label} and how to position your outreach."
+            )
+        if pain_label:
+            return f"Review the {pain_label} signals driving accounts to evaluate alternatives like {vendor}."
+        if top_target:
+            return f"See the accounts in motion from {top_target} that your team can engage now."
+        return f"Review this week's account movement signals relevant to {vendor}."
+
+    if top_target and pain_label:
+        return (
+            f"Review the {pain_label} signals behind the shift toward "
+            f"{top_target} before the next renewal cycle."
+        )
+    if pain_label:
+        return f"Review the {pain_label} cluster behind this alert to prioritize retention plays."
+    if top_target:
+        return f"Review the accounts trending toward {top_target} to focus retention outreach early."
+    return f"Review this week's measured churn signals for {vendor}."
+
+
+def _finalize_briefing_presentation(briefing: dict[str, Any]) -> None:
+    """Fill presentation fields deterministically after enrichment.
+
+    Sanitizes any pre-existing ``pain_labels`` dict so blank-key entries
+    (e.g. ``{"": "Overall Dissatisfaction"}`` produced by upstream
+    synthesis when the category was missing) do not survive into the
+    rendered briefing. Real categories from ``pain_breakdown`` still get
+    formatted via ``_default_pain_label`` and added when missing.
+    """
+    raw_pain_labels = briefing.get("pain_labels") or {}
+    if not isinstance(raw_pain_labels, dict):
+        raw_pain_labels = {}
+    pain_labels: dict[str, str] = {
+        k: v
+        for k, v in raw_pain_labels.items()
+        if isinstance(k, str) and k.strip()
+    }
+    for pain in briefing.get("pain_breakdown") or []:
+        if not isinstance(pain, dict):
+            continue
+        raw_category = str(pain.get("category") or "").strip()
+        if not raw_category or raw_category in pain_labels:
+            continue
+        label = _default_pain_label(raw_category)
+        if label:
+            pain_labels[raw_category] = label
+    briefing["pain_labels"] = pain_labels
+
+    if not briefing.get("executive_summary"):
+        account_pressure_summary = str(
+            briefing.get("account_pressure_summary") or ""
+        ).strip()
+        if account_pressure_summary and not briefing.get("account_reasoning_preview_only"):
+            briefing["executive_summary"] = account_pressure_summary
+        else:
+            timing_summary = str(briefing.get("timing_summary") or "").strip()
+            if timing_summary:
+                briefing["executive_summary"] = timing_summary
+
+    if not briefing.get("cta_hook"):
+        briefing["cta_hook"] = _build_default_cta_hook(briefing)
+
+    if briefing.get("cta_hook") and not briefing.get("cta_description"):
+        briefing["cta_description"] = ""
+
+
+def _briefing_pain_breakdown_from_evidence_vault(
+    vault: dict[str, Any],
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Map canonical vault pain rows to vendor-briefing pain breakdown."""
+    rows: list[dict[str, Any]] = []
+    for item in (vault.get("weakness_evidence") or []):
+        if str(item.get("evidence_type") or "") != "pain_category":
+            continue
+        key = str(item.get("key") or "").strip().lower()
+        if not key:
+            continue
+        metrics = item.get("supporting_metrics") or {}
+        rows.append({
+            "category": key,
+            "count": int(item.get("mention_count_total") or 0),
+            "avg_urgency": metrics.get("avg_urgency_when_mentioned") or metrics.get("avg_urgency"),
+        })
+    rows.sort(key=lambda r: int(r.get("count") or 0), reverse=True)
+    return rows[:limit]
+
+
+def _briefing_feature_gaps_from_evidence_vault(
+    vault: dict[str, Any],
+    *,
+    limit: int = 5,
+) -> list[str]:
+    """Map canonical vault feature-gap rows to briefing strings."""
+    gaps: list[tuple[int, str]] = []
+    for item in (vault.get("weakness_evidence") or []):
+        if str(item.get("evidence_type") or "") != "feature_gap":
+            continue
+        label = str(item.get("label") or item.get("key") or "").strip()
+        if not label:
+            continue
+        gaps.append((int(item.get("mention_count_total") or 0), label))
+    gaps.sort(key=lambda row: row[0], reverse=True)
+    return [label for _, label in gaps[:limit]]
+
+
+def _briefing_quotes_from_evidence_vault(
+    vault: dict[str, Any],
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Build quotable briefing evidence rows from canonical weakness evidence."""
+    quotes: list[dict[str, Any]] = []
+    for item in (vault.get("weakness_evidence") or []):
+        if item.get("phrase_verbatim") is not True:
+            continue
+        text = str(item.get("best_quote") or "").strip()
+        if not text:
+            continue
+        source = item.get("quote_source") or {}
+        metrics = item.get("supporting_metrics") or {}
+        quotes.append({
+            "quote": text,
+            "text": text,
+            "company": source.get("company"),
+            "title": source.get("reviewer_title") or source.get("title"),
+            "company_size": source.get("company_size"),
+            "industry": source.get("industry"),
+            "source": source.get("source"),
+            "review_id": source.get("review_id"),
+            "rating": source.get("rating"),
+            "reviewed_at": source.get("reviewed_at"),
+            "urgency": metrics.get("avg_urgency_when_mentioned") or metrics.get("avg_urgency"),
+            "pain_category": item.get("key"),
+            "mention_count": int(item.get("mention_count_total") or 0),
+            "phrase_verbatim": True,
+            "quote_origin": "vault",
+        })
+    quotes.sort(
+        key=lambda q: (
+            float(q.get("urgency") or 0),
+            int(q.get("mention_count") or 0),
+        ),
+        reverse=True,
+    )
+    return quotes[:limit]
+
+
+def _briefing_named_accounts_from_evidence_vault(
+    vault: dict[str, Any],
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Map canonical company signals into briefing named-account rows."""
+    accounts: list[dict[str, Any]] = []
+    for item in (vault.get("company_signals") or []):
+        company = str(item.get("company_name") or "").strip()
+        if not company:
+            continue
+        pain = str(item.get("pain_category") or "").strip().lower()
+        acct: dict[str, Any] = {
+            "company": company,
+            "title": item.get("buyer_role"),
+            "company_size": item.get("seat_count"),
+            "industry": item.get("industry"),
+            "urgency": item.get("urgency_score"),
+            "pain_breakdown": [{"category": pain, "count": 1}] if pain else [],
+            "evidence": [],
+            "buying_stage": item.get("buying_stage"),
+            "source": item.get("source"),
+            "contract_end": item.get("contract_end"),
+            "confidence_score": item.get("confidence_score"),
+        }
+        if item.get("decision_maker") is not None:
+            acct["decision_maker"] = item["decision_maker"]
+        accounts.append(acct)
+    accounts.sort(
+        key=lambda a: (
+            float(a.get("urgency") or 0),
+            float(a.get("confidence_score") or 0),
+        ),
+        reverse=True,
+    )
+    return accounts[:limit]
+
+
+def _briefing_strengths_from_evidence_vault(
+    vault: dict[str, Any],
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Map canonical vault strength rows to vendor-briefing retention strengths."""
+    rows: list[dict[str, Any]] = []
+    for item in (vault.get("strength_evidence") or []):
+        if not isinstance(item, dict):
+            continue
+        area = str(item.get("label") or item.get("key") or "").strip()
+        if not area:
+            continue
+        total = int(item.get("mention_count_total") or 0)
+        trend = item.get("trend") if isinstance(item.get("trend"), dict) else {}
+        entry: dict[str, Any] = {
+            "area": area,
+            "mention_count": total,
+        }
+        direction = str(trend.get("direction") or "").strip()
+        if direction:
+            entry["trend"] = direction
+        quote = str(item.get("best_quote") or "").strip()
+        if quote:
+            entry["customer_quote"] = quote
+        rows.append(entry)
+    rows.sort(key=lambda r: int(r.get("mention_count") or 0), reverse=True)
+    return rows[:limit]
+
+
+def _apply_evidence_vault_to_briefing(
+    briefing: dict[str, Any],
+    vault: dict[str, Any] | None,
+) -> bool:
+    """Overlay canonical evidence-vault fields without replacing richer sources."""
+    if not vault:
+        return False
+
+    used = False
+    snapshot = vault.get("metric_snapshot") or {}
+
+    if not briefing.get("review_count"):
+        review_count = snapshot.get("reviews_in_analysis_window") or snapshot.get("total_reviews")
+        if review_count is not None:
+            briefing["review_count"] = review_count
+            used = True
+    if not briefing.get("avg_urgency") and snapshot.get("avg_urgency") is not None:
+        briefing["avg_urgency"] = snapshot.get("avg_urgency")
+        used = True
+    if not briefing.get("churn_signal_density") and snapshot.get("churn_density") is not None:
+        briefing["churn_signal_density"] = snapshot.get("churn_density")
+        used = True
+    if not briefing.get("dm_churn_rate") and snapshot.get("dm_churn_rate") is not None:
+        briefing["dm_churn_rate"] = float(snapshot.get("dm_churn_rate") or 0) * 100.0
+        used = True
+    if not briefing.get("recommend_ratio") and snapshot.get("recommend_ratio") is not None:
+        try:
+            briefing["recommend_ratio"] = round(float(snapshot["recommend_ratio"]), 2)
+            used = True
+        except (TypeError, ValueError):
+            pass
+
+    if not briefing.get("pain_breakdown"):
+        pain_breakdown = _briefing_pain_breakdown_from_evidence_vault(vault)
+        if pain_breakdown:
+            briefing["pain_breakdown"] = pain_breakdown
+            used = True
+    if not briefing.get("top_feature_gaps"):
+        feature_gaps = _briefing_feature_gaps_from_evidence_vault(vault)
+        if feature_gaps:
+            briefing["top_feature_gaps"] = feature_gaps
+            used = True
+    if not briefing.get("named_accounts"):
+        named_accounts = _briefing_named_accounts_from_evidence_vault(vault)
+        if named_accounts:
+            briefing["named_accounts"] = named_accounts
+            used = True
+    if not briefing.get("retention_strengths"):
+        retention_strengths = _briefing_strengths_from_evidence_vault(vault)
+        if retention_strengths:
+            briefing["retention_strengths"] = retention_strengths
+            used = True
+
+    existing_evidence = list(briefing.get("evidence") or [])
+    if len(existing_evidence) < 2:
+        existing_text = {
+            str(e.get("quote") or e.get("text") or "").strip().lower()
+            for e in existing_evidence
+            if isinstance(e, dict)
+        }
+        for item in _briefing_quotes_from_evidence_vault(vault):
+            text = str(item.get("quote") or item.get("text") or "").strip().lower()
+            if not text or text in existing_text:
+                continue
+            existing_evidence.append(item)
+            existing_text.add(text)
+            used = True
+            if len(existing_evidence) >= 5:
+                break
+        briefing["evidence"] = existing_evidence
+
+    return used
+
+
+async def _enrich_with_analyst_summary(briefing: dict[str, Any]) -> None:
+    """Call Kimi K2.5 to generate analyst summary, headline, and pain labels.
+
+    Mutates *briefing* in place. Fails silently -- the briefing renders fine
+    without enrichment.
+    """
+    api_key = settings.b2b_churn.openrouter_api_key
+    if not api_key:
+        return
+
+    # Build a compact payload (only what the LLM needs)
+    score = float(briefing.get("churn_pressure_score") or 0)
+    urgency = float(briefing.get("avg_urgency") or 0)
+    trend = briefing.get("trend")
+
+    payload = {
+        "vendor_name": briefing.get("vendor_name"),
+        "category": briefing.get("category"),
+        "churn_pressure_score": score,
+        "churn_signal_density": briefing.get("churn_signal_density"),
+        "avg_urgency": urgency,
+        "trend": trend or "stable",
+        "review_count": briefing.get("review_count"),
+        "dm_churn_rate": briefing.get("dm_churn_rate"),
+        "recommend_ratio": briefing.get("recommend_ratio"),
+        "tone_band": _tone_band(score, urgency),
+        "pain_breakdown": briefing.get("pain_breakdown", [])[:5],
+        "top_displacement_targets": briefing.get("top_displacement_targets", [])[:5],
+        "evidence": [
+            (e.get("quote", e) if isinstance(e, dict) else e)
+            for e in (briefing.get("evidence") or [])[:3]
+        ],
+        "named_accounts": briefing.get("named_accounts", [])[:5],
+        "account_pressure_summary": briefing.get("account_pressure_summary"),
+        "account_pressure_metrics": briefing.get("account_pressure_metrics"),
+        "account_pressure_disclaimer": briefing.get("account_pressure_disclaimer"),
+        "account_actionability_tier": briefing.get("account_actionability_tier"),
+        "priority_account_names": briefing.get("priority_account_names", [])[:5],
+        "top_feature_gaps": briefing.get("top_feature_gaps", [])[:3],
+        "retention_strengths": briefing.get("retention_strengths", [])[:3],
+        "named_account_personas": [
+            {"company": a.get("company"), "title": a.get("title"),
+             "company_size": a.get("company_size"), "industry": a.get("industry")}
+            for a in (briefing.get("named_accounts") or [])[:5]
+            if isinstance(a, dict) and a.get("title")
+        ],
+    }
+    payload_json = json.dumps(payload)
+    cache_namespace = "b2b_vendor_briefing.analyst_summary"
+
+    try:
+        from ...pipelines.llm import clean_llm_output, normalize_openrouter_model
+        from ...services.b2b.cache_runner import (
+            lookup_b2b_exact_stage_text,
+            prepare_b2b_exact_stage_request,
+            store_b2b_exact_stage_text,
+        )
+        analyst_model = normalize_openrouter_model(
+            settings.b2b_churn.briefing_analyst_model,
+            context="vendor briefing analyst summary",
+        )
+
+        request = prepare_b2b_exact_stage_request(
+            "b2b_vendor_briefing.analyst_summary",
+            provider="openrouter",
+            model=analyst_model,
+            messages=[
+                {"role": "system", "content": _ANALYST_SYSTEM_PROMPT},
+                {"role": "user", "content": payload_json},
+            ],
+            max_tokens=4000,
+            temperature=0.3,
+            extra={"reasoning": {"effort": "low"}},
+        )
+        content: str | None = None
+        cached = await lookup_b2b_exact_stage_text(request)
+        if cached is not None:
+            try:
+                cleaned_cached = clean_llm_output(cached["response_text"])
+                json.loads(cleaned_cached)
+                content = cleaned_cached
+            except json.JSONDecodeError:
+                content = None
+
+        if content is None:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(
+                    "https://openrouter.ai/api/v1/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": analyst_model,
+                        "messages": [
+                            {"role": "system", "content": _ANALYST_SYSTEM_PROMPT},
+                            {"role": "user", "content": payload_json},
+                        ],
+                        "temperature": 0.3,
+                        "max_tokens": 4000,
+                        "reasoning": {"effort": "low"},
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            content = data["choices"][0]["message"].get("content")
+            if not content:
+                logger.warning("Analyst enrichment returned empty content")
+                return
+            content = clean_llm_output(content)
+
+        result = json.loads(content)
+
+        if result.get("executive_summary"):
+            briefing["executive_summary"] = result["executive_summary"]
+        if result.get("headline"):
+            briefing["headline"] = result["headline"]
+        if result.get("pain_labels") and isinstance(result["pain_labels"], dict):
+            briefing["pain_labels"] = result["pain_labels"]
+        if result.get("cta_hook"):
+            briefing["cta_hook"] = result["cta_hook"]
+        if result.get("displacement_qualifier"):
+            briefing["displacement_qualifier"] = result["displacement_qualifier"]
+        if result.get("account_persona_context"):
+            briefing["account_persona_context"] = result["account_persona_context"]
+
+        await store_b2b_exact_stage_text(
+            request,
+            response_text=content,
+            metadata={
+                "vendor_name": briefing.get("vendor_name"),
+                "category": briefing.get("category"),
+            },
+        )
+
+        logger.info(
+            "Analyst enrichment applied for %s (tone_band=%s)",
+            briefing.get("vendor_name"),
+            payload["tone_band"],
+        )
+
+    except Exception:
+        logger.exception("Analyst enrichment failed (non-fatal)")
+
+
+# ---------------------------------------------------------------------------
+# Account cards -- tiered reasoning (depth 0/1/2)
+# ---------------------------------------------------------------------------
+
+_PERSONA_KEYWORDS: dict[str, list[str]] = {
+    "retention_leader": ["vp cs", "head of cx", "cs director", "vp customer success",
+                         "director of customer success", "chief customer officer"],
+    "growth_leader": ["vp sales", "cro", "bd director", "chief revenue officer",
+                      "head of sales", "director of sales", "vp business development"],
+    "product_leader": ["vp product", "cpo", "chief product officer", "head of product",
+                       "director of product"],
+    "technical_leader": ["cto", "vp eng", "vp engineering", "chief technology officer",
+                         "director of engineering", "head of engineering"],
+    "executive": ["ceo", "coo", "chief executive", "chief operating", "founder",
+                  "managing director", "general manager"],
+}
+
+
+def _classify_persona(title: str | None) -> str:
+    """Classify a reviewer title into a persona bucket via keyword match."""
+    if not title:
+        return "unknown"
+    t = title.strip().lower()
+    for persona, keywords in _PERSONA_KEYWORDS.items():
+        for kw in keywords:
+            if kw in t:
+                return persona
+    return "unknown"
+
+
+def _classify_company_tier(company_size: Any) -> str:
+    """Classify company size into a tier label."""
+    try:
+        size = int(company_size)
+    except (TypeError, ValueError):
+        return "unknown"
+    if size <= 200:
+        return "smb"
+    if size <= 1000:
+        return "mid_market"
+    if size <= 10000:
+        return "enterprise"
+    return "large_enterprise"
+
+
+def _urgency_label(urgency: float) -> str:
+    """Map urgency score to a human label."""
+    if urgency >= 8:
+        return "critical"
+    if urgency >= 6:
+        return "high"
+    if urgency >= 4:
+        return "moderate"
+    return "watch"
+
+
+def _compute_data_richness(account: dict[str, Any], briefing_data: dict[str, Any]) -> int:
+    """Score 0-10 counting non-empty optional fields for depth selection."""
+    score = 0
+    if account.get("title"):
+        score += 1
+    if account.get("company_size"):
+        score += 1
+    if account.get("industry"):
+        score += 1
+    pains = account.get("pain_breakdown") or briefing_data.get("pain_breakdown") or []
+    if len(pains) >= 2:
+        score += 1
+    evidence = account.get("evidence") or briefing_data.get("evidence") or []
+    if len(evidence) >= 2:
+        score += 1
+    displacement = account.get("top_displacement_targets") or briefing_data.get("top_displacement_targets") or []
+    if len(displacement) >= 1:
+        score += 1
+    gaps = account.get("top_feature_gaps") or briefing_data.get("top_feature_gaps") or []
+    if len(gaps) >= 1:
+        score += 1
+    if account.get("budget_context") or briefing_data.get("budget_context"):
+        score += 1
+    trend = account.get("trend") or briefing_data.get("trend")
+    if trend and trend != "stable":
+        score += 1
+    churn_score = float(account.get("churn_pressure_score") or briefing_data.get("churn_pressure_score") or 0)
+    if churn_score > 0:
+        score += 1
+    return score
+
+
+def _select_reasoning_depth(
+    account: dict[str, Any],
+    briefing_data: dict[str, Any],
+    max_depth: int,
+) -> int:
+    """Adaptively select reasoning depth based on urgency and data richness."""
+    urgency = float(account.get("urgency", 0))
+    richness = _compute_data_richness(account, briefing_data)
+
+    if urgency >= 8 and richness >= 5 and max_depth >= 2:
+        return 2
+    if (urgency >= 6 or richness >= 6) and max_depth >= 1:
+        return 1
+    if richness < 3:
+        return 0
+    return min(1, max_depth)
+
+
+def _build_enriched_baseline(
+    account: dict[str, Any],
+    briefing_data: dict[str, Any],
+    vendor_name: str,
+    target_mode: str,
+) -> dict[str, Any]:
+    """Build depth-0 baseline with all raw + computed fields (no LLM)."""
+    company = account.get("company", "Unknown") if isinstance(account, dict) else str(account)
+    urgency = float(account.get("urgency", 0)) if isinstance(account, dict) else 0.0
+
+    # Raw fields from account, falling back to briefing-level data
+    def _get(field: str) -> Any:
+        val = account.get(field) if isinstance(account, dict) else None
+        if val is None:
+            val = briefing_data.get(field)
+        return val
+
+    title = _get("title")
+    company_size = _get("company_size")
+    industry = _get("industry")
+    pain_breakdown = _get("pain_breakdown") or []
+    evidence = _get("evidence") or []
+    displacement = _get("top_displacement_targets") or []
+    feature_gaps = _get("top_feature_gaps") or []
+    budget_context = _get("budget_context")
+    trend = _get("trend")
+
+    # Computed fields
+    persona = _classify_persona(title)
+    company_tier = _classify_company_tier(company_size)
+    urg_label = _urgency_label(urgency)
+    data_richness = _compute_data_richness(account, briefing_data)
+
+    top_pain = ""
+    if pain_breakdown and isinstance(pain_breakdown[0], dict):
+        top_pain = pain_breakdown[0].get("category", "")
+    elif pain_breakdown:
+        top_pain = str(pain_breakdown[0])
+
+    top_competitor = ""
+    if displacement and isinstance(displacement[0], dict):
+        top_competitor = displacement[0].get("competitor", "")
+    elif displacement:
+        top_competitor = str(displacement[0])
+
+    baseline: dict[str, Any] = {
+        "company": company,
+        "urgency": urgency,
+        "vendor_name": vendor_name,
+        "target_mode": target_mode,
+        # Raw fields
+        "title": title,
+        "company_size": company_size,
+        "industry": industry,
+        "pain_breakdown": pain_breakdown,
+        "evidence": evidence,
+        "top_displacement_targets": displacement,
+        "top_feature_gaps": feature_gaps,
+        "budget_context": budget_context,
+        "trend": trend,
+        # Computed fields
+        "persona": persona,
+        "company_tier": company_tier,
+        "urgency_label": urg_label,
+        "data_richness": data_richness,
+        "top_pain": top_pain,
+        "top_competitor": top_competitor,
+    }
+    return baseline
+
+
+def _fill_template(prompt_text: str, data: dict[str, Any]) -> str:
+    """Substitute {field} placeholders in a template string."""
+    for key, val in data.items():
+        placeholder = "{" + key + "}"
+        if placeholder in prompt_text:
+            if isinstance(val, (list, dict)):
+                replacement = json.dumps(val, default=str)
+            elif val is None:
+                replacement = "N/A"
+            else:
+                replacement = str(val)
+            prompt_text = prompt_text.replace(placeholder, replacement)
+    # Strip unreplaced placeholders
+    prompt_text = re.sub(r"\{[a-z_]+\}", "N/A", prompt_text)
+    return prompt_text
+
+
+def _mode_instruction(target_mode: str) -> str:
+    """Return mode-specific instruction for STEP 4 of CoT prompt."""
+    if target_mode == "challenger_intel":
+        return (
+            "Frame around capturing accounts in motion for a VP Sales / CRO. "
+            "Position your solution against the incumbent's weaknesses."
+        )
+    return (
+        "Frame around preventing further customer loss for a VP CS / Head of Product. "
+        "Focus on retention levers and risk mitigation."
+    )
+
+
+def _get_llm() -> Any:
+    """Get LLM instance for account card enrichment."""
+    from ...services.llm_router import get_llm
+    llm = get_llm("campaign")
+    if llm is None:
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    return llm
+
+
+async def _llm_call(
+    llm: Any,
+    system_prompt: str,
+    user_prompt: str,
+    max_tokens: int = 1024,
+    *,
+    cache_namespace: str = "b2b_vendor_briefing.account_card",
+    cache_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Single LLM call returning parsed JSON or None."""
+    from ...services.protocols import Message
+    from ...services.b2b.cache_runner import (
+        lookup_b2b_exact_stage_text,
+        prepare_b2b_exact_stage_request,
+        store_b2b_exact_stage_text,
+    )
+
+    messages = [
+        Message(role="system", content=system_prompt),
+        Message(role="user", content=user_prompt),
+    ]
+    request = prepare_b2b_exact_stage_request(
+        cache_namespace,
+        llm=llm,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=0.3,
+    )
+    model_name = request.model
+
+    try:
+        cached = await lookup_b2b_exact_stage_text(request)
+        text: str | None = None
+        usage: dict[str, int] = {}
+        if cached is not None:
+            text = cached["response_text"]
+
+        if hasattr(llm, "chat_async"):
+            if text is None:
+                text = (await llm.chat_async(
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=0.3,
+                )).strip()
+        elif text is None:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    llm.chat,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=0.3,
+                ),
+                timeout=60,
+            )
+            text = result.get("response", "").strip() if isinstance(result, dict) else str(result).strip()
+            usage = result.get("usage", {}) if isinstance(result, dict) else {}
+
+        if not text:
+            return None
+
+        # Clean markdown fences
+        text = re.sub(r"^```\w*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text)
+        text = text.strip()
+
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            if cached is None:
+                raise
+            logger.warning("Cached account card response was invalid JSON; retrying live")
+            text = None
+            usage = {}
+            if hasattr(llm, "chat_async"):
+                text = (await llm.chat_async(
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=0.3,
+                )).strip()
+            else:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        llm.chat,
+                        messages=messages,
+                        max_tokens=max_tokens,
+                        temperature=0.3,
+                    ),
+                    timeout=60,
+                )
+                text = result.get("response", "").strip() if isinstance(result, dict) else str(result).strip()
+                usage = result.get("usage", {}) if isinstance(result, dict) else {}
+            if not text:
+                return None
+            text = re.sub(r"^```\w*\n?", "", text)
+            text = re.sub(r"\n?```$", "", text)
+            text = text.strip()
+            data = json.loads(text)
+        await store_b2b_exact_stage_text(
+            request,
+            response_text=text,
+            usage=usage,
+            metadata=cache_metadata,
+        )
+        return {
+            "data": data,
+            "model": model_name,
+            "token_usage": {
+                "input_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+            },
+        }
+    except json.JSONDecodeError:
+        logger.warning(
+            "Account card LLM returned invalid JSON (text=%s)",
+            text[:200] if text else "<empty>",
+        )
+        return None
+    except Exception:
+        logger.exception("LLM call failed")
+        return None
+
+
+def _merge_token_usage(usages: list[dict[str, int]]) -> dict[str, int]:
+    """Sum token usage dicts."""
+    return {
+        "input_tokens": sum(u.get("input_tokens", 0) for u in usages),
+        "output_tokens": sum(u.get("output_tokens", 0) for u in usages),
+    }
+
+
+async def _enrich_account_card_cot(
+    template: dict[str, Any],
+    baseline: dict[str, Any],
+    target_mode: str,
+) -> dict[str, Any] | None:
+    """Depth 1: Chain-of-thought single-pass enrichment (1 LLM call)."""
+    llm = _get_llm()
+    if llm is None:
+        logger.warning("No LLM available for depth-1 account card enrichment")
+        return None
+
+    # Inject mode-specific instruction into the baseline for template filling
+    enriched_baseline = {**baseline, "target_mode": _mode_instruction(target_mode)}
+    prompt_text = _fill_template(template.get("prompt_template") or "", enriched_baseline)
+    system_prompt = template.get("system_prompt") or _ACCOUNT_CARD_SYSTEM_PROMPT
+
+    result = await _llm_call(llm, system_prompt, prompt_text)
+    if not result:
+        logger.warning("Depth-1 enrichment returned nothing for %s", baseline.get("company"))
+        return None
+
+    return result
+
+
+async def _deep_enrich_account_card(
+    templates: dict[str, dict[str, Any]],
+    baseline: dict[str, Any],
+    target_mode: str,
+    briefing_data: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Depth 2: Multi-pass recursive reasoning (2-4 LLM calls)."""
+    llm = _get_llm()
+    if llm is None:
+        logger.warning("No LLM available for depth-2 account card enrichment")
+        return None
+
+    company = baseline.get("company", "Unknown")
+    urgency = float(baseline.get("urgency", 0))
+    enriched_baseline = {**baseline, "target_mode": _mode_instruction(target_mode)}
+    all_usages: list[dict[str, int]] = []
+    calls_made = 0
+    conditional_calls: list[str] = []
+
+    # --- Call 1: Decompose and Analyze (always runs) ---
+    decompose_tpl = templates.get("sales_action_decompose")
+    if not decompose_tpl:
+        logger.warning("Missing sales_action_decompose template, falling back to depth 1")
+        cot_tpl = templates.get("sales_action_cot")
+        if cot_tpl:
+            return await _enrich_account_card_cot(cot_tpl, baseline, target_mode)
+        return None
+
+    decompose_prompt = _fill_template(
+        decompose_tpl.get("prompt_template") or "", enriched_baseline
+    )
+    decompose_system = decompose_tpl.get("system_prompt") or _ACCOUNT_CARD_SYSTEM_PROMPT
+
+    decompose_result = await _llm_call(llm, decompose_system, decompose_prompt, max_tokens=2048)
+    if not decompose_result:
+        logger.warning("Depth-2 decompose failed for %s, falling back to depth 1", company)
+        cot_tpl = templates.get("sales_action_cot")
+        if cot_tpl:
+            return await _enrich_account_card_cot(cot_tpl, baseline, target_mode)
+        return None
+
+    calls_made += 1
+    all_usages.append(decompose_result["token_usage"])
+    decomposition = decompose_result["data"]
+
+    # --- Call 2: Synthesize + Self-Correct (always runs) ---
+    synthesize_tpl = templates.get("sales_action_synthesize")
+    if not synthesize_tpl:
+        # Return raw decomposition if no synthesis template
+        decompose_result["token_usage"] = _merge_token_usage(all_usages)
+        decompose_result["data"]["reasoning_meta"] = {
+            "calls_made": calls_made,
+            "conditional_calls": conditional_calls,
+        }
+        return decompose_result
+
+    synth_data = {
+        **enriched_baseline,
+        "decomposition": json.dumps(decomposition, default=str),
+        "baseline_json": json.dumps(baseline, default=str),
+    }
+    synth_prompt = _fill_template(
+        synthesize_tpl.get("prompt_template") or "", synth_data
+    )
+    synth_system = synthesize_tpl.get("system_prompt") or _ACCOUNT_CARD_SYSTEM_PROMPT
+
+    synth_result = await _llm_call(llm, synth_system, synth_prompt, max_tokens=2048)
+    if synth_result:
+        calls_made += 1
+        all_usages.append(synth_result["token_usage"])
+        final_data = synth_result["data"]
+    else:
+        logger.warning("Depth-2 synthesis failed for %s, using decomposition", company)
+        final_data = decomposition
+
+    # --- Calls 3+4: Conditional, run in parallel ---
+    displacement = baseline.get("top_displacement_targets") or []
+    parallel_tasks: list[tuple[str, Any]] = []
+
+    # Call 3: Competitive Deep-Dive (>= 2 displacement targets AND urgency >= 7)
+    if len(displacement) >= 2 and urgency >= 7:
+        comp_prompt = (
+            f"Competitive deep-dive for {company} (urgency {urgency}/10).\n\n"
+            f"Displacement targets: {json.dumps(displacement[:5], default=str)}\n"
+            f"Pain drivers: {json.dumps(baseline.get('pain_breakdown', [])[:5], default=str)}\n"
+            f"Persona: {baseline.get('persona', 'unknown')}\n\n"
+            "Return JSON with:\n"
+            '- "primary_threat": The competitor most likely to win this account and why.\n'
+            '- "differentiators_to_emphasize": Array of 2-3 key differentiators to lead with.\n'
+            '- "landmine_questions": Array of 2-3 questions that expose competitor weaknesses.\n\n'
+            "Return ONLY valid JSON."
+        )
+        parallel_tasks.append(("competitive_deep_dive", _llm_call(
+            llm, _ACCOUNT_CARD_SYSTEM_PROMPT, comp_prompt
+        )))
+
+    # Call 4: Objection Pre-handling (urgency >= 8, critical accounts)
+    if urgency >= 8:
+        obj_prompt = (
+            f"Objection pre-handling for {company} (urgency {urgency}/10, CRITICAL).\n\n"
+            f"Pain drivers: {json.dumps(baseline.get('pain_breakdown', [])[:5], default=str)}\n"
+            f"Evidence: {json.dumps(baseline.get('evidence', [])[:3], default=str)}\n"
+            f"Persona: {baseline.get('persona', 'unknown')}\n"
+            f"Industry: {baseline.get('industry', 'N/A')}\n\n"
+            "Return JSON with:\n"
+            '- "objections": Array of 2-3 objects with "objection", "response", "data_reference".\n\n'
+            "Return ONLY valid JSON."
+        )
+        parallel_tasks.append(("objection_prehandling", _llm_call(
+            llm, _ACCOUNT_CARD_SYSTEM_PROMPT, obj_prompt
+        )))
+
+    if parallel_tasks:
+        results = await asyncio.gather(
+            *(task[1] for task in parallel_tasks),
+            return_exceptions=True,
+        )
+        for (call_name, _), result in zip(parallel_tasks, results):
+            if isinstance(result, Exception):
+                logger.warning("Depth-2 %s failed for %s: %s", call_name, company, result)
+                continue
+            if result is None:
+                continue
+            calls_made += 1
+            all_usages.append(result["token_usage"])
+            conditional_calls.append(call_name)
+            # Merge conditional call data into final output
+            final_data[call_name] = result["data"]
+
+    final_data["reasoning_meta"] = {
+        "calls_made": calls_made,
+        "conditional_calls": conditional_calls,
+    }
+
+    return {
+        "data": final_data,
+        "model": decompose_result.get("model", "unknown"),
+        "token_usage": _merge_token_usage(all_usages),
+    }
+
+
+async def generate_account_cards(
+    briefing_data: dict[str, Any],
+    reasoning_depth: int | None = None,
+    target_mode: str = "vendor_retention",
+) -> list[dict[str, Any]]:
+    """Generate intelligence cards for top named accounts.
+
+    Tiered reasoning system:
+    - depth 0: enriched baseline (deterministic, no LLM)
+    - depth 1: chain-of-thought single pass (1 LLM call)
+    - depth 2: multi-pass recursive reasoning (2-4 LLM calls)
+
+    Mutates briefing_data["account_cards"] in place. Returns the card list.
+    """
+    cfg = settings.b2b_churn
+    if not cfg.vendor_briefing_account_cards_enabled:
+        briefing_data["account_cards"] = []
+        return []
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        briefing_data["account_cards"] = []
+        return []
+
+    max_cards = cfg.vendor_briefing_account_cards_max
+    if reasoning_depth is None:
+        reasoning_depth = cfg.vendor_briefing_account_cards_reasoning_depth
+    adaptive = cfg.vendor_briefing_account_cards_adaptive_depth
+
+    # Fetch enabled card templates, index by name
+    template_rows = await pool.fetch(
+        "SELECT * FROM card_templates WHERE enabled = true ORDER BY name"
+    )
+    if not template_rows:
+        briefing_data["account_cards"] = []
+        return []
+
+    templates_by_name: dict[str, dict[str, Any]] = {
+        dict(r)["name"]: dict(r) for r in template_rows
+    }
+
+    # Select top accounts by urgency
+    named_accounts = briefing_data.get("named_accounts") or []
+    sorted_accounts = sorted(
+        named_accounts,
+        key=lambda a: float(a.get("urgency", 0)) if isinstance(a, dict) else 0,
+        reverse=True,
+    )[:max_cards]
+
+    if not sorted_accounts:
+        briefing_data["account_cards"] = []
+        return []
+
+    vendor_name = briefing_data.get("vendor_name", "Unknown")
+    cards: list[dict[str, Any]] = []
+
+    for account in sorted_accounts:
+        if not isinstance(account, dict):
+            continue
+
+        # Step 1: always compute enriched baseline (depth 0)
+        baseline = _build_enriched_baseline(account, briefing_data, vendor_name, target_mode)
+
+        # Step 2: select depth
+        if adaptive:
+            depth = _select_reasoning_depth(account, briefing_data, reasoning_depth)
+        else:
+            depth = reasoning_depth
+
+        card: dict[str, Any] = {
+            "template_name": "sales_action",
+            "template_label": "Sales Action Card",
+            "company": baseline["company"],
+            "urgency": baseline["urgency"],
+            "reasoning_depth": depth,
+            "baseline": baseline,
+            "enriched": None,
+            "token_usage": None,
+        }
+
+        # Step 3: route to enrichment function by depth
+        if depth >= 2:
+            card["template_name"] = "sales_action_decompose"
+            card["template_label"] = "Sales Action Card (Deep Analysis)"
+            enriched = await _deep_enrich_account_card(
+                templates_by_name, baseline, target_mode, briefing_data,
+            )
+            if enriched:
+                card["enriched"] = enriched.get("data")
+                card["token_usage"] = enriched.get("token_usage")
+                card["model"] = enriched.get("model")
+            elif depth >= 1:
+                # Depth 2 failed entirely, try depth 1 fallback
+                cot_tpl = templates_by_name.get("sales_action_cot")
+                if cot_tpl:
+                    card["template_name"] = "sales_action_cot"
+                    card["template_label"] = "Sales Action Card (Analyzed)"
+                    card["reasoning_depth"] = 1
+                    enriched = await _enrich_account_card_cot(
+                        cot_tpl, baseline, target_mode,
+                    )
+                    if enriched:
+                        card["enriched"] = enriched.get("data")
+                        card["token_usage"] = enriched.get("token_usage")
+                        card["model"] = enriched.get("model")
+
+        elif depth == 1:
+            cot_tpl = templates_by_name.get("sales_action_cot")
+            if cot_tpl:
+                card["template_name"] = "sales_action_cot"
+                card["template_label"] = "Sales Action Card (Analyzed)"
+                enriched = await _enrich_account_card_cot(
+                    cot_tpl, baseline, target_mode,
+                )
+                if enriched:
+                    card["enriched"] = enriched.get("data")
+                    card["token_usage"] = enriched.get("token_usage")
+                    card["model"] = enriched.get("model")
+
+        # depth 0: baseline only, no LLM -- card already has enriched=None
+
+        cards.append(card)
+
+    briefing_data["account_cards"] = cards
+
+    total_in = sum(c["token_usage"]["input_tokens"] for c in cards if c.get("token_usage"))
+    total_out = sum(c["token_usage"]["output_tokens"] for c in cards if c.get("token_usage"))
+    if total_in:
+        logger.info(
+            "Account cards: %d cards, tokens in=%d out=%d vendor=%s",
+            len(cards), total_in, total_out, vendor_name,
+        )
+        from ...pipelines.llm import trace_llm_call
+        from ...services.llm_router import get_llm as _get_llm_router
+        _llm = _get_llm_router("campaign")
+        trace_llm_call("task.vendor_briefing.account_cards", input_tokens=total_in,
+                       output_tokens=total_out,
+                       model=getattr(_llm, "model", "") if _llm else "",
+                       provider=getattr(_llm, "name", "") if _llm else "",
+                       metadata={"vendor": vendor_name, "card_count": len(cards)})
+
+    return cards
+
+
+# ---------------------------------------------------------------------------
+# Briefing apply helpers (Sources 10-12)
+# ---------------------------------------------------------------------------
+
+def _apply_pain_points_to_briefing(
+    briefing: dict[str, Any],
+    pain_pts: list[dict[str, Any]],
+) -> bool:
+    """Backfill or enrich pain_breakdown from b2b_vendor_pain_points rows.
+
+    Backfills when pain_breakdown is absent or sparse (< 2 entries).
+    Enriches existing entries with avg_urgency, avg_rating, and
+    confidence_score when the category matches.
+    """
+    if not pain_pts:
+        return False
+    current_pain = briefing.get("pain_breakdown") or []
+    if len(current_pain) < 2:
+        briefing["pain_breakdown"] = [
+            {
+                "category": p["pain_category"],
+                "count": p["mention_count"],
+                "avg_urgency": float(p.get("avg_urgency") or 0),
+                "avg_rating": (
+                    float(p["avg_rating"]) if p.get("avg_rating") is not None else None
+                ),
+                "confidence_score": float(p.get("confidence_score") or 0),
+            }
+            for p in pain_pts[:8]
+        ]
+        return True
+    pp_by_cat = {p["pain_category"]: p for p in pain_pts}
+    enriched = False
+    for item in current_pain:
+        if not isinstance(item, dict):
+            continue
+        cat = item.get("category") or item.get("pain_category") or ""
+        pp = pp_by_cat.get(cat)
+        if not pp:
+            continue
+        if pp.get("avg_urgency") is not None and "avg_urgency" not in item:
+            item["avg_urgency"] = float(pp["avg_urgency"])
+            enriched = True
+        if pp.get("avg_rating") is not None and "avg_rating" not in item:
+            item["avg_rating"] = float(pp["avg_rating"])
+            enriched = True
+        if pp.get("confidence_score") is not None and "confidence_score" not in item:
+            item["confidence_score"] = float(pp["confidence_score"])
+            enriched = True
+    if enriched:
+        briefing["pain_breakdown"] = current_pain
+    return enriched
+
+
+def _apply_account_intelligence_to_briefing(
+    briefing: dict[str, Any],
+    acct_data: dict[str, Any],
+) -> bool:
+    """Populate account-pressure fields from b2b_account_intelligence payload.
+
+    Always writes account_pressure_metrics.
+    Only backfills account_pressure_summary, named_account_count, and
+    priority_account_names when the briefing does not already have them.
+    """
+    summary = acct_data.get("summary") or {}
+    if not summary:
+        return False
+    briefing["account_pressure_metrics"] = {
+        k: v for k, v in summary.items() if isinstance(v, (int, float))
+    }
+    actionability_note = str(summary.get("account_actionability_note") or "").strip()
+    actionability_tier = str(summary.get("account_actionability_tier") or "").strip()
+    if actionability_note and not briefing.get("account_pressure_disclaimer"):
+        briefing["account_pressure_disclaimer"] = actionability_note
+    if actionability_tier and not briefing.get("account_actionability_tier"):
+        briefing["account_actionability_tier"] = actionability_tier
+    if not briefing.get("account_pressure_summary"):
+        high_intent = int(summary.get("high_intent_count") or 0)
+        active_eval = int(summary.get("active_eval_signal_count") or 0)
+        dm_count = int(summary.get("decision_maker_count") or 0)
+        parts = []
+        if high_intent:
+            parts.append(
+                f"{high_intent} high-intent account{'s' if high_intent != 1 else ''}"
+            )
+        if active_eval:
+            parts.append(
+                f"{active_eval} active evaluation signal{'s' if active_eval != 1 else ''}"
+            )
+        if dm_count:
+            parts.append(
+                f"{dm_count} decision-maker signal{'s' if dm_count != 1 else ''}"
+            )
+        if parts:
+            briefing["account_pressure_summary"] = (
+                "Detected: " + ", ".join(parts) + "."
+            )
+    if not briefing.get("named_account_count"):
+        total = int(summary.get("total_accounts") or 0)
+        if total:
+            briefing["named_account_count"] = total
+    accounts_raw = acct_data.get("accounts") or []
+    # Materialize named_accounts when the briefing doesn't already have them.
+    # Normalizes canonical account_intelligence shape to the named_accounts
+    # format consumed by generate_account_cards() and the email template.
+    if not briefing.get("named_accounts") and accounts_raw:
+        normalized: list[dict[str, Any]] = []
+        for a in accounts_raw:
+            if not isinstance(a, dict):
+                continue
+            company = (
+                a.get("company_name")
+                or a.get("account_name")
+                or a.get("name")
+                or ""
+            )
+            if not company:
+                continue
+            urgency = float(a.get("urgency_score") or a.get("urgency") or 0)
+            raw_title = a.get("buyer_role") or a.get("title") or ""
+            title = raw_title if raw_title not in ("unknown", "") else None
+            normalized.append({
+                "company": company,
+                "urgency": urgency,
+                "title": title,
+                "company_size": a.get("company_size"),
+                "buying_stage": a.get("buying_stage"),
+                "pain_category": a.get("pain_category"),
+                "source": a.get("source"),
+                "confidence_score": float(a.get("confidence_score") or 0),
+                "reasoning_backed": False,
+            })
+        normalized.sort(key=lambda x: x["urgency"], reverse=True)
+        if normalized:
+            briefing["named_accounts"] = normalized[:10]
+    if not briefing.get("priority_account_names"):
+        priority: list[str] = []
+        for a in accounts_raw:
+            if not isinstance(a, dict):
+                continue
+            name = (
+                a.get("company_name")
+                or a.get("account_name")
+                or a.get("name")
+                or ""
+            )
+            if name and (
+                a.get("high_intent")
+                or float(a.get("urgency_score") or 0) >= 6.0
+            ):
+                priority.append(name)
+        if priority:
+            briefing["priority_account_names"] = priority[:5]
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Data builder
+# ---------------------------------------------------------------------------
+
+async def build_vendor_briefing(
+    vendor_name: str,
+    target_mode: str = "vendor_retention",
+    analyst_summary_enabled: bool = True,
+    account_cards_reasoning_depth: int | None = None,
+) -> dict[str, Any] | None:
+    """
+    Build a briefing data dict for *vendor_name* from existing DB tables.
+
+    When *target_mode* is ``'challenger_intel'``, the displacement data is
+    flipped: instead of showing who the vendor is losing customers to, we
+    show which incumbents are losing customers to this challenger.
+
+    Returns None if the vendor is not found in any source.
+    """
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return None
+
+    challenger_mode = target_mode == "challenger_intel"
+
+    briefing: dict[str, Any] = {
+        "vendor_name": vendor_name,
+        "report_date": date.today().isoformat(),
+        "booking_url": build_gate_url(vendor_name),
+        "challenger_mode": challenger_mode,
+        "data_sources": {
+            "weekly_churn_feed": False,
+            "reasoning_synthesis": False,
+            "account_reasoning": False,
+            "company_signal_review_queue": False,
+            "churn_signals": False,
+            "evidence_vault": False,
+            "product_profile": False,
+            "segment_intelligence": False,
+            "temporal_intelligence": False,
+            "cross_vendor_conclusions": False,
+            "buyer_profiles": False,
+            "pain_points": False,
+            "account_intelligence": False,
+            "displacement_dynamics": False,
+            "raw_review_quotes": False,
+        },
+    }
+
+    found = False
+    signals: dict[str, Any] | None = None
+
+    # ------------------------------------------------------------------
+    # Source 1: weekly_churn_feed from b2b_intelligence
+    # ------------------------------------------------------------------
+    feed_entry = await _extract_feed_entry(pool, vendor_name)
+    if feed_entry:
+        found = True
+        briefing["data_sources"]["weekly_churn_feed"] = True
+        briefing.update({
+            "churn_pressure_score": feed_entry.get("churn_pressure_score", 0),
+            "churn_signal_density": feed_entry.get("churn_signal_density", 0),
+            "avg_urgency": feed_entry.get("avg_urgency", 0),
+            "review_count": feed_entry.get("total_reviews", 0),
+            "dm_churn_rate": feed_entry.get("dm_churn_rate", 0),
+            "pain_breakdown": feed_entry.get("pain_breakdown", []),
+            "top_displacement_targets": _normalize_displacement(
+                feed_entry.get("top_displacement_targets", [])
+            ),
+            "evidence": feed_entry.get("evidence", []),
+            "trend": feed_entry.get("trend"),
+            "named_accounts": feed_entry.get("named_accounts", []),
+            "top_feature_gaps": feed_entry.get("top_feature_gaps", []),
+            "category": feed_entry.get("category", "Software"),
+            "budget_context": feed_entry.get("budget_context"),
+        })
+        if _apply_reasoning_synthesis_to_briefing(briefing, feed_entry):
+            briefing["data_sources"]["reasoning_synthesis"] = True
+        if briefing.get("account_reasoning"):
+            briefing["data_sources"]["account_reasoning"] = True
+
+    # ------------------------------------------------------------------
+    # Source 2: b2b_churn_signals (fallback if no feed entry)
+    # ------------------------------------------------------------------
+    if not found:
+        signals = await _fetch_churn_signals(pool, vendor_name)
+        if signals:
+            found = True
+            briefing["data_sources"]["churn_signals"] = True
+            # top_feature_gaps from signals is [{feature, count}] -- extract names
+            raw_gaps = _jsonb_list(signals.get("top_feature_gaps"))
+            feature_gap_strings = [
+                g.get("feature", str(g)) if isinstance(g, dict) else str(g)
+                for g in raw_gaps[:5]
+            ]
+            briefing.update({
+                "churn_pressure_score": _compute_pressure(signals),
+                "churn_signal_density": _safe_density(signals),
+                "avg_urgency": float(signals.get("avg_urgency_score", 0)),
+                "review_count": signals.get("total_reviews", 0),
+                "dm_churn_rate": float(signals.get("decision_maker_churn_rate", 0) or 0) * 100,
+                "pain_breakdown": _jsonb_list(signals.get("top_pain_categories")),
+                "top_displacement_targets": _normalize_displacement(
+                    _jsonb_list(signals.get("top_competitors"))
+                ),
+                "evidence": _jsonb_list(signals.get("quotable_evidence")),
+                "trend": None,
+                "named_accounts": _jsonb_list(signals.get("company_churn_list")),
+                "top_feature_gaps": feature_gap_strings,
+                "category": signals.get("product_category") or "Software",
+            })
+
+    if not found:
+        return None
+
+    # ------------------------------------------------------------------
+    # Source 3: b2b_evidence_vault (canonical overlay for sparse fields)
+    # ------------------------------------------------------------------
+    if signals:
+        vault_record = await _fetch_vendor_evidence_record(pool, vendor_name)
+        vault, vault_alignment = _align_vendor_intelligence_record_to_scorecard(
+            signals,
+            vault_record,
+        )
+        if vault_alignment["mismatched_vendor_count"] > 0:
+            logger.info(
+                "Suppressed stale vendor briefing evidence-vault overlay for %s",
+                vendor_name,
+            )
+    else:
+        vault = await _fetch_vendor_evidence_vault(pool, vendor_name)
+    if _apply_evidence_vault_to_briefing(briefing, vault):
+        briefing["data_sources"]["evidence_vault"] = True
+
+    # ------------------------------------------------------------------
+    # Source 4: b2b_product_profiles (enrichment)
+    # ------------------------------------------------------------------
+    profile = await _fetch_product_profile(pool, vendor_name)
+    if profile:
+        briefing["data_sources"]["product_profile"] = True
+        if not briefing.get("category") or briefing["category"] == "Software":
+            briefing["category"] = profile.get("product_category") or "Software"
+        if profile.get("profile_summary"):
+            briefing["profile_summary"] = profile["profile_summary"]
+        # Feature gaps from weaknesses if not already populated
+        if not briefing.get("top_feature_gaps"):
+            weaknesses = _jsonb_list(profile.get("weaknesses"))
+            briefing["top_feature_gaps"] = [
+                w.get("area", str(w)) if isinstance(w, dict) else str(w)
+                for w in weaknesses[:3]
+            ]
+
+    # ------------------------------------------------------------------
+    # Source 5: reasoning view (synthesis-first, legacy fallback)
+    # ------------------------------------------------------------------
+    reasoning_view = None
+    if (
+        not briefing.get("reasoning_contracts")
+        or not briefing.get("reasoning_anchor_examples")
+        or not briefing.get("reasoning_reference_ids")
+    ):
+        from ._b2b_synthesis_reader import load_best_reasoning_view
+
+        reasoning_view = await load_best_reasoning_view(
+            pool,
+            vendor_name,
+        )
+        if reasoning_view is not None:
+            if _apply_synthesis_view_to_briefing(briefing, reasoning_view):
+                briefing["data_sources"]["reasoning_synthesis"] = True
+    if await _attach_company_signal_review_queue_to_briefing(
+        pool,
+        briefing,
+        vendor_name=vendor_name,
+    ):
+        briefing["data_sources"]["company_signal_review_queue"] = True
+
+    # ------------------------------------------------------------------
+    # Source 6: b2b_segment_intelligence
+    # ------------------------------------------------------------------
+    seg_data = await _fetch_segment_intelligence(pool, vendor_name)
+    if seg_data:
+        briefing["segment_intelligence"] = seg_data
+        briefing["data_sources"]["segment_intelligence"] = True
+
+    # ------------------------------------------------------------------
+    # Source 7: b2b_temporal_intelligence (fallback when feed is absent)
+    # ------------------------------------------------------------------
+    if not briefing.get("timing_intelligence"):
+        temporal = await _fetch_temporal_intelligence(pool, vendor_name)
+        if temporal:
+            briefing["timing_intelligence"] = temporal
+            timing_summary, timing_metrics, priority_triggers = (
+                _timing_summary_payload(temporal)
+            )
+            if timing_summary:
+                briefing["timing_summary"] = timing_summary
+            if timing_metrics:
+                briefing["timing_metrics"] = timing_metrics
+            if priority_triggers:
+                briefing["priority_timing_triggers"] = priority_triggers
+            briefing["data_sources"]["temporal_intelligence"] = True
+
+    # ------------------------------------------------------------------
+    # Source 8: cross-vendor reasoning (synthesis-first, legacy fallback)
+    # ------------------------------------------------------------------
+    conclusions = await _fetch_cross_vendor_conclusions(
+        pool,
+        vendor_name,
+        category=str(briefing.get("category") or "").strip() or None,
+    )
+    if conclusions:
+        briefing["cross_vendor_conclusions"] = conclusions
+        briefing["data_sources"]["cross_vendor_conclusions"] = True
+
+    # ------------------------------------------------------------------
+    # Source 9: b2b_vendor_buyer_profiles
+    # ------------------------------------------------------------------
+    buyer_profiles = await _fetch_buyer_profiles(pool, vendor_name)
+    if buyer_profiles:
+        briefing["buyer_profiles"] = buyer_profiles
+        briefing["data_sources"]["buyer_profiles"] = True
+
+    # ------------------------------------------------------------------
+    # Source 10: b2b_vendor_pain_points (fallback + urgency enrichment)
+    # ------------------------------------------------------------------
+    pain_pts = await _fetch_pain_points(pool, vendor_name)
+    if pain_pts:
+        if _apply_pain_points_to_briefing(briefing, pain_pts):
+            briefing["data_sources"]["pain_points"] = True
+
+    # ------------------------------------------------------------------
+    # Source 11: b2b_account_intelligence
+    # ------------------------------------------------------------------
+    acct_data = await _fetch_account_intelligence(pool, vendor_name)
+    if acct_data:
+        if _apply_account_intelligence_to_briefing(briefing, acct_data):
+            briefing["data_sources"]["account_intelligence"] = True
+
+    # ------------------------------------------------------------------
+    # Source 12: b2b_displacement_dynamics (competitive augmentation)
+    # ------------------------------------------------------------------
+    disp_dynamics = await _fetch_displacement_dynamics(
+        pool, vendor_name, challenger_mode=challenger_mode
+    )
+    if disp_dynamics:
+        briefing["competitive_dynamics"] = disp_dynamics
+        briefing["data_sources"]["displacement_dynamics"] = True
+        # Augment cross_vendor_conclusions when fewer than 2 pairwise entries
+        existing = briefing.get("cross_vendor_conclusions") or []
+        pairwise_count = sum(
+            1 for c in existing
+            if isinstance(c, dict) and c.get("analysis_type") == "pairwise_battle"
+        )
+        if pairwise_count < 2:
+            for pair in disp_dynamics.get("pairs") or []:
+                summary = pair.get("battle_summary") or ""
+                if not summary:
+                    continue
+                existing.append({
+                    "analysis_type": "pairwise_battle",
+                    "vendors": [vendor_name, pair.get("challenger") or ""],
+                    "summary": summary,
+                    "confidence": 0.6,
+                    "source": "displacement_dynamics",
+                })
+                new_count = sum(
+                    1 for c in existing
+                    if isinstance(c, dict) and c.get("analysis_type") == "pairwise_battle"
+                )
+                if new_count >= 2:
+                    break
+            briefing["cross_vendor_conclusions"] = existing
+
+    # ------------------------------------------------------------------
+    # Challenger mode: flip displacement to show incumbents losing TO us
+    # ------------------------------------------------------------------
+    if challenger_mode:
+        challenger_edges = await pool.fetch(
+            """
+            SELECT from_vendor AS competitor, SUM(mention_count) AS count
+            FROM b2b_displacement_edges
+            WHERE LOWER(to_vendor) = LOWER($1)
+              AND computed_date > NOW() - INTERVAL '30 days'
+            GROUP BY from_vendor
+            ORDER BY count DESC
+            LIMIT 5
+            """,
+            vendor_name,
+        )
+        if challenger_edges:
+            briefing["top_displacement_targets"] = [
+                {"competitor": r["competitor"], "count": int(r["count"] or 0)}
+                for r in challenger_edges
+            ]
+
+    # ------------------------------------------------------------------
+    # Source 5: b2b_reviews (high-urgency quotes if evidence thin)
+    # ------------------------------------------------------------------
+    evidence = briefing.get("evidence") or []
+    if len(evidence) < 2:
+        extra_quotes = await _fetch_high_urgency_quotes(pool, vendor_name, limit=5)
+        # Deduplicate against existing evidence (evidence items may be dicts or strings)
+        existing: set[str] = set()
+        for e in evidence:
+            text = e.get("quote", e.get("text", e)) if isinstance(e, dict) else e
+            if isinstance(text, str):
+                existing.add(text)
+        for q in extra_quotes:
+            q_text = q.get("text", "") if isinstance(q, dict) else q
+            if q_text and q_text not in existing:
+                evidence.append(q)
+                existing.add(q_text)
+                briefing["data_sources"]["raw_review_quotes"] = True
+        briefing["evidence"] = evidence
+
+    # ------------------------------------------------------------------
+    # Archetype / wedge context: "why now" + falsification
+    # ------------------------------------------------------------------
+    try:
+        if reasoning_view is None:
+            from ._b2b_synthesis_reader import load_best_reasoning_view
+            reasoning_view = await load_best_reasoning_view(
+                pool,
+                vendor_name,
+            )
+        if reasoning_view is not None:
+            wedge = reasoning_view.primary_wedge
+            cn = reasoning_view.section("causal_narrative")
+            # Prefer validated wedge, fall back to raw primary_wedge from contracts
+            briefing["archetype"] = (
+                wedge.value if wedge
+                else cn.get("primary_wedge", "")
+            )
+            briefing["archetype_confidence"] = reasoning_view.confidence("causal_narrative")
+            briefing["falsification_conditions"] = [
+                fc.get("condition", fc) if isinstance(fc, dict) else fc
+                for fc in reasoning_view.falsification_conditions()
+            ]
+
+            # "What changed" context via prior reasoning snapshot
+            from ._b2b_synthesis_reader import load_prior_reasoning_snapshots
+
+            prior = await load_prior_reasoning_snapshots(pool, [vendor_name])
+            prior_data = prior.get(vendor_name, {})
+            if prior_data.get("archetype"):
+                briefing["archetype_was"] = prior_data["archetype"]
+                # Compare using raw legacy archetype when available
+                current_legacy = cn.get("_legacy_archetype") or briefing["archetype"]
+                briefing["archetype_changed"] = (
+                    prior_data["archetype"] != current_legacy
+                )
+    except Exception:
+        logger.debug("Archetype enrichment skipped for %s", vendor_name, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Correlated articles: news articles aligned with archetype
+    # ------------------------------------------------------------------
+    try:
+        art_rows = await pool.fetch(
+            """
+            SELECT na.title, na.url, na.source_name,
+                   bac.correlation_type, bac.relevance_score,
+                   bac.archetype AS corr_archetype
+            FROM b2b_article_correlations bac
+            JOIN news_articles na ON na.id = bac.article_id
+            WHERE bac.vendor_name = $1
+            ORDER BY bac.relevance_score DESC, bac.created_at DESC
+            LIMIT 3
+            """,
+            vendor_name,
+        )
+        if art_rows:
+            briefing["correlated_articles"] = [
+                {
+                    "title": r["title"],
+                    "url": r["url"],
+                    "source": r["source_name"],
+                    "correlation_type": r["correlation_type"],
+                    "relevance": float(r["relevance_score"] or 0),
+                }
+                for r in art_rows
+            ]
+    except Exception:
+        logger.debug("Correlated articles skipped for %s", vendor_name, exc_info=True)
+
+    # Analyst enrichment -- optional for scheduled deterministic batching.
+    if analyst_summary_enabled:
+        await _enrich_with_analyst_summary(briefing)
+
+    # Account cards -- baseline data + optional LLM enrichment
+    await generate_account_cards(
+        briefing,
+        reasoning_depth=account_cards_reasoning_depth,
+        target_mode=target_mode,
+    )
+
+    _finalize_briefing_presentation(briefing)
+
+    return briefing
+
+
+async def _extract_feed_entry(pool: Any, vendor_name: str) -> dict | None:
+    """Find vendor in the latest weekly_churn_feed."""
+    row = await pool.fetchrow(
+        """
+        SELECT intelligence_data
+        FROM b2b_intelligence
+        WHERE report_type = 'weekly_churn_feed'
+        ORDER BY report_date DESC, created_at DESC
+        LIMIT 1
+        """,
+    )
+    if not row:
+        return None
+
+    data = row["intelligence_data"]
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    # intelligence_data is the full report; the feed is a list inside it
+    feed = data if isinstance(data, list) else data.get("weekly_churn_feed", data)
+    if not isinstance(feed, list):
+        return None
+
+    vn_lower = vendor_name.lower()
+    for entry in feed:
+        if not isinstance(entry, dict):
+            continue
+        entry_vendor = entry.get("vendor", "") or entry.get("vendor_name", "")
+        if entry_vendor.lower() == vn_lower:
+            return entry
+
+    return None
+
+
+async def _fetch_reasoning_synthesis(pool: Any, vendor_name: str) -> dict[str, Any] | None:
+    """Fetch best reasoning for one vendor (synthesis-first, legacy fallback).
+
+    Returns the raw dict suitable for _apply_reasoning_synthesis_to_briefing.
+    """
+    from ._b2b_synthesis_reader import load_best_reasoning_view
+
+    view = await load_best_reasoning_view(
+        pool,
+        vendor_name,
+    )
+    if view is None:
+        return None
+    # Return materialized contracts as the raw dict for the existing applier
+    contracts = view.materialized_contracts()
+    if not contracts:
+        return None
+    result: dict[str, Any] = {"reasoning_contracts": contracts}
+    if view.primary_wedge:
+        result["synthesis_wedge"] = view.primary_wedge.value
+        result["synthesis_wedge_label"] = view.wedge_label
+    result["reasoning_source"] = "b2b_reasoning_synthesis"
+    result["synthesis_schema_version"] = view.schema_version
+    if view.as_of_date:
+        result["data_as_of_date"] = view.as_of_date.isoformat()
+    meta = view.meta
+    if meta:
+        result["evidence_window"] = meta
+    return result
+
+
+async def _fetch_segment_intelligence(pool: Any, vendor_name: str) -> dict[str, Any] | None:
+    """Fetch top priority segments from b2b_segment_intelligence."""
+    row = await pool.fetchrow(
+        """
+        SELECT segments
+        FROM b2b_segment_intelligence
+        WHERE LOWER(vendor_name) = LOWER($1)
+        ORDER BY as_of_date DESC
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    if not row:
+        return None
+    data = row["segments"]
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(data, dict):
+        return None
+    roles = data.get("affected_roles") or []
+    if not isinstance(roles, list):
+        return None
+    top_segments = sorted(
+        [r for r in roles if isinstance(r, dict)],
+        key=lambda r: float(r.get("priority_score") or 0),
+        reverse=True,
+    )[:4]
+    if not top_segments:
+        return None
+    return {
+        "top_segments": top_segments,
+        "as_of_date": data.get("as_of_date"),
+    }
+
+
+async def _fetch_temporal_intelligence(pool: Any, vendor_name: str) -> dict[str, Any] | None:
+    """Fetch temporal intelligence signals for one vendor."""
+    row = await pool.fetchrow(
+        """
+        SELECT temporal
+        FROM b2b_temporal_intelligence
+        WHERE LOWER(vendor_name) = LOWER($1)
+        ORDER BY as_of_date DESC
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    if not row:
+        return None
+    data = row["temporal"]
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    return data if isinstance(data, dict) else None
+
+
+async def _fetch_cross_vendor_conclusions(
+    pool: Any,
+    vendor_name: str,
+    *,
+    category: str | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch pairwise battle and category council conclusions for one vendor."""
+    window_days = max(settings.b2b_churn.intelligence_window_days, 60)
+    from ._b2b_cross_vendor_synthesis import (
+        build_cross_vendor_conclusions_for_vendor,
+        load_best_cross_vendor_lookup,
+    )
+
+    xv_lookup = await load_best_cross_vendor_lookup(
+        pool,
+        as_of=date.today(),
+        analysis_window_days=window_days,
+    )
+    return build_cross_vendor_conclusions_for_vendor(
+        vendor_name,
+        category=category,
+        xv_lookup=xv_lookup,
+        limit=5,
+    )
+
+
+async def _fetch_buyer_profiles(
+    pool: Any, vendor_name: str
+) -> list[dict[str, Any]]:
+    """Fetch buyer role/stage profiles ranked by urgency-weighted intent signal.
+
+    Rows at renewal_decision / evaluation stages with high urgency surface
+    first even when they have lower review volume than post-purchase rows.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT role_type, buying_stage, review_count, dm_count,
+               avg_urgency, confidence_score
+        FROM b2b_vendor_buyer_profiles
+        WHERE LOWER(vendor_name) = LOWER($1)
+          AND confidence_score >= 0.4
+          AND role_type != 'unknown'
+        ORDER BY
+            (COALESCE(avg_urgency, 0) * confidence_score) DESC,
+            review_count DESC
+        LIMIT 6
+        """,
+        vendor_name,
+    )
+    if not rows:
+        return []
+    return [
+        {
+            "role_type": r["role_type"],
+            "buying_stage": r["buying_stage"],
+            "review_count": r["review_count"],
+            "dm_count": r["dm_count"],
+            "avg_urgency": float(r["avg_urgency"] or 0),
+            "confidence_score": float(r["confidence_score"] or 0),
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_pain_points(
+    pool: Any, vendor_name: str
+) -> list[dict[str, Any]]:
+    """Fetch pain-category signal counts from b2b_vendor_pain_points."""
+    rows = await pool.fetch(
+        """
+        SELECT pain_category, mention_count, primary_count,
+               avg_urgency, avg_rating, confidence_score
+        FROM b2b_vendor_pain_points
+        WHERE LOWER(vendor_name) = LOWER($1)
+          AND confidence_score >= 0.3
+        ORDER BY mention_count DESC, confidence_score DESC
+        LIMIT 8
+        """,
+        vendor_name,
+    )
+    if not rows:
+        return []
+    return [
+        {
+            "pain_category": r["pain_category"],
+            "mention_count": r["mention_count"],
+            "primary_count": r["primary_count"],
+            "avg_urgency": float(r["avg_urgency"] or 0),
+            "avg_rating": (
+                float(r["avg_rating"]) if r["avg_rating"] is not None else None
+            ),
+            "confidence_score": float(r["confidence_score"] or 0),
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_account_intelligence(
+    pool: Any, vendor_name: str
+) -> dict[str, Any] | None:
+    """Fetch latest account-intelligence payload from b2b_account_intelligence."""
+    row = await pool.fetchrow(
+        """
+        SELECT accounts, as_of_date
+        FROM b2b_account_intelligence
+        WHERE LOWER(vendor_name) = LOWER($1)
+        ORDER BY as_of_date DESC
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    if not row:
+        return None
+    data = row["accounts"]
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+async def _fetch_displacement_dynamics(
+    pool: Any, vendor_name: str, *, challenger_mode: bool = False
+) -> dict[str, Any] | None:
+    """Fetch top competitive displacement dynamics for one vendor.
+
+    In standard mode: rows where vendor is from_vendor (losing customers).
+    In challenger mode: rows where vendor is to_vendor (gaining customers);
+    the 'challenger' field in each pair is the incumbent from_vendor.
+
+    battle_summary is extracted as a plain conclusion string from the
+    canonical dict shape built by build_displacement_dynamics().
+    Sort key is edge_metrics.mention_count (canonical field name).
+    """
+    if challenger_mode:
+        query = """
+            SELECT DISTINCT ON (from_vendor)
+                from_vendor AS peer_vendor, dynamics, as_of_date
+            FROM b2b_displacement_dynamics
+            WHERE LOWER(to_vendor) = LOWER($1)
+            ORDER BY from_vendor, as_of_date DESC
+            LIMIT 5
+        """
+    else:
+        query = """
+            SELECT DISTINCT ON (to_vendor)
+                to_vendor AS peer_vendor, dynamics, as_of_date
+            FROM b2b_displacement_dynamics
+            WHERE LOWER(from_vendor) = LOWER($1)
+            ORDER BY to_vendor, as_of_date DESC
+            LIMIT 5
+        """
+    rows = await pool.fetch(query, vendor_name)
+    if not rows:
+        return None
+    pairs = []
+    for r in rows:
+        dyn = r["dynamics"]
+        if isinstance(dyn, str):
+            try:
+                dyn = json.loads(dyn)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        if not isinstance(dyn, dict):
+            continue
+        # battle_summary is a dict in the canonical shape; extract conclusion string
+        raw_summary = dyn.get("battle_summary")
+        if isinstance(raw_summary, dict):
+            battle_text = (
+                raw_summary.get("conclusion")
+                or raw_summary.get("winner") or ""
+            )
+        else:
+            battle_text = str(raw_summary) if raw_summary else ""
+        pairs.append({
+            "challenger": r["peer_vendor"],
+            "battle_summary": battle_text,
+            "switch_reasons": (dyn.get("switch_reasons") or [])[:5],
+            "flow_summary": dyn.get("flow_summary") or {},
+            "edge_metrics": dyn.get("edge_metrics") or {},
+            "trend_acceleration": dyn.get("trend_acceleration") or {},
+            "as_of_date": (
+                r["as_of_date"].isoformat()
+                if r["as_of_date"] and hasattr(r["as_of_date"], "isoformat")
+                else str(r["as_of_date"]) if r["as_of_date"] else None
+            ),
+        })
+    if not pairs:
+        return None
+    # Sort by canonical edge_metrics.mention_count (not total_mentions)
+    pairs.sort(
+        key=lambda p: float(
+            (p.get("edge_metrics") or {}).get("mention_count") or 0
+        ),
+        reverse=True,
+    )
+    return {"pairs": pairs[:2]}
+
+
+async def _fetch_vendor_evidence_vault(pool: Any, vendor_name: str) -> dict[str, Any] | None:
+    """Compatibility seam delegating canonical reads to the shared adapter."""
+    return await read_vendor_intelligence(
+        pool,
+        vendor_name,
+        as_of=date.today(),
+        analysis_window_days=settings.b2b_churn.intelligence_window_days,
+    )
+
+
+async def _fetch_vendor_evidence_record(
+    pool: Any,
+    vendor_name: str,
+) -> dict[str, Any] | None:
+    """Read the canonical vendor-intelligence record with run metadata."""
+    return await read_vendor_intelligence_record(
+        pool,
+        vendor_name,
+        as_of=date.today(),
+        analysis_window_days=settings.b2b_churn.intelligence_window_days,
+    )
+
+
+async def _fetch_churn_signals(pool: Any, vendor_name: str) -> dict[str, Any] | None:
+    """Compatibility seam delegating derived reads to the shared adapter."""
+    return await read_vendor_scorecard_detail(pool, vendor_name)
+
+
+async def _fetch_product_profile(pool: Any, vendor_name: str) -> dict | None:
+    """Fetch product profile for vendor."""
+    row = await pool.fetchrow(
+        """
+        SELECT profile_summary, commonly_compared_to, commonly_switched_from,
+               weaknesses, product_category
+        FROM b2b_product_profiles
+        WHERE LOWER(vendor_name) = LOWER($1)
+        ORDER BY last_computed_at DESC
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    return dict(row) if row else None
+
+
+async def _fetch_high_urgency_quotes(
+    pool: Any, vendor_name: str, limit: int = 5
+) -> list[dict[str, Any]]:
+    """Fetch quote-grade phrases from high-urgency reviews.
+
+    Phase 2.3 4c-B: routes the SQL evidence path through the enrichment
+    contract (``quote_grade_phrases``) so output rows carry the
+    ``phrase_verbatim=True`` marker that the email template requires
+    after 4c-A. v3-era enrichments produce nothing because we have no
+    verbatim guarantee. Output rows are stamped with traceability
+    fields (review_id, source, field) and ``quote_origin='review'``
+    for downstream audit -- matches the blog producer convention.
+    """
+    from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
+    from atlas_brain.services.b2b.enrichment_contract import quote_grade_phrases
+
+    rows = await read_vendor_quote_evidence(
+        pool,
+        vendor_name=vendor_name,
+        min_urgency=7.0,
+        limit=limit,
+        require_quotes=True,
+    )
+    quotes: list[dict[str, Any]] = []
+    for row in rows:
+        enrichment_raw = row.get("enrichment_raw")
+        if isinstance(enrichment_raw, str):
+            try:
+                enrichment = json.loads(enrichment_raw)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+        elif isinstance(enrichment_raw, dict):
+            enrichment = enrichment_raw
+        else:
+            continue
+        for phrase in quote_grade_phrases(enrichment):
+            text = str(phrase.get("text") or "").strip()
+            if not text:
+                continue
+            quotes.append({
+                "quote": text,
+                "text": text,
+                "company": row.get("reviewer_company"),
+                "title": row.get("reviewer_title"),
+                "industry": row.get("industry"),
+                "review_id": row.get("review_id"),
+                "source": row.get("source"),
+                "field": phrase.get("field"),
+                "phrase_verbatim": True,
+                "quote_origin": "review",
+            })
+            if len(quotes) >= limit:
+                return quotes
+    return quotes
+
+
+# ---------------------------------------------------------------------------
+# Normalization helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_displacement(targets: list) -> list[dict]:
+    """Normalize displacement target dicts to {competitor, count}."""
+    result = []
+    for t in (targets or []):
+        if isinstance(t, dict):
+            raw = t.get("competitor", t.get("name", "Unknown"))
+            # Handle stringified JSON like '{"name": "Pardot", "context": ...}'
+            if isinstance(raw, str) and raw.startswith("{"):
+                try:
+                    parsed = json.loads(raw)
+                    raw = parsed.get("name") or parsed.get("competitor") or raw
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            elif isinstance(raw, dict):
+                raw = raw.get("name") or raw.get("competitor") or "Unknown"
+            result.append({
+                "competitor": raw,
+                "count": t.get("count", t.get("mentions", 0)),
+            })
+        elif isinstance(t, str):
+            result.append({"competitor": t, "count": 0})
+    return result
+
+
+def _jsonb_list(val: Any) -> list:
+    """Parse a JSONB value that should be a list."""
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return val
+    if isinstance(val, str):
+        try:
+            parsed = json.loads(val)
+            return parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, TypeError):
+            return []
+    return []
+
+
+def _safe_density(signals: dict) -> float:
+    """Compute churn signal density % from signals row."""
+    total = signals.get("total_reviews", 0)
+    churn = signals.get("churn_intent_count", 0)
+    if total <= 0:
+        return 0.0
+    return round((churn / total) * 100, 1)
+
+
+def _compute_pressure(signals: dict) -> float:
+    """Compute a pressure score from churn signals (0-100 scale)."""
+    density = _safe_density(signals)
+    urgency = float(signals.get("avg_urgency_score", 0))
+    dm_rate = float(signals.get("decision_maker_churn_rate", 0) or 0) * 100
+    # Weighted composite: density (40%), urgency*10 (40%), DM rate (20%)
+    score = (density * 0.4) + (urgency * 10 * 0.4) + (dm_rate * 0.2)
+    return min(round(score, 1), 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Sender
+# ---------------------------------------------------------------------------
+
+async def send_vendor_briefing(
+    *,
+    to_email: str,
+    vendor_name: str,
+    briefing_html: str,
+    briefing_data: dict,
+) -> dict | None:
+    """Send a vendor briefing email via CampaignSender and persist to DB."""
+    cfg = settings.campaign_sequence
+    if not cfg.resend_api_key or not cfg.resend_from_email:
+        logger.warning("Resend not configured -- cannot send briefing")
+        return None
+
+    # Canonicalize vendor name for consistent DB storage
+    vendor_name = await resolve_vendor_name(vendor_name)
+
+    pool = get_db_pool()
+
+    challenger_mode = briefing_data.get("challenger_mode", False)
+
+    # Suppression check
+    if pool.is_initialized:
+        suppressed = await is_suppressed(pool, email=to_email)
+        if suppressed:
+            logger.info("Suppressed briefing to %s (vendor=%s)", to_email, vendor_name)
+            suppressed_subject = (
+                f"Sales Intelligence Briefing: {vendor_name}"
+                if challenger_mode
+                else f"Churn Intelligence Briefing: {vendor_name}"
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO b2b_vendor_briefings
+                        (vendor_name, recipient_email, subject, briefing_data, status)
+                    VALUES ($1, $2, $3, $4::jsonb, 'suppressed')
+                    """,
+                    vendor_name,
+                    to_email,
+                    suppressed_subject,
+                    json.dumps(briefing_data, default=str),
+                )
+            except Exception as exc:
+                logger.warning("Failed to persist suppressed record: %s", exc)
+            return None
+
+    sender_name = settings.b2b_churn.vendor_briefing_sender_name
+    from_addr = f"{sender_name} <{cfg.resend_from_email}>"
+
+    if briefing_data.get("prospect_mode"):
+        if challenger_mode:
+            subject = f"{vendor_name} -- Accounts In Motion"
+        else:
+            subject = f"{vendor_name} -- Churn Signals Detected"
+    elif briefing_data.get("is_gated_delivery"):
+        if challenger_mode:
+            subject = f"Your {vendor_name} Sales Intelligence Report"
+        else:
+            subject = f"Your {vendor_name} Churn Intelligence Report"
+    else:
+        if challenger_mode:
+            subject = f"Sales Intelligence Briefing: {vendor_name}"
+        else:
+            subject = f"Churn Intelligence Briefing: {vendor_name}"
+
+    resend_id: str | None = None
+    status = "sent"
+
+    try:
+        sender = get_campaign_sender()
+        result = await sender.send(
+            to=to_email,
+            from_email=from_addr,
+            subject=subject,
+            body=briefing_html,
+            tags=[
+                {"name": "type", "value": "vendor_briefing"},
+                {"name": "vendor", "value": vendor_name},
+            ],
+        )
+        resend_id = result.get("id")
+    except Exception as exc:
+        logger.warning("Failed to send briefing to %s: %s", to_email, exc)
+        status = "failed"
+
+    # Persist delivery record
+    if pool.is_initialized:
+        try:
+            await pool.execute(
+                """
+                INSERT INTO b2b_vendor_briefings
+                    (vendor_name, recipient_email, subject, briefing_data, resend_id, status)
+                VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+                """,
+                vendor_name,
+                to_email,
+                subject,
+                json.dumps(briefing_data, default=str),
+                resend_id,
+                status,
+            )
+        except Exception as exc:
+            logger.warning("Failed to persist briefing record: %s", exc)
+
+    if status == "failed":
+        return None
+
+    return {"resend_id": resend_id, "status": status, "subject": subject}
+
+
+# ---------------------------------------------------------------------------
+# Approve / reject pending briefings (HITL)
+# ---------------------------------------------------------------------------
+
+async def send_approved_briefing(briefing_id: str) -> dict[str, Any]:
+    """Send a pending_approval briefing and update its status to sent."""
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"error": "Database not ready"}
+
+    row = await pool.fetchrow(
+        """
+        SELECT id, vendor_name, recipient_email, subject,
+               briefing_data, briefing_html
+        FROM b2b_vendor_briefings
+        WHERE id = $1 AND status = 'pending_approval'
+        """,
+        briefing_id,
+    )
+    if not row:
+        return {"error": "Briefing not found or not pending approval"}
+
+    vendor_name = row["vendor_name"]
+    to_email = row["recipient_email"]
+    subject = row["subject"]
+    html = row["briefing_html"]
+    bd = row["briefing_data"]
+    briefing_data = json.loads(bd) if isinstance(bd, str) else (bd or {})
+
+    if not html:
+        return {"error": "No rendered HTML stored for this briefing"}
+
+    # Send via CampaignSender
+    cfg = settings.campaign_sequence
+    if not cfg.resend_api_key or not cfg.resend_from_email:
+        return {"error": "Resend not configured"}
+
+    sender_name = settings.b2b_churn.vendor_briefing_sender_name
+    from_addr = f"{sender_name} <{cfg.resend_from_email}>"
+
+    resend_id: str | None = None
+    status = "sent"
+
+    try:
+        sender = get_campaign_sender()
+        result = await sender.send(
+            to=to_email,
+            from_email=from_addr,
+            subject=subject,
+            body=html,
+            tags=[
+                {"name": "type", "value": "vendor_briefing"},
+                {"name": "vendor", "value": vendor_name},
+            ],
+        )
+        resend_id = result.get("id")
+    except Exception as exc:
+        logger.warning("Failed to send approved briefing %s: %s", briefing_id, exc)
+        status = "failed"
+
+    if status == "sent":
+        await pool.execute(
+            """
+            UPDATE b2b_vendor_briefings
+            SET status = $1, resend_id = $2, approved_at = NOW()
+            WHERE id = $3
+            """,
+            status,
+            resend_id,
+            briefing_id,
+        )
+    else:
+        await pool.execute(
+            """
+            UPDATE b2b_vendor_briefings
+            SET status = $1
+            WHERE id = $2
+            """,
+            status,
+            briefing_id,
+        )
+
+    return {
+        "id": str(briefing_id),
+        "vendor_name": vendor_name,
+        "to_email": to_email,
+        "status": status,
+        "resend_id": resend_id,
+    }
+
+
+async def reject_briefing(briefing_id: str, reason: str | None = None) -> dict[str, Any]:
+    """Reject a pending_approval briefing."""
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"error": "Database not ready"}
+
+    result = await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = 'rejected', rejected_at = NOW(), reject_reason = $1
+        WHERE id = $2 AND status = 'pending_approval'
+        """,
+        reason,
+        briefing_id,
+    )
+    if result == "UPDATE 0":
+        return {"error": "Briefing not found or not pending approval"}
+
+    return {"id": str(briefing_id), "status": "rejected"}
+
+
+# ---------------------------------------------------------------------------
+# Recipient resolution
+# ---------------------------------------------------------------------------
+
+async def resolve_briefing_recipient(
+    pool: Any, vendor_name: str
+) -> dict[str, str] | None:
+    """Resolve the best contact for a vendor briefing.
+
+    Lookup priority:
+    1. vendor_targets (active vendor_retention with contact_email)
+    2. prospects (active, verified/probabilistic email, best seniority)
+    """
+    # Priority 1: vendor_targets (both vendor_retention and challenger_intel)
+    row = await pool.fetchrow(
+        """
+        SELECT contact_email AS email, contact_name AS name,
+               contact_role AS role, target_mode
+        FROM vendor_targets
+        WHERE LOWER(company_name) = LOWER($1)
+          AND target_mode IN ('vendor_retention', 'challenger_intel')
+          AND status = 'active'
+          AND contact_email IS NOT NULL
+        ORDER BY CASE WHEN account_id IS NULL THEN 1 ELSE 0 END,
+                 updated_at DESC NULLS LAST,
+                 created_at DESC NULLS LAST
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    if row:
+        return {
+            "email": row["email"],
+            "name": row["name"] or "",
+            "role": row["role"] or "",
+            "source": "vendor_target",
+            "target_mode": row["target_mode"],
+        }
+
+    # Priority 2: prospects
+    row = await pool.fetchrow(
+        """
+        SELECT email, first_name || ' ' || last_name AS name,
+               title AS role
+        FROM prospects
+        WHERE LOWER(company_name) = LOWER($1)
+          AND status = 'active'
+          AND email IS NOT NULL
+          AND email_status IN ('verified', 'probabilistic')
+        ORDER BY CASE seniority
+            WHEN 'c_suite' THEN 1
+            WHEN 'owner' THEN 2
+            WHEN 'founder' THEN 2
+            WHEN 'vp' THEN 3
+            WHEN 'head' THEN 4
+            WHEN 'director' THEN 4
+            WHEN 'manager' THEN 5
+            WHEN 'senior' THEN 6
+            ELSE 7
+        END ASC
+        LIMIT 1
+        """,
+        vendor_name,
+    )
+    if row:
+        return {
+            "email": row["email"],
+            "name": row["name"] or "",
+            "role": row["role"] or "",
+            "source": "prospect",
+        }
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cooldown check
+# ---------------------------------------------------------------------------
+
+async def _check_cooldown(
+    pool: Any, vendor_name: str, cooldown_days: int
+) -> bool:
+    """Return True if a recent briefing exists (should skip)."""
+    row = await pool.fetchval(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM b2b_vendor_briefings
+            WHERE LOWER(vendor_name) = LOWER($1)
+              AND status NOT IN ('failed', 'suppressed', 'rejected')
+              AND created_at > NOW() - make_interval(days => $2)
+        )
+        """,
+        vendor_name,
+        cooldown_days,
+    )
+    return bool(row)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+async def generate_and_send_briefing(
+    *,
+    vendor_name: str,
+    to_email: str | None = None,
+) -> dict[str, Any]:
+    """Build, render, send, and return summary for a vendor briefing."""
+    pool = get_db_pool()
+
+    # Auto-resolve recipient if not provided
+    target_mode = "vendor_retention"
+    if to_email is None:
+        if not pool.is_initialized:
+            return {"error": "Database not ready -- cannot resolve recipient"}
+        contact = await resolve_briefing_recipient(pool, vendor_name)
+        if not contact:
+            return {"error": f"No contact found for vendor: {vendor_name}"}
+        to_email = contact["email"]
+        target_mode = contact.get("target_mode", "vendor_retention")
+
+    briefing_data = await build_vendor_briefing(vendor_name, target_mode=target_mode)
+    if not briefing_data:
+        return {"error": f"No data found for vendor: {vendor_name}"}
+
+    # First briefing to this vendor -> redacted prospect mode with gate CTA
+    if pool.is_initialized and await _is_first_briefing(pool, vendor_name):
+        briefing_data["prospect_mode"] = True
+        briefing_data["gate_url"] = build_gate_url(vendor_name)
+
+    briefing_html = render_vendor_briefing_html(briefing_data)
+
+    result = await send_vendor_briefing(
+        to_email=to_email,
+        vendor_name=vendor_name,
+        briefing_html=briefing_html,
+        briefing_data=briefing_data,
+    )
+
+    if result is None:
+        return {"error": "Failed to send briefing email (check Resend config or suppression)"}
+
+    return {
+        "vendor_name": vendor_name,
+        "to_email": to_email,
+        "resend_id": result.get("resend_id"),
+        "status": result.get("status"),
+        "subject": result.get("subject"),
+        "sections": {
+            "has_pain_breakdown": bool(briefing_data.get("pain_breakdown")),
+            "has_displacement": bool(briefing_data.get("top_displacement_targets")),
+            "has_quotes": bool(briefing_data.get("evidence")),
+            "has_named_accounts": bool(briefing_data.get("named_accounts")),
+            "has_feature_gaps": bool(briefing_data.get("top_feature_gaps")),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Batch sender
+# ---------------------------------------------------------------------------
+
+async def send_batch_briefings() -> dict[str, Any]:
+    """Send briefings to all eligible vendor targets with contacts."""
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"error": "Database not ready"}
+
+    cfg = settings.b2b_churn
+    max_batch = cfg.vendor_briefing_max_per_batch
+    cooldown_days = cfg.vendor_briefing_cooldown_days
+    analyst_summary_enabled = cfg.vendor_briefing_scheduled_analyst_enrichment_enabled
+    account_cards_reasoning_depth = (
+        cfg.vendor_briefing_scheduled_account_cards_reasoning_depth
+    )
+
+    # Fetch eligible vendor targets (both retention and challenger)
+    rows = await pool.fetch(
+        """
+        SELECT company_name, contact_email, contact_name, contact_role,
+               target_mode, account_id, created_at, updated_at
+        FROM vendor_targets
+        WHERE target_mode IN ('vendor_retention', 'challenger_intel')
+          AND status = 'active'
+          AND contact_email IS NOT NULL
+        ORDER BY company_name
+        """,
+    )
+    rows = dedupe_vendor_target_rows(rows)[:max_batch]
+
+    queued = 0
+    skipped_cooldown = 0
+    skipped_suppressed = 0
+    skipped_no_data = 0
+    failed = 0
+    details: list[dict] = []
+
+    for row in rows:
+        vendor_name = row["company_name"]
+        to_email = row["contact_email"]
+        target_mode = row["target_mode"]
+
+        # Cooldown check
+        if await _check_cooldown(pool, vendor_name, cooldown_days):
+            skipped_cooldown += 1
+            details.append({"vendor": vendor_name, "status": "skipped_cooldown"})
+            continue
+
+        # Suppression check
+        suppressed = await is_suppressed(pool, email=to_email)
+        if suppressed:
+            skipped_suppressed += 1
+            details.append({"vendor": vendor_name, "status": "skipped_suppressed"})
+            continue
+
+        # Build briefing data (pass target_mode for challenger framing)
+        briefing_data = await build_vendor_briefing(
+            vendor_name,
+            target_mode=target_mode,
+            analyst_summary_enabled=analyst_summary_enabled,
+            account_cards_reasoning_depth=account_cards_reasoning_depth,
+        )
+        if not briefing_data:
+            skipped_no_data += 1
+            details.append({"vendor": vendor_name, "status": "skipped_no_data"})
+            continue
+
+        # First briefing to this vendor -> redacted prospect mode with gate CTA
+        if await _is_first_briefing(pool, vendor_name):
+            briefing_data["prospect_mode"] = True
+            briefing_data["gate_url"] = build_gate_url(vendor_name)
+
+        # Render HTML and store as pending_approval (HITL gate)
+        briefing_html = render_vendor_briefing_html(briefing_data)
+
+        challenger_mode = briefing_data.get("challenger_mode", False)
+        if briefing_data.get("prospect_mode"):
+            subject = (
+                f"{vendor_name} -- Accounts In Motion"
+                if challenger_mode
+                else f"{vendor_name} -- Churn Signals Detected"
+            )
+        else:
+            subject = (
+                f"Sales Intelligence Briefing: {vendor_name}"
+                if challenger_mode
+                else f"Churn Intelligence Briefing: {vendor_name}"
+            )
+
+        try:
+            await pool.execute(
+                """
+                INSERT INTO b2b_vendor_briefings
+                    (vendor_name, recipient_email, subject, briefing_data,
+                     briefing_html, status, target_mode)
+                VALUES ($1, $2, $3, $4::jsonb, $5, 'pending_approval', $6)
+                """,
+                vendor_name,
+                to_email,
+                subject,
+                json.dumps(briefing_data, default=str),
+                briefing_html,
+                target_mode,
+            )
+            queued += 1
+            details.append({
+                "vendor": vendor_name,
+                "status": "pending_approval",
+                "to": to_email,
+            })
+        except Exception as exc:
+            logger.warning("Failed to queue briefing for %s: %s", vendor_name, exc)
+            failed += 1
+            details.append({"vendor": vendor_name, "status": "failed"})
+
+    return {
+        "queued": queued,
+        "skipped_cooldown": skipped_cooldown,
+        "skipped_suppressed": skipped_suppressed,
+        "skipped_no_data": skipped_no_data,
+        "failed": failed,
+        "details": details,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scheduled task entry-point
+# ---------------------------------------------------------------------------
+
+async def run(task: ScheduledTask) -> dict:
+    """Run vendor briefings as a scheduled task."""
+    cfg = settings.b2b_churn
+    if not cfg.vendor_briefing_enabled:
+        return {"_skip_synthesis": True, "skipped": "vendor_briefing_enabled=false"}
+
+    result = await send_batch_briefings()
+    result["_skip_synthesis"] = True
+    return result

--- a/extracted_content_pipeline/autonomous/tasks/blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/blog_post_generation.py
@@ -1,0 +1,1758 @@
+"""
+Blog post generation: picks the best data story each night, builds a
+deterministic blueprint (sections + chart specs), generates prose via LLM,
+and stores the assembled draft in blog_posts.
+
+Runs daily after complaint_content_generation (default 11 PM).
+
+Pipeline stages:
+  1. Topic selection  -- score candidates, pick best unwritten story
+  2. Data gathering   -- reuse existing SQL fetchers
+  3. Blueprint build  -- deterministic section/chart layout
+  4. Content gen      -- single LLM call with blueprint as input
+  5. Assembly/store   -- draft in blog_posts, ntfy notification
+
+Returns _skip_synthesis.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.autonomous.tasks.blog_post_generation")
+
+
+# -- dataclasses --------------------------------------------------
+
+@dataclass
+class ChartSpec:
+    chart_id: str
+    chart_type: str  # bar | horizontal_bar | radar | line
+    title: str
+    data: list[dict[str, Any]]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SectionSpec:
+    id: str
+    heading: str
+    goal: str
+    key_stats: dict[str, Any] = field(default_factory=dict)
+    chart_ids: list[str] = field(default_factory=list)
+    data_summary: str = ""
+
+
+@dataclass
+class PostBlueprint:
+    topic_type: str
+    slug: str
+    suggested_title: str
+    tags: list[str]
+    data_context: dict[str, Any]
+    sections: list[SectionSpec]
+    charts: list[ChartSpec]
+    quotable_phrases: list[dict[str, Any]] = field(default_factory=list)
+
+
+# -- entry point --------------------------------------------------
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: generate data-backed blog posts.
+
+    Loops up to ``max_per_run`` times, picking a fresh topic each iteration.
+    All posts are stored as drafts.
+    """
+    cfg = settings.external_data
+    if not cfg.complaint_mining_enabled or not cfg.blog_post_enabled:
+        return {"_skip_synthesis": "Blog post generation disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    from ...pipelines.llm import get_pipeline_llm, clean_llm_output, parse_json_response
+    from ...pipelines.notify import send_pipeline_notification
+
+    llm = get_pipeline_llm(
+        workload="synthesis",
+        try_openrouter=True,
+        auto_activate_ollama=False,
+        openrouter_model=cfg.blog_post_openrouter_model,
+    )
+    if llm is None:
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    if llm is None:
+        return {"_skip_synthesis": "No LLM available for blog post generation"}
+
+    max_posts = max(1, cfg.blog_post_max_per_run)
+    results: list[dict[str, Any]] = []
+
+    for i in range(max_posts):
+        topic = await _select_topic(pool)
+        if topic is None:
+            logger.info("No more viable topics after %d posts", i)
+            break
+
+        topic_type, topic_ctx = topic
+        data = await _gather_data(pool, topic_type, topic_ctx)
+        blueprint = _build_blueprint(topic_type, topic_ctx, data)
+        related_posts = await _fetch_related_for_linking(
+            pool, blueprint.tags, current_slug=blueprint.slug,
+        )
+        content = _generate_content(llm, blueprint, cfg.blog_post_max_tokens, related_posts)
+        if content is None:
+            logger.warning("LLM failed for topic %s, skipping", blueprint.slug)
+            continue
+
+        post_id = await _assemble_and_store(pool, blueprint, content, llm)
+        if not post_id:
+            logger.info("Slug %s already published, skipping", blueprint.slug)
+            continue
+
+        n_charts = len(blueprint.charts)
+        results.append({
+            "post_id": str(post_id),
+            "topic_type": blueprint.topic_type,
+            "slug": blueprint.slug,
+            "charts": n_charts,
+        })
+
+    if not results:
+        return {"_skip_synthesis": "No blog posts generated this run"}
+
+    slugs = ", ".join(r["slug"] for r in results)
+    msg = f"Blog: {len(results)} draft(s) created -- {slugs}"
+    await send_pipeline_notification(
+        msg, task, title="Atlas: Blog Post Drafts",
+        default_tags="brain,newspaper",
+    )
+
+    return {
+        "_skip_synthesis": msg,
+        "posts": results,
+        "count": len(results),
+    }
+
+
+# -- Stage 1: Topic Selection -------------------------------------
+
+async def _select_topic(pool) -> tuple[str, dict[str, Any]] | None:
+    """Score candidates and pick the best unwritten topic."""
+    today = date.today()
+    month_suffix = today.strftime("%Y-%m")
+
+    # Gather all candidate data in parallel
+    brand_pairs, cat_stats, migrations, safety, best_for = await asyncio.gather(
+        _find_brand_showdown_candidates(pool),
+        _find_complaint_roundup_candidates(pool),
+        _find_migration_candidates(pool),
+        _find_safety_candidates(pool),
+        _find_best_for_candidates(pool),
+        return_exceptions=True,
+    )
+    brand_pairs = brand_pairs if not isinstance(brand_pairs, Exception) else []
+    cat_stats = cat_stats if not isinstance(cat_stats, Exception) else []
+    migrations = migrations if not isinstance(migrations, Exception) else []
+    safety = safety if not isinstance(safety, Exception) else []
+    best_for = best_for if not isinstance(best_for, Exception) else []
+
+    # Build slug -> (score, topic_type, ctx) candidates
+    raw_candidates: list[tuple[str, float, str, dict[str, Any]]] = []
+
+    for pair in brand_pairs:
+        slug = f"{_slugify(pair['brand_a'])}-vs-{_slugify(pair['brand_b'])}-{month_suffix}"
+        score = pair["review_total"] * 0.3 + pair["pain_diff"] * 10
+        raw_candidates.append((slug, score, "brand_showdown", {**pair, "slug": slug}))
+
+    for cat in cat_stats:
+        slug = f"top-complaints-{_slugify(cat['category'])}-{month_suffix}"
+        score = cat["review_count"] * 0.2 + cat["avg_pain"] * 8
+        raw_candidates.append((slug, score, "complaint_roundup", {**cat, "slug": slug}))
+
+    for mig in migrations:
+        slug = f"migration-{_slugify(mig['category'])}-{month_suffix}"
+        score = mig["total_mentions"] * 5
+        raw_candidates.append((slug, score, "migration_report", {**mig, "slug": slug}))
+
+    for sf in safety:
+        slug = f"safety-{_slugify(sf['category'])}-{month_suffix}"
+        score = sf["safety_count"] * 15
+        raw_candidates.append((slug, score, "safety_spotlight", {**sf, "slug": slug}))
+
+    for bf in best_for:
+        slug = f"best-{_slugify(bf['category'])}-{month_suffix}"
+        score = bf["asin_count"] * 0.5 + bf["avg_pain"] * 5
+        raw_candidates.append((slug, score, "best_for_products", {**bf, "slug": slug}))
+
+    if not raw_candidates:
+        return None
+
+    # --- Dedup layer 1: exact slug match (same topic+category+month) ---
+    all_slugs = list({c[0] for c in raw_candidates})
+    existing_slugs = await _batch_slug_check(pool, all_slugs)
+
+    # --- Dedup layer 2: category-level cooldown (any topic type, 14 days) ---
+    # 14 days at 1x/week cadence prevents the same category from
+    # appearing in consecutive weekly posts
+    covered = await _recently_covered_subjects(pool, days=14)
+
+    def _subject_key(ctx: dict) -> str:
+        """Normalize category/brand for dedup."""
+        return (
+            ctx.get("category") or ctx.get("brand_a") or ""
+        ).lower().strip()
+
+    candidates = [
+        (score, topic_type, ctx)
+        for slug, score, topic_type, ctx in raw_candidates
+        if slug not in existing_slugs
+        and _subject_key(ctx) not in covered
+    ]
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda x: x[0], reverse=True)
+
+    # --- Dedup layer 3: one subject per run (pick highest-scoring) ---
+    seen: set[str] = set()
+    best = None
+    for c in candidates:
+        sk = _subject_key(c[2])
+        if sk in seen:
+            continue
+        seen.add(sk)
+        if best is None:
+            best = c
+
+    if best is None:
+        return None
+    logger.info(
+        "Selected topic: %s (score=%.1f, slug=%s)",
+        best[1], best[0], best[2].get("slug"),
+    )
+    return best[1], best[2]
+
+
+async def _find_brand_showdown_candidates(pool) -> list[dict[str, Any]]:
+    """Find pairs of brands in the same category suitable for a showdown."""
+    rows = await pool.fetch(
+        """
+        WITH brand_stats AS (
+            SELECT
+                pm.brand,
+                COALESCE(
+                    REPLACE(pm.categories->>2, '&amp;', '&'),
+                    REPLACE(pm.categories->>1, '&amp;', '&'),
+                    pr.source_category
+                ) AS category,
+                count(*) AS review_count,
+                avg(pr.pain_score) AS avg_pain,
+                avg(pr.rating) AS avg_rating
+            FROM product_reviews pr
+            JOIN product_metadata pm ON pm.asin = pr.asin
+            WHERE pr.deep_enrichment_status = 'enriched'
+              AND pm.brand IS NOT NULL AND pm.brand != ''
+            GROUP BY pm.brand, category
+            HAVING count(*) >= 20
+        )
+        SELECT
+            a.brand AS brand_a, b.brand AS brand_b,
+            a.category,
+            a.review_count AS reviews_a, b.review_count AS reviews_b,
+            (a.review_count + b.review_count) AS review_total,
+            a.avg_pain AS pain_a, b.avg_pain AS pain_b,
+            abs(a.avg_pain - b.avg_pain) AS pain_diff,
+            a.avg_rating AS rating_a, b.avg_rating AS rating_b
+        FROM brand_stats a
+        JOIN brand_stats b ON a.category = b.category AND a.brand < b.brand
+        WHERE abs(a.avg_pain - b.avg_pain) > 1.5
+          AND LEAST(a.review_count, b.review_count)::float
+              / GREATEST(a.review_count, b.review_count) >= 0.1
+        ORDER BY (a.review_count + b.review_count) DESC
+        LIMIT 10
+        """
+    )
+    return [
+        {
+            "brand_a": r["brand_a"],
+            "brand_b": r["brand_b"],
+            "category": r["category"],
+            "reviews_a": r["reviews_a"],
+            "reviews_b": r["reviews_b"],
+            "review_total": r["review_total"],
+            "pain_a": round(float(r["pain_a"]), 1),
+            "pain_b": round(float(r["pain_b"]), 1),
+            "pain_diff": round(float(r["pain_diff"]), 1),
+            "rating_a": round(float(r["rating_a"]), 2),
+            "rating_b": round(float(r["rating_b"]), 2),
+        }
+        for r in rows
+    ]
+
+
+async def _find_complaint_roundup_candidates(pool) -> list[dict[str, Any]]:
+    """Find categories with enough enriched reviews and high pain."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            COALESCE(
+                REPLACE(pm.categories->>2, '&amp;', '&'),
+                REPLACE(pm.categories->>1, '&amp;', '&'),
+                pr.source_category
+            ) AS category,
+            count(*) AS review_count,
+            avg(pr.pain_score) AS avg_pain,
+            avg(pr.rating) AS avg_rating
+        FROM product_reviews pr
+        LEFT JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+        GROUP BY category
+        HAVING count(*) >= 50 AND avg(pr.pain_score) >= 5.0
+        ORDER BY avg(pr.pain_score) DESC
+        LIMIT 10
+        """
+    )
+    return [
+        {
+            "category": r["category"],
+            "review_count": r["review_count"],
+            "avg_pain": round(float(r["avg_pain"]), 1),
+            "avg_rating": round(float(r["avg_rating"]), 2),
+        }
+        for r in rows
+    ]
+
+
+async def _find_migration_candidates(pool) -> list[dict[str, Any]]:
+    """Find categories with significant competitive migration mentions."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            COALESCE(
+                REPLACE(pm.categories->>2, '&amp;', '&'),
+                REPLACE(pm.categories->>1, '&amp;', '&'),
+                pr.source_category
+            ) AS category,
+            count(*) AS total_mentions
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        CROSS JOIN jsonb_array_elements(pr.deep_extraction->'product_comparisons') AS comp
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND comp->>'direction' = 'switched_to'
+          AND jsonb_array_length(pr.deep_extraction->'product_comparisons') > 0
+        GROUP BY category
+        HAVING count(*) >= 10
+        ORDER BY count(*) DESC
+        LIMIT 10
+        """
+    )
+    return [
+        {
+            "category": r["category"],
+            "total_mentions": r["total_mentions"],
+        }
+        for r in rows
+    ]
+
+
+async def _find_safety_candidates(pool) -> list[dict[str, Any]]:
+    """Find categories with safety-flagged reviews.
+
+    Requires >= 2 distinct brands with safety flags and >= 3 distinct
+    products with metadata to ensure the generated post has enough
+    data density for charts and product-level analysis.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT
+            COALESCE(
+                REPLACE(pm.categories->>2, '&amp;', '&'),
+                REPLACE(pm.categories->>1, '&amp;', '&'),
+                pr.source_category
+            ) AS category,
+            count(*) AS safety_count,
+            avg(pr.pain_score) AS avg_pain,
+            count(DISTINCT pm.brand) FILTER (WHERE pm.brand IS NOT NULL AND pm.brand != '') AS brand_count,
+            count(DISTINCT pm.asin) FILTER (WHERE pm.asin IS NOT NULL) AS product_count
+        FROM product_reviews pr
+        LEFT JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND (pr.deep_extraction->'safety_flag'->>'flagged')::boolean IS TRUE
+        GROUP BY category
+        HAVING count(*) >= 5
+           AND count(DISTINCT pm.brand) FILTER (WHERE pm.brand IS NOT NULL AND pm.brand != '') >= 2
+           AND count(DISTINCT pm.asin) FILTER (WHERE pm.asin IS NOT NULL) >= 3
+        ORDER BY count(*) DESC
+        LIMIT 10
+        """
+    )
+    return [
+        {
+            "category": r["category"],
+            "safety_count": r["safety_count"],
+            "avg_pain": round(float(r["avg_pain"]), 1),
+            "brand_count": r["brand_count"],
+            "product_count": r["product_count"],
+        }
+        for r in rows
+    ]
+
+
+async def _find_best_for_candidates(pool) -> list[dict[str, Any]]:
+    """Find categories with enough enriched products for a best-for guide."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            COALESCE(
+                REPLACE(pm.categories->>2, '&amp;', '&'),
+                REPLACE(pm.categories->>1, '&amp;', '&'),
+                pr.source_category
+            ) AS category,
+            count(DISTINCT pm.asin) AS asin_count,
+            avg(pr.pain_score) AS avg_pain,
+            avg(pr.rating) AS avg_rating,
+            count(*) AS review_count
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+        GROUP BY category
+        HAVING count(DISTINCT pm.asin) >= 10
+           AND count(*) >= 50
+        ORDER BY count(DISTINCT pm.asin) DESC
+        LIMIT 10
+        """
+    )
+    return [
+        {
+            "category": r["category"],
+            "asin_count": r["asin_count"],
+            "avg_pain": round(float(r["avg_pain"]), 1),
+            "avg_rating": round(float(r["avg_rating"]), 2),
+            "review_count": r["review_count"],
+        }
+        for r in rows
+    ]
+
+
+async def _batch_slug_check(pool, slugs: list[str]) -> set[str]:
+    """Check which slugs already exist (all time). Single query."""
+    if not slugs:
+        return set()
+    rows = await pool.fetch(
+        "SELECT slug FROM blog_posts WHERE slug = ANY($1)",
+        slugs,
+    )
+    return {r["slug"] for r in rows}
+
+
+async def _recently_covered_subjects(pool, days: int = 90) -> set[str]:
+    """Return category/brand names that already have a blog post in the last N days.
+
+    Prevents the same category from dominating the blog across topic types.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT
+            LOWER(COALESCE(
+                data_context->>'category',
+                data_context->>'brand_a',
+                ''
+            )) AS subject
+        FROM blog_posts
+        WHERE topic_type IN ('brand_showdown','complaint_roundup','migration_report','safety_spotlight','best_for_products')
+          AND created_at > NOW() - make_interval(days => $1)
+          AND COALESCE(data_context->>'category', data_context->>'brand_a', '') != ''
+        """,
+        days,
+    )
+    return {r["subject"] for r in rows if r["subject"]}
+
+
+def _slugify(text: str) -> str:
+    """Convert text to URL-safe slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    return re.sub(r"-+", "-", text).strip("-")[:60]
+
+
+# -- Stage 2: Data Gathering --------------------------------------
+
+async def _gather_data(
+    pool, topic_type: str, topic_ctx: dict[str, Any]
+) -> dict[str, Any]:
+    """Fetch data needed for the blueprint. Reuses existing SQL fetchers."""
+    from .competitive_intelligence import (
+        _fetch_brand_health,
+        _fetch_competitive_flows,
+        _fetch_feature_gaps,
+        _fetch_safety_signals,
+        _fetch_safety_products,
+        _fetch_loyalty_churn,
+        _fetch_sentiment_landscape,
+    )
+    from .complaint_analysis import _fetch_category_stats, _fetch_product_stats
+
+    data: dict[str, Any] = {}
+
+    cat = topic_ctx.get("category")
+
+    if topic_type == "brand_showdown":
+        brand_health, flows, sentiment, loyalty = await asyncio.gather(
+            _fetch_brand_health(pool, category=cat),
+            _fetch_competitive_flows(pool, category=cat),
+            _fetch_sentiment_landscape(pool, category=cat),
+            _fetch_loyalty_churn(pool, category=cat),
+            return_exceptions=True,
+        )
+        data["brand_health"] = brand_health if not isinstance(brand_health, Exception) else []
+        data["flows"] = flows if not isinstance(flows, Exception) else []
+        data["sentiment"] = sentiment if not isinstance(sentiment, Exception) else []
+        data["loyalty"] = loyalty if not isinstance(loyalty, Exception) else []
+
+    elif topic_type == "complaint_roundup":
+        cat_stats, prod_stats, feature_gaps = await asyncio.gather(
+            _fetch_category_stats(pool, category=cat),
+            _fetch_product_stats(pool, category=cat),
+            _fetch_feature_gaps(pool, category=cat),
+            return_exceptions=True,
+        )
+        data["category_stats"] = cat_stats if not isinstance(cat_stats, Exception) else []
+        data["product_stats"] = prod_stats if not isinstance(prod_stats, Exception) else []
+        data["feature_gaps"] = feature_gaps if not isinstance(feature_gaps, Exception) else []
+
+    elif topic_type == "migration_report":
+        flows, brand_health, feature_gaps = await asyncio.gather(
+            _fetch_competitive_flows(pool, category=cat),
+            _fetch_brand_health(pool, category=cat),
+            _fetch_feature_gaps(pool, category=cat),
+            return_exceptions=True,
+        )
+        data["flows"] = flows if not isinstance(flows, Exception) else []
+        data["brand_health"] = brand_health if not isinstance(brand_health, Exception) else []
+        data["feature_gaps"] = feature_gaps if not isinstance(feature_gaps, Exception) else []
+
+    elif topic_type == "safety_spotlight":
+        safety, safety_prods, brand_health, cat_stats = await asyncio.gather(
+            _fetch_safety_signals(pool, category=cat),
+            _fetch_safety_products(pool, category=cat),
+            _fetch_brand_health(pool, category=cat),
+            _fetch_category_stats(pool, category=cat),
+            return_exceptions=True,
+        )
+        data["safety"] = safety if not isinstance(safety, Exception) else []
+        data["safety_products"] = safety_prods if not isinstance(safety_prods, Exception) else []
+        data["brand_health"] = brand_health if not isinstance(brand_health, Exception) else []
+        data["category_stats"] = cat_stats if not isinstance(cat_stats, Exception) else []
+
+    elif topic_type == "best_for_products":
+        brand_health, cat_stats, feature_gaps, top_prods = await asyncio.gather(
+            _fetch_brand_health(pool, category=cat),
+            _fetch_category_stats(pool, category=cat),
+            _fetch_feature_gaps(pool, category=cat),
+            _fetch_best_for_products(pool, cat),
+            return_exceptions=True,
+        )
+        data["brand_health"] = brand_health if not isinstance(brand_health, Exception) else []
+        data["category_stats"] = cat_stats if not isinstance(cat_stats, Exception) else []
+        data["feature_gaps"] = feature_gaps if not isinstance(feature_gaps, Exception) else []
+        data["top_products"] = top_prods if not isinstance(top_prods, Exception) else []
+
+    # Shared: quotable phrases for all topic types
+    try:
+        data["quotes"] = await _fetch_quotable_phrases(pool, topic_type, topic_ctx)
+    except Exception:
+        logger.warning("Failed to fetch quotable phrases, continuing without", exc_info=True)
+        data["quotes"] = []
+
+    # Data context metadata (scoped to category when available)
+    if cat:
+        _ce = (
+            "COALESCE(REPLACE(pm.categories->>2, '&amp;', '&'),"
+            " REPLACE(pm.categories->>1, '&amp;', '&'), pr.source_category)"
+        )
+        ctx_row = await pool.fetchrow(
+            f"""
+            SELECT
+                count(*) AS total_reviews,
+                count(*) FILTER (WHERE pr.deep_enrichment_status = 'enriched') AS deep_enriched,
+                min(pr.reviewed_at)::date AS earliest,
+                max(pr.reviewed_at)::date AS latest
+            FROM product_reviews pr
+            LEFT JOIN product_metadata pm ON pm.asin = pr.asin
+            WHERE pr.enrichment_status = 'enriched'
+              AND {_ce} = $1
+            """,
+            cat,
+        )
+    else:
+        ctx_row = await pool.fetchrow(
+            """
+            SELECT
+                count(*) AS total_reviews,
+                count(*) FILTER (WHERE deep_enrichment_status = 'enriched') AS deep_enriched,
+                min(reviewed_at)::date AS earliest,
+                max(reviewed_at)::date AS latest
+            FROM product_reviews
+            WHERE enrichment_status = 'enriched'
+            """
+        )
+    data["data_context"] = {
+        "total_reviews_analyzed": ctx_row["total_reviews"] if ctx_row else 0,
+        "deep_enriched_count": ctx_row["deep_enriched"] if ctx_row else 0,
+        "review_period": (
+            f"{ctx_row['earliest']} to {ctx_row['latest']}"
+            if ctx_row and ctx_row["earliest"]
+            else "dates unavailable"
+        ),
+        "report_date": str(date.today()),
+    }
+
+    # Embed subject keys so category/brand-level dedup can query data_context
+    if topic_ctx.get("category"):
+        data["data_context"]["category"] = topic_ctx["category"]
+    if topic_ctx.get("brand_a"):
+        data["data_context"]["brand_a"] = topic_ctx["brand_a"]
+    if topic_ctx.get("brand_b"):
+        data["data_context"]["brand_b"] = topic_ctx["brand_b"]
+
+    return data
+
+
+async def _fetch_quotable_phrases(
+    pool, topic_type: str, topic_ctx: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Pull impactful review excerpts relevant to the topic."""
+    # Build a topic-specific filter
+    if topic_type == "brand_showdown":
+        where = (
+            "AND pm.brand IN ($1, $2)"
+        )
+        args = [topic_ctx["brand_a"], topic_ctx["brand_b"]]
+    elif topic_type in ("complaint_roundup", "migration_report", "safety_spotlight", "best_for_products"):
+        where = """
+            AND COALESCE(
+                REPLACE(pm.categories->>2, '&amp;', '&'),
+                REPLACE(pm.categories->>1, '&amp;', '&'),
+                pr.source_category
+            ) = $1
+        """
+        args = [topic_ctx["category"]]
+    else:
+        where = ""
+        args = []
+
+    query = f"""
+        SELECT qp.value AS phrase, pr.asin, pm.brand, pr.rating
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin,
+             jsonb_array_elements_text(pr.deep_extraction->'quotable_phrases') AS qp
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND jsonb_typeof(pr.deep_extraction->'quotable_phrases') = 'array'
+          AND jsonb_array_length(pr.deep_extraction->'quotable_phrases') > 0
+          {where}
+        ORDER BY pr.pain_score DESC
+        LIMIT 10
+    """
+    rows = await pool.fetch(query, *args)
+    return [
+        {
+            "phrase": r["phrase"],
+            "brand": r["brand"],
+            "rating": r["rating"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_best_for_products(pool, category: str) -> list[dict[str, Any]]:
+    """Fetch top products by review count for a best-for guide."""
+    _ce = (
+        "COALESCE(REPLACE(pm.categories->>2, '&amp;', '&'),"
+        " REPLACE(pm.categories->>1, '&amp;', '&'), pr.source_category)"
+    )
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.asin,
+            pm.product_title,
+            pm.brand,
+            count(*) AS review_count,
+            avg(pr.pain_score) AS avg_pain,
+            avg(pr.rating) AS avg_rating,
+            count(*) FILTER (
+                WHERE (pr.deep_extraction->'safety_flag'->>'flagged')::boolean IS TRUE
+            ) AS safety_flags
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND {_ce} = $1
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+        GROUP BY pm.asin, pm.product_title, pm.brand
+        HAVING count(*) >= 5
+        ORDER BY count(*) DESC
+        LIMIT 12
+        """,
+        category,
+    )
+    return [
+        {
+            "asin": r["asin"],
+            "product_title": r["product_title"],
+            "brand": r["brand"],
+            "review_count": r["review_count"],
+            "avg_pain": round(float(r["avg_pain"]), 1),
+            "avg_rating": round(float(r["avg_rating"]), 2),
+            "safety_flags": r["safety_flags"],
+        }
+        for r in rows
+    ]
+
+
+# -- Stage 3: Blueprint Construction ------------------------------
+
+def _build_blueprint(
+    topic_type: str, topic_ctx: dict[str, Any], data: dict[str, Any]
+) -> PostBlueprint:
+    """Build a structured post blueprint deterministically from data."""
+    builder = {
+        "brand_showdown": _blueprint_brand_showdown,
+        "complaint_roundup": _blueprint_complaint_roundup,
+        "migration_report": _blueprint_migration_report,
+        "safety_spotlight": _blueprint_safety_spotlight,
+        "best_for_products": _blueprint_best_for_products,
+    }[topic_type]
+    return builder(topic_ctx, data)
+
+
+def _blueprint_brand_showdown(ctx: dict, data: dict) -> PostBlueprint:
+    brand_a, brand_b = ctx["brand_a"], ctx["brand_b"]
+    category = ctx.get("category", "products")
+
+    # Filter brand_health to our two brands
+    bh = {
+        b["brand"]: b for b in data.get("brand_health", [])
+        if b["brand"] in (brand_a, brand_b)
+    }
+    bh_a = bh.get(brand_a, {})
+    bh_b = bh.get(brand_b, {})
+
+    # Head-to-head chart
+    h2h_data = []
+    for metric, key_a, key_b, label in [
+        ("Pain Score", "avg_pain_score", "avg_pain_score", "Pain Score (0-10)"),
+        ("Avg Rating", "avg_rating", "avg_rating", "Avg Rating (1-5)"),
+        ("Critical Issues", "critical", "critical", "Critical Issues"),
+    ]:
+        val_a = bh_a.get(key_a) or (bh_a.get("severity_distribution", {}).get(key_a, 0))
+        val_b = bh_b.get(key_b) or (bh_b.get("severity_distribution", {}).get(key_b, 0))
+        h2h_data.append({"name": label, brand_a: val_a, brand_b: val_b})
+
+    h2h_chart = ChartSpec(
+        chart_id="head2head-bar",
+        chart_type="horizontal_bar",
+        title=f"Head-to-Head: {brand_a} vs {brand_b}",
+        data=h2h_data,
+        config={
+            "x_key": "name",
+            "bars": [
+                {"dataKey": brand_a, "color": "#22d3ee"},
+                {"dataKey": brand_b, "color": "#f472b6"},
+            ],
+        },
+    )
+
+    # Complaint distribution chart -- top root causes from category stats
+    complaint_data = _build_complaint_comparison_data(brand_a, brand_b, data)
+    complaint_chart = ChartSpec(
+        chart_id="complaints-bar",
+        chart_type="bar",
+        title=f"Top Complaint Categories",
+        data=complaint_data,
+        config={
+            "x_key": "name",
+            "bars": [
+                {"dataKey": brand_a, "color": "#22d3ee"},
+                {"dataKey": brand_b, "color": "#f472b6"},
+            ],
+        },
+    )
+
+    # Migration flows chart
+    flow_data = _build_flow_data(brand_a, brand_b, data)
+    charts = [h2h_chart, complaint_chart]
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal="Hook the reader with a surprising stat or contrast between the brands",
+            key_stats={
+                "brand_a": brand_a,
+                "brand_b": brand_b,
+                "category": category,
+                "reviews_a": ctx["reviews_a"],
+                "reviews_b": ctx["reviews_b"],
+                "pain_a": ctx["pain_a"],
+                "pain_b": ctx["pain_b"],
+                "pain_diff": ctx["pain_diff"],
+            },
+            data_summary=(
+                f"{brand_a} has {ctx['reviews_a']} negative reviews (avg pain {ctx['pain_a']}) "
+                f"vs {brand_b}'s {ctx['reviews_b']} (avg pain {ctx['pain_b']}). "
+                f"Pain score difference: {ctx['pain_diff']}."
+            ),
+        ),
+        SectionSpec(
+            id="head2head",
+            heading=f"{brand_a} vs {brand_b}: By the Numbers",
+            goal="Present core metrics side by side with the chart",
+            key_stats={
+                "rating_a": ctx["rating_a"],
+                "rating_b": ctx["rating_b"],
+                "pain_a": ctx["pain_a"],
+                "pain_b": ctx["pain_b"],
+            },
+            chart_ids=["head2head-bar"],
+            data_summary=(
+                f"{brand_a}: rating {ctx['rating_a']}, pain {ctx['pain_a']}. "
+                f"{brand_b}: rating {ctx['rating_b']}, pain {ctx['pain_b']}."
+            ),
+        ),
+        SectionSpec(
+            id="complaints",
+            heading="What Buyers Complain About Most",
+            goal="Break down the top complaint categories per brand",
+            chart_ids=["complaints-bar"],
+            data_summary=f"Grouped comparison of top complaint types for {brand_a} and {brand_b}.",
+        ),
+    ]
+
+    if flow_data:
+        flow_chart = ChartSpec(
+            chart_id="migration-bar",
+            chart_type="horizontal_bar",
+            title=f"Customer Migration: {brand_a} vs {brand_b}",
+            data=flow_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "mentions", "color": "#22d3ee"}],
+            },
+        )
+        charts.append(flow_chart)
+        sections.append(SectionSpec(
+            id="migration",
+            heading="Where Are Customers Going?",
+            goal="Show the migration direction between brands",
+            chart_ids=["migration-bar"],
+            data_summary=f"Net customer flow between {brand_a} and {brand_b}.",
+        ))
+
+    sections.append(SectionSpec(
+        id="verdict",
+        heading="The Verdict",
+        goal="Summarize findings and declare which brand fares better in this data",
+        key_stats={
+            "brand_a": brand_a,
+            "brand_b": brand_b,
+            "pain_a": ctx["pain_a"],
+            "pain_b": ctx["pain_b"],
+        },
+    ))
+
+    return PostBlueprint(
+        topic_type="brand_showdown",
+        slug=ctx["slug"],
+        suggested_title=f"{brand_a} vs {brand_b}: What {ctx['review_total']}+ Negative Reviews Reveal",
+        tags=[category, brand_a.lower(), brand_b.lower(), "comparison", "reviews"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=data.get("quotes", []),
+    )
+
+
+def _blueprint_complaint_roundup(ctx: dict, data: dict) -> PostBlueprint:
+    category = ctx["category"]
+
+    # Data already scoped to category by _gather_data
+    products = data.get("product_stats", [])[:10]
+
+    # Top products by pain chart
+    # _fetch_product_stats returns "avg_pain_score" (not "avg_pain") and no "brand" key
+    prod_chart_data = [
+        {
+            "name": p.get("asin", "?")[:20],
+            "pain_score": p.get("avg_pain_score", 0),
+            "reviews": p.get("complaint_count", 0),
+        }
+        for p in products[:8]
+    ]
+    prod_chart = ChartSpec(
+        chart_id="products-bar",
+        chart_type="bar",
+        title=f"Highest Pain Products in {category}",
+        data=prod_chart_data,
+        config={
+            "x_key": "name",
+            "bars": [
+                {"dataKey": "pain_score", "color": "#f87171"},
+                {"dataKey": "reviews", "color": "#22d3ee"},
+            ],
+        },
+    )
+
+    # Feature gaps chart (already scoped to category by _gather_data)
+    gaps = data.get("feature_gaps", [])[:6]
+    gap_chart_data = [
+        {"name": g["feature"][:30], "mentions": g["mentions"]}
+        for g in gaps
+    ]
+    charts = [prod_chart]
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal="Highlight the scale of complaints in this category",
+            key_stats={
+                "category": category,
+                "review_count": ctx["review_count"],
+                "avg_pain": ctx["avg_pain"],
+                "avg_rating": ctx["avg_rating"],
+            },
+            data_summary=(
+                f"Analyzed {ctx['review_count']} negative reviews in {category}. "
+                f"Average pain score: {ctx['avg_pain']}/10, average rating: {ctx['avg_rating']}/5."
+            ),
+        ),
+        SectionSpec(
+            id="worst_offenders",
+            heading="The Products Generating the Most Complaints",
+            goal="Rank the most-complained-about products",
+            chart_ids=["products-bar"],
+            data_summary=f"Top {len(prod_chart_data)} products by pain score in {category}.",
+        ),
+    ]
+
+    if gap_chart_data:
+        gap_chart = ChartSpec(
+            chart_id="gaps-bar",
+            chart_type="horizontal_bar",
+            title=f"Most Requested Features in {category}",
+            data=gap_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "mentions", "color": "#a78bfa"}],
+            },
+        )
+        charts.append(gap_chart)
+        sections.append(SectionSpec(
+            id="feature_gaps",
+            heading="What Buyers Wish These Products Had",
+            goal="List the most requested features",
+            chart_ids=["gaps-bar"],
+            data_summary=f"Top {len(gap_chart_data)} feature requests in {category}.",
+        ))
+
+    sections.append(SectionSpec(
+        id="takeaway",
+        heading="Key Takeaways",
+        goal="Actionable summary for buyers considering this category",
+        key_stats={"category": category, "review_count": ctx["review_count"]},
+    ))
+
+    return PostBlueprint(
+        topic_type="complaint_roundup",
+        slug=ctx["slug"],
+        suggested_title=f"Top Complaints in {category}: What {ctx['review_count']}+ Reviews Reveal",
+        tags=[category, "complaints", "reviews", "buyer-guide"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=data.get("quotes", []),
+    )
+
+
+def _blueprint_migration_report(ctx: dict, data: dict) -> PostBlueprint:
+    category = ctx["category"]
+
+    # Filter flows to this category
+    all_flows = data.get("flows", [])
+    # Get top migration destinations
+    dest_counts: dict[str, int] = {}
+    for f in all_flows:
+        if f.get("direction") == "switched_to":
+            dest = f.get("to_brand", "")
+            dest_counts[dest] = dest_counts.get(dest, 0) + f.get("count", 0)
+
+    top_dests = sorted(dest_counts.items(), key=lambda x: x[1], reverse=True)[:8]
+    flow_chart_data = [
+        {"name": name[:25], "mentions": count}
+        for name, count in top_dests
+    ]
+
+    flow_chart = ChartSpec(
+        chart_id="flow-bar",
+        chart_type="horizontal_bar",
+        title=f"Top Migration Destinations in {category}",
+        data=flow_chart_data,
+        config={
+            "x_key": "name",
+            "bars": [{"dataKey": "mentions", "color": "#34d399"}],
+        },
+    )
+
+    # Source brands losing customers
+    source_counts: dict[str, int] = {}
+    for f in all_flows:
+        if f.get("direction") == "switched_to":
+            src = f.get("from_brand", "")
+            source_counts[src] = source_counts.get(src, 0) + f.get("count", 0)
+
+    top_sources = sorted(source_counts.items(), key=lambda x: x[1], reverse=True)[:8]
+    source_chart_data = [
+        {"name": name[:25], "lost_customers": count}
+        for name, count in top_sources
+    ]
+
+    charts = [flow_chart]
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal="Highlight the volume of customer migration in this category",
+            key_stats={
+                "category": category,
+                "total_mentions": ctx["total_mentions"],
+            },
+            data_summary=(
+                f"Found {ctx['total_mentions']} mentions of customers switching products "
+                f"in the {category} category."
+            ),
+        ),
+        SectionSpec(
+            id="destinations",
+            heading="Where Are Customers Migrating To?",
+            goal="Show the top destinations customers are switching to",
+            chart_ids=["flow-bar"],
+            data_summary=f"Top {len(flow_chart_data)} products customers are switching to.",
+        ),
+    ]
+
+    if source_chart_data:
+        source_chart = ChartSpec(
+            chart_id="sources-bar",
+            chart_type="bar",
+            title=f"Brands Losing Customers in {category}",
+            data=source_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "lost_customers", "color": "#f87171"}],
+            },
+        )
+        charts.append(source_chart)
+        sections.append(SectionSpec(
+            id="sources",
+            heading="Which Brands Are Losing the Most Customers?",
+            goal="Rank brands by outgoing migration",
+            chart_ids=["sources-bar"],
+            data_summary=f"Top {len(source_chart_data)} brands losing customers.",
+        ))
+
+    sections.append(SectionSpec(
+        id="triggers",
+        heading="What Triggers the Switch?",
+        goal="Explain the common reasons behind migration",
+        key_stats={"category": category},
+    ))
+    sections.append(SectionSpec(
+        id="takeaway",
+        heading="Key Takeaways",
+        goal="Summary and recommendations for buyers",
+        key_stats={"category": category, "total_mentions": ctx["total_mentions"]},
+    ))
+
+    return PostBlueprint(
+        topic_type="migration_report",
+        slug=ctx["slug"],
+        suggested_title=f"Product Migration in {category}: Where {ctx['total_mentions']}+ Customers Are Switching",
+        tags=[category, "migration", "competitive-analysis", "reviews"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=data.get("quotes", []),
+    )
+
+
+def _blueprint_safety_spotlight(ctx: dict, data: dict) -> PostBlueprint:
+    category = ctx["category"]
+
+    # Safety by brand
+    safety_rows = data.get("safety", [])
+    brand_safety: dict[str, int] = {}
+    consequence_dist: dict[str, int] = {}
+    for s in safety_rows:
+        brand_safety[s["brand"]] = brand_safety.get(s["brand"], 0) + s["count"]
+        cons = s.get("consequence") or "unspecified"
+        consequence_dist[cons] = consequence_dist.get(cons, 0) + s["count"]
+
+    top_brands = sorted(brand_safety.items(), key=lambda x: x[1], reverse=True)[:8]
+    brand_chart_data = [
+        {"name": name[:25], "safety_flags": count}
+        for name, count in top_brands
+    ]
+
+    charts: list[ChartSpec] = []
+
+    # Only emit the brand chart when there are 3+ brands -- a 1-2 bar chart
+    # looks empty.  For thin brand sets, fold stats into the section prose.
+    use_brand_chart = len(brand_chart_data) >= 3
+    if use_brand_chart:
+        charts.append(ChartSpec(
+            chart_id="safety-brands-bar",
+            chart_type="bar",
+            title=f"Safety Flags by Brand in {category}",
+            data=brand_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "safety_flags", "color": "#f87171"}],
+            },
+        ))
+
+    # Product-level breakdown chart
+    safety_products = data.get("safety_products", [])[:10]
+    if safety_products:
+        product_chart_data = [
+            {
+                "name": p["product_title"][:40],
+                "safety_flags": p["safety_flags"],
+            }
+            for p in safety_products
+        ]
+        charts.append(ChartSpec(
+            chart_id="safety-products-bar",
+            chart_type="horizontal_bar",
+            title=f"Most Flagged Products in {category}",
+            data=product_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "safety_flags", "color": "#ef4444"}],
+            },
+        ))
+
+    # Consequence severity chart -- filter out nonsensical labels
+    _CONSEQUENCE_LABELS = {
+        "safety_concern": "Safety Concern",
+        "inconvenience": "Inconvenience",
+        "financial_loss": "Financial Loss",
+        "workflow_impact": "Workflow Disruption",
+        "health_impact": "Health Impact",
+        "property_damage": "Property Damage",
+        "unspecified": "Unspecified",
+    }
+    _CONSEQUENCE_EXCLUDE = {"none", "positive_impact"}
+    cons_chart_data = [
+        {"name": _CONSEQUENCE_LABELS.get(k, k.replace("_", " ").title()), "count": v}
+        for k, v in sorted(consequence_dist.items(), key=lambda x: x[1], reverse=True)
+        if k not in _CONSEQUENCE_EXCLUDE
+    ]
+    if cons_chart_data:
+        charts.append(ChartSpec(
+            chart_id="consequence-bar",
+            chart_type="horizontal_bar",
+            title="Safety Issues by Severity",
+            data=cons_chart_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "count", "color": "#fbbf24"}],
+            },
+        ))
+
+    # Build brand summary for the section prose
+    if use_brand_chart:
+        brand_section_summary = f"Top {len(brand_chart_data)} brands by safety flags."
+        brand_section_stats: dict[str, Any] = {}
+    else:
+        # Inline the brand stats so the LLM can write them as prose
+        brand_lines = ", ".join(
+            f"{name} ({count} flags)" for name, count in top_brands
+        )
+        brand_section_summary = (
+            f"Safety flags by brand: {brand_lines}. "
+            f"Write these as prose rather than referencing a chart."
+        )
+        brand_section_stats = {
+            "brands": [{"name": n, "safety_flags": c} for n, c in top_brands],
+        }
+
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal="Lead with the most concerning safety signal",
+            key_stats={
+                "category": category,
+                "safety_count": ctx["safety_count"],
+                "avg_pain": ctx["avg_pain"],
+            },
+            data_summary=(
+                f"Found {ctx['safety_count']} safety-flagged reviews in {category}. "
+                f"Average pain score: {ctx['avg_pain']}/10."
+            ),
+        ),
+        SectionSpec(
+            id="brands",
+            heading="Which Brands Have the Most Safety Concerns?",
+            goal="Rank brands by safety flag count",
+            chart_ids=["safety-brands-bar"] if use_brand_chart else [],
+            key_stats=brand_section_stats,
+            data_summary=brand_section_summary,
+        ),
+        *(
+            [SectionSpec(
+                id="products",
+                heading="Which Specific Products Are Most Flagged?",
+                goal="Name the specific product models with highest safety flags so readers know what to watch out for",
+                chart_ids=["safety-products-bar"],
+                key_stats={
+                    "top_products": [
+                        {"title": p["product_title"], "brand": p["brand"],
+                         "safety_flags": p["safety_flags"],
+                         "avg_pain": p.get("avg_pain")}
+                        for p in safety_products[:6]
+                    ],
+                },
+                data_summary=(
+                    f"Top {len(safety_products)} products by safety flags. "
+                    f"Highest: {safety_products[0]['product_title'][:40]} "
+                    f"with {safety_products[0]['safety_flags']} flags."
+                ),
+            )] if safety_products else []
+        ),
+        *(
+            [SectionSpec(
+                id="severity",
+                heading="How Serious Are These Issues?",
+                goal="Break down by consequence severity",
+                chart_ids=["consequence-bar"],
+                data_summary=f"Distribution of consequence severity across {ctx['safety_count']} flagged reviews.",
+            )] if cons_chart_data else []
+        ),
+        SectionSpec(
+            id="takeaway",
+            heading="What Buyers Should Know",
+            goal="Actionable safety guidance for buyers",
+            key_stats={"category": category, "safety_count": ctx["safety_count"]},
+        ),
+    ]
+
+    return PostBlueprint(
+        topic_type="safety_spotlight",
+        slug=ctx["slug"],
+        suggested_title=f"Safety Alert: {ctx['safety_count']} Flagged Reviews in {category}",
+        tags=[category, "safety", "consumer-protection", "reviews"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=data.get("quotes", []),
+    )
+
+
+def _blueprint_best_for_products(ctx: dict, data: dict) -> PostBlueprint:
+    category = ctx["category"]
+    top_products = data.get("top_products", [])[:10]
+    brand_health = data.get("brand_health", [])
+
+    # Overview chart: top products by review count
+    overview_data = [
+        {
+            "name": p["product_title"][:30],
+            "reviews": p["review_count"],
+            "pain_score": p["avg_pain"],
+        }
+        for p in top_products[:8]
+    ]
+    overview_chart = ChartSpec(
+        chart_id="overview-bar",
+        chart_type="bar",
+        title=f"Top Products in {category} by Review Volume",
+        data=overview_data,
+        config={
+            "x_key": "name",
+            "bars": [
+                {"dataKey": "reviews", "color": "#22d3ee"},
+                {"dataKey": "pain_score", "color": "#f87171"},
+            ],
+        },
+    )
+
+    # Brand comparison chart
+    brand_data = [
+        {
+            "name": b["brand"][:25],
+            "avg_pain": round(float(b.get("avg_pain_score", 0)), 1),
+            "reviews": b.get("review_count", 0),
+        }
+        for b in brand_health[:8]
+    ]
+    charts = [overview_chart]
+
+    if brand_data:
+        brand_chart = ChartSpec(
+            chart_id="brands-bar",
+            chart_type="horizontal_bar",
+            title=f"Brand Pain Scores in {category}",
+            data=brand_data,
+            config={
+                "x_key": "name",
+                "bars": [{"dataKey": "avg_pain", "color": "#a78bfa"}],
+            },
+        )
+        charts.append(brand_chart)
+
+    sections = [
+        SectionSpec(
+            id="hook",
+            heading="Introduction",
+            goal="Set the stage: how many products/reviews we analyzed in this category",
+            key_stats={
+                "category": category,
+                "asin_count": ctx["asin_count"],
+                "review_count": ctx["review_count"],
+                "avg_pain": ctx["avg_pain"],
+                "avg_rating": ctx["avg_rating"],
+            },
+            data_summary=(
+                f"Analyzed {ctx['review_count']} reviews across {ctx['asin_count']} "
+                f"products in {category}. Average pain: {ctx['avg_pain']}/10, "
+                f"average rating: {ctx['avg_rating']}/5."
+            ),
+        ),
+        SectionSpec(
+            id="overview",
+            heading=f"Best {category} Products: The Data at a Glance",
+            goal="Present the top products by review volume and pain scores",
+            chart_ids=["overview-bar"],
+            key_stats={
+                "top_products": [
+                    {
+                        "title": p["product_title"],
+                        "brand": p["brand"],
+                        "reviews": p["review_count"],
+                        "avg_pain": p["avg_pain"],
+                        "avg_rating": p["avg_rating"],
+                        "safety_flags": p["safety_flags"],
+                    }
+                    for p in top_products[:6]
+                ],
+            },
+            data_summary=f"Top {len(overview_data)} products ranked by review volume.",
+        ),
+    ]
+
+    if brand_data:
+        sections.append(SectionSpec(
+            id="brands",
+            heading="Which Brands Have the Fewest Complaints?",
+            goal="Compare brands by pain score and review volume",
+            chart_ids=["brands-bar"],
+            data_summary=f"Brand-level pain scores across {len(brand_data)} brands.",
+        ))
+
+    sections.append(SectionSpec(
+        id="verdict",
+        heading="The Verdict: Which Products to Consider",
+        goal="Summarize the best options by use case with specific product recommendations",
+        key_stats={"category": category, "asin_count": ctx["asin_count"]},
+    ))
+
+    return PostBlueprint(
+        topic_type="best_for_products",
+        slug=ctx["slug"],
+        suggested_title=f"Best {category} Products: {ctx['asin_count']} Products Analyzed",
+        tags=[category, "best-of", "buyer-guide", "reviews"],
+        data_context=data["data_context"],
+        sections=sections,
+        charts=charts,
+        quotable_phrases=data.get("quotes", []),
+    )
+
+
+# -- Blueprint helpers ---------------------------------------------
+
+def _build_complaint_comparison_data(
+    brand_a: str, brand_b: str, data: dict
+) -> list[dict[str, Any]]:
+    """Build grouped bar data comparing sentiment aspects between brands."""
+    sentiment = data.get("sentiment", [])
+    aspects_a: dict[str, int] = {}
+    aspects_b: dict[str, int] = {}
+    for s in sentiment:
+        if s.get("sentiment") == "negative":
+            if s["brand"] == brand_a:
+                aspects_a[s["aspect"]] = aspects_a.get(s["aspect"], 0) + s["count"]
+            elif s["brand"] == brand_b:
+                aspects_b[s["aspect"]] = aspects_b.get(s["aspect"], 0) + s["count"]
+
+    # Merge and take top 6
+    all_aspects = set(aspects_a.keys()) | set(aspects_b.keys())
+    ranked = sorted(
+        all_aspects,
+        key=lambda a: (aspects_a.get(a, 0) + aspects_b.get(a, 0)),
+        reverse=True,
+    )[:6]
+
+    return [
+        {"name": asp, brand_a: aspects_a.get(asp, 0), brand_b: aspects_b.get(asp, 0)}
+        for asp in ranked
+    ]
+
+
+def _build_flow_data(
+    brand_a: str, brand_b: str, data: dict
+) -> list[dict[str, Any]]:
+    """Build migration flow data between two brands."""
+    flows = data.get("flows", [])
+    relevant = [
+        f for f in flows
+        if f.get("from_brand") in (brand_a, brand_b)
+        and f.get("direction") == "switched_to"
+    ]
+    if not relevant:
+        return []
+
+    agg: dict[str, int] = {}
+    for f in relevant:
+        label = f"{f['from_brand']} -> {f['to_brand']}"
+        agg[label] = agg.get(label, 0) + f.get("count", 0)
+
+    top = sorted(agg.items(), key=lambda x: x[1], reverse=True)[:6]
+    return [{"name": label, "mentions": count} for label, count in top]
+
+
+# -- Related slugs ------------------------------------------------
+
+async def _compute_related_slugs(
+    pool, current_slug: str, tags: list[str], limit: int = 4
+) -> list[str]:
+    """Find related blog posts by overlapping tags/category."""
+    if not tags:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT slug FROM blog_posts
+        WHERE slug != $1
+          AND status IN ('draft', 'published')
+          AND tags::jsonb ?| $2
+        ORDER BY created_at DESC
+        LIMIT $3
+        """,
+        current_slug, tags[:3], limit,
+    )
+    return [r["slug"] for r in rows]
+
+
+async def _fetch_related_for_linking(
+    pool, tags: list[str], current_slug: str = "", limit: int = 6
+) -> list[dict[str, str]]:
+    """Fetch published/draft posts with overlapping tags for internal linking."""
+    if not tags:
+        return []
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT slug, title FROM blog_posts
+            WHERE slug != $1
+              AND status IN ('draft', 'published')
+              AND tags::jsonb ?| $2
+            ORDER BY created_at DESC
+            LIMIT $3
+            """,
+            current_slug, tags[:3], limit,
+        )
+        return [{"slug": r["slug"], "title": r["title"]} for r in rows]
+    except Exception:
+        logger.debug("Failed to fetch related posts for linking", exc_info=True)
+        return []
+
+
+# -- Stage 4: Content Generation ----------------------------------
+
+def _generate_content(
+    llm,
+    blueprint: PostBlueprint,
+    max_tokens: int,
+    related_posts: list[dict[str, str]] | None = None,
+) -> dict[str, Any] | None:
+    """Single LLM call: blueprint in, {title, description, content, SEO fields} out."""
+    from ...pipelines.llm import clean_llm_output, parse_json_response
+    from ...skills.registry import get_skill_registry
+
+    skill = get_skill_registry().get("digest/blog_post_generation")
+    if skill is None:
+        logger.error("Skill digest/blog_post_generation not found")
+        return None
+
+    # Build the payload from blueprint
+    payload: dict[str, Any] = {
+        "topic_type": blueprint.topic_type,
+        "suggested_title": blueprint.suggested_title,
+        "data_context": blueprint.data_context,
+        "sections": [
+            {
+                "id": s.id,
+                "heading": s.heading,
+                "goal": s.goal,
+                "key_stats": s.key_stats,
+                "chart_ids": s.chart_ids,
+                "data_summary": s.data_summary,
+            }
+            for s in blueprint.sections
+        ],
+        "available_charts": [
+            {
+                "chart_id": c.chart_id,
+                "chart_type": c.chart_type,
+                "title": c.title,
+            }
+            for c in blueprint.charts
+        ],
+        "quotable_phrases": blueprint.quotable_phrases[:5],
+    }
+    if related_posts:
+        payload["related_posts"] = related_posts
+
+    from ...services.protocols import Message
+
+    messages = [
+        Message(role="system", content=skill.content),
+        Message(role="user", content=json.dumps(payload, separators=(",", ":"), default=str)),
+    ]
+
+    try:
+        result = llm.chat(messages=messages, max_tokens=max_tokens, temperature=0.7)
+        _usage = result.get("usage", {}) if isinstance(result, dict) else {}
+        if _usage.get("input_tokens"):
+            logger.info("blog_post_generation LLM tokens: in=%d out=%d",
+                         _usage["input_tokens"], _usage.get("output_tokens", 0))
+            from ...pipelines.llm import trace_llm_call
+            _trace_meta = result.get("_trace_meta", {}) if isinstance(result, dict) else {}
+            _resp_text = (result.get("response", "") if isinstance(result, dict) else str(result)) or ""
+            _biz_ctx = {
+                "topic_type": blueprint.topic_type,
+                "slug": blueprint.slug,
+                "suggested_title": blueprint.suggested_title[:200],
+                "tags": blueprint.tags[:10],
+            }
+            _dc = blueprint.data_context or {}
+            if _dc.get("brand_a"):
+                _biz_ctx["brand_a"] = str(_dc["brand_a"])[:200]
+            if _dc.get("brand_b"):
+                _biz_ctx["brand_b"] = str(_dc["brand_b"])[:200]
+            if _dc.get("category"):
+                _biz_ctx["category"] = str(_dc["category"])[:200]
+            trace_llm_call("task.blog_post_generation", input_tokens=_usage["input_tokens"],
+                           output_tokens=_usage.get("output_tokens", 0),
+                           cached_tokens=_trace_meta.get("cached_tokens") or _trace_meta.get("cache_read_tokens"),
+                           cache_write_tokens=_trace_meta.get("cache_write_tokens") or _trace_meta.get("cache_creation_tokens"),
+                           billable_input_tokens=_trace_meta.get("billable_input_tokens"),
+                           model=getattr(llm, "model", ""), provider=getattr(llm, "name", ""),
+                           input_data={"messages": [{"role": m.role, "content": (m.content or "")[:500]} for m in messages]},
+                           output_data={"response": _resp_text[:2000]},
+                           api_endpoint=_trace_meta.get("api_endpoint"),
+                           provider_request_id=_trace_meta.get("provider_request_id"),
+                           ttft_ms=_trace_meta.get("ttft_ms"),
+                           inference_time_ms=_trace_meta.get("inference_time_ms"),
+                           queue_time_ms=_trace_meta.get("queue_time_ms"),
+                           metadata=_biz_ctx)
+        text = result.get("response", "") if isinstance(result, dict) else str(result)
+        text = clean_llm_output(text)
+        parsed = parse_json_response(text, recover_truncated=True)
+
+        # parse_json_response returns fallback dict on failure, not None
+        if parsed.get("_parse_fallback"):
+            logger.error("Failed to parse LLM response as JSON")
+            return None
+
+        # Validate required keys
+        if not all(k in parsed for k in ("title", "description", "content")):
+            logger.error("LLM response missing required keys: %s", list(parsed.keys()))
+            return None
+
+        # Ensure SEO fields have sane defaults if LLM didn't produce them
+        if "seo_title" not in parsed or not parsed["seo_title"]:
+            parsed["seo_title"] = parsed["title"][:60]
+        if "seo_description" not in parsed or not parsed["seo_description"]:
+            parsed["seo_description"] = parsed["description"][:155]
+        if "target_keyword" not in parsed:
+            parsed["target_keyword"] = ""
+        if "secondary_keywords" not in parsed:
+            parsed["secondary_keywords"] = []
+        if "faq" not in parsed or not isinstance(parsed["faq"], list):
+            parsed["faq"] = []
+
+        return parsed
+    except Exception:
+        logger.exception("LLM content generation failed")
+        return None
+
+
+# -- Stage 5: Assembly & Storage ----------------------------------
+
+async def _assemble_and_store(
+    pool, blueprint: PostBlueprint, content: dict[str, Any], llm
+) -> str:
+    """Store the assembled post as a draft in blog_posts."""
+    charts_json = [asdict(c) for c in blueprint.charts]
+    model_name = getattr(llm, "model_name", None) or getattr(llm, "model", "unknown")
+
+    # Inject Amazon Associates tag so frontend can build affiliate links for ASINs
+    tag = settings.external_data.amazon_associate_tag
+    if tag:
+        blueprint.data_context["amazon_associate_tag"] = tag
+
+    row = await pool.fetchrow(
+        """
+        INSERT INTO blog_posts (
+            slug, title, description, topic_type, tags,
+            content, charts, data_context,
+            status, llm_model, source_report_date,
+            seo_title, seo_description, target_keyword,
+            secondary_keywords, faq
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'draft',$9,$10,$11,$12,$13,$14,$15)
+        ON CONFLICT (slug) DO UPDATE SET
+            title = EXCLUDED.title,
+            description = EXCLUDED.description,
+            content = EXCLUDED.content,
+            charts = EXCLUDED.charts,
+            data_context = EXCLUDED.data_context,
+            llm_model = EXCLUDED.llm_model,
+            source_report_date = EXCLUDED.source_report_date,
+            seo_title = EXCLUDED.seo_title,
+            seo_description = EXCLUDED.seo_description,
+            target_keyword = EXCLUDED.target_keyword,
+            secondary_keywords = EXCLUDED.secondary_keywords,
+            faq = EXCLUDED.faq
+        WHERE blog_posts.status != 'published'
+        RETURNING id
+        """,
+        blueprint.slug,
+        content["title"],
+        content.get("description", ""),
+        blueprint.topic_type,
+        json.dumps(blueprint.tags),
+        content["content"],
+        json.dumps(charts_json, default=str),
+        json.dumps(blueprint.data_context, default=str),
+        str(model_name),
+        date.today(),
+        content.get("seo_title", content["title"][:60]),
+        content.get("seo_description", content.get("description", "")[:155]),
+        content.get("target_keyword", ""),
+        json.dumps(content.get("secondary_keywords", []), default=str),
+        json.dumps(content.get("faq", []), default=str),
+    )
+    if not row:
+        logger.warning(
+            "Skipped overwrite of published post: slug=%s", blueprint.slug
+        )
+        return ""
+    post_id = str(row["id"])
+    logger.info("Stored blog draft: slug=%s, id=%s", blueprint.slug, post_id)
+
+    # Compute related slugs for internal linking
+    related_slugs: list[str] = []
+    try:
+        related_slugs = await _compute_related_slugs(pool, blueprint.slug, blueprint.tags)
+        if related_slugs:
+            await pool.execute(
+                "UPDATE blog_posts SET related_slugs = $1 WHERE id = $2",
+                json.dumps(related_slugs), row["id"],
+            )
+    except Exception:
+        logger.debug("Related slug computation skipped", exc_info=True)
+
+    # Write .ts file for the frontend if ui_path is configured
+    cfg = settings.external_data
+    if cfg.blog_post_ui_path:
+        try:
+            _write_ui_post(
+                cfg.blog_post_ui_path,
+                blueprint,
+                content,
+                charts_json,
+                related_slugs=related_slugs,
+            )
+        except Exception:
+            logger.warning("Failed to write UI blog file", exc_info=True)
+        else:
+            try:
+                from ._blog_deploy import auto_deploy_blog
+                await auto_deploy_blog(
+                    cfg.blog_post_ui_path,
+                    blueprint.slug,
+                    enabled=cfg.blog_auto_deploy_enabled,
+                    branch=cfg.blog_auto_deploy_branch,
+                    hook_url=cfg.blog_auto_deploy_hook_url,
+                )
+            except Exception:
+                logger.warning("Blog auto-deploy failed", exc_info=True)
+
+    return post_id
+
+
+def _write_ui_post(
+    ui_path: str,
+    blueprint: PostBlueprint,
+    content: dict[str, Any],
+    charts_json: list[dict[str, Any]],
+    related_slugs: list[str] | None = None,
+) -> None:
+    """Write a .ts post file and register it in index.ts."""
+    from pathlib import Path
+    from ._blog_ts import build_post_ts, update_blog_index
+
+    # Resolve relative paths against project root (where main.py lives)
+    blog_dir = Path(ui_path)
+    if not blog_dir.is_absolute():
+        project_root = Path(__file__).resolve().parent.parent.parent.parent
+        blog_dir = project_root / blog_dir
+    if not blog_dir.is_dir():
+        logger.warning("blog_post_ui_path does not exist: %s", blog_dir)
+        return
+
+    slug = blueprint.slug
+    var_name, ts_content = build_post_ts(
+        slug=slug,
+        title=content["title"],
+        description=content.get("description", ""),
+        date_str=date.today().isoformat(),
+        author="Atlas Intelligence Team",
+        tags=blueprint.tags,
+        topic_type=blueprint.topic_type,
+        charts_json=charts_json,
+        content=content["content"],
+        seo_title=content.get("seo_title", ""),
+        seo_description=content.get("seo_description", ""),
+        target_keyword=content.get("target_keyword", ""),
+        secondary_keywords=content.get("secondary_keywords"),
+        faq=content.get("faq"),
+        related_slugs=related_slugs,
+    )
+
+    post_path = blog_dir / (slug + ".ts")
+    post_path.write_text(ts_content, encoding="utf-8")
+    logger.info("Wrote blog UI file: %s", post_path)
+
+    update_blog_index(blog_dir / "index.ts", slug, var_name)

--- a/extracted_content_pipeline/autonomous/tasks/campaign_audit.py
+++ b/extracted_content_pipeline/autonomous/tasks/campaign_audit.py
@@ -1,0 +1,65 @@
+"""
+Campaign audit log helper.
+
+Single function used by all campaign code to record state changes
+into the campaign_audit_log table.  Never raises.
+"""
+
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger("atlas.autonomous.tasks.campaign_audit")
+
+
+async def log_campaign_event(
+    pool,
+    *,
+    event_type: str,
+    source: str = "system",
+    campaign_id: UUID | str | None = None,
+    sequence_id: UUID | str | None = None,
+    step_number: int | None = None,
+    subject: str | None = None,
+    body: str | None = None,
+    recipient_email: str | None = None,
+    esp_message_id: str | None = None,
+    error_detail: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Insert a row into campaign_audit_log.  Never raises."""
+    try:
+        await pool.execute(
+            """
+            INSERT INTO campaign_audit_log
+                (campaign_id, sequence_id, event_type, step_number,
+                 subject, body, recipient_email, esp_message_id,
+                 error_detail, source, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            """,
+            _to_uuid(campaign_id),
+            _to_uuid(sequence_id),
+            event_type,
+            step_number,
+            subject,
+            body,
+            recipient_email,
+            esp_message_id,
+            error_detail,
+            source,
+            json.dumps(metadata or {}),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to write audit log (event=%s, seq=%s): %s",
+            event_type, sequence_id, exc,
+        )
+
+
+def _to_uuid(val: UUID | str | None) -> UUID | None:
+    if val is None:
+        return None
+    if isinstance(val, UUID):
+        return val
+    return UUID(val)

--- a/extracted_content_pipeline/autonomous/tasks/competitive_intelligence.py
+++ b/extracted_content_pipeline/autonomous/tasks/competitive_intelligence.py
@@ -1,0 +1,1455 @@
+"""
+Complaint vulnerability intelligence: cross-brand analysis from deep-extracted reviews.
+
+Aggregates deep_extraction JSONB fields across brands to produce competitive
+flow maps, feature gap rankings, buyer persona clusters, and brand vulnerability
+scores. Source data is complaint/negative reviews only -- scores measure
+vulnerability and dissatisfaction, not overall brand health.
+
+Runs daily (default 9:30 PM, after complaint_analysis at 9 PM). Handles its
+own LLM call, report persistence, brand_intelligence upserts, and ntfy
+notification -- returns _skip_synthesis so the runner does not double-synthesize.
+"""
+
+import asyncio
+import json
+import logging
+import math
+import re
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...services.brand_registry import resolve_brand_name_cached, _ensure_cache as _ensure_brand_cache
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.autonomous.tasks.competitive_intelligence")
+
+# Category filter expression matching blog topic selection (categories->>2 granular)
+_CAT_EXPR = (
+    "COALESCE(REPLACE(pm.categories->>2, '&amp;', '&'),"
+    " REPLACE(pm.categories->>1, '&amp;', '&'), pr.source_category)"
+)
+
+
+def _build_llm_payload(
+    today: date,
+    brand_health: list[dict[str, Any]],
+    competitive_flows: list[dict[str, Any]],
+    feature_gaps: list[dict[str, Any]],
+    buyer_personas: list[dict[str, Any]],
+    safety_signals: list[dict[str, Any]],
+    loyalty_churn: list[dict[str, Any]],
+    data_context: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the exact competitive-intelligence LLM payload used in production."""
+    llm_brands = [
+        {
+            "brand": brand["brand"],
+            "reviews": brand["total_reviews"],
+            "period": brand.get("review_period", ""),
+            "rating": brand["avg_rating"],
+            "pain": brand["avg_pain_score"],
+            "repurchase": f"{brand['repurchase_yes']}/{brand['repurchase_yes'] + brand['repurchase_no']}",
+            "safety": brand["safety_flagged_count"],
+        }
+        for brand in brand_health[:15]
+    ]
+    return {
+        "date": str(today),
+        "data_context": data_context,
+        "total_brands": len(brand_health),
+        "brand_health": llm_brands,
+        "competitive_flows": competitive_flows[:10],
+        "feature_gaps": feature_gaps[:8],
+        "buyer_personas": buyer_personas[:6],
+        "safety_signals": safety_signals[:6],
+        "loyalty_churn": loyalty_churn[:8],
+    }
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: daily competitive intelligence."""
+    cfg = settings.external_data
+    if not cfg.complaint_mining_enabled or not cfg.competitive_intelligence_enabled:
+        return {"_skip_synthesis": "Competitive intelligence disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    today = date.today()
+
+    # Skip if we already have a report for today
+    existing = await pool.fetchrow(
+        "SELECT id FROM market_intelligence_reports "
+        "WHERE report_date = $1 AND report_type = 'daily_competitive' LIMIT 1",
+        today,
+    )
+    if existing:
+        return {"_skip_synthesis": f"Report already exists for {today}"}
+
+    # Check minimum deep-enriched count
+    count_row = await pool.fetchrow(
+        "SELECT count(*) AS cnt FROM product_reviews "
+        "WHERE deep_enrichment_status = 'enriched'"
+    )
+    total_deep = count_row["cnt"] if count_row else 0
+    if total_deep < cfg.competitive_intelligence_min_deep_enriched:
+        return {
+            "_skip_synthesis": f"Only {total_deep} deep-enriched reviews "
+            f"(need {cfg.competitive_intelligence_min_deep_enriched})"
+        }
+
+    # Verify product_metadata table exists (populated by match_product_metadata script)
+    has_metadata = await pool.fetchrow(
+        "SELECT EXISTS ("
+        "  SELECT 1 FROM information_schema.tables "
+        "  WHERE table_name = 'product_metadata'"
+        ") AS ok"
+    )
+    if not has_metadata or not has_metadata["ok"]:
+        return {"_skip_synthesis": "product_metadata table not found (run match_product_metadata first)"}
+
+    # Gather 9 data sources in parallel
+    (
+        brand_health,
+        competitive_flows,
+        feature_gaps,
+        buyer_personas,
+        sentiment_landscape,
+        safety_signals,
+        loyalty_churn,
+        prior_reports,
+        data_context,
+    ) = await asyncio.gather(
+        _fetch_brand_health(pool),
+        _fetch_competitive_flows(pool),
+        _fetch_feature_gaps(pool),
+        _fetch_buyer_personas(pool),
+        _fetch_sentiment_landscape(pool),
+        _fetch_safety_signals(pool),
+        _fetch_loyalty_churn(pool),
+        _fetch_prior_reports(pool),
+        _fetch_data_context(pool),
+        return_exceptions=True,
+    )
+
+    # Convert exceptions to empty values
+    fetchers = {
+        "brand_health": brand_health,
+        "competitive_flows": competitive_flows,
+        "feature_gaps": feature_gaps,
+        "buyer_personas": buyer_personas,
+        "sentiment_landscape": sentiment_landscape,
+        "safety_signals": safety_signals,
+        "loyalty_churn": loyalty_churn,
+        "prior_reports": prior_reports,
+    }
+    for key, val in fetchers.items():
+        if isinstance(val, Exception):
+            logger.warning("%s fetch failed: %s", key, val)
+            fetchers[key] = []
+    if isinstance(data_context, Exception):
+        logger.warning("Data context fetch failed: %s", data_context)
+        data_context = {}
+
+    if not fetchers["brand_health"]:
+        return {"_skip_synthesis": "No brand data to analyze"}
+
+    # Post-process: normalize feature requests
+    # (competitive_flows already normalized by fetch_competitive_flows)
+    if fetchers["feature_gaps"]:
+        fetchers["feature_gaps"] = _normalize_feature_requests(fetchers["feature_gaps"])
+
+    # Build LLM payload -- trim to fit ~4k token input budget (8k context - 4k output).
+    # Full fetchers data used below for upserts.
+    payload = _build_llm_payload(
+        today,
+        fetchers["brand_health"],
+        fetchers["competitive_flows"],
+        fetchers["feature_gaps"],
+        fetchers["buyer_personas"],
+        fetchers["safety_signals"],
+        fetchers["loyalty_churn"],
+        data_context,
+    )
+
+    # Load skill and call LLM
+    from ...pipelines.llm import call_llm_with_skill, parse_json_response
+
+    usage: dict[str, Any] = {}
+    try:
+        analysis = await asyncio.wait_for(
+            asyncio.to_thread(
+                call_llm_with_skill,
+                "digest/competitive_intelligence",
+                payload,
+                max_tokens=cfg.competitive_intelligence_max_tokens,
+                temperature=0.4,
+                workload="synthesis",
+                response_format={"type": "json_object"},
+                usage_out=usage,
+            ),
+            timeout=600,
+        )
+    except asyncio.TimeoutError:
+        logger.error("LLM call timed out after 600s for competitive_intelligence")
+        return {"_skip_synthesis": "LLM analysis timed out"}
+    if usage.get("input_tokens"):
+        logger.info("competitive_intelligence LLM tokens: in=%d out=%d model=%s",
+                     usage["input_tokens"], usage["output_tokens"], usage.get("model", ""))
+    if not analysis:
+        return {"_skip_synthesis": "LLM analysis failed"}
+
+    parsed = parse_json_response(analysis, recover_truncated=True)
+
+    # Persist to market_intelligence_reports
+    report_stored = False
+    try:
+        await pool.execute(
+            """
+            INSERT INTO market_intelligence_reports (
+                report_date, report_type, analysis_text,
+                competitive_flows, feature_gaps, buyer_personas,
+                brand_scorecards, insights, recommendations
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            today,
+            "daily_competitive",
+            parsed.get("analysis_text", analysis),
+            json.dumps(parsed.get("competitive_flows", [])),
+            json.dumps(parsed.get("feature_gaps", [])),
+            json.dumps(parsed.get("buyer_personas", [])),
+            json.dumps(parsed.get("brand_vulnerability", parsed.get("brand_scorecards", []))),
+            json.dumps(parsed.get("insights", [])),
+            json.dumps(parsed.get("recommendations", [])),
+        )
+        report_stored = True
+        logger.info("Stored competitive intelligence report for %s", today)
+    except Exception:
+        logger.exception("Failed to store competitive intelligence report")
+
+    # Upsert brand_intelligence scorecards (only if report stored successfully)
+    snapshots_persisted = 0
+    change_events_detected = 0
+    concurrent_shifts = 0
+    displacement_edges_persisted = 0
+    if report_stored:
+        await _upsert_brand_intelligence(
+            pool, fetchers["brand_health"], parsed,
+            safety_signals=fetchers["safety_signals"],
+            loyalty_churn=fetchers["loyalty_churn"],
+        )
+        # Persist daily brand snapshots + detect change events
+        snapshots_persisted = await _persist_brand_snapshots(
+            pool, fetchers["brand_health"], parsed,
+        )
+        change_events_detected = await _detect_change_events(
+            pool, fetchers["brand_health"],
+        )
+        # Detect market-level concurrent shifts (3+ brands with same event today)
+        concurrent_shifts = await _detect_concurrent_shifts(pool)
+        displacement_edges_persisted = await _persist_displacement_edges(pool)
+
+        # Dispatch consumer webhooks for change events + report
+        await _dispatch_consumer_events(
+            pool, fetchers["brand_health"], change_events_detected, concurrent_shifts,
+        )
+
+    # Send ntfy notification
+    from ...pipelines.notify import send_pipeline_notification
+
+    await send_pipeline_notification(
+        parsed.get("analysis_text", analysis),
+        task,
+        title="Atlas: Complaint Vulnerability Intelligence",
+        default_tags="brain,bar_chart",
+        parsed=parsed,
+    )
+
+    return {
+        "_skip_synthesis": "Competitive intelligence complete",
+        "date": str(today),
+        "brands_analyzed": len(fetchers["brand_health"]),
+        "competitive_flows": len(fetchers["competitive_flows"]),
+        "feature_gaps": len(fetchers["feature_gaps"]),
+        "insights": len(parsed.get("insights", [])),
+        "snapshots_persisted": snapshots_persisted,
+        "change_events_detected": change_events_detected,
+        "concurrent_shifts_detected": concurrent_shifts,
+        "displacement_edges_persisted": displacement_edges_persisted,
+    }
+
+
+# ------------------------------------------------------------------
+# Data fetchers
+# ------------------------------------------------------------------
+
+
+async def _fetch_data_context(pool) -> dict[str, Any]:
+    """Compute temporal metadata so the LLM can anchor claims with timeframes."""
+    row = await pool.fetchrow(
+        """
+        SELECT
+            count(*) AS total,
+            count(*) FILTER (WHERE reviewed_at IS NOT NULL) AS with_date,
+            min(reviewed_at) AS earliest,
+            max(reviewed_at) AS latest,
+            count(*) FILTER (WHERE reviewed_at >= NOW() - INTERVAL '1 year') AS last_1y,
+            count(*) FILTER (WHERE reviewed_at >= NOW() - INTERVAL '3 years') AS last_3y,
+            count(*) FILTER (WHERE reviewed_at < NOW() - INTERVAL '3 years') AS older_3y
+        FROM product_reviews
+        WHERE deep_enrichment_status = 'enriched'
+        """
+    )
+    return {
+        "total_deep_enriched": row["total"],
+        "reviews_with_dates": row["with_date"],
+        "review_period": {
+            "earliest": str(row["earliest"].date()) if row["earliest"] else None,
+            "latest": str(row["latest"].date()) if row["latest"] else None,
+        },
+        "recency": {
+            "last_1_year": row["last_1y"],
+            "last_3_years": row["last_3y"],
+            "older_than_3_years": row["older_3y"],
+        },
+        "note": "IMPORTANT: Always anchor statistics with timeframes. Say 'between 2012 and 2023' or 'over the review period' instead of unqualified claims. Use the date range per brand when available.",
+    }
+
+
+async def _fetch_brand_health(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Per-brand health: reviews, rating, pain, severity, repurchase, safety."""
+    # Warm brand registry cache for sync resolution below
+    await _ensure_brand_cache()
+
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.brand,
+            count(*) AS total_reviews,
+            avg(pr.rating) AS avg_rating,
+            avg(pr.pain_score) AS avg_pain_score,
+            count(*) FILTER (WHERE pr.severity = 'critical') AS critical_count,
+            count(*) FILTER (WHERE pr.severity = 'major') AS major_count,
+            count(*) FILTER (WHERE pr.severity = 'minor') AS minor_count,
+            count(*) FILTER (
+                WHERE pr.would_repurchase IS TRUE
+            ) AS repurchase_yes,
+            count(*) FILTER (
+                WHERE pr.would_repurchase IS FALSE
+            ) AS repurchase_no,
+            count(*) FILTER (
+                WHERE (pr.deep_extraction->'safety_flag'->>'flagged')::boolean IS TRUE
+            ) AS safety_flagged_count,
+            min(pr.reviewed_at)::date AS earliest_review,
+            max(pr.reviewed_at)::date AS latest_review
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+          {cat_filter}
+        GROUP BY pm.brand
+        HAVING count(*) >= 5
+        ORDER BY count(*) DESC
+        """,
+        *params,
+    )
+    return [
+        {
+            "brand": resolve_brand_name_cached(r["brand"]),
+            "total_reviews": r["total_reviews"],
+            "review_period": f"{r['earliest_review']} to {r['latest_review']}" if r["earliest_review"] else "dates unavailable",
+            "avg_rating": round(float(r["avg_rating"]), 2) if r["avg_rating"] else 0.0,
+            "avg_pain_score": round(float(r["avg_pain_score"]), 1) if r["avg_pain_score"] else 0.0,
+            "severity_distribution": {
+                "critical": r["critical_count"],
+                "major": r["major_count"],
+                "minor": r["minor_count"],
+            },
+            "repurchase_yes": r["repurchase_yes"],
+            "repurchase_no": r["repurchase_no"],
+            "safety_flagged_count": r["safety_flagged_count"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_competitive_flows(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Brand-to-brand customer migration from product_comparisons."""
+    from ...pipelines.comparisons import fetch_competitive_flows
+
+    where = "pm.brand IS NOT NULL AND pm.brand != ''"
+    params: list = []
+    if category:
+        where += f" AND {_CAT_EXPR} = $1"
+        params = [category]
+    return await fetch_competitive_flows(
+        pool,
+        where_clause=where,
+        params=params,
+        min_mentions=2,
+        limit=500,
+    )
+
+
+async def _fetch_feature_gaps(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Most-requested features across all products."""
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            {_CAT_EXPR} AS category,
+            feat AS feature,
+            count(*) AS mentions,
+            avg(pr.pain_score) AS avg_pain_score
+        FROM product_reviews pr
+        LEFT JOIN product_metadata pm ON pm.asin = pr.asin
+        CROSS JOIN jsonb_array_elements_text(pr.deep_extraction->'feature_requests') AS feat
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND jsonb_array_length(pr.deep_extraction->'feature_requests') > 0
+          {cat_filter}
+        GROUP BY category, feat
+        HAVING count(*) >= 2
+        ORDER BY count(*) DESC
+        LIMIT 500
+        """,
+        *params,
+    )
+    return [
+        {
+            "category": r["category"],
+            "feature": r["feature"],
+            "mentions": r["mentions"],
+            "avg_pain_score": round(float(r["avg_pain_score"]), 1) if r["avg_pain_score"] else 0.0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_buyer_personas(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Buyer segment clusters from buyer_context + expertise/budget."""
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            {_CAT_EXPR} AS category,
+            pr.deep_extraction->'buyer_context'->>'buyer_type' AS buyer_type,
+            pr.deep_extraction->'buyer_context'->>'use_case' AS use_case,
+            pr.deep_extraction->'buyer_context'->>'price_sentiment' AS price_sentiment,
+            pr.deep_extraction->>'expertise_level' AS expertise_level,
+            pr.deep_extraction->>'budget_type' AS budget_type,
+            count(*) AS review_count,
+            avg(pr.rating) AS avg_rating,
+            avg(pr.pain_score) AS avg_pain
+        FROM product_reviews pr
+        LEFT JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND pr.deep_extraction->'buyer_context' IS NOT NULL
+          {cat_filter}
+        GROUP BY
+            category,
+            pr.deep_extraction->'buyer_context'->>'buyer_type',
+            pr.deep_extraction->'buyer_context'->>'use_case',
+            pr.deep_extraction->'buyer_context'->>'price_sentiment',
+            pr.deep_extraction->>'expertise_level',
+            pr.deep_extraction->>'budget_type'
+        HAVING count(*) >= 3
+        ORDER BY count(*) DESC
+        LIMIT 500
+        """,
+        *params,
+    )
+    return [
+        {
+            "category": r["category"],
+            "buyer_type": r["buyer_type"],
+            "use_case": r["use_case"],
+            "price_sentiment": r["price_sentiment"],
+            "expertise_level": r["expertise_level"],
+            "budget_type": r["budget_type"],
+            "review_count": r["review_count"],
+            "avg_rating": round(float(r["avg_rating"]), 2) if r["avg_rating"] else 0.0,
+            "avg_pain": round(float(r["avg_pain"]), 1) if r["avg_pain"] else 0.0,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_sentiment_landscape(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Per-brand sentiment on specific aspects."""
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.brand,
+            asp->>'aspect' AS aspect,
+            asp->>'sentiment' AS sentiment,
+            count(*) AS cnt
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        CROSS JOIN jsonb_array_elements(pr.deep_extraction->'sentiment_aspects') AS asp
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+          AND jsonb_array_length(pr.deep_extraction->'sentiment_aspects') > 0
+          {cat_filter}
+        GROUP BY pm.brand, asp->>'aspect', asp->>'sentiment'
+        ORDER BY count(*) DESC
+        LIMIT 500
+        """,
+        *params,
+    )
+    return [
+        {
+            "brand": r["brand"],
+            "aspect": r["aspect"],
+            "sentiment": r["sentiment"],
+            "count": r["cnt"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_safety_signals(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Per-brand safety-flagged reviews with consequence_severity breakdown."""
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.brand,
+            pr.consequence_severity AS consequence,
+            count(*) AS cnt
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND (pr.deep_extraction->'safety_flag'->>'flagged')::boolean IS TRUE
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+          {cat_filter}
+        GROUP BY pm.brand, pr.consequence_severity
+        ORDER BY count(*) DESC
+        LIMIT 500
+        """,
+        *params,
+    )
+    return [
+        {
+            "brand": r["brand"],
+            "consequence": r["consequence"],
+            "count": r["cnt"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_safety_products(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Top products (ASINs) by safety-flag count with product title."""
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.asin,
+            pm.title AS product_title,
+            pm.brand,
+            count(*) AS safety_flags,
+            round(avg(pr.pain_score), 1) AS avg_pain
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND (pr.deep_extraction->'safety_flag'->>'flagged')::boolean IS TRUE
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+          {cat_filter}
+        GROUP BY pm.asin, pm.title, pm.brand
+        ORDER BY count(*) DESC
+        LIMIT 15
+        """,
+        *params,
+    )
+    return [
+        {
+            "asin": r["asin"],
+            "product_title": r["product_title"],
+            "brand": r["brand"],
+            "safety_flags": r["safety_flags"],
+            "avg_pain": float(r["avg_pain"]) if r["avg_pain"] else None,
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_loyalty_churn(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Per-brand loyalty depth x replacement behavior cross-tab."""
+    cat_filter = ""
+    params: list = []
+    if category:
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params = [category]
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.brand,
+            pr.deep_extraction->>'brand_loyalty_depth' AS loyalty,
+            pr.replacement_behavior AS replacement,
+            count(*) AS cnt
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+          {cat_filter}
+        GROUP BY pm.brand,
+            pr.deep_extraction->>'brand_loyalty_depth',
+            pr.replacement_behavior
+        HAVING count(*) >= 2
+        ORDER BY count(*) DESC
+        LIMIT 500
+        """,
+        *params,
+    )
+    return [
+        {
+            "brand": r["brand"],
+            "loyalty": r["loyalty"],
+            "replacement": r["replacement"],
+            "count": r["cnt"],
+        }
+        for r in rows
+    ]
+
+
+async def _fetch_prior_reports(pool, limit: int = 3) -> list[dict[str, Any]]:
+    """Fetch prior market_intelligence_reports for trend context."""
+    rows = await pool.fetch(
+        """
+        SELECT report_date, analysis_text,
+               competitive_flows, feature_gaps, buyer_personas,
+               brand_scorecards, insights, recommendations
+        FROM market_intelligence_reports
+        WHERE report_type = 'daily_competitive'
+        ORDER BY report_date DESC
+        LIMIT $1
+        """,
+        limit,
+    )
+    result = []
+    for r in rows:
+        entry: dict[str, Any] = {
+            "report_date": str(r["report_date"]),
+            "analysis_text": (r["analysis_text"] or "")[:1000],
+        }
+        for field in (
+            "competitive_flows", "feature_gaps", "buyer_personas",
+            "brand_scorecards", "insights", "recommendations",
+        ):
+            val = r[field]
+            if isinstance(val, str):
+                try:
+                    val = json.loads(val)
+                except (json.JSONDecodeError, TypeError):
+                    val = []
+            entry[field] = val if isinstance(val, list) else []
+        result.append(entry)
+    return result
+
+
+# ------------------------------------------------------------------
+# Post-processing normalization
+# ------------------------------------------------------------------
+
+
+# _normalize_competitors and _COMPETITOR_NOISE moved to atlas_brain.pipelines.comparisons
+
+
+def _normalize_feature_requests(gaps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Lowercase dedup + merge counts for near-identical feature requests."""
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for gap in gaps:
+        feat_raw = (gap.get("feature") or "").strip()
+        if not feat_raw:
+            continue
+
+        # Normalize: lowercase, collapse whitespace
+        feat_key = re.sub(r"\s+", " ", feat_raw.lower())
+        category = gap.get("category", "")
+        key = (category, feat_key)
+
+        if key in merged:
+            merged[key]["mentions"] += gap.get("mentions", 0)
+            # Keep the higher pain score
+            existing_pain = merged[key].get("avg_pain_score", 0.0)
+            new_pain = gap.get("avg_pain_score", 0.0)
+            merged[key]["avg_pain_score"] = max(existing_pain, new_pain)
+        else:
+            merged[key] = {
+                "category": category,
+                "feature": feat_raw.strip(),  # Keep original casing for display
+                "mentions": gap.get("mentions", 0),
+                "avg_pain_score": gap.get("avg_pain_score", 0.0),
+            }
+
+    result = sorted(merged.values(), key=lambda x: x["mentions"], reverse=True)
+    return result
+
+
+# ------------------------------------------------------------------
+# Confidence scoring
+# ------------------------------------------------------------------
+
+
+def _compute_consumer_confidence(
+    mention_count: int,
+    deep_enriched_count: int,
+    total_count: int,
+    severity_counts: dict[str, int] | None = None,
+) -> float:
+    """Evidence-based confidence score for consumer entities (0.0-1.0).
+
+    Three equally-weighted signals (each 0-1, averaged):
+      1. mention_weight:     log-scaled mention count (caps at 50)
+      2. enrichment_weight:  proportion of reviews that are deep-enriched
+      3. severity_weight:    consistency of severity signals (entropy-based)
+
+    Adapted from B2B ``_compute_evidence_confidence()`` which uses
+    mention weight + source diversity + verified source proportion.
+    Consumer has a single source (Amazon), so source signals are replaced
+    with enrichment depth and severity consistency.
+    """
+    mention_weight = min(
+        math.log2(max(mention_count, 1)) / math.log2(50), 1.0
+    )
+
+    enrichment_weight = (
+        deep_enriched_count / total_count if total_count > 0 else 0.0
+    )
+
+    severity_weight = 0.5
+    if severity_counts:
+        vals = [severity_counts.get(s, 0) for s in ("critical", "major", "minor")]
+        total_sev = sum(vals)
+        if total_sev > 0:
+            probs = [v / total_sev for v in vals if v > 0]
+            entropy = -sum(p * math.log2(p) for p in probs)
+            max_entropy = math.log2(3)
+            severity_weight = 1.0 - (entropy / max_entropy)
+
+    score = (mention_weight + enrichment_weight + severity_weight) / 3.0
+    return round(max(0.0, min(1.0, score)), 2)
+
+
+# ------------------------------------------------------------------
+# Brand intelligence upserts
+# ------------------------------------------------------------------
+
+
+def _compute_vulnerability_score(brand_data: dict) -> float:
+    """Composite vulnerability score 0-100. Higher = more vulnerable.
+
+    Formula: (1 - repurchase_rate) * 30 + pain/10 * 30 + (5 - rating)/5 * 15
+             + churn_signal * 10 + safety_rate * 15
+    Where churn_signal = proportion of reviews with would_repurchase=false out of
+    total with any signal, and safety_rate = safety_flagged_count / total_reviews.
+    Weights: 30 + 30 + 15 + 10 + 15 = 100.
+    """
+    yes = brand_data.get("repurchase_yes", 0)
+    no = brand_data.get("repurchase_no", 0)
+    total_signal = yes + no
+    repurchase_rate = yes / total_signal if total_signal > 0 else 0.5
+    churn_signal = no / total_signal if total_signal > 0 else 0.5
+
+    pain = brand_data.get("avg_pain_score", 5.0)
+    rating = brand_data.get("avg_rating", 3.0)
+
+    total_reviews = brand_data.get("total_reviews", 0)
+    safety_flagged = brand_data.get("safety_flagged_count", 0)
+    safety_rate = safety_flagged / total_reviews if total_reviews > 0 else 0.0
+
+    score = (
+        (1 - repurchase_rate) * 30
+        + pain / 10 * 30
+        + (5 - rating) / 5 * 15
+        + churn_signal * 10
+        + safety_rate * 15
+    )
+    return max(0.0, min(100.0, round(score, 2)))
+
+
+async def _upsert_brand_intelligence(
+    pool,
+    brand_health: list[dict[str, Any]],
+    parsed: dict[str, Any],
+    safety_signals: list[dict[str, Any]] | None = None,
+    loyalty_churn: list[dict[str, Any]] | None = None,
+) -> None:
+    """Upsert brand_intelligence from aggregated brand stats + LLM scorecards."""
+    now = datetime.now(timezone.utc)
+    upserted = 0
+
+    # Build lookup from LLM-generated scorecards (new key: brand_vulnerability)
+    raw_scorecards = parsed.get("brand_vulnerability", []) or parsed.get("brand_scorecards", [])
+    scorecards = {
+        sc["brand"]: sc
+        for sc in raw_scorecards
+        if isinstance(sc, dict) and sc.get("brand")
+    }
+
+    # Build competitive flows per brand
+    flows_by_brand: dict[str, list] = {}
+    for flow in parsed.get("competitive_flows", []):
+        if isinstance(flow, dict):
+            brand = flow.get("from_brand", "")
+            if brand:
+                flows_by_brand.setdefault(brand, []).append(flow)
+
+    # Build brand-keyed safety signal lookups
+    safety_by_brand: dict[str, dict[str, int]] = {}
+    for sig in (safety_signals or []):
+        b = sig.get("brand", "")
+        if b:
+            safety_by_brand.setdefault(b, {})[sig.get("consequence") or "unknown"] = sig.get("count", 0)
+
+    # Build brand-keyed loyalty/replacement lookups
+    loyalty_by_brand: dict[str, dict[str, int]] = {}
+    replacement_by_brand: dict[str, dict[str, int]] = {}
+    for row in (loyalty_churn or []):
+        b = row.get("brand", "")
+        if not b:
+            continue
+        cnt = row.get("count", 0)
+        loy = row.get("loyalty") or "unknown"
+        rep = row.get("replacement") or "unknown"
+        loyalty_by_brand.setdefault(b, {})
+        loyalty_by_brand[b][loy] = loyalty_by_brand[b].get(loy, 0) + cnt
+        replacement_by_brand.setdefault(b, {})
+        replacement_by_brand[b][rep] = replacement_by_brand[b].get(rep, 0) + cnt
+
+    # Build batch of parameter tuples
+    upsert_rows: list[tuple] = []
+    for brand_data in brand_health:
+        brand = brand_data.get("brand")
+        if not brand:
+            continue
+
+        scorecard = scorecards.get(brand, {})
+        health = _compute_vulnerability_score(brand_data)
+
+        # Merge safety signals into sentiment_breakdown
+        sentiment = dict(scorecard.get("sentiment_breakdown", {}))
+        brand_safety = safety_by_brand.get(brand)
+        if brand_safety:
+            sentiment["safety_signals"] = brand_safety
+
+        # Merge loyalty/replacement into buyer_profile
+        buyer = dict(scorecard.get("buyer_profile", {}))
+        brand_loyalty = loyalty_by_brand.get(brand)
+        if brand_loyalty:
+            buyer["loyalty_distribution"] = brand_loyalty
+        brand_replacement = replacement_by_brand.get(brand)
+        if brand_replacement:
+            buyer["replacement_distribution"] = brand_replacement
+
+        source_review_count = brand_data.get("total_reviews", 0)
+        source_dist = json.dumps({"amazon": source_review_count})
+        brand_confidence = _compute_consumer_confidence(
+            mention_count=brand_data.get("total_reviews", 0),
+            deep_enriched_count=brand_data.get("total_reviews", 0),
+            total_count=brand_data.get("total_reviews", 0),
+            severity_counts=brand_data.get("severity_distribution"),
+        )
+
+        upsert_rows.append((
+            brand,
+            "all",
+            brand_data.get("total_reviews", 0),
+            brand_data.get("avg_rating"),
+            brand_data.get("avg_pain_score"),
+            brand_data.get("repurchase_yes", 0),
+            brand_data.get("repurchase_no", 0),
+            json.dumps(sentiment),
+            json.dumps(scorecard.get("top_feature_requests", [])),
+            json.dumps(scorecard.get("top_complaints", [])),
+            json.dumps(flows_by_brand.get(brand, [])),
+            json.dumps(buyer),
+            json.dumps(scorecard.get("positive_aspects", [])),
+            health,
+            now,
+            source_review_count,
+            source_dist,
+            brand_confidence,
+        ))
+
+    if upsert_rows:
+        try:
+            await pool.executemany(
+                """
+                INSERT INTO brand_intelligence (
+                    brand, source, total_reviews, avg_rating, avg_pain_score,
+                    repurchase_yes, repurchase_no,
+                    sentiment_breakdown, top_feature_requests, top_complaints,
+                    competitive_flows, buyer_profile, positive_aspects,
+                    health_score, last_computed_at,
+                    source_review_count, source_distribution, confidence_score
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb, $18)
+                ON CONFLICT (brand, source) DO UPDATE SET
+                    total_reviews = EXCLUDED.total_reviews,
+                    avg_rating = EXCLUDED.avg_rating,
+                    avg_pain_score = EXCLUDED.avg_pain_score,
+                    repurchase_yes = EXCLUDED.repurchase_yes,
+                    repurchase_no = EXCLUDED.repurchase_no,
+                    sentiment_breakdown = EXCLUDED.sentiment_breakdown,
+                    top_feature_requests = EXCLUDED.top_feature_requests,
+                    top_complaints = EXCLUDED.top_complaints,
+                    competitive_flows = EXCLUDED.competitive_flows,
+                    buyer_profile = EXCLUDED.buyer_profile,
+                    positive_aspects = EXCLUDED.positive_aspects,
+                    health_score = EXCLUDED.health_score,
+                    last_computed_at = EXCLUDED.last_computed_at,
+                    source_review_count = EXCLUDED.source_review_count,
+                    source_distribution = EXCLUDED.source_distribution,
+                    confidence_score = EXCLUDED.confidence_score
+                """,
+                upsert_rows,
+            )
+            upserted = len(upsert_rows)
+        except Exception:
+            logger.exception("Failed to batch-upsert brand intelligence")
+
+    if upserted:
+        logger.info("Upserted %d brand intelligence scorecards", upserted)
+
+
+async def _persist_brand_snapshots(
+    pool,
+    brand_health: list[dict[str, Any]],
+    parsed: dict[str, Any],
+) -> int:
+    """Persist daily brand health snapshots (append-only)."""
+    today = date.today()
+    persisted = 0
+
+    scorecards = {
+        sc["brand"]: sc
+        for sc in (parsed.get("brand_vulnerability", []) or parsed.get("brand_scorecards", []))
+        if isinstance(sc, dict) and sc.get("brand")
+    }
+
+    # Fetch trajectory data from materialized view (if it exists)
+    trajectory_by_brand: dict[str, tuple[int, int]] = {}
+    try:
+        traj_rows = await pool.fetch(
+            "SELECT brand, trajectory_positive, trajectory_negative "
+            "FROM mv_brand_summary WHERE brand IS NOT NULL"
+        )
+        for tr in traj_rows:
+            trajectory_by_brand[tr["brand"]] = (
+                tr["trajectory_positive"] or 0,
+                tr["trajectory_negative"] or 0,
+            )
+    except Exception:
+        logger.debug("mv_brand_summary not available for trajectory data", exc_info=True)
+
+    snapshot_rows: list[tuple] = []
+    for bd in brand_health:
+        brand = bd.get("brand")
+        if not brand:
+            continue
+        sc = scorecards.get(brand, {})
+        top_complaints = sc.get("top_complaints", [])
+        top_features = sc.get("top_feature_requests", [])
+        flows = sc.get("competitive_flows") or parsed.get("competitive_flows", [])
+        flow_count = sum(1 for f in flows if isinstance(f, dict) and f.get("from_brand") == brand)
+
+        snapshot_rows.append((
+            brand, today,
+            bd.get("total_reviews", 0),
+            bd.get("avg_rating"),
+            bd.get("avg_pain_score"),
+            _compute_vulnerability_score(bd),
+            bd.get("repurchase_yes", 0),
+            bd.get("repurchase_no", 0),
+            sum(bd.get("severity_distribution", {}).values()),
+            bd.get("safety_flagged_count", 0),
+            top_complaints[0].get("complaint", "") if top_complaints else None,
+            top_features[0].get("feature", "") if top_features else None,
+            flow_count,
+            trajectory_by_brand.get(brand, (0, 0))[0],
+            trajectory_by_brand.get(brand, (0, 0))[1],
+        ))
+
+    if snapshot_rows:
+        try:
+            await pool.executemany(
+                """
+                INSERT INTO brand_intelligence_snapshots (
+                    brand, snapshot_date, total_reviews, avg_rating,
+                    avg_pain_score, health_score,
+                    repurchase_yes, repurchase_no,
+                    complaint_count, safety_count,
+                    top_complaint, top_feature_request,
+                    competitive_flow_count,
+                    trajectory_positive, trajectory_negative
+                ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                ON CONFLICT (brand, snapshot_date) DO UPDATE SET
+                    total_reviews = EXCLUDED.total_reviews,
+                    avg_rating = EXCLUDED.avg_rating,
+                    avg_pain_score = EXCLUDED.avg_pain_score,
+                    health_score = EXCLUDED.health_score,
+                    repurchase_yes = EXCLUDED.repurchase_yes,
+                    repurchase_no = EXCLUDED.repurchase_no,
+                    complaint_count = EXCLUDED.complaint_count,
+                    safety_count = EXCLUDED.safety_count,
+                    top_complaint = EXCLUDED.top_complaint,
+                    top_feature_request = EXCLUDED.top_feature_request,
+                    competitive_flow_count = EXCLUDED.competitive_flow_count,
+                    trajectory_positive = EXCLUDED.trajectory_positive,
+                    trajectory_negative = EXCLUDED.trajectory_negative
+                """,
+                snapshot_rows,
+            )
+            persisted = len(snapshot_rows)
+        except Exception:
+            logger.exception("Failed to batch-persist brand snapshots")
+
+    if persisted:
+        logger.info("Persisted %d brand intelligence snapshots for %s", persisted, today)
+    return persisted
+
+
+async def _detect_change_events(
+    pool,
+    brand_health: list[dict[str, Any]],
+) -> int:
+    """Compare today's brand metrics against prior snapshot; log anomalies."""
+    today = date.today()
+    detected = 0
+
+    for bd in brand_health:
+        brand = bd.get("brand")
+        if not brand:
+            continue
+
+        # Fetch most recent prior snapshot
+        prior = await pool.fetchrow(
+            """
+            SELECT avg_pain_score, health_score, safety_count,
+                   repurchase_yes, repurchase_no, avg_rating
+            FROM brand_intelligence_snapshots
+            WHERE brand = $1 AND snapshot_date < $2
+            ORDER BY snapshot_date DESC LIMIT 1
+            """,
+            brand, today,
+        )
+        if not prior:
+            continue
+
+        events: list[tuple[str, str, float | None, float | None, float | None]] = []
+        cur_pain = float(bd.get("avg_pain_score") or 0)
+        old_pain = float(prior["avg_pain_score"] or 0)
+
+        # Pain score spike (>= 1.5 points)
+        if old_pain > 0 and cur_pain - old_pain >= 1.5:
+            events.append((
+                "pain_score_spike",
+                f"{brand} pain score spiked from {old_pain:.1f} to {cur_pain:.1f}",
+                old_pain, cur_pain, cur_pain - old_pain,
+            ))
+
+        # Health score spike (vulnerability increase >= 10 pts on 0-100)
+        cur_health = _compute_vulnerability_score(bd)
+        old_health = float(prior["health_score"] or 0)
+        if old_health > 0 and cur_health - old_health >= 10:
+            events.append((
+                "vulnerability_spike",
+                f"{brand} vulnerability score rose from {old_health:.0f} to {cur_health:.0f}",
+                old_health, cur_health, cur_health - old_health,
+            ))
+
+        # Safety signal emergence (new safety count > 0 when prior was 0)
+        cur_safety = bd.get("safety_flagged_count", 0)
+        old_safety = prior["safety_count"] or 0
+        if cur_safety > 0 and old_safety == 0:
+            events.append((
+                "safety_flag_emergence",
+                f"{brand} gained {cur_safety} safety-flagged reviews (was 0)",
+                float(old_safety), float(cur_safety), float(cur_safety),
+            ))
+
+        # Repurchase rate decline (>= 15 percentage points)
+        cur_yes = bd.get("repurchase_yes", 0)
+        cur_no = bd.get("repurchase_no", 0)
+        old_yes = prior["repurchase_yes"] or 0
+        old_no = prior["repurchase_no"] or 0
+        cur_rate = cur_yes / (cur_yes + cur_no) * 100 if (cur_yes + cur_no) > 0 else 0
+        old_rate = old_yes / (old_yes + old_no) * 100 if (old_yes + old_no) > 0 else 0
+        if old_rate > 0 and old_rate - cur_rate >= 15:
+            events.append((
+                "repurchase_decline",
+                f"{brand} repurchase rate dropped from {old_rate:.0f}% to {cur_rate:.0f}%",
+                old_rate, cur_rate, cur_rate - old_rate,
+            ))
+
+        # Rating drop (>= 0.5 stars)
+        cur_rating = float(bd.get("avg_rating") or 0)
+        old_rating = float(prior["avg_rating"] or 0)
+        if old_rating > 0 and old_rating - cur_rating >= 0.5:
+            events.append((
+                "rating_drop",
+                f"{brand} avg rating dropped from {old_rating:.2f} to {cur_rating:.2f}",
+                old_rating, cur_rating, cur_rating - old_rating,
+            ))
+
+        for event_type, description, old_val, new_val, delta in events:
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO product_change_events
+                        (brand, event_date, event_type, description,
+                         old_value, new_value, delta)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    """,
+                    brand, today, event_type, description,
+                    old_val, new_val, delta,
+                )
+                detected += 1
+            except Exception:
+                logger.warning("Failed to log change event for %s", brand, exc_info=True)
+
+    if detected:
+        logger.info("Detected %d consumer change events", detected)
+    return detected
+
+
+# ------------------------------------------------------------------
+# Concurrent shift detection (market-level)
+# ------------------------------------------------------------------
+
+
+async def _detect_concurrent_shifts(pool) -> int:
+    """Detect dates where 3+ brands had the same event type -- signals market trend."""
+    today = date.today()
+    detected = 0
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT event_type, COUNT(DISTINCT brand) AS brand_count,
+                   ARRAY_AGG(DISTINCT brand ORDER BY brand) AS brands,
+                   AVG(delta) AS avg_delta
+            FROM product_change_events
+            WHERE event_date = $1
+              AND brand != '__market__'
+            GROUP BY event_type
+            HAVING COUNT(DISTINCT brand) >= 3
+            """,
+            today,
+        )
+        for row in rows:
+            event_type = row["event_type"]
+            brand_count = row["brand_count"]
+            brands = row["brands"]
+            avg_delta = round(float(row["avg_delta"] or 0), 2)
+            brand_list = ", ".join(brands[:5])
+            suffix = f" +{brand_count - 5} more" if brand_count > 5 else ""
+            description = (
+                f"Concurrent {event_type} across {brand_count} brands: "
+                f"{brand_list}{suffix} (avg delta: {avg_delta})"
+            )
+            try:
+                await pool.execute(
+                    """
+                    INSERT INTO product_change_events
+                        (brand, event_date, event_type, description, delta, metadata)
+                    VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                    """,
+                    "__market__",
+                    today,
+                    "concurrent_shift",
+                    description,
+                    avg_delta,
+                    json.dumps({
+                        "original_event_type": event_type,
+                        "brand_count": brand_count,
+                        "brands": brands,
+                    }),
+                )
+                detected += 1
+            except Exception:
+                logger.debug("Failed to persist concurrent_shift for %s", event_type)
+    except Exception:
+        logger.debug("Concurrent shift detection skipped", exc_info=True)
+    if detected:
+        logger.info("Detected %d concurrent shifts for %s", detected, today)
+    return detected
+
+
+# ------------------------------------------------------------------
+# Webhook dispatch for consumer events
+# ------------------------------------------------------------------
+
+
+async def _dispatch_consumer_events(
+    pool, brand_health: list, change_events: int, concurrent_shifts: int,
+) -> None:
+    """Dispatch consumer webhook events for change events and report generation."""
+    try:
+        from ...services.b2b.webhook_dispatcher import dispatch_consumer_webhooks
+
+        _METRIC_KEYS = {
+            "avg_rating", "total_reviews", "avg_pain_score",
+            "repurchase_yes", "repurchase_no", "safety_flagged_count",
+        }
+
+        # Dispatch report_generated for each brand analyzed
+        # brand_health is a list[dict] from _fetch_brand_health()
+        for bd in brand_health:
+            brand_name = bd.get("brand", "")
+            if not brand_name:
+                continue
+            await dispatch_consumer_webhooks(
+                pool, "consumer_report_generated", brand_name, {
+                    "event": "report_generated",
+                    "brand": brand_name,
+                    "metrics": {
+                        k: v for k, v in bd.items() if k in _METRIC_KEYS
+                    },
+                },
+            )
+
+        # Dispatch change events (already persisted, fetch today's)
+        if change_events > 0:
+            today = date.today()
+            rows = await pool.fetch(
+                """
+                SELECT brand, event_type, description, delta
+                FROM product_change_events
+                WHERE event_date = $1 AND brand != '__market__'
+                """,
+                today,
+            )
+            for r in rows:
+                await dispatch_consumer_webhooks(
+                    pool, "consumer_change_event", r["brand"], {
+                        "event_type": r["event_type"],
+                        "brand": r["brand"],
+                        "description": r["description"],
+                        "delta": float(r["delta"]) if r["delta"] else None,
+                    },
+                )
+
+        # Dispatch concurrent shifts
+        if concurrent_shifts > 0:
+            today = date.today()
+            shifts = await pool.fetch(
+                """
+                SELECT description, delta, metadata
+                FROM product_change_events
+                WHERE event_date = $1 AND brand = '__market__'
+                  AND event_type = 'concurrent_shift'
+                """,
+                today,
+            )
+            for s in shifts:
+                meta = s["metadata"]
+                if isinstance(meta, str):
+                    meta = json.loads(meta)
+                brands = (meta or {}).get("brands", [])
+                for brand in brands:
+                    await dispatch_consumer_webhooks(
+                        pool, "consumer_concurrent_shift", brand, {
+                            "description": s["description"],
+                            "delta": float(s["delta"]) if s["delta"] else None,
+                            "metadata": meta,
+                        },
+                    )
+    except Exception:
+        logger.debug("Consumer webhook dispatch skipped", exc_info=True)
+
+
+# ------------------------------------------------------------------
+# Displacement edge persistence
+# ------------------------------------------------------------------
+
+
+async def _persist_displacement_edges(pool) -> int:
+    """Extract competitive flows from deep-enriched reviews and persist as canonical edges.
+
+    Uses SQL-level GROUP BY to pre-aggregate per (brand, product_name, direction),
+    reducing ~100k rows to ~500-1000 groups before Python brand normalization.
+    """
+    from ...pipelines.comparisons import (
+        ADJACENCY_DIRECTIONS,
+        load_known_brands,
+        normalize_brand,
+        normalize_canonical_brand,
+    )
+
+    today = date.today()
+    known_brands = await load_known_brands(pool)
+
+    # Pre-aggregate in SQL -- avoids fetching 100k+ individual rows
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pm.brand AS reviewed_brand,
+            comp->>'product_name' AS product_name,
+            COALESCE(comp->>'direction', 'compared') AS direction,
+            COUNT(*) AS mention_count,
+            AVG(pr.rating) AS avg_rating,
+            COUNT(*) FILTER (WHERE pr.severity = 'critical') AS sev_critical,
+            COUNT(*) FILTER (WHERE pr.severity = 'major') AS sev_major,
+            COUNT(*) FILTER (WHERE pr.severity = 'minor') AS sev_minor,
+            MODE() WITHIN GROUP (ORDER BY {_CAT_EXPR}) AS top_category,
+            (ARRAY_AGG(pr.id))[1:20] AS sample_ids
+        FROM product_reviews pr
+        JOIN product_metadata pm ON pm.asin = pr.asin,
+             jsonb_array_elements(
+                 CASE jsonb_typeof(pr.deep_extraction->'product_comparisons')
+                      WHEN 'array' THEN pr.deep_extraction->'product_comparisons'
+                      ELSE '[]'::jsonb
+                 END
+             ) AS comp
+        WHERE pr.deep_enrichment_status = 'enriched'
+          AND pr.deep_extraction->'product_comparisons' IS NOT NULL
+          AND pm.brand IS NOT NULL AND pm.brand != ''
+        GROUP BY pm.brand, comp->>'product_name', comp->>'direction'
+        """,
+    )
+
+    # Normalize brands and merge groups that collapse to the same canonical pair
+    edge_map: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    for row in rows:
+        direction = row["direction"]
+        if direction in ADJACENCY_DIRECTIONS:
+            continue
+
+        raw_other = (row["product_name"] or "").strip()
+        reviewed_brand = (row["reviewed_brand"] or "").strip()
+
+        normalized_other = normalize_brand(raw_other, known_brands)
+        if not normalized_other:
+            continue
+        normalized_reviewed = normalize_canonical_brand(reviewed_brand, known_brands)
+        if not normalized_reviewed:
+            continue
+        if normalized_other.lower() == normalized_reviewed.lower():
+            continue
+
+        if direction == "switched_from":
+            from_brand, to_brand = normalized_other, normalized_reviewed
+        elif direction == "switched_to":
+            from_brand, to_brand = normalized_reviewed, normalized_other
+        else:
+            from_brand, to_brand = normalized_reviewed, normalized_other
+
+        # Resolve through brand registry
+        from_brand = resolve_brand_name_cached(from_brand)
+        to_brand = resolve_brand_name_cached(to_brand)
+
+        mc = row["mention_count"]
+        key = (from_brand, to_brand, direction)
+        if key not in edge_map:
+            edge_map[key] = {
+                "mention_count": 0,
+                "rating_sum": 0.0,
+                "rating_count": 0,
+                "categories": {},
+                "sample_ids": [],
+                "severity": {"critical": 0, "major": 0, "minor": 0},
+                "deep_count": 0,
+            }
+
+        e = edge_map[key]
+        e["mention_count"] += mc
+        e["deep_count"] += mc  # all rows are enriched by WHERE clause
+        if row["avg_rating"] is not None:
+            e["rating_sum"] += float(row["avg_rating"]) * mc
+            e["rating_count"] += mc
+        cat = row["top_category"] or "unknown"
+        e["categories"][cat] = e["categories"].get(cat, 0) + mc
+        # Merge sample_ids (cap at 20)
+        if len(e["sample_ids"]) < 20:
+            for sid in (row["sample_ids"] or []):
+                if len(e["sample_ids"]) >= 20:
+                    break
+                e["sample_ids"].append(sid)
+        e["severity"]["critical"] += row["sev_critical"]
+        e["severity"]["major"] += row["sev_major"]
+        e["severity"]["minor"] += row["sev_minor"]
+
+    # Build batch of rows for executemany (edges with >= 2 mentions)
+    upsert_rows: list[tuple] = []
+    for (from_b, to_b, dirn), e in edge_map.items():
+        mc = e["mention_count"]
+        if mc < 2:
+            continue
+
+        if mc >= 10:
+            strength = "strong"
+        elif mc >= 4:
+            strength = "moderate"
+        else:
+            strength = "emerging"
+
+        avg_r = round(e["rating_sum"] / e["rating_count"], 2) if e["rating_count"] else None
+        conf = _compute_consumer_confidence(mc, e["deep_count"], mc, e["severity"])
+
+        upsert_rows.append((
+            from_b, to_b, dirn, mc, strength, avg_r,
+            json.dumps(e["categories"]), e["sample_ids"][:20], conf, today,
+        ))
+
+    if not upsert_rows:
+        return 0
+
+    persisted = 0
+    try:
+        await pool.executemany(
+            """
+            INSERT INTO product_displacement_edges (
+                from_brand, to_brand, direction, mention_count,
+                signal_strength, avg_rating, category_distribution,
+                sample_review_ids, confidence_score, computed_date
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::uuid[], $9, $10)
+            ON CONFLICT (from_brand, to_brand, direction, computed_date)
+            DO UPDATE SET
+                mention_count = EXCLUDED.mention_count,
+                signal_strength = EXCLUDED.signal_strength,
+                avg_rating = EXCLUDED.avg_rating,
+                category_distribution = EXCLUDED.category_distribution,
+                sample_review_ids = EXCLUDED.sample_review_ids,
+                confidence_score = EXCLUDED.confidence_score
+            """,
+            upsert_rows,
+        )
+        persisted = len(upsert_rows)
+    except Exception:
+        logger.exception("Failed to batch-persist displacement edges")
+
+    if persisted:
+        logger.info("Persisted %d product displacement edges for %s", persisted, today)
+    return persisted

--- a/extracted_content_pipeline/autonomous/tasks/complaint_analysis.py
+++ b/extracted_content_pipeline/autonomous/tasks/complaint_analysis.py
@@ -1,0 +1,527 @@
+"""
+Complaint analysis: aggregate enriched product reviews by category and ASIN,
+feed to LLM with prior reports, and persist structured conclusions.
+
+Runs daily (default 9 PM). Handles its own LLM call, report persistence,
+product_pain_points upserts, and ntfy notification -- returns _skip_synthesis
+so the runner does not double-synthesize.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.autonomous.tasks.complaint_analysis")
+
+# Category filter expression matching blog topic selection (categories->>2 granular)
+_CAT_EXPR = (
+    "COALESCE(REPLACE(pm.categories->>2, '&amp;', '&'),"
+    " REPLACE(pm.categories->>1, '&amp;', '&'), pr.source_category)"
+)
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: daily complaint analysis."""
+    cfg = settings.external_data
+    if not cfg.complaint_mining_enabled or not cfg.complaint_analysis_enabled:
+        return {"_skip_synthesis": "Complaint analysis disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    today = date.today()
+
+    # Skip if we already have a report for today
+    existing = await pool.fetchrow(
+        "SELECT id FROM complaint_reports WHERE report_date = $1 LIMIT 1",
+        today,
+    )
+    if existing:
+        return {"_skip_synthesis": f"Report already exists for {today}"}
+
+    # Gather data sources in parallel
+    category_stats, product_stats, prior_reports, data_context = await asyncio.gather(
+        _fetch_category_stats(pool),
+        _fetch_product_stats(pool),
+        _fetch_prior_reports(pool),
+        _fetch_data_context(pool),
+        return_exceptions=True,
+    )
+
+    # Convert exceptions to empty values
+    if isinstance(category_stats, Exception):
+        logger.warning("Category stats fetch failed: %s", category_stats)
+        category_stats = []
+    if isinstance(product_stats, Exception):
+        logger.warning("Product stats fetch failed: %s", product_stats)
+        product_stats = []
+    if isinstance(prior_reports, Exception):
+        logger.warning("Prior reports fetch failed: %s", prior_reports)
+        prior_reports = []
+    if isinstance(data_context, Exception):
+        logger.warning("Data context fetch failed: %s", data_context)
+        data_context = {}
+
+    # Check if there's enough data
+    total_enriched = sum(c.get("total_enriched", 0) for c in category_stats)
+    if total_enriched == 0 and not product_stats:
+        return {"_skip_synthesis": "No enriched reviews to analyze"}
+
+    # Build payload -- trim to fit ~4k token input budget (8k context - 4k output).
+    # Full product_stats used below for upserts.
+    llm_product_stats = [
+        {
+            "asin": p["asin"],
+            "category": p["category"],
+            "complaints": p["complaint_count"],
+            "pain": p["avg_pain_score"],
+            "rating": p["avg_rating"],
+            "top_complaints": p["top_complaints"][:2],
+            "root_causes": p["root_causes"],
+        }
+        for p in product_stats[:15]
+    ]
+    # Compact category stats for LLM
+    llm_categories = [
+        {
+            "category": c["category"],
+            "count": c["total_enriched"],
+            "period": c.get("review_period", ""),
+            "pain": c["avg_pain_score"],
+            "top_cause": c["top_root_cause"],
+        }
+        for c in category_stats
+    ]
+    payload = {
+        "date": str(today),
+        "data_context": data_context,
+        "total_products_with_complaints": len(product_stats),
+        "category_stats": llm_categories,
+        "product_stats": llm_product_stats,
+    }
+
+    # Load skill and call LLM (in thread to avoid blocking event loop)
+    from ...pipelines.llm import call_llm_with_skill, parse_json_response
+
+    usage: dict[str, Any] = {}
+    try:
+        analysis = await asyncio.wait_for(
+            asyncio.to_thread(
+                call_llm_with_skill,
+                "digest/complaint_analysis", payload,
+                max_tokens=cfg.complaint_analysis_max_tokens, temperature=0.4,
+                workload="synthesis",
+                response_format={"type": "json_object"},
+                usage_out=usage,
+            ),
+            timeout=300,
+        )
+    except asyncio.TimeoutError:
+        logger.error("LLM call timed out after 300s for complaint_analysis")
+        # Still upsert pain points even if LLM times out
+        await _upsert_pain_points(pool, product_stats, {})
+        return {"_skip_synthesis": "LLM analysis timed out", "products_upserted": len(product_stats)}
+    if usage.get("input_tokens"):
+        logger.info("complaint_analysis LLM tokens: in=%d out=%d model=%s",
+                     usage["input_tokens"], usage["output_tokens"], usage.get("model", ""))
+    if not analysis:
+        return {"_skip_synthesis": "LLM analysis failed"}
+
+    # Parse structured output
+    parsed = parse_json_response(analysis, recover_truncated=True)
+
+    # Persist to complaint_reports
+    try:
+        await pool.execute(
+            """
+            INSERT INTO complaint_reports (
+                report_date, report_type, category_filter,
+                analysis_output, top_pain_points, opportunities,
+                recommendations, product_highlights
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            """,
+            today,
+            "daily",
+            None,
+            parsed.get("analysis_text", analysis),
+            json.dumps(parsed.get("top_pain_points", [])),
+            json.dumps(parsed.get("opportunities", [])),
+            json.dumps(parsed.get("recommendations", [])),
+            json.dumps(parsed.get("product_highlights", [])),
+        )
+        logger.info("Stored complaint report for %s", today)
+    except Exception:
+        logger.exception("Failed to store complaint report")
+
+    # Upsert product_pain_points from product_stats
+    await _upsert_pain_points(pool, product_stats, parsed)
+
+    # Send ntfy notification
+    from ...pipelines.notify import send_pipeline_notification
+
+    await send_pipeline_notification(
+        parsed.get("analysis_text", analysis), task,
+        title="Atlas: Complaint Analysis",
+        default_tags="brain,shopping_cart",
+        parsed=parsed,
+    )
+
+    return {
+        "_skip_synthesis": "Complaint analysis complete",
+        "date": str(today),
+        "categories": len(category_stats),
+        "products_analyzed": len(product_stats),
+        "total_enriched": total_enriched,
+        "pain_points": len(parsed.get("top_pain_points", [])),
+        "opportunities": len(parsed.get("opportunities", [])),
+    }
+
+
+# ------------------------------------------------------------------
+# Data fetchers
+# ------------------------------------------------------------------
+
+
+async def _fetch_data_context(pool) -> dict[str, Any]:
+    """Compute temporal metadata for the dataset so the LLM can anchor claims."""
+    row = await pool.fetchrow(
+        """
+        SELECT
+            count(*) AS total_enriched,
+            count(*) FILTER (WHERE reviewed_at IS NOT NULL) AS with_date,
+            min(reviewed_at) AS earliest_review,
+            max(reviewed_at) AS latest_review,
+            count(*) FILTER (WHERE reviewed_at >= NOW() - INTERVAL '1 year') AS last_1y,
+            count(*) FILTER (WHERE reviewed_at >= NOW() - INTERVAL '3 years') AS last_3y,
+            count(*) FILTER (WHERE reviewed_at < NOW() - INTERVAL '3 years') AS older_3y
+        FROM product_reviews
+        WHERE enrichment_status = 'enriched'
+        """
+    )
+    return {
+        "total_reviews_analyzed": row["total_enriched"],
+        "reviews_with_dates": row["with_date"],
+        "review_period": {
+            "earliest": str(row["earliest_review"].date()) if row["earliest_review"] else None,
+            "latest": str(row["latest_review"].date()) if row["latest_review"] else None,
+        },
+        "recency": {
+            "last_1_year": row["last_1y"],
+            "last_3_years": row["last_3y"],
+            "older_than_3_years": row["older_3y"],
+        },
+        "note": "Use these date ranges when citing statistics. Say 'over the past N years' or 'between YYYY and YYYY' instead of unanchored claims.",
+    }
+
+
+async def _fetch_category_stats(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Aggregate enriched reviews by category (all enriched, no time window).
+
+    Uses a single bulk query for root cause distributions instead of N+1.
+    When category is given, JOINs product_metadata and uses the granular
+    COALESCE expression instead of source_category.
+    """
+    if category:
+        cat_group = _CAT_EXPR
+        join_clause = "LEFT JOIN product_metadata pm ON pm.asin = pr.asin"
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params: list = [category]
+    else:
+        cat_group = "pr.source_category"
+        join_clause = ""
+        cat_filter = ""
+        params = []
+
+    rows, rc_rows = await asyncio.gather(
+        pool.fetch(
+            f"""
+            SELECT
+                {cat_group} AS category,
+                count(*) AS total_enriched,
+                count(*) FILTER (WHERE pr.severity = 'critical') AS critical_count,
+                count(*) FILTER (WHERE pr.severity = 'major') AS major_count,
+                count(*) FILTER (WHERE pr.severity = 'minor') AS minor_count,
+                avg(pr.pain_score) AS avg_pain_score,
+                mode() WITHIN GROUP (ORDER BY pr.root_cause) AS top_root_cause,
+                min(pr.reviewed_at)::date AS earliest_review,
+                max(pr.reviewed_at)::date AS latest_review
+            FROM product_reviews pr
+            {join_clause}
+            WHERE pr.enrichment_status = 'enriched'
+              {cat_filter}
+            GROUP BY category
+            ORDER BY count(*) DESC
+            """,
+            *params,
+        ),
+        pool.fetch(
+            f"""
+            SELECT {cat_group} AS category, pr.root_cause, count(*) AS cnt
+            FROM product_reviews pr
+            {join_clause}
+            WHERE pr.enrichment_status = 'enriched'
+              AND pr.root_cause IS NOT NULL
+              {cat_filter}
+            GROUP BY category, pr.root_cause
+            ORDER BY category, cnt DESC
+            """,
+            *params,
+        ),
+    )
+
+    # Build root cause lookup by category
+    rc_by_cat: dict[str, dict[str, int]] = {}
+    for row in rc_rows:
+        rc_by_cat.setdefault(row["category"], {})[row["root_cause"]] = row["cnt"]
+
+    result = []
+    for r in rows:
+        result.append({
+            "category": r["category"],
+            "total_enriched": r["total_enriched"],
+            "review_period": f"{r['earliest_review']} to {r['latest_review']}" if r["earliest_review"] else "dates unavailable",
+            "severity_distribution": {
+                "critical": r["critical_count"],
+                "major": r["major_count"],
+                "minor": r["minor_count"],
+            },
+            "root_cause_distribution": rc_by_cat.get(r["category"], {}),
+            "avg_pain_score": round(float(r["avg_pain_score"]), 2) if r["avg_pain_score"] else 0.0,
+            "top_root_cause": r["top_root_cause"],
+        })
+    return result
+
+
+async def _fetch_product_stats(pool, *, category: str | None = None) -> list[dict[str, Any]]:
+    """Aggregate by ASIN for products with 5+ complaints (all enriched, no time window).
+
+    Uses bulk queries instead of per-ASIN sub-queries to avoid N+1 pattern.
+    4 queries total instead of 4*N (was ~14k queries for 3,710 ASINs).
+    When category is given, JOINs product_metadata and filters to that category.
+    """
+    if category:
+        cat_group = _CAT_EXPR
+        join_clause = "LEFT JOIN product_metadata pm ON pm.asin = pr.asin"
+        cat_filter = f"AND {_CAT_EXPR} = $1"
+        params: list = [category]
+    else:
+        cat_group = "pr.source_category"
+        join_clause = ""
+        cat_filter = ""
+        params = []
+
+    rows = await pool.fetch(
+        f"""
+        SELECT
+            pr.asin,
+            {cat_group} AS category,
+            count(*) AS complaint_count,
+            avg(pr.pain_score) AS avg_pain_score,
+            avg(pr.rating) AS avg_rating
+        FROM product_reviews pr
+        {join_clause}
+        WHERE pr.enrichment_status = 'enriched'
+          {cat_filter}
+        GROUP BY pr.asin, category
+        HAVING count(*) >= 5
+        ORDER BY avg(pr.pain_score) DESC
+        """,
+        *params,
+    )
+    if not rows:
+        return []
+
+    # Bulk fetch all sub-data in 4 queries (replaces 4 queries per ASIN)
+    complaint_rows, rc_rows, mfg_rows, alt_rows = await asyncio.gather(
+        pool.fetch(
+            """
+            SELECT asin, specific_complaint, count(*) AS cnt
+            FROM product_reviews
+            WHERE enrichment_status = 'enriched'
+              AND specific_complaint IS NOT NULL
+            GROUP BY asin, specific_complaint
+            ORDER BY asin, cnt DESC
+            """,
+        ),
+        pool.fetch(
+            """
+            SELECT asin, root_cause, count(*) AS cnt
+            FROM product_reviews
+            WHERE enrichment_status = 'enriched'
+              AND root_cause IS NOT NULL
+            GROUP BY asin, root_cause
+            ORDER BY asin, cnt DESC
+            """,
+        ),
+        pool.fetch(
+            """
+            SELECT DISTINCT ON (asin, manufacturing_suggestion)
+                asin, manufacturing_suggestion
+            FROM product_reviews
+            WHERE enrichment_status = 'enriched'
+              AND actionable_for_manufacturing = true
+              AND manufacturing_suggestion IS NOT NULL
+            ORDER BY asin, manufacturing_suggestion
+            """,
+        ),
+        pool.fetch(
+            """
+            SELECT asin, alternative_name, count(*) AS cnt
+            FROM product_reviews
+            WHERE enrichment_status = 'enriched'
+              AND alternative_mentioned = true
+              AND alternative_name IS NOT NULL
+            GROUP BY asin, alternative_name
+            ORDER BY asin, cnt DESC
+            """,
+        ),
+    )
+
+    # Build lookup dicts keyed by ASIN
+    complaints_by_asin: dict[str, list[str]] = {}
+    for row in complaint_rows:
+        complaints_by_asin.setdefault(row["asin"], []).append(row["specific_complaint"])
+
+    rc_by_asin: dict[str, dict[str, int]] = {}
+    for row in rc_rows:
+        rc_by_asin.setdefault(row["asin"], {})[row["root_cause"]] = row["cnt"]
+
+    mfg_by_asin: dict[str, list[str]] = {}
+    for row in mfg_rows:
+        mfg_by_asin.setdefault(row["asin"], []).append(row["manufacturing_suggestion"])
+
+    alt_by_asin: dict[str, list[dict]] = {}
+    for row in alt_rows:
+        alt_by_asin.setdefault(row["asin"], []).append(
+            {"name": row["alternative_name"], "mentions": row["cnt"]}
+        )
+
+    # Assemble results
+    result = []
+    for r in rows:
+        asin = r["asin"]
+        result.append({
+            "asin": asin,
+            "category": r["category"],
+            "complaint_count": r["complaint_count"],
+            "avg_pain_score": round(float(r["avg_pain_score"]), 2) if r["avg_pain_score"] else 0.0,
+            "avg_rating": round(float(r["avg_rating"]), 2) if r["avg_rating"] else 0.0,
+            "top_complaints": complaints_by_asin.get(asin, [])[:5],
+            "root_causes": rc_by_asin.get(asin, {}),
+            "manufacturing_suggestions": mfg_by_asin.get(asin, [])[:5],
+            "alternatives": alt_by_asin.get(asin, [])[:5],
+        })
+
+    return result
+
+
+async def _fetch_prior_reports(pool, limit: int = 5) -> list[dict[str, Any]]:
+    """Fetch prior complaint_reports (most recent first)."""
+    rows = await pool.fetch(
+        """
+        SELECT report_date, report_type, analysis_output,
+               top_pain_points, opportunities, recommendations,
+               product_highlights
+        FROM complaint_reports
+        ORDER BY report_date DESC
+        LIMIT $1
+        """,
+        limit,
+    )
+    result = []
+    for r in rows:
+        entry: dict[str, Any] = {
+            "report_date": str(r["report_date"]),
+            "report_type": r["report_type"],
+            "analysis_output": (r["analysis_output"] or "")[:1000],
+        }
+        for field in ("top_pain_points", "opportunities", "recommendations", "product_highlights"):
+            val = r[field]
+            if isinstance(val, str):
+                try:
+                    val = json.loads(val)
+                except (json.JSONDecodeError, TypeError):
+                    val = []
+            entry[field] = val if isinstance(val, list) else []
+        result.append(entry)
+    return result
+
+
+# ------------------------------------------------------------------
+# Pain point upserts
+# ------------------------------------------------------------------
+
+
+async def _upsert_pain_points(
+    pool, product_stats: list[dict[str, Any]], parsed: dict[str, Any]
+) -> None:
+    """Upsert product_pain_points from aggregated product stats."""
+    now = datetime.now(timezone.utc)
+    upserted = 0
+
+    # Build a lookup from parsed highlights for product_name
+    highlights = {
+        h["asin"]: h
+        for h in parsed.get("product_highlights", [])
+        if isinstance(h, dict) and h.get("asin")
+    }
+
+    for prod in product_stats:
+        asin = prod.get("asin")
+        if not asin:
+            continue
+
+        highlight = highlights.get(asin, {})
+        product_name = highlight.get("product_name", "")
+
+        try:
+            await pool.execute(
+                """
+                INSERT INTO product_pain_points (
+                    asin, product_name, category,
+                    total_reviews, complaint_reviews, complaint_rate,
+                    top_complaints, root_cause_distribution, severity_distribution,
+                    differentiation_opportunities, alternative_products,
+                    pain_score, last_computed_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                ON CONFLICT (asin) DO UPDATE SET
+                    product_name = COALESCE(NULLIF(EXCLUDED.product_name, ''), product_pain_points.product_name),
+                    category = EXCLUDED.category,
+                    complaint_reviews = EXCLUDED.complaint_reviews,
+                    complaint_rate = EXCLUDED.complaint_rate,
+                    top_complaints = EXCLUDED.top_complaints,
+                    root_cause_distribution = EXCLUDED.root_cause_distribution,
+                    differentiation_opportunities = EXCLUDED.differentiation_opportunities,
+                    alternative_products = EXCLUDED.alternative_products,
+                    pain_score = EXCLUDED.pain_score,
+                    last_computed_at = EXCLUDED.last_computed_at
+                """,
+                asin,
+                product_name,
+                prod.get("category", ""),
+                prod.get("complaint_count", 0),  # total_reviews approximation
+                prod.get("complaint_count", 0),
+                1.0,  # all reviews in our dataset are complaints
+                json.dumps(prod.get("top_complaints", [])),
+                json.dumps(prod.get("root_causes", {})),
+                json.dumps({}),  # severity_distribution computed at category level
+                json.dumps([]),  # filled by analysis
+                json.dumps(prod.get("alternatives", [])),
+                prod.get("avg_pain_score", 0.0),
+                now,
+            )
+            upserted += 1
+        except Exception:
+            logger.warning("Failed to upsert pain point for %s", asin, exc_info=True)
+
+    if upserted:
+        logger.info("Upserted %d product pain points", upserted)
+
+

--- a/extracted_content_pipeline/autonomous/tasks/complaint_content_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/complaint_content_generation.py
@@ -1,0 +1,348 @@
+"""
+Content generation from complaint analysis: uses Claude (triage LLM) to produce
+sellable content -- forum posts, comparison articles, email copy -- from
+the highest-pain-score products identified by complaint_analysis.
+
+Runs daily after complaint_analysis (default 10 PM). Reads product_pain_points
+and recent complaint_reports, picks the top N products with alternatives, and
+generates content for each.
+
+Forces triage LLM (Claude) -- local models do not produce publication-quality
+copy. Falls back gracefully if Claude is unavailable.
+
+Returns _skip_synthesis.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.autonomous.tasks.complaint_content_generation")
+
+# Content types to generate per qualifying product
+_CONTENT_TYPES = ["comparison_article", "forum_post", "email_copy"]
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: generate sellable content from pain points."""
+    cfg = settings.external_data
+    if not cfg.complaint_mining_enabled or not cfg.complaint_content_enabled:
+        return {"_skip_synthesis": "Complaint content generation disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    max_products = cfg.complaint_content_max_per_run
+
+    # Find top pain-point products that have alternatives
+    candidates = await _fetch_candidates(pool, max_products)
+    if not candidates:
+        return {"_skip_synthesis": "No products with alternatives to generate content for"}
+
+    # Get category context for enriching prompts
+    category_ctx = await _fetch_category_context(pool)
+
+    from ...pipelines.llm import get_pipeline_llm
+
+    llm = get_pipeline_llm(workload="synthesis", try_openrouter=True, auto_activate_ollama=False)
+    if llm is None:
+        # Last resort: try active LLM
+        from ...services import llm_registry
+        llm = llm_registry.get_active()
+    if llm is None:
+        return {"_skip_synthesis": "Claude LLM not available for content generation"}
+
+    generated = 0
+    failed = 0
+    today = date.today()
+
+    for product in candidates:
+        asin = product["asin"]
+        # Check what content we've already generated for this ASIN recently
+        existing = await _get_existing_content_types(pool, asin)
+
+        for content_type in _CONTENT_TYPES:
+            if content_type in existing:
+                continue  # Already generated this type
+
+            payload = _build_payload(content_type, product, category_ctx)
+            content = await _generate_content(llm, payload, cfg.complaint_content_max_tokens)
+
+            if content:
+                try:
+                    await pool.execute(
+                        """
+                        INSERT INTO complaint_content (
+                            content_type, category, target_asin, competitor_asin,
+                            title, body, pain_point_summary, source_report_date,
+                            status, llm_model
+                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                        """,
+                        content_type,
+                        product.get("category"),
+                        asin,
+                        (product.get("alternatives") or [{}])[0].get("name"),
+                        content.get("title", ""),
+                        content.get("body", ""),
+                        product.get("top_complaint", ""),
+                        today,
+                        "draft",
+                        "claude",
+                    )
+                    generated += 1
+                except Exception:
+                    logger.exception("Failed to store content for %s/%s", asin, content_type)
+                    failed += 1
+            else:
+                failed += 1
+
+    logger.info(
+        "Content generation: %d pieces generated, %d failed (from %d products)",
+        generated, failed, len(candidates),
+    )
+
+    # Send notification
+    if generated > 0:
+        from ...pipelines.notify import send_pipeline_notification
+
+        msg = f"Generated {generated} content pieces from {len(candidates)} high-pain products. Review drafts in complaint_content table."
+        await send_pipeline_notification(
+            msg, task, title="Atlas: Complaint Content",
+            default_tags="brain,memo",
+        )
+
+    return {
+        "_skip_synthesis": "Content generation complete",
+        "products": len(candidates),
+        "generated": generated,
+        "failed": failed,
+    }
+
+
+# ------------------------------------------------------------------
+# Data fetchers
+# ------------------------------------------------------------------
+
+
+async def _fetch_candidates(pool, limit: int) -> list[dict[str, Any]]:
+    """Fetch top pain-point products that have reviewer-mentioned alternatives."""
+    rows = await pool.fetch(
+        """
+        SELECT asin, product_name, category,
+               complaint_reviews, pain_score,
+               top_complaints, root_cause_distribution,
+               alternative_products
+        FROM product_pain_points
+        WHERE pain_score >= 4.0
+          AND alternative_products != '[]'::jsonb
+        ORDER BY pain_score DESC, complaint_reviews DESC
+        LIMIT $1
+        """,
+        limit,
+    )
+
+    result = []
+    for r in rows:
+        alternatives = r["alternative_products"]
+        if isinstance(alternatives, str):
+            try:
+                alternatives = json.loads(alternatives)
+            except (json.JSONDecodeError, TypeError):
+                alternatives = []
+
+        if not alternatives:
+            continue
+
+        top_complaints = r["top_complaints"]
+        if isinstance(top_complaints, str):
+            try:
+                top_complaints = json.loads(top_complaints)
+            except (json.JSONDecodeError, TypeError):
+                top_complaints = []
+
+        root_causes = r["root_cause_distribution"]
+        if isinstance(root_causes, str):
+            try:
+                root_causes = json.loads(root_causes)
+            except (json.JSONDecodeError, TypeError):
+                root_causes = {}
+
+        # Get avg rating from reviews
+        rating_row = await pool.fetchrow(
+            "SELECT avg(rating) AS avg_rating FROM product_reviews WHERE asin = $1",
+            r["asin"],
+        )
+        avg_rating = round(float(rating_row["avg_rating"]), 1) if rating_row and rating_row["avg_rating"] else 0.0
+
+        result.append({
+            "asin": r["asin"],
+            "product_name": r["product_name"] or r["asin"],
+            "category": r["category"],
+            "complaint_count": r["complaint_reviews"],
+            "avg_pain_score": float(r["pain_score"]),
+            "avg_rating": avg_rating,
+            "top_complaints": top_complaints[:5] if isinstance(top_complaints, list) else [],
+            "root_causes": root_causes if isinstance(root_causes, dict) else {},
+            "alternatives": alternatives[:3] if isinstance(alternatives, list) else [],
+            "top_complaint": top_complaints[0] if isinstance(top_complaints, list) and top_complaints else "",
+        })
+
+    return result
+
+
+async def _fetch_category_context(pool) -> dict[str, dict[str, Any]]:
+    """Fetch per-category aggregate context for content enrichment."""
+    rows = await pool.fetch(
+        """
+        SELECT source_category AS category,
+               count(*) AS total_complaints,
+               avg(pain_score) AS avg_pain_score,
+               mode() WITHIN GROUP (ORDER BY root_cause) AS top_root_cause
+        FROM product_reviews
+        WHERE enrichment_status = 'enriched'
+        GROUP BY source_category
+        """,
+    )
+    return {
+        r["category"]: {
+            "category": r["category"],
+            "total_complaints": r["total_complaints"],
+            "avg_pain_score": round(float(r["avg_pain_score"]), 1) if r["avg_pain_score"] else 0.0,
+            "top_root_cause": r["top_root_cause"],
+        }
+        for r in rows
+    }
+
+
+async def _get_existing_content_types(pool, asin: str) -> set[str]:
+    """Check which content types already exist for this ASIN (within last 30 days)."""
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT content_type
+        FROM complaint_content
+        WHERE target_asin = $1
+          AND created_at > NOW() - INTERVAL '30 days'
+        """,
+        asin,
+    )
+    return {r["content_type"] for r in rows}
+
+
+# ------------------------------------------------------------------
+# Payload & LLM
+# ------------------------------------------------------------------
+
+
+def _build_payload(
+    content_type: str,
+    product: dict[str, Any],
+    category_ctx: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the LLM input payload for content generation."""
+    # Get manufacturing suggestions from reviews if available
+    mfg = []
+    for complaint in product.get("top_complaints", []):
+        if isinstance(complaint, str) and complaint:
+            mfg.append(complaint)
+
+    return {
+        "content_type": content_type,
+        "target_product": {
+            "asin": product["asin"],
+            "product_name": product.get("product_name", product["asin"]),
+            "category": product.get("category", ""),
+            "complaint_count": product.get("complaint_count", 0),
+            "avg_pain_score": product.get("avg_pain_score", 0),
+            "avg_rating": product.get("avg_rating", 0),
+            "top_complaints": product.get("top_complaints", []),
+            "root_causes": product.get("root_causes", {}),
+            "manufacturing_suggestions": mfg[:3],
+        },
+        "alternatives": product.get("alternatives", []),
+        "category_context": category_ctx.get(product.get("category", ""), {}),
+    }
+
+
+async def _generate_content(
+    llm, payload: dict[str, Any], max_tokens: int
+) -> dict[str, Any] | None:
+    """Call LLM with content generation skill and parse response."""
+    from ...pipelines.llm import clean_llm_output
+    from ...skills import get_skill_registry
+    from ...services.protocols import Message
+
+    skill = get_skill_registry().get("digest/complaint_content_generation")
+    if not skill:
+        logger.warning("Skill 'digest/complaint_content_generation' not found")
+        return None
+
+    messages = [
+        Message(role="system", content=skill.content),
+        Message(role="user", content=json.dumps(payload, separators=(",", ":"), default=str)),
+    ]
+
+    try:
+        result = llm.chat(
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=0.7,  # Higher temp for creative writing
+        )
+        _usage = result.get("usage", {})
+        if _usage.get("input_tokens"):
+            logger.info("complaint_content_generation LLM tokens: in=%d out=%d",
+                         _usage["input_tokens"], _usage.get("output_tokens", 0))
+            from ...pipelines.llm import trace_llm_call
+            _trace = result.get("_trace_meta", {})
+            _target = payload.get("target_product", {})
+            trace_llm_call("task.complaint_content_generation", input_tokens=_usage["input_tokens"],
+                           output_tokens=_usage.get("output_tokens", 0),
+                           cached_tokens=_trace.get("cached_tokens") or _trace.get("cache_read_tokens"),
+                           cache_write_tokens=_trace.get("cache_write_tokens") or _trace.get("cache_creation_tokens"),
+                           billable_input_tokens=_trace.get("billable_input_tokens"),
+                           model=getattr(llm, "model", ""), provider=getattr(llm, "name", ""),
+                           input_data={
+                               "messages": [
+                                   {"role": m.role, "content": m.content[:500]} for m in messages
+                               ],
+                           },
+                           output_data={
+                               "response": result.get("response", "")[:2000],
+                           },
+                           api_endpoint=_trace.get("api_endpoint"),
+                           provider_request_id=_trace.get("provider_request_id"),
+                           ttft_ms=_trace.get("ttft_ms"),
+                           inference_time_ms=_trace.get("inference_time_ms"),
+                           queue_time_ms=_trace.get("queue_time_ms"),
+                           metadata={
+                               "workflow": "complaint_content_generation",
+                               "content_type": payload.get("content_type", ""),
+                               "asin": _target.get("asin", ""),
+                               "category": _target.get("category", ""),
+                               "avg_pain_score": _target.get("avg_pain_score", 0),
+                               "avg_rating": _target.get("avg_rating", 0),
+                           })
+        text = result.get("response", "").strip()
+        if not text:
+            return None
+
+        text = clean_llm_output(text)
+
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict) or "body" not in parsed:
+            logger.debug("Content generation missing 'body' field")
+            return None
+
+        return parsed
+
+    except json.JSONDecodeError:
+        logger.debug("Failed to parse content generation JSON: %.200s", text)
+        return None
+    except Exception:
+        logger.exception("Content generation LLM call failed")
+        return None

--- a/extracted_content_pipeline/autonomous/tasks/complaint_enrichment.py
+++ b/extracted_content_pipeline/autonomous/tasks/complaint_enrichment.py
@@ -1,0 +1,493 @@
+"""
+Review enrichment pipeline: classify pending product reviews via LLM.
+
+Routes by rating:
+  - 1-3 star: complaint_classification skill (root_cause, severity, pain_score...)
+  - 4-5 star: praise_classification skill (praise category, loyalty score...)
+
+Single phase (review text already stored -- no HTTP fetch needed).
+Polls product_reviews WHERE enrichment_status = 'pending', calls LLM,
+updates enrichment columns, sets status to 'enriched'.
+
+Supports two modes:
+  - Single (reviews_per_call=1): one LLM call per review (default, most reliable)
+  - Batch (reviews_per_call=2-10): N reviews per call (higher throughput, falls
+    back to single on parse failure)
+
+LLM routing:
+  - local_only=False (default): uses local vLLM first, then Anthropic only if vLLM is unavailable
+  - local_only=True: uses only the local vLLM path
+
+Runs on an interval (default 5 min). Returns _skip_synthesis so the
+runner does not double-synthesize.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from ...config import settings
+from ...storage.database import get_db_pool
+from ...storage.models import ScheduledTask
+
+logger = logging.getLogger("atlas.autonomous.tasks.complaint_enrichment")
+
+
+async def run(task: ScheduledTask) -> dict[str, Any]:
+    """Autonomous task handler: enrich pending product reviews."""
+    cfg = settings.external_data
+    if not cfg.complaint_mining_enabled:
+        return {"_skip_synthesis": "Complaint mining disabled"}
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "DB not ready"}
+
+    max_batch = cfg.complaint_enrichment_max_per_batch
+    max_attempts = cfg.complaint_enrichment_max_attempts
+    reviews_per_call = min(cfg.complaint_enrichment_reviews_per_call, 10)
+
+    rows = await pool.fetch(
+        """
+        SELECT id, asin, rating, summary, review_text,
+               hardware_category, issue_types,
+               enrichment_attempts
+        FROM product_reviews
+        WHERE enrichment_status = 'pending'
+          AND enrichment_attempts < $1
+        ORDER BY imported_at ASC
+        LIMIT $2
+        """,
+        max_attempts,
+        max_batch,
+    )
+
+    if not rows:
+        return {"_skip_synthesis": "No reviews to enrich"}
+
+    enriched = 0
+    failed = 0
+
+    if reviews_per_call > 1:
+        # Batch mode: process N reviews per LLM call
+        for i in range(0, len(rows), reviews_per_call):
+            chunk = rows[i:i + reviews_per_call]
+            batch_results = await _classify_batch(chunk, cfg.complaint_enrichment_local_only)
+
+            if batch_results and len(batch_results) == len(chunk):
+                # Batch succeeded -- apply all results
+                for row, classification in zip(chunk, batch_results):
+                    if classification and classification.get("root_cause"):
+                        await _apply_enrichment(pool, row, classification)
+                        enriched += 1
+                    else:
+                        await _increment_attempts(pool, row, max_attempts)
+                        if (row["enrichment_attempts"] + 1) >= max_attempts:
+                            failed += 1
+            else:
+                # Batch parse failed -- fall back to individual calls
+                logger.debug(
+                    "Batch parse failed for %d reviews, falling back to single mode",
+                    len(chunk),
+                )
+                for row in chunk:
+                    ok = await _enrich_single(pool, row, max_attempts, cfg.complaint_enrichment_local_only)
+                    if ok:
+                        enriched += 1
+                    elif (row["enrichment_attempts"] + 1) >= max_attempts:
+                        failed += 1
+    else:
+        # Single mode: one LLM call per review
+        for row in rows:
+            ok = await _enrich_single(pool, row, max_attempts, cfg.complaint_enrichment_local_only)
+            if ok:
+                enriched += 1
+            elif (row["enrichment_attempts"] + 1) >= max_attempts:
+                failed += 1
+
+    logger.info(
+        "Complaint enrichment: %d enriched, %d failed (of %d) [batch=%d]",
+        enriched, failed, len(rows), reviews_per_call,
+    )
+
+    return {
+        "_skip_synthesis": "Complaint enrichment complete",
+        "total": len(rows),
+        "enriched": enriched,
+        "failed": failed,
+        "batch_size": reviews_per_call,
+    }
+
+
+# ------------------------------------------------------------------
+# Single-review enrichment
+# ------------------------------------------------------------------
+
+
+async def _enrich_single(pool, row, max_attempts: int, local_only: bool) -> bool:
+    """Classify and store a single review. Returns True on success."""
+    review_id = row["id"]
+    attempts = row["enrichment_attempts"]
+
+    try:
+        classification = await _classify_review(
+            asin=row["asin"],
+            rating=float(row["rating"]),
+            summary=row["summary"] or "",
+            review_text=row["review_text"] or "",
+            hardware_category=list(row["hardware_category"] or []),
+            issue_types=list(row["issue_types"] or []),
+            local_only=local_only,
+        )
+
+        if classification:
+            await _apply_enrichment(pool, row, classification)
+            return True
+        else:
+            await _increment_attempts(pool, row, max_attempts)
+            return False
+
+    except Exception:
+        logger.exception("Failed to enrich review %s", review_id)
+        try:
+            await pool.execute(
+                "UPDATE product_reviews SET enrichment_attempts = enrichment_attempts + 1 WHERE id = $1",
+                review_id,
+            )
+        except Exception:
+            pass
+        return False
+
+
+async def _apply_enrichment(pool, row, classification: dict[str, Any]) -> None:
+    """Write classification results to the review row."""
+    await pool.execute(
+        """
+        UPDATE product_reviews
+        SET root_cause = $1,
+            specific_complaint = $2,
+            severity = $3,
+            pain_score = $4,
+            time_to_failure = $5,
+            workaround_found = $6,
+            workaround_text = $7,
+            alternative_mentioned = $8,
+            alternative_asin = $9,
+            alternative_name = $10,
+            actionable_for_manufacturing = $11,
+            manufacturing_suggestion = $12,
+            enrichment_status = 'enriched',
+            enrichment_attempts = $13,
+            enriched_at = $14
+        WHERE id = $15
+        """,
+        classification.get("root_cause"),
+        classification.get("specific_complaint"),
+        classification.get("severity"),
+        classification.get("pain_score"),
+        classification.get("time_to_failure"),
+        classification.get("workaround_found"),
+        classification.get("workaround_text"),
+        classification.get("alternative_mentioned"),
+        classification.get("alternative_asin"),
+        classification.get("alternative_name"),
+        classification.get("actionable_for_manufacturing"),
+        classification.get("manufacturing_suggestion"),
+        row["enrichment_attempts"] + 1,
+        datetime.now(timezone.utc),
+        row["id"],
+    )
+
+
+async def _increment_attempts(pool, row, max_attempts: int) -> None:
+    """Bump attempts; mark failed if exhausted."""
+    review_id = row["id"]
+    new_attempts = row["enrichment_attempts"] + 1
+    await pool.execute(
+        "UPDATE product_reviews SET enrichment_attempts = $1 WHERE id = $2",
+        new_attempts, review_id,
+    )
+    if new_attempts >= max_attempts:
+        await pool.execute(
+            "UPDATE product_reviews SET enrichment_status = 'failed' WHERE id = $1",
+            review_id,
+        )
+
+
+# ------------------------------------------------------------------
+# LLM classification (single)
+# ------------------------------------------------------------------
+
+
+def _get_llm(local_only: bool):
+    """Resolve the LLM to use for classification."""
+    from ...pipelines.llm import get_pipeline_llm
+
+    llm = get_pipeline_llm(
+        workload="vllm",
+        try_openrouter=False,
+        auto_activate_ollama=False,
+    )
+    if llm is not None or local_only:
+        return llm
+
+    return get_pipeline_llm(
+        workload="anthropic",
+        try_openrouter=False,
+        auto_activate_ollama=False,
+    )
+
+
+def _skill_for_rating(rating: float) -> str:
+    """Return the skill name to use based on review rating."""
+    if rating <= 3.0:
+        return "digest/complaint_classification"
+    return "digest/praise_classification"
+
+
+async def _classify_review(
+    asin: str,
+    rating: float,
+    summary: str,
+    review_text: str,
+    hardware_category: list[str],
+    issue_types: list[str],
+    local_only: bool = False,
+) -> dict[str, Any] | None:
+    """Classify a single product review via LLM (complaint or praise by rating)."""
+    from ...skills import get_skill_registry
+    from ...services.protocols import Message
+
+    skill_name = _skill_for_rating(rating)
+    skill = get_skill_registry().get(skill_name)
+    if not skill:
+        logger.warning("Skill '%s' not found", skill_name)
+        return None
+
+    llm = _get_llm(local_only)
+    if llm is None:
+        logger.warning("No LLM available for complaint classification")
+        return None
+
+    truncated = review_text[:2000] if review_text else ""
+
+    user_payload = json.dumps({
+        "asin": asin,
+        "rating": rating,
+        "summary": summary,
+        "review_text": truncated,
+        "hardware_category": hardware_category,
+        "issue_types": issue_types,
+    })
+
+    messages = [
+        Message(role="system", content=skill.content),
+        Message(role="user", content=user_payload),
+    ]
+
+    return _call_and_parse(llm, messages, max_tokens=256)
+
+
+# ------------------------------------------------------------------
+# LLM classification (batch)
+# ------------------------------------------------------------------
+
+
+_BATCH_SYSTEM_SUFFIX = """
+
+## BATCH MODE
+
+You will receive a JSON array of reviews. Classify EACH review independently.
+Return a JSON array of classification objects in the SAME ORDER as the input.
+Each object must follow the single-review output format above.
+Return ONLY the JSON array -- no prose, no markdown fencing."""
+
+
+async def _classify_batch(rows, local_only: bool) -> list[dict[str, Any]] | None:
+    """Classify multiple reviews in a single LLM call. Returns list or None on failure.
+
+    Splits rows by rating band (complaint vs praise) and calls the appropriate
+    skill for each sub-batch, then reassembles results in original order.
+    """
+    from ...skills import get_skill_registry
+    from ...services.protocols import Message
+
+    registry = get_skill_registry()
+    llm = _get_llm(local_only)
+    if llm is None:
+        return None
+
+    # Split rows into complaint (<=3) and praise (>3) with original indices
+    complaint_idx, praise_idx = [], []
+    for i, row in enumerate(rows):
+        if float(row["rating"]) <= 3.0:
+            complaint_idx.append(i)
+        else:
+            praise_idx.append(i)
+
+    results: list[dict[str, Any] | None] = [None] * len(rows)
+
+    for indices, skill_name in [
+        (complaint_idx, "digest/complaint_classification"),
+        (praise_idx, "digest/praise_classification"),
+    ]:
+        if not indices:
+            continue
+        skill = registry.get(skill_name)
+        if not skill:
+            return None
+
+        sub_rows = [rows[i] for i in indices]
+        reviews = []
+        for row in sub_rows:
+            reviews.append({
+                "asin": row["asin"],
+                "rating": float(row["rating"]),
+                "summary": row["summary"] or "",
+                "review_text": (row["review_text"] or "")[:2000],
+                "hardware_category": list(row["hardware_category"] or []),
+                "issue_types": list(row["issue_types"] or []),
+            })
+
+        messages = [
+            Message(role="system", content=skill.content + _BATCH_SYSTEM_SUFFIX),
+            Message(role="user", content=json.dumps(reviews)),
+        ]
+
+        max_tokens = 300 * len(reviews)
+        sub_results = _call_and_parse_array(llm, messages, max_tokens=max_tokens)
+        if not sub_results or len(sub_results) != len(indices):
+            return None  # batch parse failed, caller falls back to single mode
+
+        for idx, classification in zip(indices, sub_results):
+            results[idx] = classification
+
+    return results
+
+
+# ------------------------------------------------------------------
+# LLM call helpers
+# ------------------------------------------------------------------
+
+
+def _call_and_parse(llm, messages, max_tokens: int) -> dict[str, Any] | None:
+    """Call LLM and parse single JSON object response."""
+    try:
+        result = llm.chat(messages=messages, max_tokens=max_tokens, temperature=0.1)
+        _usage = result.get("usage", {})
+        if _usage.get("input_tokens"):
+            logger.info("complaint_enrichment LLM tokens: in=%d out=%d",
+                         _usage["input_tokens"], _usage.get("output_tokens", 0))
+            from ...pipelines.llm import trace_llm_call
+            _trace = result.get("_trace_meta", {})
+            # Extract business context from user message payload
+            _biz_ctx: dict[str, Any] = {"workflow": "complaint_enrichment"}
+            try:
+                _user_payload = json.loads(messages[-1].content)
+                _biz_ctx["asin"] = _user_payload.get("asin", "")
+                _biz_ctx["rating"] = _user_payload.get("rating")
+            except Exception:
+                pass
+            trace_llm_call("task.complaint_enrichment", input_tokens=_usage["input_tokens"],
+                           output_tokens=_usage.get("output_tokens", 0),
+                           cached_tokens=_trace.get("cached_tokens") or _trace.get("cache_read_tokens"),
+                           cache_write_tokens=_trace.get("cache_write_tokens") or _trace.get("cache_creation_tokens"),
+                           billable_input_tokens=_trace.get("billable_input_tokens"),
+                           model=getattr(llm, "model", ""), provider=getattr(llm, "name", ""),
+                           input_data={
+                               "messages": [
+                                   {"role": m.role, "content": m.content[:500]} for m in messages
+                               ],
+                           },
+                           output_data={
+                               "response": result.get("response", "")[:2000],
+                           },
+                           api_endpoint=_trace.get("api_endpoint"),
+                           provider_request_id=_trace.get("provider_request_id"),
+                           ttft_ms=_trace.get("ttft_ms"),
+                           inference_time_ms=_trace.get("inference_time_ms"),
+                           queue_time_ms=_trace.get("queue_time_ms"),
+                           metadata=_biz_ctx)
+        text = result.get("response", "").strip()
+        if not text:
+            return None
+        text = _clean_llm_output(text)
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict):
+            return None
+        if "root_cause" not in parsed or "specific_complaint" not in parsed:
+            return None
+        return parsed
+    except json.JSONDecodeError:
+        logger.debug("Failed to parse classification JSON: %.200s", text)
+        return None
+    except Exception:
+        logger.exception("Classification LLM call failed")
+        return None
+
+
+def _call_and_parse_array(llm, messages, max_tokens: int) -> list[dict[str, Any]] | None:
+    """Call LLM and parse JSON array response."""
+    try:
+        result = llm.chat(messages=messages, max_tokens=max_tokens, temperature=0.1)
+        _usage = result.get("usage", {})
+        if _usage.get("input_tokens"):
+            logger.info("complaint_enrichment_array LLM tokens: in=%d out=%d",
+                         _usage["input_tokens"], _usage.get("output_tokens", 0))
+            from ...pipelines.llm import trace_llm_call
+            _trace = result.get("_trace_meta", {})
+            # Extract batch context from user message payload
+            _biz_ctx: dict[str, Any] = {"workflow": "complaint_enrichment_batch"}
+            try:
+                _batch_payload = json.loads(messages[-1].content)
+                if isinstance(_batch_payload, list):
+                    _biz_ctx["batch_size"] = len(_batch_payload)
+                    _biz_ctx["asins"] = [r.get("asin", "") for r in _batch_payload[:10]]
+            except Exception:
+                pass
+            trace_llm_call("task.complaint_enrichment_batch", input_tokens=_usage["input_tokens"],
+                           output_tokens=_usage.get("output_tokens", 0),
+                           cached_tokens=_trace.get("cached_tokens") or _trace.get("cache_read_tokens"),
+                           cache_write_tokens=_trace.get("cache_write_tokens") or _trace.get("cache_creation_tokens"),
+                           billable_input_tokens=_trace.get("billable_input_tokens"),
+                           model=getattr(llm, "model", ""), provider=getattr(llm, "name", ""),
+                           input_data={
+                               "messages": [
+                                   {"role": m.role, "content": m.content[:500]} for m in messages
+                               ],
+                           },
+                           output_data={
+                               "response": result.get("response", "")[:2000],
+                           },
+                           api_endpoint=_trace.get("api_endpoint"),
+                           provider_request_id=_trace.get("provider_request_id"),
+                           ttft_ms=_trace.get("ttft_ms"),
+                           inference_time_ms=_trace.get("inference_time_ms"),
+                           queue_time_ms=_trace.get("queue_time_ms"),
+                           metadata=_biz_ctx)
+        text = result.get("response", "").strip()
+        if not text:
+            return None
+        text = _clean_llm_output(text)
+        parsed = json.loads(text)
+        if not isinstance(parsed, list):
+            return None
+        # Validate each item has required fields
+        for item in parsed:
+            if not isinstance(item, dict) or "root_cause" not in item:
+                return None
+        return parsed
+    except json.JSONDecodeError:
+        logger.debug("Failed to parse batch classification JSON: %.200s", text)
+        return None
+    except Exception:
+        logger.exception("Batch classification LLM call failed")
+        return None
+
+
+def _clean_llm_output(text: str) -> str:
+    """Strip think tags and markdown fencing from LLM output."""
+    from ...pipelines.llm import clean_llm_output
+
+    return clean_llm_output(text)

--- a/extracted_content_pipeline/config.py
+++ b/extracted_content_pipeline/config.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import os
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    from .settings import build_settings
+
+    settings = build_settings()
+else:
+    from atlas_brain.config import settings
+
+__all__ = ["settings"]

--- a/extracted_content_pipeline/import_debt_allowlist.txt
+++ b/extracted_content_pipeline/import_debt_allowlist.txt
@@ -1,0 +1,12 @@
+._google_news
+._execution_progress
+._b2b_shared
+._b2b_specificity
+.b2b_campaign_generation
+._b2b_synthesis_reader
+._blog_ts
+._b2b_cross_vendor_synthesis
+..visibility
+._blog_deploy
+.competitive_intelligence
+.complaint_analysis

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -1,0 +1,116 @@
+{
+  "mappings": [
+    {
+      "source": "atlas_brain/autonomous/tasks/blog_post_generation.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/blog_post_generation.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/b2b_blog_post_generation.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/complaint_content_generation.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/complaint_content_generation.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/article_enrichment.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/article_enrichment.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/complaint_enrichment.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/complaint_enrichment.py"
+    },
+    {
+      "source": "atlas_brain/skills/digest/blog_post_generation.md",
+      "target": "extracted_content_pipeline/skills/digest/blog_post_generation.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_blog_post_generation.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_blog_post_generation.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/complaint_content_generation.md",
+      "target": "extracted_content_pipeline/skills/digest/complaint_content_generation.md"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/084_blog_posts.sql",
+      "target": "extracted_content_pipeline/storage/migrations/084_blog_posts.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/264_blog_post_rejection_count.sql",
+      "target": "extracted_content_pipeline/storage/migrations/264_blog_post_rejection_count.sql"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_execution_progress.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_execution_progress.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_shared.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_shared.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_specificity.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_specificity.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_google_news.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_google_news.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/competitive_intelligence.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/competitive_intelligence.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/complaint_analysis.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/complaint_analysis.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_blog_ts.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_blog_ts.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_blog_deploy.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_synthesis_reader.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_cross_vendor_synthesis.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_cross_vendor_synthesis.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/b2b_campaign_generation.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_reasoning_contracts.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_reasoning_contracts.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_pool_compression.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_pool_compression.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_campaign_sequence_context.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/campaign_audit.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/campaign_audit.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_blog_matching.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_blog_matching.py"
+    },
+    {
+      "source": "atlas_brain/autonomous/tasks/_b2b_batch_utils.py",
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py"
+    }
+  ]
+}

--- a/extracted_content_pipeline/pipelines/__init__.py
+++ b/extracted_content_pipeline/pipelines/__init__.py
@@ -1,0 +1,2 @@
+from .llm import *
+from .notify import *

--- a/extracted_content_pipeline/pipelines/llm.py
+++ b/extracted_content_pipeline/pipelines/llm.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    def get_pipeline_llm(*args: Any, **kwargs: Any):
+        return None
+
+    def clean_llm_output(text: str) -> str:
+        return (text or "").strip()
+
+    def parse_json_response(text: str) -> dict[str, Any] | list[Any] | None:
+        cleaned = clean_llm_output(text)
+        if not cleaned:
+            return None
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError:
+            return None
+
+    def trace_llm_call(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    def call_llm_with_skill(*args: Any, **kwargs: Any):
+        return None
+else:
+    from atlas_brain.pipelines.llm import *

--- a/extracted_content_pipeline/pipelines/notify.py
+++ b/extracted_content_pipeline/pipelines/notify.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    async def send_pipeline_notification(*args: Any, **kwargs: Any) -> None:
+        return None
+else:
+    from atlas_brain.pipelines.notify import *

--- a/extracted_content_pipeline/reasoning/__init__.py
+++ b/extracted_content_pipeline/reasoning/__init__.py
@@ -1,0 +1,1 @@
+from .wedge_registry import *

--- a/extracted_content_pipeline/reasoning/archetypes.py
+++ b/extracted_content_pipeline/reasoning/archetypes.py
@@ -1,0 +1,1 @@
+from atlas_brain.reasoning.archetypes import *

--- a/extracted_content_pipeline/reasoning/evidence_engine.py
+++ b/extracted_content_pipeline/reasoning/evidence_engine.py
@@ -1,0 +1,1 @@
+from atlas_brain.reasoning.evidence_engine import *

--- a/extracted_content_pipeline/reasoning/temporal.py
+++ b/extracted_content_pipeline/reasoning/temporal.py
@@ -1,0 +1,1 @@
+from atlas_brain.reasoning.temporal import *

--- a/extracted_content_pipeline/reasoning/wedge_registry.py
+++ b/extracted_content_pipeline/reasoning/wedge_registry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    class Wedge(str, Enum):
+        PRICING = "pricing"
+        SUPPORT = "support"
+        RELIABILITY = "reliability"
+        FEATURES = "features"
+        INTEGRATIONS = "integrations"
+
+    @dataclass
+    class WedgeMeta:
+        label: str
+
+    def get_wedge_meta(wedge: Wedge) -> WedgeMeta:
+        return WedgeMeta(label=str(wedge.value).replace("_", " ").title())
+
+    def validate_wedge(value: str) -> str:
+        norm = str(value or "").strip().lower()
+        if norm in {w.value for w in Wedge}:
+            return norm
+        return Wedge.SUPPORT.value
+else:
+    from atlas_brain.reasoning.wedge_registry import *

--- a/extracted_content_pipeline/services/__init__.py
+++ b/extracted_content_pipeline/services/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    class _StandaloneLLMRegistry:
+        @staticmethod
+        def get_active():
+            return None
+
+    llm_registry = _StandaloneLLMRegistry()
+else:
+    from atlas_brain.services import llm_registry
+
+__all__ = ["llm_registry"]

--- a/extracted_content_pipeline/services/apollo_company_overrides.py
+++ b/extracted_content_pipeline/services/apollo_company_overrides.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.apollo_company_overrides import *

--- a/extracted_content_pipeline/services/b2b/__init__.py
+++ b/extracted_content_pipeline/services/b2b/__init__.py
@@ -1,0 +1,3 @@
+from .anthropic_batch import *
+from .cache_runner import *
+from .enrichment_contract import *

--- a/extracted_content_pipeline/services/b2b/anthropic_batch.py
+++ b/extracted_content_pipeline/services/b2b/anthropic_batch.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.b2b.anthropic_batch import *

--- a/extracted_content_pipeline/services/b2b/cache_runner.py
+++ b/extracted_content_pipeline/services/b2b/cache_runner.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.b2b.cache_runner import *

--- a/extracted_content_pipeline/services/b2b/corrections.py
+++ b/extracted_content_pipeline/services/b2b/corrections.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.b2b.corrections import *

--- a/extracted_content_pipeline/services/b2b/enrichment_contract.py
+++ b/extracted_content_pipeline/services/b2b/enrichment_contract.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.b2b.enrichment_contract import *

--- a/extracted_content_pipeline/services/blog_quality.py
+++ b/extracted_content_pipeline/services/blog_quality.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.blog_quality import *

--- a/extracted_content_pipeline/services/blog_quality.py
+++ b/extracted_content_pipeline/services/blog_quality.py
@@ -1,1 +1,42 @@
-from atlas_brain.services.blog_quality import *
+from __future__ import annotations
+
+import os
+from typing import Any
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    def blog_quality_summary(data_context: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {
+            "score": 100,
+            "threshold": 0,
+            "blocking_issues": [],
+            "warnings": [],
+        }
+
+    def blog_quality_revalidation(
+        data_context: dict[str, Any] | None = None,
+        content: dict[str, Any] | None = None,
+        report: dict[str, Any] | None = None,
+        boundary: str | None = None,
+    ) -> dict[str, Any]:
+        base = blog_quality_summary(data_context)
+        if isinstance(report, dict):
+            for key in ("score", "threshold", "blocking_issues", "warnings"):
+                if key in report:
+                    base[key] = report[key]
+        return base
+
+    def merge_blog_first_pass_quality_data_context(
+        data_context: dict[str, Any] | None,
+        audit: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        merged = dict(data_context or {})
+        if isinstance(audit, dict):
+            merged["first_pass_quality"] = {
+                "score": audit.get("score"),
+                "threshold": audit.get("threshold"),
+                "blocking_issues": list(audit.get("blocking_issues") or []),
+                "warnings": list(audit.get("warnings") or []),
+            }
+        return merged
+else:
+    from atlas_brain.services.blog_quality import *

--- a/extracted_content_pipeline/services/company_normalization.py
+++ b/extracted_content_pipeline/services/company_normalization.py
@@ -1,1 +1,12 @@
-from atlas_brain.services.company_normalization import *
+from __future__ import annotations
+
+import os
+import re
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    def normalize_company_name(value: str | None) -> str:
+        text = str(value or "").strip().lower()
+        text = re.sub(r"\s+", " ", text)
+        return text
+else:
+    from atlas_brain.services.company_normalization import *

--- a/extracted_content_pipeline/services/company_normalization.py
+++ b/extracted_content_pipeline/services/company_normalization.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.company_normalization import *

--- a/extracted_content_pipeline/services/llm/__init__.py
+++ b/extracted_content_pipeline/services/llm/__init__.py
@@ -1,0 +1,1 @@
+from .anthropic import *

--- a/extracted_content_pipeline/services/llm/anthropic.py
+++ b/extracted_content_pipeline/services/llm/anthropic.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.llm.anthropic import *

--- a/extracted_content_pipeline/services/protocols.py
+++ b/extracted_content_pipeline/services/protocols.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    @dataclass
+    class Message:
+        role: str
+        content: str
+else:
+    from atlas_brain.services.protocols import *

--- a/extracted_content_pipeline/services/scraping/__init__.py
+++ b/extracted_content_pipeline/services/scraping/__init__.py
@@ -1,0 +1,1 @@
+from .sources import *

--- a/extracted_content_pipeline/services/scraping/sources.py
+++ b/extracted_content_pipeline/services/scraping/sources.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import Iterable
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    class ReviewSource(str, Enum):
+        G2 = "g2"
+        CAPTERRA = "capterra"
+        GARTNER = "gartner_peer_insights"
+        TRUST_RADIUS = "trustradius"
+
+    VERIFIED_SOURCES = {
+        ReviewSource.G2,
+        ReviewSource.CAPTERRA,
+        ReviewSource.GARTNER,
+        ReviewSource.TRUST_RADIUS,
+    }
+
+    REQUIRED_ACTIONABLE_SOURCES = VERIFIED_SOURCES
+
+    def display_name(source: ReviewSource | str) -> str:
+        return str(source).replace("_", " ").title()
+
+    def parse_source_allowlist(value: str | None) -> set[ReviewSource]:
+        if not value:
+            return set(VERIFIED_SOURCES)
+        out = set()
+        for token in value.split(","):
+            token = token.strip().lower()
+            for src in ReviewSource:
+                if src.value == token:
+                    out.add(src)
+                    break
+        return out or set(VERIFIED_SOURCES)
+
+    def with_required_sources(sources: Iterable[ReviewSource]) -> set[ReviewSource]:
+        return set(sources) | set(REQUIRED_ACTIONABLE_SOURCES)
+
+    def filter_deprecated_sources(sources: Iterable[ReviewSource], deprecated: Iterable[str] | None = None) -> set[ReviewSource]:
+        deprecated_set = {str(x).strip().lower() for x in (deprecated or [])}
+        return {src for src in sources if src.value not in deprecated_set}
+
+    def filter_blocked_sources(sources: Iterable[ReviewSource], blocked: Iterable[str] | None = None) -> set[ReviewSource]:
+        blocked_set = {str(x).strip().lower() for x in (blocked or [])}
+        return {src for src in sources if src.value not in blocked_set}
+else:
+    from atlas_brain.services.scraping.sources import *

--- a/extracted_content_pipeline/services/scraping/universal/__init__.py
+++ b/extracted_content_pipeline/services/scraping/universal/__init__.py
@@ -1,0 +1,1 @@
+from .html_cleaner import *

--- a/extracted_content_pipeline/services/scraping/universal/html_cleaner.py
+++ b/extracted_content_pipeline/services/scraping/universal/html_cleaner.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.scraping.universal.html_cleaner import *

--- a/extracted_content_pipeline/services/tracing.py
+++ b/extracted_content_pipeline/services/tracing.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.tracing import *

--- a/extracted_content_pipeline/services/tracing.py
+++ b/extracted_content_pipeline/services/tracing.py
@@ -1,1 +1,10 @@
-from atlas_brain.services.tracing import *
+from __future__ import annotations
+
+import os
+from typing import Any
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    def build_business_trace_context(**kwargs: Any) -> dict[str, Any]:
+        return {k: v for k, v in kwargs.items() if v is not None}
+else:
+    from atlas_brain.services.tracing import *

--- a/extracted_content_pipeline/services/vendor_registry.py
+++ b/extracted_content_pipeline/services/vendor_registry.py
@@ -1,0 +1,1 @@
+from atlas_brain.services.vendor_registry import *

--- a/extracted_content_pipeline/services/vendor_registry.py
+++ b/extracted_content_pipeline/services/vendor_registry.py
@@ -1,1 +1,9 @@
-from atlas_brain.services.vendor_registry import *
+from __future__ import annotations
+
+import os
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    def resolve_vendor_name_cached(value: str | None) -> str:
+        return str(value or "").strip()
+else:
+    from atlas_brain.services.vendor_registry import *

--- a/extracted_content_pipeline/settings.py
+++ b/extracted_content_pipeline/settings.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+
+def _to_bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _to_int(value: str | None, default: int) -> int:
+    try:
+        return int(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+def _to_float(value: str | None, default: float) -> float:
+    try:
+        return float(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+def build_settings() -> SimpleNamespace:
+    external_data = SimpleNamespace(
+        enabled=_to_bool(os.getenv("EXTRACTED_EXTERNAL_ENABLED"), True),
+        enrichment_enabled=_to_bool(os.getenv("EXTRACTED_ENRICHMENT_ENABLED"), True),
+        complaint_mining_enabled=_to_bool(os.getenv("EXTRACTED_COMPLAINT_MINING_ENABLED"), True),
+        blog_post_enabled=_to_bool(os.getenv("EXTRACTED_BLOG_POST_ENABLED"), True),
+        complaint_content_enabled=_to_bool(os.getenv("EXTRACTED_COMPLAINT_CONTENT_ENABLED"), True),
+        blog_post_max_per_run=_to_int(os.getenv("EXTRACTED_BLOG_POST_MAX_PER_RUN"), 1),
+        blog_post_max_tokens=_to_int(os.getenv("EXTRACTED_BLOG_POST_MAX_TOKENS"), 2800),
+        complaint_content_max_per_run=_to_int(os.getenv("EXTRACTED_COMPLAINT_CONTENT_MAX_PER_RUN"), 10),
+        complaint_content_max_tokens=_to_int(os.getenv("EXTRACTED_COMPLAINT_CONTENT_MAX_TOKENS"), 1200),
+    )
+
+    b2b_churn = SimpleNamespace(
+        blog_post_enabled=_to_bool(os.getenv("EXTRACTED_B2B_BLOG_POST_ENABLED"), True),
+        blog_post_max_per_run=_to_int(os.getenv("EXTRACTED_B2B_BLOG_POST_MAX_PER_RUN"), 1),
+        blog_post_max_tokens=_to_int(os.getenv("EXTRACTED_B2B_BLOG_POST_MAX_TOKENS"), 3200),
+        blog_post_temperature=_to_float(os.getenv("EXTRACTED_B2B_BLOG_POST_TEMPERATURE"), 0.2),
+    )
+
+    return SimpleNamespace(external_data=external_data, b2b_churn=b2b_churn)

--- a/extracted_content_pipeline/skills/__init__.py
+++ b/extracted_content_pipeline/skills/__init__.py
@@ -1,0 +1,3 @@
+from .registry import get_skill_registry
+
+__all__ = ["get_skill_registry"]

--- a/extracted_content_pipeline/skills/digest/b2b_blog_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/b2b_blog_post_generation.md
@@ -1,0 +1,219 @@
+---
+name: digest/b2b_blog_post_generation
+domain: digest
+description: Generate data-backed B2B SaaS blog posts with rigorous source attribution, balanced claims, and honest limits
+tags: [digest, blog, b2b, churn, content, charts, autonomous]
+version: 4
+---
+
+# B2B Churn Signals Blog Writer
+
+You are writing for B2B software decision-makers. The source material is structured evidence from public software reviews, churn signals, product profiles, witness highlights, and deterministic reasoning aids.
+
+Your job is to turn that structured blueprint into a useful, search-friendly article without overstating what review data can prove.
+
+## Core stance
+
+- Public reviews are a self-selected sample. Treat them as sentiment and pattern evidence, not universal product truth.
+- Never turn correlation into causation.
+- Narrow, defensible claims are better than dramatic ones.
+- Let the evidence do the work. Specific quotes and concrete scope beat generic commentary.
+- Do not favor affiliate or partner products unless the supplied evidence genuinely supports it.
+
+## Input overview
+
+The input is a JSON blueprint. It may include:
+- `topic_type`
+- `suggested_title`
+- `data_context`
+- ordered `sections`
+- `available_charts`
+- `quotable_phrases`
+- `anchor_examples`
+- `witness_highlights`
+- `reference_ids`
+- `claim_plan`
+- `reasoning_scope_summary`
+- `reasoning_atom_context`
+- `reasoning_delta_summary`
+- `related_posts`
+
+Use what is present. Do not invent missing fields.
+
+## Required output
+
+Return one valid JSON object only.
+
+Use these keys:
+- `title`
+- `seo_title`
+- `description`
+- `seo_description`
+- `target_keyword`
+- `secondary_keywords`
+- `faq`
+- `content`
+- `cta_body`
+
+If there is no CTA context in the input, set `cta_body` to an empty string.
+
+## Output field guidance
+
+- `title`: natural display headline with exact counts. Never use inflated `N+` phrasing.
+- `seo_title`: max 60 characters. Front-load the target keyword.
+- `description`: natural summary for the article page.
+- `seo_description`: max 155 characters. Include the target keyword naturally.
+- `target_keyword`: one primary search query matched to the topic.
+- `secondary_keywords`: 2-3 related queries.
+- `faq`: 3-5 question-answer pairs with concrete, data-backed answers.
+- `content`: markdown article body.
+- `cta_body`: short teaser for the gated report or next step when CTA context exists.
+
+## Topic-to-keyword mapping
+
+Use these defaults unless the blueprint clearly suggests something better:
+- `vendor_deep_dive` -> `{vendor} reviews`
+- `vendor_showdown` -> `{vendor_a} vs {vendor_b}`
+- `vendor_alternative` -> `{vendor} alternatives`
+- `churn_report` -> `{vendor} churn rate`
+- `pricing_reality_check` -> `{vendor} pricing`
+- `migration_guide` -> `switch to {vendor}`
+- `switching_story` -> `why teams leave {vendor}`
+- `pain_point_roundup` -> `{category} software complaints`
+- `best_fit_guide` -> `best {category} software`
+- `market_landscape` -> `{category} software comparison`
+
+## Hard rules
+
+### Data integrity
+
+- Use only numbers that appear in the input.
+- Never inflate counts, invent review totals, or blur the difference between total reviews and churn or switching signals.
+- If 200 reviews were analyzed and 45 had switching intent, keep those scopes separate.
+- If you cannot support a number from the blueprint, remove the number and keep the sentence qualitative.
+- Never invent vendor capabilities, ROI, savings, migration effort, or causal claims.
+
+### Claim discipline
+
+- Use phrasing like "reviewers report," "complaint patterns suggest," or "signals cluster around."
+- Do not write "users churn because..." or "X is better than Y" as a definitive fact.
+- Do not generalize reviewer sentiment to all users.
+- Keep support, policy, and enforcement claims tied to reviewer experience, not presented as official vendor policy.
+
+### Source attribution
+
+Use blockquotes for 3-5 quotes from `quotable_phrases`.
+
+Verified review platforms:
+- G2
+- Capterra
+- Gartner Peer Insights
+- TrustRadius
+- PeerSpot
+- GetApp
+- Software Advice
+
+Community platforms:
+- Reddit
+- Hacker News
+- Twitter/X
+- forums
+- blog comments
+
+Attribution rules:
+- verified platform -> `-- verified reviewer on <platform>`
+- community platform -> `-- reviewer on <platform>`
+- if role exists, include it
+- if industry or company size exists, include those
+- never reveal the actual company name
+- if source is missing, use `-- software reviewer`
+
+Do not quote anchor context directly unless it also appears in `quotable_phrases`.
+
+### Chart and section discipline
+
+- Follow the section order from the blueprint.
+- Use each section heading as an H2.
+- Every `chart_id` listed in a section must appear exactly once as `{{chart:chart-id}}` on its own line.
+- Do not invent chart IDs.
+- Strongest claim language like "top", "most common", or "primary" must match the chart or scoped data actually supplied.
+
+### Balance and trust
+
+- For every vendor discussed, include at least one strength and one weakness when the data supports both.
+- No hit pieces.
+- No puff pieces.
+- State sample size, date range, and source mix early in the article.
+- If confidence is low or sample size is small, say so clearly.
+
+### Witness-backed specificity
+
+- When `anchor_examples`, `witness_highlights`, `claim_plan`, or reasoning summaries are present, use at least one concrete proof anchor in the main narrative.
+- Prefer timing windows, spend or seat signals, named competitors, workflow details, and explicit switching or evaluation patterns.
+- Use those fields to sharpen the article, not to bypass quote attribution rules.
+
+### Topic-specific discipline
+
+- `migration_guide`: stay focused on switching to the destination vendor. Mention outbound caveats only briefly.
+- `vendor_showdown` and `best_fit_guide`: include at least one HTML comparison table.
+- `migration_guide`: include a numbered migration section if the blueprint supports it.
+- `market_landscape` and category posts: use market-regime or reasoning context as backdrop, not as causal proof.
+
+## Content rules
+
+- If the payload includes `length_policy`, treat `min_words` as a hard floor and `target_words` as the preferred range.
+- If the payload includes `section_word_budget`, use it to distribute depth across the full article instead of front-loading the opening sections.
+- Cover every section in the payload with enough depth that the full article can realistically clear the stated floor.
+- Do not collapse the last sections into a rushed summary. The article should still be substantive in the second half.
+- Aim for a length that fits the topic:
+  - `vendor_showdown`, `market_landscape`, `best_fit_guide`: 2600-3400 words
+  - `vendor_deep_dive`, `vendor_alternative`, `churn_report`, `pain_point_roundup`: 2200-3200 words
+  - `pricing_reality_check`, `migration_guide`, `switching_story`: 1800-2600 words
+- Use concise paragraphs.
+- Use markdown headings, bullets, blockquotes, and HTML tables when useful.
+- After a question-like H2, start with a direct 40-60 word answer before expanding.
+- Make each H2 section reasonably self-contained so it can stand alone in search or AI citation.
+- Use full vendor names on first mention in each section.
+- Include date anchoring when the blueprint gives it.
+
+## Linking rules
+
+### Internal links
+
+- If `related_posts` exists, include 2-3 natural internal links.
+- Only link to slugs that appear in `related_posts`.
+- Do not invent `/blog/` slugs.
+
+### External links
+
+- Include 1-2 links to authoritative non-competing sources when relevant.
+- Good targets: official vendor product pages, official docs, analyst category pages.
+- Do not link to competing review aggregators or competitor blogs.
+
+### Partner links
+
+Use only when contextually natural:
+- `https://atlasbizintel.co` for business intelligence or competitive intelligence tooling
+- `https://finetunelab.ai` for AI, model monitoring, or AI pipeline topics
+
+If the link is not naturally relevant, omit it.
+
+## SEO and FAQ rules
+
+- `seo_title` must stay under 60 characters.
+- `seo_description` must stay under 155 characters.
+- Use the target keyword naturally, not mechanically.
+- FAQ answers should be short, factual, and data-backed.
+- Do not stuff keywords or repeat the same phrase unnaturally.
+
+## Final check before returning
+
+Before you return:
+- confirm the JSON is valid
+- confirm the article uses exact counts, not inflated counts
+- confirm chart tags match the blueprint
+- confirm internal links only use supplied slugs
+- confirm no real company names leaked from reviewer context
+- confirm the article stays within review-evidence limits
+
+Return only the JSON object.

--- a/extracted_content_pipeline/skills/digest/blog_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/blog_post_generation.md
@@ -1,0 +1,229 @@
+---
+name: digest/blog_post_generation
+domain: digest
+description: Generate data-backed blog posts with interactive chart placeholders from product review intelligence
+tags: [digest, blog, content, charts, autonomous]
+version: 2
+---
+
+# Data-Backed Blog Post Generator
+
+You are an expert data journalist and product analyst. Given a structured blueprint containing real data from aggregated product reviews, write an engaging, authoritative blog post that helps consumers make informed purchasing decisions.
+
+## Input
+
+```json
+{
+  "topic_type": "brand_showdown | complaint_roundup | migration_report | safety_spotlight | best_for_products",
+  "suggested_title": "Logitech vs Razer: What 500+ Negative Reviews Reveal",
+  "data_context": {
+    "review_period": "2025-01 to 2026-03",
+    "total_reviews_analyzed": 1247,
+    "deep_enriched_count": 982,
+    "report_date": "2026-03-03"
+  },
+  "sections": [
+    {
+      "id": "hook",
+      "heading": "Introduction",
+      "goal": "Hook the reader with a surprising stat or contrast",
+      "key_stats": {"brand_a": "Logitech", "brand_b": "Razer", "total_reviews": 523, "pain_diff": 2.1},
+      "chart_ids": [],
+      "data_summary": "Logitech has 280 negative reviews vs Razer's 243. Logitech avg pain 6.2 vs Razer 4.1."
+    },
+    {
+      "id": "head2head",
+      "heading": "Head-to-Head Comparison",
+      "goal": "Present the core metrics side by side",
+      "key_stats": {},
+      "chart_ids": ["head2head-bar"],
+      "data_summary": "..."
+    }
+  ],
+  "available_charts": [
+    {
+      "chart_id": "head2head-bar",
+      "chart_type": "horizontal_bar",
+      "title": "Head-to-Head: Logitech vs Razer"
+    }
+  ],
+  "quotable_phrases": [
+    {"phrase": "Third mouse in 6 months with the same scroll wheel issue", "brand": "Logitech", "rating": 1}
+  ],
+  "related_posts": [
+    {"slug": "migration-computer-accessories-peripherals-2026-03", "title": "Migration Trends: Computer Accessories"}
+  ]
+}
+```
+
+## Output
+
+Return valid JSON with exactly these keys:
+
+```json
+{
+  "title": "Logitech vs Razer: What 523 Negative Reviews Reveal About Each Brand",
+  "seo_title": "Logitech vs Razer Mouse 2026: 523 Reviews Analyzed",
+  "description": "A data-driven comparison of Logitech and Razer based on 523 verified negative reviews.",
+  "seo_description": "Data-driven comparison of Logitech and Razer based on 523 verified negative reviews.",
+  "target_keyword": "logitech vs razer",
+  "secondary_keywords": ["logitech mouse problems", "razer mouse issues", "gaming mouse comparison"],
+  "faq": [
+    {"question": "What are the most common Logitech mouse complaints?", "answer": "Based on 280 negative reviews, the most common Logitech complaints are scroll wheel failure (34%), double-click issues (22%), and wireless connectivity drops (18%)."},
+    {"question": "Is Razer more reliable than Logitech?", "answer": "Review data shows Razer has a lower average pain score (4.1 vs 6.2), but complaints cluster around software bloat and RGB failure rather than hardware reliability."}
+  ],
+  "content": "Markdown content here..."
+}
+```
+
+## SEO Field Rules
+
+- **`seo_title`**: Max 60 characters. Front-load the target keyword. Include year if relevant. This is the `<title>` tag -- distinct from the display H1.
+- **`seo_description`**: Max 155 characters. Include the target keyword naturally. Lead with a compelling data point. Written for click-through rate in search results.
+- **`target_keyword`**: The primary search query this post should rank for. Derive from topic_type + brand/category names:
+  - `brand_showdown` -> "{brand_a} vs {brand_b}" (e.g., "logitech vs razer")
+  - `complaint_roundup` -> "{category} product complaints" (e.g., "networking product complaints")
+  - `migration_report` -> "switch from {brand}" or "{brand} alternatives" (e.g., "switch from corsair")
+  - `safety_spotlight` -> "{category} safety issues" or "{product} safety" (e.g., "cycling safety issues")
+  - `best_for_products` -> "best {category}" (e.g., "best cpu cooler for gaming")
+- **`secondary_keywords`**: 2-3 related long-tail keywords. Include brand names, common question phrases, or feature-specific queries.
+- **`faq`**: 3-5 question-answer pairs. Questions should match real search queries people would ask about this topic. Answers should be 2-3 sentences, factual, and reference specific numbers from the data. These render as FAQ schema markup for Google rich snippets.
+
+## Content Rules
+
+1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, or review counts.
+2. **Chart placement**: Every `chart_id` listed in a section's `chart_ids` MUST appear exactly once in the content as `{{chart:chart-id}}` on its own line. Do not invent chart IDs that are not in `available_charts`.
+3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`).
+4. **Tone**: Authoritative but accessible. Data journalist style -- let the numbers tell the story. Avoid marketing fluff, superlatives, and filler.
+5. **Quotable phrases**: Where `quotable_phrases` are provided, weave 2-4 of them into the text as blockquotes (`> "quote" -- verified buyer`). Choose the most impactful ones.
+6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..."
+7. **Length**: 800-1500 words for the main content. Concise paragraphs (2-4 sentences each).
+8. **No CTA in content**: The frontend adds its own call-to-action section. End with a conclusion/verdict, not a sales pitch.
+9. **Formatting**: Use markdown headers (##), bold for key numbers, blockquotes for review excerpts, and bullet lists for comparisons. No HTML tags except tables.
+10. **SEO**: `seo_title` must be under 60 characters with the target keyword front-loaded. `seo_description` must be under 155 characters and include the target keyword. Use the target keyword naturally in H2 headings (2-3 times in the content, not forced). The display `title` can be longer and more natural -- it is the H1 on the page.
+
+## Linking Rules
+
+Links improve SEO authority and user navigation. Follow these rules for every post.
+
+### Internal Links (required)
+When `related_posts` is provided in the input, link to 2-3 related posts naturally within the body text. Use contextual anchor text that describes what the linked post covers -- not "click here" or "read more."
+
+Format: `[anchor text](/blog/slug-here)`
+
+Examples:
+- "For a deeper look at migration patterns in this category, see our [Computer Accessories migration analysis](/blog/migration-computer-accessories-peripherals-2026-03)."
+- "Safety concerns in this space are covered in our [cycling safety spotlight](/blog/safety-cycling-2026-03)."
+
+Place internal links where they genuinely add value to the reader's journey. Do not force links into unrelated paragraphs.
+
+### Outbound Authority Links (required)
+Include 1-2 outbound links to authoritative, non-competing sources. Link to:
+- The brand's official product page (e.g., `[Logitech](https://www.logitech.com/)`)
+- Amazon product listing pages when discussing specific products
+- Manufacturer recall or safety pages when relevant
+
+Do NOT link to competitor review aggregators.
+
+## Featured Snippet Optimization
+
+Structure content so Google can extract featured snippets (the answer box at the top of search results).
+
+### Answer-First Paragraphs
+After each H2 that poses or implies a question, write a direct 40-60 word answer in the first paragraph. This is the snippet candidate. Then expand with supporting data.
+
+Example:
+```
+## What Are the Most Common Logitech Mouse Problems?
+
+The most common Logitech mouse complaints cluster around three areas: scroll wheel failure (34% of negative reviews), double-click issues (22%), and wireless connectivity drops (18%). These patterns emerge from 280 negative reviews collected between January 2025 and March 2026.
+
+[Expanded analysis follows...]
+```
+
+### Comparison Tables
+For `brand_showdown` and `best_for_products` posts, include at least one HTML comparison table. Google frequently pulls tables into featured snippets.
+
+```html
+<table>
+<tr><th>Metric</th><th>Brand A</th><th>Brand B</th></tr>
+<tr><td>Negative reviews</td><td>280</td><td>243</td></tr>
+<tr><td>Avg pain score</td><td>6.2</td><td>4.1</td></tr>
+</table>
+```
+
+### Migration Steps
+For `migration_report` posts, structure the migration process as a numbered list with clear step headings. This enables HowTo rich results in Google.
+
+```
+## How to Switch from Brand A to Brand B
+
+1. **Check compatibility** -- Verify the replacement product supports your existing setup.
+2. **Compare specifications** -- Match key specs (DPI, connectivity, weight) to your requirements.
+3. **Read targeted reviews** -- Focus on reviews from users who made the same switch.
+4. **Plan the transition** -- Order during sales and keep your old product as backup during adjustment.
+```
+
+### Definition Lists
+When a section defines or explains categories (complaint types, product tiers, safety ratings), use bold term + description format. Google can extract these as definitions.
+
+```
+**Scroll Wheel Failure** -- Physical degradation of the scroll mechanism, often reported within 6-12 months. Pain score: 7.8/10.
+**Double-Click Issue** -- Unintended double-click registration on single press, typically linked to switch wear. Pain score: 7.2/10.
+```
+
+## AEO (Answer Engine Optimization)
+
+Structure content so AI answer engines (ChatGPT, Perplexity, Google AI Overviews) can cite it directly.
+
+### Inverted Pyramid
+Start each section with a direct answer in the first 40-60 words. AI engines extract the first substantive paragraph as the cited answer. Put the conclusion first, then the supporting data.
+
+### Self-Contained Sections
+Each H2 section should be independently citable (200-500 words). An AI engine should be able to extract any single section and present it as a complete answer without needing context from other sections.
+
+### Question-Format H2s
+Where natural, phrase H2 headings as questions that match real search queries. Example: "What Are the Most Common Logitech Mouse Problems?" rather than "Logitech Complaint Analysis."
+
+### Quantitative Claims
+Always include specific numbers: review counts, percentages, pain scores, time periods. AI engines prefer answers with concrete data over vague statements. "34% of negative reviews cite scroll wheel failure" is more citable than "many reviews cite scroll wheel failure."
+
+### Freshness Signals
+Include date references and "as of [month year]" anchoring in key claims. AI engines weigh recency. Example: "As of March 2026, 523 negative reviews have been analyzed across both brands."
+
+### Entity Clarity
+Use full brand/product names on first mention in each section, not abbreviations. AI engines need unambiguous entity references to cite correctly.
+
+### Structured Comparisons
+Use HTML tables for any 2+ item comparison. AI engines extract tabular data more reliably than prose comparisons.
+
+## Topic-Specific Guidance
+
+### brand_showdown
+- Lead with the most surprising contrast between the two brands
+- Structure as a fair comparison, not a hit piece
+- Include a clear verdict section with the decisive factor
+- Include comparison table with key metrics
+
+### complaint_roundup
+- Lead with the scale of the problem (X reviews, Y products affected)
+- Group complaints by root cause, not by product
+- Highlight which products are most/least affected
+
+### migration_report
+- Lead with the dominant migration direction
+- Quantify the flow (X reviewers mentioned switching from A to B)
+- Explain what triggers the migration
+- Structure migration steps for HowTo rich results
+
+### safety_spotlight
+- Lead with the most concerning safety signal
+- Group by consequence severity
+- Include specific product identifiers where available
+
+### best_for_products
+- Organize by use case or buyer persona (e.g., "best for gaming", "best for workstation builds")
+- For each product: what reviewers praise, what they complain about, and who it suits
+- Use real data (review counts, pain scores, safety flags) to support recommendations
+- Include comparison table with key metrics across all products
+- Target keyword mapping: "best {category}" (e.g., "best cpu cooler for gaming")

--- a/extracted_content_pipeline/skills/digest/complaint_content_generation.md
+++ b/extracted_content_pipeline/skills/digest/complaint_content_generation.md
@@ -1,0 +1,102 @@
+---
+name: digest/complaint_content_generation
+domain: digest
+description: Generate sellable content (forum posts, comparison articles, email copy) from product pain point data
+tags: [digest, complaints, content, copywriting, autonomous]
+version: 1
+---
+
+# Product Pain Point Content Generator
+
+You are a skilled copywriter and product reviewer. Given structured data about a product's pain points (from aggregated Amazon review analysis), generate compelling, authentic content that helps buyers make informed decisions while naturally guiding them toward better alternatives.
+
+## Input
+
+```json
+{
+  "content_type": "comparison_article|forum_post|email_copy|review_summary",
+  "target_product": {
+    "asin": "B08N5WRWNW",
+    "category": "storage",
+    "complaint_count": 45,
+    "avg_pain_score": 7.8,
+    "avg_rating": 1.8,
+    "top_complaints": ["SSD fails SMART check after 3 months", "Firmware causes random disconnects"],
+    "root_causes": {"hardware_defect": 20, "software_bug": 15, "durability": 10},
+    "manufacturing_suggestions": ["Improve NAND flash QC", "Fix firmware write amplification"]
+  },
+  "alternatives": [
+    {"name": "Samsung 970 EVO", "mentions": 12},
+    {"name": "WD Black SN770", "mentions": 5}
+  ],
+  "category_context": {
+    "category": "storage",
+    "total_complaints": 3200,
+    "top_root_cause": "hardware_defect",
+    "avg_pain_score": 5.4
+  }
+}
+```
+
+## Content Types
+
+### comparison_article
+A 400-600 word product comparison article suitable for a blog or review site.
+- Lead with the problem (based on real complaint data)
+- Compare the troubled product vs the most-mentioned alternative
+- Use specific complaint data as evidence ("45 buyers reported X within 3 months")
+- Include a clear recommendation
+- Tone: authoritative, data-driven, helpful
+
+### forum_post
+A 150-300 word forum-style post (Reddit, tech forums, community boards).
+- Write as a knowledgeable community member, not a marketer
+- Reference specific failure patterns from the data
+- Naturally mention alternatives other reviewers recommended
+- Include a "what I'd buy instead" recommendation
+- Tone: casual, experienced, peer-to-peer
+
+### email_copy
+A 200-400 word marketing email for buyers who may own the troubled product.
+- Subject line + body
+- Lead with empathy (acknowledge the known issue)
+- Present the alternative as the solution
+- Include one clear CTA
+- Tone: helpful, not pushy
+
+### review_summary
+A 200-400 word aggregated review summary for a product page or buyer's guide.
+- Synthesize the top complaints into a balanced assessment
+- Include data points (complaint counts, failure rates, pain scores)
+- Highlight both the product's weaknesses and any mentioned alternatives
+- Tone: objective, data-backed
+
+## Output
+
+Respond with ONLY a valid JSON object:
+
+```json
+{
+  "title": "Content title or subject line",
+  "body": "The full content piece",
+  "meta": {
+    "word_count": 350,
+    "target_audience": "Brief description of who this targets",
+    "key_selling_point": "The core message in one sentence"
+  }
+}
+```
+
+## Rules
+
+- Output the raw JSON object directly -- NO markdown code fences
+- NEVER fabricate statistics -- only use numbers from the input data
+- NEVER use phrases like "according to our analysis" or reveal the automated origin
+- DO use specific numbers: "45 buyers reported..." not "many users experienced..."
+- Comparison articles and forum posts should feel like they were written by a real person who researched the product
+- Email copy should have a clear subject line in the title field
+- Do not use excessive exclamation marks or hype language
+- Do not disparage products beyond what the data supports
+- Always frame alternatives as "what other buyers switched to" not as ads
+- Keep forum posts casual -- use contractions, first person where appropriate
+- Review summaries should be balanced -- include positives if the data shows any (e.g., "works well for X but fails at Y")

--- a/extracted_content_pipeline/skills/registry.py
+++ b/extracted_content_pipeline/skills/registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class LocalSkill:
+    name: str
+    content: str
+
+
+class LocalSkillRegistry:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def get(self, name: str):
+        rel = Path(*name.split("/"))
+        path = self.root / f"{rel}.md"
+        if not path.exists():
+            return None
+        return LocalSkill(name=name, content=path.read_text())
+
+
+def get_skill_registry():
+    if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+        root = Path(__file__).resolve().parent
+        return LocalSkillRegistry(root)
+
+    from atlas_brain.skills.registry import get_skill_registry as atlas_get_skill_registry
+
+    return atlas_get_skill_registry()

--- a/extracted_content_pipeline/storage/database.py
+++ b/extracted_content_pipeline/storage/database.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    @dataclass
+    class _StandalonePool:
+        is_initialized: bool = False
+
+        async def initialize(self) -> None:
+            self.is_initialized = True
+
+    _POOL = _StandalonePool()
+
+    def get_db_pool() -> _StandalonePool:
+        return _POOL
+else:
+    from atlas_brain.storage.database import *

--- a/extracted_content_pipeline/storage/migrations/084_blog_posts.sql
+++ b/extracted_content_pipeline/storage/migrations/084_blog_posts.sql
@@ -1,0 +1,24 @@
+-- Blog posts: data-backed articles generated from review analysis pipelines.
+-- Each post includes markdown content with {{chart:id}} placeholders and a
+-- JSONB array of chart specifications rendered by the frontend.
+
+CREATE TABLE IF NOT EXISTS blog_posts (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug                TEXT NOT NULL UNIQUE,
+    title               TEXT NOT NULL,
+    description         TEXT,
+    topic_type          TEXT NOT NULL,
+    tags                JSONB NOT NULL DEFAULT '[]',
+    content             TEXT NOT NULL,
+    charts              JSONB NOT NULL DEFAULT '[]',
+    data_context        JSONB,
+    status              TEXT NOT NULL DEFAULT 'draft',
+    reviewer_notes      TEXT,
+    llm_model           TEXT,
+    source_report_date  DATE,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    published_at        TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_blog_posts_status ON blog_posts(status);
+CREATE INDEX IF NOT EXISTS idx_blog_posts_slug ON blog_posts(slug);

--- a/extracted_content_pipeline/storage/migrations/264_blog_post_rejection_count.sql
+++ b/extracted_content_pipeline/storage/migrations/264_blog_post_rejection_count.sql
@@ -1,0 +1,5 @@
+-- Track how many times a blog post slug has been rejected.
+-- Used to cap regeneration attempts and stop wasting LLM tokens
+-- on slugs that repeatedly fail the quality gate.
+ALTER TABLE blog_posts
+    ADD COLUMN IF NOT EXISTS rejection_count integer NOT NULL DEFAULT 0;

--- a/extracted_content_pipeline/storage/models.py
+++ b/extracted_content_pipeline/storage/models.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    @dataclass
+    class ScheduledTask:
+        id: UUID = field(default_factory=uuid4)
+        metadata: dict[str, Any] = field(default_factory=dict)
+else:
+    from atlas_brain.storage.models import *

--- a/extracted_content_pipeline/storage/repositories/__init__.py
+++ b/extracted_content_pipeline/storage/repositories/__init__.py
@@ -1,0 +1,1 @@
+from .scheduled_task import *

--- a/extracted_content_pipeline/storage/repositories/scheduled_task.py
+++ b/extracted_content_pipeline/storage/repositories/scheduled_task.py
@@ -1,0 +1,1 @@
+from atlas_brain.storage.repositories.scheduled_task import *

--- a/scripts/check_ascii_python.sh
+++ b/scripts/check_ascii_python.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+status=0
+while IFS= read -r file; do
+  if ! python - "$file" <<'PY'
+import sys
+from pathlib import Path
+path = Path(sys.argv[1])
+data = path.read_bytes()
+violations = [(idx + 1, b) for idx, b in enumerate(data) if b > 0x7F]
+if violations:
+    print(path)
+    for idx, b in violations[:20]:
+        print(f"  byte_offset={idx} value=0x{b:02X}")
+    sys.exit(1)
+PY
+  then
+    status=1
+  fi
+done < <(printf '%s\n' \
+  extracted_content_pipeline/autonomous/tasks/blog_post_generation.py \
+  extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py \
+  extracted_content_pipeline/autonomous/tasks/complaint_content_generation.py \
+  extracted_content_pipeline/autonomous/tasks/complaint_enrichment.py \
+  extracted_content_pipeline/autonomous/tasks/article_enrichment.py)
+
+if [[ "$status" -ne 0 ]]; then
+  echo "ASCII check failed"
+  exit 1
+fi
+
+echo "ASCII check passed for extracted_content_pipeline Python files"

--- a/scripts/check_extracted_imports.py
+++ b/scripts/check_extracted_imports.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+TASK_DIR = ROOT / "extracted_content_pipeline" / "autonomous" / "tasks"
+
+# Relative-import fallback roots for copied modules that still reference atlas code.
+def resolve_relative(module_path: Path, level: int, module: str | None) -> list[Path]:
+    base_parts = list(module_path.relative_to(ROOT).parts)
+    package_parts = base_parts[:-1]
+    target_parts = package_parts[: max(0, len(package_parts) - level)]
+    if module:
+        target_parts.extend(module.split("."))
+
+    rel = Path(*target_parts) if target_parts else Path()
+    candidates: list[Path] = []
+
+    # Candidate 1: exact relative path from repository root.
+    candidates.append((ROOT / rel).with_suffix(".py"))
+    candidates.append(ROOT / rel / "__init__.py")
+
+    # Candidate 2: atlas fallback by swapping extracted root for atlas_brain.
+    if target_parts and target_parts[0] == "extracted_content_pipeline":
+        atlas_rel = Path("atlas_brain", *target_parts[1:])
+        candidates.append((ROOT / atlas_rel).with_suffix(".py"))
+        candidates.append(ROOT / atlas_rel / "__init__.py")
+
+    return candidates
+
+
+def load_allowlist() -> set[str]:
+    path = ROOT / "extracted_content_pipeline" / "import_debt_allowlist.txt"
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text().splitlines() if line.strip() and not line.strip().startswith("#")}
+
+
+def check_file(path: Path, allowlist: set[str]) -> list[str]:
+    errors: list[str] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level > 0:
+            candidates = resolve_relative(path, node.level, node.module)
+            if not any(c.exists() for c in candidates):
+                mod = f"{'.' * node.level}{node.module or ''}"
+                if mod.startswith("..."):
+                    continue
+                if mod not in allowlist:
+                    errors.append(f"{path}: unresolved relative import '{mod}'")
+    return errors
+
+
+def main() -> int:
+    tracked = [
+        "blog_post_generation.py",
+        "b2b_blog_post_generation.py",
+        "complaint_content_generation.py",
+        "complaint_enrichment.py",
+        "article_enrichment.py",
+    ]
+    py_files = [TASK_DIR / name for name in tracked]
+    allowlist = load_allowlist()
+    errors: list[str] = []
+    for f in py_files:
+        errors.extend(check_file(f, allowlist))
+
+    if errors:
+        print("Import check failed:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print("Import check passed for extracted task modules")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/list_extracted_pipeline_files.sh
+++ b/scripts/list_extracted_pipeline_files.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="$ROOT_DIR/extracted_content_pipeline"
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "Missing directory: $TARGET_DIR"
+  exit 1
+fi
+
+echo "Scaffold root: $TARGET_DIR"
+rg --files "$TARGET_DIR"

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+bash scripts/validate_extracted_content_pipeline.sh
+bash scripts/check_ascii_python.sh
+python scripts/check_extracted_imports.py
+python scripts/smoke_extracted_pipeline_imports.py
+
+echo "All extracted_content_pipeline checks passed"

--- a/scripts/smoke_extracted_pipeline_imports.py
+++ b/scripts/smoke_extracted_pipeline_imports.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MODULES = [
+    "extracted_content_pipeline.autonomous.tasks.blog_post_generation",
+    "extracted_content_pipeline.autonomous.tasks.b2b_blog_post_generation",
+    "extracted_content_pipeline.autonomous.tasks.complaint_content_generation",
+    "extracted_content_pipeline.autonomous.tasks.complaint_enrichment",
+    "extracted_content_pipeline.autonomous.tasks.article_enrichment",
+]
+
+
+def main() -> int:
+    failed: list[str] = []
+    for module in MODULES:
+        try:
+            importlib.import_module(module)
+            print(f"OK {module}")
+        except Exception as exc:
+            print(f"FAIL {module}: {exc}")
+            failed.append(module)
+
+    if failed:
+        print(f"Import smoke failed for {len(failed)} module(s)")
+        return 1
+
+    print("Import smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_extracted_content_pipeline.sh
+++ b/scripts/sync_extracted_content_pipeline.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+python - <<'PY'
+import json
+from pathlib import Path
+
+manifest = Path("extracted_content_pipeline/manifest.json")
+obj = json.loads(manifest.read_text())
+for mapping in obj["mappings"]:
+    src = Path(mapping["source"])
+    dst = Path(mapping["target"])
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_bytes(src.read_bytes())
+
+print("extracted_content_pipeline refreshed from atlas_brain sources")
+PY

--- a/scripts/validate_extracted_content_pipeline.sh
+++ b/scripts/validate_extracted_content_pipeline.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+python - <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = Path("extracted_content_pipeline/manifest.json")
+obj = json.loads(manifest.read_text())
+status = 0
+for mapping in obj["mappings"]:
+    src = Path(mapping["source"])
+    dst = Path(mapping["target"])
+    if not dst.exists() or src.read_bytes() != dst.read_bytes():
+        print(f"OUT OF SYNC: {dst}")
+        status = 1
+
+if status:
+    print("Validation failed: run scripts/sync_extracted_content_pipeline.sh")
+    sys.exit(1)
+
+print("Validation passed: extracted_content_pipeline matches atlas_brain sources")
+PY


### PR DESCRIPTION
### Motivation

- Introduce an in-repo extraction scaffold that mirrors Atlas pipeline code so reasoning and B2B churn logic can be worked on outside the monolith.
- Provide compatibility shims and a standalone toggle so copied modules remain importable while extraction progresses.
- Add lightweight CI gates and validation scripts to ensure the extracted scaffold stays importable and ASCII-compliant when updated.

### Description

- Added a new GitHub Actions workflow `.github/workflows/extracted_pipeline_checks.yml` that runs `bash scripts/run_extracted_pipeline_checks.sh` on PRs and pushes touching the extracted scaffold and helper scripts.
- Introduced `extracted_content_pipeline/` with package boilerplate and a README/STATUS tracker explaining sync/validation commands, standalone mode, and current contents.
- Copied and extracted core B2B churn/reasoning modules under `extracted_content_pipeline/autonomous/tasks/`, including large, self-contained components: `_b2b_shared.py`, `_b2b_pool_compression.py`, `_b2b_reasoning_contracts.py`, `_b2b_cross_vendor_conclusion`/`_b2b_cross_vendor_synthesis.py`, `_b2b_batch_utils.py`, and related helpers and __init__ files to make the scaffold importable.
- Added pass-through and compatibility notes in the README describing how the scaffold delegates to `atlas_brain` implementations by default and how to enable standalone behavior via `EXTRACTED_PIPELINE_STANDALONE=1`.

### Testing

- Configured CI to execute `bash scripts/run_extracted_pipeline_checks.sh` for changes to the scaffold via `.github/workflows/extracted_pipeline_checks.yml` (workflow added in this PR).
- Ran smoke import checks (`python scripts/smoke_extracted_pipeline_imports.py`) and ASCII compliance (`bash scripts/check_ascii_python.sh`) against the scaffold; these automated checks completed successfully.
- Executed the one-shot validation wrapper (`bash scripts/run_extracted_pipeline_checks.sh`) to exercise the combined checks; the script completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3dea6edb8832eb447f1033a155431)