### PR TITLE
Add standalone campaign productization slices

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -8,8 +8,10 @@ on:
       - "scripts/validate_extracted_content_pipeline.sh"
       - "scripts/check_ascii_python.sh"
       - "scripts/check_extracted_imports.py"
+      - "scripts/audit_extracted_standalone.py"
       - "scripts/smoke_extracted_pipeline_imports.py"
       - "scripts/run_extracted_pipeline_checks.sh"
+      - "tests/test_extracted_campaign_*.py"
   push:
     paths:
       - "extracted_content_pipeline/**"
@@ -17,8 +19,10 @@ on:
       - "scripts/validate_extracted_content_pipeline.sh"
       - "scripts/check_ascii_python.sh"
       - "scripts/check_extracted_imports.py"
+      - "scripts/audit_extracted_standalone.py"
       - "scripts/smoke_extracted_pipeline_imports.py"
       - "scripts/run_extracted_pipeline_checks.sh"
+      - "tests/test_extracted_campaign_*.py"
 
 jobs:
   extracted-checks:
@@ -31,6 +35,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest beautifulsoup4
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   extracted-checks:
     runs-on: ubuntu-latest
+    env:
+      EXTRACTED_PIPELINE_STANDALONE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install pytest beautifulsoup4
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -7,8 +7,10 @@ carved out safely without removing or changing production code.
 ## Current contents
 
 - `autonomous/tasks/`: copied task implementations
+- `services/`: copied support shims and staged service dependencies
 - `skills/digest/`: copied prompt skill contracts
-- `storage/migrations/`: copied blog persistence migrations
+- `storage/migrations/`: copied persistence migrations
+- `docs/`: extraction maps for productized pipeline slices
 
 ## Sync command
 
@@ -26,6 +28,11 @@ Mirror mappings are declared in `extracted_content_pipeline/manifest.json` so sy
 
 This scaffold preserves code exactly as copied so behavior and signatures remain
 unchanged while extraction work continues.
+
+This is not yet the sellable product boundary. A customer-usable module must be
+able to install and run without the Atlas monolith on `PYTHONPATH`. Until the
+standalone audit reaches zero runtime `atlas_brain` imports, this package is a
+staging copy, not a deployable product.
 
 
 ## Validation command
@@ -48,6 +55,17 @@ python scripts/check_extracted_imports.py
 
 Known unresolved relative imports are tracked in `extracted_content_pipeline/import_debt_allowlist.txt`.
 
+## Standalone readiness audit
+
+```bash
+python scripts/audit_extracted_standalone.py
+python scripts/audit_extracted_standalone.py --fail-on-debt
+```
+
+The first command reports Atlas runtime coupling. The second is the product gate
+we should enable once staged shims have been replaced with product-owned ports
+and adapters.
+
 ## One-shot checks
 
 ```bash
@@ -59,6 +77,11 @@ bash scripts/run_extracted_pipeline_checks.sh
 To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`) that delegate to `atlas_brain` implementations.
 
 B2B helper siblings required by `b2b_blog_post_generation.py` are also copied into `extracted_content_pipeline/autonomous/tasks/`.
+
+These shims are temporary extraction scaffolding. They should not ship in the
+customer product.
+
+The email/campaign generation slice is mapped in `docs/email_campaign_generation_pipeline.md`, with standalone productization requirements in `docs/standalone_productization.md`.
 
 ## Import smoke test
 

--- a/extracted_content_pipeline/campaign_analytics.py
+++ b/extracted_content_pipeline/campaign_analytics.py
@@ -1,0 +1,56 @@
+"""Standalone campaign analytics refresh orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .campaign_ports import AuditSink, CampaignRepository, VisibilitySink
+
+
+@dataclass(frozen=True)
+class CampaignAnalyticsRefreshResult:
+    refreshed: bool
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"refreshed": self.refreshed, "error": self.error}
+
+
+class CampaignAnalyticsRefreshService:
+    """Refresh campaign analytics through host-provided persistence ports."""
+
+    def __init__(
+        self,
+        *,
+        campaigns: CampaignRepository,
+        audit: AuditSink | None = None,
+        visibility: VisibilitySink | None = None,
+    ):
+        self._campaigns = campaigns
+        self._audit = audit
+        self._visibility = visibility
+
+    async def refresh(self) -> CampaignAnalyticsRefreshResult:
+        try:
+            await self._campaigns.refresh_analytics()
+        except Exception as exc:
+            result = CampaignAnalyticsRefreshResult(refreshed=False, error=str(exc))
+            await self._record("analytics_refresh_failed", result.as_dict())
+            return result
+
+        result = CampaignAnalyticsRefreshResult(refreshed=True)
+        await self._record("analytics_refreshed", result.as_dict())
+        return result
+
+    async def _record(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        if self._audit:
+            try:
+                await self._audit.record(event_type, metadata=payload)
+            except Exception:
+                pass
+        if self._visibility:
+            try:
+                await self._visibility.emit(event_type, payload)
+            except Exception:
+                pass

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -1,0 +1,246 @@
+"""Standalone campaign draft generation orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any, Mapping
+
+from .campaign_ports import (
+    CampaignDraft,
+    CampaignRepository,
+    IntelligenceRepository,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
+
+
+@dataclass(frozen=True)
+class CampaignGenerationConfig:
+    skill_name: str = "digest/b2b_campaign_generation"
+    channel: str = "email"
+    limit: int = 20
+    max_tokens: int = 1200
+    temperature: float = 0.4
+    include_source_opportunity: bool = True
+
+
+@dataclass(frozen=True)
+class CampaignGenerationResult:
+    requested: int = 0
+    generated: int = 0
+    skipped: int = 0
+    saved_ids: tuple[str, ...] = ()
+    errors: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "requested": self.requested,
+            "generated": self.generated,
+            "skipped": self.skipped,
+            "saved_ids": list(self.saved_ids),
+            "errors": list(self.errors),
+        }
+
+
+def parse_campaign_draft_response(text: str) -> dict[str, Any] | None:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    candidates: list[Any] = []
+    try:
+        candidates.append(json.loads(cleaned))
+    except json.JSONDecodeError:
+        pass
+
+    depth = 0
+    start = -1
+    for index, char in enumerate(cleaned):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    candidates.append(json.loads(cleaned[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, dict):
+            continue
+        subject = str(candidate.get("subject") or "").strip()
+        body = str(
+            candidate.get("body")
+            or candidate.get("email_body")
+            or candidate.get("content")
+            or ""
+        ).strip()
+        if subject and body:
+            return {**candidate, "subject": subject, "body": body}
+    return None
+
+
+def opportunity_target_id(opportunity: Mapping[str, Any]) -> str:
+    for key in ("target_id", "id", "company_id", "vendor_id", "email"):
+        value = str(opportunity.get(key) or "").strip()
+        if value:
+            return value
+    for key in ("company_name", "vendor_name", "name"):
+        value = str(opportunity.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+class CampaignGenerationService:
+    """Generate campaign drafts through product-owned ports."""
+
+    def __init__(
+        self,
+        *,
+        intelligence: IntelligenceRepository,
+        campaigns: CampaignRepository,
+        llm: LLMClient,
+        skills: SkillStore,
+        config: CampaignGenerationConfig | None = None,
+    ):
+        self._intelligence = intelligence
+        self._campaigns = campaigns
+        self._llm = llm
+        self._skills = skills
+        self._config = config or CampaignGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> CampaignGenerationResult:
+        prompt_template = self._skills.get_prompt(self._config.skill_name)
+        if not prompt_template:
+            raise ValueError(f"Campaign generation skill not found: {self._config.skill_name}")
+
+        requested = int(limit or self._config.limit)
+        opportunities = [
+            dict(row)
+            for row in await self._intelligence.read_campaign_opportunities(
+                scope=scope,
+                target_mode=target_mode,
+                limit=requested,
+                filters=filters,
+            )
+        ]
+
+        drafts: list[CampaignDraft] = []
+        errors: list[dict[str, Any]] = []
+        skipped = 0
+        for opportunity in opportunities:
+            target_id = opportunity_target_id(opportunity)
+            if not target_id:
+                skipped += 1
+                errors.append({"reason": "missing_target_id", "opportunity": opportunity})
+                continue
+            try:
+                parsed = await self._generate_one(
+                    prompt_template,
+                    opportunity=opportunity,
+                    target_mode=target_mode,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+            if not parsed:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": "unparseable_response"})
+                continue
+            drafts.append(
+                CampaignDraft(
+                    target_id=target_id,
+                    target_mode=target_mode,
+                    channel=self._config.channel,
+                    subject=parsed["subject"],
+                    body=parsed["body"],
+                    metadata=self._metadata(parsed, opportunity),
+                )
+            )
+
+        saved_ids: tuple[str, ...] = ()
+        if drafts:
+            saved_ids = tuple(
+                str(item)
+                for item in await self._campaigns.save_drafts(drafts, scope=scope)
+            )
+        return CampaignGenerationResult(
+            requested=len(opportunities),
+            generated=len(drafts),
+            skipped=skipped,
+            saved_ids=saved_ids,
+            errors=tuple(errors),
+        )
+
+    async def _generate_one(
+        self,
+        prompt_template: str,
+        *,
+        opportunity: Mapping[str, Any],
+        target_mode: str,
+    ) -> dict[str, Any] | None:
+        opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
+        system_prompt = (
+            prompt_template
+            .replace("{target_mode}", target_mode)
+            .replace("{opportunity}", opportunity_json)
+            .replace("{opportunity_json}", opportunity_json)
+        )
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(role="user", content="Generate one campaign draft."),
+            ],
+            max_tokens=self._config.max_tokens,
+            temperature=self._config.temperature,
+            metadata={
+                "target_mode": target_mode,
+                "target_id": opportunity_target_id(opportunity),
+                "skill_name": self._config.skill_name,
+            },
+        )
+        parsed = parse_campaign_draft_response(response.content)
+        if not parsed:
+            return None
+        return {
+            **parsed,
+            "_model": response.model,
+            "_usage": dict(response.usage or {}),
+        }
+
+    def _metadata(
+        self,
+        parsed: Mapping[str, Any],
+        opportunity: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "cta": parsed.get("cta"),
+            "angle_reasoning": parsed.get("angle_reasoning"),
+            "generation_model": parsed.get("_model"),
+            "generation_usage": parsed.get("_usage") or {},
+        }
+        if self._config.include_source_opportunity:
+            metadata["source_opportunity"] = dict(opportunity)
+        return {key: value for key, value in metadata.items() if value not in (None, "", {})}

--- a/extracted_content_pipeline/campaign_ports.py
+++ b/extracted_content_pipeline/campaign_ports.py
@@ -1,0 +1,267 @@
+"""Standalone ports for the campaign generation product.
+
+These interfaces define what the sellable campaign module is allowed to ask
+from its host application. Product code should depend on these ports, not on
+Atlas runtime modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Protocol, Sequence
+
+
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TenantScope:
+    """Host-provided tenant/account context for scoped campaign reads."""
+
+    account_id: str | None = None
+    user_id: str | None = None
+    allowed_vendors: tuple[str, ...] = ()
+    roles: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LLMMessage:
+    role: str
+    content: str
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    content: str
+    model: str | None = None
+    usage: Mapping[str, Any] = field(default_factory=dict)
+    raw: Any | None = None
+
+
+@dataclass(frozen=True)
+class CampaignDraft:
+    target_id: str
+    target_mode: str
+    channel: str
+    subject: str
+    body: str
+    metadata: JsonDict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SendRequest:
+    campaign_id: str
+    to_email: str
+    subject: str
+    html_body: str
+    text_body: str | None = None
+    from_email: str | None = None
+    reply_to: str | None = None
+    headers: Mapping[str, str] = field(default_factory=dict)
+    tags: Sequence[Mapping[str, str]] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SendResult:
+    provider: str
+    message_id: str
+    raw: Any | None = None
+
+
+@dataclass(frozen=True)
+class WebhookEvent:
+    provider: str
+    event_type: str
+    message_id: str | None = None
+    email: str | None = None
+    occurred_at: datetime | None = None
+    payload: JsonDict = field(default_factory=dict)
+
+
+class LLMClient(Protocol):
+    async def complete(
+        self,
+        messages: Sequence[LLMMessage],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LLMResponse:
+        """Return a completion for a campaign prompt."""
+
+
+class SkillStore(Protocol):
+    def get_prompt(self, name: str) -> str | None:
+        """Return a prompt contract by name."""
+
+
+class IntelligenceRepository(Protocol):
+    async def read_campaign_opportunities(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Sequence[JsonDict]:
+        """Return source intelligence for campaign generation."""
+
+    async def read_vendor_targets(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        vendor_name: str | None = None,
+    ) -> Sequence[JsonDict]:
+        """Return configured vendor/account targets."""
+
+
+class CampaignRepository(Protocol):
+    async def save_drafts(
+        self,
+        drafts: Sequence[CampaignDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist generated drafts and return campaign ids."""
+
+    async def list_due_sends(
+        self,
+        *,
+        limit: int,
+        now: datetime,
+    ) -> Sequence[JsonDict]:
+        """Return queued campaigns ready for send evaluation."""
+
+    async def mark_sent(
+        self,
+        *,
+        campaign_id: str,
+        result: SendResult,
+        sent_at: datetime,
+    ) -> None:
+        """Persist provider send result."""
+
+    async def mark_cancelled(
+        self,
+        *,
+        campaign_id: str,
+        reason: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist a terminal cancellation before send."""
+
+    async def mark_send_failed(
+        self,
+        *,
+        campaign_id: str,
+        error: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist a failed send attempt."""
+
+    async def record_webhook_event(self, event: WebhookEvent) -> None:
+        """Persist provider engagement or delivery event."""
+
+    async def refresh_analytics(self) -> None:
+        """Refresh campaign analytics aggregates."""
+
+
+class CampaignSequenceRepository(Protocol):
+    async def list_due_sequences(
+        self,
+        *,
+        limit: int,
+        now: datetime,
+    ) -> Sequence[JsonDict]:
+        """Return active sequences ready for follow-up generation."""
+
+    async def list_previous_campaigns(
+        self,
+        *,
+        sequence_id: str,
+        limit: int,
+    ) -> Sequence[JsonDict]:
+        """Return prior campaigns for a sequence in step order."""
+
+    async def queue_sequence_step(
+        self,
+        *,
+        sequence: JsonDict,
+        content: JsonDict,
+        from_email: str,
+        queued_at: datetime,
+    ) -> str:
+        """Persist a generated follow-up campaign and return its id."""
+
+    async def mark_sequence_step(
+        self,
+        *,
+        sequence_id: str,
+        current_step: int,
+        updated_at: datetime,
+    ) -> None:
+        """Persist sequence progression after a follow-up is queued."""
+
+
+class SuppressionRepository(Protocol):
+    async def is_suppressed(
+        self,
+        *,
+        email: str | None = None,
+        domain: str | None = None,
+    ) -> bool:
+        """Return whether the recipient or domain is suppressed."""
+
+    async def add_suppression(
+        self,
+        *,
+        reason: str,
+        email: str | None = None,
+        domain: str | None = None,
+        source: str = "system",
+        campaign_id: str | None = None,
+        notes: str | None = None,
+        expires_at: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist an email/domain suppression."""
+
+
+class CampaignSender(Protocol):
+    async def send(self, request: SendRequest) -> SendResult:
+        """Send one campaign email through an ESP."""
+
+
+class WebhookVerifier(Protocol):
+    def verify_and_parse(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+    ) -> WebhookEvent:
+        """Verify provider signature and normalize the webhook payload."""
+
+
+class AuditSink(Protocol):
+    async def record(
+        self,
+        event_type: str,
+        *,
+        campaign_id: str | None = None,
+        sequence_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Record an immutable campaign lifecycle event."""
+
+
+class VisibilitySink(Protocol):
+    async def emit(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        """Emit host-visible task progress without coupling to a host runtime."""
+
+
+class Clock(Protocol):
+    def now(self) -> datetime:
+        """Return the current time for scheduling and tests."""

--- a/extracted_content_pipeline/campaign_send.py
+++ b/extracted_content_pipeline/campaign_send.py
@@ -1,0 +1,285 @@
+"""Standalone send orchestration for campaign emails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+from urllib.parse import quote
+
+from .campaign_ports import (
+    AuditSink,
+    CampaignRepository,
+    CampaignSender,
+    Clock,
+    SendRequest,
+)
+from .campaign_suppression import CampaignSuppressionService, domain_from_email, normalize_email
+
+
+@dataclass(frozen=True)
+class CampaignSendConfig:
+    """Runtime send config owned by the campaign product."""
+
+    default_from_email: str = ""
+    default_reply_to: str | None = None
+    unsubscribe_base_url: str = ""
+    company_address: str = ""
+    limit: int = 20
+
+
+@dataclass(frozen=True)
+class CampaignSendSummary:
+    sent: int = 0
+    failed: int = 0
+    suppressed: int = 0
+    skipped: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "sent": self.sent,
+            "failed": self.failed,
+            "suppressed": self.suppressed,
+            "skipped": self.skipped,
+        }
+
+
+class SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+def build_unsubscribe_url(base_url: str, recipient_email: str) -> str:
+    sep = "&" if "?" in base_url else "?"
+    return f"{base_url}{sep}email={quote(recipient_email, safe='')}"
+
+
+def unsubscribe_headers(base_url: str, recipient_email: str) -> dict[str, str]:
+    if not base_url:
+        return {}
+    unsubscribe_url = build_unsubscribe_url(base_url, recipient_email)
+    return {
+        "List-Unsubscribe": f"<{unsubscribe_url}>",
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    }
+
+
+def wrap_with_footer(
+    body: str,
+    *,
+    recipient_email: str,
+    config: CampaignSendConfig,
+) -> str:
+    if not config.unsubscribe_base_url and not config.company_address:
+        return body
+
+    parts: list[str] = []
+    if config.company_address:
+        parts.append(config.company_address)
+    if config.unsubscribe_base_url:
+        unsubscribe_url = build_unsubscribe_url(
+            config.unsubscribe_base_url,
+            recipient_email,
+        )
+        parts.append(f'<a href="{unsubscribe_url}" style="color:#999;">Unsubscribe</a>')
+
+    footer = (
+        '<p style="font-size:11px;color:#999;margin-top:24px;'
+        'border-top:1px solid #eee;padding-top:8px;">'
+        + "<br>".join(parts)
+        + "</p>"
+    )
+    return body + footer
+
+
+def _value(row: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return default
+
+
+def _merge_headers(
+    row_headers: Any,
+    *,
+    unsubscribe_base_url: str,
+    recipient_email: str,
+) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if isinstance(row_headers, Mapping):
+        headers.update({str(k): str(v) for k, v in row_headers.items()})
+    headers.update(unsubscribe_headers(unsubscribe_base_url, recipient_email))
+    return headers
+
+
+def _tags_for(row: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
+    tags: list[dict[str, str]] = []
+    raw_tags = row.get("tags")
+    if isinstance(raw_tags, Sequence) and not isinstance(raw_tags, (str, bytes)):
+        for item in raw_tags:
+            if isinstance(item, Mapping):
+                name = str(item.get("name") or "").strip()
+                value = str(item.get("value") or "").strip()
+                if name and value:
+                    tags.append({"name": name, "value": value})
+
+    campaign_id = str(_value(row, "id", "campaign_id", default="") or "").strip()
+    company_name = str(row.get("company_name") or "").strip()
+    step_number = str(row.get("step_number") or "").strip()
+    if campaign_id and not any(item["name"] == "campaign" for item in tags):
+        tags.append({"name": "campaign", "value": campaign_id})
+    if company_name and not any(item["name"] == "company" for item in tags):
+        tags.append({"name": "company", "value": company_name})
+    if step_number and not any(item["name"] == "step" for item in tags):
+        tags.append({"name": "step", "value": step_number})
+    return tuple(tags)
+
+
+class CampaignSendService:
+    """Orchestrate queued campaign sends through injected product ports."""
+
+    def __init__(
+        self,
+        *,
+        campaigns: CampaignRepository,
+        suppression: CampaignSuppressionService,
+        sender: CampaignSender,
+        audit: AuditSink,
+        clock: Clock | None = None,
+        config: CampaignSendConfig | None = None,
+    ) -> None:
+        self._campaigns = campaigns
+        self._suppression = suppression
+        self._sender = sender
+        self._audit = audit
+        self._clock = clock or SystemClock()
+        self._config = config or CampaignSendConfig()
+
+    async def send_due(self, *, limit: int | None = None) -> CampaignSendSummary:
+        now = self._clock.now()
+        rows = await self._campaigns.list_due_sends(
+            limit=int(limit or self._config.limit),
+            now=now,
+        )
+
+        sent = failed = suppressed = skipped = 0
+        for row in rows:
+            campaign_id = str(_value(row, "id", "campaign_id", default="") or "").strip()
+            sequence_id = _value(row, "sequence_id")
+            recipient_email = normalize_email(_value(row, "recipient_email", "to_email"))
+            from_email = str(row.get("from_email") or self._config.default_from_email or "").strip()
+
+            if not campaign_id:
+                skipped += 1
+                continue
+            if not recipient_email:
+                await self._campaigns.mark_send_failed(
+                    campaign_id=campaign_id,
+                    error="recipient_email_missing",
+                    metadata={"reason": "recipient_email_missing"},
+                )
+                await self._audit.record(
+                    "send_skipped",
+                    campaign_id=campaign_id,
+                    sequence_id=str(sequence_id) if sequence_id else None,
+                    metadata={"reason": "recipient_email_missing"},
+                )
+                skipped += 1
+                continue
+            if not from_email:
+                await self._campaigns.mark_send_failed(
+                    campaign_id=campaign_id,
+                    error="from_email_missing",
+                    metadata={"reason": "from_email_missing"},
+                )
+                await self._audit.record(
+                    "send_skipped",
+                    campaign_id=campaign_id,
+                    sequence_id=str(sequence_id) if sequence_id else None,
+                    metadata={"reason": "from_email_missing"},
+                )
+                skipped += 1
+                continue
+
+            domain = domain_from_email(recipient_email)
+            if await self._suppression.is_suppressed(
+                email=recipient_email,
+                domain=domain,
+            ):
+                await self._campaigns.mark_cancelled(
+                    campaign_id=campaign_id,
+                    reason="suppressed",
+                    metadata={"recipient_email": recipient_email, "domain": domain},
+                )
+                await self._audit.record(
+                    "suppressed",
+                    campaign_id=campaign_id,
+                    sequence_id=str(sequence_id) if sequence_id else None,
+                    metadata={"recipient_email": recipient_email, "domain": domain},
+                )
+                suppressed += 1
+                continue
+
+            body = str(_value(row, "html_body", "body", default="") or "")
+            request = SendRequest(
+                campaign_id=campaign_id,
+                to_email=recipient_email,
+                from_email=from_email,
+                reply_to=str(row.get("reply_to") or self._config.default_reply_to or "") or None,
+                subject=str(row.get("subject") or ""),
+                html_body=wrap_with_footer(
+                    body,
+                    recipient_email=recipient_email,
+                    config=self._config,
+                ),
+                text_body=row.get("text_body"),
+                headers=_merge_headers(
+                    row.get("headers"),
+                    unsubscribe_base_url=self._config.unsubscribe_base_url,
+                    recipient_email=recipient_email,
+                ),
+                tags=_tags_for(row),
+                metadata=dict(row.get("metadata") or {}) if isinstance(row.get("metadata"), dict) else {},
+            )
+
+            try:
+                result = await self._sender.send(request)
+            except Exception as exc:
+                error = f"{type(exc).__name__}: {str(exc)[:200]}"
+                await self._campaigns.mark_send_failed(
+                    campaign_id=campaign_id,
+                    error=error,
+                    metadata={"recipient_email": recipient_email},
+                )
+                await self._audit.record(
+                    "send_failed",
+                    campaign_id=campaign_id,
+                    sequence_id=str(sequence_id) if sequence_id else None,
+                    metadata={"error": error, "recipient_email": recipient_email},
+                )
+                failed += 1
+                continue
+
+            await self._campaigns.mark_sent(
+                campaign_id=campaign_id,
+                result=result,
+                sent_at=now,
+            )
+            await self._audit.record(
+                "sent",
+                campaign_id=campaign_id,
+                sequence_id=str(sequence_id) if sequence_id else None,
+                metadata={
+                    "provider": result.provider,
+                    "message_id": result.message_id,
+                    "recipient_email": recipient_email,
+                },
+            )
+            sent += 1
+
+        return CampaignSendSummary(
+            sent=sent,
+            failed=failed,
+            suppressed=suppressed,
+            skipped=skipped,
+        )

--- a/extracted_content_pipeline/campaign_sender.py
+++ b/extracted_content_pipeline/campaign_sender.py
@@ -1,0 +1,203 @@
+"""Standalone campaign email sender adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import re
+from typing import Any, Mapping
+
+import httpx
+
+from .campaign_ports import SendRequest, SendResult
+
+
+RESEND_API_URL = "https://api.resend.com/emails"
+_TAG_SANITIZE_RE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def sanitize_tag_value(value: str) -> str:
+    return _TAG_SANITIZE_RE.sub("_", str(value))
+
+
+def normalize_tags(tags: Any) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    for item in tags or []:
+        if not isinstance(item, Mapping):
+            continue
+        name = str(item.get("name") or "").strip()
+        value = str(item.get("value") or "").strip()
+        if not name or not value:
+            continue
+        normalized.append({"name": name, "value": sanitize_tag_value(value)})
+    return normalized
+
+
+@dataclass(frozen=True)
+class ResendSenderConfig:
+    api_key: str
+    api_url: str = RESEND_API_URL
+    timeout_seconds: float = 30.0
+
+
+class ResendCampaignSender:
+    """Send campaign emails through Resend without Atlas settings."""
+
+    def __init__(
+        self,
+        config: ResendSenderConfig,
+        *,
+        http_client: Any | None = None,
+    ) -> None:
+        if not config.api_key:
+            raise ValueError("Resend api_key is required")
+        self._config = config
+        self._http_client = http_client
+
+    async def send(self, request: SendRequest) -> SendResult:
+        payload: dict[str, Any] = {
+            "from": request.from_email,
+            "to": [request.to_email],
+            "subject": request.subject,
+            "html": request.html_body,
+        }
+        if request.text_body:
+            payload["text"] = request.text_body
+        if request.reply_to:
+            payload["reply_to"] = request.reply_to
+        if request.headers:
+            payload["headers"] = dict(request.headers)
+        tags = normalize_tags(request.tags)
+        if tags:
+            payload["tags"] = tags
+
+        headers = {
+            "Authorization": f"Bearer {self._config.api_key}",
+            "Content-Type": "application/json",
+        }
+        if self._http_client is not None:
+            response = await self._http_client.post(
+                self._config.api_url,
+                json=payload,
+                headers=headers,
+            )
+        else:
+            async with httpx.AsyncClient(timeout=self._config.timeout_seconds) as client:
+                response = await client.post(
+                    self._config.api_url,
+                    json=payload,
+                    headers=headers,
+                )
+        response.raise_for_status()
+        data = response.json()
+        return SendResult(provider="resend", message_id=str(data["id"]), raw=data)
+
+
+@dataclass(frozen=True)
+class SESSenderConfig:
+    from_email: str
+    region: str = "us-east-1"
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+    configuration_set: str | None = None
+
+
+class SESCampaignSender:
+    """Send campaign emails through Amazon SES without Atlas settings."""
+
+    def __init__(
+        self,
+        config: SESSenderConfig,
+        *,
+        client: Any | None = None,
+    ) -> None:
+        if not config.from_email:
+            raise ValueError("SES from_email is required")
+        self._config = config
+        if client is not None:
+            self._client = client
+            return
+
+        import boto3
+
+        kwargs: dict[str, Any] = {"region_name": config.region}
+        if config.access_key_id and config.secret_access_key:
+            kwargs["aws_access_key_id"] = config.access_key_id
+            kwargs["aws_secret_access_key"] = config.secret_access_key
+        self._client = boto3.client("sesv2", **kwargs)
+
+    async def send(self, request: SendRequest) -> SendResult:
+        body: dict[str, Any] = {
+            "Html": {"Data": request.html_body, "Charset": "UTF-8"},
+        }
+        if request.text_body:
+            body["Text"] = {"Data": request.text_body, "Charset": "UTF-8"}
+
+        simple: dict[str, Any] = {
+            "Subject": {"Data": request.subject, "Charset": "UTF-8"},
+            "Body": body,
+        }
+        if request.headers:
+            simple["Headers"] = [
+                {"Name": key, "Value": value}
+                for key, value in request.headers.items()
+            ]
+
+        send_kwargs: dict[str, Any] = {
+            "FromEmailAddress": request.from_email or self._config.from_email,
+            "Destination": {"ToAddresses": [request.to_email]},
+            "Content": {"Simple": simple},
+        }
+        if request.reply_to:
+            send_kwargs["ReplyToAddresses"] = [request.reply_to]
+        if self._config.configuration_set:
+            send_kwargs["ConfigurationSetName"] = self._config.configuration_set
+        tags = normalize_tags(request.tags)
+        if tags:
+            send_kwargs["EmailTags"] = [
+                {"Name": item["name"], "Value": item["value"]}
+                for item in tags
+            ]
+
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None,
+            lambda: self._client.send_email(**send_kwargs),
+        )
+        return SendResult(
+            provider="ses",
+            message_id=str(response.get("MessageId", "")),
+            raw=response,
+        )
+
+
+def create_campaign_sender(
+    provider: str,
+    config: Mapping[str, Any],
+    *,
+    http_client: Any | None = None,
+    ses_client: Any | None = None,
+) -> ResendCampaignSender | SESCampaignSender:
+    """Create a sender from product-owned provider config."""
+    normalized = str(provider or "").strip().lower()
+    if normalized == "resend":
+        return ResendCampaignSender(
+            ResendSenderConfig(
+                api_key=str(config.get("api_key") or ""),
+                api_url=str(config.get("api_url") or RESEND_API_URL),
+                timeout_seconds=float(config.get("timeout_seconds") or 30.0),
+            ),
+            http_client=http_client,
+        )
+    if normalized == "ses":
+        return SESCampaignSender(
+            SESSenderConfig(
+                from_email=str(config.get("from_email") or ""),
+                region=str(config.get("region") or "us-east-1"),
+                access_key_id=config.get("access_key_id"),
+                secret_access_key=config.get("secret_access_key"),
+                configuration_set=config.get("configuration_set"),
+            ),
+            client=ses_client,
+        )
+    raise ValueError(f"Unsupported campaign sender provider: {provider!r}")

--- a/extracted_content_pipeline/campaign_sequence_context.py
+++ b/extracted_content_pipeline/campaign_sequence_context.py
@@ -1,0 +1,472 @@
+"""Standalone sequence-context compaction for campaign follow-up prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import json
+import re
+from typing import Any
+
+
+_STORAGE_DROP_COMPANY_CONTEXT_KEYS = frozenset({
+    "selling",
+    "comparison_asset",
+    "reasoning_contracts",
+    "qualification",
+    "partner",
+    "primary_blog_post",
+    "supporting_blog_posts",
+})
+_PROMPT_ONLY_DROP_COMPANY_CONTEXT_KEYS = frozenset({
+    "reasoning_anchor_examples",
+    "reasoning_witness_highlights",
+    "reasoning_reference_ids",
+})
+_SKIP = object()
+
+
+@dataclass(frozen=True)
+class SequenceContextLimits:
+    """Limits used when compacting stored and prompt-visible sequence context."""
+
+    prompt_max_tokens: int = 512
+    prompt_list_limit: int = 5
+    prompt_quote_limit: int = 3
+    prompt_blog_post_limit: int = 3
+    prompt_email_body_preview_chars: int = 220
+
+
+DEFAULT_LIMITS = SequenceContextLimits()
+
+
+def prompt_max_tokens(limits: SequenceContextLimits = DEFAULT_LIMITS) -> int:
+    return int(limits.prompt_max_tokens)
+
+
+def prompt_email_body_preview_chars(limits: SequenceContextLimits = DEFAULT_LIMITS) -> int:
+    return int(limits.prompt_email_body_preview_chars)
+
+
+def _has_context_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict, tuple, set)):
+        return bool(value)
+    return True
+
+
+def _parse_context_blob(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _compact_scalar_list(items: Any, *, max_items: int) -> list[str]:
+    compact: list[str] = []
+    for item in items or []:
+        if not isinstance(item, str):
+            continue
+        text = item.strip()
+        if text:
+            compact.append(text)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_object_list(items: Any, *, max_items: int) -> list[dict[str, Any]]:
+    compact: list[dict[str, Any]] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            key: value
+            for key, value in item.items()
+            if isinstance(value, (str, int, float, bool)) and _has_context_value(value)
+        }
+        if entry:
+            compact.append(entry)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_named_rows(
+    items: Any,
+    *,
+    keys: tuple[str, ...],
+    max_items: int,
+) -> list[dict[str, Any]]:
+    compact: list[dict[str, Any]] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        entry = {key: item[key] for key in keys if _has_context_value(item.get(key))}
+        if entry:
+            compact.append(entry)
+        if len(compact) >= max_items:
+            break
+    return compact
+
+
+def _compact_scalar_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: item
+        for key, item in value.items()
+        if isinstance(item, (str, int, float, bool)) and _has_context_value(item)
+    }
+
+
+def _compact_blog_posts(posts: Any, *, limits: SequenceContextLimits) -> list[dict[str, str]]:
+    compact: list[dict[str, str]] = []
+    for post in posts or []:
+        if not isinstance(post, dict):
+            continue
+        entry = {
+            key: str(post.get(key) or "").strip()
+            for key in ("title", "url", "topic_type")
+            if str(post.get(key) or "").strip()
+        }
+        if entry:
+            compact.append(entry)
+        if len(compact) >= limits.prompt_blog_post_limit:
+            break
+    return compact
+
+
+def _compact_briefing_context(
+    value: Any,
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for key, item in value.items():
+        if isinstance(item, (str, int, float, bool)) and _has_context_value(item):
+            compact[key] = item
+        elif isinstance(item, list):
+            compact_list = _compact_scalar_list(
+                item,
+                max_items=limits.prompt_list_limit,
+            )
+            if compact_list:
+                compact[key] = compact_list
+    return compact
+
+
+def _compact_reasoning_context(
+    value: Any,
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for key in ("wedge", "confidence", "summary", "account_summary"):
+        item = value.get(key)
+        if _has_context_value(item):
+            compact[key] = item
+
+    key_signals = _compact_scalar_list(
+        value.get("key_signals"),
+        max_items=limits.prompt_quote_limit,
+    )
+    if key_signals:
+        compact["key_signals"] = key_signals
+
+    why_they_stay = value.get("why_they_stay")
+    if isinstance(why_they_stay, dict):
+        summary = str(why_they_stay.get("summary") or "").strip()
+        if summary:
+            compact["why_they_stay"] = {"summary": summary}
+
+    timing = value.get("timing")
+    if isinstance(timing, dict):
+        timing_compact = {
+            key: timing[key]
+            for key in ("best_window", "trigger_count")
+            if _has_context_value(timing.get(key))
+        }
+        if timing_compact:
+            compact["timing"] = timing_compact
+
+    switch_triggers = _compact_object_list(
+        value.get("switch_triggers"),
+        max_items=limits.prompt_quote_limit,
+    )
+    if switch_triggers:
+        compact["switch_triggers"] = switch_triggers
+    return compact
+
+
+def _compact_signal_summary(
+    value: Any,
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    row_keys = {
+        "pain_distribution": ("category", "count"),
+        "competitor_distribution": ("name", "count"),
+        "role_distribution": ("role", "count"),
+        "pain_driving_switch": ("category", "count"),
+        "incumbents_losing": ("name", "count"),
+    }
+    scalar_lists = {"feature_gaps", "feature_mentions"}
+    for key, item in value.items():
+        if key in row_keys:
+            rows = _compact_named_rows(
+                item,
+                keys=row_keys[key],
+                max_items=limits.prompt_list_limit,
+            )
+            if rows:
+                compact[key] = rows
+        elif key in scalar_lists:
+            rows = _compact_scalar_list(item, max_items=limits.prompt_list_limit)
+            if rows:
+                compact[key] = rows
+        elif isinstance(item, dict):
+            nested = _compact_scalar_mapping(item)
+            if nested:
+                compact[key] = nested
+        elif _has_context_value(item):
+            compact[key] = item
+    return compact
+
+
+def _compact_incumbent_reasoning(
+    value: Any,
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for vendor_name, item in value.items():
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            key: item[key]
+            for key in ("wedge", "summary", "why_they_stay")
+            if _has_context_value(item.get(key))
+        }
+        switch_triggers = _compact_scalar_list(
+            item.get("switch_triggers"),
+            max_items=limits.prompt_quote_limit,
+        )
+        if switch_triggers:
+            entry["switch_triggers"] = switch_triggers
+        if entry:
+            compact[str(vendor_name)] = entry
+        if len(compact) >= limits.prompt_list_limit:
+            break
+    return compact
+
+
+def _compact_incumbent_archetypes(
+    value: Any,
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, list[str]] = {}
+    for group, items in value.items():
+        compact_items = _compact_scalar_list(
+            items,
+            max_items=limits.prompt_quote_limit,
+        )
+        if compact_items:
+            compact[str(group)] = compact_items
+    return compact
+
+
+def _compact_category_intelligence(
+    value: Any,
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    stats = _compact_scalar_mapping(value.get("category_stats"))
+    if stats:
+        compact["category_stats"] = stats
+    for key in (
+        "top_pain_points",
+        "feature_gaps",
+        "competitive_flows",
+        "brand_health",
+        "safety_signals",
+        "top_root_causes",
+    ):
+        rows = _compact_object_list(value.get(key), max_items=limits.prompt_list_limit)
+        if rows:
+            compact[key] = rows
+    return compact
+
+
+def _company_context_drop_keys(*, prompt_safe: bool) -> frozenset[str]:
+    if prompt_safe:
+        return _STORAGE_DROP_COMPANY_CONTEXT_KEYS | _PROMPT_ONLY_DROP_COMPANY_CONTEXT_KEYS
+    return _STORAGE_DROP_COMPANY_CONTEXT_KEYS
+
+
+def _compact_company_context_value(
+    key: str,
+    value: Any,
+    *,
+    prompt_safe: bool,
+    limits: SequenceContextLimits,
+) -> Any:
+    if key in _company_context_drop_keys(prompt_safe=prompt_safe):
+        return _SKIP
+    if key == "key_quotes":
+        return _compact_scalar_list(value, max_items=limits.prompt_quote_limit)
+    if key == "pain_categories":
+        return _compact_named_rows(
+            value,
+            keys=("category", "severity"),
+            max_items=limits.prompt_list_limit,
+        )
+    if key == "competitors_considering":
+        return _compact_named_rows(
+            value,
+            keys=("name", "reason"),
+            max_items=limits.prompt_list_limit,
+        )
+    if key in {"feature_gaps", "integration_stack"}:
+        return _compact_scalar_list(value, max_items=limits.prompt_list_limit)
+    if key == "signal_summary":
+        return _compact_signal_summary(value, limits=limits)
+    if key == "briefing_context":
+        return _compact_briefing_context(value, limits=limits)
+    if key == "reasoning_context":
+        return _compact_reasoning_context(value, limits=limits)
+    if key == "incumbent_reasoning":
+        return _compact_incumbent_reasoning(value, limits=limits)
+    if key == "incumbent_archetypes":
+        return _compact_incumbent_archetypes(value, limits=limits)
+    if key == "category_intelligence":
+        return _compact_category_intelligence(value, limits=limits)
+    return value
+
+
+def _compact_company_context(
+    company_context: dict[str, Any],
+    *,
+    prompt_safe: bool,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key, value in company_context.items():
+        compact_value = _compact_company_context_value(
+            key,
+            value,
+            prompt_safe=prompt_safe,
+            limits=limits,
+        )
+        if compact_value is _SKIP or not _has_context_value(compact_value):
+            continue
+        compact[key] = compact_value
+    return compact
+
+
+def _compact_selling_context(
+    selling_context: dict[str, Any],
+    *,
+    limits: SequenceContextLimits,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key, value in selling_context.items():
+        if key in {"blog_posts", "primary_blog_post"}:
+            continue
+        if isinstance(value, (str, int, float, bool)) and _has_context_value(value):
+            compact[key] = value
+
+    blog_posts = selling_context.get("blog_posts")
+    if not blog_posts and isinstance(selling_context.get("primary_blog_post"), dict):
+        blog_posts = [selling_context["primary_blog_post"]]
+    compact_posts = _compact_blog_posts(blog_posts, limits=limits)
+    if compact_posts:
+        compact["blog_posts"] = compact_posts
+    return compact
+
+
+def compact_sequence_contexts(
+    company_context: Any,
+    selling_context: Any,
+    *,
+    prompt_safe: bool,
+    limits: SequenceContextLimits = DEFAULT_LIMITS,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    parsed_company_context = _parse_context_blob(company_context)
+    parsed_selling_context = _parse_context_blob(selling_context)
+
+    legacy_selling = parsed_company_context.get("selling")
+    if not parsed_selling_context and isinstance(legacy_selling, dict):
+        parsed_selling_context = legacy_selling
+
+    return (
+        _compact_company_context(
+            parsed_company_context,
+            prompt_safe=prompt_safe,
+            limits=limits,
+        ),
+        _compact_selling_context(parsed_selling_context, limits=limits),
+    )
+
+
+def prepare_sequence_prompt_contexts(
+    seq: dict[str, Any],
+    *,
+    limits: SequenceContextLimits = DEFAULT_LIMITS,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    return compact_sequence_contexts(
+        seq.get("company_context"),
+        seq.get("selling_context"),
+        prompt_safe=True,
+        limits=limits,
+    )
+
+
+def prepare_sequence_storage_contexts(
+    company_context: Any,
+    selling_context: Any,
+    *,
+    limits: SequenceContextLimits = DEFAULT_LIMITS,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    return compact_sequence_contexts(
+        company_context,
+        selling_context,
+        prompt_safe=False,
+        limits=limits,
+    )
+
+
+def plain_text_preview(
+    body: str,
+    *,
+    limit: int | None = None,
+    limits: SequenceContextLimits = DEFAULT_LIMITS,
+) -> str:
+    max_chars = int(limit or prompt_email_body_preview_chars(limits))
+    text = re.sub(r"<[^>]+>", " ", body or "")
+    text = html.unescape(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars].rstrip()}..."

--- a/extracted_content_pipeline/campaign_sequence_progression.py
+++ b/extracted_content_pipeline/campaign_sequence_progression.py
@@ -1,0 +1,420 @@
+"""Standalone campaign sequence progression orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import (
+    AuditSink,
+    CampaignSequenceRepository,
+    Clock,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+)
+from .campaign_sequence_context import (
+    DEFAULT_LIMITS,
+    SequenceContextLimits,
+    plain_text_preview,
+    prepare_sequence_prompt_contexts,
+    prompt_max_tokens,
+)
+
+
+@dataclass(frozen=True)
+class CampaignSequenceProgressionConfig:
+    enabled: bool = True
+    batch_limit: int = 20
+    max_steps: int = 5
+    from_email: str = ""
+    onboarding_product_name: str = ""
+    temperature: float = 0.7
+    context_limits: SequenceContextLimits = DEFAULT_LIMITS
+
+
+@dataclass(frozen=True)
+class CampaignSequenceProgressionResult:
+    due_sequences: int = 0
+    progressed: int = 0
+    skipped: int = 0
+    disabled: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "due_sequences": self.due_sequences,
+            "progressed": self.progressed,
+            "skipped": self.skipped,
+            "disabled": self.disabled,
+        }
+
+
+class SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+def sequence_max_steps(
+    sequence: Mapping[str, Any],
+    *,
+    config: CampaignSequenceProgressionConfig | None = None,
+) -> int:
+    configured = config or CampaignSequenceProgressionConfig()
+    return int(sequence.get("max_steps") or configured.max_steps)
+
+
+def build_engagement_summary(
+    sequence: Mapping[str, Any],
+    previous_campaigns: Sequence[Mapping[str, Any]] | None = None,
+) -> str:
+    parts: list[str] = []
+    opens = int(sequence.get("open_count") or 0)
+    clicks = int(sequence.get("click_count") or 0)
+
+    parts.append(f"Opened {opens} time(s)" if opens > 0 else "No opens recorded")
+    parts.append(f"Clicked {clicks} time(s)" if clicks > 0 else "No clicks recorded")
+
+    if sequence.get("reply_received_at"):
+        intent = str(sequence.get("reply_intent") or "unknown")
+        summary = str(sequence.get("reply_summary") or "")
+        parts.append(f"Reply received ({intent}): {summary[:200]}")
+
+    if previous_campaigns:
+        parts.append("")
+        parts.append("Per-step breakdown:")
+        for campaign in previous_campaigns:
+            step = campaign.get("step_number", "?")
+            opened = "Opened" if campaign.get("opened_at") else "No opens"
+            clicked = "Clicked" if campaign.get("clicked_at") else "No clicks"
+            parts.append(f"- Step {step}: {opened}, {clicked}")
+    return "\n".join(parts)
+
+
+def build_previous_emails(
+    campaigns: Sequence[Mapping[str, Any]],
+    *,
+    limits: SequenceContextLimits = DEFAULT_LIMITS,
+) -> str:
+    if not campaigns:
+        return "No previous emails sent."
+
+    parts: list[str] = []
+    for campaign in campaigns:
+        step = campaign.get("step_number", "?")
+        subject = campaign.get("subject") or "(no subject)"
+        body = plain_text_preview(str(campaign.get("body") or ""), limits=limits)
+        status = campaign.get("status") or ""
+
+        engagement_parts: list[str] = []
+        if campaign.get("opened_at"):
+            engagement_parts.append("Opened")
+        if campaign.get("clicked_at"):
+            engagement_parts.append("Clicked")
+        engagement_line = (
+            f"Engagement: {' | '.join(engagement_parts)}"
+            if engagement_parts
+            else "Engagement: No opens or clicks recorded"
+        )
+
+        parts.append(
+            f"--- Step {step} (status: {status}) ---\n"
+            f"Subject: {subject}\n"
+            f"{engagement_line}\n"
+            f"Preview: {body or '(no body)'}\n"
+        )
+    return "\n".join(parts)
+
+
+def sequence_skill_name(recipient_type: str | None) -> str:
+    if recipient_type == "onboarding":
+        return "digest/b2b_onboarding_sequence"
+    if recipient_type == "amazon_seller":
+        return "digest/amazon_seller_campaign_sequence"
+    if recipient_type == "vendor_retention":
+        return "digest/b2b_vendor_sequence"
+    if recipient_type == "challenger_intel":
+        return "digest/b2b_challenger_sequence"
+    return "digest/b2b_campaign_sequence"
+
+
+def target_mode_for_recipient_type(recipient_type: str | None) -> str:
+    if recipient_type == "amazon_seller":
+        return "amazon_seller"
+    if recipient_type == "vendor_retention":
+        return "vendor_retention"
+    if recipient_type == "challenger_intel":
+        return "challenger_intel"
+    return "churning_company"
+
+
+def parse_generated_sequence_step(text: str) -> dict[str, Any] | None:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict) and parsed.get("subject"):
+        return parsed
+
+    depth = 0
+    start = -1
+    for index, char in enumerate(cleaned):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    parsed = json.loads(cleaned[start : index + 1])
+                except json.JSONDecodeError:
+                    parsed = None
+                if isinstance(parsed, dict) and parsed.get("subject"):
+                    return parsed
+                start = -1
+    return None
+
+
+class CampaignSequenceProgressionService:
+    """Generate and queue due follow-up campaign steps through product ports."""
+
+    def __init__(
+        self,
+        *,
+        sequences: CampaignSequenceRepository,
+        llm: LLMClient,
+        skills: SkillStore,
+        audit: AuditSink | None = None,
+        clock: Clock | None = None,
+        config: CampaignSequenceProgressionConfig | None = None,
+    ):
+        self._sequences = sequences
+        self._llm = llm
+        self._skills = skills
+        self._audit = audit
+        self._clock = clock or SystemClock()
+        self._config = config or CampaignSequenceProgressionConfig()
+
+    async def progress_due(self) -> CampaignSequenceProgressionResult:
+        if not self._config.enabled:
+            return CampaignSequenceProgressionResult(disabled=True)
+
+        now = self._clock.now()
+        due = [
+            dict(row)
+            for row in await self._sequences.list_due_sequences(
+                limit=self._config.batch_limit,
+                now=now,
+            )
+        ]
+        if not due:
+            return CampaignSequenceProgressionResult()
+
+        progressed = 0
+        skipped = 0
+        for sequence in due:
+            sequence_id = str(sequence.get("id") or "").strip()
+            if not sequence_id:
+                skipped += 1
+                continue
+
+            max_steps = sequence_max_steps(sequence, config=self._config)
+            previous = [
+                dict(row)
+                for row in await self._sequences.list_previous_campaigns(
+                    sequence_id=sequence_id,
+                    limit=max_steps,
+                )
+            ]
+            content = await self.generate_next_step(sequence, previous)
+            if not content:
+                skipped += 1
+                continue
+
+            next_step = int(sequence.get("current_step") or 0) + 1
+            content = {
+                **content,
+                "step_number": next_step,
+                "target_mode": target_mode_for_recipient_type(
+                    content.get("_recipient_type")
+                ),
+                "product_category": (
+                    content.get("_category")
+                    if content.get("_recipient_type") == "amazon_seller"
+                    else None
+                ),
+            }
+            campaign_id = await self._sequences.queue_sequence_step(
+                sequence=sequence,
+                content=content,
+                from_email=self._config.from_email,
+                queued_at=now,
+            )
+            await self._sequences.mark_sequence_step(
+                sequence_id=sequence_id,
+                current_step=next_step,
+                updated_at=now,
+            )
+            await self._record_audit(
+                "generated",
+                campaign_id=campaign_id,
+                sequence_id=sequence_id,
+                step_number=next_step,
+                sequence=sequence,
+                content=content,
+            )
+            await self._record_audit(
+                "queued",
+                campaign_id=campaign_id,
+                sequence_id=sequence_id,
+                step_number=next_step,
+                sequence=sequence,
+                content=content,
+            )
+            progressed += 1
+
+        return CampaignSequenceProgressionResult(
+            due_sequences=len(due),
+            progressed=progressed,
+            skipped=skipped,
+        )
+
+    async def generate_next_step(
+        self,
+        sequence: Mapping[str, Any],
+        previous_campaigns: Sequence[Mapping[str, Any]],
+    ) -> dict[str, Any] | None:
+        company_context, selling_context = prepare_sequence_prompt_contexts(
+            dict(sequence),
+            limits=self._config.context_limits,
+        )
+        recipient_type = str(company_context.get("recipient_type") or "").strip() or None
+        skill = self._skills.get_prompt(sequence_skill_name(recipient_type))
+        if not skill:
+            return None
+
+        replacements = self._template_replacements(
+            sequence,
+            previous_campaigns,
+            company_context=company_context,
+            selling_context=selling_context,
+        )
+        system_prompt = skill
+        for placeholder, value in replacements.items():
+            system_prompt = system_prompt.replace(placeholder, value)
+
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(
+                    role="user",
+                    content="Generate the next email in this sequence.",
+                ),
+            ],
+            max_tokens=prompt_max_tokens(self._config.context_limits),
+            temperature=self._config.temperature,
+            metadata={
+                "sequence_id": sequence.get("id"),
+                "company_name": sequence.get("company_name"),
+                "recipient_type": recipient_type,
+            },
+        )
+        parsed = parse_generated_sequence_step(response.content)
+        if not parsed:
+            return None
+        return {
+            **parsed,
+            "_recipient_type": recipient_type,
+            "_category": company_context.get("category"),
+        }
+
+    def _template_replacements(
+        self,
+        sequence: Mapping[str, Any],
+        previous_campaigns: Sequence[Mapping[str, Any]],
+        *,
+        company_context: Mapping[str, Any],
+        selling_context: Mapping[str, Any],
+    ) -> dict[str, str]:
+        days_since = "N/A"
+        last_sent_at = sequence.get("last_sent_at")
+        if isinstance(last_sent_at, datetime):
+            days_since = str((self._clock.now() - last_sent_at).days)
+
+        max_steps = sequence_max_steps(sequence, config=self._config)
+        replacements = {
+            "{company_name}": str(sequence.get("company_name") or ""),
+            "{company_context}": json.dumps(
+                dict(company_context),
+                separators=(",", ":"),
+                default=str,
+            ),
+            "{selling_context}": json.dumps(
+                dict(selling_context),
+                separators=(",", ":"),
+                default=str,
+            ),
+            "{current_step}": str(int(sequence.get("current_step") or 0) + 1),
+            "{max_steps}": str(max_steps),
+            "{days_since_last}": days_since,
+            "{engagement_summary}": build_engagement_summary(
+                sequence,
+                previous_campaigns,
+            ),
+            "{previous_emails}": build_previous_emails(
+                previous_campaigns,
+                limits=self._config.context_limits,
+            ),
+            "{product_name}": str(
+                company_context.get("product_name")
+                or self._config.onboarding_product_name
+            ),
+        }
+        if company_context.get("recipient_type") == "amazon_seller":
+            category_intel = company_context.get("category_intelligence")
+            replacements.update({
+                "{recipient_name}": str(company_context.get("seller_name") or ""),
+                "{recipient_company}": str(company_context.get("seller_name") or ""),
+                "{recipient_type}": "amazon_seller",
+                "{category}": str(company_context.get("category") or ""),
+                "{category_intelligence}": json.dumps(
+                    category_intel if isinstance(category_intel, dict) else {},
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            })
+        return replacements
+
+    async def _record_audit(
+        self,
+        event_type: str,
+        *,
+        campaign_id: str,
+        sequence_id: str,
+        step_number: int,
+        sequence: Mapping[str, Any],
+        content: Mapping[str, Any],
+    ) -> None:
+        if not self._audit:
+            return
+        await self._audit.record(
+            event_type,
+            campaign_id=campaign_id,
+            sequence_id=sequence_id,
+            metadata={
+                "step_number": step_number,
+                "subject": content.get("subject"),
+                "recipient_email": sequence.get("recipient_email"),
+                "angle_reasoning": content.get("angle_reasoning"),
+            },
+        )

--- a/extracted_content_pipeline/campaign_suppression.py
+++ b/extracted_content_pipeline/campaign_suppression.py
@@ -1,0 +1,156 @@
+"""Standalone suppression policy for the campaign generation product."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+
+from .campaign_ports import SuppressionRepository
+
+
+def normalize_email(email: str | None) -> str | None:
+    """Normalize an email address for suppression matching."""
+    if email is None:
+        return None
+    value = str(email).strip().lower()
+    return value or None
+
+
+def normalize_domain(domain: str | None) -> str | None:
+    """Normalize a domain for suppression matching."""
+    if domain is None:
+        return None
+    value = str(domain).strip().lower()
+    if value.startswith("@"):
+        value = value[1:]
+    value = value.strip().strip(".")
+    return value or None
+
+
+def domain_from_email(email: str | None) -> str | None:
+    """Extract a suppressible domain from a normalized email address."""
+    value = normalize_email(email)
+    if not value:
+        return None
+    local, sep, domain = value.rpartition("@")
+    if not sep or not local or not domain:
+        return None
+    return normalize_domain(domain)
+
+
+@dataclass(frozen=True)
+class SuppressionInput:
+    """Normalized suppression write payload."""
+
+    reason: str
+    email: str | None = None
+    domain: str | None = None
+    source: str = "system"
+    campaign_id: str | None = None
+    notes: str | None = None
+    expires_at: datetime | None = None
+    metadata: Mapping[str, Any] | None = None
+
+
+class CampaignSuppressionService:
+    """Campaign suppression checks decoupled from Atlas persistence."""
+
+    def __init__(self, repository: SuppressionRepository):
+        self._repository = repository
+
+    async def is_suppressed(
+        self,
+        *,
+        email: str | None,
+        domain: str | None = None,
+    ) -> bool:
+        """Return whether an email or domain is suppressed.
+
+        Exact email suppressions win first, matching Atlas' production helper.
+        If no exact email match exists, the explicit domain or email domain is
+        checked next.
+        """
+        normalized_email = normalize_email(email)
+        if normalized_email:
+            if await self._repository.is_suppressed(email=normalized_email, domain=None):
+                return True
+
+        normalized_domain = normalize_domain(domain) or domain_from_email(normalized_email)
+        if normalized_domain:
+            return bool(
+                await self._repository.is_suppressed(
+                    email=None,
+                    domain=normalized_domain,
+                )
+            )
+        return False
+
+    async def add_suppression(
+        self,
+        *,
+        reason: str,
+        email: str | None = None,
+        domain: str | None = None,
+        source: str = "system",
+        campaign_id: str | None = None,
+        notes: str | None = None,
+        expires_at: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> bool:
+        """Persist a normalized suppression if it has an email or domain."""
+        payload = build_suppression_input(
+            reason=reason,
+            email=email,
+            domain=domain,
+            source=source,
+            campaign_id=campaign_id,
+            notes=notes,
+            expires_at=expires_at,
+            metadata=metadata,
+        )
+        if payload is None:
+            return False
+        await self._repository.add_suppression(
+            reason=payload.reason,
+            email=payload.email,
+            domain=payload.domain,
+            source=payload.source,
+            campaign_id=payload.campaign_id,
+            notes=payload.notes,
+            expires_at=payload.expires_at,
+            metadata=payload.metadata,
+        )
+        return True
+
+
+def build_suppression_input(
+    *,
+    reason: str,
+    email: str | None = None,
+    domain: str | None = None,
+    source: str = "system",
+    campaign_id: str | None = None,
+    notes: str | None = None,
+    expires_at: datetime | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> SuppressionInput | None:
+    """Normalize and validate a suppression write payload."""
+    normalized_email = normalize_email(email)
+    normalized_domain = normalize_domain(domain)
+    normalized_reason = str(reason or "").strip()
+    normalized_source = str(source or "system").strip() or "system"
+    if not normalized_reason:
+        raise ValueError("reason is required")
+    if not normalized_email and not normalized_domain:
+        return None
+    return SuppressionInput(
+        reason=normalized_reason,
+        email=normalized_email,
+        domain=normalized_domain,
+        source=normalized_source,
+        campaign_id=str(campaign_id).strip() if campaign_id else None,
+        notes=str(notes).strip() if notes else None,
+        expires_at=expires_at,
+        metadata=metadata,
+    )

--- a/extracted_content_pipeline/campaign_webhooks.py
+++ b/extracted_content_pipeline/campaign_webhooks.py
@@ -1,0 +1,305 @@
+"""Standalone webhook verification and event normalization for campaign ESPs."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import hmac
+import json
+from typing import Any, Mapping
+
+from .campaign_ports import AuditSink, CampaignRepository, Clock, WebhookEvent, WebhookVerifier
+from .campaign_suppression import CampaignSuppressionService
+
+
+class WebhookVerificationError(ValueError):
+    """Raised when a webhook signature is invalid."""
+
+
+class WebhookPayloadError(ValueError):
+    """Raised when a webhook payload cannot be parsed."""
+
+
+_RESEND_EVENT_MAP = {
+    "email.opened": "opened",
+    "email.clicked": "clicked",
+    "email.bounced": "bounced",
+    "email.complained": "complained",
+    "email.delivered": "delivered",
+    "email.unsubscribed": "unsubscribed",
+}
+
+_HANDLED_EVENT_TYPES = {
+    "opened",
+    "clicked",
+    "bounced",
+    "complained",
+    "delivered",
+    "unsubscribed",
+}
+
+
+@dataclass(frozen=True)
+class ResendWebhookConfig:
+    signing_secret: str = ""
+    verify_signatures: bool = True
+
+
+@dataclass(frozen=True)
+class CampaignWebhookIngestionConfig:
+    soft_bounce_suppression_days: int = 30
+    record_unknown_events: bool = False
+
+
+@dataclass(frozen=True)
+class CampaignWebhookIngestionResult:
+    status: str
+    event_type: str | None = None
+    message_id: str | None = None
+    reason: str | None = None
+    suppressed: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "event_type": self.event_type,
+            "message_id": self.message_id,
+            "reason": self.reason,
+            "suppressed": self.suppressed,
+        }
+
+
+class SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == wanted:
+            return str(value or "")
+    return ""
+
+
+def verify_svix_signature(
+    payload_bytes: bytes,
+    headers: Mapping[str, str],
+    secret: str,
+    *,
+    verify_signatures: bool = True,
+) -> bool:
+    """Verify a Svix-format Resend webhook signature."""
+    if not verify_signatures or not secret:
+        return True
+
+    msg_id = _header(headers, "svix-id")
+    timestamp = _header(headers, "svix-timestamp")
+    signature_header = _header(headers, "svix-signature")
+    if not msg_id or not timestamp or not signature_header:
+        return False
+
+    raw_secret = str(secret)
+    if raw_secret.startswith("whsec_"):
+        raw_secret = raw_secret[6:]
+
+    try:
+        secret_bytes = base64.b64decode(raw_secret)
+    except Exception:
+        return False
+
+    to_sign = f"{msg_id}.{timestamp}.".encode("utf-8") + payload_bytes
+    expected = base64.b64encode(
+        hmac.new(secret_bytes, to_sign, hashlib.sha256).digest()
+    ).decode("utf-8")
+
+    for signature in signature_header.split(" "):
+        version, sep, value = signature.partition(",")
+        if sep and version == "v1" and hmac.compare_digest(value, expected):
+            return True
+    return False
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def normalize_resend_payload(payload: Mapping[str, Any]) -> WebhookEvent:
+    raw_type = str(payload.get("type") or "").strip()
+    data = payload.get("data")
+    data = data if isinstance(data, Mapping) else {}
+    event_type = _RESEND_EVENT_MAP.get(raw_type, raw_type or "unknown")
+    click = data.get("click") if isinstance(data.get("click"), Mapping) else {}
+    bounce = data.get("bounce") if isinstance(data.get("bounce"), Mapping) else {}
+    normalized_payload = dict(payload)
+    normalized_payload["normalized"] = {
+        "raw_event_type": raw_type,
+        "click_url": click.get("link"),
+        "bounce_type": bounce.get("type"),
+    }
+    return WebhookEvent(
+        provider="resend",
+        event_type=event_type,
+        message_id=str(data.get("email_id") or "").strip() or None,
+        email=str(data.get("to") or data.get("email") or "").strip() or None,
+        occurred_at=_parse_datetime(
+            data.get("created_at")
+            or data.get("createdAt")
+            or payload.get("created_at")
+            or payload.get("createdAt")
+        ),
+        payload=normalized_payload,
+    )
+
+
+class ResendWebhookVerifier:
+    """Verify and normalize Resend/Svix campaign webhook payloads."""
+
+    def __init__(self, config: ResendWebhookConfig):
+        self._config = config
+
+    def verify_and_parse(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+    ) -> WebhookEvent:
+        if not verify_svix_signature(
+            body,
+            headers,
+            self._config.signing_secret,
+            verify_signatures=self._config.verify_signatures,
+        ):
+            raise WebhookVerificationError("Invalid webhook signature")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise WebhookPayloadError("Invalid JSON") from exc
+        if not isinstance(payload, Mapping):
+            raise WebhookPayloadError("Webhook payload must be a JSON object")
+        return normalize_resend_payload(payload)
+
+
+def _bounce_type(event: WebhookEvent) -> str:
+    normalized = event.payload.get("normalized")
+    if isinstance(normalized, Mapping):
+        value = str(normalized.get("bounce_type") or "").strip().lower()
+        if value:
+            return value
+    data = event.payload.get("data")
+    data = data if isinstance(data, Mapping) else {}
+    bounce = data.get("bounce")
+    bounce = bounce if isinstance(bounce, Mapping) else {}
+    return str(bounce.get("type") or "hard").strip().lower() or "hard"
+
+
+class CampaignWebhookIngestionService:
+    """Process normalized campaign webhooks through product-owned ports."""
+
+    def __init__(
+        self,
+        *,
+        verifier: WebhookVerifier,
+        campaigns: CampaignRepository,
+        suppression: CampaignSuppressionService | None = None,
+        audit: AuditSink | None = None,
+        clock: Clock | None = None,
+        config: CampaignWebhookIngestionConfig | None = None,
+    ):
+        self._verifier = verifier
+        self._campaigns = campaigns
+        self._suppression = suppression
+        self._audit = audit
+        self._clock = clock or SystemClock()
+        self._config = config or CampaignWebhookIngestionConfig()
+
+    async def ingest(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+    ) -> CampaignWebhookIngestionResult:
+        event = self._verifier.verify_and_parse(body=body, headers=headers)
+        if not event.message_id:
+            return CampaignWebhookIngestionResult(
+                status="ignored",
+                event_type=event.event_type,
+                reason="no_message_id",
+            )
+        if event.event_type not in _HANDLED_EVENT_TYPES and not self._config.record_unknown_events:
+            return CampaignWebhookIngestionResult(
+                status="ignored",
+                event_type=event.event_type,
+                message_id=event.message_id,
+                reason="unhandled_event_type",
+            )
+
+        await self._campaigns.record_webhook_event(event)
+        suppressed = await self._apply_suppression(event)
+        if self._audit:
+            await self._audit.record(
+                f"webhook_{event.event_type}",
+                metadata={
+                    "provider": event.provider,
+                    "message_id": event.message_id,
+                    "email": event.email,
+                    "suppressed": suppressed,
+                },
+            )
+        return CampaignWebhookIngestionResult(
+            status="ok",
+            event_type=event.event_type,
+            message_id=event.message_id,
+            suppressed=suppressed,
+        )
+
+    async def _apply_suppression(self, event: WebhookEvent) -> bool:
+        if not self._suppression:
+            return False
+        if event.event_type == "complained":
+            return await self._suppression.add_suppression(
+                email=event.email,
+                reason="complaint",
+                source="webhook",
+                metadata={"provider_message_id": event.message_id},
+            )
+        if event.event_type == "unsubscribed":
+            return await self._suppression.add_suppression(
+                email=event.email,
+                reason="unsubscribe",
+                source="webhook",
+                metadata={"provider_message_id": event.message_id},
+            )
+        if event.event_type == "bounced":
+            bounce_type = _bounce_type(event)
+            expires_at = None
+            if bounce_type != "hard":
+                expires_at = self._clock.now() + timedelta(
+                    days=self._config.soft_bounce_suppression_days
+                )
+            return await self._suppression.add_suppression(
+                email=event.email,
+                reason="bounce_hard" if bounce_type == "hard" else "bounce_soft",
+                source="webhook",
+                expires_at=expires_at,
+                metadata={
+                    "provider_message_id": event.message_id,
+                    "bounce_type": bounce_type,
+                },
+            )
+        return False

--- a/extracted_content_pipeline/docs/email_campaign_generation_pipeline.md
+++ b/extracted_content_pipeline/docs/email_campaign_generation_pipeline.md
@@ -1,0 +1,184 @@
+# Email / Campaign Generation Pipeline
+
+This maps the sellable campaign system currently living in `atlas_brain`.
+The important distinction: copied Atlas files are source material, not the final
+customer module. The product version must replace Atlas runtime imports with
+product-owned ports and adapters before it can be shipped outside the repo.
+
+## Product Shape
+
+This is a data-backed outbound platform, closer to a Smartlead/Lemlist/Outreach
+competitor than a single generation task. It combines intelligence selection,
+reasoning-aware copy generation, quality checks, manual review, send
+orchestration, suppression, webhook ingestion, follow-up sequencing, analytics,
+and multi-vertical campaign support.
+
+## Runtime Flow
+
+1. Opportunity sourcing
+   - B2B opportunities are assembled from vendor intelligence, account signals,
+     review candidates, target lists, blog matches, and calibrated score
+     components.
+   - Amazon seller opportunities are assembled from product review/category
+     intelligence and seller targets.
+
+2. Blueprint and prompt assembly
+   - `b2b_campaign_generation.py` builds channel/persona-specific campaign
+     payloads.
+   - `amazon_seller_campaign_generation.py` builds seller/category outreach
+     payloads.
+   - `_campaign_sequence_context.py` compacts prior sequence, signal, quote, and
+     selling-context data for follow-up prompts.
+
+3. LLM generation
+   - Prompt contracts live under `skills/digest/`.
+   - B2B generation uses `b2b_campaign_generation`, `b2b_vendor_outreach`, and
+     `b2b_challenger_outreach`.
+   - Sequence progression uses `b2b_campaign_sequence`,
+     `b2b_vendor_sequence`, `b2b_challenger_sequence`,
+     `b2b_onboarding_sequence`, and `amazon_seller_campaign_sequence`.
+
+4. Quality gates
+   - `campaign_quality.py` revalidates drafts for witness-backed specificity
+     before approval, queueing, and send.
+   - `campaign_specificity_backfill.py` repairs stored campaign metadata when
+     policy changes.
+
+5. Review and approval
+   - `api/b2b_campaigns.py` exposes review queues, quality diagnostics,
+     bulk approval/rejection, sequence details, suppression management,
+     generation, export, and analytics.
+   - `api/seller_campaigns.py` exposes seller target and seller campaign
+     endpoints.
+
+6. Send orchestration
+   - `campaign_send.py` sends queued campaigns through the configured sender
+     after suppression, fatigue, send-window, and quality checks.
+   - `campaign_sender.py` abstracts Resend and SES.
+   - `campaign_suppression.py` manages email/domain suppression.
+
+7. Engagement and progression
+   - `campaign_webhooks.py` ingests ESP events, updates campaign/sequence state,
+     records opens/clicks/bounces/unsubscribes/complaints, and adds suppressions.
+   - `campaign_sequence_progression.py` generates next-step follow-ups from
+     prior messages and engagement context.
+
+8. Analytics and audit
+   - `campaign_audit.py` writes immutable state-change events.
+   - `campaign_analytics_refresh.py` refreshes `campaign_funnel_stats`.
+   - Outcome, score component, timing, and audit metadata migrations preserve
+     funnel attribution and later scoring loops.
+
+## Source Inventory
+
+Already staged in the current extraction scaffold:
+
+- `autonomous/tasks/b2b_campaign_generation.py`
+- `autonomous/tasks/campaign_audit.py`
+- `autonomous/tasks/_campaign_sequence_context.py`
+
+Still to extract after ports/adapters exist:
+
+Core generation and orchestration:
+
+- `autonomous/tasks/amazon_seller_campaign_generation.py`
+- `autonomous/tasks/campaign_send.py`
+- `autonomous/tasks/campaign_sequence_progression.py`
+- `autonomous/tasks/campaign_suppression.py`
+- `autonomous/tasks/campaign_analytics_refresh.py`
+
+Services:
+
+- `services/campaign_quality.py`
+- `services/campaign_reasoning_context.py`
+- `services/campaign_sender.py`
+- `services/campaign_specificity_backfill.py`
+
+API surfaces:
+
+- `api/b2b_campaigns.py`
+- `api/seller_campaigns.py`
+- `api/campaign_webhooks.py`
+
+Prompt contracts:
+
+- `skills/digest/b2b_campaign_generation.md`
+- `skills/digest/b2b_vendor_outreach.md`
+- `skills/digest/b2b_challenger_outreach.md`
+- `skills/digest/b2b_campaign_sequence.md`
+- `skills/digest/b2b_vendor_sequence.md`
+- `skills/digest/b2b_challenger_sequence.md`
+- `skills/digest/b2b_onboarding_sequence.md`
+- `skills/digest/amazon_seller_campaign_generation.md`
+- `skills/digest/amazon_seller_campaign_sequence.md`
+
+Campaign schema:
+
+- `storage/migrations/066_b2b_campaigns.sql`
+- `storage/migrations/068_campaign_sequences.sql`
+- `storage/migrations/069_campaign_analytics.sql`
+- `storage/migrations/070_campaign_suppressions.sql`
+- `storage/migrations/073_campaign_sequence_fixes.sql`
+- `storage/migrations/074_campaign_target_modes.sql`
+- `storage/migrations/075_amazon_seller_campaigns.sql`
+- `storage/migrations/080_b2b_alert_baselines.sql`
+- `storage/migrations/090_audit_log_metadata_index.sql`
+- `storage/migrations/104_campaign_outcomes.sql`
+- `storage/migrations/106_score_calibration.sql`
+- `storage/migrations/146_campaign_score_components.sql`
+- `storage/migrations/150_campaign_engagement_timing.sql`
+- `storage/migrations/235_vendor_targets_account_scope.sql`
+- `storage/migrations/255_anthropic_message_batches.sql`
+
+## External Providers And Env
+
+- Current Atlas source uses Atlas LLM registry and pipeline helpers.
+- Product target needs a standalone LLM client port with OpenAI/Anthropic
+  adapters.
+- Optional Anthropic Message Batches for campaign generation replay and
+  reconciliation.
+- ESP sending through Resend or AWS SES.
+- Resend/Svix webhook signing for inbound events.
+- Campaign sequence config currently under `ATLAS_CAMPAIGN_SEQ_*`.
+- B2B campaign config currently under `ATLAS_B2B_CAMPAIGN_*`.
+- Amazon seller campaign config currently under `ATLAS_SELLER_CAMPAIGN_*`.
+- Product target should rename config away from Atlas-prefixed env vars before
+  customer deployment.
+
+## Extraction Debt
+
+This scaffold still leans on Atlas framework modules. The biggest dependency
+clusters are auth/tenant scope, scheduled-task models, DB pool lifecycle,
+visibility events, LLM routing, skills registry, B2B intelligence helpers,
+vendor/account opportunity selection, and Anthropic exact-cache/batch helpers.
+
+The next extraction step should turn this map into seams:
+
+1. Define product-local interfaces for DB access, LLM, sender, auth scope, and
+   audit events.
+2. Replace direct Atlas imports in copied modules with those interfaces.
+3. Add import smoke coverage for campaign modules once the interfaces exist.
+4. Add fixture-level tests around review queue, suppression, send, webhook,
+   sequence progression, and analytics refresh.
+
+## Product-Owned Modules Started
+
+- `campaign_ports.py`: host-facing interfaces and shared dataclasses.
+- `campaign_suppression.py`: standalone suppression policy using
+  `SuppressionRepository`.
+- `campaign_sequence_context.py`: standalone sequence context compaction using
+  explicit `SequenceContextLimits`.
+- `campaign_sender.py`: standalone Resend/SES sender adapters using explicit
+  provider config.
+- `campaign_send.py`: standalone due-send orchestrator using repository,
+  suppression, sender, audit, and clock ports.
+- `campaign_webhooks.py`: standalone Resend/Svix signature verification,
+  webhook event normalization, event recording, and webhook-driven suppression
+  policy using product ports.
+- `campaign_analytics.py`: standalone analytics refresh orchestration using
+  repository, audit, and visibility ports.
+- `campaign_sequence_progression.py`: standalone due-sequence follow-up
+  generation using sequence repository, LLM, skill-store, context, and audit
+  ports.
+- `campaign_generation.py`: standalone draft generation shell using
+  intelligence, campaign repository, LLM, and skill-store ports.

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -1,0 +1,131 @@
+# Standalone Productization Contract
+
+The extracted package must be installable and runnable without the Atlas
+monolith. The current PR is a staging mirror, so it still contains Atlas bridge
+imports. That is acceptable for extraction traceability, but it is not the
+customer product.
+
+## Non-Negotiable Product Rule
+
+Runtime product code must not import `atlas_brain`.
+
+Allowed during extraction:
+
+- `manifest.json` source paths that point at Atlas source-of-truth files.
+- Documentation that references Atlas as the origin.
+- Temporary compatibility shims in the staging scaffold.
+
+Not allowed in the sellable module:
+
+- `from atlas_brain... import ...`
+- `import atlas_brain...`
+- A package install that requires the Atlas repo on `PYTHONPATH`.
+- API/task code that reaches directly into Atlas settings, DB pools, auth,
+  visibility events, scheduled-task models, LLM registry, or B2B helper modules.
+
+## Required Product Ports
+
+Before the campaign system can be sold as its own module, Atlas infrastructure
+must be replaced with product-owned interfaces:
+
+- `CampaignRepository`: campaign, sequence, suppression, audit, analytics, and
+  target persistence.
+- `IntelligenceRepository`: account/vendor/category inputs used to build
+  campaign blueprints.
+- `LLMClient`: message completion, JSON cleanup, tracing metadata, batch replay.
+- `SkillStore`: prompt contract lookup by name/version.
+- `CampaignSender`: Resend/SES send abstraction plus provider message ids.
+- `WebhookVerifier`: provider signature verification and event normalization.
+- `AuditSink`: immutable campaign lifecycle events.
+- `VisibilitySink`: progress/events for hosted dashboards.
+- `TenantScope`: account ownership and permission filtering.
+- `Clock`: deterministic send-window and delay calculations.
+
+The first pass of these boundaries lives in
+`extracted_content_pipeline/campaign_ports.py`. Refactors should move copied
+campaign code toward those interfaces before adding more raw Atlas modules to
+the manifest.
+
+## Decoupling Order
+
+1. Define product-local models, settings, and ports.
+2. Move pure helpers first: sequence context, suppression decisions, quality
+   validation, send-window logic, webhook event normalization, and analytics
+   summaries.
+3. Convert services to accept injected ports instead of importing Atlas
+   settings, DB pools, LLM registry, or visibility helpers.
+4. Convert tasks into orchestrators that receive a dependency bundle.
+5. Convert APIs into an app/router factory that receives auth and repository
+   adapters from the host app.
+6. Keep Atlas adapters in a separate optional package or directory so Atlas can
+   still run the product internally without contaminating the customer module.
+
+## First Standalone Slice
+
+`extracted_content_pipeline/campaign_suppression.py` is the first product-owned
+campaign module in this scaffold. It implements normalized email/domain
+suppression behavior against `SuppressionRepository` and does not import Atlas.
+Use it as the pattern for the next slices: keep policy and orchestration in the
+product package, and push persistence/provider concerns behind ports.
+
+`extracted_content_pipeline/campaign_sequence_context.py` is the second
+standalone slice. It keeps the sequence prompt/storage compaction behavior but
+replaces Atlas settings reads with explicit `SequenceContextLimits`.
+
+`extracted_content_pipeline/campaign_sender.py` is the third standalone slice.
+It keeps Resend and SES provider behavior but uses explicit provider config and
+the product `SendRequest`/`SendResult` dataclasses.
+
+`extracted_content_pipeline/campaign_send.py` is the fourth standalone slice.
+It orchestrates due sends through `CampaignRepository`,
+`CampaignSuppressionService`, `CampaignSender`, `AuditSink`, and `Clock`.
+Atlas-specific quality revalidation, fatigue SQL, sequence scheduling, and
+visibility events remain later adapter/service work.
+
+`extracted_content_pipeline/campaign_webhooks.py` is the fifth standalone
+slice. It verifies Resend/Svix signatures, normalizes ESP webhook payloads into
+the product `WebhookEvent` dataclass, records events through
+`CampaignRepository`, and applies bounce/complaint/unsubscribe suppressions
+through `CampaignSuppressionService` without importing Atlas API code.
+
+`extracted_content_pipeline/campaign_analytics.py` is the sixth standalone
+slice. It wraps analytics refresh through `CampaignRepository.refresh_analytics`
+and reports success/failure through optional audit and visibility ports.
+
+`extracted_content_pipeline/campaign_sequence_progression.py` is the seventh
+standalone slice. It builds follow-up prompt context, selects the sequence skill,
+parses generated JSON, and queues due follow-up steps through
+`CampaignSequenceRepository`, `LLMClient`, `SkillStore`, and optional audit
+ports.
+
+`extracted_content_pipeline/campaign_generation.py` is the eighth standalone
+slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
+through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
+`CampaignDraft` rows through `CampaignRepository`.
+
+## Readiness Gate
+
+Run:
+
+```bash
+python scripts/audit_extracted_standalone.py --fail-on-debt
+```
+
+The command must pass before this package is considered customer-usable.
+
+## Current Campaign-Specific Blockers
+
+- `b2b_campaign_generation.py` imports Atlas config, DB, visibility, skills,
+  LLM routing, B2B batch helpers, vendor target selection, product matching,
+  and B2B intelligence readers.
+- `campaign_send.py` imports Atlas config, DB, visibility, campaign quality,
+  sender, and suppression helpers.
+- `campaign_sequence_progression.py` imports Atlas config, DB, scheduled-task
+  model, skills, LLM routing, tracing, and protocol classes.
+- `api/b2b_campaigns.py`, `api/seller_campaigns.py`, and
+  `api/campaign_webhooks.py` need an app-factory boundary and host-provided
+  auth/tenant dependencies.
+- Prompt skills are portable, but the skill registry is currently an Atlas
+  shim.
+- SQL migrations are portable only after the product owns its base schema and
+  migration runner.

--- a/extracted_content_pipeline/services/b2b/anthropic_batch.py
+++ b/extracted_content_pipeline/services/b2b/anthropic_batch.py
@@ -1,1 +1,34 @@
-from atlas_brain.services.b2b.anthropic_batch import *
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    @dataclass
+    class AnthropicBatchItem:
+        custom_id: str
+        artifact_type: str
+        artifact_id: str
+        vendor_name: str | None = None
+        messages: list[Any] = field(default_factory=list)
+        max_tokens: int | None = None
+        temperature: float | None = None
+        trace_span_name: str | None = None
+        trace_metadata: dict[str, Any] = field(default_factory=dict)
+        request_metadata: dict[str, Any] = field(default_factory=dict)
+        cached_response_text: str | None = None
+        cached_usage: dict[str, Any] = field(default_factory=dict)
+
+    @dataclass
+    class AnthropicBatchExecution:
+        local_batch_id: str = "standalone"
+        results_by_custom_id: dict[str, Any] = field(default_factory=dict)
+
+    async def run_anthropic_message_batch(*args: Any, **kwargs: Any) -> AnthropicBatchExecution:
+        return AnthropicBatchExecution()
+
+    async def mark_batch_fallback_result(*args: Any, **kwargs: Any) -> None:
+        return None
+else:
+    from atlas_brain.services.b2b.anthropic_batch import *

--- a/extracted_content_pipeline/services/b2b/cache_runner.py
+++ b/extracted_content_pipeline/services/b2b/cache_runner.py
@@ -1,1 +1,69 @@
-from atlas_brain.services.b2b.cache_runner import *
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    @dataclass(frozen=True)
+    class B2BExactStageRequest:
+        stage_id: str
+        provider: str = "standalone"
+        model: str = "standalone"
+        request_envelope: dict[str, Any] = field(default_factory=dict)
+
+    def prepare_b2b_exact_stage_request(
+        stage_id: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        llm: Any | None = None,
+        messages: list[Any] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        request_envelope: dict[str, Any] | None = None,
+        **metadata: Any,
+    ) -> B2BExactStageRequest:
+        resolved_provider = provider or getattr(llm, "provider", None) or "standalone"
+        resolved_model = model or getattr(llm, "model", None) or "standalone"
+        envelope = dict(request_envelope or {})
+        if messages is not None:
+            envelope["messages"] = messages
+        if max_tokens is not None:
+            envelope["max_tokens"] = max_tokens
+        if temperature is not None:
+            envelope["temperature"] = temperature
+        if metadata:
+            envelope["metadata"] = metadata
+        return B2BExactStageRequest(
+            stage_id=stage_id,
+            provider=str(resolved_provider),
+            model=str(resolved_model),
+            request_envelope=envelope,
+        )
+
+    def bind_b2b_exact_stage_request(
+        stage_id: str,
+        *,
+        provider: str,
+        model: str,
+        request_envelope: dict[str, Any],
+        **metadata: Any,
+    ) -> B2BExactStageRequest:
+        envelope = dict(request_envelope or {})
+        if metadata:
+            envelope["metadata"] = metadata
+        return B2BExactStageRequest(
+            stage_id=stage_id,
+            provider=str(provider),
+            model=str(model),
+            request_envelope=envelope,
+        )
+
+    async def lookup_b2b_exact_stage_text(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def store_b2b_exact_stage_text(*args: Any, **kwargs: Any) -> bool:
+        return False
+else:
+    from atlas_brain.services.b2b.cache_runner import *

--- a/extracted_content_pipeline/services/scraping/universal/html_cleaner.py
+++ b/extracted_content_pipeline/services/scraping/universal/html_cleaner.py
@@ -1,1 +1,23 @@
-from atlas_brain.services.scraping.universal.html_cleaner import *
+from __future__ import annotations
+
+import os
+import re
+from html import unescape
+
+if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
+    _SCRIPT_STYLE_RE = re.compile(
+        r"<\s*(script|style)[^>]*>.*?<\s*/\s*\1\s*>",
+        re.IGNORECASE | re.DOTALL,
+    )
+    _TAG_RE = re.compile(r"<[^>]+>")
+    _SPACE_RE = re.compile(r"\s+")
+
+    def html_to_text(html: str | None, max_chars: int = 30000) -> str:
+        text = _SCRIPT_STYLE_RE.sub(" ", str(html or ""))
+        text = _TAG_RE.sub(" ", text)
+        text = _SPACE_RE.sub(" ", unescape(text)).strip()
+        if max_chars and len(text) > max_chars:
+            return text[:max_chars].rstrip()
+        return text
+else:
+    from atlas_brain.services.scraping.universal.html_cleaner import *

--- a/scripts/audit_extracted_standalone.py
+++ b/scripts/audit_extracted_standalone.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = ROOT / "extracted_content_pipeline"
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    module: str
+    statement: str
+    kind: str
+
+
+def _python_files() -> list[Path]:
+    return sorted(
+        path
+        for path in PACKAGE_ROOT.rglob("*.py")
+        if "__pycache__" not in path.parts
+    )
+
+
+def _shim_kind(path: Path) -> str:
+    lines = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if not lines:
+        return "empty"
+    if all(
+        line.startswith("from atlas_brain.")
+        or line.startswith("from atlas_brain import")
+        or line.startswith("import atlas_brain")
+        for line in lines
+    ):
+        return "bridge_shim"
+    return "hard_import"
+
+
+def _statement(source: str, node: ast.AST) -> str:
+    segment = ast.get_source_segment(source, node)
+    if segment:
+        return " ".join(segment.strip().split())
+    return type(node).__name__
+
+
+def audit() -> list[Finding]:
+    findings: list[Finding] = []
+    for path in _python_files():
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            findings.append(
+                Finding(
+                    path=str(path.relative_to(ROOT)),
+                    line=exc.lineno or 0,
+                    module="<syntax-error>",
+                    statement=str(exc),
+                    kind="syntax_error",
+                )
+            )
+            continue
+        kind = _shim_kind(path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "atlas_brain" or alias.name.startswith("atlas_brain."):
+                        findings.append(
+                            Finding(
+                                path=str(path.relative_to(ROOT)),
+                                line=node.lineno,
+                                module=alias.name,
+                                statement=_statement(source, node),
+                                kind=kind,
+                            )
+                        )
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "atlas_brain" or module.startswith("atlas_brain."):
+                    findings.append(
+                        Finding(
+                            path=str(path.relative_to(ROOT)),
+                            line=node.lineno,
+                            module=module,
+                            statement=_statement(source, node),
+                            kind=kind,
+                        )
+                    )
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit extracted_content_pipeline for Atlas runtime coupling."
+    )
+    parser.add_argument(
+        "--fail-on-debt",
+        action="store_true",
+        help="Return non-zero when any atlas_brain runtime import remains.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    args = parser.parse_args()
+
+    findings = audit()
+    counts: dict[str, int] = {}
+    for item in findings:
+        counts[item.kind] = counts.get(item.kind, 0) + 1
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "total": len(findings),
+                    "counts": counts,
+                    "findings": [asdict(item) for item in findings],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"Atlas runtime import findings: {len(findings)}")
+        for kind, count in sorted(counts.items()):
+            print(f"  {kind}: {count}")
+        if findings:
+            print()
+            for item in findings:
+                print(f"{item.path}:{item.line}: [{item.kind}] {item.statement}")
+
+    if args.fail_on_debt and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -8,5 +8,15 @@ bash scripts/validate_extracted_content_pipeline.sh
 bash scripts/check_ascii_python.sh
 python scripts/check_extracted_imports.py
 python scripts/smoke_extracted_pipeline_imports.py
+python scripts/audit_extracted_standalone.py
+pytest \
+  tests/test_extracted_campaign_analytics.py \
+  tests/test_extracted_campaign_generation.py \
+  tests/test_extracted_campaign_suppression.py \
+  tests/test_extracted_campaign_sequence_context.py \
+  tests/test_extracted_campaign_sequence_progression.py \
+  tests/test_extracted_campaign_sender.py \
+  tests/test_extracted_campaign_send.py \
+  tests/test_extracted_campaign_webhooks.py
 
-echo "All extracted_content_pipeline checks passed"
+echo "All extracted_content_pipeline checks completed"

--- a/tests/test_extracted_campaign_analytics.py
+++ b/tests/test_extracted_campaign_analytics.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_analytics import CampaignAnalyticsRefreshService
+
+
+class _CampaignRepo:
+    def __init__(self, *, error: Exception | None = None):
+        self.error = error
+        self.refresh_calls = 0
+
+    async def refresh_analytics(self):
+        self.refresh_calls += 1
+        if self.error:
+            raise self.error
+
+    async def save_drafts(self, drafts, *, scope):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def list_due_sends(self, *, limit, now):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def mark_sent(self, *, campaign_id, result, sent_at):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def mark_cancelled(self, *, campaign_id, reason, metadata=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def mark_send_failed(self, *, campaign_id, error, metadata=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def record_webhook_event(self, event):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+
+class _Audit:
+    def __init__(self):
+        self.events = []
+
+    async def record(self, event_type, *, campaign_id=None, sequence_id=None, metadata=None):
+        self.events.append({
+            "event_type": event_type,
+            "campaign_id": campaign_id,
+            "sequence_id": sequence_id,
+            "metadata": metadata,
+        })
+
+
+class _Visibility:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event_type, payload):
+        self.events.append({"event_type": event_type, "payload": payload})
+
+
+class _FailingObservers:
+    async def record(self, event_type, *, campaign_id=None, sequence_id=None, metadata=None):
+        raise RuntimeError("audit down")
+
+    async def emit(self, event_type, payload):
+        raise RuntimeError("visibility down")
+
+
+@pytest.mark.asyncio
+async def test_refresh_calls_repository_and_records_success():
+    repo = _CampaignRepo()
+    audit = _Audit()
+    visibility = _Visibility()
+    service = CampaignAnalyticsRefreshService(
+        campaigns=repo,
+        audit=audit,
+        visibility=visibility,
+    )
+
+    result = await service.refresh()
+
+    assert result.as_dict() == {"refreshed": True, "error": None}
+    assert repo.refresh_calls == 1
+    assert audit.events == [{
+        "event_type": "analytics_refreshed",
+        "campaign_id": None,
+        "sequence_id": None,
+        "metadata": {"refreshed": True, "error": None},
+    }]
+    assert visibility.events == [{
+        "event_type": "analytics_refreshed",
+        "payload": {"refreshed": True, "error": None},
+    }]
+
+
+@pytest.mark.asyncio
+async def test_refresh_returns_error_result_without_raising():
+    repo = _CampaignRepo(error=RuntimeError("view locked"))
+    audit = _Audit()
+    service = CampaignAnalyticsRefreshService(campaigns=repo, audit=audit)
+
+    result = await service.refresh()
+
+    assert result.as_dict() == {"refreshed": False, "error": "view locked"}
+    assert repo.refresh_calls == 1
+    assert audit.events == [{
+        "event_type": "analytics_refresh_failed",
+        "campaign_id": None,
+        "sequence_id": None,
+        "metadata": {"refreshed": False, "error": "view locked"},
+    }]
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_require_observers():
+    repo = _CampaignRepo()
+    service = CampaignAnalyticsRefreshService(campaigns=repo)
+
+    result = await service.refresh()
+
+    assert result.refreshed is True
+    assert repo.refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_raise_when_optional_observers_fail():
+    repo = _CampaignRepo()
+    observers = _FailingObservers()
+    service = CampaignAnalyticsRefreshService(
+        campaigns=repo,
+        audit=observers,
+        visibility=observers,
+    )
+
+    result = await service.refresh()
+
+    assert result.as_dict() == {"refreshed": True, "error": None}
+    assert repo.refresh_calls == 1

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_generation import (
+    CampaignGenerationConfig,
+    CampaignGenerationService,
+    opportunity_target_id,
+    parse_campaign_draft_response,
+)
+from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
+
+
+class _Intelligence:
+    def __init__(self, opportunities):
+        self.opportunities = opportunities
+        self.calls = []
+
+    async def read_campaign_opportunities(self, *, scope, target_mode, limit, filters=None):
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": filters,
+        })
+        return self.opportunities
+
+    async def read_vendor_targets(self, *, scope, target_mode, vendor_name=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _Campaigns:
+    def __init__(self):
+        self.saved = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": list(drafts), "scope": scope})
+        return [f"draft-{index + 1}" for index, _ in enumerate(drafts)]
+
+    async def list_due_sends(self, *, limit, now):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def mark_sent(self, *, campaign_id, result, sent_at):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def mark_cancelled(self, *, campaign_id, reason, metadata=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def mark_send_failed(self, *, campaign_id, error, metadata=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def record_webhook_event(self, event):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def refresh_analytics(self):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _LLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": metadata,
+        })
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return LLMResponse(
+            content=response,
+            model="test-model",
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+
+class _Skills:
+    def __init__(self, prompts):
+        self.prompts = prompts
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompts.get(name)
+
+
+def _service(opportunities, responses, *, config=None, prompts=None):
+    intelligence = _Intelligence(opportunities)
+    campaigns = _Campaigns()
+    llm = _LLM(responses)
+    default_prompts = {
+        "digest/b2b_campaign_generation": (
+            "Mode={target_mode}; opportunity={opportunity_json}"
+        )
+    }
+    skills = _Skills(default_prompts if prompts is None else prompts)
+    service = CampaignGenerationService(
+        intelligence=intelligence,
+        campaigns=campaigns,
+        llm=llm,
+        skills=skills,
+        config=config,
+    )
+    return service, intelligence, campaigns, llm, skills
+
+
+def test_parse_campaign_draft_response_accepts_fenced_json_and_alias_body():
+    parsed = parse_campaign_draft_response(
+        '```json\n{"subject":"Hi","email_body":"Body","cta":"Reply"}\n```'
+    )
+
+    assert parsed == {
+        "subject": "Hi",
+        "email_body": "Body",
+        "cta": "Reply",
+        "body": "Body",
+    }
+
+
+def test_parse_campaign_draft_response_finds_json_inside_prose():
+    parsed = parse_campaign_draft_response(
+        'Draft: {"subject":"Hi","content":"Body"}'
+    )
+
+    assert parsed == {"subject": "Hi", "content": "Body", "body": "Body"}
+
+
+def test_parse_campaign_draft_response_accepts_first_item_from_array():
+    parsed = parse_campaign_draft_response(
+        '[{"subject":"Hi","body":"Body"},{"subject":"Second","body":"No"}]'
+    )
+
+    assert parsed == {"subject": "Hi", "body": "Body"}
+
+
+def test_opportunity_target_id_prefers_stable_ids_then_names():
+    assert opportunity_target_id({"target_id": "target-1", "company_name": "Acme"}) == "target-1"
+    assert opportunity_target_id({"id": "row-1"}) == "row-1"
+    assert opportunity_target_id({"company_name": "Acme"}) == "Acme"
+    assert opportunity_target_id({}) == ""
+
+
+@pytest.mark.asyncio
+async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
+    scope = TenantScope(account_id="acct-1")
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "pain": "pricing pressure",
+    }
+    service, intelligence, campaigns, llm, skills = _service(
+        [opportunity],
+        [json.dumps({
+            "subject": "Acme pricing signal",
+            "body": "<p>Pricing note</p>",
+            "cta": "Book time",
+            "angle_reasoning": "Pricing complaints are rising.",
+        })],
+    )
+
+    result = await service.generate(
+        scope=scope,
+        target_mode="churning_company",
+        limit=5,
+        filters={"vendor": "HubSpot"},
+    )
+
+    assert result.as_dict() == {
+        "requested": 1,
+        "generated": 1,
+        "skipped": 0,
+        "saved_ids": ["draft-1"],
+        "errors": [],
+    }
+    assert intelligence.calls == [{
+        "scope": scope,
+        "target_mode": "churning_company",
+        "limit": 5,
+        "filters": {"vendor": "HubSpot"},
+    }]
+    assert skills.calls == ["digest/b2b_campaign_generation"]
+    llm_call = llm.calls[0]
+    assert llm_call["max_tokens"] == 1200
+    assert llm_call["temperature"] == 0.4
+    assert '"company_name":"Acme"' in llm_call["messages"][0].content
+    assert llm_call["metadata"] == {
+        "target_mode": "churning_company",
+        "target_id": "opp-1",
+        "skill_name": "digest/b2b_campaign_generation",
+    }
+    draft = campaigns.saved[0]["drafts"][0]
+    assert draft.target_id == "opp-1"
+    assert draft.target_mode == "churning_company"
+    assert draft.channel == "email"
+    assert draft.subject == "Acme pricing signal"
+    assert draft.body == "<p>Pricing note</p>"
+    assert draft.metadata["cta"] == "Book time"
+    assert draft.metadata["generation_model"] == "test-model"
+    assert draft.metadata["source_opportunity"] == opportunity
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_custom_config_and_omits_source_opportunity():
+    config = CampaignGenerationConfig(
+        skill_name="custom",
+        channel="linkedin",
+        max_tokens=300,
+        temperature=0.2,
+        include_source_opportunity=False,
+    )
+    service, _, campaigns, llm, skills = _service(
+        [{"company_name": "Acme"}],
+        ['{"subject":"Hi","body":"Body"}'],
+        config=config,
+        prompts={"custom": "custom prompt {target_mode} {opportunity}"},
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    assert skills.calls == ["custom"]
+    assert llm.calls[0]["max_tokens"] == 300
+    assert llm.calls[0]["temperature"] == 0.2
+    draft = campaigns.saved[0]["drafts"][0]
+    assert draft.channel == "linkedin"
+    assert "source_opportunity" not in draft.metadata
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_missing_target_and_unparseable_responses():
+    service, _, campaigns, _, _ = _service(
+        [
+            {"pain": "missing id"},
+            {"id": "opp-2"},
+        ],
+        ["not-json"],
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="churning_company")
+
+    assert result.generated == 0
+    assert result.skipped == 2
+    assert result.errors[0]["reason"] == "missing_target_id"
+    assert result.errors[1] == {"target_id": "opp-2", "reason": "unparseable_response"}
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_continues_after_llm_error():
+    service, _, campaigns, _, _ = _service(
+        [
+            {"id": "opp-1"},
+            {"id": "opp-2"},
+        ],
+        [
+            RuntimeError("provider down"),
+            '{"subject":"Hi","body":"Body"}',
+        ],
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="churning_company")
+
+    assert result.generated == 1
+    assert result.skipped == 1
+    assert result.errors == ({"target_id": "opp-1", "reason": "provider down"},)
+    assert campaigns.saved[0]["drafts"][0].target_id == "opp-2"
+
+
+@pytest.mark.asyncio
+async def test_generate_raises_clear_error_when_skill_missing():
+    service, _, _, _, _ = _service(
+        [{"id": "opp-1"}],
+        ['{"subject":"Hi","body":"Body"}'],
+        prompts={},
+    )
+
+    with pytest.raises(ValueError, match="Campaign generation skill not found"):
+        await service.generate(scope=TenantScope(), target_mode="churning_company")

--- a/tests/test_extracted_campaign_send.py
+++ b/tests/test_extracted_campaign_send.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import SendResult
+from extracted_content_pipeline.campaign_send import (
+    CampaignSendConfig,
+    CampaignSendService,
+    build_unsubscribe_url,
+    unsubscribe_headers,
+    wrap_with_footer,
+)
+from extracted_content_pipeline.campaign_suppression import CampaignSuppressionService
+
+
+class _Clock:
+    def __init__(self):
+        self.value = datetime(2026, 5, 1, 15, 30, tzinfo=timezone.utc)
+
+    def now(self):
+        return self.value
+
+
+class _CampaignRepo:
+    def __init__(self, rows):
+        self.rows = rows
+        self.list_calls = []
+        self.sent = []
+        self.cancelled = []
+        self.failed = []
+
+    async def list_due_sends(self, *, limit, now):
+        self.list_calls.append({"limit": limit, "now": now})
+        return self.rows
+
+    async def mark_sent(self, *, campaign_id, result, sent_at):
+        self.sent.append({"campaign_id": campaign_id, "result": result, "sent_at": sent_at})
+
+    async def mark_cancelled(self, *, campaign_id, reason, metadata=None):
+        self.cancelled.append({"campaign_id": campaign_id, "reason": reason, "metadata": metadata})
+
+    async def mark_send_failed(self, *, campaign_id, error, metadata=None):
+        self.failed.append({"campaign_id": campaign_id, "error": error, "metadata": metadata})
+
+    async def save_drafts(self, drafts, *, scope):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def record_webhook_event(self, event):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def refresh_analytics(self):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+
+class _SuppressionRepo:
+    def __init__(self, suppressed=None):
+        self.suppressed = suppressed or set()
+        self.calls = []
+
+    async def is_suppressed(self, *, email=None, domain=None):
+        self.calls.append({"email": email, "domain": domain})
+        return (email, domain) in self.suppressed
+
+    async def add_suppression(self, **kwargs):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+
+class _Sender:
+    def __init__(self, *, error: Exception | None = None):
+        self.error = error
+        self.requests = []
+
+    async def send(self, request):
+        self.requests.append(request)
+        if self.error:
+            raise self.error
+        return SendResult(provider="test", message_id=f"msg-{request.campaign_id}")
+
+
+class _Audit:
+    def __init__(self):
+        self.events = []
+
+    async def record(self, event_type, *, campaign_id=None, sequence_id=None, metadata=None):
+        self.events.append({
+            "event_type": event_type,
+            "campaign_id": campaign_id,
+            "sequence_id": sequence_id,
+            "metadata": metadata,
+        })
+
+
+def _service(rows, *, suppressed=None, sender=None, config=None):
+    repo = _CampaignRepo(rows)
+    suppression_repo = _SuppressionRepo(suppressed=suppressed)
+    audit = _Audit()
+    clock = _Clock()
+    service = CampaignSendService(
+        campaigns=repo,
+        suppression=CampaignSuppressionService(suppression_repo),
+        sender=sender or _Sender(),
+        audit=audit,
+        clock=clock,
+        config=config or CampaignSendConfig(
+            default_from_email="sender@example.com",
+            default_reply_to="reply@example.com",
+            unsubscribe_base_url="https://example.test/unsub",
+            company_address="123 Market St",
+            limit=10,
+        ),
+    )
+    return service, repo, suppression_repo, service._sender, audit, clock
+
+
+def _row(**overrides):
+    data = {
+        "id": "campaign-1",
+        "sequence_id": "sequence-1",
+        "recipient_email": " Buyer@Example.COM ",
+        "from_email": "",
+        "subject": "Pricing signal",
+        "body": "<p>Hello</p>",
+        "company_name": "Acme",
+        "step_number": 2,
+        "metadata": {"source": "test"},
+    }
+    data.update(overrides)
+    return data
+
+
+def test_build_unsubscribe_url_handles_existing_query_string():
+    assert (
+        build_unsubscribe_url("https://example.test/unsub?source=email", "a+b@example.com")
+        == "https://example.test/unsub?source=email&email=a%2Bb%40example.com"
+    )
+
+
+def test_unsubscribe_headers_and_footer_are_optional():
+    assert unsubscribe_headers("", "person@example.com") == {}
+    assert wrap_with_footer(
+        "<p>Hello</p>",
+        recipient_email="person@example.com",
+        config=CampaignSendConfig(),
+    ) == "<p>Hello</p>"
+
+
+@pytest.mark.asyncio
+async def test_send_due_sends_campaign_and_records_audit():
+    service, repo, suppression_repo, sender, audit, clock = _service([_row()])
+
+    summary = await service.send_due()
+
+    assert summary.as_dict() == {"sent": 1, "failed": 0, "suppressed": 0, "skipped": 0}
+    assert repo.list_calls == [{"limit": 10, "now": clock.value}]
+    assert suppression_repo.calls == [
+        {"email": "buyer@example.com", "domain": None},
+        {"email": None, "domain": "example.com"},
+    ]
+    assert len(sender.requests) == 1
+    request = sender.requests[0]
+    assert request.to_email == "buyer@example.com"
+    assert request.from_email == "sender@example.com"
+    assert request.reply_to == "reply@example.com"
+    assert "Unsubscribe" in request.html_body
+    assert request.headers["List-Unsubscribe"] == "<https://example.test/unsub?email=buyer%40example.com>"
+    assert {"name": "company", "value": "Acme"} in request.tags
+    assert repo.sent == [{
+        "campaign_id": "campaign-1",
+        "result": SendResult(provider="test", message_id="msg-campaign-1"),
+        "sent_at": clock.value,
+    }]
+    assert audit.events == [{
+        "event_type": "sent",
+        "campaign_id": "campaign-1",
+        "sequence_id": "sequence-1",
+        "metadata": {
+            "provider": "test",
+            "message_id": "msg-campaign-1",
+            "recipient_email": "buyer@example.com",
+        },
+    }]
+
+
+@pytest.mark.asyncio
+async def test_send_due_cancels_suppressed_campaign_before_sender_call():
+    service, repo, _, sender, audit, _ = _service(
+        [_row()],
+        suppressed={("buyer@example.com", None)},
+    )
+
+    summary = await service.send_due()
+
+    assert summary.as_dict() == {"sent": 0, "failed": 0, "suppressed": 1, "skipped": 0}
+    assert sender.requests == []
+    assert repo.cancelled == [{
+        "campaign_id": "campaign-1",
+        "reason": "suppressed",
+        "metadata": {"recipient_email": "buyer@example.com", "domain": "example.com"},
+    }]
+    assert audit.events[0]["event_type"] == "suppressed"
+
+
+@pytest.mark.asyncio
+async def test_send_due_skips_missing_recipient_and_marks_failed():
+    service, repo, _, sender, audit, _ = _service([_row(recipient_email=" ")])
+
+    summary = await service.send_due()
+
+    assert summary.as_dict() == {"sent": 0, "failed": 0, "suppressed": 0, "skipped": 1}
+    assert sender.requests == []
+    assert repo.failed == [{
+        "campaign_id": "campaign-1",
+        "error": "recipient_email_missing",
+        "metadata": {"reason": "recipient_email_missing"},
+    }]
+    assert audit.events[0]["event_type"] == "send_skipped"
+
+
+@pytest.mark.asyncio
+async def test_send_due_skips_missing_from_email_and_marks_failed():
+    service, repo, _, sender, audit, _ = _service(
+        [_row(from_email=" ")],
+        config=CampaignSendConfig(default_from_email=""),
+    )
+
+    summary = await service.send_due()
+
+    assert summary.as_dict() == {"sent": 0, "failed": 0, "suppressed": 0, "skipped": 1}
+    assert sender.requests == []
+    assert repo.failed == [{
+        "campaign_id": "campaign-1",
+        "error": "from_email_missing",
+        "metadata": {"reason": "from_email_missing"},
+    }]
+    assert audit.events[0]["metadata"] == {"reason": "from_email_missing"}
+
+
+@pytest.mark.asyncio
+async def test_send_due_records_sender_failure():
+    service, repo, _, sender, audit, _ = _service(
+        [_row()],
+        sender=_Sender(error=RuntimeError("provider down")),
+    )
+
+    summary = await service.send_due()
+
+    assert summary.as_dict() == {"sent": 0, "failed": 1, "suppressed": 0, "skipped": 0}
+    assert len(sender.requests) == 1
+    assert repo.failed == [{
+        "campaign_id": "campaign-1",
+        "error": "RuntimeError: provider down",
+        "metadata": {"recipient_email": "buyer@example.com"},
+    }]
+    assert audit.events[0]["event_type"] == "send_failed"
+
+
+@pytest.mark.asyncio
+async def test_send_due_skips_rows_without_campaign_id_without_touching_ports():
+    service, repo, suppression_repo, sender, audit, _ = _service([_row(id=" ")])
+
+    summary = await service.send_due()
+
+    assert summary.as_dict() == {"sent": 0, "failed": 0, "suppressed": 0, "skipped": 1}
+    assert suppression_repo.calls == []
+    assert sender.requests == []
+    assert repo.sent == []
+    assert repo.failed == []
+    assert audit.events == []

--- a/tests/test_extracted_campaign_sender.py
+++ b/tests/test_extracted_campaign_sender.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import SendRequest
+from extracted_content_pipeline.campaign_sender import (
+    RESEND_API_URL,
+    ResendCampaignSender,
+    ResendSenderConfig,
+    SESCampaignSender,
+    SESSenderConfig,
+    create_campaign_sender,
+    normalize_tags,
+    sanitize_tag_value,
+)
+
+
+class _Response:
+    def __init__(self, payload, *, status_error: Exception | None = None):
+        self._payload = payload
+        self._status_error = status_error
+
+    def raise_for_status(self):
+        if self._status_error:
+            raise self._status_error
+
+    def json(self):
+        return self._payload
+
+
+class _HTTPClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    async def post(self, url, *, json, headers):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        return self.response
+
+
+class _SESClient:
+    def __init__(self):
+        self.calls = []
+
+    def send_email(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"MessageId": "ses-1"}
+
+
+def _request(**overrides):
+    data = {
+        "campaign_id": "campaign-1",
+        "to_email": "buyer@example.com",
+        "from_email": "seller@example.com",
+        "reply_to": "reply@example.com",
+        "subject": "Pricing signal",
+        "html_body": "<p>Hello</p>",
+        "text_body": "Hello",
+        "headers": {"List-Unsubscribe": "<https://example.test/unsub>"},
+        "tags": (
+            {"name": "campaign", "value": "campaign/1"},
+            {"name": "mode", "value": "vendor retention"},
+        ),
+    }
+    data.update(overrides)
+    return SendRequest(**data)
+
+
+def test_sanitize_tag_value_replaces_provider_unsafe_characters():
+    assert sanitize_tag_value("vendor retention/step 1") == "vendor_retention_step_1"
+
+
+def test_normalize_tags_drops_blank_and_non_mapping_values():
+    assert normalize_tags([
+        {"name": "campaign", "value": "campaign/1"},
+        {"name": "", "value": "drop"},
+        {"name": "drop", "value": ""},
+        "bad",
+    ]) == [{"name": "campaign", "value": "campaign_1"}]
+
+
+@pytest.mark.asyncio
+async def test_resend_sender_builds_payload_and_returns_message_id():
+    client = _HTTPClient(_Response({"id": "resend-1"}))
+    sender = ResendCampaignSender(ResendSenderConfig(api_key="re_key"), http_client=client)
+
+    result = await sender.send(_request())
+
+    assert result.provider == "resend"
+    assert result.message_id == "resend-1"
+    assert result.raw == {"id": "resend-1"}
+    assert client.calls == [{
+        "url": RESEND_API_URL,
+        "json": {
+            "from": "seller@example.com",
+            "to": ["buyer@example.com"],
+            "subject": "Pricing signal",
+            "html": "<p>Hello</p>",
+            "text": "Hello",
+            "reply_to": "reply@example.com",
+            "headers": {"List-Unsubscribe": "<https://example.test/unsub>"},
+            "tags": [
+                {"name": "campaign", "value": "campaign_1"},
+                {"name": "mode", "value": "vendor_retention"},
+            ],
+        },
+        "headers": {
+            "Authorization": "Bearer re_key",
+            "Content-Type": "application/json",
+        },
+    }]
+
+
+def test_resend_sender_requires_api_key():
+    with pytest.raises(ValueError, match="api_key is required"):
+        ResendCampaignSender(ResendSenderConfig(api_key=""))
+
+
+@pytest.mark.asyncio
+async def test_ses_sender_builds_payload_and_returns_message_id():
+    client = _SESClient()
+    sender = SESCampaignSender(
+        SESSenderConfig(
+            from_email="default@example.com",
+            configuration_set="tracking",
+        ),
+        client=client,
+    )
+
+    result = await sender.send(_request(from_email=""))
+
+    assert result.provider == "ses"
+    assert result.message_id == "ses-1"
+    assert client.calls == [{
+        "FromEmailAddress": "default@example.com",
+        "Destination": {"ToAddresses": ["buyer@example.com"]},
+        "Content": {
+            "Simple": {
+                "Subject": {"Data": "Pricing signal", "Charset": "UTF-8"},
+                "Body": {
+                    "Html": {"Data": "<p>Hello</p>", "Charset": "UTF-8"},
+                    "Text": {"Data": "Hello", "Charset": "UTF-8"},
+                },
+                "Headers": [
+                    {"Name": "List-Unsubscribe", "Value": "<https://example.test/unsub>"},
+                ],
+            },
+        },
+        "ReplyToAddresses": ["reply@example.com"],
+        "ConfigurationSetName": "tracking",
+        "EmailTags": [
+            {"Name": "campaign", "Value": "campaign_1"},
+            {"Name": "mode", "Value": "vendor_retention"},
+        ],
+    }]
+
+
+def test_ses_sender_requires_from_email():
+    with pytest.raises(ValueError, match="from_email is required"):
+        SESCampaignSender(SESSenderConfig(from_email=""), client=_SESClient())
+
+
+def test_create_campaign_sender_builds_resend_sender():
+    sender = create_campaign_sender(
+        "resend",
+        {"api_key": "re_key", "api_url": "https://example.test/send"},
+        http_client=_HTTPClient(_Response({"id": "msg"})),
+    )
+
+    assert isinstance(sender, ResendCampaignSender)
+
+
+def test_create_campaign_sender_builds_ses_sender():
+    sender = create_campaign_sender(
+        "ses",
+        {"from_email": "sender@example.com"},
+        ses_client=_SESClient(),
+    )
+
+    assert isinstance(sender, SESCampaignSender)
+
+
+def test_create_campaign_sender_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unsupported campaign sender provider"):
+        create_campaign_sender("smtp", {})

--- a/tests/test_extracted_campaign_sequence_context.py
+++ b/tests/test_extracted_campaign_sequence_context.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+
+from extracted_content_pipeline.campaign_sequence_context import (
+    SequenceContextLimits,
+    plain_text_preview,
+    prepare_sequence_prompt_contexts,
+    prepare_sequence_storage_contexts,
+    prompt_email_body_preview_chars,
+    prompt_max_tokens,
+)
+
+
+def test_prepare_prompt_contexts_removes_duplicate_and_heavy_fields():
+    seq = {
+        "company_context": json.dumps({
+            "target_persona": "executive",
+            "key_quotes": ["q1", "q2", "q3", "q4"],
+            "pain_categories": [
+                {"category": "pricing", "severity": "high", "extra": "drop"},
+                {"category": "support", "severity": "medium"},
+            ],
+            "feature_gaps": ["automation", "reporting", "search", "alerts", "exports", "audit"],
+            "comparison_asset": {"alternative_vendor": "ClickUp"},
+            "reasoning_witness_highlights": [{"excerpt_text": "drop from prompt"}],
+            "selling": {
+                "sender_name": "Atlas Intel",
+                "booking_url": "https://example.test/book",
+                "blog_posts": [{
+                    "title": "Pricing pressure",
+                    "url": "https://example.test/blog/pricing",
+                    "topic_type": "pricing_reality_check",
+                    "slug": "drop",
+                }],
+            },
+        }),
+        "selling_context": "",
+    }
+
+    company_context, selling_context = prepare_sequence_prompt_contexts(seq)
+
+    assert "selling" not in company_context
+    assert "comparison_asset" not in company_context
+    assert "reasoning_witness_highlights" not in company_context
+    assert company_context["key_quotes"] == ["q1", "q2", "q3"]
+    assert company_context["pain_categories"] == [
+        {"category": "pricing", "severity": "high"},
+        {"category": "support", "severity": "medium"},
+    ]
+    assert company_context["feature_gaps"] == [
+        "automation",
+        "reporting",
+        "search",
+        "alerts",
+        "exports",
+    ]
+    assert selling_context == {
+        "sender_name": "Atlas Intel",
+        "booking_url": "https://example.test/book",
+        "blog_posts": [{
+            "title": "Pricing pressure",
+            "url": "https://example.test/blog/pricing",
+            "topic_type": "pricing_reality_check",
+        }],
+    }
+
+
+def test_prepare_storage_contexts_preserves_specificity_fields():
+    company_context, selling_context = prepare_sequence_storage_contexts(
+        {
+            "target_persona": "executive",
+            "selling": {"sender_name": "Atlas Intel"},
+            "comparison_asset": {"alternative_vendor": "ClickUp"},
+            "reasoning_anchor_examples": {"outlier": [{"witness_id": "w1"}]},
+            "reasoning_witness_highlights": [{"witness_id": "w1"}],
+            "reasoning_reference_ids": {"witness_ids": ["w1"]},
+            "reasoning_contracts": {"raw": "drop"},
+        },
+        {},
+    )
+
+    assert "selling" not in company_context
+    assert "comparison_asset" not in company_context
+    assert "reasoning_contracts" not in company_context
+    assert company_context["reasoning_anchor_examples"]["outlier"][0]["witness_id"] == "w1"
+    assert company_context["reasoning_witness_highlights"][0]["witness_id"] == "w1"
+    assert company_context["reasoning_reference_ids"]["witness_ids"] == ["w1"]
+    assert selling_context["sender_name"] == "Atlas Intel"
+
+
+def test_custom_limits_drive_compaction_without_settings_import():
+    limits = SequenceContextLimits(
+        prompt_max_tokens=333,
+        prompt_list_limit=2,
+        prompt_quote_limit=1,
+        prompt_blog_post_limit=1,
+        prompt_email_body_preview_chars=12,
+    )
+    seq = {
+        "company_context": {
+            "key_quotes": ["q1", "q2"],
+            "feature_gaps": ["gap1", "gap2", "gap3"],
+        },
+        "selling_context": {
+            "blog_posts": [
+                {"title": "one", "url": "https://example.test/one", "topic_type": "a"},
+                {"title": "two", "url": "https://example.test/two", "topic_type": "b"},
+            ],
+        },
+    }
+
+    company_context, selling_context = prepare_sequence_prompt_contexts(seq, limits=limits)
+
+    assert prompt_max_tokens(limits) == 333
+    assert prompt_email_body_preview_chars(limits) == 12
+    assert company_context["key_quotes"] == ["q1"]
+    assert company_context["feature_gaps"] == ["gap1", "gap2"]
+    assert selling_context["blog_posts"] == [{
+        "title": "one",
+        "url": "https://example.test/one",
+        "topic_type": "a",
+    }]
+
+
+def test_invalid_json_contexts_compact_to_empty_dicts():
+    company_context, selling_context = prepare_sequence_prompt_contexts({
+        "company_context": "{not-json",
+        "selling_context": "{also-not-json",
+    })
+
+    assert company_context == {}
+    assert selling_context == {}
+
+
+def test_plain_text_preview_strips_html_and_truncates():
+    rendered = plain_text_preview(
+        "<p>Hello <strong>team</strong>.</p><p>We tracked a sharp pricing shift.</p>",
+        limit=24,
+    )
+
+    assert rendered == "Hello team. We tracked a..."
+    assert "<p>" not in rendered
+    assert "<strong>" not in rendered

--- a/tests/test_extracted_campaign_sequence_progression.py
+++ b/tests/test_extracted_campaign_sequence_progression.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import LLMResponse
+from extracted_content_pipeline.campaign_sequence_context import SequenceContextLimits
+from extracted_content_pipeline.campaign_sequence_progression import (
+    CampaignSequenceProgressionConfig,
+    CampaignSequenceProgressionService,
+    build_engagement_summary,
+    build_previous_emails,
+    parse_generated_sequence_step,
+    sequence_skill_name,
+    target_mode_for_recipient_type,
+)
+
+
+class _Clock:
+    def __init__(self):
+        self.value = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+    def now(self):
+        return self.value
+
+
+class _SequenceRepo:
+    def __init__(self, due=None, previous=None):
+        self.due = due or []
+        self.previous = previous or []
+        self.list_due_calls = []
+        self.previous_calls = []
+        self.queued = []
+        self.marked = []
+
+    async def list_due_sequences(self, *, limit, now):
+        self.list_due_calls.append({"limit": limit, "now": now})
+        return self.due
+
+    async def list_previous_campaigns(self, *, sequence_id, limit):
+        self.previous_calls.append({"sequence_id": sequence_id, "limit": limit})
+        return self.previous
+
+    async def queue_sequence_step(self, *, sequence, content, from_email, queued_at):
+        campaign_id = f"campaign-{len(self.queued) + 1}"
+        self.queued.append({
+            "sequence": sequence,
+            "content": content,
+            "from_email": from_email,
+            "queued_at": queued_at,
+            "campaign_id": campaign_id,
+        })
+        return campaign_id
+
+    async def mark_sequence_step(self, *, sequence_id, current_step, updated_at):
+        self.marked.append({
+            "sequence_id": sequence_id,
+            "current_step": current_step,
+            "updated_at": updated_at,
+        })
+
+
+class _Skills:
+    def __init__(self, prompts):
+        self.prompts = prompts
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompts.get(name)
+
+
+class _LLM:
+    def __init__(self, content):
+        self.content = content
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": metadata,
+        })
+        return LLMResponse(content=self.content, model="test-model")
+
+
+class _Audit:
+    def __init__(self):
+        self.events = []
+
+    async def record(self, event_type, *, campaign_id=None, sequence_id=None, metadata=None):
+        self.events.append({
+            "event_type": event_type,
+            "campaign_id": campaign_id,
+            "sequence_id": sequence_id,
+            "metadata": metadata,
+        })
+
+
+def _sequence(**overrides):
+    data = {
+        "id": "sequence-1",
+        "company_name": "Acme",
+        "recipient_email": "buyer@example.com",
+        "current_step": 1,
+        "max_steps": 4,
+        "open_count": 2,
+        "click_count": 0,
+        "last_sent_at": datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc),
+        "company_context": {
+            "recipient_type": "vendor_retention",
+            "category": "crm",
+            "selling": {"product_name": "Atlas"},
+            "reasoning_anchor_examples": {"pricing": ["hidden from prompt"]},
+        },
+        "selling_context": {"value_prop": "research-backed outreach"},
+    }
+    data.update(overrides)
+    return data
+
+
+def _previous(**overrides):
+    data = {
+        "step_number": 1,
+        "subject": "First note",
+        "body": "<p>Hello <b>there</b>.</p>",
+        "status": "sent",
+        "opened_at": datetime(2026, 4, 30, tzinfo=timezone.utc),
+        "clicked_at": None,
+    }
+    data.update(overrides)
+    return data
+
+
+def _service(seq, *, llm_content=None, skills=None, previous=None, config=None):
+    repo = _SequenceRepo(due=[seq], previous=previous or [_previous()])
+    audit = _Audit()
+    clock = _Clock()
+    service = CampaignSequenceProgressionService(
+        sequences=repo,
+        llm=_LLM(
+            llm_content
+            or json.dumps({
+                "subject": "Following up",
+                "body": "<p>Second note</p>",
+                "cta": "Book time",
+                "angle_reasoning": "Opened prior note",
+            })
+        ),
+        skills=skills
+        or _Skills({
+            "digest/b2b_vendor_sequence": (
+                "Company {company_name}; step {current_step}/{max_steps}; "
+                "days {days_since_last}; product {product_name}; "
+                "ctx {company_context}; sell {selling_context}; "
+                "eng {engagement_summary}; prev {previous_emails}"
+            )
+        }),
+        audit=audit,
+        clock=clock,
+        config=config
+        or CampaignSequenceProgressionConfig(
+            batch_limit=3,
+            from_email="seller@example.com",
+            onboarding_product_name="Fallback Product",
+            context_limits=SequenceContextLimits(
+                prompt_max_tokens=123,
+                prompt_email_body_preview_chars=40,
+            ),
+        ),
+    )
+    return service, repo, audit, clock
+
+
+def test_engagement_summary_includes_counts_reply_and_step_breakdown():
+    summary = build_engagement_summary(
+        {
+            "open_count": 1,
+            "click_count": 2,
+            "reply_received_at": datetime.now(timezone.utc),
+            "reply_intent": "interested",
+            "reply_summary": "Asked for pricing.",
+        },
+        [_previous(clicked_at=datetime.now(timezone.utc))],
+    )
+
+    assert "Opened 1 time(s)" in summary
+    assert "Clicked 2 time(s)" in summary
+    assert "Reply received (interested): Asked for pricing." in summary
+    assert "- Step 1: Opened, Clicked" in summary
+
+
+def test_previous_emails_formats_preview_and_engagement():
+    rendered = build_previous_emails([
+        _previous(body="<p>Hello&nbsp;buyer</p>", clicked_at=None),
+        _previous(step_number=2, subject="", body="", opened_at=None),
+    ])
+
+    assert "--- Step 1 (status: sent) ---" in rendered
+    assert "Subject: First note" in rendered
+    assert "Preview: Hello buyer" in rendered
+    assert "Engagement: Opened" in rendered
+    assert "Subject: (no subject)" in rendered
+    assert "Engagement: No opens or clicks recorded" in rendered
+
+
+def test_skill_and_target_mode_mapping():
+    assert sequence_skill_name("onboarding") == "digest/b2b_onboarding_sequence"
+    assert sequence_skill_name("amazon_seller") == "digest/amazon_seller_campaign_sequence"
+    assert sequence_skill_name("vendor_retention") == "digest/b2b_vendor_sequence"
+    assert sequence_skill_name("challenger_intel") == "digest/b2b_challenger_sequence"
+    assert sequence_skill_name(None) == "digest/b2b_campaign_sequence"
+
+    assert target_mode_for_recipient_type("amazon_seller") == "amazon_seller"
+    assert target_mode_for_recipient_type("vendor_retention") == "vendor_retention"
+    assert target_mode_for_recipient_type("challenger_intel") == "challenger_intel"
+    assert target_mode_for_recipient_type(None) == "churning_company"
+
+
+def test_parse_generated_sequence_step_accepts_fenced_json_and_think_tags():
+    parsed = parse_generated_sequence_step(
+        '<think>notes</think>\n```json\n{"subject":"Hi","body":"Body"}\n```'
+    )
+
+    assert parsed == {"subject": "Hi", "body": "Body"}
+
+
+def test_parse_generated_sequence_step_finds_json_inside_prose():
+    parsed = parse_generated_sequence_step(
+        'Sure, here it is: {"subject":"Hi","body":"Body"} Thanks.'
+    )
+
+    assert parsed == {"subject": "Hi", "body": "Body"}
+
+
+@pytest.mark.asyncio
+async def test_generate_next_step_uses_skill_prompt_context_and_llm_budget():
+    service, repo, _, _ = _service(_sequence())
+
+    content = await service.generate_next_step(repo.due[0], repo.previous)
+
+    assert content["subject"] == "Following up"
+    assert content["_recipient_type"] == "vendor_retention"
+    llm_call = service._llm.calls[0]
+    system_prompt = llm_call["messages"][0].content
+    assert "Company Acme" in system_prompt
+    assert "step 2/4" in system_prompt
+    assert "days 2" in system_prompt
+    assert "product Fallback Product" in system_prompt
+    assert "hidden from prompt" not in system_prompt
+    assert llm_call["max_tokens"] == 123
+    assert llm_call["temperature"] == 0.7
+
+
+@pytest.mark.asyncio
+async def test_generate_next_step_uses_amazon_seller_placeholders():
+    seq = _sequence(
+        company_context={
+            "recipient_type": "amazon_seller",
+            "seller_name": "Acme Seller",
+            "category": "supplements",
+            "category_intelligence": {"top_pain_points": [{"pain": "taste"}]},
+        }
+    )
+    service, repo, _, _ = _service(
+        seq,
+        skills=_Skills({
+            "digest/amazon_seller_campaign_sequence": (
+                "{recipient_name}|{recipient_company}|{recipient_type}|"
+                "{category}|{category_intelligence}"
+            )
+        }),
+    )
+
+    content = await service.generate_next_step(repo.due[0], repo.previous)
+
+    assert content["_recipient_type"] == "amazon_seller"
+    assert content["_category"] == "supplements"
+    prompt = service._llm.calls[0]["messages"][0].content
+    assert prompt.startswith("Acme Seller|Acme Seller|amazon_seller|supplements|")
+    assert "taste" in prompt
+
+
+@pytest.mark.asyncio
+async def test_progress_due_queues_followup_and_marks_sequence():
+    service, repo, audit, clock = _service(_sequence())
+
+    result = await service.progress_due()
+
+    assert result.as_dict() == {
+        "due_sequences": 1,
+        "progressed": 1,
+        "skipped": 0,
+        "disabled": False,
+    }
+    assert repo.list_due_calls == [{"limit": 3, "now": clock.value}]
+    assert repo.previous_calls == [{"sequence_id": "sequence-1", "limit": 4}]
+    queued = repo.queued[0]
+    assert queued["from_email"] == "seller@example.com"
+    assert queued["queued_at"] == clock.value
+    assert queued["content"]["step_number"] == 2
+    assert queued["content"]["target_mode"] == "vendor_retention"
+    assert repo.marked == [{
+        "sequence_id": "sequence-1",
+        "current_step": 2,
+        "updated_at": clock.value,
+    }]
+    assert [event["event_type"] for event in audit.events] == ["generated", "queued"]
+    assert audit.events[0]["campaign_id"] == "campaign-1"
+    assert audit.events[0]["metadata"]["subject"] == "Following up"
+
+
+@pytest.mark.asyncio
+async def test_progress_due_skips_when_skill_missing():
+    service, repo, audit, _ = _service(_sequence(), skills=_Skills({}))
+
+    result = await service.progress_due()
+
+    assert result.progressed == 0
+    assert result.skipped == 1
+    assert repo.queued == []
+    assert repo.marked == []
+    assert audit.events == []
+
+
+@pytest.mark.asyncio
+async def test_progress_due_skips_when_llm_returns_unparseable_content():
+    service, repo, audit, _ = _service(_sequence(), llm_content="not json")
+
+    result = await service.progress_due()
+
+    assert result.progressed == 0
+    assert result.skipped == 1
+    assert repo.queued == []
+    assert repo.marked == []
+    assert audit.events == []
+
+
+@pytest.mark.asyncio
+async def test_progress_due_returns_disabled_result_without_repo_touch():
+    service, repo, _, _ = _service(
+        _sequence(),
+        config=CampaignSequenceProgressionConfig(enabled=False),
+    )
+
+    result = await service.progress_due()
+
+    assert result.as_dict() == {
+        "due_sequences": 0,
+        "progressed": 0,
+        "skipped": 0,
+        "disabled": True,
+    }
+    assert repo.list_due_calls == []

--- a/tests/test_extracted_campaign_suppression.py
+++ b/tests/test_extracted_campaign_suppression.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from extracted_content_pipeline.campaign_suppression import (
+    CampaignSuppressionService,
+    build_suppression_input,
+    domain_from_email,
+    normalize_domain,
+    normalize_email,
+)
+
+
+class _SuppressionRepo:
+    def __init__(self, suppressed: set[tuple[str | None, str | None]] | None = None):
+        self.suppressed = suppressed or set()
+        self.check_calls: list[dict] = []
+        self.add_calls: list[dict] = []
+
+    async def is_suppressed(self, *, email=None, domain=None):
+        self.check_calls.append({"email": email, "domain": domain})
+        return (email, domain) in self.suppressed
+
+    async def add_suppression(self, **kwargs):
+        self.add_calls.append(kwargs)
+
+
+def test_normalize_email_trims_and_lowercases():
+    assert normalize_email("  USER@Example.COM  ") == "user@example.com"
+    assert normalize_email("   ") is None
+    assert normalize_email(None) is None
+
+
+def test_normalize_domain_trims_lowercases_and_accepts_at_prefix():
+    assert normalize_domain("  @Example.COM.  ") == "example.com"
+    assert normalize_domain(" . ") is None
+    assert normalize_domain(None) is None
+
+
+def test_domain_from_email_returns_none_for_invalid_email():
+    assert domain_from_email("person@example.com") == "example.com"
+    assert domain_from_email("not-an-email") is None
+    assert domain_from_email("@example.com") is None
+    assert domain_from_email("person@") is None
+
+
+def test_build_suppression_input_normalizes_payload():
+    expires_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    payload = build_suppression_input(
+        email=" USER@Example.COM ",
+        domain=" @Example.COM. ",
+        reason=" unsubscribe ",
+        source=" webhook ",
+        campaign_id=" campaign-1 ",
+        notes=" requested ",
+        expires_at=expires_at,
+        metadata={"provider": "resend"},
+    )
+
+    assert payload is not None
+    assert payload.email == "user@example.com"
+    assert payload.domain == "example.com"
+    assert payload.reason == "unsubscribe"
+    assert payload.source == "webhook"
+    assert payload.campaign_id == "campaign-1"
+    assert payload.notes == "requested"
+    assert payload.expires_at == expires_at
+    assert payload.metadata == {"provider": "resend"}
+
+
+def test_build_suppression_input_returns_none_without_target():
+    assert build_suppression_input(reason="unsubscribe") is None
+
+
+def test_build_suppression_input_requires_reason():
+    with pytest.raises(ValueError, match="reason is required"):
+        build_suppression_input(email="person@example.com", reason=" ")
+
+
+@pytest.mark.asyncio
+async def test_service_checks_exact_email_before_domain_and_short_circuits():
+    repo = _SuppressionRepo(suppressed={("person@example.com", None)})
+    service = CampaignSuppressionService(repo)
+
+    assert await service.is_suppressed(email=" PERSON@Example.COM ") is True
+
+    assert repo.check_calls == [{"email": "person@example.com", "domain": None}]
+
+
+@pytest.mark.asyncio
+async def test_service_falls_back_to_email_domain_when_email_clear():
+    repo = _SuppressionRepo(suppressed={(None, "example.com")})
+    service = CampaignSuppressionService(repo)
+
+    assert await service.is_suppressed(email="person@example.com") is True
+
+    assert repo.check_calls == [
+        {"email": "person@example.com", "domain": None},
+        {"email": None, "domain": "example.com"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_service_checks_explicit_domain_when_email_missing():
+    repo = _SuppressionRepo(suppressed={(None, "example.com")})
+    service = CampaignSuppressionService(repo)
+
+    assert await service.is_suppressed(email=None, domain=" @Example.COM. ") is True
+
+    assert repo.check_calls == [{"email": None, "domain": "example.com"}]
+
+
+@pytest.mark.asyncio
+async def test_service_returns_false_without_email_or_domain():
+    repo = _SuppressionRepo()
+    service = CampaignSuppressionService(repo)
+
+    assert await service.is_suppressed(email=" ") is False
+    assert repo.check_calls == []
+
+
+@pytest.mark.asyncio
+async def test_service_add_suppression_normalizes_and_calls_repository():
+    repo = _SuppressionRepo()
+    service = CampaignSuppressionService(repo)
+    expires_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    added = await service.add_suppression(
+        email=" Person@Example.COM ",
+        reason=" complaint ",
+        source=" webhook ",
+        campaign_id=" campaign-1 ",
+        notes=" user complained ",
+        expires_at=expires_at,
+        metadata={"provider": "resend"},
+    )
+
+    assert added is True
+    assert repo.add_calls == [{
+        "reason": "complaint",
+        "email": "person@example.com",
+        "domain": None,
+        "source": "webhook",
+        "campaign_id": "campaign-1",
+        "notes": "user complained",
+        "expires_at": expires_at,
+        "metadata": {"provider": "resend"},
+    }]
+
+
+@pytest.mark.asyncio
+async def test_service_add_suppression_skips_blank_target():
+    repo = _SuppressionRepo()
+    service = CampaignSuppressionService(repo)
+
+    assert await service.add_suppression(email=" ", domain=None, reason="unsubscribe") is False
+    assert repo.add_calls == []

--- a/tests/test_extracted_campaign_webhooks.py
+++ b/tests/test_extracted_campaign_webhooks.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import WebhookEvent
+from extracted_content_pipeline.campaign_suppression import CampaignSuppressionService
+from extracted_content_pipeline.campaign_webhooks import (
+    CampaignWebhookIngestionConfig,
+    CampaignWebhookIngestionService,
+    ResendWebhookConfig,
+    ResendWebhookVerifier,
+    WebhookPayloadError,
+    WebhookVerificationError,
+    normalize_resend_payload,
+    verify_svix_signature,
+)
+
+
+def _secret() -> str:
+    return "whsec_" + base64.b64encode(b"secret").decode("utf-8")
+
+
+def _headers(body: bytes, *, secret: str | None = None, msg_id: str = "msg_1"):
+    secret_text = secret or _secret()
+    raw_secret = secret_text[6:] if secret_text.startswith("whsec_") else secret_text
+    secret_bytes = base64.b64decode(raw_secret)
+    timestamp = "1714550400"
+    to_sign = f"{msg_id}.{timestamp}.".encode("utf-8") + body
+    signature = base64.b64encode(
+        hmac.new(secret_bytes, to_sign, hashlib.sha256).digest()
+    ).decode("utf-8")
+    return {
+        "svix-id": msg_id,
+        "svix-timestamp": timestamp,
+        "svix-signature": f"v1,{signature}",
+    }
+
+
+def test_verify_svix_signature_accepts_valid_signature():
+    body = b'{"type":"email.delivered","data":{"email_id":"email_1"}}'
+
+    assert verify_svix_signature(body, _headers(body), _secret()) is True
+
+
+def test_verify_svix_signature_rejects_missing_or_wrong_signature():
+    body = b'{"type":"email.delivered","data":{"email_id":"email_1"}}'
+
+    assert verify_svix_signature(body, {}, _secret()) is False
+    assert verify_svix_signature(body, _headers(body, msg_id="msg_1"), _secret()) is True
+    bad_headers = dict(_headers(body))
+    bad_headers["svix-signature"] = "v1,bad"
+    assert verify_svix_signature(body, bad_headers, _secret()) is False
+
+
+def test_verify_svix_signature_can_be_disabled_for_local_dev():
+    assert verify_svix_signature(b"{}", {}, "", verify_signatures=False) is True
+    assert verify_svix_signature(b"{}", {}, "") is True
+
+
+def test_normalize_resend_payload_maps_known_events_and_metadata():
+    event = normalize_resend_payload({
+        "type": "email.clicked",
+        "created_at": "2026-05-01T12:00:00Z",
+        "data": {
+            "email_id": "email_1",
+            "to": "buyer@example.com",
+            "click": {"link": "https://example.test/demo"},
+        },
+    })
+
+    assert event.provider == "resend"
+    assert event.event_type == "clicked"
+    assert event.message_id == "email_1"
+    assert event.email == "buyer@example.com"
+    assert event.occurred_at.isoformat() == "2026-05-01T12:00:00+00:00"
+    assert event.payload["normalized"] == {
+        "raw_event_type": "email.clicked",
+        "click_url": "https://example.test/demo",
+        "bounce_type": None,
+    }
+
+
+def test_normalize_resend_payload_preserves_unknown_event_type():
+    event = normalize_resend_payload({
+        "type": "email.rendered",
+        "data": {"email_id": "email_1"},
+    })
+
+    assert event.event_type == "email.rendered"
+    assert event.message_id == "email_1"
+
+
+def test_normalize_resend_payload_extracts_bounce_type():
+    event = normalize_resend_payload({
+        "type": "email.bounced",
+        "data": {
+            "email_id": "email_1",
+            "email": "buyer@example.com",
+            "bounce": {"type": "hard"},
+        },
+    })
+
+    assert event.event_type == "bounced"
+    assert event.email == "buyer@example.com"
+    assert event.payload["normalized"]["bounce_type"] == "hard"
+
+
+def test_resend_verifier_returns_normalized_event_for_valid_payload():
+    body = json.dumps({
+        "type": "email.opened",
+        "data": {"email_id": "email_1", "to": "buyer@example.com"},
+    }).encode("utf-8")
+    verifier = ResendWebhookVerifier(ResendWebhookConfig(signing_secret=_secret()))
+
+    event = verifier.verify_and_parse(body=body, headers=_headers(body))
+
+    assert event.event_type == "opened"
+    assert event.message_id == "email_1"
+
+
+def test_resend_verifier_rejects_invalid_signature():
+    verifier = ResendWebhookVerifier(ResendWebhookConfig(signing_secret=_secret()))
+
+    with pytest.raises(WebhookVerificationError, match="Invalid webhook signature"):
+        verifier.verify_and_parse(body=b"{}", headers={})
+
+
+def test_resend_verifier_rejects_invalid_json():
+    verifier = ResendWebhookVerifier(
+        ResendWebhookConfig(signing_secret="", verify_signatures=False)
+    )
+
+    with pytest.raises(WebhookPayloadError, match="Invalid JSON"):
+        verifier.verify_and_parse(body=b"{not-json", headers={})
+
+
+def test_resend_verifier_rejects_non_object_json():
+    verifier = ResendWebhookVerifier(
+        ResendWebhookConfig(signing_secret="", verify_signatures=False)
+    )
+
+    with pytest.raises(WebhookPayloadError, match="must be a JSON object"):
+        verifier.verify_and_parse(body=b"[]", headers={})
+
+
+class _StaticVerifier:
+    def __init__(self, event: WebhookEvent):
+        self.event = event
+        self.calls = []
+
+    def verify_and_parse(self, *, body, headers):
+        self.calls.append({"body": body, "headers": headers})
+        return self.event
+
+
+class _CampaignRepo:
+    def __init__(self):
+        self.events = []
+
+    async def record_webhook_event(self, event):
+        self.events.append(event)
+
+    async def save_drafts(self, drafts, *, scope):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def list_due_sends(self, *, limit, now):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+    async def mark_sent(self, *, campaign_id, result, sent_at):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def mark_cancelled(self, *, campaign_id, reason, metadata=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def mark_send_failed(self, *, campaign_id, error, metadata=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def refresh_analytics(self):  # pragma: no cover - protocol filler
+        raise AssertionError("not used")
+
+
+class _SuppressionRepo:
+    def __init__(self):
+        self.writes = []
+
+    async def is_suppressed(self, *, email=None, domain=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def add_suppression(self, **kwargs):
+        self.writes.append(kwargs)
+
+
+class _Audit:
+    def __init__(self):
+        self.events = []
+
+    async def record(self, event_type, *, campaign_id=None, sequence_id=None, metadata=None):
+        self.events.append({
+            "event_type": event_type,
+            "campaign_id": campaign_id,
+            "sequence_id": sequence_id,
+            "metadata": metadata,
+        })
+
+
+class _Clock:
+    def __init__(self):
+        self.value = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+    def now(self):
+        return self.value
+
+
+def _event(event_type="delivered", **overrides):
+    data = {
+        "provider": "resend",
+        "event_type": event_type,
+        "message_id": "email_1",
+        "email": "Buyer@Example.com",
+        "payload": {"type": f"email.{event_type}", "data": {"email_id": "email_1"}},
+    }
+    data.update(overrides)
+    return WebhookEvent(**data)
+
+
+def _ingestion_service(event, *, suppression=True, audit=None, config=None):
+    repo = _CampaignRepo()
+    suppression_repo = _SuppressionRepo()
+    service = CampaignWebhookIngestionService(
+        verifier=_StaticVerifier(event),
+        campaigns=repo,
+        suppression=CampaignSuppressionService(suppression_repo) if suppression else None,
+        audit=audit,
+        clock=_Clock(),
+        config=config,
+    )
+    return service, repo, suppression_repo
+
+
+@pytest.mark.asyncio
+async def test_ingestion_records_known_event_and_audit():
+    audit = _Audit()
+    service, repo, suppression_repo = _ingestion_service(_event("delivered"), audit=audit)
+
+    result = await service.ingest(body=b"{}", headers={"x-test": "1"})
+
+    assert result.as_dict() == {
+        "status": "ok",
+        "event_type": "delivered",
+        "message_id": "email_1",
+        "reason": None,
+        "suppressed": False,
+    }
+    assert len(repo.events) == 1
+    assert repo.events[0].event_type == "delivered"
+    assert suppression_repo.writes == []
+    assert audit.events == [{
+        "event_type": "webhook_delivered",
+        "campaign_id": None,
+        "sequence_id": None,
+        "metadata": {
+            "provider": "resend",
+            "message_id": "email_1",
+            "email": "Buyer@Example.com",
+            "suppressed": False,
+        },
+    }]
+
+
+@pytest.mark.asyncio
+async def test_ingestion_ignores_event_without_message_id():
+    service, repo, suppression_repo = _ingestion_service(
+        _event("delivered", message_id=None)
+    )
+
+    result = await service.ingest(body=b"{}", headers={})
+
+    assert result.status == "ignored"
+    assert result.reason == "no_message_id"
+    assert repo.events == []
+    assert suppression_repo.writes == []
+
+
+@pytest.mark.asyncio
+async def test_ingestion_ignores_unknown_event_by_default():
+    service, repo, suppression_repo = _ingestion_service(_event("rendered"))
+
+    result = await service.ingest(body=b"{}", headers={})
+
+    assert result.status == "ignored"
+    assert result.reason == "unhandled_event_type"
+    assert repo.events == []
+    assert suppression_repo.writes == []
+
+
+@pytest.mark.asyncio
+async def test_ingestion_can_record_unknown_events_when_configured():
+    service, repo, _ = _ingestion_service(
+        _event("rendered"),
+        config=CampaignWebhookIngestionConfig(record_unknown_events=True),
+    )
+
+    result = await service.ingest(body=b"{}", headers={})
+
+    assert result.status == "ok"
+    assert repo.events[0].event_type == "rendered"
+
+
+@pytest.mark.asyncio
+async def test_ingestion_adds_complaint_suppression():
+    service, repo, suppression_repo = _ingestion_service(_event("complained"))
+
+    result = await service.ingest(body=b"{}", headers={})
+
+    assert result.suppressed is True
+    assert len(repo.events) == 1
+    assert suppression_repo.writes == [{
+        "reason": "complaint",
+        "email": "buyer@example.com",
+        "domain": None,
+        "source": "webhook",
+        "campaign_id": None,
+        "notes": None,
+        "expires_at": None,
+        "metadata": {"provider_message_id": "email_1"},
+    }]
+
+
+@pytest.mark.asyncio
+async def test_ingestion_adds_permanent_hard_bounce_suppression():
+    event = _event(
+        "bounced",
+        payload={
+            "type": "email.bounced",
+            "data": {"email_id": "email_1", "bounce": {"type": "hard"}},
+            "normalized": {"bounce_type": "hard"},
+        },
+    )
+    service, _, suppression_repo = _ingestion_service(event)
+
+    await service.ingest(body=b"{}", headers={})
+
+    assert suppression_repo.writes[0]["reason"] == "bounce_hard"
+    assert suppression_repo.writes[0]["expires_at"] is None
+    assert suppression_repo.writes[0]["metadata"] == {
+        "provider_message_id": "email_1",
+        "bounce_type": "hard",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ingestion_adds_temporary_soft_bounce_suppression():
+    event = _event(
+        "bounced",
+        payload={
+            "type": "email.bounced",
+            "data": {"email_id": "email_1", "bounce": {"type": "soft"}},
+            "normalized": {"bounce_type": "soft"},
+        },
+    )
+    service, _, suppression_repo = _ingestion_service(
+        event,
+        config=CampaignWebhookIngestionConfig(soft_bounce_suppression_days=7),
+    )
+
+    await service.ingest(body=b"{}", headers={})
+
+    assert suppression_repo.writes[0]["reason"] == "bounce_soft"
+    assert suppression_repo.writes[0]["expires_at"].isoformat() == "2026-05-08T12:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_ingestion_records_bounce_even_without_suppression_email():
+    service, repo, suppression_repo = _ingestion_service(
+        _event("bounced", email=None)
+    )
+
+    result = await service.ingest(body=b"{}", headers={})
+
+    assert result.status == "ok"
+    assert result.suppressed is False
+    assert len(repo.events) == 1
+    assert suppression_repo.writes == []


### PR DESCRIPTION
## Summary

Stacked on PR #39. This turns the extracted content pipeline scaffold toward a sellable standalone Email / Campaign Generation Pipeline by adding product-owned ports and standalone service slices that do not import `atlas_brain`.

Adds standalone modules for:

- campaign ports and shared dataclasses
- campaign draft generation shell
- due-send orchestration
- Resend/SES sender adapters
- suppression policy
- sequence context compaction
- sequence progression / follow-up generation
- Resend/Svix webhook verification, normalization, ingestion, and suppression
- analytics refresh orchestration

Also adds productization docs and a standalone readiness audit script, then wires the extracted pipeline check runner to execute the focused standalone campaign tests.

## Why Stacked

PRs #35/#37/#38/#39 all touch the same extracted_content_pipeline scaffold. This branch is intentionally based on PR #39 (`codex/trace-content-generation-pipeline-flow-ro80em`) instead of the older PR #35 branch so the productization work does not fight the current canonical scaffold.

## Verification

- `bash scripts/run_extracted_pipeline_checks.sh`
  - scaffold validation passed
  - ASCII check passed
  - import check passed
  - import smoke passed
  - standalone audit reports existing scaffold debt: 34 Atlas runtime import findings
  - extracted standalone campaign tests: 76 passed
- `python -m py_compile` over all new standalone product modules and the audit script
- `rg atlas_brain` over new product-owned modules/tests: no matches

## Notes

The audit debt is from copied scaffold/shim files inherited from PR #39. The new product-owned modules are Atlas-free by construction.