### PR TITLE
Point content pipeline LLM bridges at extracted infra

### DIFF
--- a/atlas_brain/autonomous/tasks/_b2b_shared.py
+++ b/atlas_brain/autonomous/tasks/_b2b_shared.py
@@ -16185,7 +16185,7 @@ async def read_review_details(
     specific_complaints, relevance_score, author_churn_score,
     low_fidelity, low_fidelity_reasons.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     if recency_column == "enriched_at":
         recency_expr = "r.enriched_at"
@@ -16347,7 +16347,7 @@ async def read_campaign_opportunities(
     context, pain categories, and quotable phrases extracted from enrichment.
     Consumers add domain-specific logic (scoring, affiliate matching, etc.).
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     conditions = [
         "r.enrichment_status = 'enriched'",
@@ -16489,7 +16489,7 @@ def _vendor_evidence_base_filters(
     Centralizes enrichment status check, recency semantics, and suppression.
     Returns a SQL fragment with $<window_param> as the window_days placeholder.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     if recency_column == "enriched_at":
         recency = f"{alias}.enriched_at"
@@ -16556,7 +16556,7 @@ async def read_vendor_quote_evidence(
     Returns dicts with: vendor_name, source, reviewer_company, reviewer_title,
     role_level, pain_category, urgency, review_text, quotable_phrases, rating.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     if recency_column == "imported_at":
         recency_expr = "r.imported_at"
@@ -16662,7 +16662,7 @@ async def read_category_quote_evidence(
 
     Same return shape as read_vendor_quote_evidence.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     conditions = [
         "r.enrichment_status = 'enriched'",

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -5558,7 +5558,7 @@ async def _gather_data(
             evidence_vault_lookup.get(vendor),
         )
         # Pull actual pricing complaint reviews directly
-        from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
+        from ._b2b_shared import read_vendor_quote_evidence
         sources = _blog_source_allowlist()
         pricing_rows = await read_vendor_quote_evidence(
             pool,

--- a/atlas_brain/autonomous/tasks/b2b_campaign_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_campaign_generation.py
@@ -3769,7 +3769,7 @@ async def _fetch_opportunities(
     dm_only: bool = True,
 ) -> list[dict[str, Any]]:
     """Fetch and score top opportunities from enriched b2b_reviews."""
-    from atlas_brain.autonomous.tasks._b2b_shared import read_campaign_opportunities
+    from ._b2b_shared import read_campaign_opportunities
 
     rows = await read_campaign_opportunities(
         pool,

--- a/atlas_brain/autonomous/tasks/b2b_vendor_briefing.py
+++ b/atlas_brain/autonomous/tasks/b2b_vendor_briefing.py
@@ -2591,8 +2591,8 @@ async def _fetch_high_urgency_quotes(
     fields (review_id, source, field) and ``quote_origin='review'``
     for downstream audit -- matches the blog producer convention.
     """
-    from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
-    from atlas_brain.services.b2b.enrichment_contract import quote_grade_phrases
+    from ._b2b_shared import read_vendor_quote_evidence
+    from ...services.b2b.enrichment_contract import quote_grade_phrases
 
     rows = await read_vendor_quote_evidence(
         pool,

--- a/extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py
+++ b/extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py
@@ -2591,8 +2591,8 @@ async def _fetch_high_urgency_quotes(
     fields (review_id, source, field) and ``quote_origin='review'``
     for downstream audit -- matches the blog producer convention.
     """
-    from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
-    from atlas_brain.services.b2b.enrichment_contract import quote_grade_phrases
+    from ._b2b_shared import read_vendor_quote_evidence
+    from ...services.b2b.enrichment_contract import quote_grade_phrases
 
     rows = await read_vendor_quote_evidence(
         pool,

--- a/extracted_competitive_intelligence/services/b2b/enrichment_contract.py
+++ b/extracted_competitive_intelligence/services/b2b/enrichment_contract.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def pain_category_for_bucket(bucket: str | None) -> str:
+    return str(bucket or "other").strip().lower() or "other"
+
+
+def quote_grade_phrases(*args: Any, **kwargs: Any) -> list[str]:
+    return []
+
+
+def resolve_pain_confidence(value: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -122,7 +122,9 @@ Several small utility shims provide product-owned local behavior by default so t
 
 - `config.py`: extracted settings from `settings.py`
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
+- `storage/repositories/scheduled_task.py`: local execution metadata updater
 - `skills/registry.py`: local markdown-backed skill registry
+- `reasoning/archetypes.py`, `reasoning/evidence_engine.py`, and `reasoning/temporal.py`: minimal reasoning adapters for extracted report builders
 - `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
 - `services/b2b/cache_runner.py`: local exact-cache request helpers and no-op lookup/store
 - `services/b2b/enrichment_contract.py`: local enrichment contract fallbacks

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -111,6 +111,11 @@ Set `EXTRACTED_PIPELINE_STANDALONE=1` to use `extracted_content_pipeline/setting
 
 In standalone mode (`EXTRACTED_PIPELINE_STANDALONE=1`), `extracted_content_pipeline/pipelines/llm.py` and `extracted_content_pipeline/pipelines/notify.py` provide local fallback behavior (no-op notifier and safe JSON/cleaning helpers) so task modules can execute without Atlas pipeline services.
 
+Outside standalone mode, content-pipeline LLM bridge modules delegate to
+`extracted_llm_infrastructure` instead of `atlas_brain`. That keeps the content
+generation product boundary pointed at the extracted LLM/cost-optimization
+product rather than at the monolith.
+
 ## Standalone storage shims
 
 In standalone mode, `extracted_content_pipeline/storage/database.py` and `extracted_content_pipeline/storage/models.py` provide minimal local fallbacks (`get_db_pool`, `ScheduledTask`) so task entrypoints can execute without Atlas storage imports.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -103,9 +103,9 @@ GitHub Actions workflow: `.github/workflows/extracted_pipeline_checks.yml` runs 
 bash scripts/list_extracted_pipeline_files.sh
 ```
 
-## Standalone mode toggle
+## LLM offline fallback
 
-Set `EXTRACTED_PIPELINE_STANDALONE=1` to use `extracted_content_pipeline/settings.py` instead of delegating config to `atlas_brain.config`.
+Set `EXTRACTED_PIPELINE_STANDALONE=1` to make the LLM bridge modules use their local no-op fallbacks instead of delegating to `extracted_llm_infrastructure`.
 
 ## Pipeline shims
 
@@ -116,26 +116,19 @@ Content-pipeline LLM bridge modules delegate to
 generation product boundary pointed at the extracted LLM/cost-optimization
 product rather than at the monolith.
 
-## Standalone storage shims
-
-In standalone mode, `extracted_content_pipeline/storage/database.py` and `extracted_content_pipeline/storage/models.py` provide minimal local fallbacks (`get_db_pool`, `ScheduledTask`) so task entrypoints can execute without Atlas storage imports.
-
-## Standalone skill registry
-
-In standalone mode, `extracted_content_pipeline/skills/registry.py` uses local markdown files under `extracted_content_pipeline/skills/` for `get_skill_registry()` lookups.
-
 ## Local utility shims
 
 Several small utility shims provide product-owned local behavior by default so task imports do not require Atlas service modules:
 
+- `config.py`: extracted settings from `settings.py`
+- `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
+- `skills/registry.py`: local markdown-backed skill registry
 - `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
+- `services/b2b/cache_runner.py`: local exact-cache request helpers and no-op lookup/store
+- `services/b2b/enrichment_contract.py`: local enrichment contract fallbacks
 - `services/scraping/sources.py`: `ReviewSource` enums and allowlist helpers
 - `reasoning/wedge_registry.py`: `Wedge`, `get_wedge_meta`, and `validate_wedge`
 - `services/blog_quality.py`: blog quality summary/revalidation helpers
 - `services/company_normalization.py`: `normalize_company_name`
 - `services/vendor_registry.py`: `resolve_vendor_name_cached`
 - `services/apollo_company_overrides.py`, `services/b2b/corrections.py`, `services/tracing.py`, and `services/scraping/universal/html_cleaner.py`: local no-op or lightweight helpers
-
-## Standalone B2B contract shims
-
-In standalone mode, `extracted_content_pipeline/services/b2b/enrichment_contract.py` provides local fallbacks (`pain_category_for_bucket`, `quote_grade_phrases`, `resolve_pain_confidence`) used by extracted B2B helpers.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -110,6 +110,11 @@ bash scripts/list_extracted_pipeline_files.sh
 
 Set `EXTRACTED_PIPELINE_STANDALONE=1` to make the LLM bridge modules use their local no-op fallbacks instead of delegating to `extracted_llm_infrastructure`.
 
+`campaign_llm_client.py` provides the product-owned `PipelineLLMClient`
+adapter for campaign services. It satisfies the `campaign_ports.LLMClient`
+port, resolves an LLM through the extracted LLM bridge when configured, and
+normalizes `chat()` / `generate()` provider responses into `LLMResponse`.
+
 ## Pipeline shims
 
 `extracted_content_pipeline/pipelines/notify.py` provides a local no-op notifier so task modules can execute without Atlas pipeline services.
@@ -124,6 +129,8 @@ product rather than at the monolith.
 Several small utility shims provide product-owned local behavior by default so task imports do not require Atlas service modules:
 
 - `config.py`: extracted settings from `settings.py`
+- `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
+  `LLMClient` port to extracted LLM infrastructure services
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
 - `skills/registry.py`: local markdown-backed skill registry implementing

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -132,6 +132,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
+- `campaign_postgres.py`: async Postgres adapters for campaign, sequence,
+  suppression, and audit ports
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
 - `skills/registry.py`: local markdown-backed skill registry implementing
   `.get()` and product `SkillStore.get_prompt()`

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -71,6 +71,9 @@ for keeping the extracted package free of runtime `atlas_brain` imports.
 bash scripts/run_extracted_pipeline_checks.sh
 ```
 
+The one-shot runner enforces the standalone readiness audit with
+`--fail-on-debt`; any new runtime `atlas_brain` import fails CI.
+
 ## Compatibility shims
 
 To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`). Runtime imports no longer delegate to `atlas_brain`; most adapters are intentionally minimal local implementations.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -8,7 +8,8 @@ carved out safely without removing or changing production code.
 
 - `autonomous/tasks/`: copied task implementations
 - `services/`: copied support shims and staged service dependencies
-- `skills/digest/`: copied prompt skill contracts
+- `skills/digest/`: copied prompt skill contracts, including campaign and
+  sequence prompts used by the standalone services
 - `storage/migrations/`: copied persistence migrations
 - `docs/`: extraction maps for productized pipeline slices
 
@@ -125,7 +126,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `config.py`: extracted settings from `settings.py`
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
-- `skills/registry.py`: local markdown-backed skill registry
+- `skills/registry.py`: local markdown-backed skill registry implementing
+  `.get()` and product `SkillStore.get_prompt()`
 - `reasoning/archetypes.py`, `reasoning/evidence_engine.py`, and `reasoning/temporal.py`: minimal reasoning adapters for extracted report builders
 - `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
 - `services/b2b/cache_runner.py`: local exact-cache request helpers and no-op lookup/store

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -74,7 +74,7 @@ bash scripts/run_extracted_pipeline_checks.sh
 
 ## Compatibility shims
 
-To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`) that delegate to `atlas_brain` implementations.
+To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`). Some remain compatibility delegates to `atlas_brain`; small utility shims now use product-owned local implementations by default.
 
 B2B helper siblings required by `b2b_blog_post_generation.py` are also copied into `extracted_content_pipeline/autonomous/tasks/`.
 
@@ -107,11 +107,11 @@ bash scripts/list_extracted_pipeline_files.sh
 
 Set `EXTRACTED_PIPELINE_STANDALONE=1` to use `extracted_content_pipeline/settings.py` instead of delegating config to `atlas_brain.config`.
 
-## Standalone pipeline shims
+## Pipeline shims
 
-In standalone mode (`EXTRACTED_PIPELINE_STANDALONE=1`), `extracted_content_pipeline/pipelines/llm.py` and `extracted_content_pipeline/pipelines/notify.py` provide local fallback behavior (no-op notifier and safe JSON/cleaning helpers) so task modules can execute without Atlas pipeline services.
+`extracted_content_pipeline/pipelines/notify.py` provides a local no-op notifier so task modules can execute without Atlas pipeline services.
 
-Outside standalone mode, content-pipeline LLM bridge modules delegate to
+Content-pipeline LLM bridge modules delegate to
 `extracted_llm_infrastructure` instead of `atlas_brain`. That keeps the content
 generation product boundary pointed at the extracted LLM/cost-optimization
 product rather than at the monolith.
@@ -124,41 +124,17 @@ In standalone mode, `extracted_content_pipeline/storage/database.py` and `extrac
 
 In standalone mode, `extracted_content_pipeline/skills/registry.py` uses local markdown files under `extracted_content_pipeline/skills/` for `get_skill_registry()` lookups.
 
-## Standalone service shims
+## Local utility shims
 
-In standalone mode, `extracted_content_pipeline/services/__init__.py` and `extracted_content_pipeline/services/protocols.py` provide minimal local fallbacks (`llm_registry.get_active()`, `Message`) so task imports do not require Atlas service modules.
+Several small utility shims provide product-owned local behavior by default so task imports do not require Atlas service modules:
 
-## Standalone source shims
-
-In standalone mode, `extracted_content_pipeline/services/scraping/sources.py` provides local `ReviewSource` enums and allowlist helpers used by B2B tasks without requiring Atlas source modules.
-
-## Standalone reasoning shims
-
-In standalone mode, `extracted_content_pipeline/reasoning/wedge_registry.py` provides local `Wedge`, `get_wedge_meta`, and `validate_wedge` fallbacks used by B2B extracted modules.
-
-## Standalone quality shims
-
-In standalone mode, `extracted_content_pipeline/services/blog_quality.py` provides local fallback quality helpers (`blog_quality_summary`, `blog_quality_revalidation`, and `merge_blog_first_pass_quality_data_context`) for B2B blog pipeline paths.
-
-## Standalone normalization shims
-
-In standalone mode, `extracted_content_pipeline/services/company_normalization.py` provides a local `normalize_company_name` fallback used by extracted B2B helpers.
-
-## Standalone vendor registry shims
-
-In standalone mode, `extracted_content_pipeline/services/vendor_registry.py` provides a local `resolve_vendor_name_cached` fallback used by extracted B2B helpers.
-
-## Standalone tracing shims
-
-In standalone mode, `extracted_content_pipeline/services/tracing.py` provides a local `build_business_trace_context` fallback used by extracted B2B helpers.
-
-## Standalone Apollo override shims
-
-In standalone mode, `extracted_content_pipeline/services/apollo_company_overrides.py` provides a local async `fetch_company_override_map` fallback used by extracted B2B helpers.
-
-## Standalone corrections shims
-
-In standalone mode, `extracted_content_pipeline/services/b2b/corrections.py` provides a local `suppress_predicate` fallback for extracted B2B helper logic.
+- `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
+- `services/scraping/sources.py`: `ReviewSource` enums and allowlist helpers
+- `reasoning/wedge_registry.py`: `Wedge`, `get_wedge_meta`, and `validate_wedge`
+- `services/blog_quality.py`: blog quality summary/revalidation helpers
+- `services/company_normalization.py`: `normalize_company_name`
+- `services/vendor_registry.py`: `resolve_vendor_name_cached`
+- `services/apollo_company_overrides.py`, `services/b2b/corrections.py`, `services/tracing.py`, and `services/scraping/universal/html_cleaner.py`: local no-op or lightweight helpers
 
 ## Standalone B2B contract shims
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -29,10 +29,10 @@ Mirror mappings are declared in `extracted_content_pipeline/manifest.json` so sy
 This scaffold preserves code exactly as copied so behavior and signatures remain
 unchanged while extraction work continues.
 
-This is not yet the sellable product boundary. A customer-usable module must be
-able to install and run without the Atlas monolith on `PYTHONPATH`. Until the
-standalone audit reaches zero runtime `atlas_brain` imports, this package is a
-staging copy, not a deployable product.
+The standalone audit now passes with zero runtime `atlas_brain` imports. The
+scaffold is still a staging boundary until the minimal runtime adapters are
+hardened into customer-grade ports and the copied helper surface is trimmed to
+the sellable workflows.
 
 
 ## Validation command
@@ -63,8 +63,7 @@ python scripts/audit_extracted_standalone.py --fail-on-debt
 ```
 
 The first command reports Atlas runtime coupling. The second is the product gate
-we should enable once staged shims have been replaced with product-owned ports
-and adapters.
+for keeping the extracted package free of runtime `atlas_brain` imports.
 
 ## One-shot checks
 
@@ -74,12 +73,12 @@ bash scripts/run_extracted_pipeline_checks.sh
 
 ## Compatibility shims
 
-To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`). Some remain compatibility delegates to `atlas_brain`; small utility shims now use product-owned local implementations by default.
+To keep copied task modules importable inside this repo, package-level bridge modules are provided under `extracted_content_pipeline/` (for example `config.py`, `storage/database.py`, `pipelines/llm.py`, and `services/*`). Runtime imports no longer delegate to `atlas_brain`; most adapters are intentionally minimal local implementations.
 
 B2B helper siblings required by `b2b_blog_post_generation.py` are also copied into `extracted_content_pipeline/autonomous/tasks/`.
 
-These shims are temporary extraction scaffolding. They should not ship in the
-customer product.
+These minimal adapters are extraction scaffolding. They need hardening before
+shipping in the customer product.
 
 The email/campaign generation slice is mapped in `docs/email_campaign_generation_pipeline.md`, with standalone productization requirements in `docs/standalone_productization.md`.
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -11,6 +11,9 @@
   - `article_enrichment.py`
 - B2B helper siblings required by copied blog/campaign flows are present.
 - Compatibility bridge modules map extracted package imports back to `atlas_brain` for side-by-side operation.
+- LLM-facing content bridges now target `extracted_llm_infrastructure`
+  (`pipelines.llm`, `services.b2b.anthropic_batch`, `services.llm.anthropic`)
+  instead of pointing directly at `atlas_brain`.
 
 ## Validation gates in repo
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -22,6 +22,8 @@
   instead of pointing directly at `atlas_brain`.
 - `campaign_llm_client.PipelineLLMClient` adapts extracted LLM infrastructure
   services to the standalone campaign `LLMClient` port.
+- `campaign_postgres` provides async Postgres adapters for the campaign,
+  sequence, suppression, and audit ports against the copied campaign schema.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,
@@ -47,7 +49,7 @@
 
 ## Remaining extraction work
 
-1. Harden minimal local adapters into customer-grade ports for DB/notify/reasoning
+1. Harden minimal local adapters into customer-grade ports for notify/reasoning
    and provider-specific LLM configuration.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -10,6 +10,8 @@
   - `complaint_enrichment.py`
   - `article_enrichment.py`
 - B2B helper siblings required by copied blog/campaign flows are present.
+- Campaign and sequence prompt contracts are copied into `skills/digest/`, and
+  the local skill registry implements `SkillStore.get_prompt()`.
 - Compatibility bridge modules no longer map extracted package imports back to
   `atlas_brain` at runtime.
 - LLM-facing content bridges now target `extracted_llm_infrastructure`
@@ -40,7 +42,7 @@
 
 ## Remaining extraction work
 
-1. Harden minimal local adapters into customer-grade ports for DB/LLM/skills/notify/reasoning.
+1. Harden minimal local adapters into customer-grade ports for DB/LLM/notify/reasoning.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -12,6 +12,9 @@
 - B2B helper siblings required by copied blog/campaign flows are present.
 - Campaign and sequence prompt contracts are copied into `skills/digest/`, and
   the local skill registry implements `SkillStore.get_prompt()`.
+- Core campaign schema migrations are copied into `storage/migrations/`
+  (`b2b_campaigns`, `campaign_sequences`, suppressions, analytics, vendor and
+  seller targets, outcomes, score components, and engagement timing).
 - Compatibility bridge modules no longer map extracted package imports back to
   `atlas_brain` at runtime.
 - LLM-facing content bridges now target `extracted_llm_infrastructure`

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -10,10 +10,19 @@
   - `complaint_enrichment.py`
   - `article_enrichment.py`
 - B2B helper siblings required by copied blog/campaign flows are present.
-- Compatibility bridge modules map extracted package imports back to `atlas_brain` for side-by-side operation.
+- Compatibility bridge modules still map some extracted package imports back to `atlas_brain` for side-by-side operation.
 - LLM-facing content bridges now target `extracted_llm_infrastructure`
   (`pipelines.llm`, `services.b2b.anthropic_batch`, `services.llm.anthropic`)
   instead of pointing directly at `atlas_brain`.
+- Small utility shims now default to local extracted implementations:
+  `pipelines.notify`, `reasoning.wedge_registry`, `services.__init__`,
+  `services.protocols`, `services.blog_quality`,
+  `services.company_normalization`, `services.vendor_registry`,
+  `services.apollo_company_overrides`, `services.b2b.corrections`,
+  `services.tracing`, `services.scraping.sources`, and
+  `services.scraping.universal.html_cleaner`.
+- Standalone readiness audit is down to 19 Atlas runtime import findings
+  (15 hard imports, 4 bridge shims).
 
 ## Validation gates in repo
 
@@ -26,7 +35,7 @@
 
 ## Remaining extraction work
 
-1. Replace bridge-module delegation (`from atlas_brain...`) with native extracted implementations package by package.
+1. Replace remaining bridge-module delegation (`from atlas_brain...`) with native extracted implementations package by package.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Introduce standalone config and runtime wiring for DB/LLM/skills/notify.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -17,6 +17,8 @@
 - LLM-facing content bridges now target `extracted_llm_infrastructure`
   (`pipelines.llm`, `services.b2b.anthropic_batch`, `services.llm.anthropic`)
   instead of pointing directly at `atlas_brain`.
+- `campaign_llm_client.PipelineLLMClient` adapts extracted LLM infrastructure
+  services to the standalone campaign `LLMClient` port.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,
@@ -42,7 +44,8 @@
 
 ## Remaining extraction work
 
-1. Harden minimal local adapters into customer-grade ports for DB/LLM/notify/reasoning.
+1. Harden minimal local adapters into customer-grade ports for DB/notify/reasoning
+   and provider-specific LLM configuration.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -35,7 +35,8 @@
 - `scripts/check_ascii_python.sh`
 - `scripts/check_extracted_imports.py`
 - `scripts/smoke_extracted_pipeline_imports.py`
-- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/run_extracted_pipeline_checks.sh` (includes
+  `audit_extracted_standalone.py --fail-on-debt`)
 
 ## Remaining extraction work
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -16,15 +16,17 @@
   instead of pointing directly at `atlas_brain`.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
+  `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,
   `skills.registry`, `storage.database`, `storage.models`,
+  `storage.repositories.scheduled_task`,
   `services.__init__`, `services.protocols`, `services.blog_quality`,
   `services.b2b.cache_runner`, `services.b2b.enrichment_contract`,
   `services.company_normalization`, `services.vendor_registry`,
   `services.apollo_company_overrides`, `services.b2b.corrections`,
   `services.tracing`, `services.scraping.sources`, and
   `services.scraping.universal.html_cleaner`.
-- Standalone readiness audit is down to 13 Atlas runtime import findings
-  (9 hard imports, 4 bridge shims).
+- Standalone readiness audit is down to 9 Atlas runtime import findings
+  (all hard imports inside copied task/helper files).
 
 ## Validation gates in repo
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -10,7 +10,8 @@
   - `complaint_enrichment.py`
   - `article_enrichment.py`
 - B2B helper siblings required by copied blog/campaign flows are present.
-- Compatibility bridge modules still map some extracted package imports back to `atlas_brain` for side-by-side operation.
+- Compatibility bridge modules no longer map extracted package imports back to
+  `atlas_brain` at runtime.
 - LLM-facing content bridges now target `extracted_llm_infrastructure`
   (`pipelines.llm`, `services.b2b.anthropic_batch`, `services.llm.anthropic`)
   instead of pointing directly at `atlas_brain`.
@@ -25,8 +26,7 @@
   `services.apollo_company_overrides`, `services.b2b.corrections`,
   `services.tracing`, `services.scraping.sources`, and
   `services.scraping.universal.html_cleaner`.
-- Standalone readiness audit is down to 9 Atlas runtime import findings
-  (all hard imports inside copied task/helper files).
+- Standalone readiness audit reports 0 Atlas runtime import findings.
 
 ## Validation gates in repo
 
@@ -39,11 +39,11 @@
 
 ## Remaining extraction work
 
-1. Replace remaining bridge-module delegation (`from atlas_brain...`) with native extracted implementations package by package.
+1. Harden minimal local adapters into customer-grade ports for DB/LLM/skills/notify/reasoning.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
-3. Introduce standalone config and runtime wiring for DB/LLM/skills/notify.
+3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).
 
 ## Operational note
 
-Until bridge-module delegation is removed, this scaffold remains an in-repo extraction staging area (not yet a fully detached standalone runtime).
+The runtime import gate is clean, but this scaffold remains an in-repo extraction staging area until adapters are productionized and copied helper scope is narrowed.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -15,14 +15,16 @@
   (`pipelines.llm`, `services.b2b.anthropic_batch`, `services.llm.anthropic`)
   instead of pointing directly at `atlas_brain`.
 - Small utility shims now default to local extracted implementations:
-  `pipelines.notify`, `reasoning.wedge_registry`, `services.__init__`,
-  `services.protocols`, `services.blog_quality`,
+  `config`, `pipelines.notify`, `reasoning.wedge_registry`,
+  `skills.registry`, `storage.database`, `storage.models`,
+  `services.__init__`, `services.protocols`, `services.blog_quality`,
+  `services.b2b.cache_runner`, `services.b2b.enrichment_contract`,
   `services.company_normalization`, `services.vendor_registry`,
   `services.apollo_company_overrides`, `services.b2b.corrections`,
   `services.tracing`, `services.scraping.sources`, and
   `services.scraping.universal.html_cleaner`.
-- Standalone readiness audit is down to 19 Atlas runtime import findings
-  (15 hard imports, 4 bridge shims).
+- Standalone readiness audit is down to 13 Atlas runtime import findings
+  (9 hard imports, 4 bridge shims).
 
 ## Validation gates in repo
 

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_shared.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_shared.py
@@ -16185,7 +16185,7 @@ async def read_review_details(
     specific_complaints, relevance_score, author_churn_score,
     low_fidelity, low_fidelity_reasons.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     if recency_column == "enriched_at":
         recency_expr = "r.enriched_at"
@@ -16347,7 +16347,7 @@ async def read_campaign_opportunities(
     context, pain categories, and quotable phrases extracted from enrichment.
     Consumers add domain-specific logic (scoring, affiliate matching, etc.).
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     conditions = [
         "r.enrichment_status = 'enriched'",
@@ -16489,7 +16489,7 @@ def _vendor_evidence_base_filters(
     Centralizes enrichment status check, recency semantics, and suppression.
     Returns a SQL fragment with $<window_param> as the window_days placeholder.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     if recency_column == "enriched_at":
         recency = f"{alias}.enriched_at"
@@ -16556,7 +16556,7 @@ async def read_vendor_quote_evidence(
     Returns dicts with: vendor_name, source, reviewer_company, reviewer_title,
     role_level, pain_category, urgency, review_text, quotable_phrases, rating.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     if recency_column == "imported_at":
         recency_expr = "r.imported_at"
@@ -16662,7 +16662,7 @@ async def read_category_quote_evidence(
 
     Same return shape as read_vendor_quote_evidence.
     """
-    from atlas_brain.services.b2b.corrections import suppress_predicate
+    from ...services.b2b.corrections import suppress_predicate
 
     conditions = [
         "r.enrichment_status = 'enriched'",

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -5558,7 +5558,7 @@ async def _gather_data(
             evidence_vault_lookup.get(vendor),
         )
         # Pull actual pricing complaint reviews directly
-        from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
+        from ._b2b_shared import read_vendor_quote_evidence
         sources = _blog_source_allowlist()
         pricing_rows = await read_vendor_quote_evidence(
             pool,

--- a/extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py
@@ -3769,7 +3769,7 @@ async def _fetch_opportunities(
     dm_only: bool = True,
 ) -> list[dict[str, Any]]:
     """Fetch and score top opportunities from enriched b2b_reviews."""
-    from atlas_brain.autonomous.tasks._b2b_shared import read_campaign_opportunities
+    from ._b2b_shared import read_campaign_opportunities
 
     rows = await read_campaign_opportunities(
         pool,

--- a/extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py
@@ -2591,8 +2591,8 @@ async def _fetch_high_urgency_quotes(
     fields (review_id, source, field) and ``quote_origin='review'``
     for downstream audit -- matches the blog producer convention.
     """
-    from atlas_brain.autonomous.tasks._b2b_shared import read_vendor_quote_evidence
-    from atlas_brain.services.b2b.enrichment_contract import quote_grade_phrases
+    from ._b2b_shared import read_vendor_quote_evidence
+    from ...services.b2b.enrichment_contract import quote_grade_phrases
 
     rows = await read_vendor_quote_evidence(
         pool,

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -1,0 +1,135 @@
+"""LLMClient adapter for the standalone campaign product."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .campaign_ports import LLMMessage, LLMResponse
+
+
+class LLMUnavailableError(RuntimeError):
+    """Raised when the host has not configured an LLM route."""
+
+
+LLMResolver = Callable[..., Any]
+
+
+def _default_resolver(**kwargs: Any) -> Any:
+    from .pipelines.llm import get_pipeline_llm
+
+    return get_pipeline_llm(**kwargs)
+
+
+@dataclass(frozen=True)
+class PipelineLLMClient:
+    """Adapt extracted LLM infrastructure services to the product LLMClient port."""
+
+    workload: str | None = "draft"
+    prefer_cloud: bool = True
+    try_openrouter: bool = True
+    auto_activate_ollama: bool = True
+    openrouter_model: str | None = None
+    resolver: LLMResolver = _default_resolver
+
+    async def complete(
+        self,
+        messages: Sequence[LLMMessage],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LLMResponse:
+        llm = self.resolver(
+            workload=self.workload,
+            prefer_cloud=self.prefer_cloud,
+            try_openrouter=self.try_openrouter,
+            auto_activate_ollama=self.auto_activate_ollama,
+            openrouter_model=self.openrouter_model,
+        )
+        if llm is None:
+            raise LLMUnavailableError("No LLM route configured for campaign generation")
+
+        result = self._call_llm(
+            llm,
+            list(messages),
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        return _to_response(result, llm=llm)
+
+    def _call_llm(
+        self,
+        llm: Any,
+        messages: list[LLMMessage],
+        *,
+        max_tokens: int,
+        temperature: float,
+    ) -> Any:
+        if hasattr(llm, "chat"):
+            return llm.chat(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        if hasattr(llm, "generate"):
+            system_prompt, prompt = _messages_to_prompt(messages)
+            return llm.generate(
+                prompt,
+                system_prompt=system_prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        raise LLMUnavailableError("Resolved LLM does not expose chat() or generate()")
+
+
+def _messages_to_prompt(messages: Sequence[LLMMessage]) -> tuple[str | None, str]:
+    system_parts: list[str] = []
+    prompt_parts: list[str] = []
+    for message in messages:
+        content = str(getattr(message, "content", "") or "").strip()
+        if not content:
+            continue
+        if getattr(message, "role", "") == "system":
+            system_parts.append(content)
+        else:
+            prompt_parts.append(content)
+    return "\n\n".join(system_parts) or None, "\n\n".join(prompt_parts)
+
+
+def _to_response(result: Any, *, llm: Any) -> LLMResponse:
+    if isinstance(result, str):
+        return LLMResponse(content=result, model=_model_name(llm), raw=result)
+
+    if not isinstance(result, Mapping):
+        return LLMResponse(content=str(result or ""), model=_model_name(llm), raw=result)
+
+    message = result.get("message")
+    content = (
+        result.get("response")
+        or result.get("content")
+        or result.get("text")
+        or (message.get("content") if isinstance(message, Mapping) else None)
+        or ""
+    )
+    usage = result.get("usage") if isinstance(result.get("usage"), Mapping) else {}
+    return LLMResponse(
+        content=str(content),
+        model=str(result.get("model") or _model_name(llm) or "") or None,
+        usage=dict(usage),
+        raw=result,
+    )
+
+
+def _model_name(llm: Any) -> str | None:
+    for attr in ("model", "model_id", "name"):
+        value = getattr(llm, attr, None)
+        if value:
+            return str(value)
+    model_info = getattr(llm, "model_info", None)
+    value = getattr(model_info, "model_id", None) if model_info is not None else None
+    return str(value) if value else None

--- a/extracted_content_pipeline/campaign_postgres.py
+++ b/extracted_content_pipeline/campaign_postgres.py
@@ -1,0 +1,457 @@
+"""Postgres repository adapters for the standalone campaign product."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import (
+    CampaignDraft,
+    SendResult,
+    TenantScope,
+    WebhookEvent,
+)
+
+
+JsonDict = dict[str, Any]
+
+
+def _jsonb(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
+
+
+def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
+    if isinstance(row, Mapping):
+        return dict(row)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _source_opportunity(draft: CampaignDraft) -> JsonDict:
+    raw = draft.metadata.get("source_opportunity") if isinstance(draft.metadata, Mapping) else None
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _campaign_company_name(draft: CampaignDraft, opportunity: Mapping[str, Any]) -> str:
+    return (
+        _clean(opportunity.get("company_name"))
+        or _clean(opportunity.get("name"))
+        or _clean(opportunity.get("seller_name"))
+        or draft.target_id
+    )
+
+
+def _campaign_vendor_name(draft: CampaignDraft, opportunity: Mapping[str, Any]) -> str | None:
+    return (
+        _clean(opportunity.get("vendor_name"))
+        or _clean(opportunity.get("vendor"))
+        or _clean(draft.metadata.get("vendor_name"))
+        or None
+    )
+
+
+@dataclass(frozen=True)
+class PostgresCampaignRepository:
+    """Async Postgres adapter for generated campaigns and webhook events."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[CampaignDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        for draft in drafts:
+            opportunity = _source_opportunity(draft)
+            metadata = {
+                **dict(draft.metadata or {}),
+                "target_id": draft.target_id,
+                "target_mode": draft.target_mode,
+                "scope": {
+                    "account_id": scope.account_id,
+                    "user_id": scope.user_id,
+                },
+            }
+            campaign_id = await self.pool.fetchval(
+                """
+                INSERT INTO b2b_campaigns (
+                    company_name, vendor_name, product_category, target_mode,
+                    channel, subject, body, cta, status, recipient_email,
+                    metadata, llm_model
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft', $9, $10::jsonb, $11)
+                RETURNING id
+                """,
+                _campaign_company_name(draft, opportunity),
+                _campaign_vendor_name(draft, opportunity),
+                _clean(opportunity.get("product_category") or opportunity.get("category")) or None,
+                draft.target_mode,
+                draft.channel,
+                draft.subject,
+                draft.body,
+                draft.metadata.get("cta"),
+                (
+                    _clean(opportunity.get("recipient_email"))
+                    or _clean(opportunity.get("contact_email"))
+                    or _clean(opportunity.get("email"))
+                    or None
+                ),
+                _jsonb(metadata),
+                draft.metadata.get("generation_model"),
+            )
+            saved.append(str(campaign_id))
+        return tuple(saved)
+
+    async def list_due_sends(
+        self,
+        *,
+        limit: int,
+        now: datetime,
+    ) -> Sequence[JsonDict]:
+        rows = await self.pool.fetch(
+            """
+            SELECT
+                id, sequence_id, recipient_email, from_email, subject, body,
+                metadata, company_name, vendor_name, channel, step_number
+            FROM b2b_campaigns
+            WHERE status = 'queued'
+              AND recipient_email IS NOT NULL
+            ORDER BY created_at ASC
+            LIMIT $1
+            """,
+            int(limit),
+        )
+        return tuple(_row_dict(row) for row in rows)
+
+    async def mark_sent(
+        self,
+        *,
+        campaign_id: str,
+        result: SendResult,
+        sent_at: datetime,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE b2b_campaigns
+               SET status = 'sent',
+                   sent_at = $2,
+                   esp_message_id = $3,
+                   sent_message_id = $3,
+                   metadata = COALESCE(metadata, '{}'::jsonb) || $4::jsonb,
+                   updated_at = NOW()
+             WHERE id = $1
+            """,
+            campaign_id,
+            sent_at,
+            result.message_id,
+            _jsonb({"send_provider": result.provider, "send_raw": result.raw}),
+        )
+
+    async def mark_cancelled(
+        self,
+        *,
+        campaign_id: str,
+        reason: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE b2b_campaigns
+               SET status = 'cancelled',
+                   metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
+                   updated_at = NOW()
+             WHERE id = $1
+            """,
+            campaign_id,
+            reason,
+            _jsonb({"cancel_reason": reason, **dict(metadata or {})}),
+        )
+
+    async def mark_send_failed(
+        self,
+        *,
+        campaign_id: str,
+        error: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE b2b_campaigns
+               SET status = 'cancelled',
+                   metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
+                   updated_at = NOW()
+             WHERE id = $1
+            """,
+            campaign_id,
+            error,
+            _jsonb({"send_error": error, **dict(metadata or {})}),
+        )
+
+    async def record_webhook_event(self, event: WebhookEvent) -> None:
+        if event.event_type in {"opened", "clicked"}:
+            column = "opened_at" if event.event_type == "opened" else "clicked_at"
+            await self.pool.execute(
+                f"""
+                UPDATE b2b_campaigns
+                   SET {column} = COALESCE({column}, $2),
+                       metadata = COALESCE(metadata, '{{}}'::jsonb) || $3::jsonb,
+                       updated_at = NOW()
+                 WHERE esp_message_id = $1 OR sent_message_id = $1
+                """,
+                event.message_id,
+                event.occurred_at,
+                _jsonb({"last_webhook_event": event.event_type}),
+            )
+        await self.pool.execute(
+            """
+            INSERT INTO campaign_audit_log (
+                event_type, esp_message_id, metadata, source, created_at
+            )
+            VALUES ($1, $2, $3::jsonb, $4, COALESCE($5, NOW()))
+            """,
+            f"webhook_{event.event_type}",
+            event.message_id,
+            _jsonb({"provider": event.provider, "email": event.email, "payload": event.payload}),
+            event.provider or "webhook",
+            event.occurred_at,
+        )
+
+    async def refresh_analytics(self) -> None:
+        await self.pool.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY campaign_funnel_stats")
+
+
+@dataclass(frozen=True)
+class PostgresCampaignSequenceRepository:
+    """Async Postgres adapter for campaign sequence progression."""
+
+    pool: Any
+
+    async def list_due_sequences(
+        self,
+        *,
+        limit: int,
+        now: datetime,
+    ) -> Sequence[JsonDict]:
+        rows = await self.pool.fetch(
+            """
+            SELECT *
+              FROM campaign_sequences
+             WHERE status = 'active'
+               AND next_step_after IS NOT NULL
+               AND next_step_after <= $1
+               AND recipient_email IS NOT NULL
+             ORDER BY next_step_after ASC
+             LIMIT $2
+            """,
+            now,
+            int(limit),
+        )
+        return tuple(_row_dict(row) for row in rows)
+
+    async def list_previous_campaigns(
+        self,
+        *,
+        sequence_id: str,
+        limit: int,
+    ) -> Sequence[JsonDict]:
+        rows = await self.pool.fetch(
+            """
+            SELECT *
+              FROM b2b_campaigns
+             WHERE sequence_id = $1
+             ORDER BY step_number ASC NULLS LAST, created_at ASC
+             LIMIT $2
+            """,
+            sequence_id,
+            int(limit),
+        )
+        return tuple(_row_dict(row) for row in rows)
+
+    async def queue_sequence_step(
+        self,
+        *,
+        sequence: JsonDict,
+        content: JsonDict,
+        from_email: str,
+        queued_at: datetime,
+    ) -> str:
+        campaign_id = await self.pool.fetchval(
+            """
+            INSERT INTO b2b_campaigns (
+                sequence_id, company_name, batch_id, channel, subject, body,
+                cta, status, step_number, recipient_email, from_email,
+                target_mode, product_category, metadata, created_at, updated_at
+            )
+            VALUES (
+                $1, $2, $3, 'email_followup', $4, $5, $6, 'queued', $7, $8, $9,
+                $10, $11, $12::jsonb, $13, $13
+            )
+            RETURNING id
+            """,
+            sequence.get("id"),
+            sequence.get("company_name"),
+            sequence.get("batch_id"),
+            content.get("subject"),
+            content.get("body"),
+            content.get("cta"),
+            content.get("step_number"),
+            sequence.get("recipient_email"),
+            from_email,
+            content.get("target_mode"),
+            content.get("product_category"),
+            _jsonb({
+                "angle_reasoning": content.get("angle_reasoning"),
+                "sequence_context": {
+                    "current_step": sequence.get("current_step"),
+                    "max_steps": sequence.get("max_steps"),
+                },
+            }),
+            queued_at,
+        )
+        return str(campaign_id)
+
+    async def mark_sequence_step(
+        self,
+        *,
+        sequence_id: str,
+        current_step: int,
+        updated_at: datetime,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE campaign_sequences
+               SET current_step = $2,
+                   updated_at = $3
+             WHERE id = $1
+            """,
+            sequence_id,
+            int(current_step),
+            updated_at,
+        )
+
+
+@dataclass(frozen=True)
+class PostgresSuppressionRepository:
+    """Async Postgres adapter for campaign email/domain suppressions."""
+
+    pool: Any
+
+    async def is_suppressed(
+        self,
+        *,
+        email: str | None = None,
+        domain: str | None = None,
+    ) -> bool:
+        if email:
+            row = await self.pool.fetchrow(
+                """
+                SELECT id
+                  FROM campaign_suppressions
+                 WHERE LOWER(email) = LOWER($1)
+                   AND (expires_at IS NULL OR expires_at > NOW())
+                 LIMIT 1
+                """,
+                email,
+            )
+            return row is not None
+        if domain:
+            row = await self.pool.fetchrow(
+                """
+                SELECT id
+                  FROM campaign_suppressions
+                 WHERE LOWER(domain) = LOWER($1)
+                   AND (expires_at IS NULL OR expires_at > NOW())
+                 LIMIT 1
+                """,
+                domain,
+            )
+            return row is not None
+        return False
+
+    async def add_suppression(
+        self,
+        *,
+        reason: str,
+        email: str | None = None,
+        domain: str | None = None,
+        source: str = "system",
+        campaign_id: str | None = None,
+        notes: str | None = None,
+        expires_at: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        if email:
+            await self.pool.execute(
+                """
+                INSERT INTO campaign_suppressions (
+                    email, reason, source, campaign_id, notes, expires_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6)
+                ON CONFLICT (LOWER(email)) WHERE email IS NOT NULL
+                DO UPDATE SET
+                    reason = EXCLUDED.reason,
+                    source = EXCLUDED.source,
+                    campaign_id = COALESCE(EXCLUDED.campaign_id, campaign_suppressions.campaign_id),
+                    notes = COALESCE(EXCLUDED.notes, campaign_suppressions.notes),
+                    expires_at = EXCLUDED.expires_at
+                """,
+                email,
+                reason,
+                source,
+                campaign_id,
+                notes or _clean((metadata or {}).get("notes")) or None,
+                expires_at,
+            )
+            return
+        await self.pool.execute(
+            """
+            INSERT INTO campaign_suppressions (
+                domain, reason, source, campaign_id, notes, expires_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            domain,
+            reason,
+            source,
+            campaign_id,
+            notes or _clean((metadata or {}).get("notes")) or None,
+            expires_at,
+        )
+
+
+@dataclass(frozen=True)
+class PostgresCampaignAuditSink:
+    """AuditSink adapter backed by campaign_audit_log."""
+
+    pool: Any
+
+    async def record(
+        self,
+        event_type: str,
+        *,
+        campaign_id: str | None = None,
+        sequence_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        await self.pool.execute(
+            """
+            INSERT INTO campaign_audit_log (
+                campaign_id, sequence_id, event_type, metadata, source
+            )
+            VALUES ($1, $2, $3, $4::jsonb, 'product')
+            """,
+            campaign_id,
+            sequence_id,
+            event_type,
+            _jsonb(dict(metadata or {})),
+        )

--- a/extracted_content_pipeline/config.py
+++ b/extracted_content_pipeline/config.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    from .settings import build_settings
+from .settings import build_settings
 
-    settings = build_settings()
-else:
-    from atlas_brain.config import settings
+
+settings = build_settings()
 
 __all__ = ["settings"]

--- a/extracted_content_pipeline/docs/email_campaign_generation_pipeline.md
+++ b/extracted_content_pipeline/docs/email_campaign_generation_pipeline.md
@@ -112,7 +112,7 @@ Prompt contracts:
 - `skills/digest/amazon_seller_campaign_generation.md`
 - `skills/digest/amazon_seller_campaign_sequence.md`
 
-Campaign schema:
+Campaign schema copied into this scaffold:
 
 - `storage/migrations/066_b2b_campaigns.sql`
 - `storage/migrations/068_campaign_sequences.sql`
@@ -121,14 +121,19 @@ Campaign schema:
 - `storage/migrations/073_campaign_sequence_fixes.sql`
 - `storage/migrations/074_campaign_target_modes.sql`
 - `storage/migrations/075_amazon_seller_campaigns.sql`
-- `storage/migrations/080_b2b_alert_baselines.sql`
 - `storage/migrations/090_audit_log_metadata_index.sql`
 - `storage/migrations/104_campaign_outcomes.sql`
-- `storage/migrations/106_score_calibration.sql`
 - `storage/migrations/146_campaign_score_components.sql`
 - `storage/migrations/150_campaign_engagement_timing.sql`
+
+Campaign-adjacent migrations intentionally deferred from the core scaffold:
+
+- `storage/migrations/080_b2b_alert_baselines.sql` (also depends on tenant
+  alert tables and `saas_accounts`)
+- `storage/migrations/106_score_calibration.sql` (model calibration slice)
 - `storage/migrations/235_vendor_targets_account_scope.sql`
-- `storage/migrations/255_anthropic_message_batches.sql`
+- `storage/migrations/255_anthropic_message_batches.sql` (batch LLM replay
+  infrastructure)
 
 ## External Providers And Env
 

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -33,6 +33,42 @@
       "target": "extracted_content_pipeline/skills/digest/complaint_content_generation.md"
     },
     {
+      "source": "atlas_brain/skills/digest/b2b_campaign_generation.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_campaign_generation.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_vendor_outreach.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_vendor_outreach.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_challenger_outreach.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_challenger_outreach.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_campaign_sequence.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_campaign_sequence.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_vendor_sequence.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_vendor_sequence.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_challenger_sequence.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_challenger_sequence.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/b2b_onboarding_sequence.md",
+      "target": "extracted_content_pipeline/skills/digest/b2b_onboarding_sequence.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/amazon_seller_campaign_generation.md",
+      "target": "extracted_content_pipeline/skills/digest/amazon_seller_campaign_generation.md"
+    },
+    {
+      "source": "atlas_brain/skills/digest/amazon_seller_campaign_sequence.md",
+      "target": "extracted_content_pipeline/skills/digest/amazon_seller_campaign_sequence.md"
+    },
+    {
       "source": "atlas_brain/storage/migrations/084_blog_posts.sql",
       "target": "extracted_content_pipeline/storage/migrations/084_blog_posts.sql"
     },

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -77,6 +77,50 @@
       "target": "extracted_content_pipeline/storage/migrations/264_blog_post_rejection_count.sql"
     },
     {
+      "source": "atlas_brain/storage/migrations/066_b2b_campaigns.sql",
+      "target": "extracted_content_pipeline/storage/migrations/066_b2b_campaigns.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/068_campaign_sequences.sql",
+      "target": "extracted_content_pipeline/storage/migrations/068_campaign_sequences.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/069_campaign_analytics.sql",
+      "target": "extracted_content_pipeline/storage/migrations/069_campaign_analytics.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/070_campaign_suppressions.sql",
+      "target": "extracted_content_pipeline/storage/migrations/070_campaign_suppressions.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/073_campaign_sequence_fixes.sql",
+      "target": "extracted_content_pipeline/storage/migrations/073_campaign_sequence_fixes.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/074_campaign_target_modes.sql",
+      "target": "extracted_content_pipeline/storage/migrations/074_campaign_target_modes.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/075_amazon_seller_campaigns.sql",
+      "target": "extracted_content_pipeline/storage/migrations/075_amazon_seller_campaigns.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/090_audit_log_metadata_index.sql",
+      "target": "extracted_content_pipeline/storage/migrations/090_audit_log_metadata_index.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/104_campaign_outcomes.sql",
+      "target": "extracted_content_pipeline/storage/migrations/104_campaign_outcomes.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/146_campaign_score_components.sql",
+      "target": "extracted_content_pipeline/storage/migrations/146_campaign_score_components.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/150_campaign_engagement_timing.sql",
+      "target": "extracted_content_pipeline/storage/migrations/150_campaign_engagement_timing.sql"
+    },
+    {
       "source": "atlas_brain/autonomous/tasks/_execution_progress.py",
       "target": "extracted_content_pipeline/autonomous/tasks/_execution_progress.py"
     },

--- a/extracted_content_pipeline/pipelines/llm.py
+++ b/extracted_content_pipeline/pipelines/llm.py
@@ -26,4 +26,4 @@ if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
     def call_llm_with_skill(*args: Any, **kwargs: Any):
         return None
 else:
-    from atlas_brain.pipelines.llm import *
+    from extracted_llm_infrastructure.pipelines.llm import *

--- a/extracted_content_pipeline/pipelines/notify.py
+++ b/extracted_content_pipeline/pipelines/notify.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    async def send_pipeline_notification(*args: Any, **kwargs: Any) -> None:
-        return None
-else:
-    from atlas_brain.pipelines.notify import *
+
+async def send_pipeline_notification(*args: Any, **kwargs: Any) -> None:
+    return None

--- a/extracted_content_pipeline/reasoning/archetypes.py
+++ b/extracted_content_pipeline/reasoning/archetypes.py
@@ -1,1 +1,77 @@
-from atlas_brain.reasoning.archetypes import *
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+MATCH_THRESHOLD = 0.25
+
+
+@dataclass(frozen=True)
+class ArchetypeProfile:
+    name: str
+    description: str = ""
+    typical_risk: str = "medium"
+    falsification_templates: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ArchetypeMatch:
+    archetype: str
+    score: float
+    matched_signals: list[str]
+    missing_signals: list[str]
+    risk_level: str
+
+
+ARCHETYPES: dict[str, ArchetypeProfile] = {
+    name: ArchetypeProfile(name=name)
+    for name in (
+        "pricing_shock",
+        "feature_gap",
+        "acquisition_decay",
+        "leadership_redesign",
+        "integration_break",
+        "support_collapse",
+        "category_disruption",
+        "compliance_gap",
+    )
+}
+
+
+def score_evidence(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+) -> list[ArchetypeMatch]:
+    return []
+
+
+def best_match(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+) -> ArchetypeMatch | None:
+    return None
+
+
+def top_matches(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+    *,
+    limit: int = 3,
+) -> list[ArchetypeMatch]:
+    return []
+
+
+def get_archetype(name: str) -> ArchetypeProfile | None:
+    return ARCHETYPES.get(name)
+
+
+def get_falsification_conditions(archetype_name: str) -> list[str]:
+    profile = ARCHETYPES.get(archetype_name)
+    return list(profile.falsification_templates) if profile else []
+
+
+def enrich_evidence_with_archetypes(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return dict(evidence or {})

--- a/extracted_content_pipeline/reasoning/evidence_engine.py
+++ b/extracted_content_pipeline/reasoning/evidence_engine.py
@@ -1,1 +1,51 @@
-from atlas_brain.reasoning.evidence_engine import *
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ConclusionResult:
+    conclusion_id: str
+    met: bool
+    confidence: str
+    fallback_label: str | None = None
+    fallback_action: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SuppressionResult:
+    suppress: bool = False
+    degrade: bool = False
+    disclaimer: str | None = None
+    fallback_label: str | None = None
+
+
+class EvidenceEngine:
+    def __init__(self, map_path: str | Path | None = None) -> None:
+        self.map_path = str(map_path or "")
+        self.map_hash = "standalone"
+
+    def evaluate_conclusions(
+        self,
+        vendor_evidence: dict[str, Any],
+    ) -> list[ConclusionResult]:
+        return []
+
+    def evaluate_suppression(
+        self,
+        section: str,
+        evidence: dict[str, Any],
+    ) -> SuppressionResult:
+        return SuppressionResult()
+
+
+_engine: EvidenceEngine | None = None
+
+
+def get_evidence_engine(map_path: str | Path | None = None) -> EvidenceEngine:
+    global _engine
+    if _engine is None or map_path is not None:
+        _engine = EvidenceEngine(map_path)
+    return _engine

--- a/extracted_content_pipeline/reasoning/temporal.py
+++ b/extracted_content_pipeline/reasoning/temporal.py
@@ -1,1 +1,84 @@
-from atlas_brain.reasoning.temporal import *
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VendorVelocity:
+    vendor_name: str
+    metric: str
+    current_value: float
+    previous_value: float
+    velocity: float
+    days_between: int
+    acceleration: float | None = None
+
+
+@dataclass(frozen=True)
+class LongTermTrend:
+    metric: str
+    slope_30d: float | None = None
+    slope_90d: float | None = None
+    volatility: float | None = None
+    data_points: int = 0
+
+
+@dataclass(frozen=True)
+class CategoryPercentile:
+    product_category: str
+    metric: str
+    p25: float
+    p50: float
+    p75: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class AnomalyScore:
+    vendor_name: str
+    metric: str
+    value: float
+    z_score: float
+    p_value: float | None = None
+    is_anomaly: bool = False
+
+
+@dataclass(frozen=True)
+class TemporalEvidence:
+    vendor_name: str
+    snapshot_days: int
+    velocities: list[VendorVelocity] = field(default_factory=list)
+    trends: list[LongTermTrend] = field(default_factory=list)
+    anomalies: list[AnomalyScore] = field(default_factory=list)
+    category_baselines: list[CategoryPercentile] = field(default_factory=list)
+    insufficient_data: bool = False
+
+
+class TemporalEngine:
+    def __init__(self, pool: Any):
+        self._pool = pool
+
+    async def analyze_vendor(self, vendor_name: str) -> TemporalEvidence:
+        return TemporalEvidence(
+            vendor_name=str(vendor_name or ""),
+            snapshot_days=0,
+            insufficient_data=True,
+        )
+
+    async def analyze_all_vendors(self) -> dict[str, TemporalEvidence]:
+        return {}
+
+    @staticmethod
+    def to_evidence_dict(te: TemporalEvidence) -> dict[str, Any]:
+        if te.insufficient_data:
+            return {
+                "temporal_status": "insufficient_data",
+                "snapshot_days": te.snapshot_days,
+            }
+        evidence: dict[str, Any] = {"snapshot_days": te.snapshot_days}
+        for velocity in te.velocities:
+            evidence[f"velocity_{velocity.metric}"] = round(velocity.velocity, 4)
+            if velocity.acceleration is not None:
+                evidence[f"accel_{velocity.metric}"] = round(velocity.acceleration, 4)
+        return evidence

--- a/extracted_content_pipeline/reasoning/wedge_registry.py
+++ b/extracted_content_pipeline/reasoning/wedge_registry.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from enum import Enum
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    class Wedge(str, Enum):
-        PRICING = "pricing"
-        SUPPORT = "support"
-        RELIABILITY = "reliability"
-        FEATURES = "features"
-        INTEGRATIONS = "integrations"
 
-    @dataclass
-    class WedgeMeta:
-        label: str
+class Wedge(str, Enum):
+    PRICING = "pricing"
+    SUPPORT = "support"
+    RELIABILITY = "reliability"
+    FEATURES = "features"
+    INTEGRATIONS = "integrations"
 
-    def get_wedge_meta(wedge: Wedge) -> WedgeMeta:
-        return WedgeMeta(label=str(wedge.value).replace("_", " ").title())
 
-    def validate_wedge(value: str) -> str:
-        norm = str(value or "").strip().lower()
-        if norm in {w.value for w in Wedge}:
-            return norm
-        return Wedge.SUPPORT.value
-else:
-    from atlas_brain.reasoning.wedge_registry import *
+@dataclass
+class WedgeMeta:
+    label: str
+
+
+def get_wedge_meta(wedge: Wedge) -> WedgeMeta:
+    return WedgeMeta(label=str(wedge.value).replace("_", " ").title())
+
+
+def validate_wedge(value: str) -> str:
+    norm = str(value or "").strip().lower()
+    if norm in {w.value for w in Wedge}:
+        return norm
+    return Wedge.SUPPORT.value

--- a/extracted_content_pipeline/services/__init__.py
+++ b/extracted_content_pipeline/services/__init__.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import os
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    class _StandaloneLLMRegistry:
-        @staticmethod
-        def get_active():
-            return None
+class _StandaloneLLMRegistry:
+    @staticmethod
+    def get_active():
+        return None
 
-    llm_registry = _StandaloneLLMRegistry()
-else:
-    from atlas_brain.services import llm_registry
+
+llm_registry = _StandaloneLLMRegistry()
 
 __all__ = ["llm_registry"]

--- a/extracted_content_pipeline/services/apollo_company_overrides.py
+++ b/extracted_content_pipeline/services/apollo_company_overrides.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import os
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    async def fetch_company_override_map(*args, **kwargs) -> dict[str, str]:
-        return {}
-else:
-    from atlas_brain.services.apollo_company_overrides import *
+async def fetch_company_override_map(*args, **kwargs) -> dict[str, str]:
+    return {}

--- a/extracted_content_pipeline/services/b2b/anthropic_batch.py
+++ b/extracted_content_pipeline/services/b2b/anthropic_batch.py
@@ -31,4 +31,4 @@ if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
     async def mark_batch_fallback_result(*args: Any, **kwargs: Any) -> None:
         return None
 else:
-    from atlas_brain.services.b2b.anthropic_batch import *
+    from extracted_llm_infrastructure.services.b2b.anthropic_batch import *

--- a/extracted_content_pipeline/services/b2b/cache_runner.py
+++ b/extracted_content_pipeline/services/b2b/cache_runner.py
@@ -1,69 +1,70 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from typing import Any
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    @dataclass(frozen=True)
-    class B2BExactStageRequest:
-        stage_id: str
-        provider: str = "standalone"
-        model: str = "standalone"
-        request_envelope: dict[str, Any] = field(default_factory=dict)
 
-    def prepare_b2b_exact_stage_request(
-        stage_id: str,
-        *,
-        provider: str | None = None,
-        model: str | None = None,
-        llm: Any | None = None,
-        messages: list[Any] | None = None,
-        max_tokens: int | None = None,
-        temperature: float | None = None,
-        request_envelope: dict[str, Any] | None = None,
-        **metadata: Any,
-    ) -> B2BExactStageRequest:
-        resolved_provider = provider or getattr(llm, "provider", None) or "standalone"
-        resolved_model = model or getattr(llm, "model", None) or "standalone"
-        envelope = dict(request_envelope or {})
-        if messages is not None:
-            envelope["messages"] = messages
-        if max_tokens is not None:
-            envelope["max_tokens"] = max_tokens
-        if temperature is not None:
-            envelope["temperature"] = temperature
-        if metadata:
-            envelope["metadata"] = metadata
-        return B2BExactStageRequest(
-            stage_id=stage_id,
-            provider=str(resolved_provider),
-            model=str(resolved_model),
-            request_envelope=envelope,
-        )
+@dataclass(frozen=True)
+class B2BExactStageRequest:
+    stage_id: str
+    provider: str = "standalone"
+    model: str = "standalone"
+    request_envelope: dict[str, Any] = field(default_factory=dict)
 
-    def bind_b2b_exact_stage_request(
-        stage_id: str,
-        *,
-        provider: str,
-        model: str,
-        request_envelope: dict[str, Any],
-        **metadata: Any,
-    ) -> B2BExactStageRequest:
-        envelope = dict(request_envelope or {})
-        if metadata:
-            envelope["metadata"] = metadata
-        return B2BExactStageRequest(
-            stage_id=stage_id,
-            provider=str(provider),
-            model=str(model),
-            request_envelope=envelope,
-        )
 
-    async def lookup_b2b_exact_stage_text(*args: Any, **kwargs: Any) -> None:
-        return None
+def prepare_b2b_exact_stage_request(
+    stage_id: str,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    llm: Any | None = None,
+    messages: list[Any] | None = None,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    request_envelope: dict[str, Any] | None = None,
+    **metadata: Any,
+) -> B2BExactStageRequest:
+    resolved_provider = provider or getattr(llm, "provider", None) or "standalone"
+    resolved_model = model or getattr(llm, "model", None) or "standalone"
+    envelope = dict(request_envelope or {})
+    if messages is not None:
+        envelope["messages"] = messages
+    if max_tokens is not None:
+        envelope["max_tokens"] = max_tokens
+    if temperature is not None:
+        envelope["temperature"] = temperature
+    if metadata:
+        envelope["metadata"] = metadata
+    return B2BExactStageRequest(
+        stage_id=stage_id,
+        provider=str(resolved_provider),
+        model=str(resolved_model),
+        request_envelope=envelope,
+    )
 
-    async def store_b2b_exact_stage_text(*args: Any, **kwargs: Any) -> bool:
-        return False
-else:
-    from atlas_brain.services.b2b.cache_runner import *
+
+def bind_b2b_exact_stage_request(
+    stage_id: str,
+    *,
+    provider: str,
+    model: str,
+    request_envelope: dict[str, Any],
+    **metadata: Any,
+) -> B2BExactStageRequest:
+    envelope = dict(request_envelope or {})
+    if metadata:
+        envelope["metadata"] = metadata
+    return B2BExactStageRequest(
+        stage_id=stage_id,
+        provider=str(provider),
+        model=str(model),
+        request_envelope=envelope,
+    )
+
+
+async def lookup_b2b_exact_stage_text(*args: Any, **kwargs: Any) -> None:
+    return None
+
+
+async def store_b2b_exact_stage_text(*args: Any, **kwargs: Any) -> bool:
+    return False

--- a/extracted_content_pipeline/services/b2b/corrections.py
+++ b/extracted_content_pipeline/services/b2b/corrections.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import os
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    def suppress_predicate(*args, **kwargs) -> bool:
-        return False
-else:
-    from atlas_brain.services.b2b.corrections import *
+def suppress_predicate(*args, **kwargs) -> bool:
+    return False

--- a/extracted_content_pipeline/services/b2b/enrichment_contract.py
+++ b/extracted_content_pipeline/services/b2b/enrichment_contract.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    def pain_category_for_bucket(bucket: str | None) -> str:
-        return str(bucket or "other").strip().lower() or "other"
 
-    def quote_grade_phrases(*args: Any, **kwargs: Any) -> list[str]:
-        return []
+def pain_category_for_bucket(bucket: str | None) -> str:
+    return str(bucket or "other").strip().lower() or "other"
 
-    def resolve_pain_confidence(value: Any) -> float:
-        try:
-            return max(0.0, min(1.0, float(value)))
-        except (TypeError, ValueError):
-            return 0.0
-else:
-    from atlas_brain.services.b2b.enrichment_contract import *
+
+def quote_grade_phrases(*args: Any, **kwargs: Any) -> list[str]:
+    return []
+
+
+def resolve_pain_confidence(value: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0

--- a/extracted_content_pipeline/services/blog_quality.py
+++ b/extracted_content_pipeline/services/blog_quality.py
@@ -1,42 +1,41 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    def blog_quality_summary(data_context: dict[str, Any] | None = None) -> dict[str, Any]:
-        return {
-            "score": 100,
-            "threshold": 0,
-            "blocking_issues": [],
-            "warnings": [],
+
+def blog_quality_summary(data_context: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "score": 100,
+        "threshold": 0,
+        "blocking_issues": [],
+        "warnings": [],
+    }
+
+
+def blog_quality_revalidation(
+    data_context: dict[str, Any] | None = None,
+    content: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+    boundary: str | None = None,
+) -> dict[str, Any]:
+    base = blog_quality_summary(data_context)
+    if isinstance(report, dict):
+        for key in ("score", "threshold", "blocking_issues", "warnings"):
+            if key in report:
+                base[key] = report[key]
+    return base
+
+
+def merge_blog_first_pass_quality_data_context(
+    data_context: dict[str, Any] | None,
+    audit: dict[str, Any] | None,
+) -> dict[str, Any]:
+    merged = dict(data_context or {})
+    if isinstance(audit, dict):
+        merged["first_pass_quality"] = {
+            "score": audit.get("score"),
+            "threshold": audit.get("threshold"),
+            "blocking_issues": list(audit.get("blocking_issues") or []),
+            "warnings": list(audit.get("warnings") or []),
         }
-
-    def blog_quality_revalidation(
-        data_context: dict[str, Any] | None = None,
-        content: dict[str, Any] | None = None,
-        report: dict[str, Any] | None = None,
-        boundary: str | None = None,
-    ) -> dict[str, Any]:
-        base = blog_quality_summary(data_context)
-        if isinstance(report, dict):
-            for key in ("score", "threshold", "blocking_issues", "warnings"):
-                if key in report:
-                    base[key] = report[key]
-        return base
-
-    def merge_blog_first_pass_quality_data_context(
-        data_context: dict[str, Any] | None,
-        audit: dict[str, Any] | None,
-    ) -> dict[str, Any]:
-        merged = dict(data_context or {})
-        if isinstance(audit, dict):
-            merged["first_pass_quality"] = {
-                "score": audit.get("score"),
-                "threshold": audit.get("threshold"),
-                "blocking_issues": list(audit.get("blocking_issues") or []),
-                "warnings": list(audit.get("warnings") or []),
-            }
-        return merged
-else:
-    from atlas_brain.services.blog_quality import *
+    return merged

--- a/extracted_content_pipeline/services/company_normalization.py
+++ b/extracted_content_pipeline/services/company_normalization.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
 import re
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    def normalize_company_name(value: str | None) -> str:
-        text = str(value or "").strip().lower()
-        text = re.sub(r"\s+", " ", text)
-        return text
-else:
-    from atlas_brain.services.company_normalization import *
+
+def normalize_company_name(value: str | None) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"\s+", " ", text)
+    return text

--- a/extracted_content_pipeline/services/llm/anthropic.py
+++ b/extracted_content_pipeline/services/llm/anthropic.py
@@ -1,1 +1,1 @@
-from atlas_brain.services.llm.anthropic import *
+from extracted_llm_infrastructure.services.llm.anthropic import *

--- a/extracted_content_pipeline/services/protocols.py
+++ b/extracted_content_pipeline/services/protocols.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    @dataclass
-    class Message:
-        role: str
-        content: str
-else:
-    from atlas_brain.services.protocols import *
+
+@dataclass
+class Message:
+    role: str
+    content: str

--- a/extracted_content_pipeline/services/scraping/sources.py
+++ b/extracted_content_pipeline/services/scraping/sources.py
@@ -1,49 +1,60 @@
 from __future__ import annotations
 
-import os
 from enum import Enum
 from typing import Iterable
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    class ReviewSource(str, Enum):
-        G2 = "g2"
-        CAPTERRA = "capterra"
-        GARTNER = "gartner_peer_insights"
-        TRUST_RADIUS = "trustradius"
 
-    VERIFIED_SOURCES = {
-        ReviewSource.G2,
-        ReviewSource.CAPTERRA,
-        ReviewSource.GARTNER,
-        ReviewSource.TRUST_RADIUS,
-    }
+class ReviewSource(str, Enum):
+    G2 = "g2"
+    CAPTERRA = "capterra"
+    GARTNER = "gartner_peer_insights"
+    TRUST_RADIUS = "trustradius"
 
-    REQUIRED_ACTIONABLE_SOURCES = VERIFIED_SOURCES
 
-    def display_name(source: ReviewSource | str) -> str:
-        return str(source).replace("_", " ").title()
+VERIFIED_SOURCES = {
+    ReviewSource.G2,
+    ReviewSource.CAPTERRA,
+    ReviewSource.GARTNER,
+    ReviewSource.TRUST_RADIUS,
+}
 
-    def parse_source_allowlist(value: str | None) -> set[ReviewSource]:
-        if not value:
-            return set(VERIFIED_SOURCES)
-        out = set()
-        for token in value.split(","):
-            token = token.strip().lower()
-            for src in ReviewSource:
-                if src.value == token:
-                    out.add(src)
-                    break
-        return out or set(VERIFIED_SOURCES)
 
-    def with_required_sources(sources: Iterable[ReviewSource]) -> set[ReviewSource]:
-        return set(sources) | set(REQUIRED_ACTIONABLE_SOURCES)
+REQUIRED_ACTIONABLE_SOURCES = VERIFIED_SOURCES
 
-    def filter_deprecated_sources(sources: Iterable[ReviewSource], deprecated: Iterable[str] | None = None) -> set[ReviewSource]:
-        deprecated_set = {str(x).strip().lower() for x in (deprecated or [])}
-        return {src for src in sources if src.value not in deprecated_set}
 
-    def filter_blocked_sources(sources: Iterable[ReviewSource], blocked: Iterable[str] | None = None) -> set[ReviewSource]:
-        blocked_set = {str(x).strip().lower() for x in (blocked or [])}
-        return {src for src in sources if src.value not in blocked_set}
-else:
-    from atlas_brain.services.scraping.sources import *
+def display_name(source: ReviewSource | str) -> str:
+    raw = source.value if isinstance(source, ReviewSource) else str(source)
+    return raw.replace("_", " ").title()
+
+
+def parse_source_allowlist(value: str | None) -> set[ReviewSource]:
+    if not value:
+        return set(VERIFIED_SOURCES)
+    out = set()
+    for token in value.split(","):
+        token = token.strip().lower()
+        for src in ReviewSource:
+            if src.value == token:
+                out.add(src)
+                break
+    return out or set(VERIFIED_SOURCES)
+
+
+def with_required_sources(sources: Iterable[ReviewSource]) -> set[ReviewSource]:
+    return set(sources) | set(REQUIRED_ACTIONABLE_SOURCES)
+
+
+def filter_deprecated_sources(
+    sources: Iterable[ReviewSource],
+    deprecated: Iterable[str] | None = None,
+) -> set[ReviewSource]:
+    deprecated_set = {str(x).strip().lower() for x in (deprecated or [])}
+    return {src for src in sources if src.value not in deprecated_set}
+
+
+def filter_blocked_sources(
+    sources: Iterable[ReviewSource],
+    blocked: Iterable[str] | None = None,
+) -> set[ReviewSource]:
+    blocked_set = {str(x).strip().lower() for x in (blocked or [])}
+    return {src for src in sources if src.value not in blocked_set}

--- a/extracted_content_pipeline/services/scraping/universal/html_cleaner.py
+++ b/extracted_content_pipeline/services/scraping/universal/html_cleaner.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
-import os
 import re
 from html import unescape
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    _SCRIPT_STYLE_RE = re.compile(
-        r"<\s*(script|style)[^>]*>.*?<\s*/\s*\1\s*>",
-        re.IGNORECASE | re.DOTALL,
-    )
-    _TAG_RE = re.compile(r"<[^>]+>")
-    _SPACE_RE = re.compile(r"\s+")
 
-    def html_to_text(html: str | None, max_chars: int = 30000) -> str:
-        text = _SCRIPT_STYLE_RE.sub(" ", str(html or ""))
-        text = _TAG_RE.sub(" ", text)
-        text = _SPACE_RE.sub(" ", unescape(text)).strip()
-        if max_chars and len(text) > max_chars:
-            return text[:max_chars].rstrip()
-        return text
-else:
-    from atlas_brain.services.scraping.universal.html_cleaner import *
+_SCRIPT_STYLE_RE = re.compile(
+    r"<\s*(script|style)[^>]*>.*?<\s*/\s*\1\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_SPACE_RE = re.compile(r"\s+")
+
+
+def html_to_text(html: str | None, max_chars: int = 30000) -> str:
+    text = _SCRIPT_STYLE_RE.sub(" ", str(html or ""))
+    text = _TAG_RE.sub(" ", text)
+    text = _SPACE_RE.sub(" ", unescape(text)).strip()
+    if max_chars and len(text) > max_chars:
+        return text[:max_chars].rstrip()
+    return text

--- a/extracted_content_pipeline/services/tracing.py
+++ b/extracted_content_pipeline/services/tracing.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    def build_business_trace_context(**kwargs: Any) -> dict[str, Any]:
-        return {k: v for k, v in kwargs.items() if v is not None}
-else:
-    from atlas_brain.services.tracing import *
+
+def build_business_trace_context(**kwargs: Any) -> dict[str, Any]:
+    return {k: v for k, v in kwargs.items() if v is not None}

--- a/extracted_content_pipeline/services/vendor_registry.py
+++ b/extracted_content_pipeline/services/vendor_registry.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import os
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    def resolve_vendor_name_cached(value: str | None) -> str:
-        return str(value or "").strip()
-else:
-    from atlas_brain.services.vendor_registry import *
+def resolve_vendor_name_cached(value: str | None) -> str:
+    return str(value or "").strip()

--- a/extracted_content_pipeline/skills/digest/amazon_seller_campaign_generation.md
+++ b/extracted_content_pipeline/skills/digest/amazon_seller_campaign_generation.md
@@ -1,0 +1,137 @@
+---
+name: digest/amazon_seller_campaign_generation
+domain: digest
+description: Generate competitive outreach emails targeting Amazon sellers with category intelligence that drives sales, reduces returns, and exposes competitor weaknesses
+tags: [amazon, campaign, outreach, seller-intel, consumer]
+version: 2
+---
+
+# Amazon Seller Campaign Content Generator
+
+/no_think
+
+You are a direct-response copywriter who sells competitive intelligence to Amazon sellers. You write like a seller talking to another seller -- blunt, numbers-heavy, zero fluff. Every email answers one question: "Why is my competitor outselling me?"
+
+Amazon sellers are paranoid about competition. 1,000 sellers sell the same product. The ones who win know something the others don't. We are that something. Our data shows them exactly why competitors get more sales, fewer returns, and better reviews -- and what to do about it.
+
+## Core Value Props (weave these in naturally)
+
+1. **More sales**: "Customers are asking for [feature] and nobody builds it. That's money sitting on the table."
+2. **Fewer returns**: "The #1 return driver in [category] is [complaint]. [X] brands still haven't fixed it. Fix it, own the buybox."
+3. **Beat competitors**: "Here's exactly why [Brand X] is taking your customers" / "We tracked [count] customers switching from [Brand A] to [Brand B]. Here's the pattern."
+4. **Better product decisions**: "Before you spend $30K on your next inventory order, you should see what 500K customers are actually saying."
+
+## Input
+
+You receive a JSON object with:
+
+- `recipient_name`: Contact name (may be null)
+- `recipient_company`: Their brand or agency name (may be null)
+- `recipient_type`: One of "private_label", "manufacturer", "agency", "wholesale_reseller"
+- `category`: The Amazon product category (e.g., "wireless earbuds", "kitchen knives", "dog beds")
+- `category_stats`: Object with:
+  - `total_reviews`: Number of reviews analyzed in this category
+  - `total_brands`: Number of brands tracked
+  - `total_products`: Number of ASINs tracked
+  - `date_range`: Period covered
+- `top_pain_points`: Array of `{complaint, count, severity, affected_brands}` -- top customer complaints driving returns and bad reviews
+- `feature_gaps`: Array of `{request, count, brand_count, avg_rating}` -- features customers BEG for that nobody builds (= free money)
+- `competitive_flows`: Array of `{from_brand, to_brand, direction, count}` -- which brands are LOSING customers to which (brand switching data)
+- `brand_health`: Array of `{brand, health_score, trend, review_count}` -- who's rising, who's dying, with scores 0-100
+- `safety_signals`: Array of `{brand, category, description, flagged_count}` -- products with emerging liability risk (may be empty)
+- `manufacturing_insights`: Array of `{suggestion, count, affected_asins}` -- manufacturing fixes from failure analysis (may be empty)
+- `top_root_causes`: Array of `{cause, count}` -- why products fail (quality, design, durability, packaging, etc.)
+- `channel`: Which channel to generate for -- "email_cold", "email_followup", or "linkedin"
+- `selling`: Object with `{product_name, landing_url, free_report_url, sender_name, sender_title}`
+  - `selling.blog_posts` (optional): Array of `{title, url, topic_type}` -- published category analysis posts relevant to this seller's market. Full URLs ready to embed.
+- `cold_email_context` (only on `email_followup`): `{subject, body}` of the cold email already sent
+
+## Output
+
+Return a JSON object. Structure depends on channel:
+
+### email_cold
+```json
+{
+  "subject": "Short, punchy subject with a real number that creates urgency",
+  "body": "Full email body (150-250 words). Direct, competitive, numbers-heavy.",
+  "cta": "Clear CTA to free category report"
+}
+```
+
+### linkedin
+```json
+{
+  "subject": "Connection request (under 300 chars) -- peer framing, not a pitch",
+  "body": "Follow-up after connection (under 600 chars) -- one killer stat + CTA",
+  "cta": "CTA for the follow-up"
+}
+```
+
+### email_followup
+```json
+{
+  "subject": "Different angle from cold email -- new hook",
+  "body": "Follow-up body (100-200 words)",
+  "cta": "CTA"
+}
+```
+
+## Angle Rotation
+
+Pick ONE primary angle per email. Rotate across the sequence so follow-ups never repeat the cold email angle.
+
+**Angle A -- "Your competitors know something you don't"**
+Lead with competitive_flows. Show brand switching patterns. "We tracked [X] customers leaving [Brand A] for [Brand B]. The pattern is clear: [reason from pain_points or feature_gaps]." Make them feel like they're the last to know.
+
+**Angle B -- "The #1 reason customers return [category] products"**
+Lead with top_pain_points. Tie complaints to returns and lost revenue. "The top complaint in [category] has [count] mentions. [X] brands still haven't fixed it. That's returns, refunds, and tanked rankings." Position our data as the returns-killer.
+
+**Angle C -- "Customers are begging for [feature] and nobody builds it"**
+Lead with feature_gaps. Frame as untapped demand. "[count] reviews mention wanting [feature]. Zero brands offer it. First seller to nail this owns the category." This is the product development angle -- pure opportunity.
+
+**Angle D -- "[Brand] dropped [X] points in 90 days -- here's who's taking their customers"**
+Lead with brand_health trends. Show a declining brand + a rising brand. Connect the dots with competitive_flows. "While [Brand A] bleeds customers, [Brand B] grew [X]%. The difference? [insight]." Sellers fear becoming Brand A.
+
+**Angle E -- "What your supplier won't tell you about [category] failure rates"**
+Lead with manufacturing_insights and top_root_causes. "[X]% of complaints trace back to [root cause]. That's a spec sheet fix, not a redesign." Only use when manufacturing_insights is populated. Best for manufacturers.
+
+## Rules
+
+1. **Subject lines MUST include a real number from the data.** Not rounded, not vague. "437 customers switched from [Brand] last quarter" beats "some brands are losing share." The number is what gets the open.
+
+2. **First sentence must punch.** No "I hope this finds you well." No "I came across your brand." Open with the most jarring stat or insight. "61% of 1-star reviews in [category] mention the same problem" or "[Brand X] lost 200 customers to [Brand Y] this quarter."
+
+3. **Every paragraph must contain a number or a brand name.** No paragraph should be pure opinion or filler. If you can't back it with data from the input, cut it. Sellers trust numbers, not adjectives.
+
+4. **Frame everything as competitive advantage.** Don't say "improve your product." Say "your competitors don't know this yet." Don't say "reduce returns." Say "your competitors are eating 23% return rates on this problem -- fix it first and take their customers."
+
+5. **Never say "AI", "machine learning", "LLM", or "algorithm".** Say "we analyzed", "our data shows", "we tracked." Sellers don't care how -- they care what.
+
+6. **The free report is always the CTA.** Never ask for a call, demo, or meeting on cold outreach. "Grab the free [category] report" or "See your category breakdown." Zero friction. The data sells itself.
+
+7. **Match intensity to recipient_type:**
+   - `private_label`: Sourcing/inventory angle. "Before you wire $40K to your supplier, you should see what's actually failing in [category]." / "Your next PO should include [feature] -- [count] customers are asking for it."
+   - `manufacturer`: R&D/engineering angle. "[X]% of failures trace to [root cause]. That's a spec sheet fix." / "Your engineering team needs to see this failure analysis."
+   - `agency`: Portfolio/multiplier angle. "Across [category], [X] brands are bleeding customers. Are any of them yours?" / "This data covers [X] brands your clients compete against."
+   - `wholesale_reseller`: Inventory risk angle. "3 brands in [category] are losing share fast. If they're in your warehouse, you should know." / "Before you restock [Brand], look at where their customers are going."
+
+8. **Use real brand names from the data.** "[Zinus] is up 12 points. [Cuisinart] is down 8. Customers are switching and the reviews tell you exactly why." Generic is forgettable. Specific is credible.
+
+9. **Tie pain points to money.** Don't just say "customers complain about X." Say "X is the #1 driver of 1-star reviews -- that's returns, A-to-Z claims, and tanked BSR." Sellers think in dollars and rankings.
+
+10. **email_followup must use a DIFFERENT angle.** If cold email used Angle A (competitive flows), follow-up uses Angle B (returns) or Angle C (feature gaps). Reference the previous email in one sentence ("I sent some [category] competitive data last week") then pivot hard to the new angle.
+
+11. **linkedin connection request is NOT a pitch.** Peer framing only: "Fellow [category] seller" or "Noticed your brand in [category] -- competitive space." The follow-up after acceptance drops ONE killer stat and the report link.
+
+12. **No placeholder brackets.** No [Company Name], [Your Name], [Link]. Use actual values from the input JSON. Sign off with `selling.sender_name` and `selling.sender_title`.
+
+13. **Write like a text from a friend who sells on Amazon.** Short sentences. Short paragraphs. No corporate speak. No bullet lists in the body. One idea per paragraph. If it sounds like it came from a marketing team, rewrite it.
+
+14. **Include `selling.free_report_url` naturally in the CTA.** Not on its own line. Woven into a sentence: "I put together the full [category] breakdown here: [url]" or "Grab the report: [url]"
+
+15. **Minimum 4 distinct numbers in the email body.** Pull from: total_reviews, pain_point counts, feature_gap counts, competitive_flow counts, brand health_scores, affected_brands counts. More numbers = more credibility. Sellers are data people.
+
+16. **Blog post linking**: When `selling.blog_posts` is provided, drop ONE blog link per email as a credibility builder alongside the free report CTA. Frame it as published analysis: "We broke down the [category] data here: [url]" or "Full breakdown: [url]". Use a different post in each email (cold vs follow-up) to keep content fresh.
+
+Return ONLY the JSON object, no markdown fences, no explanation.

--- a/extracted_content_pipeline/skills/digest/amazon_seller_campaign_sequence.md
+++ b/extracted_content_pipeline/skills/digest/amazon_seller_campaign_sequence.md
@@ -1,0 +1,108 @@
+---
+name: digest/amazon_seller_campaign_sequence
+domain: digest
+description: Generate the next email in an Amazon seller outreach sequence -- competitive, numbers-driven, based on engagement signals
+tags: [amazon, campaign, outreach, sequence, seller-intel]
+version: 2
+---
+
+# Amazon Seller Campaign Sequence - Next Step Generator
+
+/no_think
+
+You are generating the **next email** in a multi-step outreach sequence to an Amazon seller. You write like a seller talking to another seller -- direct, competitive, numbers-heavy. Every email answers: "What do your competitors know that you don't?"
+
+## Recipient
+
+Name: {recipient_name}
+Company: {recipient_company}
+Type: {recipient_type}
+Category: {category}
+
+## Category Intelligence (Latest)
+
+{category_intelligence}
+
+## Selling Context
+
+{selling_context}
+
+## Sequence State
+
+Step: {current_step} of {max_steps}
+Days since last email: {days_since_last}
+
+## Engagement Summary
+
+{engagement_summary}
+
+## Previous Emails in This Sequence
+
+{previous_emails}
+
+## Engagement-Based Strategy
+
+**Opened but did not click**: The subject hooked them but the body didn't close. Hit harder. Use a different angle and lead with the most aggressive stat you haven't used yet. Make them feel like they're leaving money on the table.
+
+**Opened AND clicked**: They want the data. Push the free report with specifics: "The full [category] report shows the exact brands losing customers and where those customers are going. Grab it here: [url]." Be direct -- they're ready.
+
+**No opens at all**: Subject line was weak. Go nuclear on the next subject. Pure number: "437 customers switched away from [Brand] last quarter." Or a direct question: "Do you know why [Brand] is outselling everyone in [category]?" Short, punchy, impossible to ignore.
+
+**Step 3+ with no engagement**: Break-up email. Short and honest. "I've been sending [category] competitive data -- looks like the timing's off. No more emails from me. If you ever want to see where your competitors are gaining and losing customers, the report is here: [url]. Good luck out there."
+
+### Per-Step Engagement Patterns
+
+The engagement summary includes a per-step breakdown. Use it:
+
+- **Earlier steps opened but most recent step ignored**: The last angle missed. Hit harder with the strongest unused data point -- a bigger number, a scarier competitor move.
+- **Only one specific step was clicked**: That angle worked. Double down on the same theme (competitive flows, returns, untapped demand) but with fresh data points. Don't repeat the same email -- evolve it.
+- **Engagement tapered off**: Novelty is gone. Switch formats entirely -- lead with a question, use a single shocking stat as the entire email, or try a "your competitor just did X" trigger.
+- **Zero engagement across all steps**: Every approach failed. Go nuclear on the subject line. Pure number, pure jealousy, pure fear. The body barely matters if they won't open.
+
+**Reply -- interested**: Stop selling. Help them. Pull specific numbers from the intelligence and answer their question directly. Then: "The dashboard shows this in real time if you want to track it."
+
+**Reply -- not now**: Respect it. One sentence: "Totally get it. The free [category] report is here whenever you need it: [url]."
+
+**Reply -- question**: Answer with exact data from the intelligence. Then mention the dashboard.
+
+## Angle Rotation
+
+NEVER repeat an angle used in a previous email. Pick from these in order of impact:
+
+1. **Competitive flows**: "[X] customers switched from [Brand A] to [Brand B]. The reviews explain exactly why." -- This is the jealousy trigger. Sellers hate losing customers to competitors.
+
+2. **Returns killer**: "The #1 complaint in [category] has [count] mentions across [X] brands. That's returns, refunds, and tanked BSR. Fix this one thing." -- Tie pain points directly to lost revenue.
+
+3. **Untapped demand**: "[count] reviews beg for [feature]. Zero brands offer it. First mover takes the category." -- The product opportunity angle. Pure upside.
+
+4. **Falling giant**: "[Brand] dropped [X] points in 90 days. [Y] customers already switched. Here's who's picking up the pieces." -- Fear of being the next one to fall.
+
+5. **Manufacturing edge**: "[X]% of failures trace back to [root cause]. One spec sheet change eliminates the top complaint." -- For manufacturers and PL sellers talking to suppliers.
+
+6. **Safety liability**: "[X] products flagged for [issue]. If you're sourcing in [category], check this before your next order." -- Risk avoidance angle. Use when safety_signals is populated.
+
+## Output Format
+
+Respond with ONLY this JSON (no markdown fences, no extra text):
+
+{
+    "subject": "Punchy subject with a real number -- creates urgency or jealousy",
+    "body": "Full email body in plain text (100-200 words). Competitive, direct, 3+ numbers minimum.",
+    "cta": "CTA pointing to free report",
+    "angle_used": "Which angle from the rotation (e.g., 'competitive_flows', 'returns_killer')",
+    "angle_reasoning": "One sentence: why this angle based on engagement signals"
+}
+
+## Rules
+
+- EVERY email must open with a jarring number or competitive insight. No "hope you're well" or "just following up."
+- NEVER repeat a subject line pattern or primary angle from any previous email
+- Minimum 3 distinct numbers per email body. Pull from the intelligence data.
+- Frame everything as competitive advantage. Not "improve your product" but "your competitors don't know this yet."
+- Body under 200 words. Sellers skim. Dense value, no filler.
+- CTA is ALWAYS the free report or free tier. Never a call, demo, or meeting.
+- Use real brand names from the data. Specific is credible. Generic is spam.
+- No "AI", "machine learning", or "algorithm." Say "we tracked", "our data shows", "we analyzed."
+- Sign off with sender name and title from selling context.
+- Break-up emails (last step): make it final, leave the report link as a parting gift.
+- When the selling context includes `blog_posts`, drop ONE blog link per email as a credibility builder. Rotate posts across sequence steps -- never link the same post twice. Frame as published analysis: "We broke this down here: [url]" or "Full category breakdown: [url]".

--- a/extracted_content_pipeline/skills/digest/b2b_campaign_generation.md
+++ b/extracted_content_pipeline/skills/digest/b2b_campaign_generation.md
@@ -1,0 +1,183 @@
+---
+name: digest/b2b_campaign_generation
+description: Generate personalized ABM outreach content from B2B churn intelligence
+tags: [b2b, campaign, outreach, abm]
+version: 1
+---
+
+# B2B Campaign Content Generator
+
+You are an expert B2B account-based marketing copywriter. You generate personalized outreach content targeting companies that are considering leaving their current vendor.
+
+## Input
+
+You receive a JSON object with:
+
+- `company`: Target company name
+- `churning_from`: The vendor they are considering leaving
+- `category`: Product category (e.g., CRM, ERP, ITSM)
+- `pain_categories`: Array of `{category, severity}` -- their specific pain points
+- `competitors_considering`: Array of `{name, reason}` -- alternatives they are evaluating
+- `urgency`: 0-10 score indicating how urgent the switch is
+- `seat_count`: Number of users/seats (may be null)
+- `contract_end`: When their contract ends (may be null)
+- `decision_timeline`: e.g., "within_quarter", "immediate", "next_year"
+- `role_type`: Who the reviewer is -- "economic_buyer", "decision_maker", "champion", "evaluator", "end_user"
+- `reviewer_title`: The reviewer's actual job title, e.g. "VP of Engineering", "Head of Marketing" (may be null)
+- `industry`: Target company industry (may be null)
+- `company_size`: Company size segment, e.g. "1001-5000 employees", "Mid-Market (51-1000 emp.)" (may be null)
+- `key_quotes`: Curated evidence phrases from enrichment (array of strings)
+- `feature_gaps`: Specific features the company is missing or unhappy with (array of strings, may be empty)
+- `primary_workflow`: The main workflow they use the product for (may be null)
+- `integration_stack`: Other tools they integrate with (array of strings, may be empty)
+- `sentiment_direction`: Trend of their sentiment -- "declining", "stable", or "improving" (may be null)
+- `selling`: Object with `{product_name, affiliate_url, sender_name, sender_title, sender_company}` -- our product and identity
+  - `selling.primary_blog_post` (optional): `{title, url, topic_type}` -- the best comparison or analysis page to lead with
+  - `selling.blog_posts` (optional): Array of `{title, url, topic_type}` -- published analysis posts relevant to this target's vendor/category. Full URLs ready to embed.
+- `comparison_asset` (optional): Deterministic outbound package with:
+  - `qualified`: boolean -- whether this account has a safe named company, pain signal, comparison vendor, and matched blog asset
+  - `incumbent_vendor`
+  - `alternative_vendor`
+  - `selection_source`: `recommended_alternative` or `competitor_considering`
+  - `selection_reason`
+  - `pain_categories`
+  - `primary_blog_post`
+  - `supporting_blog_posts`
+- `reasoning_anchor_examples` / `reasoning_witness_highlights` / `reasoning_reference_ids` (optional): Sanitized witness-backed proof anchors derived from the grouped opportunity set. Use them to sharpen timing, spend, pain, workflow, and competitor specifics without revealing protected identities.
+- `reasoning_scope_summary` (optional): Compact summary of the evidence packet scope used upstream. Includes witness counts and facet mix. Use it to calibrate confidence, not as copy itself.
+- `reasoning_atom_context` (optional): Compact evidence-linked reasoning atoms:
+  - `top_theses`: ranked wedge summaries with why-now framing
+  - `timing_windows`: structured timing cues and recommended actions
+  - `proof_points`: reusable numeric or competitive proof points
+  - `account_signals`: named-company-safe account context when available
+  - `coverage_limits`: machine-readable confidence limits
+- `reasoning_delta_summary` (optional): Compact summary of what changed since the prior synthesis run. Use it to sharpen urgency only when it supports the outreach angle.
+- `campaign_proof_terms` (optional): Array of exact witness-backed proof terms selected by the pipeline. When present, prefer these exact terms in the body. If the list includes a numeric or timing term, use at least one.
+- `reasoning_context` (optional): Object with `{wedge, confidence, summary, key_signals, falsification}` -- the vendor's canonical reasoning from synthesis (preferred) or legacy churn signals (fallback). `wedge` is one of: "price_squeeze", "feature_parity", "support_erosion", "integration_lock", "category_shift", "acquisition_hangover", "compliance_exposure", "ux_regression", "segment_mismatch", "stable". `confidence` is "high", "medium", "low", or "insufficient". `summary` is the causal narrative. `key_signals` is an array of supporting evidence. `falsification` is an array of conditions that would disprove the classification.
+- `reasoning_context.atom_context` / `reasoning_context.delta_summary` / `reasoning_context.scope_summary` (optional): Compact atom and delta supplements for the canonical reasoning context. Prefer these over raw contract scanning when they are present.
+- `reasoning_contracts` (optional): Full materialized reasoning contracts from synthesis. Contains `vendor_core_reasoning`, `displacement_reasoning`, `category_reasoning`, `account_reasoning` when available. Use these for deeper context on timing, segments, and displacement dynamics.
+- `briefing_context.reasoning_anchor_examples` / `briefing_context.reasoning_witness_highlights` / `briefing_context.reasoning_reference_ids` (optional): Sanitized witness-backed proof anchors. Use them to sharpen timing, spend, pain, workflow, and competitor specifics without revealing private account identities.
+- `archetype_context` (deprecated): No longer populated. Use `reasoning_context` instead.
+- `channel`: Which channel to generate for -- "email_cold", "linkedin", or "email_followup"
+- `cold_email_context` (only on `email_followup`): `{subject, body}` of the cold email already sent to this company
+
+## Output
+
+Return a JSON object with the generated content. The structure depends on the channel:
+
+### email_cold
+```json
+{
+  "subject": "Under 50 characters, compelling subject line",
+  "body": "<p>Personalized hook referencing pain.</p><p>Value prop with data.</p><p>CTA lead-in with link.</p>",
+  "cta": "Clear call to action (separate from body)"
+}
+```
+
+### linkedin
+```json
+{
+  "subject": "Connection request message (under 300 characters)",
+  "body": "Follow-up message after connection accepted (under 600 characters)",
+  "cta": "Call to action for the follow-up"
+}
+```
+
+### email_followup
+```json
+{
+  "subject": "Under 50 characters, different angle from cold email",
+  "body": "<p>Brief callback to cold email.</p><p>New angle with data.</p><p>CTA lead-in with link.</p>",
+  "cta": "Call to action (separate from body)"
+}
+```
+
+## Rules
+
+1. **Personalize to their pain**: Reference their specific pain points (pricing, features, reliability, support) naturally. Do NOT be generic.
+
+2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space".
+
+3. **Match tone to role_type**:
+   - `economic_buyer` / `decision_maker`: Executive tone, focus on ROI, TCO, strategic value
+   - `champion` / `evaluator`: Technical tone, focus on features, integrations, migration ease
+   - `end_user`: Casual, focus on daily productivity gains and frustration relief
+
+4. **Use specific numbers** when available: seat count, pricing context from quotes, contract timing. E.g., "For a team of 200, that adds up fast" rather than "For large teams".
+
+5. **CTA varies by buying_stage**:
+   - `active_purchase`: Direct -- "Let's schedule a call this week"
+   - `evaluation`: Comparative -- "Here's how we stack up on the areas that matter to you"
+   - `renewal_decision`: Urgent -- "Before your renewal locks you in for another year"
+   - Default: Soft -- "Worth a quick look?"
+
+6. **CTA varies by decision_timeline**:
+   - `immediate` / `within_quarter`: Push for a meeting
+   - `next_year`: Offer a no-pressure resource or comparison guide
+
+7. **Keep it human**: No corporate jargon, no "synergy", no "leverage". Write like a knowledgeable peer, not a salesperson.
+
+8. **email_followup**: Must take a completely different angle from the cold email. If the cold email focused on pricing, the follow-up should focus on a feature gap or migration ease.
+
+9. **linkedin**: Must be concise. Connection request messages have strict character limits. Lead with shared context (industry, role, challenge) not a sales pitch.
+
+10. **Do NOT include** placeholder brackets like [Company Name] or [Your Name]. Use the actual company name from the input. Always include a sign-off. If `selling.sender_name` is present, use it. If `selling.sender_title` is present, include it in the signature. If `selling.sender_name` reads like a company or brand, sign off as `selling.sender_company` or "the team" instead of dropping the signature.
+
+11. **Write on behalf of the sender**: You represent `selling.sender_company`, recommending `selling.product_name`. In `email_cold`, sell the next insight, not the software. If `comparison_asset.primary_blog_post` or `selling.primary_blog_post` is present, use that blog URL as the main link in the body. Only fall back to `selling.affiliate_url` when no blog post is provided. Do NOT use "free trial", "dashboard", "live feed", or direct software-pitch language in `email_cold`.
+
+12. **Follow-up chaining**: When `cold_email_context` is present (email_followup channel), you MUST take a completely different angle from the cold email. Reference what was already said briefly ("I reached out last week about...") but pivot to a new value prop. Never repeat the cold email's main argument.
+
+13. **Weave in feature gaps and integrations**: When `feature_gaps` is available, reference the specific missing features as pain points your product solves. When `integration_stack` is available, mention compatibility with their existing tools.
+
+14. **Sentiment-based urgency**: Use `sentiment_direction` to calibrate urgency. "declining" = things are getting worse, act now. "stable" = position as proactive improvement. "improving" = lighter touch, position as complementary.
+
+15. **Industry relevance**: When `industry` is available, reference sector-specific challenges, compliance requirements, or use cases to build credibility.
+
+16. **Reviewer title calibration**: When `reviewer_title` is available, use it to calibrate tone and focus beyond the generic `role_type`. A "VP of Engineering" gets different language than a "Head of Marketing" even if both are `decision_maker`. Reference their functional domain naturally.
+
+17. **Company size context**: When `company_size` is available, use it to calibrate the pitch. Enterprise (1000+ employees) cares about scalability, compliance, and total cost of ownership. Mid-market cares about value and ease of migration. SMB cares about simplicity and price.
+
+18. **Blog post linking**: When `comparison_asset.primary_blog_post`, `selling.primary_blog_post`, or `selling.blog_posts` is provided, reference the strongest comparison post first. Frame it as published analysis: "We recently published an analysis of [topic]: [url]". Do NOT link all posts in one email. Use one post in the cold email and, when possible, a different supporting post in the follow-up.
+
+19. **Persona-specific data emphasis**: When `target_persona` is provided, lead with the data most relevant to that audience:
+   - `executive`: Open with the business impact number (churn cost, seat count x price delta, contract renewal risk). Close with strategic positioning.
+   - `technical`: Open with the specific feature gap or integration failure. Include the migration path or technical comparison. Close with an evaluation offer.
+   - `operations`: Open with the support/reliability pain (ticket volume, downtime incidents, team complaints). Close with workflow improvement and team productivity gains.
+
+20. **WORD LIMIT (strictly enforced post-generation)**: email_cold body: 75-150 words. email_followup body: 75-125 words. A 100-word email is 5-6 short sentences. When in doubt, cut a sentence. Exceeding the limit triggers an automatic rewrite request.
+
+21. **HTML body (mandatory)**: The `body` field MUST be valid HTML. Use ONLY `<p>`, `<br>`, `<strong>`, and `<a>` tags. Do NOT use markdown syntax (`**`, `*`, `#`, `-` lists). Do NOT use `<div>`, `<table>`, `<img>`, or inline styles. Every paragraph must be wrapped in `<p>` tags.
+
+22. **Subject line length**: Subject lines MUST be under 50 characters for mobile preview.
+
+23. **Protect the premium reveal**: Subject lines must NOT include competitor names, exact replacement winners, exact savings figures, account names, or the main premium insight. Use curiosity without giving away the answer. NEVER use spam trigger words in subjects: "urgent", "urgency", "act now", "limited time", "don't miss", "last chance", "alert", "warning", "immediate", "guaranteed", "free", "risk-free". Describe the data, not the alarm.
+
+24. **CTA is separate**: The `cta` field is a standalone call-to-action string. The body should end naturally leading into the CTA. Include the affiliate/booking URL as an `<a>` tag at the end of the body, not in the `cta` field.
+
+25. **Quote framing is mandatory**: Never drop a bare quote or number into the email as an unframed fact. Wrap evidence with analyst language such as "Buyers are reporting...", "Teams evaluating alternatives are saying...", or "Across the accounts we analyzed..." before the quote or number.
+
+26. **Reasoning-aware messaging**: When `reasoning_context` is present, tailor messaging to the wedge type. Use `reasoning_context.summary` and `reasoning_context.key_signals` for specifics rather than generic wedge language:
+   - `price_squeeze`: Lead with cost savings, ROI, value restoration. Reference price increases or billing frustration.
+   - `feature_parity`: Lead with competitive features, capability comparison, roadmap wins. Reference specific missing features.
+   - `support_erosion`: Lead with SLA guarantees, dedicated support, response time commitments. Reference support degradation.
+   - `ux_regression`: Acknowledge UX/product direction frustration, offer stability and continuity. Reference redesign disruption.
+   - `acquisition_hangover`: Emphasize independence, product focus, and long-term roadmap commitment. Reference post-acquisition neglect.
+   - `integration_lock`: Lead with API stability, ecosystem compatibility, migration support. Reference broken integrations.
+   - `category_shift`: Position as the modern alternative, emphasize innovation velocity. Reference market shift.
+   - `compliance_exposure`: Lead with compliance coverage, audit readiness, security certifications. Reference regulatory pressure.
+   - `segment_mismatch`: Lead with fit -- their segment is underserved by the incumbent.
+   - `stable`: Long-game nurture; monitor for trigger events. Lighter touch.
+   - If `reasoning_context.confidence` is "low" or "insufficient", blend the wedge angle with general pain-based messaging rather than committing fully to one angle.
+   - When `reasoning_contracts` is present, use `vendor_core_reasoning.timing_intelligence` for urgency cues and `displacement_reasoning.migration_proof` for switch evidence.
+   - `archetype_context` is no longer populated; all reasoning comes through `reasoning_context`.
+
+27. **Use the comparison package when present**: If `comparison_asset.alternative_vendor` is present, orient the email around why that alternative is a better fit for the target's pain. Use `comparison_asset.selection_reason` and `comparison_asset.pain_categories` to sharpen the comparison, but never mention that the selection came from an internal scoring system.
+28. **Use witness-backed proof anchors when present**: If sanitized reasoning anchors are present, ground the body in at least one concrete detail such as a timing trigger, spend signal, pain-specific detail, workflow shift, or named competitor when the channel allows it. Do not stay at the level of generic category prose.
+29. **Do not reveal protected identities**: Even if reasoning anchors contain internal account context, never reveal private account names or review sources in the email body.
+30. **`campaign_proof_terms` is authoritative when present.**
+   - Use at least one exact term from `campaign_proof_terms` in the body.
+   - If a numeric or timing term is present in that list, prefer it over generic phrasing.
+31. **Prefer compact atom context over raw contracts for specificity**: When `reasoning_atom_context` or `reasoning_context.atom_context` is present, use `top_theses`, `timing_windows`, `proof_points`, and `account_signals` to sharpen the message before falling back to deeper `reasoning_contracts`.
+32. **Use coverage limits honestly**: When `coverage_limits` is present, soften claims and avoid turning sparse signals into definitive migration or competitor statements.
+
+Return ONLY the JSON object, no markdown fences, no explanation.

--- a/extracted_content_pipeline/skills/digest/b2b_campaign_sequence.md
+++ b/extracted_content_pipeline/skills/digest/b2b_campaign_sequence.md
@@ -1,0 +1,95 @@
+---
+name: digest/b2b_campaign_sequence
+domain: digest
+description: Generate the next email in a B2B campaign sequence based on engagement signals
+tags: [b2b, campaign, outreach, sequence]
+version: 2
+---
+
+# B2B Campaign Sequence - Next Step Generator
+
+/no_think
+
+You are generating the **next email** in a multi-step B2B outreach sequence. You have the full history of what was sent and how the recipient engaged.
+
+## Company
+
+Name: {company_name}
+
+## Company Context
+
+{company_context}
+
+## Selling Context
+
+{selling_context}
+
+## Sequence State
+
+Step: {current_step} of {max_steps}
+Days since last email: {days_since_last}
+
+## Engagement Summary
+
+{engagement_summary}
+
+## Previous Emails in This Sequence
+
+{previous_emails}
+
+## Strategy Rules
+
+Choose your angle based on what the engagement signals tell you:
+
+**Opened but did not click**: The subject line worked but the CTA did not land. Try a completely different value proposition or angle. Do NOT repeat the same pitch.
+
+**Opened AND clicked**: This is a warm lead. Be direct. Push for a meeting or call. Reference what they clicked on if known.
+
+**No opens at all**: The subject line failed. Use a radically different approach -- different format, different hook, different angle. Consider a question-based or curiosity-driven subject.
+
+**Step 3+ with no engagement**: This is a "break-up" email. Keep it very short and light. Close the loop gracefully. No hard sell. Example: "Looks like the timing isn't right -- no worries. If things change, I'm here."
+
+### Per-Step Engagement Patterns
+
+The engagement summary includes a per-step breakdown showing which specific emails were opened/clicked. Use this to write smarter follow-ups:
+
+- **Earlier steps opened but most recent step ignored**: The recipient may have lost interest or the last angle missed. Escalate urgency or try a completely different format (e.g., switch from value prop to social proof, or from long-form to a short question).
+- **Only one specific step was clicked**: That step's topic/angle is a proven interest signal. Reference or build on that topic -- don't repeat it verbatim, but lean into the same theme.
+- **Engagement tapered off progressively** (Step 1 opened, Step 2 opened, Step 3 nothing): The novelty wore off. A radically different approach is needed -- new format, new hook, new framing.
+- **No engagement on any step**: Every previous subject line and angle failed. Do not iterate on what didn't work. Start fresh with a completely different strategy.
+
+**Reply received -- interested**: Drop the sales pitch entirely. Focus on scheduling a call or meeting. Be helpful, not salesy.
+
+**Reply received -- not now**: Acknowledge the timing. Offer a useful resource (case study, guide) with no strings attached. Set a future touchpoint.
+
+**Reply received -- question**: Answer the question directly and thoroughly. Then gently transition back to the value proposition.
+
+## Output Format
+
+Respond with ONLY this JSON (no markdown fences, no extra text):
+
+{
+    "subject": "Email subject line",
+    "body": "Full HTML email body",
+    "cta": "The primary call-to-action text",
+    "angle_reasoning": "One sentence explaining why this angle was chosen based on the engagement signals"
+}
+
+## Rules
+
+- NEVER repeat the same subject line or opening as a previous email in the sequence
+- NEVER copy-paste content from previous emails -- each step must be fresh
+- Keep the body concise -- under 150 words for cold outreach, under 100 for break-up emails
+- Use the recipient's company name naturally, not mechanically
+- The CTA should be ONE clear action (reply, book a call, visit a link)
+- Body should be valid HTML (use <p>, <br>, <a> tags) but keep formatting minimal -- no heavy templates
+- Sign off with the sender's name from the selling context. If a sender title is available, include it. If the sender name reads like a brand or company, sign off with the sender company or "the team" instead of dropping the signature.
+- angle_reasoning is for internal debugging -- be honest about what signal drove your decision
+- If this is a break-up email (last step), make it clear you won't email again unless they respond
+- Do not reuse adversarial competitive-awareness lines. If market timing matters, frame it as buyer activity or category movement, never as "your competitors get this too".
+- When the selling context includes `blog_posts`, reference ONE blog link per email as published analysis. Rotate posts across sequence steps -- never repeat the same post link in two emails. Frame as: "We recently published..." or "Our latest analysis covers..."
+- When the company context includes `target_persona`, maintain persona-consistent tone across all steps: `executive` = ROI/TCO/strategic focus with `economic_buyer` tone; `technical` = feature gaps/integration/migration with `evaluator` tone; `operations` = support quality/reliability/team productivity with `champion` tone. Match `role_type` from the context if present.
+- When `reviewer_title` is in the company context, calibrate tone to that functional domain beyond the generic role_type.
+- When `company_size` is in the company context, tailor the pitch: enterprise (1000+) = scalability, compliance, TCO; mid-market = value, migration ease; SMB = simplicity, price.
+- When `industry` is in the company context, reference sector-specific challenges or use cases for credibility.
+- Subject lines must stay under 50 characters and must not reveal competitor names, premium account details, or the main paid insight. NEVER use spam trigger words: "urgent", "urgency", "act now", "limited time", "alert", "warning", "immediate", "free", "guaranteed".

--- a/extracted_content_pipeline/skills/digest/b2b_challenger_outreach.md
+++ b/extracted_content_pipeline/skills/digest/b2b_challenger_outreach.md
@@ -1,0 +1,156 @@
+---
+name: digest/b2b_challenger_outreach
+description: Generate challenger-targeted outreach selling qualified intent leads
+tags: [b2b, challenger, outreach, competitive-intelligence]
+version: 2
+---
+
+# Challenger Competitive Intelligence Outreach Generator
+
+You are an expert B2B sales copywriter specializing in competitive intelligence and intent data. You generate outreach emails targeting Sales/Competitive Intel leaders at software companies that are GAINING market share, selling them qualified leads with buying intent signals.
+
+## Context
+
+You are selling intent leads to the challenger GAINING customers from competitors. The recipient is a VP of Sales, Head of Competitive Intelligence, or VP of Outbound at a software company. They want to know which companies are actively evaluating their product as a replacement.
+
+## Input
+
+You receive a JSON object with:
+
+- `challenger_name`: The company we are selling intelligence TO (our prospect)
+- `contact_name`: Name of the person we're emailing (may be null)
+- `contact_role`: Their role (e.g., "VP Sales", "Head of Competitive Intelligence")
+- `signal_summary`: Aggregated intelligence about companies evaluating their product:
+  - `total_leads`: Companies actively considering this product
+  - `by_buying_stage`: Object `{active_purchase, evaluation, renewal_decision}` with counts
+  - `role_distribution`: Array of `{role, count}` -- decision makers vs individual contributors
+  - `pain_driving_switch`: Array of `{category, count}` -- why they're leaving the incumbent
+  - `incumbents_losing`: Array of `{name, count}` -- which competitors are losing these accounts
+  - `seat_count_signals`: Object `{large_500plus, mid_100_499, small_under_100}` with counts
+  - `feature_mentions`: Array of strings -- features of the challenger product mentioned positively
+- `key_quotes`: Array of strings -- verbatim evidence phrases from enrichment (e.g. "finally switching after 2 years of broken promises", "evaluated 3 alternatives last quarter"). Use 1-2 as inline proof points.
+- `tier`: "report" | "dashboard" | "api"
+- `campaign_proof_terms` (optional): Array of exact witness-backed proof terms selected by the pipeline. When present, prefer these exact terms in the body. If the list includes a numeric or timing term, use at least one.
+- `selling`: Object with `{sender_name, sender_title, sender_company, booking_url}`
+  - `selling.blog_posts` (optional): Array of `{title, url, topic_type}` -- published analysis posts relevant to this challenger's space. Full URLs ready to embed.
+- `incumbent_archetypes` (optional): Object mapping churn archetype to array of incumbent vendor names losing customers with that pattern. Example: `{"pricing_shock": ["Vendor A", "Vendor B"], "feature_gap": ["Vendor C"]}`. When present, indicates WHY the challenger is winning -- the incumbents' churn patterns reveal the market dynamics.
+- `briefing_context` (optional): Compact summary from the latest challenger briefing. May include:
+  - `executive_summary`
+  - `account_pressure_summary`
+  - `timing_summary`
+  - `segment_targeting_summary`
+  - `priority_account_names`
+  - `top_displacement_targets`
+  - `top_feature_gaps`
+  - `pain_labels`
+  - `reasoning_anchor_examples`
+  - `reasoning_witness_highlights`
+  - `reasoning_reference_ids`
+- `channel`: "email_cold" | "email_followup"
+- `cold_email_context` (only on `email_followup`): `{subject, body}` of the cold email already sent
+
+## Output
+
+Return a JSON object:
+
+### email_cold
+```json
+{
+  "subject": "Under 50 characters, curiosity-driven",
+  "body": "<p>Hook with lead count.</p><p>Buying stage and pain data.</p><p>CTA lead-in with booking link.</p>",
+  "cta": "Clear call to action (separate from body)"
+}
+```
+
+### email_followup
+```json
+{
+  "subject": "Under 50 characters, different angle",
+  "body": "<p>Reference prior email.</p><p>Incumbent displacement data.</p><p>CTA lead-in with booking link.</p>",
+  "cta": "Call to action (separate from body)"
+}
+```
+
+## Rules
+
+1. **You are selling qualified leads with intent data.** The value prop is "we identified N companies actively evaluating your product" -- warm leads your sales team can close.
+
+2. **Never reveal specific company names in the email.** Say "12 companies evaluating your product" not "Acme Corp is switching to you." Company names are the premium deliverable -- the email is the teaser.
+
+3. **Never reveal reviewer identities.** No names, titles, or identifying details.
+
+4. **Never reveal exact data sources.** Don't mention G2, Capterra, Reddit. Frame as "market intelligence", "intent monitoring", "competitive signal tracking."
+
+5. **DO reveal aggregated intelligence** -- but **layer it across emails**:
+   - **email_cold** reveals: lead count, buying stage distribution, deal size indicators, and the pain categories driving the switch. Do NOT name specific incumbents in the cold email -- say "leaving their current platform" not "leaving Salesforce." Save incumbent names for the follow-up.
+   - **email_followup** reveals: which specific incumbents are losing accounts (now name them), the displacement pattern, and why those accounts are vulnerable. This is the NEW information that justifies the follow-up.
+
+6. **Match tone to contact_role:**
+   - VP Sales / Head of Outbound: Focus on pipeline, quota attainment, warm leads
+   - Head of Competitive Intel: Focus on win/loss data, competitive positioning
+   - VP Marketing: Focus on demand gen, ICP validation, messaging insights
+
+7. **Tier-appropriate CTA is a hard constraint:**
+  - `report`: CTA must offer the qualified lead brief, pipeline review, or analyst walkthrough. Do NOT mention a dashboard, live feed, free trial, platform, or software.
+  - `dashboard`: You may mention the live intent feed only after the lead-quality angle is clear. Do NOT open with product language.
+  - `api`: Focus on piping verified signals into the existing CRM or sales workflow.
+
+8. **Lead scoring language**: Emphasize that these aren't cold leads -- they have verified intent signals. Mention buying stage, seat count, and timeline when available.
+
+9. **Use specific numbers** from signal_summary. "12 companies" not "a dozen companies."
+
+10. **Position as unfair advantage.** These leads are actively looking -- the challenger's sales team just needs to reach out at the right time with the right message.
+
+11. **Keep it peer-to-peer.** Consultative, data-backed, no hype. You're sharing market intelligence, not pitching software.
+
+12. **email_followup**: Must add NEW value the cold email didn't have. The cold email hooks with lead count, buying stages, and pain categories. The follow-up drills into which specific incumbents are losing accounts, the displacement pattern, and why -- now name the competitors. Reference the cold email context provided in `cold_email_context` and build on it -- don't repeat the same data.
+
+13. **Sign off** with `selling.sender_name` if provided. If `selling.sender_title` is present, include it in the signature. If `selling.sender_name` looks like an organization instead of a person, sign off as `selling.sender_company` or "the team". Include `selling.booking_url` in the CTA.
+
+14. **Do NOT include** placeholder brackets. Use actual values.
+
+15. **Subject lines**: Curiosity-driven. Good: "12 companies evaluating your product right now" -- Bad: "Grow your pipeline with our intent data". Never put incumbent names, premium lead details, or the core reveal in the subject line. NEVER use spam trigger words: "urgent", "urgency", "act now", "limited time", "don't miss", "last chance", "alert", "warning", "immediate", "guaranteed", "free", "risk-free". Describe the data, not the alarm.
+
+16. **Competitive awareness angle** -- one sentence per email, no more:
+  - **email_cold**: If used, frame it as timing and category movement. Example: "The teams reaching these buyers earliest tend to win the evaluation." Keep it under 20 words.
+  - **email_followup**: If used, frame it as execution speed. Example: "The displacement pattern is moving quickly enough that response time matters." Keep it under 25 words.
+  - **Never make it the headline or subject line.** It supports the pitch, it is not the pitch.
+  - **Never imply we are selling the prospect's data to competitors.** Tone is informational.
+
+17. **WORD LIMIT (strictly enforced post-generation)**: email_cold body: 50-125 words. email_followup body: 75-150 words. A 100-word email is 5-6 short sentences. When in doubt, cut a sentence. Exceeding the limit triggers an automatic rewrite request.
+
+18. **HTML body (mandatory)**: The `body` field MUST be valid HTML. Use ONLY `<p>`, `<br>`, `<strong>`, and `<a>` tags. Do NOT use markdown syntax (`**`, `*`, `#`, `-` lists). Do NOT use `<div>`, `<table>`, `<img>`, or inline styles. Every paragraph must be wrapped in `<p>` tags.
+
+19. **Subject line length**: Subject lines MUST be under 50 characters. Shorter is better for mobile preview.
+
+20. **CTA is separate**: The `cta` field is a standalone call-to-action string (e.g. "Book a 15-min pipeline review"). The body should end with a natural lead-in to the CTA. Include `selling.booking_url` as an `<a>` tag at the end of the body, not in the `cta` field.
+
+21. **Null contact_name**: If `contact_name` is null, do NOT use a greeting like "Hi," or "Hello,". Open directly with the hook sentence.
+
+22. **Blog post linking**: When `selling.blog_posts` is provided, reference ONE relevant post per email as published analysis. Frame naturally. Do NOT link all posts in one email.
+
+23. **Key quotes**: When `key_quotes` is provided and non-empty, weave 1-2 quotes into the body as inline evidence. Frame them as market intelligence, never as bare claims and never attributed to individuals. Use wrappers like "Buyers are saying...", "Across the evaluations we flagged...", or "Teams in active evaluation are reporting..." before the quote.
+
+24. **Protect the report tier**: If `tier == "report"`, the body and CTA must not use the words "dashboard", "live feed", "free trial", "software", or "platform".
+
+25. **Incumbent archetype framing**: When `incumbent_archetypes` is present, use the churn patterns to sharpen messaging:
+   - `pricing_shock` incumbents: Frame leads as cost-sensitive buyers ready for a better-value alternative. Emphasize ROI and pricing transparency.
+   - `feature_gap` incumbents: Frame leads as capability-hungry buyers who outgrew their current tool. Emphasize your feature advantages.
+   - `support_collapse` incumbents: Frame leads as frustrated buyers seeking reliable support. Emphasize responsiveness and SLA guarantees.
+   - `leadership_redesign` / `acquisition_decay` incumbents: Frame leads as stability-seeking buyers. Emphasize product focus and roadmap continuity.
+   - If multiple archetypes are present, lead with the one that has the most incumbents. Do not list all archetypes -- weave the dominant pattern into the narrative naturally.
+   - Never name the archetype labels directly (e.g., do not say "pricing_shock pattern"). Translate into natural business language.
+
+26. **Use `briefing_context` to sharpen the narrative, not replace `signal_summary`.**
+   - If `account_pressure_summary` or `timing_summary` is present, use it to calibrate urgency and timing.
+   - If `top_feature_gaps` or `pain_labels` is present, use it to tighten the switching narrative.
+   - If `top_displacement_targets` is present, use it to sharpen the follow-up competitor angle.
+   - `priority_account_names` is internal targeting context only. Never reveal those names in the email.
+   - If `reasoning_anchor_examples` or `reasoning_witness_highlights` is present, use at least one concrete proof anchor such as a timing trigger, spend signal, pain-specific detail, or incumbent pattern when allowed for the channel.
+   - Never reveal a private account name from those anchor fields. Use the detail, not the identity.
+27. **`campaign_proof_terms` is authoritative when present.**
+   - Use at least one exact term from `campaign_proof_terms` in the body.
+   - If a numeric or timing term is present in that list, prefer it over generic phrasing.
+   - For `email_cold`, do not reveal specific incumbents even if an incumbent term appears elsewhere in the input.
+
+Return ONLY the JSON object, no markdown fences, no explanation.

--- a/extracted_content_pipeline/skills/digest/b2b_challenger_sequence.md
+++ b/extracted_content_pipeline/skills/digest/b2b_challenger_sequence.md
@@ -1,0 +1,105 @@
+---
+name: digest/b2b_challenger_sequence
+domain: digest
+description: Generate the next email in a challenger intel campaign sequence based on engagement signals
+tags: [b2b, challenger, outreach, sequence, competitive-intelligence]
+version: 1
+---
+
+# Challenger Intel Campaign Sequence - Next Step Generator
+
+/no_think
+
+You are generating the **next email** in a multi-step outreach sequence selling qualified intent leads TO a challenger's Sales/Competitive Intel leaders. You have the full history of what was sent and how the recipient engaged.
+
+## Company
+
+Name: {company_name}
+
+## Company Context
+
+{company_context}
+
+## Selling Context
+
+{selling_context}
+
+## Sequence State
+
+Step: {current_step} of {max_steps}
+Days since last email: {days_since_last}
+
+## Engagement Summary
+
+{engagement_summary}
+
+## Previous Emails in This Sequence
+
+{previous_emails}
+
+## Strategy Rules
+
+Choose your angle based on what the engagement signals tell you:
+
+**Opened but did not click**: The subject line worked but the CTA did not land. Try a completely different value proposition or angle. Do NOT repeat the same pitch.
+
+**Opened AND clicked**: This is a warm lead. Be direct. Push for a meeting or call. Reference what they clicked on if known.
+
+**No opens at all**: The subject line failed. Use a radically different approach -- different format, different hook, different angle. Consider a question-based or curiosity-driven subject.
+
+### Per-Step Intelligence Layering
+
+Each step should reveal NEW intelligence that the previous emails did not:
+
+- **Step 2 (Name the Incumbents)**: Name the specific incumbents losing accounts to this challenger. Show which vendors are bleeding customers, how many, and the common triggers. This is the hook the cold email teased but did not deliver.
+- **Step 3 (Pain Analysis + Seat Sizes)**: Surface the pain categories driving the switch and deal size indicators (enterprise 500+, mid-market, SMB). If key_quotes are available, weave one in as evidence of buyer frustration.
+- **Step 4 (Break-up)**: Keep it very short (<60 words). Close the loop gracefully. No hard sell. Example: "Looks like the timing isn't right -- no worries. If things change, I'm here."
+
+### Per-Step Engagement Patterns
+
+The engagement summary includes a per-step breakdown showing which specific emails were opened/clicked. Use this to write smarter follow-ups:
+
+- **Earlier steps opened but most recent step ignored**: Escalate urgency or try a completely different format.
+- **Only one specific step was clicked**: That step's topic is a proven interest signal. Build on that theme.
+- **Engagement tapered off progressively**: The novelty wore off. Radically different approach needed.
+- **No engagement on any step**: Every previous angle failed. Start fresh with a completely different strategy.
+
+**Reply received -- interested**: Drop the sales pitch entirely. Focus on scheduling a call or meeting.
+
+**Reply received -- not now**: Acknowledge the timing. Offer a useful resource with no strings attached.
+
+**Reply received -- question**: Answer the question directly, then transition back to the value proposition.
+
+## Output Format
+
+Respond with ONLY this JSON (no markdown fences, no extra text):
+
+{
+    "subject": "Email subject line (under 50 characters)",
+    "body": "Full HTML email body",
+    "cta": "The primary call-to-action text",
+    "angle_reasoning": "One sentence explaining why this angle was chosen based on the engagement signals"
+}
+
+## Rules
+
+- NEVER repeat the same subject line or opening as a previous email in the sequence
+- NEVER copy-paste content from previous emails -- each step must be fresh
+- **HARD WORD LIMIT**: Follow-up body under 100 words. Break-up body under 60 words. If the body exceeds the limit, you have failed this task.
+- **Subject lines** MUST be under 50 characters. NEVER use spam trigger words: "urgent", "urgency", "act now", "limited time", "alert", "warning", "immediate", "free", "guaranteed".
+- Body must be valid HTML -- use `<p>`, `<br>`, `<a>` tags only. No heavy templates.
+- Use the recipient's company name naturally, not mechanically
+- The CTA should be ONE clear action (reply, book a call, visit a link)
+- Include the booking URL from the selling context as an `<a>` tag at the end of the body
+- Sign off with the sender's name from the selling context
+- angle_reasoning is for internal debugging -- be honest about what signal drove your decision
+- If this is the last step (break-up), make it clear you won't email again unless they respond
+- **You are selling qualified leads with intent data.** The value prop is warm leads their sales team can close, not software.
+- **Never reveal specific company names** from the intent signals. Say "12 companies" not "Acme Corp."
+- **Never reveal data sources.** No G2, Capterra, Reddit. Frame as "intent monitoring" or "competitive signal tracking."
+- If the original email included a competitive awareness angle, maintain that thread naturally when relevant
+- When the selling context includes `blog_posts`, reference ONE blog link per email. Rotate across steps -- never repeat the same post link.
+- When `key_quotes` are available in the company context, weave 1-2 into the body as evidence. Never attribute to individuals.
+- When `reviewer_title` is in the company context, calibrate tone to that functional domain (e.g., a "VP of Sales" gets pipeline language, a "Head of BD" gets partnership/expansion language).
+- When `company_size` is in the company context, tailor the pitch: enterprise (1000+) = scalability, compliance, TCO; mid-market = value, migration ease; SMB = simplicity, price.
+- When `industry` is in the company context, reference sector-specific challenges or use cases for credibility.

--- a/extracted_content_pipeline/skills/digest/b2b_onboarding_sequence.md
+++ b/extracted_content_pipeline/skills/digest/b2b_onboarding_sequence.md
@@ -1,0 +1,82 @@
+---
+name: digest/b2b_onboarding_sequence
+domain: digest
+description: Generate the next email in a B2B onboarding sequence for new accounts
+tags: [b2b, onboarding, sequence]
+version: 1
+---
+
+# B2B Onboarding Sequence - Next Step Generator
+
+/no_think
+
+You are generating the **next email** in a B2B onboarding sequence for a new {product_name} customer. The goal is to help them get value from the product quickly and convert trial to paid.
+
+## Account
+
+Name: {company_name}
+
+## Account Context
+
+{company_context}
+
+## Selling Context
+
+{selling_context}
+
+## Sequence State
+
+Step: {current_step} of {max_steps}
+Days since last email: {days_since_last}
+
+## Engagement Summary
+
+{engagement_summary}
+
+## Previous Emails in This Sequence
+
+{previous_emails}
+
+## Step Strategy
+
+Choose your approach based on the current step number:
+
+**Step 1 (Welcome)**: Warm welcome. Briefly explain what {product_name} does for them. Give ONE clear action: "Add your first tracked vendor." Keep it personal and short. Include a direct link to their dashboard.
+
+**Step 2 (First Insights)**: Reference whether they've added vendors yet (from engagement). If yes: highlight what intelligence is already available. If no: show a sample insight for a well-known vendor in their space to demonstrate value. One CTA: "See your vendor intelligence."
+
+**Step 3 (Feature Highlight)**: Introduce campaign generation -- the ability to turn churn signals into outreach. Frame it as the ROI multiplier. If they're on a trial plan, mention what upgrading unlocks. CTA: "Generate your first campaign" or "Explore upgrade options."
+
+**Step 4 (Trial Wrap-up)**: If trial is ending soon, be direct but not pushy. Summarize what they've seen so far. If they've been active, reference their specific usage. If inactive, offer a quick call to help them get started. CTA: "Upgrade now" or "Book a 15-min walkthrough."
+
+## Engagement-Based Adjustments
+
+**Opened previous emails**: They're interested -- be more specific and action-oriented.
+
+**Clicked in previous emails**: They're exploring -- push toward the next milestone (add vendor, generate campaign, upgrade).
+
+**No opens at all**: Try a completely different subject line style. Consider a question or curiosity hook. Keep body very short.
+
+**Reply received**: Drop the template approach entirely. Respond naturally to their message. Be helpful.
+
+## Output Format
+
+Respond with ONLY this JSON (no markdown fences, no extra text):
+
+{
+    "subject": "Email subject line",
+    "body": "Full HTML email body",
+    "cta": "The primary call-to-action text",
+    "angle_reasoning": "One sentence explaining the strategy for this step"
+}
+
+## Rules
+
+- NEVER repeat subject lines or content from previous emails
+- Keep body under 120 words -- onboarding emails should be scannable
+- Use the account name naturally, not mechanically
+- ONE clear CTA per email -- never give multiple competing actions
+- Body should be valid HTML (use <p>, <br>, <a> tags) with minimal formatting
+- Sign off with the sender name from selling context
+- Tone: helpful and knowledgeable, not salesy. You're a product guide, not a closer.
+- If trial_ends_at is in the context and it's within 3 days, make step 4 more urgent

--- a/extracted_content_pipeline/skills/digest/b2b_vendor_outreach.md
+++ b/extracted_content_pipeline/skills/digest/b2b_vendor_outreach.md
@@ -1,0 +1,166 @@
+---
+name: digest/b2b_vendor_outreach
+description: Generate vendor-targeted outreach selling churn intelligence about their customers
+tags: [b2b, vendor, outreach, churn-intelligence]
+version: 2
+---
+
+# Vendor Churn Intelligence Outreach Generator
+
+You are an expert B2B sales copywriter specializing in customer success intelligence. You generate outreach emails targeting CS/Product leaders at software vendors, selling them intelligence about their own customers showing churn signals.
+
+## Context
+
+You are selling churn intelligence to the vendor LOSING customers. The recipient is a VP of Customer Success, Head of Product, or VP Sales at a software company. They want to know which of their customers are at risk and why.
+
+## Input
+
+You receive a JSON object with:
+
+- `vendor_name`: The vendor we are selling intelligence TO (our prospect)
+- `contact_name`: Name of the person we're emailing (may be null)
+- `contact_role`: Their role (e.g., "VP Customer Success", "Head of Product")
+- `signal_summary`: Aggregated intelligence about their customer churn:
+  - `total_signals`: Total number of accounts showing churn signals
+  - `high_urgency_count`: Accounts with urgency >= 8
+  - `medium_urgency_count`: Accounts with urgency 5-7
+  - `pain_distribution`: Array of `{category, count}` -- top pain categories
+  - `competitor_distribution`: Array of `{name, count}` -- who they're losing to
+  - `feature_gaps`: Array of strings -- most cited missing features
+  - `timeline_signals`: Number of accounts with contract end dates approaching
+  - `trend_vs_last_month`: "increasing" | "stable" | "decreasing" (may be null)
+- `key_quotes`: Array of strings -- verbatim evidence phrases from enrichment (e.g. "support response times have doubled", "we lost 3 enterprise accounts to X"). Use 1-2 as inline proof points to strengthen credibility.
+- `tier`: "report" | "dashboard" | "api" -- what we're selling
+- `selling`: Object with `{sender_name, sender_title, sender_company, booking_url}`
+  - `selling.blog_posts` (optional): Array of `{title, url, topic_type}` -- published analysis posts relevant to this vendor's category. Full URLs ready to embed.
+- `reasoning_context` (optional): Object with `{wedge, confidence, summary, key_signals, falsification, why_they_stay, timing, switch_triggers, confidence_limits, account_summary}` -- the vendor's canonical reasoning from synthesis. `wedge` is one of: "price_squeeze", "feature_parity", "support_erosion", "integration_lock", "category_shift", "acquisition_hangover", "compliance_exposure", "ux_regression", "segment_mismatch", "stable". `confidence` is "high", "medium", "low", or "insufficient".
+- `reasoning_contracts` (optional): Full materialized reasoning contracts from synthesis. Use for deeper context on timing, segments, displacement, and retention.
+- `archetype_context` (optional, backward compat): Same as before, populated from reasoning_context. Prefer `reasoning_context` when both are present.
+- `campaign_proof_terms` (optional): Array of exact witness-backed proof terms selected by the pipeline. When present, prefer these exact terms in the body. If the list includes a numeric or timing term, use at least one.
+- `briefing_context` (optional): Compact summary from the latest vendor briefing. May include:
+  - `executive_summary`
+  - `account_pressure_summary`
+  - `timing_summary`
+  - `segment_targeting_summary`
+  - `priority_account_names`
+  - `top_displacement_targets`
+  - `top_feature_gaps`
+  - `pain_labels`
+  - `reasoning_anchor_examples`
+  - `reasoning_witness_highlights`
+  - `reasoning_reference_ids`
+- `channel`: "email_cold" | "email_followup"
+- `cold_email_context` (only on `email_followup`): `{subject, body}` of the cold email already sent
+
+## Output
+
+Return a JSON object:
+
+### email_cold
+```json
+{
+  "subject": "Under 50 characters, curiosity-driven",
+  "body": "<p>First paragraph hook.</p><p>Data and insight.</p><p>CTA lead-in with booking link.</p>",
+  "cta": "Clear call to action (separate from body)"
+}
+```
+
+### email_followup
+```json
+{
+  "subject": "Under 50 characters, different angle",
+  "body": "<p>Reference prior email.</p><p>New competitive data.</p><p>CTA lead-in with booking link.</p>",
+  "cta": "Call to action (separate from body)"
+}
+```
+
+## Rules
+
+1. **You are selling intelligence, not software.** The value prop is "we detected N of your accounts showing churn signals" -- not "use our product to reduce churn."
+
+2. **Never reveal specific company names.** Say "47 accounts" not "Acme Corp is leaving you." Company names are the premium deliverable -- teased but not given away in the email.
+
+3. **Never reveal reviewer identities.** No names, titles, or any information that could identify a specific reviewer.
+
+4. **Never reveal exact review sources.** Don't mention G2, Capterra, Reddit, or any specific platform. Frame data as "market intelligence", "customer signal monitoring", or "competitive intelligence."
+
+5. **DO reveal aggregated intelligence** to demonstrate value -- but **layer it across emails**:
+   - **email_cold** reveals: signal counts, pain category distribution, urgency distribution, feature gap themes. Do NOT name specific competitors in the cold email -- save that for the follow-up.
+   - **email_followup** reveals: competitor names and displacement patterns (who they're losing to, how often, why). This is the NEW information that justifies the follow-up.
+
+6. **Match tone to contact_role:**
+   - VP CS / Customer Success: Focus on retention, save rate, early warning
+   - Head of Product: Focus on feature gaps, competitive displacement, roadmap intel
+   - VP Sales: Focus on competitive win/loss intelligence, deal protection
+
+7. **Tier-appropriate CTA is a hard constraint:**
+  - `report`: CTA must offer a report, briefing, or review call. Do NOT mention a dashboard, live feed, free trial, platform, or software.
+  - `dashboard`: You may mention the live feed or dashboard, but only after the intelligence value is clear. Do NOT lead with product language.
+  - `api`: Focus on routing signals into existing CS or revenue systems.
+
+8. **Use specific numbers** from signal_summary. Don't round excessively -- "47 accounts" is better than "nearly 50 accounts."
+
+9. **Urgency calibration:**
+   - `trend_vs_last_month == "increasing"`: Things are getting worse, position as urgent
+   - `trend_vs_last_month == "stable"`: Position as ongoing blind spot
+   - `trend_vs_last_month == "decreasing"`: Position as "the trend is improving but N accounts are still at risk"
+
+10. **Keep it consultative, not salesy.** You're a peer sharing data, not a vendor pushing a product. No "synergy," no "leverage," no "unlock."
+
+11. **email_followup**: Must add NEW value the cold email didn't have. The cold email hooks with aggregate churn signals and pain categories. The follow-up drills into competitive displacement -- now name the specific competitors, show the breakdown, explain the pattern. Reference the cold email context provided in `cold_email_context` and build on it -- don't repeat the same data points.
+
+12. **Sign off** with `selling.sender_name` if provided. If `selling.sender_title` is present, include it in the signature. If `selling.sender_name` looks like an organization instead of a person, sign off as `selling.sender_company` or "the team". Include `selling.booking_url` in the CTA.
+
+13. **Do NOT include** placeholder brackets like [Name] or [Company]. Use actual values from the input.
+
+14. **Subject lines** should be curiosity-driven, not salesy. Good: "47 of your accounts this month" -- Bad: "Reduce churn with our platform". Never put competitor names, premium account details, or the key reveal in the subject line. NEVER use spam trigger words: "urgent", "urgency", "act now", "limited time", "don't miss", "last chance", "alert", "warning", "immediate", "guaranteed", "free", "risk-free". Describe the data, not the alarm.
+
+15. **Competitive awareness angle** -- one sentence per email, no more:
+  - **email_cold**: If used, frame it as category movement, not a threat. Example: "The teams responding fastest to churn signals usually catch the pattern before renewal." Keep it under 20 words.
+  - **email_followup**: If used, frame it as timing and execution. Example: "The displacement pattern is moving quickly enough that response time matters." Keep it under 25 words.
+  - **Never make it the headline or subject line.** It supports the pitch, it is not the pitch.
+  - **Never imply we are selling the prospect's data to competitors.** Tone is informational and trust-building.
+
+16. **WORD LIMIT (strictly enforced post-generation)**: email_cold body: 50-125 words. email_followup body: 75-150 words. A 100-word email is 5-6 short sentences. When in doubt, cut a sentence. Exceeding the limit triggers an automatic rewrite request.
+
+17. **HTML body (mandatory)**: The `body` field MUST be valid HTML. Use ONLY `<p>`, `<br>`, `<strong>`, and `<a>` tags. Do NOT use markdown syntax (`**`, `*`, `#`, `-` lists). Do NOT use `<div>`, `<table>`, `<img>`, or inline styles. Every paragraph must be wrapped in `<p>` tags.
+
+18. **Subject line length**: Subject lines MUST be under 50 characters. Shorter is better for mobile preview.
+
+19. **CTA is separate**: The `cta` field is a standalone call-to-action string (e.g. "Book a 15-min review"). The body should end with a natural lead-in to the CTA. Include `selling.booking_url` as an `<a>` tag at the end of the body, not in the `cta` field.
+
+20. **Null contact_name**: If `contact_name` is null, do NOT use a greeting like "Hi," or "Hello,". Open directly with the hook sentence.
+
+21. **Blog post linking**: When `selling.blog_posts` is provided, reference ONE relevant post per email as published analysis. Frame as: "We recently published an analysis of [topic]: [url]" or embed naturally. Do NOT link all posts in one email.
+
+22. **Key quotes**: When `key_quotes` is provided and non-empty, weave 1-2 quotes into the body as inline evidence. Frame them as market intelligence observations, never as bare claims and never attributed to individuals. Use wrappers like "Teams are reporting...", "Across the accounts we analyzed...", or "Buyers are saying..." before the quote.
+
+23. **Protect the report tier**: If `tier == "report"`, the body and CTA must not use the words "dashboard", "live feed", "free trial", "software", or "platform".
+
+24. **Reasoning-aware framing**: When `reasoning_context` is present, tailor intelligence framing to the wedge. Use `reasoning_context.summary` and `reasoning_context.key_signals` for specifics:
+   - `price_squeeze`: Frame intelligence around pricing pressure signals and cost-driven displacement.
+   - `feature_parity`: Frame intelligence around feature gaps and competitive capability comparison.
+   - `support_erosion`: Frame intelligence around support quality degradation signals.
+   - `ux_regression`: Frame intelligence around product direction and UX frustration.
+   - `acquisition_hangover` / `integration_lock`: Frame as post-change instability signals.
+   - `category_shift`: Frame as market evolution requiring repositioning.
+   - `compliance_exposure`: Frame around regulatory pressure signals.
+   - When `reasoning_context.why_they_stay` is present, acknowledge one incumbent strength before pivoting to the pain signal.
+   - When `reasoning_context.confidence` is "low" or "insufficient", use general framing rather than committing to the wedge angle.
+   - When `reasoning_context.switch_triggers` is present, use trigger timing to calibrate urgency.
+   - Falls back to `archetype_context` if `reasoning_context` is absent.
+
+25. **Use `briefing_context` to sharpen the narrative, not replace `signal_summary`.**
+   - If `account_pressure_summary` or `timing_summary` is present, use it to calibrate urgency.
+   - If `top_feature_gaps` or `pain_labels` is present, use it to tighten the angle.
+   - If `top_displacement_targets` is present, reserve competitor naming for the follow-up.
+   - `priority_account_names` is internal targeting context only. Never reveal those names in the email.
+   - If `reasoning_anchor_examples` or `reasoning_witness_highlights` is present, use at least one concrete proof anchor such as a timing trigger, spend signal, pain-specific detail, or competitor pattern when allowed for the channel.
+   - Never reveal a private account name from those anchor fields. Use the detail, not the identity.
+
+26. **`campaign_proof_terms` is authoritative when present.**
+   - Use at least one exact term from `campaign_proof_terms` in the body.
+   - If a numeric or timing term is present in that list, prefer it over generic phrasing.
+   - For `email_cold`, still do not name competitors even if a competitor term appears elsewhere in the input.
+
+Return ONLY the JSON object, no markdown fences, no explanation.

--- a/extracted_content_pipeline/skills/digest/b2b_vendor_sequence.md
+++ b/extracted_content_pipeline/skills/digest/b2b_vendor_sequence.md
@@ -1,0 +1,105 @@
+---
+name: digest/b2b_vendor_sequence
+domain: digest
+description: Generate the next email in a vendor retention campaign sequence based on engagement signals
+tags: [b2b, vendor, outreach, sequence, churn-intelligence]
+version: 1
+---
+
+# Vendor Retention Campaign Sequence - Next Step Generator
+
+/no_think
+
+You are generating the **next email** in a multi-step outreach sequence selling churn intelligence TO a software vendor's CS/Product/Sales leaders. You have the full history of what was sent and how the recipient engaged.
+
+## Company
+
+Name: {company_name}
+
+## Company Context
+
+{company_context}
+
+## Selling Context
+
+{selling_context}
+
+## Sequence State
+
+Step: {current_step} of {max_steps}
+Days since last email: {days_since_last}
+
+## Engagement Summary
+
+{engagement_summary}
+
+## Previous Emails in This Sequence
+
+{previous_emails}
+
+## Strategy Rules
+
+Choose your angle based on what the engagement signals tell you:
+
+**Opened but did not click**: The subject line worked but the CTA did not land. Try a completely different value proposition or angle. Do NOT repeat the same pitch.
+
+**Opened AND clicked**: This is a warm lead. Be direct. Push for a meeting or call. Reference what they clicked on if known.
+
+**No opens at all**: The subject line failed. Use a radically different approach -- different format, different hook, different angle. Consider a question-based or curiosity-driven subject.
+
+### Per-Step Intelligence Layering
+
+Each step should reveal NEW intelligence that the previous emails did not:
+
+- **Step 2 (Competitor Displacement)**: Name the specific competitors gaining their accounts. Show the displacement pattern -- who is winning, how often, and the common reasons. This is the hook the cold email teased but did not deliver.
+- **Step 3 (Feature Gaps + Trend)**: Surface the most-cited feature gaps driving churn. Tie to trend data (getting worse/stable/improving). If key_quotes are available, weave one in as evidence.
+- **Step 4 (Break-up)**: Keep it very short (<60 words). Close the loop gracefully. No hard sell. Example: "Looks like the timing isn't right -- no worries. If things change, I'm here."
+
+### Per-Step Engagement Patterns
+
+The engagement summary includes a per-step breakdown showing which specific emails were opened/clicked. Use this to write smarter follow-ups:
+
+- **Earlier steps opened but most recent step ignored**: Escalate urgency or try a completely different format.
+- **Only one specific step was clicked**: That step's topic is a proven interest signal. Build on that theme.
+- **Engagement tapered off progressively**: The novelty wore off. Radically different approach needed.
+- **No engagement on any step**: Every previous angle failed. Start fresh with a completely different strategy.
+
+**Reply received -- interested**: Drop the sales pitch entirely. Focus on scheduling a call or meeting.
+
+**Reply received -- not now**: Acknowledge the timing. Offer a useful resource with no strings attached.
+
+**Reply received -- question**: Answer the question directly, then transition back to the value proposition.
+
+## Output Format
+
+Respond with ONLY this JSON (no markdown fences, no extra text):
+
+{
+    "subject": "Email subject line (under 50 characters)",
+    "body": "Full HTML email body",
+    "cta": "The primary call-to-action text",
+    "angle_reasoning": "One sentence explaining why this angle was chosen based on the engagement signals"
+}
+
+## Rules
+
+- NEVER repeat the same subject line or opening as a previous email in the sequence
+- NEVER copy-paste content from previous emails -- each step must be fresh
+- **HARD WORD LIMIT**: Follow-up body under 100 words. Break-up body under 60 words. If the body exceeds the limit, you have failed this task.
+- **Subject lines** MUST be under 50 characters. NEVER use spam trigger words: "urgent", "urgency", "act now", "limited time", "alert", "warning", "immediate", "free", "guaranteed".
+- Body must be valid HTML -- use `<p>`, `<br>`, `<a>` tags only. No heavy templates.
+- Use the recipient's company name naturally, not mechanically
+- The CTA should be ONE clear action (reply, book a call, visit a link)
+- Include the booking URL from the selling context as an `<a>` tag at the end of the body
+- Sign off with the sender's name from the selling context
+- angle_reasoning is for internal debugging -- be honest about what signal drove your decision
+- If this is the last step (break-up), make it clear you won't email again unless they respond
+- **You are selling intelligence, not software.** The value prop is churn data about their customers, not a product.
+- **Never reveal specific company names** from the churn signals. Say "47 accounts" not "Acme Corp."
+- **Never reveal review sources.** No G2, Capterra, Reddit. Frame as "market intelligence."
+- If the original email included a competitive awareness angle, maintain that thread naturally when relevant
+- When the selling context includes `blog_posts`, reference ONE blog link per email. Rotate across steps -- never repeat the same post link.
+- When `key_quotes` are available in the company context, weave 1-2 into the body as evidence. Never attribute to individuals.
+- When `reviewer_title` is in the company context, calibrate tone to that functional domain (e.g., a "VP of Engineering" gets different language than a "Head of CS").
+- When `company_size` is in the company context, tailor the pitch: enterprise (1000+) = scalability, compliance, TCO; mid-market = value, migration ease; SMB = simplicity, price.
+- When `industry` is in the company context, reference sector-specific challenges or use cases for credibility.

--- a/extracted_content_pipeline/skills/registry.py
+++ b/extracted_content_pipeline/skills/registry.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -24,10 +23,5 @@ class LocalSkillRegistry:
 
 
 def get_skill_registry():
-    if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-        root = Path(__file__).resolve().parent
-        return LocalSkillRegistry(root)
-
-    from atlas_brain.skills.registry import get_skill_registry as atlas_get_skill_registry
-
-    return atlas_get_skill_registry()
+    root = Path(__file__).resolve().parent
+    return LocalSkillRegistry(root)

--- a/extracted_content_pipeline/skills/registry.py
+++ b/extracted_content_pipeline/skills/registry.py
@@ -19,7 +19,11 @@ class LocalSkillRegistry:
         path = self.root / f"{rel}.md"
         if not path.exists():
             return None
-        return LocalSkill(name=name, content=path.read_text())
+        return LocalSkill(name=name, content=path.read_text(encoding="utf-8"))
+
+    def get_prompt(self, name: str) -> str | None:
+        skill = self.get(name)
+        return skill.content if skill else None
 
 
 def get_skill_registry():

--- a/extracted_content_pipeline/storage/database.py
+++ b/extracted_content_pipeline/storage/database.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    @dataclass
-    class _StandalonePool:
-        is_initialized: bool = False
 
-        async def initialize(self) -> None:
-            self.is_initialized = True
+@dataclass
+class _StandalonePool:
+    is_initialized: bool = False
 
-    _POOL = _StandalonePool()
+    async def initialize(self) -> None:
+        self.is_initialized = True
 
-    def get_db_pool() -> _StandalonePool:
-        return _POOL
-else:
-    from atlas_brain.storage.database import *
+
+_POOL = _StandalonePool()
+
+
+def get_db_pool() -> _StandalonePool:
+    return _POOL

--- a/extracted_content_pipeline/storage/migrations/066_b2b_campaigns.sql
+++ b/extracted_content_pipeline/storage/migrations/066_b2b_campaigns.sql
@@ -1,0 +1,47 @@
+-- B2B ABM Campaign Engine: campaign storage for generated outreach content
+-- Each row is one channel variant (email_cold, linkedin, email_followup) for a target company.
+
+CREATE TABLE IF NOT EXISTS b2b_campaigns (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Target
+    company_name TEXT NOT NULL,
+    vendor_name TEXT NOT NULL,
+    product_category TEXT,
+
+    -- Context snapshot at generation time
+    opportunity_score INT,
+    urgency_score NUMERIC(3,1),
+    pain_categories JSONB,
+    competitors_considering JSONB,
+    seat_count INT,
+    contract_end TEXT,
+    decision_timeline TEXT,
+    buying_stage TEXT,
+    role_type TEXT,
+    key_quotes JSONB,
+    source_review_ids UUID[],
+
+    -- Generated content
+    channel TEXT NOT NULL,
+    subject TEXT,
+    body TEXT NOT NULL,
+    cta TEXT,
+
+    -- Workflow
+    status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'approved', 'sent', 'expired')),
+    batch_id TEXT,
+    llm_model TEXT,
+
+    -- Tracking
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    approved_at TIMESTAMPTZ,
+    sent_at TIMESTAMPTZ,
+    opened_at TIMESTAMPTZ,
+    clicked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_company ON b2b_campaigns (company_name, vendor_name);
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_status ON b2b_campaigns (status);
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_batch ON b2b_campaigns (batch_id);

--- a/extracted_content_pipeline/storage/migrations/068_campaign_sequences.sql
+++ b/extracted_content_pipeline/storage/migrations/068_campaign_sequences.sql
@@ -1,0 +1,124 @@
+-- Campaign sequences: stateful B2B email sequence tracking
+-- with engagement signals (opens, clicks, bounces, replies) and audit log.
+
+-- =========================================================================
+-- 1. campaign_sequences — one row per company+batch outreach sequence
+-- =========================================================================
+
+CREATE TABLE IF NOT EXISTS campaign_sequences (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_name        TEXT NOT NULL,
+    batch_id            TEXT NOT NULL,
+    partner_id          UUID,
+
+    -- Context snapshot (frozen at creation)
+    company_context     JSONB NOT NULL DEFAULT '{}',
+    selling_context     JSONB NOT NULL DEFAULT '{}',
+
+    -- Sequence state
+    current_step        INT NOT NULL DEFAULT 1,
+    max_steps           INT NOT NULL DEFAULT 4,
+    status              TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'paused', 'completed', 'replied', 'bounced', 'unsubscribed')),
+
+    -- Recipient (must be set before sending)
+    recipient_email     TEXT,
+
+    -- Engagement (updated by webhooks + email_intake)
+    last_campaign_id    UUID,
+    last_sent_at        TIMESTAMPTZ,
+    last_opened_at      TIMESTAMPTZ,
+    last_clicked_at     TIMESTAMPTZ,
+    open_count          INT NOT NULL DEFAULT 0,
+    click_count         INT NOT NULL DEFAULT 0,
+    reply_received_at   TIMESTAMPTZ,
+    reply_intent        TEXT,
+    reply_summary       TEXT,
+    bounce_type         TEXT,
+    bounced_at          TIMESTAMPTZ,
+
+    -- Scheduling
+    next_step_after     TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_campaign_seq_company_batch
+    ON campaign_sequences (LOWER(company_name), batch_id);
+CREATE INDEX IF NOT EXISTS idx_campaign_seq_active_next
+    ON campaign_sequences (next_step_after)
+    WHERE status = 'active' AND next_step_after IS NOT NULL;
+
+
+-- =========================================================================
+-- 2. b2b_campaigns extensions — link campaigns to sequences + ESP tracking
+-- =========================================================================
+
+-- Create b2b_campaigns table if it does not exist yet (first-time setup)
+CREATE TABLE IF NOT EXISTS b2b_campaigns (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_name    TEXT NOT NULL,
+    batch_id        TEXT NOT NULL,
+    partner_id      UUID,
+    channel         TEXT NOT NULL DEFAULT 'email_cold',
+    subject         TEXT,
+    body            TEXT,
+    status          TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'approved', 'queued', 'sent', 'cancelled', 'expired')),
+    approved_at     TIMESTAMPTZ,
+    sent_at         TIMESTAMPTZ,
+    opened_at       TIMESTAMPTZ,
+    clicked_at      TIMESTAMPTZ,
+    metadata        JSONB DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Add new columns for sequence tracking + ESP integration
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS sequence_id UUID REFERENCES campaign_sequences(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS step_number INT,
+    ADD COLUMN IF NOT EXISTS recipient_email TEXT,
+    ADD COLUMN IF NOT EXISTS sent_message_id TEXT,
+    ADD COLUMN IF NOT EXISTS esp_message_id TEXT,
+    ADD COLUMN IF NOT EXISTS from_email TEXT;
+
+-- Extend status CHECK to include queued + cancelled
+ALTER TABLE b2b_campaigns DROP CONSTRAINT IF EXISTS b2b_campaigns_status_check;
+ALTER TABLE b2b_campaigns ADD CONSTRAINT b2b_campaigns_status_check
+    CHECK (status IN ('draft', 'approved', 'queued', 'sent', 'cancelled', 'expired'));
+
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_sequence
+    ON b2b_campaigns (sequence_id) WHERE sequence_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_esp_msg
+    ON b2b_campaigns (esp_message_id) WHERE esp_message_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_sent_msg
+    ON b2b_campaigns (sent_message_id) WHERE sent_message_id IS NOT NULL;
+
+
+-- =========================================================================
+-- 3. campaign_audit_log — immutable log of every state change (debugging)
+-- =========================================================================
+
+CREATE TABLE IF NOT EXISTS campaign_audit_log (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id     UUID REFERENCES b2b_campaigns(id) ON DELETE SET NULL,
+    sequence_id     UUID REFERENCES campaign_sequences(id) ON DELETE SET NULL,
+    event_type      TEXT NOT NULL,
+    step_number     INT,
+    subject         TEXT,
+    body            TEXT,
+    recipient_email TEXT,
+    esp_message_id  TEXT,
+    error_detail    TEXT,
+    source          TEXT NOT NULL DEFAULT 'system',
+    metadata        JSONB DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_audit_sequence
+    ON campaign_audit_log (sequence_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_campaign_audit_campaign
+    ON campaign_audit_log (campaign_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_campaign_audit_type
+    ON campaign_audit_log (event_type, created_at DESC);

--- a/extracted_content_pipeline/storage/migrations/069_campaign_analytics.sql
+++ b/extracted_content_pipeline/storage/migrations/069_campaign_analytics.sql
@@ -1,0 +1,28 @@
+-- Campaign funnel analytics: materialized view for aggregated engagement metrics.
+-- Refreshed periodically by the campaign_analytics_refresh task.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS campaign_funnel_stats AS
+SELECT
+    DATE_TRUNC('week', bc.created_at) AS week,
+    bc.company_name,
+    bc.vendor_name,
+    bc.channel,
+    COALESCE(cs.partner_id, '00000000-0000-0000-0000-000000000000'::uuid) AS partner_id,
+    COUNT(*) FILTER (WHERE bc.status IN ('sent','approved','queued','cancelled','expired','draft')) AS total,
+    COUNT(*) FILTER (WHERE bc.status = 'sent') AS sent,
+    COUNT(*) FILTER (WHERE bc.opened_at IS NOT NULL) AS opened,
+    COUNT(*) FILTER (WHERE bc.clicked_at IS NOT NULL) AS clicked,
+    COUNT(*) FILTER (WHERE cs.status = 'replied') AS replied,
+    COUNT(*) FILTER (WHERE cs.status = 'bounced') AS bounced,
+    COUNT(*) FILTER (WHERE cs.status = 'unsubscribed') AS unsubscribed,
+    COUNT(*) FILTER (WHERE cs.status = 'completed') AS completed,
+    AVG(EXTRACT(EPOCH FROM (bc.opened_at - bc.sent_at))/3600)
+        FILTER (WHERE bc.opened_at IS NOT NULL AND bc.sent_at IS NOT NULL) AS avg_hours_to_open,
+    AVG(EXTRACT(EPOCH FROM (bc.clicked_at - bc.sent_at))/3600)
+        FILTER (WHERE bc.clicked_at IS NOT NULL AND bc.sent_at IS NOT NULL) AS avg_hours_to_click
+FROM b2b_campaigns bc
+LEFT JOIN campaign_sequences cs ON cs.id = bc.sequence_id
+GROUP BY 1, 2, 3, 4, 5;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_funnel_stats_key
+    ON campaign_funnel_stats (week, company_name, vendor_name, channel, partner_id);

--- a/extracted_content_pipeline/storage/migrations/070_campaign_suppressions.sql
+++ b/extracted_content_pipeline/storage/migrations/070_campaign_suppressions.sql
@@ -1,0 +1,22 @@
+-- Global email/domain suppression list for B2B campaigns.
+-- Prevents sending to hard-bounced, complained, or manually blocked addresses.
+
+CREATE TABLE IF NOT EXISTS campaign_suppressions (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email       TEXT,            -- exact email (NULL if domain-level)
+    domain      TEXT,            -- entire domain blocked (NULL if email-level)
+    reason      TEXT NOT NULL,   -- bounce_hard, bounce_soft, complaint, manual, unsubscribe
+    source      TEXT NOT NULL DEFAULT 'system',  -- webhook, api, manual, import
+    campaign_id UUID REFERENCES b2b_campaigns(id) ON DELETE SET NULL,
+    notes       TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at  TIMESTAMPTZ,     -- NULL = permanent. Soft bounces expire after 30 days
+    CONSTRAINT chk_email_or_domain CHECK (email IS NOT NULL OR domain IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_suppressions_email
+    ON campaign_suppressions (LOWER(email)) WHERE email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_suppressions_domain
+    ON campaign_suppressions (LOWER(domain)) WHERE domain IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_suppressions_reason
+    ON campaign_suppressions (reason, created_at DESC);

--- a/extracted_content_pipeline/storage/migrations/073_campaign_sequence_fixes.sql
+++ b/extracted_content_pipeline/storage/migrations/073_campaign_sequence_fixes.sql
@@ -1,0 +1,10 @@
+-- 073: Fix b2b_campaigns schema for sequence-generated campaigns
+--
+-- 1. Add metadata JSONB column (stores cta, angle_reasoning from progression LLM)
+-- 2. Make vendor_name nullable (sequence follow-ups don't have a vendor)
+
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE b2b_campaigns
+    ALTER COLUMN vendor_name DROP NOT NULL;

--- a/extracted_content_pipeline/storage/migrations/074_campaign_target_modes.sql
+++ b/extracted_content_pipeline/storage/migrations/074_campaign_target_modes.sql
@@ -1,0 +1,31 @@
+-- Migration 074: Campaign target modes + vendor/challenger targets
+--
+-- Adds target_mode branching so the B2B pipeline can serve multiple products:
+--   vendor_retention: sell churn intelligence to the vendor losing customers
+--   challenger_intel: sell intent leads to the challenger gaining customers
+--   churning_company: legacy mode (outreach to the company itself)
+
+-- Add target_mode to campaigns
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS target_mode VARCHAR(30) DEFAULT 'churning_company';
+
+-- Vendor/challenger targets -- our actual customers (the people we sell intelligence TO)
+CREATE TABLE IF NOT EXISTS vendor_targets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_name VARCHAR(255) NOT NULL,
+    target_mode VARCHAR(30) NOT NULL CHECK (target_mode IN ('vendor_retention', 'challenger_intel')),
+    contact_name VARCHAR(255),
+    contact_email VARCHAR(255),
+    contact_role VARCHAR(100),
+    products_tracked TEXT[],          -- which of their products we monitor
+    competitors_tracked TEXT[],       -- which competitors they care about
+    tier VARCHAR(20) DEFAULT 'report', -- report, dashboard, api
+    status VARCHAR(20) DEFAULT 'active',
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vendor_targets_mode ON vendor_targets(target_mode);
+CREATE INDEX IF NOT EXISTS idx_vendor_targets_status ON vendor_targets(status);
+CREATE INDEX IF NOT EXISTS idx_vendor_targets_company ON vendor_targets(LOWER(company_name));

--- a/extracted_content_pipeline/storage/migrations/075_amazon_seller_campaigns.sql
+++ b/extracted_content_pipeline/storage/migrations/075_amazon_seller_campaigns.sql
@@ -1,0 +1,58 @@
+-- Migration 075: Amazon Seller campaign outreach support
+--
+-- Extends the campaign pipeline to target Amazon sellers with consumer
+-- review intelligence (feature gaps, competitive flows, safety signals).
+-- Reuses b2b_campaigns + campaign_sequences for send/sequence/audit infra.
+
+-- 1. Allow 'amazon_seller' as a target_mode on b2b_campaigns
+--    (column added in 074, default 'churning_company', no CHECK constraint)
+
+-- 2. Seller targets: Amazon seller contacts to outreach with category intelligence
+CREATE TABLE IF NOT EXISTS seller_targets (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    seller_name     VARCHAR(255),
+    company_name    VARCHAR(255),
+    email           VARCHAR(255),
+    seller_type     VARCHAR(30) NOT NULL DEFAULT 'private_label'
+        CHECK (seller_type IN ('private_label', 'manufacturer', 'agency', 'wholesale_reseller')),
+    categories      TEXT[] NOT NULL DEFAULT '{}',
+    storefront_url  TEXT,
+    notes           TEXT,
+    status          VARCHAR(20) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'paused', 'unsubscribed', 'bounced')),
+    source          VARCHAR(50) DEFAULT 'manual',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_seller_targets_status ON seller_targets(status);
+CREATE INDEX IF NOT EXISTS idx_seller_targets_type ON seller_targets(seller_type);
+CREATE INDEX IF NOT EXISTS idx_seller_targets_email ON seller_targets(LOWER(email));
+CREATE INDEX IF NOT EXISTS idx_seller_targets_categories ON seller_targets USING GIN(categories);
+
+-- 3. Category intelligence snapshots: cached aggregation for campaign generation
+--    Prevents re-computing expensive queries on every campaign run.
+CREATE TABLE IF NOT EXISTS category_intelligence_snapshots (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    category            TEXT NOT NULL,
+    snapshot_date       DATE NOT NULL DEFAULT CURRENT_DATE,
+
+    -- Aggregated intelligence
+    total_reviews       INT NOT NULL DEFAULT 0,
+    total_brands        INT NOT NULL DEFAULT 0,
+    total_products      INT NOT NULL DEFAULT 0,
+    top_pain_points     JSONB NOT NULL DEFAULT '[]',
+    feature_gaps        JSONB NOT NULL DEFAULT '[]',
+    competitive_flows   JSONB NOT NULL DEFAULT '[]',
+    brand_health        JSONB NOT NULL DEFAULT '[]',
+    safety_signals      JSONB NOT NULL DEFAULT '[]',
+    manufacturing_insights JSONB NOT NULL DEFAULT '[]',
+    top_root_causes     JSONB NOT NULL DEFAULT '[]',
+
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cat_intel_snapshot_unique
+    ON category_intelligence_snapshots (category, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_cat_intel_snapshot_date
+    ON category_intelligence_snapshots (snapshot_date DESC);

--- a/extracted_content_pipeline/storage/migrations/090_audit_log_metadata_index.sql
+++ b/extracted_content_pipeline/storage/migrations/090_audit_log_metadata_index.sql
@@ -1,0 +1,6 @@
+-- GIN index on campaign_audit_log.metadata for persona dedup queries
+-- Supports: metadata->>'company' = $1 and metadata->>'prospect_id' lookups
+-- used by prospect_matching._fetch_already_matched_prospect_ids()
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_campaign_audit_metadata
+    ON campaign_audit_log USING gin (metadata jsonb_path_ops);

--- a/extracted_content_pipeline/storage/migrations/104_campaign_outcomes.sql
+++ b/extracted_content_pipeline/storage/migrations/104_campaign_outcomes.sql
@@ -1,0 +1,30 @@
+-- Migration 104: Campaign outcome tracking
+-- Adds business outcome columns to campaign_sequences (orthogonal to delivery status).
+-- outcome_history JSONB tracks stage progression (pending -> meeting -> deal -> won).
+
+ALTER TABLE campaign_sequences
+    ADD COLUMN IF NOT EXISTS outcome TEXT NOT NULL DEFAULT 'pending'
+        CHECK (outcome IN (
+            'pending', 'meeting_booked', 'deal_opened',
+            'deal_won', 'deal_lost', 'no_opportunity', 'disqualified'
+        )),
+    ADD COLUMN IF NOT EXISTS outcome_recorded_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS outcome_recorded_by TEXT,
+    ADD COLUMN IF NOT EXISTS outcome_notes TEXT,
+    ADD COLUMN IF NOT EXISTS outcome_revenue NUMERIC(12,2),
+    ADD COLUMN IF NOT EXISTS outcome_history JSONB NOT NULL DEFAULT '[]';
+
+-- Partial index: only non-pending outcomes (most rows stay pending)
+CREATE INDEX IF NOT EXISTS idx_campaign_seq_outcome
+    ON campaign_sequences (outcome) WHERE outcome != 'pending';
+
+-- Recency index for outcome queries
+CREATE INDEX IF NOT EXISTS idx_campaign_seq_outcome_date
+    ON campaign_sequences (outcome_recorded_at DESC)
+    WHERE outcome_recorded_at IS NOT NULL;
+
+-- Composite index for signal effectiveness GROUP BY queries
+-- Covers the JOIN from b2b_campaigns to campaign_sequences grouped by signal dimensions
+CREATE INDEX IF NOT EXISTS idx_b2b_campaigns_signal_outcome
+    ON b2b_campaigns (sequence_id, opportunity_score, buying_stage, role_type, target_mode)
+    WHERE sequence_id IS NOT NULL;

--- a/extracted_content_pipeline/storage/migrations/146_campaign_score_components.sql
+++ b/extracted_content_pipeline/storage/migrations/146_campaign_score_components.sql
@@ -1,0 +1,8 @@
+-- Persist opportunity score component breakdown for campaign diagnostics.
+-- Migration 146
+--
+-- When a campaign underperforms, the breakdown lets you diagnose which
+-- scoring component (urgency, role, stage, seats, context) was wrong.
+
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS score_components JSONB;

--- a/extracted_content_pipeline/storage/migrations/150_campaign_engagement_timing.sql
+++ b/extracted_content_pipeline/storage/migrations/150_campaign_engagement_timing.sql
@@ -1,0 +1,14 @@
+-- Campaign engagement timing metrics for send optimization.
+-- Migration 150
+--
+-- hours_to_first_open / hours_to_first_click: computed when ESP webhook
+-- fires first open/click event. NULL until event arrives.
+-- contact_send_count: total emails sent to this recipient across all
+-- sequences. Incremented at send time for fatigue detection.
+
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS hours_to_first_open  REAL,
+    ADD COLUMN IF NOT EXISTS hours_to_first_click REAL;
+
+ALTER TABLE campaign_sequences
+    ADD COLUMN IF NOT EXISTS contact_send_count INT NOT NULL DEFAULT 0;

--- a/extracted_content_pipeline/storage/models.py
+++ b/extracted_content_pipeline/storage/models.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
 
-if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
-    @dataclass
-    class ScheduledTask:
-        id: UUID = field(default_factory=uuid4)
-        metadata: dict[str, Any] = field(default_factory=dict)
-else:
-    from atlas_brain.storage.models import *
+
+@dataclass
+class ScheduledTask:
+    id: UUID = field(default_factory=uuid4)
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/extracted_content_pipeline/storage/repositories/scheduled_task.py
+++ b/extracted_content_pipeline/storage/repositories/scheduled_task.py
@@ -1,1 +1,23 @@
-from atlas_brain.storage.repositories.scheduled_task import *
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+
+class ScheduledTaskRepository:
+    async def update_execution_metadata(
+        self,
+        exec_id: UUID,
+        metadata: dict[str, Any],
+    ) -> None:
+        return None
+
+
+_scheduled_task_repo: ScheduledTaskRepository | None = None
+
+
+def get_scheduled_task_repo() -> ScheduledTaskRepository:
+    global _scheduled_task_repo
+    if _scheduled_task_repo is None:
+        _scheduled_task_repo = ScheduledTaskRepository()
+    return _scheduled_task_repo

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -12,6 +12,7 @@ python scripts/audit_extracted_standalone.py
 pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_generation.py \
+  tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_suppression.py \
   tests/test_extracted_campaign_sequence_context.py \
   tests/test_extracted_campaign_sequence_progression.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -8,7 +8,7 @@ bash scripts/validate_extracted_content_pipeline.sh
 bash scripts/check_ascii_python.sh
 python scripts/check_extracted_imports.py
 python scripts/smoke_extracted_pipeline_imports.py
-python scripts/audit_extracted_standalone.py
+python scripts/audit_extracted_standalone.py --fail-on-debt
 pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_generation.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -11,6 +11,7 @@ python scripts/smoke_extracted_pipeline_imports.py
 python scripts/audit_extracted_standalone.py --fail-on-debt
 pytest \
   tests/test_extracted_campaign_analytics.py \
+  tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -15,6 +15,7 @@ pytest \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
+  tests/test_extracted_campaign_postgres.py \
   tests/test_extracted_campaign_suppression.py \
   tests/test_extracted_campaign_sequence_context.py \
   tests/test_extracted_campaign_sequence_progression.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -12,6 +12,7 @@ python scripts/audit_extracted_standalone.py --fail-on-debt
 pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_generation.py \
+  tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_suppression.py \
   tests/test_extracted_campaign_sequence_context.py \

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_content_llm_bridges_target_extracted_llm_infrastructure() -> None:
+    bridge_paths = [
+        "extracted_content_pipeline/pipelines/llm.py",
+        "extracted_content_pipeline/services/b2b/anthropic_batch.py",
+        "extracted_content_pipeline/services/llm/anthropic.py",
+    ]
+
+    for path in bridge_paths:
+        text = _read(path)
+        assert "extracted_llm_infrastructure" in text
+        assert "from atlas_brain" not in text
+
+
+def test_content_pipeline_still_owns_notify_bridge() -> None:
+    text = _read("extracted_content_pipeline/pipelines/notify.py")
+
+    assert "send_pipeline_notification" in text
+    assert "EXTRACTED_PIPELINE_STANDALONE" in text

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -14,9 +14,13 @@ LLM_BRIDGE_PATHS = [
 LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/pipelines/notify.py",
     "extracted_content_pipeline/reasoning/wedge_registry.py",
+    "extracted_content_pipeline/config.py",
+    "extracted_content_pipeline/skills/registry.py",
     "extracted_content_pipeline/services/__init__.py",
     "extracted_content_pipeline/services/apollo_company_overrides.py",
     "extracted_content_pipeline/services/b2b/corrections.py",
+    "extracted_content_pipeline/services/b2b/cache_runner.py",
+    "extracted_content_pipeline/services/b2b/enrichment_contract.py",
     "extracted_content_pipeline/services/blog_quality.py",
     "extracted_content_pipeline/services/company_normalization.py",
     "extracted_content_pipeline/services/protocols.py",
@@ -24,6 +28,8 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/services/scraping/universal/html_cleaner.py",
     "extracted_content_pipeline/services/tracing.py",
     "extracted_content_pipeline/services/vendor_registry.py",
+    "extracted_content_pipeline/storage/database.py",
+    "extracted_content_pipeline/storage/models.py",
 ]
 
 

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from extracted_content_pipeline.skills.registry import get_skill_registry
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -59,3 +61,23 @@ def test_extracted_pipeline_checks_enforce_zero_atlas_runtime_imports() -> None:
     text = _read("scripts/run_extracted_pipeline_checks.sh")
 
     assert "python scripts/audit_extracted_standalone.py --fail-on-debt" in text
+
+
+def test_local_skill_registry_exposes_campaign_prompt_contracts() -> None:
+    registry = get_skill_registry()
+    expected_skills = [
+        "digest/b2b_campaign_generation",
+        "digest/b2b_vendor_outreach",
+        "digest/b2b_challenger_outreach",
+        "digest/b2b_campaign_sequence",
+        "digest/b2b_vendor_sequence",
+        "digest/b2b_challenger_sequence",
+        "digest/b2b_onboarding_sequence",
+        "digest/amazon_seller_campaign_generation",
+        "digest/amazon_seller_campaign_sequence",
+    ]
+
+    for skill_name in expected_skills:
+        prompt = registry.get_prompt(skill_name)
+        assert prompt
+        assert registry.get(skill_name).content == prompt

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -5,26 +5,41 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+LLM_BRIDGE_PATHS = [
+    "extracted_content_pipeline/pipelines/llm.py",
+    "extracted_content_pipeline/services/b2b/anthropic_batch.py",
+    "extracted_content_pipeline/services/llm/anthropic.py",
+]
+
+LOCAL_UTILITY_SHIM_PATHS = [
+    "extracted_content_pipeline/pipelines/notify.py",
+    "extracted_content_pipeline/reasoning/wedge_registry.py",
+    "extracted_content_pipeline/services/__init__.py",
+    "extracted_content_pipeline/services/apollo_company_overrides.py",
+    "extracted_content_pipeline/services/b2b/corrections.py",
+    "extracted_content_pipeline/services/blog_quality.py",
+    "extracted_content_pipeline/services/company_normalization.py",
+    "extracted_content_pipeline/services/protocols.py",
+    "extracted_content_pipeline/services/scraping/sources.py",
+    "extracted_content_pipeline/services/scraping/universal/html_cleaner.py",
+    "extracted_content_pipeline/services/tracing.py",
+    "extracted_content_pipeline/services/vendor_registry.py",
+]
+
 
 def _read(relative_path: str) -> str:
     return (ROOT / relative_path).read_text(encoding="utf-8")
 
 
 def test_content_llm_bridges_target_extracted_llm_infrastructure() -> None:
-    bridge_paths = [
-        "extracted_content_pipeline/pipelines/llm.py",
-        "extracted_content_pipeline/services/b2b/anthropic_batch.py",
-        "extracted_content_pipeline/services/llm/anthropic.py",
-    ]
-
-    for path in bridge_paths:
+    for path in LLM_BRIDGE_PATHS:
         text = _read(path)
         assert "extracted_llm_infrastructure" in text
         assert "from atlas_brain" not in text
 
 
-def test_content_pipeline_still_owns_notify_bridge() -> None:
-    text = _read("extracted_content_pipeline/pipelines/notify.py")
-
-    assert "send_pipeline_notification" in text
-    assert "EXTRACTED_PIPELINE_STANDALONE" in text
+def test_local_utility_shims_do_not_delegate_to_atlas_brain() -> None:
+    for path in LOCAL_UTILITY_SHIM_PATHS:
+        text = _read(path)
+        assert "from atlas_brain" not in text
+        assert "import atlas_brain" not in text

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -13,6 +13,9 @@ LLM_BRIDGE_PATHS = [
 
 LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/pipelines/notify.py",
+    "extracted_content_pipeline/reasoning/archetypes.py",
+    "extracted_content_pipeline/reasoning/evidence_engine.py",
+    "extracted_content_pipeline/reasoning/temporal.py",
     "extracted_content_pipeline/reasoning/wedge_registry.py",
     "extracted_content_pipeline/config.py",
     "extracted_content_pipeline/skills/registry.py",
@@ -30,6 +33,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/services/vendor_registry.py",
     "extracted_content_pipeline/storage/database.py",
     "extracted_content_pipeline/storage/models.py",
+    "extracted_content_pipeline/storage/repositories/scheduled_task.py",
 ]
 
 

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -53,3 +53,9 @@ def test_local_utility_shims_do_not_delegate_to_atlas_brain() -> None:
         text = _read(path)
         assert "from atlas_brain" not in text
         assert "import atlas_brain" not in text
+
+
+def test_extracted_pipeline_checks_enforce_zero_atlas_runtime_imports() -> None:
+    text = _read("scripts/run_extracted_pipeline_checks.sh")
+
+    assert "python scripts/audit_extracted_standalone.py --fail-on-debt" in text

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_llm_client import (
+    LLMUnavailableError,
+    PipelineLLMClient,
+)
+from extracted_content_pipeline.campaign_ports import LLMMessage
+
+
+class _ChatLLM:
+    model = "chat-model"
+
+    def __init__(self):
+        self.calls = []
+
+    def chat(self, messages, *, max_tokens, temperature):
+        self.calls.append({
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        })
+        return {
+            "response": "chat response",
+            "usage": {"input_tokens": 10, "output_tokens": 4},
+        }
+
+
+class _AsyncChatLLM:
+    name = "async-chat-model"
+
+    async def chat(self, messages, *, max_tokens, temperature):
+        return {
+            "message": {"content": "async chat response"},
+            "model": "explicit-model",
+            "usage": {"input_tokens": 3},
+        }
+
+
+class _GenerateLLM:
+    model_id = "generate-model"
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, prompt, *, system_prompt=None, max_tokens, temperature):
+        self.calls.append({
+            "prompt": prompt,
+            "system_prompt": system_prompt,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        })
+        return {"message": {"content": "generated response"}}
+
+
+class _GenerateStringLLM:
+    def generate(self, prompt, *, system_prompt=None, max_tokens, temperature):
+        return "plain generated response"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_resolves_and_normalizes_chat_response():
+    llm = _ChatLLM()
+    resolver_calls = []
+
+    def resolver(**kwargs):
+        resolver_calls.append(kwargs)
+        return llm
+
+    client = PipelineLLMClient(workload="draft", resolver=resolver)
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="Write the email")],
+        max_tokens=200,
+        temperature=0.2,
+    )
+
+    assert response.content == "chat response"
+    assert response.model == "chat-model"
+    assert response.usage == {"input_tokens": 10, "output_tokens": 4}
+    assert llm.calls[0]["max_tokens"] == 200
+    assert resolver_calls[0]["workload"] == "draft"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_accepts_async_chat_result():
+    client = PipelineLLMClient(resolver=lambda **_: _AsyncChatLLM())
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="Write the email")],
+        max_tokens=200,
+        temperature=0.2,
+    )
+
+    assert response.content == "async chat response"
+    assert response.model == "explicit-model"
+    assert response.usage == {"input_tokens": 3}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_falls_back_to_generate_shape():
+    llm = _GenerateLLM()
+    client = PipelineLLMClient(resolver=lambda **_: llm)
+
+    response = await client.complete(
+        [
+            LLMMessage(role="system", content="System instructions"),
+            LLMMessage(role="user", content="Prompt body"),
+        ],
+        max_tokens=100,
+        temperature=0.4,
+    )
+
+    assert response.content == "generated response"
+    assert response.model == "generate-model"
+    assert llm.calls[0]["system_prompt"] == "System instructions"
+    assert llm.calls[0]["prompt"] == "Prompt body"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_normalizes_string_generate_response():
+    client = PipelineLLMClient(resolver=lambda **_: _GenerateStringLLM())
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="Prompt body")],
+        max_tokens=100,
+        temperature=0.4,
+    )
+
+    assert response.content == "plain generated response"
+    assert response.model is None
+    assert response.raw == "plain generated response"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_raises_when_no_llm_is_configured():
+    client = PipelineLLMClient(resolver=lambda **_: None)
+
+    with pytest.raises(LLMUnavailableError):
+        await client.complete(
+            [LLMMessage(role="user", content="Draft")],
+            max_tokens=100,
+            temperature=0.3,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_raises_when_resolved_llm_has_no_supported_method():
+    client = PipelineLLMClient(resolver=lambda **_: object())
+
+    with pytest.raises(LLMUnavailableError):
+        await client.complete(
+            [LLMMessage(role="user", content="Draft")],
+            max_tokens=100,
+            temperature=0.3,
+        )

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CORE_CAMPAIGN_MIGRATIONS = {
+    "066_b2b_campaigns.sql",
+    "068_campaign_sequences.sql",
+    "069_campaign_analytics.sql",
+    "070_campaign_suppressions.sql",
+    "073_campaign_sequence_fixes.sql",
+    "074_campaign_target_modes.sql",
+    "075_amazon_seller_campaigns.sql",
+    "090_audit_log_metadata_index.sql",
+    "104_campaign_outcomes.sql",
+    "146_campaign_score_components.sql",
+    "150_campaign_engagement_timing.sql",
+}
+
+DEFERRED_CROSS_PRODUCT_MIGRATIONS = {
+    "080_b2b_alert_baselines.sql",
+    "106_score_calibration.sql",
+    "235_vendor_targets_account_scope.sql",
+    "255_anthropic_message_batches.sql",
+}
+
+
+def _manifest_targets() -> set[str]:
+    data = json.loads((ROOT / "extracted_content_pipeline/manifest.json").read_text())
+    return {
+        Path(mapping["target"]).name
+        for mapping in data["mappings"]
+        if "/storage/migrations/" in mapping["target"]
+    }
+
+
+def test_manifest_syncs_core_campaign_schema_migrations() -> None:
+    targets = _manifest_targets()
+
+    assert CORE_CAMPAIGN_MIGRATIONS <= targets
+    for migration in CORE_CAMPAIGN_MIGRATIONS:
+        assert (ROOT / "extracted_content_pipeline/storage/migrations" / migration).exists()
+
+
+def test_deferred_cross_product_migrations_stay_out_of_core_manifest() -> None:
+    targets = _manifest_targets()
+
+    assert not (DEFERRED_CROSS_PRODUCT_MIGRATIONS & targets)
+
+
+def test_core_campaign_migrations_define_product_tables() -> None:
+    migrations_dir = ROOT / "extracted_content_pipeline/storage/migrations"
+
+    campaign_schema = (migrations_dir / "066_b2b_campaigns.sql").read_text()
+    sequence_schema = (migrations_dir / "068_campaign_sequences.sql").read_text()
+    suppression_schema = (migrations_dir / "070_campaign_suppressions.sql").read_text()
+    target_schema = (migrations_dir / "074_campaign_target_modes.sql").read_text()
+    seller_schema = (migrations_dir / "075_amazon_seller_campaigns.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS b2b_campaigns" in campaign_schema
+    assert "CREATE TABLE IF NOT EXISTS campaign_sequences" in sequence_schema
+    assert "CREATE TABLE IF NOT EXISTS campaign_audit_log" in sequence_schema
+    assert "CREATE TABLE IF NOT EXISTS campaign_suppressions" in suppression_schema
+    assert "CREATE TABLE IF NOT EXISTS vendor_targets" in target_schema
+    assert "CREATE TABLE IF NOT EXISTS seller_targets" in seller_schema

--- a/tests/test_extracted_campaign_postgres.py
+++ b/tests/test_extracted_campaign_postgres.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    CampaignDraft,
+    SendResult,
+    TenantScope,
+    WebhookEvent,
+)
+from extracted_content_pipeline.campaign_postgres import (
+    PostgresCampaignAuditSink,
+    PostgresCampaignRepository,
+    PostgresCampaignSequenceRepository,
+    PostgresSuppressionRepository,
+)
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results = ["campaign-1"]
+        self.fetch_rows = []
+        self.fetchrow_result = None
+        self.fetchval_calls = []
+        self.fetch_calls = []
+        self.fetchrow_calls = []
+        self.execute_calls = []
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": query, "args": args})
+        return self.fetchrow_result
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return "OK"
+
+
+@pytest.mark.asyncio
+async def test_campaign_repository_saves_drafts_with_scope_and_source_metadata():
+    pool = _Pool()
+    repo = PostgresCampaignRepository(pool)
+    draft = CampaignDraft(
+        target_id="target-1",
+        target_mode="vendor_retention",
+        channel="email",
+        subject="Pricing signal",
+        body="<p>Hello</p>",
+        metadata={
+            "cta": "Book time",
+            "generation_model": "model-1",
+            "source_opportunity": {
+                "company_name": "Acme",
+                "vendor_name": "HubSpot",
+                "product_category": "CRM",
+                "recipient_email": "buyer@example.com",
+            },
+        },
+    )
+
+    saved = await repo.save_drafts(
+        [draft],
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    assert saved == ("campaign-1",)
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO b2b_campaigns" in call["query"]
+    assert call["args"][:9] == (
+        "Acme",
+        "HubSpot",
+        "CRM",
+        "vendor_retention",
+        "email",
+        "Pricing signal",
+        "<p>Hello</p>",
+        "Book time",
+        "buyer@example.com",
+    )
+    metadata = json.loads(call["args"][9])
+    assert metadata["target_id"] == "target-1"
+    assert metadata["scope"] == {"account_id": "acct-1", "user_id": "user-1"}
+    assert call["args"][10] == "model-1"
+
+
+@pytest.mark.asyncio
+async def test_campaign_repository_lists_due_queued_sends():
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "campaign-1", "recipient_email": "buyer@example.com"}]
+    repo = PostgresCampaignRepository(pool)
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    rows = await repo.list_due_sends(limit=5, now=now)
+
+    assert rows == ({"id": "campaign-1", "recipient_email": "buyer@example.com"},)
+    assert "status = 'queued'" in pool.fetch_calls[0]["query"]
+    assert pool.fetch_calls[0]["args"] == (5,)
+
+
+@pytest.mark.asyncio
+async def test_campaign_repository_marks_sent_with_provider_metadata():
+    pool = _Pool()
+    repo = PostgresCampaignRepository(pool)
+    sent_at = datetime(2026, 5, 1, 15, tzinfo=timezone.utc)
+
+    await repo.mark_sent(
+        campaign_id="campaign-1",
+        result=SendResult(provider="resend", message_id="msg-1", raw={"id": "msg-1"}),
+        sent_at=sent_at,
+    )
+
+    call = pool.execute_calls[0]
+    assert "status = 'sent'" in call["query"]
+    assert call["args"][:3] == ("campaign-1", sent_at, "msg-1")
+    assert json.loads(call["args"][3]) == {
+        "send_provider": "resend",
+        "send_raw": {"id": "msg-1"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_campaign_repository_records_open_webhook_event():
+    pool = _Pool()
+    repo = PostgresCampaignRepository(pool)
+    occurred_at = datetime(2026, 5, 1, 15, tzinfo=timezone.utc)
+
+    await repo.record_webhook_event(
+        WebhookEvent(
+            provider="resend",
+            event_type="opened",
+            message_id="msg-1",
+            email="buyer@example.com",
+            occurred_at=occurred_at,
+            payload={"type": "email.opened"},
+        )
+    )
+
+    update_call, audit_call = pool.execute_calls
+    assert "opened_at = COALESCE(opened_at, $2)" in update_call["query"]
+    assert update_call["args"][:2] == ("msg-1", occurred_at)
+    assert "INSERT INTO campaign_audit_log" in audit_call["query"]
+    assert audit_call["args"][0] == "webhook_opened"
+
+
+@pytest.mark.asyncio
+async def test_sequence_repository_queues_followup_step():
+    pool = _Pool()
+    repo = PostgresCampaignSequenceRepository(pool)
+    queued_at = datetime(2026, 5, 1, 15, tzinfo=timezone.utc)
+
+    campaign_id = await repo.queue_sequence_step(
+        sequence={
+            "id": "sequence-1",
+            "company_name": "Acme",
+            "batch_id": "batch-1",
+            "recipient_email": "buyer@example.com",
+            "current_step": 1,
+            "max_steps": 4,
+        },
+        content={
+            "subject": "Following up",
+            "body": "<p>Hi</p>",
+            "cta": "Book time",
+            "step_number": 2,
+            "target_mode": "vendor_retention",
+            "product_category": "CRM",
+            "angle_reasoning": "Opened previous email.",
+        },
+        from_email="seller@example.com",
+        queued_at=queued_at,
+    )
+
+    assert campaign_id == "campaign-1"
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO b2b_campaigns" in call["query"]
+    assert call["args"][:12] == (
+        "sequence-1",
+        "Acme",
+        "batch-1",
+        "Following up",
+        "<p>Hi</p>",
+        "Book time",
+        2,
+        "buyer@example.com",
+        "seller@example.com",
+        "vendor_retention",
+        "CRM",
+        json.dumps(
+            {
+                "angle_reasoning": "Opened previous email.",
+                "sequence_context": {"current_step": 1, "max_steps": 4},
+            },
+            separators=(",", ":"),
+        ),
+    )
+    assert call["args"][12] == queued_at
+
+
+@pytest.mark.asyncio
+async def test_suppression_repository_checks_and_upserts_email_suppression():
+    pool = _Pool()
+    pool.fetchrow_result = {"id": "sup-1"}
+    repo = PostgresSuppressionRepository(pool)
+
+    assert await repo.is_suppressed(email="buyer@example.com") is True
+    await repo.add_suppression(
+        email="buyer@example.com",
+        reason="unsubscribe",
+        source="webhook",
+        campaign_id="campaign-1",
+    )
+
+    assert "LOWER(email) = LOWER($1)" in pool.fetchrow_calls[0]["query"]
+    assert "ON CONFLICT (LOWER(email))" in pool.execute_calls[0]["query"]
+    assert pool.execute_calls[0]["args"][:4] == (
+        "buyer@example.com",
+        "unsubscribe",
+        "webhook",
+        "campaign-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_audit_sink_writes_campaign_audit_log():
+    pool = _Pool()
+    sink = PostgresCampaignAuditSink(pool)
+
+    await sink.record(
+        "sent",
+        campaign_id="campaign-1",
+        sequence_id="sequence-1",
+        metadata={"provider": "resend"},
+    )
+
+    call = pool.execute_calls[0]
+    assert "INSERT INTO campaign_audit_log" in call["query"]
+    assert call["args"] == (
+        "campaign-1",
+        "sequence-1",
+        "sent",
+        json.dumps({"provider": "resend"}, separators=(",", ":")),
+    )


### PR DESCRIPTION
## Summary

First content-generation extraction follow-up after the extracted scaffolds landed. The content pipeline now delegates its LLM-facing bridge modules to `extracted_llm_infrastructure` instead of importing directly from `atlas_brain`:

- `extracted_content_pipeline.pipelines.llm`
- `extracted_content_pipeline.services.b2b.anthropic_batch`
- `extracted_content_pipeline.services.llm.anthropic`

This moves the content-generation product boundary toward the extracted LLM/cost-optimization product instead of the monolith, while preserving the existing lightweight `EXTRACTED_PIPELINE_STANDALONE=1` fallback behavior.

## Verification

- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`
  - sync validation passed
  - ASCII check passed
  - import check passed
  - smoke imports passed
  - standalone audit direct Atlas findings dropped from 34 to 31
  - extracted campaign/product tests: 78 passed

## Notes

Remaining Atlas coupling is mostly in manifest-synced copied task/helper files and non-LLM shims. This PR is intentionally narrow so the LLM dependency boundary is locked before the next productization slice.