### PR TITLE
Add competitive intelligence standalone substrate

### DIFF
--- a/extracted_competitive_intelligence/README.md
+++ b/extracted_competitive_intelligence/README.md
@@ -63,7 +63,9 @@ Set `EXTRACTED_COMP_INTEL_STANDALONE=1` to route core substrate imports away fro
 - `auth/dependencies.py` uses fail-closed standalone auth hooks
 - `services/campaign_sender.py` and `autonomous/tasks/campaign_suppression.py` use injectable product-owned ports
 - `services/protocols.py` and `pipelines/llm.py` use `extracted_llm_infrastructure`
+- `services/scraping/sources.py` owns the source enum and classification sets locally
 - MCP shared/server modules are extracted-owned and importable without the optional `mcp` package installed
+- Lazy package fallbacks fail closed in standalone mode instead of silently importing Atlas package namespaces
 
 Standalone adapters that require a host application fail closed until configured.
 

--- a/extracted_competitive_intelligence/README.md
+++ b/extracted_competitive_intelligence/README.md
@@ -37,14 +37,11 @@ Differentiator: every output is grounded in real switching signals and uses the 
 
 Plus 9 migrations: `095_b2b_vendor_registry.sql`, `099_displacement_edges_and_company_signals.sql`, `101_vendor_buyer_profiles.sql`, `147_displacement_velocity.sql`, `158_cross_vendor_conclusions.sql`, `245_cross_vendor_reasoning_synthesis.sql`, `261_b2b_competitive_sets.sql`, `262_b2b_competitive_set_runs.sql`, `263_b2b_competitive_set_run_constraints.sql`.
 
-## What's out of scope (Phase 2 / Phase 3)
+## What's out of scope (remaining Phase 3)
 
-- Standalone toggle (`EXTRACTED_COMP_INTEL_STANDALONE=1`) — no atlas_brain on `sys.path`
-- Slim settings carve-out from `atlas_brain.config`
 - Decoupling battle-card LLM calls so they consume `extracted_llm_infrastructure/` directly (LLM-infra extraction is in PR #40)
-- Decoupling email rendering / send from `atlas_brain.services.campaign_sender`
-- Replacing `is_suppressed()` callbacks to atlas_brain.autonomous.tasks.campaign_suppression with a Protocol
 - API endpoint extraction beyond the briefing endpoints (`/b2b/win-loss`, dashboard endpoints stay in atlas_brain)
+- Full runtime exercise without `atlas_brain` on `sys.path`; this slice adds the standalone substrate and smoke coverage, but deep task modules still carry Atlas-owned domain dependencies.
 
 ## Cross-product dependencies (acknowledged)
 
@@ -52,10 +49,23 @@ Plus 9 migrations: `095_b2b_vendor_registry.sql`, `099_displacement_edges_and_co
 |---|---|---|
 | **LLM Infrastructure** | extracted via PR #40 | `b2b_battle_cards.py:260` calls `pipelines.llm.call_llm_with_skill`; will rebase once PR #40 merges |
 | **Evidence claims** | atlas-core | `services/b2b/evidence_claim_*.py` is shared with churn intel — keep central |
-| **Campaign suppression** | atlas-core | `is_suppressed()` cross-call kept |
-| **Campaign sender (Resend)** | atlas-core | Email send infra stays in atlas_brain; Phase 3 introduces a provider Protocol |
+| **Campaign suppression** | injectable in standalone mode | Atlas bridge remains default; standalone mode uses a configured `SuppressionPolicy` |
+| **Campaign sender (Resend)** | injectable in standalone mode | Atlas bridge remains default; standalone mode uses a configured campaign sender |
 | **`_b2b_shared.py`** | atlas-core | Circular-import risk; not extracted |
 | **`challenger_dashboard_claims.py`** | atlas-core | Bridge module aggregating displacement claims |
+
+## Standalone toggle
+
+Set `EXTRACTED_COMP_INTEL_STANDALONE=1` to route core substrate imports away from Atlas:
+
+- `config.py` uses `extracted_competitive_intelligence._standalone.config`
+- `storage/database.py` uses `extracted_llm_infrastructure.storage.database`
+- `auth/dependencies.py` uses fail-closed standalone auth hooks
+- `services/campaign_sender.py` and `autonomous/tasks/campaign_suppression.py` use injectable product-owned ports
+- `services/protocols.py` and `pipelines/llm.py` use `extracted_llm_infrastructure`
+- MCP shared/server modules are extracted-owned and importable without the optional `mcp` package installed
+
+Standalone adapters that require a host application fail closed until configured.
 
 ## Sync workflow
 
@@ -75,12 +85,13 @@ When you change a source file under `atlas_brain/`, run the sync afterward and c
 bash scripts/run_extracted_competitive_intelligence_checks.sh
 ```
 
-Runs four checks in sequence:
+Runs five checks in sequence:
 
 1. `validate_*.sh` — byte-diff scaffold vs source (with explicit missing-source reporting)
 2. `check_ascii_python_*.sh` — every scaffolded `.py` is ASCII-only (true 0-based offsets on failure)
 3. `check_extracted_competitive_intelligence_imports.py` — relative imports either resolve inside the scaffold or are listed in `import_debt_allowlist.txt` (resolver honors `level - 1` Python semantics)
 4. `smoke_extracted_competitive_intelligence_imports.py` — every public module imports without raising
+5. `smoke_extracted_competitive_intelligence_standalone.py` — standalone-mode substrate imports resolve to extracted-owned or extracted-LLM modules
 
 ## Import debt
 

--- a/extracted_competitive_intelligence/STATUS.md
+++ b/extracted_competitive_intelligence/STATUS.md
@@ -21,12 +21,13 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 
 | Task | Notes |
 |---|---|
-| Carve a slim `CompIntelSettings` Pydantic class out of `atlas_brain/config.py` | Mix-in fields from b2b_churn (vendor_briefing_*, cross_vendor_*, competitive_intelligence_*) |
-| Local DB pool abstraction | Either share `extracted_llm_infrastructure/_standalone/database.py` from PR #40, or create a thin local wrapper |
-| Email-send provider Protocol | Replace `atlas_brain.services.campaign_sender:get_campaign_sender()` with an injectable `EmailSender` Protocol so the scaffold does not require the Resend singleton |
-| Suppression-callback Protocol | Replace `atlas_brain.autonomous.tasks.campaign_suppression:is_suppressed()` with an injectable `SuppressionPolicy` Protocol |
-| Bridge stubs gate on `EXTRACTED_COMP_INTEL_STANDALONE=1` | Mirror the LLM-infra Phase 2 pattern from PR #40 |
-| Standalone smoke script + CI | Add a second smoke that exercises the standalone path |
+| Carve a slim `CompIntelSettings` Pydantic class out of `atlas_brain/config.py` | ✅ done for config fields used by current scaffold |
+| Local DB pool abstraction | ✅ uses `extracted_llm_infrastructure.storage.database` in standalone mode |
+| Email-send provider Protocol | ✅ `services.campaign_sender` routes to injectable standalone campaign sender |
+| Suppression-callback Protocol | ✅ `autonomous.tasks.campaign_suppression` routes to injectable standalone suppression policy |
+| Bridge stubs gate on `EXTRACTED_COMP_INTEL_STANDALONE=1` | ✅ config, DB, auth, campaign sender, suppression, protocols, LLM bridge, and service package fallback |
+| Standalone smoke script + CI | ✅ `smoke_extracted_competitive_intelligence_standalone.py` runs in the local check driver |
+| MCP package import boundary | ✅ extracted MCP server/shared helpers no longer import `atlas_brain.mcp.b2b` just to import tool modules |
 
 ## Phase 3 — Decoupling 🔲 (later PRs)
 
@@ -48,6 +49,8 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 | `mcp/b2b/displacement.py` | ✅ | 🔲 | 🔲 |
 | `mcp/b2b/cross_vendor.py` | ✅ | 🔲 | 🔲 |
 | `mcp/b2b/write_intelligence.py` | ✅ | 🔲 | 🔲 |
+| `mcp/b2b/_shared.py` | n/a | ✅ | 🔲 |
+| `mcp/b2b/server.py` | n/a | ✅ | 🔲 |
 | `services/b2b/source_impact.py` | ✅ | 🔲 (mostly pure data; should be easy) | 🔲 |
 | `autonomous/tasks/b2b_battle_cards.py` | ✅ | 🔲 | 🔲 |
 | `autonomous/tasks/b2b_vendor_briefing.py` | ✅ | 🔲 | 🔲 |

--- a/extracted_competitive_intelligence/STATUS.md
+++ b/extracted_competitive_intelligence/STATUS.md
@@ -28,6 +28,8 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 | Bridge stubs gate on `EXTRACTED_COMP_INTEL_STANDALONE=1` | ✅ config, DB, auth, campaign sender, suppression, protocols, LLM bridge, and service package fallback |
 | Standalone smoke script + CI | ✅ `smoke_extracted_competitive_intelligence_standalone.py` runs in the local check driver |
 | MCP package import boundary | ✅ extracted MCP server/shared helpers no longer import `atlas_brain.mcp.b2b` just to import tool modules |
+| Source registry support module | ✅ `services.scraping.sources` is extracted-owned instead of an Atlas bridge |
+| Package-level Atlas fallbacks | ✅ standalone mode fails closed for lazy package access in services, B2B services, templates, reasoning, autonomous, and autonomous tasks |
 
 ## Phase 3 — Decoupling 🔲 (later PRs)
 
@@ -52,6 +54,7 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 | `mcp/b2b/_shared.py` | n/a | ✅ | 🔲 |
 | `mcp/b2b/server.py` | n/a | ✅ | 🔲 |
 | `services/b2b/source_impact.py` | ✅ | 🔲 (mostly pure data; should be easy) | 🔲 |
+| `services/scraping/sources.py` | n/a | ✅ | ✅ |
 | `autonomous/tasks/b2b_battle_cards.py` | ✅ | 🔲 | 🔲 |
 | `autonomous/tasks/b2b_vendor_briefing.py` | ✅ | 🔲 | 🔲 |
 | `autonomous/tasks/_b2b_cross_vendor_synthesis.py` | ✅ | 🔲 | 🔲 |

--- a/extracted_competitive_intelligence/_standalone/__init__.py
+++ b/extracted_competitive_intelligence/_standalone/__init__.py
@@ -1,0 +1,2 @@
+"""Standalone support for extracted_competitive_intelligence."""
+

--- a/extracted_competitive_intelligence/_standalone/auth.py
+++ b/extracted_competitive_intelligence/_standalone/auth.py
@@ -1,0 +1,23 @@
+"""Fail-closed auth helpers for standalone competitive intelligence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException
+
+
+@dataclass(frozen=True)
+class AuthUser:
+    user_id: str
+    account_id: str
+    email: str | None = None
+    plan: str | None = None
+
+
+def require_auth() -> AuthUser:
+    raise HTTPException(
+        status_code=501,
+        detail="Standalone auth adapter is not configured",
+    )
+

--- a/extracted_competitive_intelligence/_standalone/campaign_sender.py
+++ b/extracted_competitive_intelligence/_standalone/campaign_sender.py
@@ -1,0 +1,40 @@
+"""Campaign sender port for standalone competitive intelligence."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+class CampaignSenderNotConfigured(RuntimeError):
+    pass
+
+
+@runtime_checkable
+class CampaignSender(Protocol):
+    async def send(
+        self,
+        *,
+        to: str,
+        from_email: str,
+        subject: str,
+        body: str,
+        tags: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        ...
+
+
+_sender: CampaignSender | None = None
+
+
+def configure_campaign_sender(sender: CampaignSender | None) -> None:
+    global _sender
+    _sender = sender
+
+
+def get_campaign_sender() -> CampaignSender:
+    if _sender is None:
+        raise CampaignSenderNotConfigured(
+            "Standalone campaign sender adapter is not configured"
+        )
+    return _sender
+

--- a/extracted_competitive_intelligence/_standalone/campaign_suppression.py
+++ b/extracted_competitive_intelligence/_standalone/campaign_suppression.py
@@ -1,0 +1,32 @@
+"""Suppression policy port for standalone competitive intelligence."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+class SuppressionPolicyNotConfigured(RuntimeError):
+    pass
+
+
+@runtime_checkable
+class SuppressionPolicy(Protocol):
+    async def is_suppressed(self, pool: Any, *, email: str) -> dict[str, Any] | None:
+        ...
+
+
+_policy: SuppressionPolicy | None = None
+
+
+def configure_suppression_policy(policy: SuppressionPolicy | None) -> None:
+    global _policy
+    _policy = policy
+
+
+async def is_suppressed(pool: Any, *, email: str) -> dict[str, Any] | None:
+    if _policy is None:
+        raise SuppressionPolicyNotConfigured(
+            "Standalone suppression policy adapter is not configured"
+        )
+    return await _policy.is_suppressed(pool, email=email)
+

--- a/extracted_competitive_intelligence/_standalone/config.py
+++ b/extracted_competitive_intelligence/_standalone/config.py
@@ -1,0 +1,130 @@
+"""Standalone settings for extracted competitive intelligence."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class B2BChurnSubConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_B2B_CHURN_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    enabled: bool = True
+    intelligence_enabled: bool = True
+    intelligence_window_days: int = Field(default=365, ge=1, le=3650)
+    intelligence_min_reviews: int = Field(default=3, ge=0, le=10000)
+    intelligence_infra_blocked_sources: str = ""
+    mcp_tool_groups: str = "all"
+    competitive_set_preview_lookback_days: int = Field(default=90, ge=1, le=3650)
+    reasoning_synthesis_max_stale_days: int = Field(default=3, ge=0, le=3650)
+    reasoning_synthesis_rerun_if_missing_packet_artifacts: bool = True
+    reasoning_synthesis_rerun_if_missing_reference_ids: bool = True
+
+    openrouter_api_key: str = ""
+    anthropic_batch_enabled: bool = False
+    briefing_analyst_model: str = "anthropic/claude-sonnet-4-5"
+
+    vendor_briefing_enabled: bool = True
+    vendor_briefing_sender_name: str = "Atlas Intelligence"
+    vendor_briefing_gate_base_url: str = ""
+    vendor_briefing_gate_expiry_days: int = Field(default=7, ge=1, le=90)
+    vendor_briefing_cooldown_days: int = Field(default=30, ge=0, le=365)
+    vendor_briefing_max_per_batch: int = Field(default=25, ge=1, le=1000)
+    vendor_briefing_account_cards_enabled: bool = True
+    vendor_briefing_account_cards_max: int = Field(default=5, ge=0, le=100)
+    vendor_briefing_account_cards_reasoning_depth: str = "standard"
+    vendor_briefing_account_cards_adaptive_depth: bool = True
+    vendor_briefing_scheduled_account_cards_reasoning_depth: str = "standard"
+    vendor_briefing_scheduled_analyst_enrichment_enabled: bool = False
+
+    battle_card_cache_confidence: float = Field(default=0.72, ge=0.0, le=1.0)
+    battle_card_llm_attempts: int = Field(default=2, ge=0, le=10)
+    battle_card_llm_concurrency: int = Field(default=4, ge=1, le=64)
+    battle_card_llm_feedback_limit: int = Field(default=20, ge=1, le=1000)
+    battle_card_llm_max_tokens: int = Field(default=4000, ge=1, le=200000)
+    battle_card_llm_retry_delay_seconds: float = Field(default=2.0, ge=0.0, le=300.0)
+    battle_card_llm_temperature: float = Field(default=0.2, ge=0.0, le=2.0)
+    battle_card_llm_timeout_seconds: float = Field(default=120.0, ge=1.0, le=3600.0)
+    feature_gap_min_mentions: int = Field(default=2, ge=1, le=1000)
+    quotable_phrase_min_urgency: int = Field(default=60, ge=0, le=100)
+    reasoning_witness_highlight_limit: int = Field(default=8, ge=0, le=100)
+
+    challenger_brief_quote_candidate_limit: int = Field(default=30, ge=1, le=1000)
+    challenger_brief_quote_fallback_limit: int = Field(default=10, ge=0, le=1000)
+    challenger_brief_quote_similarity_threshold: float = Field(default=0.72, ge=0.0, le=1.0)
+    challenger_brief_report_fallback_days: int = Field(default=30, ge=1, le=3650)
+    accounts_in_motion_invalid_alternative_terms: str = ""
+
+
+class LLMSubConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_LLM_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    openrouter_reasoning_model: str = "anthropic/claude-sonnet-4-5"
+
+
+class CampaignSequenceSubConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_CAMPAIGN_SEQUENCE_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    resend_api_key: str = ""
+    resend_from_email: str = ""
+
+
+class SaasAuthSubConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_SAAS_AUTH_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    jwt_secret: str = ""
+    jwt_algorithm: str = "HS256"
+    stripe_secret_key: str = ""
+    stripe_vendor_standard_price_id: str = ""
+    stripe_vendor_pro_price_id: str = ""
+
+
+class B2BScrapeSubConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_B2B_SCRAPE_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    deferred_inventory_sources: str = ""
+
+
+class MCPSubConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_MCP_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    host: str = "127.0.0.1"
+    b2b_churn_port: int = Field(default=8062, ge=1, le=65535)
+
+
+class CompIntelSettings(BaseModel):
+    b2b_churn: B2BChurnSubConfig = Field(default_factory=B2BChurnSubConfig)
+    b2b_scrape: B2BScrapeSubConfig = Field(default_factory=B2BScrapeSubConfig)
+    campaign_sequence: CampaignSequenceSubConfig = Field(
+        default_factory=CampaignSequenceSubConfig
+    )
+    llm: LLMSubConfig = Field(default_factory=LLMSubConfig)
+    mcp: MCPSubConfig = Field(default_factory=MCPSubConfig)
+    saas_auth: SaasAuthSubConfig = Field(default_factory=SaasAuthSubConfig)
+
+
+settings = CompIntelSettings()

--- a/extracted_competitive_intelligence/_standalone/protocols.py
+++ b/extracted_competitive_intelligence/_standalone/protocols.py
@@ -1,0 +1,10 @@
+"""Protocol re-exports used by competitive-intelligence modules."""
+
+from __future__ import annotations
+
+from extracted_llm_infrastructure.services.protocols import (  # noqa: F401
+    InferenceMetrics,
+    LLMService,
+    Message,
+    ModelInfo,
+)

--- a/extracted_competitive_intelligence/auth/dependencies.py
+++ b/extracted_competitive_intelligence/auth/dependencies.py
@@ -1,23 +1,26 @@
-"""Phase 1 bridge: re-exports atlas_brain.auth.dependencies.
+"""Auth bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain.auth.dependencies. Standalone mode
+uses fail-closed local auth hooks; host apps should inject their own
+dependencies before serving routes.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.auth.dependencies")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    from .._standalone.auth import AuthUser, require_auth  # noqa: F401
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.auth.dependencies")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/autonomous/__init__.py
+++ b/extracted_competitive_intelligence/autonomous/__init__.py
@@ -19,10 +19,16 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+        raise AttributeError(
+            f"module {__name__!r} has no standalone attribute {name!r}; "
+            "register an explicit product task adapter instead"
+        )
     src = importlib.import_module("atlas_brain.autonomous")
     try:
         return getattr(src, name)

--- a/extracted_competitive_intelligence/autonomous/tasks/__init__.py
+++ b/extracted_competitive_intelligence/autonomous/tasks/__init__.py
@@ -19,10 +19,16 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+        raise AttributeError(
+            f"module {__name__!r} has no standalone attribute {name!r}; "
+            "import an extracted task module explicitly"
+        )
     src = importlib.import_module("atlas_brain.autonomous.tasks")
     try:
         return getattr(src, name)

--- a/extracted_competitive_intelligence/autonomous/tasks/campaign_suppression.py
+++ b/extracted_competitive_intelligence/autonomous/tasks/campaign_suppression.py
@@ -1,23 +1,31 @@
-"""Phase 1 bridge: re-exports atlas_brain.autonomous.tasks.campaign_suppression.
+"""Suppression bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain suppression helpers. Standalone mode
+exposes a configurable suppression policy and fails closed until a host
+adapter is registered.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.autonomous.tasks.campaign_suppression")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    from ..._standalone.campaign_suppression import (  # noqa: F401
+        SuppressionPolicy,
+        SuppressionPolicyNotConfigured,
+        configure_suppression_policy,
+        is_suppressed,
+    )
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.autonomous.tasks.campaign_suppression")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/config.py
+++ b/extracted_competitive_intelligence/config.py
@@ -1,23 +1,34 @@
-"""Phase 1 bridge: re-exports atlas_brain.config.
+"""Config bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain.config. Standalone mode uses the
+product-local settings in _standalone.config.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.config")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    from ._standalone.config import (  # noqa: F401
+        B2BChurnSubConfig,
+        B2BScrapeSubConfig,
+        CampaignSequenceSubConfig,
+        CompIntelSettings,
+        LLMSubConfig,
+        MCPSubConfig,
+        SaasAuthSubConfig,
+        settings,
+    )
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.config")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/mcp/b2b/__init__.py
+++ b/extracted_competitive_intelligence/mcp/b2b/__init__.py
@@ -1,32 +1,20 @@
-"""Phase 1 package bridge: lazily exposes names from atlas_brain.mcp.b2b.
-
-PEP 562 ``__getattr__`` resolves ``from PACKAGE import some_name`` at
-runtime by delegating to the atlas_brain peer package's __init__
-namespace. This avoids triggering the atlas_brain peer's heavy import
-chain at scaffold-load time -- e.g., importing
-``extracted_competitive_intelligence.services.vendor_registry`` no
-longer eagerly loads ``atlas_brain.services`` (which pulls in the
-torch/llm chain) just to satisfy a hypothetical
-``from ...services import llm_registry`` runtime fallback.
-
-Submodule imports of the form ``from PACKAGE import submodule_name``
-are handled by Python's native import machinery from the scaffold
-filesystem; this hook only fires for non-submodule attributes.
-
-Phase 2 replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
-"""
+"""Competitive intelligence MCP package exports."""
 from __future__ import annotations
 
 import importlib
 from typing import Any
 
+_LOCAL_EXPORTS = {
+    "mcp": "server",
+}
+
 
 def __getattr__(name: str) -> Any:
-    src = importlib.import_module("atlas_brain.mcp.b2b")
-    try:
-        return getattr(src, name)
-    except AttributeError:
+    module_name = _LOCAL_EXPORTS.get(name)
+    if module_name is None:
         raise AttributeError(
             f"module {__name__!r} has no attribute {name!r}"
         ) from None
+
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    return getattr(module, name)

--- a/extracted_competitive_intelligence/mcp/b2b/_shared.py
+++ b/extracted_competitive_intelligence/mcp/b2b/_shared.py
@@ -1,23 +1,175 @@
-"""Phase 1 bridge: re-exports atlas_brain.mcp.b2b._shared.
-
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
-"""
+"""Shared utilities for competitive intelligence MCP domain modules."""
 from __future__ import annotations
 
-import importlib as _importlib
+import json
+import logging
+import uuid as _uuid
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.mcp.b2b._shared")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+from ...services.b2b.corrections import (
+    apply_field_overrides as _apply_field_overrides,
+    suppress_predicate as _suppress_predicate,
+)
+from ...services.scraping.sources import ALL_SOURCES, ReviewSource
+
+logger = logging.getLogger("extracted_competitive_intelligence.mcp.b2b")
+
+VALID_REPORT_TYPES = (
+    "weekly_churn_feed",
+    "vendor_scorecard",
+    "displacement_report",
+    "category_overview",
+    "exploratory_overview",
+    "vendor_comparison",
+    "account_comparison",
+    "account_deep_dive",
+    "vendor_retention",
+    "challenger_intel",
+    "battle_card",
+    "accounts_in_motion",
+    "challenger_brief",
+)
+
+VALID_SOURCES = ALL_SOURCES
 
 
-_bridge()
-del _bridge, _importlib
+def get_pool():
+    """Get the initialized DB pool."""
+    from ...storage.database import get_db_pool
+
+    return get_db_pool()
+
+
+def _is_uuid(value: str) -> bool:
+    """Check if a string is a valid UUID."""
+    try:
+        _uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError):
+        return False
+
+
+def _safe_json(val):
+    """Return val if already decoded, else decode JSON strings when possible."""
+    if isinstance(val, (list, dict)):
+        return val
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return val
+
+
+def _canonical_review_predicate(alias: str = "") -> str:
+    """Return the canonical-review filter for analytics surfaces."""
+    prefix = f"{alias}." if alias else ""
+    return f"{prefix}duplicate_of_review_id IS NULL"
+
+
+TOOL_GROUPS: dict[str, list[str]] = {
+    "read_signals": [
+        "list_churn_signals",
+        "get_churn_signal",
+        "list_high_intent_companies",
+        "get_vendor_profile",
+        "search_reviews",
+        "get_review",
+        "get_product_profile",
+        "get_product_profile_history",
+        "match_products_tool",
+        "list_displacement_edges",
+        "get_displacement_history",
+        "list_vendor_pain_points",
+        "list_vendor_use_cases",
+        "list_vendor_integrations",
+        "list_vendor_buyer_profiles",
+        "get_vendor_history",
+        "list_change_events",
+        "compare_vendor_periods",
+        "list_concurrent_events",
+        "get_vendor_correlation",
+        "list_cross_vendor_conclusions",
+        "get_cross_vendor_conclusion",
+    ],
+    "read_reports": [
+        "list_reports",
+        "get_report",
+        "export_report_pdf",
+    ],
+    "reasoning": [
+        "reason_vendor",
+        "compare_vendors",
+    ],
+    "admin": [
+        "list_vendors_registry",
+        "fuzzy_vendor_search",
+        "fuzzy_company_search",
+        "add_vendor_to_registry",
+        "add_vendor_alias",
+        "list_scrape_targets",
+        "add_scrape_target",
+        "manage_scrape_target",
+        "delete_scrape_target",
+        "create_data_correction",
+        "list_data_corrections",
+        "revert_data_correction",
+        "get_data_correction",
+        "get_correction_stats",
+        "get_source_correction_impact",
+        "get_pipeline_status",
+        "get_parser_version_status",
+        "get_source_health",
+        "get_source_telemetry",
+        "get_source_capabilities",
+        "get_source_impact_ledger",
+        "get_operational_overview",
+        "get_parser_health",
+    ],
+    "calibration": [
+        "record_campaign_outcome",
+        "get_signal_effectiveness",
+        "get_outcome_distribution",
+        "trigger_score_calibration",
+        "get_calibration_weights",
+    ],
+    "webhooks": [
+        "list_webhook_subscriptions",
+        "send_test_webhook_tool",
+        "update_webhook",
+        "get_webhook_delivery_summary",
+    ],
+    "crm_events": [
+        "list_crm_pushes",
+        "list_crm_events",
+        "ingest_crm_event",
+        "get_crm_enrichment_stats",
+    ],
+    "content": [
+        "list_blog_posts",
+        "get_blog_post",
+        "list_affiliate_partners",
+    ],
+    "read_pools": [
+        "get_evidence_vault",
+        "list_evidence_vaults",
+        "get_segment_intelligence",
+        "list_segment_intelligence",
+        "get_temporal_intelligence",
+        "list_temporal_intelligence",
+        "get_displacement_dynamics",
+        "list_displacement_dynamics",
+        "get_category_dynamics",
+        "list_category_dynamics",
+        "get_account_intelligence",
+        "list_account_intelligence",
+    ],
+    "write_intelligence": [
+        "persist_conclusion",
+        "persist_report",
+        "build_challenger_brief",
+        "build_accounts_in_motion",
+    ],
+    "campaigns": [
+        "draft_campaign",
+    ],
+}

--- a/extracted_competitive_intelligence/mcp/b2b/server.py
+++ b/extracted_competitive_intelligence/mcp/b2b/server.py
@@ -1,23 +1,135 @@
-"""Phase 1 bridge: re-exports atlas_brain.mcp.b2b.server.
-
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
-"""
+"""Competitive intelligence MCP server entry point."""
 from __future__ import annotations
 
-import importlib as _importlib
+import importlib
+import sys
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any, Callable
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.mcp.b2b.server")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+from ._shared import TOOL_GROUPS, logger
 
 
-_bridge()
-del _bridge, _importlib
+class _ImportOnlyMCP:
+    """Minimal decorator registry for environments without the MCP package."""
+
+    def __init__(self, name: str, **_: Any) -> None:
+        self.name = name
+        self.settings = SimpleNamespace(host=None, port=None)
+        self.tools: dict[str, Callable[..., Any]] = {}
+
+    def tool(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            tool_name = kwargs.get("name") or getattr(func, "__name__", "")
+            if tool_name:
+                self.tools[tool_name] = func
+            return func
+
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return decorator(args[0])
+        return decorator
+
+    def remove_tool(self, name: str) -> None:
+        self.tools.pop(name, None)
+
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("The 'mcp' package is required to run the MCP server")
+
+
+@asynccontextmanager
+async def _lifespan(server: Any):
+    """Initialize DB pool on startup, close on shutdown."""
+    from ...storage.database import get_db_pool
+
+    pool = get_db_pool()
+    if hasattr(pool, "initialize"):
+        await pool.initialize()
+    logger.info("Competitive intelligence MCP: DB pool initialized")
+    yield
+    if hasattr(pool, "close"):
+        await pool.close()
+
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError:
+    FastMCP = _ImportOnlyMCP
+
+
+mcp = FastMCP(
+    "extracted-competitive-intelligence",
+    instructions=(
+        "Competitive intelligence server. Query vendor churn signals, search "
+        "enriched reviews, read intelligence reports, identify high-intent "
+        "companies, manage scrape targets, and persist competitive reports."
+    ),
+    lifespan=_lifespan,
+)
+
+
+def _apply_tool_gating(server: Any) -> None:
+    """Remove tools from groups not listed in config."""
+    try:
+        from ...config import settings
+
+        raw = getattr(settings.b2b_churn, "mcp_tool_groups", "all")
+    except Exception:
+        raw = "all"
+
+    raw = str(raw or "all").strip().lower()
+    if raw == "all":
+        return
+
+    enabled_groups = {g.strip() for g in raw.split(",") if g.strip()}
+    tools_to_remove: list[str] = []
+    for group_name, tool_names in TOOL_GROUPS.items():
+        if group_name not in enabled_groups:
+            tools_to_remove.extend(tool_names)
+
+    removed = 0
+    for name in tools_to_remove:
+        try:
+            server.remove_tool(name)
+            removed += 1
+        except Exception:
+            pass
+
+    if removed:
+        logger.info(
+            "Competitive intelligence MCP tool gating removed %d tools, enabled groups: %s",
+            removed,
+            enabled_groups,
+        )
+
+
+def _register_domain_modules() -> None:
+    """Import extracted domain modules so decorators register their tools."""
+    for module_name in (
+        "cross_vendor",
+        "displacement",
+        "vendor_registry",
+        "write_intelligence",
+    ):
+        importlib.import_module(f"{__package__}.{module_name}")
+
+
+_register_domain_modules()
+_apply_tool_gating(mcp)
+
+
+def main() -> None:
+    transport = "sse" if "--sse" in sys.argv else "stdio"
+    if transport == "sse":
+        from ...config import settings
+
+        mcp.settings.host = settings.mcp.host
+        mcp.settings.port = settings.mcp.b2b_churn_port
+    mcp.run(transport=transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/extracted_competitive_intelligence/pipelines/llm.py
+++ b/extracted_competitive_intelligence/pipelines/llm.py
@@ -1,23 +1,27 @@
-"""Phase 1 bridge: re-exports atlas_brain.pipelines.llm.
+"""LLM bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain.pipelines.llm. Standalone mode
+delegates to extracted_llm_infrastructure so competitive intelligence
+depends on the extracted LLM product instead of the monolith.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.pipelines.llm")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    _os.environ.setdefault("EXTRACTED_LLM_INFRA_STANDALONE", "1")
+    from extracted_llm_infrastructure.pipelines.llm import *  # noqa: F401,F403
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.pipelines.llm")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/reasoning/__init__.py
+++ b/extracted_competitive_intelligence/reasoning/__init__.py
@@ -19,10 +19,16 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+        raise AttributeError(
+            f"module {__name__!r} has no standalone attribute {name!r}; "
+            "import an extracted reasoning module explicitly"
+        )
     src = importlib.import_module("atlas_brain.reasoning")
     try:
         return getattr(src, name)

--- a/extracted_competitive_intelligence/services/__init__.py
+++ b/extracted_competitive_intelligence/services/__init__.py
@@ -19,10 +19,16 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+        raise AttributeError(
+            f"module {__name__!r} has no standalone attribute {name!r}; "
+            "register an explicit product adapter instead"
+        )
     src = importlib.import_module("atlas_brain.services")
     try:
         return getattr(src, name)

--- a/extracted_competitive_intelligence/services/b2b/__init__.py
+++ b/extracted_competitive_intelligence/services/b2b/__init__.py
@@ -19,10 +19,16 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+        raise AttributeError(
+            f"module {__name__!r} has no standalone attribute {name!r}; "
+            "register an explicit product service instead"
+        )
     src = importlib.import_module("atlas_brain.services.b2b")
     try:
         return getattr(src, name)

--- a/extracted_competitive_intelligence/services/b2b/corrections.py
+++ b/extracted_competitive_intelligence/services/b2b/corrections.py
@@ -1,0 +1,88 @@
+"""
+Shared correction-aware query helpers for competitive intelligence.
+
+These helpers are intentionally owned by the extracted product so API
+and MCP surfaces do not need to import Atlas service modules for basic
+suppression and override semantics.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("extracted_competitive_intelligence.services.b2b.corrections")
+
+
+def suppress_predicate(
+    entity_type: str,
+    id_expr: str = "id",
+    source_expr: str = "source",
+    vendor_expr: str = "vendor_name",
+) -> str:
+    """Return a SQL predicate that excludes active suppress corrections."""
+    pred = (
+        f"NOT EXISTS (SELECT 1 FROM data_corrections dc"
+        f" WHERE dc.entity_type = '{entity_type}' AND dc.entity_id = {id_expr}"
+        f" AND dc.correction_type = 'suppress' AND dc.status = 'applied')"
+    )
+    if entity_type == "review":
+        pred += " AND " + source_suppress_predicate(
+            source_expr=source_expr,
+            vendor_expr=vendor_expr,
+        )
+    return pred
+
+
+def source_suppress_predicate(
+    source_expr: str = "source",
+    vendor_expr: str = "vendor_name",
+) -> str:
+    """Return a SQL predicate that excludes reviews from suppressed sources."""
+    return (
+        f"NOT EXISTS (SELECT 1 FROM data_corrections dc_ss"
+        f" WHERE dc_ss.entity_type = 'source'"
+        f" AND dc_ss.correction_type = 'suppress_source'"
+        f" AND dc_ss.status = 'applied'"
+        f" AND LOWER(dc_ss.metadata->>'source_name') = LOWER({source_expr})"
+        f" AND (dc_ss.field_name IS NULL OR LOWER(dc_ss.field_name) = LOWER({vendor_expr}))"
+        f")"
+    )
+
+
+async def apply_field_overrides(
+    pool: Any,
+    entity_type: str,
+    entity_id: str,
+    result: dict,
+) -> dict:
+    """Apply active field overrides to a fetched entity result dict."""
+    rows = await pool.fetch(
+        """
+        SELECT field_name, new_value, old_value, reason, corrected_by
+        FROM data_corrections
+        WHERE entity_type = $1 AND entity_id = $2::uuid
+          AND correction_type = 'override_field' AND status = 'applied'
+        """,
+        entity_type,
+        entity_id,
+    )
+    if not rows:
+        return result
+
+    overrides: list[dict[str, str | None]] = []
+    for row in rows:
+        field = row["field_name"]
+        if field in result:
+            result[field] = row["new_value"]
+            overrides.append(
+                {
+                    "field": field,
+                    "old_value": row["old_value"],
+                    "new_value": row["new_value"],
+                    "reason": row["reason"],
+                }
+            )
+    if overrides:
+        result["_overrides_applied"] = overrides
+    return result

--- a/extracted_competitive_intelligence/services/campaign_sender.py
+++ b/extracted_competitive_intelligence/services/campaign_sender.py
@@ -1,23 +1,31 @@
-"""Phase 1 bridge: re-exports atlas_brain.services.campaign_sender.
+"""Campaign sender bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain.services.campaign_sender. Standalone
+mode exposes a configurable sender port and fails closed until a host
+adapter is registered.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.services.campaign_sender")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    from .._standalone.campaign_sender import (  # noqa: F401
+        CampaignSender,
+        CampaignSenderNotConfigured,
+        configure_campaign_sender,
+        get_campaign_sender,
+    )
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.services.campaign_sender")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/services/protocols.py
+++ b/extracted_competitive_intelligence/services/protocols.py
@@ -1,23 +1,30 @@
-"""Phase 1 bridge: re-exports atlas_brain.services.protocols.
+"""Protocol bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain.services.protocols. Standalone mode
+reuses the extracted LLM infrastructure protocol definitions.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.services.protocols")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    from .._standalone.protocols import (  # noqa: F401
+        InferenceMetrics,
+        LLMService,
+        Message,
+        ModelInfo,
+    )
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.services.protocols")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/services/scraping/sources.py
+++ b/extracted_competitive_intelligence/services/scraping/sources.py
@@ -1,23 +1,220 @@
-"""Phase 1 bridge: re-exports atlas_brain.services.scraping.sources.
-
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
-"""
+"""Canonical review source enum and classification sets."""
 from __future__ import annotations
 
-import importlib as _importlib
-
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.services.scraping.sources")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+from collections.abc import Iterable
+from enum import Enum
 
 
-_bridge()
-del _bridge, _importlib
+class ReviewSource(str, Enum):
+    G2 = "g2"
+    CAPTERRA = "capterra"
+    TRUSTRADIUS = "trustradius"
+    GARTNER = "gartner"
+    PEERSPOT = "peerspot"
+    GETAPP = "getapp"
+    PRODUCTHUNT = "producthunt"
+    TRUSTPILOT = "trustpilot"
+    REDDIT = "reddit"
+    HACKERNEWS = "hackernews"
+    GITHUB = "github"
+    YOUTUBE = "youtube"
+    STACKOVERFLOW = "stackoverflow"
+    QUORA = "quora"
+    TWITTER = "twitter"
+    RSS = "rss"
+    SOFTWARE_ADVICE = "software_advice"
+    SOURCEFORGE = "sourceforge"
+    SLASHDOT = "slashdot"
+
+
+_DISPLAY_NAMES: dict[ReviewSource, str] = {
+    ReviewSource.G2: "G2",
+    ReviewSource.CAPTERRA: "Capterra",
+    ReviewSource.TRUSTRADIUS: "TrustRadius",
+    ReviewSource.GARTNER: "Gartner",
+    ReviewSource.PEERSPOT: "PeerSpot",
+    ReviewSource.GETAPP: "GetApp",
+    ReviewSource.PRODUCTHUNT: "Product Hunt",
+    ReviewSource.TRUSTPILOT: "Trustpilot",
+    ReviewSource.REDDIT: "Reddit",
+    ReviewSource.HACKERNEWS: "Hacker News",
+    ReviewSource.GITHUB: "GitHub",
+    ReviewSource.YOUTUBE: "YouTube",
+    ReviewSource.STACKOVERFLOW: "Stack Overflow",
+    ReviewSource.QUORA: "Quora",
+    ReviewSource.TWITTER: "Twitter/X",
+    ReviewSource.RSS: "RSS",
+    ReviewSource.SOFTWARE_ADVICE: "Software Advice",
+    ReviewSource.SOURCEFORGE: "SourceForge",
+    ReviewSource.SLASHDOT: "Slashdot",
+}
+
+
+def display_name(source: str | ReviewSource) -> str:
+    """Human-readable label for a source."""
+    try:
+        member = ReviewSource(source)
+    except ValueError:
+        return str(source).title()
+    return _DISPLAY_NAMES.get(member, member.value.title())
+
+
+ALL_SOURCES: frozenset[ReviewSource] = frozenset(ReviewSource)
+
+SEARCH_SOURCES: frozenset[ReviewSource] = frozenset({
+    ReviewSource.REDDIT,
+    ReviewSource.HACKERNEWS,
+    ReviewSource.GITHUB,
+    ReviewSource.YOUTUBE,
+    ReviewSource.STACKOVERFLOW,
+    ReviewSource.QUORA,
+    ReviewSource.TWITTER,
+})
+
+SLUG_SOURCES: frozenset[ReviewSource] = frozenset({
+    ReviewSource.G2,
+    ReviewSource.CAPTERRA,
+    ReviewSource.TRUSTRADIUS,
+    ReviewSource.GARTNER,
+    ReviewSource.PEERSPOT,
+    ReviewSource.GETAPP,
+    ReviewSource.SOFTWARE_ADVICE,
+    ReviewSource.PRODUCTHUNT,
+    ReviewSource.TRUSTPILOT,
+    ReviewSource.SOURCEFORGE,
+    ReviewSource.SLASHDOT,
+})
+
+API_SOURCES: frozenset[ReviewSource] = frozenset({
+    ReviewSource.YOUTUBE,
+    ReviewSource.STACKOVERFLOW,
+    ReviewSource.PRODUCTHUNT,
+    ReviewSource.HACKERNEWS,
+    ReviewSource.GITHUB,
+    ReviewSource.RSS,
+})
+
+VERIFIED_SOURCES: frozenset[ReviewSource] = frozenset({
+    ReviewSource.G2,
+    ReviewSource.CAPTERRA,
+    ReviewSource.GARTNER,
+    ReviewSource.TRUSTRADIUS,
+    ReviewSource.PEERSPOT,
+    ReviewSource.GETAPP,
+    ReviewSource.SOFTWARE_ADVICE,
+    ReviewSource.TRUSTPILOT,
+})
+
+STRUCTURED_SOURCES: frozenset[ReviewSource] = VERIFIED_SOURCES | frozenset({
+    ReviewSource.SOURCEFORGE,
+    ReviewSource.SLASHDOT,
+})
+
+EXECUTIVE_SOURCES: frozenset[ReviewSource] = frozenset({
+    ReviewSource.G2,
+    ReviewSource.GARTNER,
+    ReviewSource.TRUSTRADIUS,
+    ReviewSource.PEERSPOT,
+    ReviewSource.GETAPP,
+})
+
+DEFAULT_ALLOWLIST_SOURCES: frozenset[ReviewSource] = frozenset({
+    ReviewSource.G2,
+    ReviewSource.GARTNER,
+    ReviewSource.TRUSTRADIUS,
+    ReviewSource.PEERSPOT,
+    ReviewSource.GETAPP,
+    ReviewSource.REDDIT,
+    ReviewSource.HACKERNEWS,
+    ReviewSource.GITHUB,
+    ReviewSource.STACKOVERFLOW,
+    ReviewSource.SLASHDOT,
+})
+
+REQUIRED_ACTIONABLE_SOURCES: frozenset[str] = frozenset({
+    ReviewSource.TRUSTRADIUS.value,
+    ReviewSource.SOFTWARE_ADVICE.value,
+})
+
+REQUIRED_SCRAPE_SOURCES: frozenset[str] = REQUIRED_ACTIONABLE_SOURCES | frozenset({
+    ReviewSource.CAPTERRA.value,
+})
+
+
+def parse_source_allowlist(raw: str) -> list[str]:
+    """Return a normalized source allowlist from a comma-separated string."""
+    return [part.strip().lower() for part in raw.split(",") if part.strip()]
+
+
+def with_required_sources(
+    sources: Iterable[str],
+    required: Iterable[str] | None = None,
+) -> list[str]:
+    """Append required sources while preserving order and deduplicating."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    required_sources = list(REQUIRED_ACTIONABLE_SOURCES if required is None else required)
+    for source in list(sources) + required_sources:
+        normalized = str(source).strip().lower()
+        if not normalized or normalized in seen:
+            continue
+        merged.append(normalized)
+        seen.add(normalized)
+    return merged
+
+
+def filter_deprecated_sources(
+    sources: Iterable[str],
+    deprecated: str | Iterable[str] | None,
+) -> list[str]:
+    """Remove deprecated sources from an allowlist while preserving order."""
+    if isinstance(deprecated, str):
+        deprecated_set = set(parse_source_allowlist(deprecated))
+    else:
+        deprecated_set = {
+            str(source).strip().lower()
+            for source in (deprecated or [])
+            if str(source).strip()
+        }
+    deprecated_set -= REQUIRED_ACTIONABLE_SOURCES
+    filtered: list[str] = []
+    seen: set[str] = set()
+    for source in sources:
+        normalized = str(source).strip().lower()
+        if not normalized or normalized in deprecated_set or normalized in seen:
+            continue
+        filtered.append(normalized)
+        seen.add(normalized)
+    return filtered
+
+
+def filter_blocked_sources(
+    sources: Iterable[str],
+    blocked: str | Iterable[str] | None,
+) -> list[str]:
+    """Remove operationally blocked sources from an allowlist."""
+    if isinstance(blocked, str):
+        blocked_set = set(parse_source_allowlist(blocked))
+    else:
+        blocked_set = {
+            str(source).strip().lower()
+            for source in (blocked or [])
+            if str(source).strip()
+        }
+    filtered: list[str] = []
+    seen: set[str] = set()
+    for source in sources:
+        normalized = str(source).strip().lower()
+        if not normalized or normalized in blocked_set or normalized in seen:
+            continue
+        filtered.append(normalized)
+        seen.add(normalized)
+    return filtered
+
+
+def is_source_allowed(source: str, allowlist_raw: str) -> bool:
+    """Return True when source is allowed by the configured allowlist."""
+    allowed = parse_source_allowlist(allowlist_raw)
+    if not allowed:
+        return True
+    return source.strip().lower() in allowed

--- a/extracted_competitive_intelligence/storage/database.py
+++ b/extracted_competitive_intelligence/storage/database.py
@@ -1,23 +1,29 @@
-"""Phase 1 bridge: re-exports atlas_brain.storage.database.
+"""Database bridge for extracted competitive intelligence.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Default mode re-exports atlas_brain.storage.database. Standalone mode
+uses the slim asyncpg wrapper from extracted_llm_infrastructure so the
+two extracted products share one database substrate.
 """
 from __future__ import annotations
 
 import importlib as _importlib
+import os as _os
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.storage.database")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+if _os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+    from extracted_llm_infrastructure.storage.database import (  # noqa: F401
+        DatabasePool,
+        get_db_pool,
+    )
+else:
+    def _bridge() -> None:
+        src = _importlib.import_module("atlas_brain.storage.database")
+        g = globals()
+        for name in dir(src):
+            if not name.startswith("__"):
+                g[name] = getattr(src, name)
 
 
-_bridge()
-del _bridge, _importlib
+    _bridge()
+    del _bridge
+
+del _importlib, _os

--- a/extracted_competitive_intelligence/templates/email/__init__.py
+++ b/extracted_competitive_intelligence/templates/email/__init__.py
@@ -19,10 +19,16 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
+        raise AttributeError(
+            f"module {__name__!r} has no standalone attribute {name!r}; "
+            "import an extracted template module explicitly"
+        )
     src = importlib.import_module("atlas_brain.templates.email")
     try:
         return getattr(src, name)

--- a/scripts/run_extracted_competitive_intelligence_checks.sh
+++ b/scripts/run_extracted_competitive_intelligence_checks.sh
@@ -8,5 +8,6 @@ bash scripts/validate_extracted_competitive_intelligence.sh
 bash scripts/check_ascii_python_competitive_intelligence.sh
 python scripts/check_extracted_competitive_intelligence_imports.py
 python scripts/smoke_extracted_competitive_intelligence_imports.py
+python scripts/smoke_extracted_competitive_intelligence_standalone.py
 
 echo "All extracted_competitive_intelligence checks passed"

--- a/scripts/smoke_extracted_competitive_intelligence_standalone.py
+++ b/scripts/smoke_extracted_competitive_intelligence_standalone.py
@@ -22,7 +22,9 @@ MODULES = [
     "extracted_competitive_intelligence.auth.dependencies",
     "extracted_competitive_intelligence.services.protocols",
     "extracted_competitive_intelligence.services.campaign_sender",
+    "extracted_competitive_intelligence.services.scraping.sources",
     "extracted_competitive_intelligence.autonomous.tasks.campaign_suppression",
+    "extracted_competitive_intelligence.mcp.b2b.vendor_registry",
     "extracted_competitive_intelligence.pipelines.llm",
     "extracted_competitive_intelligence.templates.email.vendor_briefing",
     "extracted_competitive_intelligence.services.b2b.source_impact",
@@ -71,6 +73,11 @@ def main() -> int:
             "Message",
             "extracted_llm_infrastructure._standalone.protocols",
         ),
+        (
+            "extracted_competitive_intelligence.services.scraping.sources",
+            "ReviewSource",
+            "extracted_competitive_intelligence.services.scraping.sources",
+        ),
     ]
     for module_name, attr_name, expected_prefix in checks:
         try:
@@ -78,6 +85,22 @@ def main() -> int:
         except Exception as exc:
             print(f"FAIL {module_name}.{attr_name}: {exc}", flush=True)
             failed.append(f"{module_name}.{attr_name}")
+
+    for module_name in (
+        "extracted_competitive_intelligence.services",
+        "extracted_competitive_intelligence.services.b2b",
+        "extracted_competitive_intelligence.templates.email",
+        "extracted_competitive_intelligence.reasoning",
+        "extracted_competitive_intelligence.autonomous",
+        "extracted_competitive_intelligence.autonomous.tasks",
+    ):
+        module = importlib.import_module(module_name)
+        try:
+            getattr(module, "__atlas_fallback_probe__")
+        except AttributeError:
+            continue
+        print(f"FAIL {module_name}: Atlas fallback did not fail closed", flush=True)
+        failed.append(module_name)
 
     if failed:
         print(f"Standalone smoke failed for {len(failed)} check(s)")
@@ -89,4 +112,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/smoke_extracted_competitive_intelligence_standalone.py
+++ b/scripts/smoke_extracted_competitive_intelligence_standalone.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Smoke-check the competitive-intelligence standalone substrate."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ["EXTRACTED_COMP_INTEL_STANDALONE"] = "1"
+os.environ.setdefault("EXTRACTED_LLM_INFRA_STANDALONE", "1")
+
+MODULES = [
+    "extracted_competitive_intelligence.config",
+    "extracted_competitive_intelligence.storage.database",
+    "extracted_competitive_intelligence.auth.dependencies",
+    "extracted_competitive_intelligence.services.protocols",
+    "extracted_competitive_intelligence.services.campaign_sender",
+    "extracted_competitive_intelligence.autonomous.tasks.campaign_suppression",
+    "extracted_competitive_intelligence.pipelines.llm",
+    "extracted_competitive_intelligence.templates.email.vendor_briefing",
+    "extracted_competitive_intelligence.services.b2b.source_impact",
+    "extracted_competitive_intelligence.services.b2b_competitive_sets",
+]
+
+
+def _assert_owner(module_name: str, attr_name: str, expected_prefix: str) -> None:
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr_name)
+    owner = getattr(value, "__module__", "")
+    if not owner.startswith(expected_prefix):
+        raise AssertionError(
+            f"{module_name}.{attr_name} resolved to {owner}, expected {expected_prefix}"
+        )
+
+
+def main() -> int:
+    failed: list[str] = []
+    for module_name in MODULES:
+        try:
+            importlib.import_module(module_name)
+            print(f"OK {module_name}", flush=True)
+        except Exception as exc:
+            print(f"FAIL {module_name}: {type(exc).__name__}: {exc}", flush=True)
+            failed.append(module_name)
+
+    checks = [
+        (
+            "extracted_competitive_intelligence.config",
+            "CompIntelSettings",
+            "extracted_competitive_intelligence._standalone.config",
+        ),
+        (
+            "extracted_competitive_intelligence.storage.database",
+            "DatabasePool",
+            "extracted_llm_infrastructure._standalone.database",
+        ),
+        (
+            "extracted_competitive_intelligence.auth.dependencies",
+            "AuthUser",
+            "extracted_competitive_intelligence._standalone.auth",
+        ),
+        (
+            "extracted_competitive_intelligence.services.protocols",
+            "Message",
+            "extracted_llm_infrastructure._standalone.protocols",
+        ),
+    ]
+    for module_name, attr_name, expected_prefix in checks:
+        try:
+            _assert_owner(module_name, attr_name, expected_prefix)
+        except Exception as exc:
+            print(f"FAIL {module_name}.{attr_name}: {exc}", flush=True)
+            failed.append(f"{module_name}.{attr_name}")
+
+    if failed:
+        print(f"Standalone smoke failed for {len(failed)} check(s)")
+        return 1
+
+    print("Standalone smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add standalone competitive intelligence substrate for config, auth, DB, campaign sender, suppression, protocols, and LLM bridge wiring
- replace extracted MCP B2B Atlas package/server bridge with extracted-owned shared/server modules and optional MCP import fallback
- add standalone smoke coverage to the competitive intelligence check driver and update extraction docs/status

## Validation
- `python -m py_compile extracted_competitive_intelligence/config.py extracted_competitive_intelligence/_standalone/config.py`
- `python -m py_compile extracted_competitive_intelligence/mcp/b2b/__init__.py extracted_competitive_intelligence/mcp/b2b/server.py`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`