### PR TITLE
Own competitive intelligence MCP vendor registry

### DIFF
--- a/extracted_competitive_intelligence/README.md
+++ b/extracted_competitive_intelligence/README.md
@@ -81,6 +81,11 @@ bash scripts/validate_extracted_competitive_intelligence.sh
 
 When you change a source file under `atlas_brain/`, run the sync afterward and commit the scaffold update in the same PR. The CI workflow at `.github/workflows/extracted_competitive_intelligence_checks.yml` enforces zero-drift on every PR that touches the scaffold.
 
+Modules listed under `owned` in `manifest.json` are intentionally product-owned:
+sync and byte-drift validation skip them, while ASCII and import checks still
+cover them. This is the handoff path for moving a scaffolded module from Atlas
+snapshot to extracted implementation.
+
 ## Local checks
 
 ```bash
@@ -89,7 +94,7 @@ bash scripts/run_extracted_competitive_intelligence_checks.sh
 
 Runs five checks in sequence:
 
-1. `validate_*.sh` — byte-diff scaffold vs source (with explicit missing-source reporting)
+1. `validate_*.sh` — byte-diff mapped scaffold files vs source, excluding product-owned manifest entries
 2. `check_ascii_python_*.sh` — every scaffolded `.py` is ASCII-only (true 0-based offsets on failure)
 3. `check_extracted_competitive_intelligence_imports.py` — relative imports either resolve inside the scaffold or are listed in `import_debt_allowlist.txt` (resolver honors `level - 1` Python semantics)
 4. `smoke_extracted_competitive_intelligence_imports.py` — every public module imports without raising

--- a/extracted_competitive_intelligence/STATUS.md
+++ b/extracted_competitive_intelligence/STATUS.md
@@ -30,6 +30,7 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 | MCP package import boundary | ✅ extracted MCP server/shared helpers no longer import `atlas_brain.mcp.b2b` just to import tool modules |
 | Source registry support module | ✅ `services.scraping.sources` is extracted-owned instead of an Atlas bridge |
 | Package-level Atlas fallbacks | ✅ standalone mode fails closed for lazy package access in services, B2B services, templates, reasoning, autonomous, and autonomous tasks |
+| Product-owned manifest entries | ✅ `manifest.json` supports `owned` modules that stay in ASCII/import checks but are skipped by byte-sync validation |
 
 ## Phase 3 — Decoupling 🔲 (later PRs)
 
@@ -47,7 +48,7 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 | Scaffold file | Phase 1 (snapshot) | Phase 2 (standalone-ready) | Phase 3 (decoupled) |
 |---|---|---|---|
 | `services/vendor_registry.py` | ✅ | 🔲 | 🔲 |
-| `mcp/b2b/vendor_registry.py` | ✅ | 🔲 | 🔲 |
+| `mcp/b2b/vendor_registry.py` | ✅ | ✅ | ✅ |
 | `mcp/b2b/displacement.py` | ✅ | 🔲 | 🔲 |
 | `mcp/b2b/cross_vendor.py` | ✅ | 🔲 | 🔲 |
 | `mcp/b2b/write_intelligence.py` | ✅ | 🔲 | 🔲 |

--- a/extracted_competitive_intelligence/manifest.json
+++ b/extracted_competitive_intelligence/manifest.json
@@ -1,7 +1,6 @@
 {
   "mappings": [
     {"source": "atlas_brain/services/vendor_registry.py", "target": "extracted_competitive_intelligence/services/vendor_registry.py"},
-    {"source": "atlas_brain/mcp/b2b/vendor_registry.py", "target": "extracted_competitive_intelligence/mcp/b2b/vendor_registry.py"},
     {"source": "atlas_brain/mcp/b2b/displacement.py", "target": "extracted_competitive_intelligence/mcp/b2b/displacement.py"},
     {"source": "atlas_brain/mcp/b2b/cross_vendor.py", "target": "extracted_competitive_intelligence/mcp/b2b/cross_vendor.py"},
     {"source": "atlas_brain/mcp/b2b/write_intelligence.py", "target": "extracted_competitive_intelligence/mcp/b2b/write_intelligence.py"},
@@ -24,5 +23,8 @@
     {"source": "atlas_brain/storage/migrations/261_b2b_competitive_sets.sql", "target": "extracted_competitive_intelligence/storage/migrations/261_b2b_competitive_sets.sql"},
     {"source": "atlas_brain/storage/migrations/262_b2b_competitive_set_runs.sql", "target": "extracted_competitive_intelligence/storage/migrations/262_b2b_competitive_set_runs.sql"},
     {"source": "atlas_brain/storage/migrations/263_b2b_competitive_set_run_constraints.sql", "target": "extracted_competitive_intelligence/storage/migrations/263_b2b_competitive_set_run_constraints.sql"}
+  ],
+  "owned": [
+    {"target": "extracted_competitive_intelligence/mcp/b2b/vendor_registry.py"}
   ]
 }

--- a/extracted_competitive_intelligence/mcp/b2b/vendor_registry.py
+++ b/extracted_competitive_intelligence/mcp/b2b/vendor_registry.py
@@ -35,7 +35,7 @@ async def list_vendors_registry(limit: int = 100) -> str:
     """
     limit = max(1, min(limit, 500))
     try:
-        from atlas_brain.services.vendor_registry import list_vendors
+        from ...services.vendor_registry import list_vendors
 
         vendors = await list_vendors()
         result = [
@@ -73,7 +73,7 @@ async def fuzzy_vendor_search(
     if clean_query is None:
         return json.dumps({"error": "query is required"})
     try:
-        from atlas_brain.services.vendor_registry import fuzzy_search_vendors
+        from ...services.vendor_registry import fuzzy_search_vendors
 
         results = await fuzzy_search_vendors(
             clean_query, limit=limit, min_similarity=min_similarity,
@@ -106,7 +106,7 @@ async def fuzzy_company_search(
         return json.dumps({"error": "query is required"})
     clean_vendor_name = _clean_optional_text(vendor_name)
     try:
-        from atlas_brain.services.vendor_registry import fuzzy_search_companies
+        from ...services.vendor_registry import fuzzy_search_companies
 
         results = await fuzzy_search_companies(
             clean_query, vendor_name=clean_vendor_name, limit=limit, min_similarity=min_similarity,
@@ -137,7 +137,7 @@ async def add_vendor_to_registry(
     if clean_canonical_name is None:
         return json.dumps({"success": False, "error": "canonical_name is required"})
     try:
-        from atlas_brain.services.vendor_registry import add_vendor
+        from ...services.vendor_registry import add_vendor
 
         alias_list = _clean_alias_csv(aliases)
 
@@ -175,7 +175,7 @@ async def add_vendor_alias(
     if clean_alias is None:
         return json.dumps({"success": False, "error": "alias is required"})
     try:
-        from atlas_brain.services.vendor_registry import add_alias
+        from ...services.vendor_registry import add_alias
 
         row = await add_alias(clean_canonical_name, clean_alias)
         if row is None:

--- a/scripts/check_ascii_python_competitive_intelligence.sh
+++ b/scripts/check_ascii_python_competitive_intelligence.sh
@@ -13,6 +13,10 @@ for mapping in obj["mappings"]:
     target = mapping["target"]
     if target.endswith(".py"):
         print(target)
+for entry in obj.get("owned", []):
+    target = entry["target"]
+    if target.endswith(".py"):
+        print(target)
 PY
 )
 

--- a/scripts/check_extracted_competitive_intelligence_imports.py
+++ b/scripts/check_extracted_competitive_intelligence_imports.py
@@ -33,6 +33,10 @@ def manifest_python_targets() -> list[Path]:
         ROOT / mapping["target"]
         for mapping in obj["mappings"]
         if mapping["target"].endswith(".py")
+    ] + [
+        ROOT / entry["target"]
+        for entry in obj.get("owned", [])
+        if entry["target"].endswith(".py")
     ]
 
 

--- a/scripts/smoke_extracted_competitive_intelligence_standalone.py
+++ b/scripts/smoke_extracted_competitive_intelligence_standalone.py
@@ -102,6 +102,18 @@ def main() -> int:
         print(f"FAIL {module_name}: Atlas fallback did not fail closed", flush=True)
         failed.append(module_name)
 
+    vendor_registry_path = (
+        ROOT
+        / "extracted_competitive_intelligence"
+        / "mcp"
+        / "b2b"
+        / "vendor_registry.py"
+    )
+    vendor_registry_source = vendor_registry_path.read_text()
+    if "atlas_brain.services.vendor_registry" in vendor_registry_source:
+        print("FAIL mcp.b2b.vendor_registry: still imports Atlas vendor registry", flush=True)
+        failed.append("mcp.b2b.vendor_registry")
+
     if failed:
         print(f"Standalone smoke failed for {len(failed)} check(s)")
         return 1

--- a/scripts/sync_extracted_competitive_intelligence.sh
+++ b/scripts/sync_extracted_competitive_intelligence.sh
@@ -11,11 +11,14 @@ from pathlib import Path
 
 manifest = Path("extracted_competitive_intelligence/manifest.json")
 obj = json.loads(manifest.read_text())
+owned = {entry["target"] for entry in obj.get("owned", [])}
 errors: list[str] = []
 copied = 0
 for mapping in obj["mappings"]:
     src = Path(mapping["source"])
     dst = Path(mapping["target"])
+    if mapping["target"] in owned:
+        continue
     if not src.exists():
         errors.append(
             f"missing source: {src} (target would be {dst}); "

--- a/scripts/validate_extracted_competitive_intelligence.sh
+++ b/scripts/validate_extracted_competitive_intelligence.sh
@@ -11,10 +11,13 @@ import sys
 
 manifest = Path("extracted_competitive_intelligence/manifest.json")
 obj = json.loads(manifest.read_text())
+owned = {entry["target"] for entry in obj.get("owned", [])}
 status = 0
 for mapping in obj["mappings"]:
     src = Path(mapping["source"])
     dst = Path(mapping["target"])
+    if mapping["target"] in owned:
+        continue
     if not src.exists():
         print(f"MISSING SOURCE: {src} (referenced by manifest target {dst})")
         status = 1
@@ -27,5 +30,5 @@ if status:
     print("Validation failed: run scripts/sync_extracted_competitive_intelligence.sh")
     sys.exit(1)
 
-print("Validation passed: extracted_competitive_intelligence matches atlas_brain sources")
+print("Validation passed: extracted_competitive_intelligence mapped files match atlas_brain sources")
 PY


### PR DESCRIPTION
## Summary
- mark the extracted MCP vendor registry as product-owned in the competitive intelligence manifest
- keep owned modules covered by ASCII/import checks while excluding them from byte-sync drift validation
- route MCP vendor registry tools through the extracted vendor registry service instead of Atlas
- extend standalone smoke coverage to catch regressions back to Atlas vendor registry imports

## Validation
- `python -m json.tool extracted_competitive_intelligence/manifest.json`
- `bash scripts/validate_extracted_competitive_intelligence.sh`
- `python scripts/check_extracted_competitive_intelligence_imports.py`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`