### PR TITLE
Own competitive intelligence MCP read tools

### DIFF
--- a/extracted_competitive_intelligence/README.md
+++ b/extracted_competitive_intelligence/README.md
@@ -86,6 +86,10 @@ sync and byte-drift validation skip them, while ASCII and import checks still
 cover them. This is the handoff path for moving a scaffolded module from Atlas
 snapshot to extracted implementation.
 
+The first owned MCP modules are `vendor_registry.py`, `displacement.py`, and
+`cross_vendor.py`; they are read-oriented surfaces with extracted-owned support
+dependencies.
+
 ## Local checks
 
 ```bash

--- a/extracted_competitive_intelligence/STATUS.md
+++ b/extracted_competitive_intelligence/STATUS.md
@@ -49,8 +49,8 @@ Goal: every scaffolded module is importable and runnable without `atlas_brain` o
 |---|---|---|---|
 | `services/vendor_registry.py` | ✅ | 🔲 | 🔲 |
 | `mcp/b2b/vendor_registry.py` | ✅ | ✅ | ✅ |
-| `mcp/b2b/displacement.py` | ✅ | 🔲 | 🔲 |
-| `mcp/b2b/cross_vendor.py` | ✅ | 🔲 | 🔲 |
+| `mcp/b2b/displacement.py` | ✅ | ✅ | ✅ |
+| `mcp/b2b/cross_vendor.py` | ✅ | ✅ | ✅ |
 | `mcp/b2b/write_intelligence.py` | ✅ | 🔲 | 🔲 |
 | `mcp/b2b/_shared.py` | n/a | ✅ | 🔲 |
 | `mcp/b2b/server.py` | n/a | ✅ | 🔲 |

--- a/extracted_competitive_intelligence/manifest.json
+++ b/extracted_competitive_intelligence/manifest.json
@@ -1,8 +1,6 @@
 {
   "mappings": [
     {"source": "atlas_brain/services/vendor_registry.py", "target": "extracted_competitive_intelligence/services/vendor_registry.py"},
-    {"source": "atlas_brain/mcp/b2b/displacement.py", "target": "extracted_competitive_intelligence/mcp/b2b/displacement.py"},
-    {"source": "atlas_brain/mcp/b2b/cross_vendor.py", "target": "extracted_competitive_intelligence/mcp/b2b/cross_vendor.py"},
     {"source": "atlas_brain/mcp/b2b/write_intelligence.py", "target": "extracted_competitive_intelligence/mcp/b2b/write_intelligence.py"},
     {"source": "atlas_brain/services/b2b/source_impact.py", "target": "extracted_competitive_intelligence/services/b2b/source_impact.py"},
     {"source": "atlas_brain/autonomous/tasks/b2b_battle_cards.py", "target": "extracted_competitive_intelligence/autonomous/tasks/b2b_battle_cards.py"},
@@ -25,6 +23,8 @@
     {"source": "atlas_brain/storage/migrations/263_b2b_competitive_set_run_constraints.sql", "target": "extracted_competitive_intelligence/storage/migrations/263_b2b_competitive_set_run_constraints.sql"}
   ],
   "owned": [
-    {"target": "extracted_competitive_intelligence/mcp/b2b/vendor_registry.py"}
+    {"target": "extracted_competitive_intelligence/mcp/b2b/vendor_registry.py"},
+    {"target": "extracted_competitive_intelligence/mcp/b2b/displacement.py"},
+    {"target": "extracted_competitive_intelligence/mcp/b2b/cross_vendor.py"}
   ]
 }

--- a/scripts/smoke_extracted_competitive_intelligence_standalone.py
+++ b/scripts/smoke_extracted_competitive_intelligence_standalone.py
@@ -102,17 +102,22 @@ def main() -> int:
         print(f"FAIL {module_name}: Atlas fallback did not fail closed", flush=True)
         failed.append(module_name)
 
-    vendor_registry_path = (
-        ROOT
-        / "extracted_competitive_intelligence"
-        / "mcp"
-        / "b2b"
-        / "vendor_registry.py"
+    owned_mcp_modules = (
+        "vendor_registry.py",
+        "displacement.py",
+        "cross_vendor.py",
     )
-    vendor_registry_source = vendor_registry_path.read_text()
-    if "atlas_brain.services.vendor_registry" in vendor_registry_source:
-        print("FAIL mcp.b2b.vendor_registry: still imports Atlas vendor registry", flush=True)
-        failed.append("mcp.b2b.vendor_registry")
+    for file_name in owned_mcp_modules:
+        module_path = (
+            ROOT
+            / "extracted_competitive_intelligence"
+            / "mcp"
+            / "b2b"
+            / file_name
+        )
+        if "atlas_brain." in module_path.read_text():
+            print(f"FAIL mcp.b2b.{file_name}: still imports Atlas", flush=True)
+            failed.append(f"mcp.b2b.{file_name}")
 
     if failed:
         print(f"Standalone smoke failed for {len(failed)} check(s)")


### PR DESCRIPTION
## Summary
- mark extracted MCP displacement and cross-vendor read tools as product-owned manifest entries
- keep those owned modules covered by ASCII/import/standalone smoke checks while excluding them from byte-sync drift validation
- document the first owned read-oriented MCP surfaces

## Validation
- `python -m json.tool extracted_competitive_intelligence/manifest.json`
- `bash scripts/validate_extracted_competitive_intelligence.sh`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`