### PR TITLE
Add extracted product umbrella tooling

### DIFF
--- a/.github/workflows/extracted_umbrella_checks.yml
+++ b/.github/workflows/extracted_umbrella_checks.yml
@@ -1,0 +1,33 @@
+name: Extracted Umbrella Checks
+
+on:
+  pull_request:
+    paths:
+      - "extracted/**"
+  push:
+    paths:
+      - "extracted/**"
+
+jobs:
+  extracted-umbrella-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate shared extraction scripts
+        run: |
+          python -m py_compile extracted/_shared/scripts/check_extracted_imports.py
+          bash extracted/_shared/scripts/validate_extracted.sh extracted_competitive_intelligence
+          bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure
+          bash extracted/_shared/scripts/validate_extracted.sh extracted_content_pipeline
+          bash extracted/_shared/scripts/check_ascii_python.sh extracted_competitive_intelligence
+          bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure
+          python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_competitive_intelligence
+          python extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure
+          python extracted/_shared/scripts/check_extracted_imports.py extracted_content_pipeline

--- a/extracted/METHODOLOGY.md
+++ b/extracted/METHODOLOGY.md
@@ -1,0 +1,58 @@
+# Extraction Methodology
+
+## Phase Legend
+
+| Phase | Meaning | Product bar |
+|---|---|---|
+| Phase 1 | Snapshot scaffold | Files are copied from Atlas and validated for byte equality. Atlas remains the runtime owner. |
+| Phase 2 | Standalone substrate | Core config, DB, auth, protocol, and service ports can run through extracted-owned adapters behind a standalone toggle. |
+| Phase 3 | Product-owned runtime | Modules no longer require Atlas imports for their product path. Host integrations are explicit ports. |
+
+## Manifest Model
+
+Each product owns a `manifest.json`.
+
+`mappings` entries are byte-synced from Atlas:
+
+```json
+{"source": "atlas_brain/path.py", "target": "extracted_product/path.py"}
+```
+
+`owned` entries are product-owned:
+
+```json
+{"target": "extracted_product/path.py"}
+```
+
+Owned files are skipped by byte-sync validation and sync, but still covered by
+ASCII and import checks. This is the controlled handoff from snapshot scaffold
+to product-owned implementation.
+
+## Standalone Toggle Pattern
+
+Standalone toggles must be explicit environment flags, for example:
+
+- `EXTRACTED_LLM_INFRA_STANDALONE=1`
+- `EXTRACTED_COMP_INTEL_STANDALONE=1`
+- `EXTRACTED_PIPELINE_STANDALONE=1`
+
+Default mode should preserve Atlas behavior. Standalone mode should prefer
+extracted-owned substrate and fail closed where a host application must provide
+an adapter.
+
+## Dependency Rule
+
+Cross-product dependencies should point to another extracted product when that
+product owns the capability. For example, competitive intelligence should use
+extracted LLM infrastructure for LLM protocols and routing substrate instead of
+importing Atlas LLM internals.
+
+Atlas can consume extracted products during the transition. Extracted products
+should not add new Atlas dependencies once a surface becomes product-owned.
+
+## Physical Move Rule
+
+Do not move existing `extracted_*` packages into `extracted/` while active PRs
+are modifying those packages. First add umbrella docs and shared tooling, then
+switch wrappers to shared scripts, then move one product at a time with
+compatibility imports and CI updates.

--- a/extracted/README.md
+++ b/extracted/README.md
@@ -1,0 +1,55 @@
+# Extracted Products
+
+This directory is the coordination layer for sellable systems being extracted
+from Atlas. It does not replace the current `extracted_*` package directories
+yet. Physical package moves should happen only after active product PRs are
+merged and compatibility wrappers are planned.
+
+## Current Products
+
+| Product | Current path | Phase | Notes |
+|---|---|---|---|
+| LLM Infrastructure | `extracted_llm_infrastructure/` | Phase 2 | Standalone substrate landed; provider-level decoupling remains Phase 3. |
+| Competitive Intelligence | `extracted_competitive_intelligence/` | Phase 2 | Standalone substrate landed; selected MCP read surfaces are product-owned. |
+| Content Pipeline | `extracted_content_pipeline/` | Phase 2 in progress | Active PR work exists; do not physically move while PR #43 is active. |
+| Quality Gate | planned | Not started | ProductClaim engine and frontend approval gate candidate. |
+| Intent Router | planned | Not started | Semantic routing, memory quality, and tool registry candidate. |
+
+## Layout Intent
+
+The long-term layout is:
+
+```text
+extracted/
+  _shared/
+    scripts/
+    docs/
+    _standalone/
+  competitive_intelligence/
+  llm_infrastructure/
+  content_pipeline/
+  quality_gate/
+  intent_router/
+```
+
+The current PR only adds the coordination layer and shared tooling. Existing
+package import paths stay unchanged.
+
+## Shared Tooling
+
+Shared scripts live in `extracted/_shared/scripts/` and accept a product
+directory such as `extracted_competitive_intelligence`.
+
+```bash
+python extracted/_shared/scripts/check_extracted_imports.py extracted_competitive_intelligence
+bash extracted/_shared/scripts/validate_extracted.sh extracted_competitive_intelligence
+bash extracted/_shared/scripts/check_ascii_python.sh extracted_competitive_intelligence
+```
+
+Use `--no-atlas-fallback` with `check_extracted_imports.py` for products that
+have moved to strict extracted-only relative import resolution. Products still
+in early scaffold mode can omit the flag to match the current LLM-infrastructure
+transition behavior.
+
+Existing per-product scripts remain the CI entry points until a later migration
+switches them to call the shared scripts.

--- a/extracted/_shared/docs/cross_product_dependency_graph.md
+++ b/extracted/_shared/docs/cross_product_dependency_graph.md
@@ -1,0 +1,23 @@
+# Cross-Product Dependency Graph
+
+This document tracks intended extracted-product dependencies. It is not a
+runtime import map yet; it is the source of truth for extraction direction.
+
+## Products
+
+| Product | Current package | Intended dependencies |
+|---|---|---|
+| LLM Infrastructure | `extracted_llm_infrastructure` | Shared standalone substrate only |
+| Competitive Intelligence | `extracted_competitive_intelligence` | LLM Infrastructure, host email/suppression adapters |
+| Content Pipeline | `extracted_content_pipeline` | LLM Infrastructure, host publishing/storage adapters |
+| Quality Gate | planned | LLM Infrastructure, Content Pipeline |
+| Intent Router | planned | LLM Infrastructure, shared memory/tool registry |
+
+## Current Notes
+
+- Competitive Intelligence already uses extracted LLM substrate in standalone
+  mode for protocols and LLM bridge wiring.
+- Content Pipeline is active in PR #43; avoid physical package moves until that
+  work lands.
+- Shared scripts under `extracted/_shared/scripts/` are safe to use before the
+  physical package consolidation.

--- a/extracted/_shared/scripts/check_ascii_python.sh
+++ b/extracted/_shared/scripts/check_ascii_python.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <product_dir>" >&2
+  exit 2
+fi
+
+PRODUCT_DIR="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+mapfile -t files < <(python - "$PRODUCT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+product = Path(sys.argv[1])
+obj = json.loads((product / "manifest.json").read_text())
+for mapping in obj["mappings"]:
+    target = mapping["target"]
+    if target.endswith(".py"):
+        print(target)
+for entry in obj.get("owned", []):
+    target = entry["target"]
+    if target.endswith(".py"):
+        print(target)
+PY
+)
+
+status=0
+for file in "${files[@]}"; do
+  if ! python - "$file" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = path.read_bytes()
+violations = [(idx, b) for idx, b in enumerate(data) if b > 0x7F]
+if violations:
+    print(path)
+    for idx, b in violations[:20]:
+        print(f"  byte_offset={idx} value=0x{b:02X}")
+    sys.exit(1)
+PY
+  then
+    status=1
+  fi
+done
+
+if [[ "$status" -ne 0 ]]; then
+  echo "ASCII check failed"
+  exit 1
+fi
+
+echo "ASCII check passed for $PRODUCT_DIR Python files"

--- a/extracted/_shared/scripts/check_extracted_imports.py
+++ b/extracted/_shared/scripts/check_extracted_imports.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Audit relative imports inside an extracted product scaffold."""
+
+from __future__ import annotations
+
+import ast
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def manifest_python_targets(product: Path) -> list[Path]:
+    obj = json.loads((product / "manifest.json").read_text())
+    targets = [
+        ROOT / mapping["target"]
+        for mapping in obj["mappings"]
+        if mapping["target"].endswith(".py")
+    ]
+    targets.extend(
+        ROOT / entry["target"]
+        for entry in obj.get("owned", [])
+        if entry["target"].endswith(".py")
+    )
+    return targets
+
+
+def resolve_relative(
+    module_path: Path,
+    product: Path,
+    level: int,
+    module: str | None,
+    allow_atlas_fallback: bool,
+) -> list[Path]:
+    base_parts = list(module_path.relative_to(ROOT).parts)
+    package_parts = base_parts[:-1]
+    ascend = max(0, level - 1)
+    target_parts = package_parts[: max(0, len(package_parts) - ascend)]
+    if module:
+        target_parts.extend(module.split("."))
+
+    rel = Path(*target_parts) if target_parts else Path()
+    candidates = [
+        (ROOT / rel).with_suffix(".py"),
+        ROOT / rel / "__init__.py",
+    ]
+    if allow_atlas_fallback and target_parts and target_parts[0] == product.name:
+        atlas_rel = Path("atlas_brain", *target_parts[1:])
+        candidates.extend([
+            (ROOT / atlas_rel).with_suffix(".py"),
+            ROOT / atlas_rel / "__init__.py",
+        ])
+    return candidates
+
+
+def load_allowlist(product: Path) -> set[str]:
+    path = product / "import_debt_allowlist.txt"
+    if not path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def check_file(
+    path: Path,
+    product: Path,
+    allowlist: set[str],
+    allow_atlas_fallback: bool,
+) -> list[str]:
+    errors: list[str] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level > 0:
+            candidates = resolve_relative(
+                path,
+                product,
+                node.level,
+                node.module,
+                allow_atlas_fallback,
+            )
+            if not any(candidate.exists() for candidate in candidates):
+                mod = f"{'.' * node.level}{node.module or ''}"
+                if mod not in allowlist:
+                    errors.append(f"{path}: unresolved relative import '{mod}'")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("product_dir")
+    parser.add_argument(
+        "--no-atlas-fallback",
+        action="store_true",
+        help="Require relative imports to resolve inside the extracted product only.",
+    )
+    args = parser.parse_args(argv[1:])
+
+    product = Path(args.product_dir)
+    manifest = product / "manifest.json"
+    if not manifest.exists():
+        print(f"ERROR missing manifest: {manifest}", file=sys.stderr)
+        return 2
+
+    py_files = manifest_python_targets(product)
+    allowlist = load_allowlist(product)
+    errors: list[str] = []
+    for file_path in py_files:
+        errors.extend(
+            check_file(
+                file_path,
+                product,
+                allowlist,
+                allow_atlas_fallback=not args.no_atlas_fallback,
+            )
+        )
+
+    if errors:
+        print("Import check failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"Import check passed for {len(py_files)} {product} module(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/extracted/_shared/scripts/sync_extracted.sh
+++ b/extracted/_shared/scripts/sync_extracted.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <product_dir>" >&2
+  exit 2
+fi
+
+PRODUCT_DIR="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+python - "$PRODUCT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+product = Path(sys.argv[1])
+manifest = product / "manifest.json"
+if not manifest.exists():
+    print(f"ERROR missing manifest: {manifest}", file=sys.stderr)
+    sys.exit(2)
+
+obj = json.loads(manifest.read_text())
+owned = {entry["target"] for entry in obj.get("owned", [])}
+errors: list[str] = []
+copied = 0
+
+for mapping in obj["mappings"]:
+    if mapping["target"] in owned:
+        continue
+    src = Path(mapping["source"])
+    dst = Path(mapping["target"])
+    if not src.exists():
+        errors.append(
+            f"missing source: {src} (target would be {dst}); "
+            "fix the manifest entry before re-running sync"
+        )
+        continue
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_bytes(src.read_bytes())
+    copied += 1
+
+if errors:
+    for line in errors:
+        print(f"ERROR {line}")
+    print(f"Sync failed: {len(errors)} missing source(s); {copied} target(s) refreshed")
+    sys.exit(1)
+
+print(f"{product} refreshed from atlas_brain sources ({copied} files)")
+PY

--- a/extracted/_shared/scripts/validate_extracted.sh
+++ b/extracted/_shared/scripts/validate_extracted.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <product_dir>" >&2
+  exit 2
+fi
+
+PRODUCT_DIR="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+python - "$PRODUCT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+product = Path(sys.argv[1])
+manifest = product / "manifest.json"
+if not manifest.exists():
+    print(f"ERROR missing manifest: {manifest}", file=sys.stderr)
+    sys.exit(2)
+
+obj = json.loads(manifest.read_text())
+owned = {entry["target"] for entry in obj.get("owned", [])}
+status = 0
+
+for mapping in obj["mappings"]:
+    if mapping["target"] in owned:
+        continue
+    src = Path(mapping["source"])
+    dst = Path(mapping["target"])
+    if not src.exists():
+        print(f"MISSING SOURCE: {src} (referenced by manifest target {dst})")
+        status = 1
+        continue
+    if not dst.exists() or src.read_bytes() != dst.read_bytes():
+        print(f"OUT OF SYNC: {dst}")
+        status = 1
+
+if status:
+    print(f"Validation failed: run extracted/_shared/scripts/sync_extracted.sh {product}")
+    sys.exit(1)
+
+print(f"Validation passed: mapped files for {product} match atlas_brain sources")
+PY


### PR DESCRIPTION
## Summary
- add non-breaking `extracted/` umbrella docs for product phases, methodology, and dependency direction
- add shared extraction scripts for sync, validate, ASCII, and relative-import checks
- keep current `extracted_*` packages and per-product CI entry points unchanged to avoid conflicts with active extraction PRs

## Validation
- `bash extracted/_shared/scripts/validate_extracted.sh extracted_competitive_intelligence`
- `bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure`
- `bash extracted/_shared/scripts/validate_extracted.sh extracted_content_pipeline`
- `bash extracted/_shared/scripts/check_ascii_python.sh extracted_competitive_intelligence`
- `bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure`
- `python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_competitive_intelligence`
- `python extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure`
- `python extracted/_shared/scripts/check_extracted_imports.py extracted_content_pipeline`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`
- `bash scripts/run_extracted_llm_infrastructure_checks.sh`

Note: shared ASCII check intentionally exposes existing non-ASCII in some content-pipeline manifest files; this PR does not modify content pipeline files while PR #43 is active.