### PR TITLE
Route competitive extraction scripts through shared tooling

### DIFF
--- a/scripts/check_ascii_python_competitive_intelligence.sh
+++ b/scripts/check_ascii_python_competitive_intelligence.sh
@@ -4,44 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-mapfile -t files < <(python - <<'PY'
-import json
-from pathlib import Path
-manifest = Path("extracted_competitive_intelligence/manifest.json")
-obj = json.loads(manifest.read_text())
-for mapping in obj["mappings"]:
-    target = mapping["target"]
-    if target.endswith(".py"):
-        print(target)
-for entry in obj.get("owned", []):
-    target = entry["target"]
-    if target.endswith(".py"):
-        print(target)
-PY
-)
-
-status=0
-for file in "${files[@]}"; do
-  if ! python - "$file" <<'PY'
-import sys
-from pathlib import Path
-path = Path(sys.argv[1])
-data = path.read_bytes()
-violations = [(idx, b) for idx, b in enumerate(data) if b > 0x7F]
-if violations:
-    print(path)
-    for idx, b in violations[:20]:
-        print(f"  byte_offset={idx} value=0x{b:02X}")
-    sys.exit(1)
-PY
-  then
-    status=1
-  fi
-done
-
-if [[ "$status" -ne 0 ]]; then
-  echo "ASCII check failed"
-  exit 1
-fi
-
-echo "ASCII check passed for extracted_competitive_intelligence Python files"
+bash extracted/_shared/scripts/check_ascii_python.sh extracted_competitive_intelligence

--- a/scripts/check_extracted_competitive_intelligence_imports.py
+++ b/scripts/check_extracted_competitive_intelligence_imports.py
@@ -1,116 +1,22 @@
 #!/usr/bin/env python3
-"""Audit relative imports inside the extracted_competitive_intelligence
-scaffold.
-
-For each Python file in the manifest, walk its AST and verify that every
-``from .x import y`` style import resolves to a real path inside the
-scaffold itself. The resolver is strict: it does NOT fall back to the
-parallel ``atlas_brain`` tree, because Python's relative-import
-machinery does not either. Missing scaffold dependencies must be
-materialized as bridge stub modules (which re-export from atlas_brain),
-not papered over via fallback. Imports that genuinely cannot be
-resolved must be listed in
-``extracted_competitive_intelligence/import_debt_allowlist.txt`` or
-this script fails.
-
-Mirrors the LLM-infra checker (PR #40) including the resolver fix:
-ascends ``level - 1`` package components rather than ``level``.
-"""
+"""Compatibility wrapper for the shared competitive-intelligence import check."""
 from __future__ import annotations
 
-import ast
-import json
+import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-SCAFFOLD = ROOT / "extracted_competitive_intelligence"
-
-
-def manifest_python_targets() -> list[Path]:
-    obj = json.loads((SCAFFOLD / "manifest.json").read_text())
-    return [
-        ROOT / mapping["target"]
-        for mapping in obj["mappings"]
-        if mapping["target"].endswith(".py")
-    ] + [
-        ROOT / entry["target"]
-        for entry in obj.get("owned", [])
-        if entry["target"].endswith(".py")
-    ]
-
-
-def resolve_relative(module_path: Path, level: int, module: str | None) -> list[Path]:
-    """Return candidate filesystem locations for a relative import.
-
-    Honors Python relative-import semantics: ``level=1`` means current
-    package (sibling of importing file), ``level=2`` means parent
-    package, etc. Ascend = ``level - 1`` package components.
-
-    Phase 1 deliberately does NOT fall back to ``atlas_brain`` paths
-    here -- Python's relative-import machinery never falls through to a
-    sibling top-level package at runtime, so a "valid" atlas_brain hit
-    would mask a real scaffold gap that crashes the smoke-import step.
-    Every scaffolded relative import must resolve to a file inside the
-    scaffold itself; missing dependencies become bridge stubs, not
-    silent atlas_brain hits.
-    """
-    base_parts = list(module_path.relative_to(ROOT).parts)
-    package_parts = base_parts[:-1]
-    ascend = max(0, level - 1)
-    target_parts = package_parts[: max(0, len(package_parts) - ascend)]
-    if module:
-        target_parts.extend(module.split("."))
-
-    rel = Path(*target_parts) if target_parts else Path()
-    candidates: list[Path] = [
-        (ROOT / rel).with_suffix(".py"),
-        ROOT / rel / "__init__.py",
-    ]
-    return candidates
-
-
-def load_allowlist() -> set[str]:
-    path = SCAFFOLD / "import_debt_allowlist.txt"
-    if not path.exists():
-        return set()
-    return {
-        line.strip()
-        for line in path.read_text().splitlines()
-        if line.strip() and not line.strip().startswith("#")
-    }
-
-
-def check_file(path: Path, allowlist: set[str]) -> list[str]:
-    errors: list[str] = []
-    tree = ast.parse(path.read_text(), filename=str(path))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.level > 0:
-            candidates = resolve_relative(path, node.level, node.module)
-            if not any(c.exists() for c in candidates):
-                mod = f"{'.' * node.level}{node.module or ''}"
-                if mod not in allowlist:
-                    errors.append(f"{path}: unresolved relative import '{mod}'")
-    return errors
 
 
 def main() -> int:
-    py_files = manifest_python_targets()
-    allowlist = load_allowlist()
-    errors: list[str] = []
-    for f in py_files:
-        errors.extend(check_file(f, allowlist))
-
-    if errors:
-        print("Import check failed:")
-        for e in errors:
-            print(f"  - {e}")
-        return 1
-
-    print(
-        f"Import check passed for {len(py_files)} extracted_competitive_intelligence module(s)"
-    )
-    return 0
+    cmd = [
+        sys.executable,
+        str(ROOT / "extracted" / "_shared" / "scripts" / "check_extracted_imports.py"),
+        "--no-atlas-fallback",
+        "extracted_competitive_intelligence",
+    ]
+    return subprocess.call(cmd, cwd=ROOT)
 
 
 if __name__ == "__main__":

--- a/scripts/sync_extracted_competitive_intelligence.sh
+++ b/scripts/sync_extracted_competitive_intelligence.sh
@@ -4,36 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python - <<'PY'
-import json
-import sys
-from pathlib import Path
-
-manifest = Path("extracted_competitive_intelligence/manifest.json")
-obj = json.loads(manifest.read_text())
-owned = {entry["target"] for entry in obj.get("owned", [])}
-errors: list[str] = []
-copied = 0
-for mapping in obj["mappings"]:
-    src = Path(mapping["source"])
-    dst = Path(mapping["target"])
-    if mapping["target"] in owned:
-        continue
-    if not src.exists():
-        errors.append(
-            f"missing source: {src} (target would be {dst}); "
-            "fix the manifest entry before re-running sync"
-        )
-        continue
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    dst.write_bytes(src.read_bytes())
-    copied += 1
-
-if errors:
-    for line in errors:
-        print(f"ERROR {line}")
-    print(f"Sync failed: {len(errors)} missing source(s); {copied} target(s) refreshed")
-    sys.exit(1)
-
-print(f"extracted_competitive_intelligence refreshed from atlas_brain sources ({copied} files)")
-PY
+bash extracted/_shared/scripts/sync_extracted.sh extracted_competitive_intelligence

--- a/scripts/validate_extracted_competitive_intelligence.sh
+++ b/scripts/validate_extracted_competitive_intelligence.sh
@@ -4,31 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python - <<'PY'
-import json
-from pathlib import Path
-import sys
-
-manifest = Path("extracted_competitive_intelligence/manifest.json")
-obj = json.loads(manifest.read_text())
-owned = {entry["target"] for entry in obj.get("owned", [])}
-status = 0
-for mapping in obj["mappings"]:
-    src = Path(mapping["source"])
-    dst = Path(mapping["target"])
-    if mapping["target"] in owned:
-        continue
-    if not src.exists():
-        print(f"MISSING SOURCE: {src} (referenced by manifest target {dst})")
-        status = 1
-        continue
-    if not dst.exists() or src.read_bytes() != dst.read_bytes():
-        print(f"OUT OF SYNC: {dst}")
-        status = 1
-
-if status:
-    print("Validation failed: run scripts/sync_extracted_competitive_intelligence.sh")
-    sys.exit(1)
-
-print("Validation passed: extracted_competitive_intelligence mapped files match atlas_brain sources")
-PY
+bash extracted/_shared/scripts/validate_extracted.sh extracted_competitive_intelligence


### PR DESCRIPTION
## Summary
- replace competitive-intelligence sync/validate/ASCII/import script bodies with thin wrappers around `extracted/_shared/scripts`
- preserve strict import behavior with `--no-atlas-fallback`
- keep existing script names and CI entry points stable

## Validation
- `python -m py_compile scripts/check_extracted_competitive_intelligence_imports.py`
- `bash scripts/validate_extracted_competitive_intelligence.sh`
- `bash scripts/sync_extracted_competitive_intelligence.sh`
- `bash scripts/check_ascii_python_competitive_intelligence.sh`
- `python scripts/check_extracted_competitive_intelligence_imports.py`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`
- `bash extracted/_shared/scripts/validate_extracted.sh extracted_competitive_intelligence`
- `python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_competitive_intelligence`