### PR TITLE
Route LLM infrastructure scripts through shared tooling

### DIFF
--- a/extracted_llm_infrastructure/README.md
+++ b/extracted_llm_infrastructure/README.md
@@ -73,7 +73,8 @@ Env vars match atlas_brain (`ATLAS_LLM_*`, `ATLAS_B2B_CHURN_*`,
 
 ## Sync workflow
 
-The scaffold must stay byte-equal with the `atlas_brain/` source. Two scripts maintain that invariant:
+The scaffold must stay byte-equal with the `atlas_brain/` source. Two scripts
+maintain that invariant while preserving the stable per-product entry points:
 
 ```bash
 # Re-copy from atlas_brain into the scaffold (idempotent; safe to re-run)
@@ -85,18 +86,23 @@ bash scripts/validate_extracted_llm_infrastructure.sh
 
 When you change a source file under `atlas_brain/`, run the sync afterward and commit the scaffold update in the same PR. The CI workflow `.github/workflows/extracted_llm_infrastructure_checks.yml` enforces zero-drift on every PR that touches the scaffold.
 
+These per-product scripts are thin wrappers over the shared extraction tooling
+in `extracted/_shared/scripts/`.
+
 ## Local checks
 
 ```bash
 bash scripts/run_extracted_llm_infrastructure_checks.sh
 ```
 
-Runs four checks in sequence:
+Runs five checks in sequence:
 
 1. `validate_extracted_llm_infrastructure.sh` — byte-diff scaffold vs source
 2. `check_ascii_python_llm_infrastructure.sh` — every scaffolded `.py` is ASCII-only
 3. `check_extracted_llm_infrastructure_imports.py` — relative imports either resolve inside the scaffold or are listed in `import_debt_allowlist.txt`
 4. `smoke_extracted_llm_infrastructure_imports.py` — every public module imports without raising
+5. `smoke_extracted_llm_infrastructure_standalone.py` — standalone substrate
+   imports use `extracted_llm_infrastructure._standalone`
 
 ## Import debt
 

--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -8,8 +8,8 @@
 | Verbatim byte-snapshot of 14 Python files | ✅ done |
 | Verbatim byte-snapshot of 6 migration SQL files | ✅ done |
 | Package `__init__.py` files at every level | ✅ done |
-| Sync + validate scripts | ✅ done |
-| ASCII / smoke-import / import-debt checks | ✅ done |
+| Sync + validate scripts | ✅ done via shared tooling wrappers |
+| ASCII / smoke-import / import-debt checks | ✅ done via shared tooling wrappers |
 | Driver script `run_extracted_llm_infrastructure_checks.sh` | ✅ done |
 | GitHub Actions workflow | ✅ done |
 | README + this STATUS file | ✅ done |

--- a/scripts/check_ascii_python_llm_infrastructure.sh
+++ b/scripts/check_ascii_python_llm_infrastructure.sh
@@ -4,45 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# Collect every .py file under the scaffold dynamically. The list comes
-# from the manifest's Python targets so a future addition gets covered
-# without touching this script.
-mapfile -t files < <(python - <<'PY'
-import json
-from pathlib import Path
-manifest = Path("extracted_llm_infrastructure/manifest.json")
-obj = json.loads(manifest.read_text())
-for mapping in obj["mappings"]:
-    target = mapping["target"]
-    if target.endswith(".py"):
-        print(target)
-PY
-)
-
-status=0
-for file in "${files[@]}"; do
-  if ! python - "$file" <<'PY'
-import sys
-from pathlib import Path
-path = Path(sys.argv[1])
-data = path.read_bytes()
-# Report 0-based byte offsets so editors / hex tools (which seek to a
-# zero-based index) point to the right byte without an off-by-one.
-violations = [(idx, b) for idx, b in enumerate(data) if b > 0x7F]
-if violations:
-    print(path)
-    for idx, b in violations[:20]:
-        print(f"  byte_offset={idx} value=0x{b:02X}")
-    sys.exit(1)
-PY
-  then
-    status=1
-  fi
-done
-
-if [[ "$status" -ne 0 ]]; then
-  echo "ASCII check failed"
-  exit 1
-fi
-
-echo "ASCII check passed for extracted_llm_infrastructure Python files"
+bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure

--- a/scripts/check_extracted_llm_infrastructure_imports.py
+++ b/scripts/check_extracted_llm_infrastructure_imports.py
@@ -1,113 +1,21 @@
 #!/usr/bin/env python3
-"""Audit relative imports inside the extracted_llm_infrastructure scaffold.
-
-For each Python file in the manifest, walk its AST and verify that every
-``from .x import y`` style import resolves to a real path -- either inside
-the scaffold itself, or, during the Phase 1 transition, inside
-``atlas_brain`` via the same parent path. Imports that cannot be resolved
-must be listed in ``extracted_llm_infrastructure/import_debt_allowlist.txt``
-or this script fails.
-
-This is the Phase 1 trip-wire: it documents (in the allowlist) every
-atlas_brain import the scaffold still depends on. Phase 2 work shrinks
-the allowlist.
-"""
+"""Compatibility wrapper for the shared LLM-infrastructure import check."""
 from __future__ import annotations
 
-import ast
-import json
+import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-SCAFFOLD = ROOT / "extracted_llm_infrastructure"
-
-
-def manifest_python_targets() -> list[Path]:
-    obj = json.loads((SCAFFOLD / "manifest.json").read_text())
-    return [
-        ROOT / mapping["target"]
-        for mapping in obj["mappings"]
-        if mapping["target"].endswith(".py")
-    ]
-
-
-def resolve_relative(module_path: Path, level: int, module: str | None) -> list[Path]:
-    """Return candidate filesystem locations for a relative import.
-
-    Honors Python's actual relative-import semantics: ``level=1`` means
-    "current package" (sibling of the importing file), ``level=2`` means
-    "parent package", ``level=3`` means "grandparent", etc. The ascend
-    is therefore ``level - 1`` package components, not ``level``.
-
-    Tries inside the scaffold first, then falls back to the atlas_brain
-    root. The scaffold and atlas_brain mirror the same package
-    hierarchy under their root, so a `from ..config import settings` in
-    a copied file resolves to ``atlas_brain.config`` only when the
-    scaffold lacks the equivalent path.
-    """
-    base_parts = list(module_path.relative_to(ROOT).parts)
-    package_parts = base_parts[:-1]
-    ascend = max(0, level - 1)
-    target_parts = package_parts[: max(0, len(package_parts) - ascend)]
-    if module:
-        target_parts.extend(module.split("."))
-
-    rel = Path(*target_parts) if target_parts else Path()
-    candidates: list[Path] = []
-
-    candidates.append((ROOT / rel).with_suffix(".py"))
-    candidates.append(ROOT / rel / "__init__.py")
-
-    if target_parts and target_parts[0] == "extracted_llm_infrastructure":
-        atlas_rel = Path("atlas_brain", *target_parts[1:])
-        candidates.append((ROOT / atlas_rel).with_suffix(".py"))
-        candidates.append(ROOT / atlas_rel / "__init__.py")
-
-    return candidates
-
-
-def load_allowlist() -> set[str]:
-    path = SCAFFOLD / "import_debt_allowlist.txt"
-    if not path.exists():
-        return set()
-    return {
-        line.strip()
-        for line in path.read_text().splitlines()
-        if line.strip() and not line.strip().startswith("#")
-    }
-
-
-def check_file(path: Path, allowlist: set[str]) -> list[str]:
-    errors: list[str] = []
-    tree = ast.parse(path.read_text(), filename=str(path))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.level > 0:
-            candidates = resolve_relative(path, node.level, node.module)
-            if not any(c.exists() for c in candidates):
-                mod = f"{'.' * node.level}{node.module or ''}"
-                if mod not in allowlist:
-                    errors.append(f"{path}: unresolved relative import '{mod}'")
-    return errors
 
 
 def main() -> int:
-    py_files = manifest_python_targets()
-    allowlist = load_allowlist()
-    errors: list[str] = []
-    for f in py_files:
-        errors.extend(check_file(f, allowlist))
-
-    if errors:
-        print("Import check failed:")
-        for e in errors:
-            print(f"  - {e}")
-        return 1
-
-    print(
-        f"Import check passed for {len(py_files)} extracted_llm_infrastructure module(s)"
-    )
-    return 0
+    cmd = [
+        sys.executable,
+        str(ROOT / "extracted" / "_shared" / "scripts" / "check_extracted_imports.py"),
+        "extracted_llm_infrastructure",
+    ]
+    return subprocess.call(cmd, cwd=ROOT)
 
 
 if __name__ == "__main__":

--- a/scripts/sync_extracted_llm_infrastructure.sh
+++ b/scripts/sync_extracted_llm_infrastructure.sh
@@ -4,33 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python - <<'PY'
-import json
-import sys
-from pathlib import Path
-
-manifest = Path("extracted_llm_infrastructure/manifest.json")
-obj = json.loads(manifest.read_text())
-errors: list[str] = []
-copied = 0
-for mapping in obj["mappings"]:
-    src = Path(mapping["source"])
-    dst = Path(mapping["target"])
-    if not src.exists():
-        errors.append(
-            f"missing source: {src} (target would be {dst}); "
-            "fix the manifest entry before re-running sync"
-        )
-        continue
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    dst.write_bytes(src.read_bytes())
-    copied += 1
-
-if errors:
-    for line in errors:
-        print(f"ERROR {line}")
-    print(f"Sync failed: {len(errors)} missing source(s); {copied} target(s) refreshed")
-    sys.exit(1)
-
-print(f"extracted_llm_infrastructure refreshed from atlas_brain sources ({copied} files)")
-PY
+bash extracted/_shared/scripts/sync_extracted.sh extracted_llm_infrastructure

--- a/scripts/validate_extracted_llm_infrastructure.sh
+++ b/scripts/validate_extracted_llm_infrastructure.sh
@@ -4,28 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python - <<'PY'
-import json
-from pathlib import Path
-import sys
-
-manifest = Path("extracted_llm_infrastructure/manifest.json")
-obj = json.loads(manifest.read_text())
-status = 0
-for mapping in obj["mappings"]:
-    src = Path(mapping["source"])
-    dst = Path(mapping["target"])
-    if not src.exists():
-        print(f"MISSING SOURCE: {src} (referenced by manifest target {dst})")
-        status = 1
-        continue
-    if not dst.exists() or src.read_bytes() != dst.read_bytes():
-        print(f"OUT OF SYNC: {dst}")
-        status = 1
-
-if status:
-    print("Validation failed: run scripts/sync_extracted_llm_infrastructure.sh")
-    sys.exit(1)
-
-print("Validation passed: extracted_llm_infrastructure matches atlas_brain sources")
-PY
+bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure


### PR DESCRIPTION
## Summary

- convert `extracted_llm_infrastructure` sync, validate, ASCII, and import-check scripts into thin wrappers around `extracted/_shared/scripts`
- preserve existing script names and CI workflow entry points
- update LLM-infrastructure docs/status to note the shared wrapper model and the standalone smoke check

## Validation

- `python -m py_compile scripts/check_extracted_llm_infrastructure_imports.py extracted/_shared/scripts/check_extracted_imports.py`
- `bash scripts/validate_extracted_llm_infrastructure.sh`
- `bash scripts/check_ascii_python_llm_infrastructure.sh`
- `python scripts/check_extracted_llm_infrastructure_imports.py`
- `bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure`
- `python extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure`
- `bash scripts/run_extracted_llm_infrastructure_checks.sh`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`