### PR TITLE
Route content pipeline scripts through shared tooling

### DIFF
--- a/atlas_brain/autonomous/tasks/_blog_matching.py
+++ b/atlas_brain/autonomous/tasks/_blog_matching.py
@@ -46,25 +46,25 @@ _PIPELINE_TOPIC_TYPES = {
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
 
-# Maps role keyword fragments → {topic_type: score_boost}.
+# Maps role keyword fragments -> {topic_type: score_boost}.
 # Higher boost = stronger preference for that topic type for this role.
 _ROLE_TOPIC_BOOSTS: list[tuple[tuple[str, ...], dict[str, int]]] = [
-    # Finance, procurement, budget holders → pricing content resonates most
+    # Finance, procurement, budget holders -> pricing content resonates most
     (("cfo", "finance", "controller", "procurement", "budget", "treasurer", "accounting"),
      {"pricing_reality_check": 3, "churn_report": 1}),
-    # Technical buyers → migration feasibility is the key concern
+    # Technical buyers -> migration feasibility is the key concern
     (("cto", "engineer", "developer", "architect", "devops", "platform", "infrastructure", "technical"),
      {"migration_guide": 3, "vendor_deep_dive": 1}),
-    # Operations/IT leadership → churn and market context
+    # Operations/IT leadership -> churn and market context
     (("operations", "coo", "director of ops", "it director", "it manager"),
      {"churn_report": 2, "market_landscape": 1}),
-    # Product/marketing → market landscape and best-fit content
+    # Product/marketing -> market landscape and best-fit content
     (("cmo", "marketing", "product", "growth", "demand gen"),
      {"market_landscape": 2, "best_fit_guide": 2}),
-    # Sales/BD → competitive comparison assets
+    # Sales/BD -> competitive comparison assets
     (("sales", "business development", "bd", "revenue", "account executive", "ae"),
      {"vendor_showdown": 2, "vendor_alternative": 2}),
-    # C-suite generalists → deep dives and landscape
+    # C-suite generalists -> deep dives and landscape
     (("ceo", "president", "founder", "owner", "vp", "vice president", "svp", "evp"),
      {"vendor_deep_dive": 2, "market_landscape": 2}),
 ]
@@ -150,7 +150,7 @@ async def fetch_relevant_blog_posts(
             evaluating.  Matches against ``data_context.vendor_b`` in
             showdown posts.
         contact_role: Contact's job title/role.  Boosts topic types that
-            resonate with the buyer persona (e.g. CFO → pricing_reality_check).
+            resonate with the buyer persona (e.g. CFO -> pricing_reality_check).
         include_drafts: When true, allow ``draft`` posts as a fallback when
             no published matches exist.
         limit: Max posts to return (default 3).
@@ -279,7 +279,7 @@ async def fetch_relevant_blog_posts(
                     score += 5
                     break
 
-        # Role-based topic boost: e.g. CFO contact → pricing_reality_check +3
+        # Role-based topic boost: e.g. CFO contact -> pricing_reality_check +3
         if role_boosts:
             topic_type = str(row.get("topic_type") or "").lower()
             score += role_boosts.get(topic_type, 0)

--- a/atlas_brain/autonomous/tasks/b2b_campaign_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_campaign_generation.py
@@ -1214,7 +1214,7 @@ async def _shadow_log_evidence_coverage(
     Vendor name and full coverage payload live in the metadata column so the
     audit is queryable by `metadata->>'vendor_name'` during the soak window.
 
-    Failures here MUST NOT break campaign generation — the shadow audit is
+    Failures here MUST NOT break campaign generation -- the shadow audit is
     measurement infra, not a load-bearing component.
     """
     if not vendor_name or not opps:

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -21,6 +21,9 @@ To refresh this scaffold from Atlas source of truth:
 bash scripts/sync_extracted_content_pipeline.sh
 ```
 
+This stable product entry point delegates to
+`extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`.
+
 ## Manifest
 
 Mirror mappings are declared in `extracted_content_pipeline/manifest.json` so sync and validation use one source of truth.
@@ -42,11 +45,17 @@ the sellable workflows.
 bash scripts/validate_extracted_content_pipeline.sh
 ```
 
+This stable product entry point delegates to
+`extracted/_shared/scripts/validate_extracted.sh extracted_content_pipeline`.
+
 ## ASCII compliance check
 
 ```bash
 bash scripts/check_ascii_python.sh
 ```
+
+This stable product entry point delegates to
+`extracted/_shared/scripts/check_ascii_python.sh extracted_content_pipeline`.
 
 ## Import debt check
 
@@ -54,6 +63,8 @@ bash scripts/check_ascii_python.sh
 python scripts/check_extracted_imports.py
 ```
 
+This stable product entry point delegates to
+`extracted/_shared/scripts/check_extracted_imports.py extracted_content_pipeline`.
 Known unresolved relative imports are tracked in `extracted_content_pipeline/import_debt_allowlist.txt`.
 
 ## Standalone readiness audit

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -47,6 +47,11 @@
 - `scripts/run_extracted_pipeline_checks.sh` (includes
   `audit_extracted_standalone.py --fail-on-debt`)
 
+The sync, validation, ASCII, and relative-import entry points are stable
+product wrappers over `extracted/_shared/scripts/`. The standalone audit remains
+content-specific because it checks runtime `atlas_brain` coupling across the
+extracted package, not just manifest-relative import resolution.
+
 ## Remaining extraction work
 
 1. Harden minimal local adapters into customer-grade ports for notify/reasoning

--- a/extracted_content_pipeline/autonomous/tasks/_blog_matching.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_matching.py
@@ -46,25 +46,25 @@ _PIPELINE_TOPIC_TYPES = {
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
 
-# Maps role keyword fragments → {topic_type: score_boost}.
+# Maps role keyword fragments -> {topic_type: score_boost}.
 # Higher boost = stronger preference for that topic type for this role.
 _ROLE_TOPIC_BOOSTS: list[tuple[tuple[str, ...], dict[str, int]]] = [
-    # Finance, procurement, budget holders → pricing content resonates most
+    # Finance, procurement, budget holders -> pricing content resonates most
     (("cfo", "finance", "controller", "procurement", "budget", "treasurer", "accounting"),
      {"pricing_reality_check": 3, "churn_report": 1}),
-    # Technical buyers → migration feasibility is the key concern
+    # Technical buyers -> migration feasibility is the key concern
     (("cto", "engineer", "developer", "architect", "devops", "platform", "infrastructure", "technical"),
      {"migration_guide": 3, "vendor_deep_dive": 1}),
-    # Operations/IT leadership → churn and market context
+    # Operations/IT leadership -> churn and market context
     (("operations", "coo", "director of ops", "it director", "it manager"),
      {"churn_report": 2, "market_landscape": 1}),
-    # Product/marketing → market landscape and best-fit content
+    # Product/marketing -> market landscape and best-fit content
     (("cmo", "marketing", "product", "growth", "demand gen"),
      {"market_landscape": 2, "best_fit_guide": 2}),
-    # Sales/BD → competitive comparison assets
+    # Sales/BD -> competitive comparison assets
     (("sales", "business development", "bd", "revenue", "account executive", "ae"),
      {"vendor_showdown": 2, "vendor_alternative": 2}),
-    # C-suite generalists → deep dives and landscape
+    # C-suite generalists -> deep dives and landscape
     (("ceo", "president", "founder", "owner", "vp", "vice president", "svp", "evp"),
      {"vendor_deep_dive": 2, "market_landscape": 2}),
 ]
@@ -150,7 +150,7 @@ async def fetch_relevant_blog_posts(
             evaluating.  Matches against ``data_context.vendor_b`` in
             showdown posts.
         contact_role: Contact's job title/role.  Boosts topic types that
-            resonate with the buyer persona (e.g. CFO → pricing_reality_check).
+            resonate with the buyer persona (e.g. CFO -> pricing_reality_check).
         include_drafts: When true, allow ``draft`` posts as a fallback when
             no published matches exist.
         limit: Max posts to return (default 3).
@@ -279,7 +279,7 @@ async def fetch_relevant_blog_posts(
                     score += 5
                     break
 
-        # Role-based topic boost: e.g. CFO contact → pricing_reality_check +3
+        # Role-based topic boost: e.g. CFO contact -> pricing_reality_check +3
         if role_boosts:
             topic_type = str(row.get("topic_type") or "").lower()
             score += role_boosts.get(topic_type, 0)

--- a/extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py
@@ -1214,7 +1214,7 @@ async def _shadow_log_evidence_coverage(
     Vendor name and full coverage payload live in the metadata column so the
     audit is queryable by `metadata->>'vendor_name'` during the soak window.
 
-    Failures here MUST NOT break campaign generation — the shadow audit is
+    Failures here MUST NOT break campaign generation -- the shadow audit is
     measurement infra, not a load-bearing component.
     """
     if not vendor_name or not opps:

--- a/scripts/check_ascii_python.sh
+++ b/scripts/check_ascii_python.sh
@@ -4,33 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-status=0
-while IFS= read -r file; do
-  if ! python - "$file" <<'PY'
-import sys
-from pathlib import Path
-path = Path(sys.argv[1])
-data = path.read_bytes()
-violations = [(idx + 1, b) for idx, b in enumerate(data) if b > 0x7F]
-if violations:
-    print(path)
-    for idx, b in violations[:20]:
-        print(f"  byte_offset={idx} value=0x{b:02X}")
-    sys.exit(1)
-PY
-  then
-    status=1
-  fi
-done < <(printf '%s\n' \
-  extracted_content_pipeline/autonomous/tasks/blog_post_generation.py \
-  extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py \
-  extracted_content_pipeline/autonomous/tasks/complaint_content_generation.py \
-  extracted_content_pipeline/autonomous/tasks/complaint_enrichment.py \
-  extracted_content_pipeline/autonomous/tasks/article_enrichment.py)
-
-if [[ "$status" -ne 0 ]]; then
-  echo "ASCII check failed"
-  exit 1
-fi
-
-echo "ASCII check passed for extracted_content_pipeline Python files"
+bash extracted/_shared/scripts/check_ascii_python.sh extracted_content_pipeline

--- a/scripts/check_extracted_imports.py
+++ b/scripts/check_extracted_imports.py
@@ -1,81 +1,22 @@
 #!/usr/bin/env python3
+"""Compatibility wrapper for the shared content-pipeline import check."""
+
 from __future__ import annotations
 
-import ast
-from pathlib import Path
+import subprocess
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-TASK_DIR = ROOT / "extracted_content_pipeline" / "autonomous" / "tasks"
-
-# Relative-import fallback roots for copied modules that still reference atlas code.
-def resolve_relative(module_path: Path, level: int, module: str | None) -> list[Path]:
-    base_parts = list(module_path.relative_to(ROOT).parts)
-    package_parts = base_parts[:-1]
-    target_parts = package_parts[: max(0, len(package_parts) - level)]
-    if module:
-        target_parts.extend(module.split("."))
-
-    rel = Path(*target_parts) if target_parts else Path()
-    candidates: list[Path] = []
-
-    # Candidate 1: exact relative path from repository root.
-    candidates.append((ROOT / rel).with_suffix(".py"))
-    candidates.append(ROOT / rel / "__init__.py")
-
-    # Candidate 2: atlas fallback by swapping extracted root for atlas_brain.
-    if target_parts and target_parts[0] == "extracted_content_pipeline":
-        atlas_rel = Path("atlas_brain", *target_parts[1:])
-        candidates.append((ROOT / atlas_rel).with_suffix(".py"))
-        candidates.append(ROOT / atlas_rel / "__init__.py")
-
-    return candidates
-
-
-def load_allowlist() -> set[str]:
-    path = ROOT / "extracted_content_pipeline" / "import_debt_allowlist.txt"
-    if not path.exists():
-        return set()
-    return {line.strip() for line in path.read_text().splitlines() if line.strip() and not line.strip().startswith("#")}
-
-
-def check_file(path: Path, allowlist: set[str]) -> list[str]:
-    errors: list[str] = []
-    tree = ast.parse(path.read_text(), filename=str(path))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.level > 0:
-            candidates = resolve_relative(path, node.level, node.module)
-            if not any(c.exists() for c in candidates):
-                mod = f"{'.' * node.level}{node.module or ''}"
-                if mod.startswith("..."):
-                    continue
-                if mod not in allowlist:
-                    errors.append(f"{path}: unresolved relative import '{mod}'")
-    return errors
 
 
 def main() -> int:
-    tracked = [
-        "blog_post_generation.py",
-        "b2b_blog_post_generation.py",
-        "complaint_content_generation.py",
-        "complaint_enrichment.py",
-        "article_enrichment.py",
+    cmd = [
+        sys.executable,
+        str(ROOT / "extracted" / "_shared" / "scripts" / "check_extracted_imports.py"),
+        "extracted_content_pipeline",
     ]
-    py_files = [TASK_DIR / name for name in tracked]
-    allowlist = load_allowlist()
-    errors: list[str] = []
-    for f in py_files:
-        errors.extend(check_file(f, allowlist))
-
-    if errors:
-        print("Import check failed:")
-        for e in errors:
-            print(f"  - {e}")
-        return 1
-
-    print("Import check passed for extracted task modules")
-    return 0
+    return subprocess.call(cmd, cwd=ROOT)
 
 
 if __name__ == "__main__":

--- a/scripts/sync_extracted_content_pipeline.sh
+++ b/scripts/sync_extracted_content_pipeline.sh
@@ -4,17 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python - <<'PY'
-import json
-from pathlib import Path
-
-manifest = Path("extracted_content_pipeline/manifest.json")
-obj = json.loads(manifest.read_text())
-for mapping in obj["mappings"]:
-    src = Path(mapping["source"])
-    dst = Path(mapping["target"])
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    dst.write_bytes(src.read_bytes())
-
-print("extracted_content_pipeline refreshed from atlas_brain sources")
-PY
+bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline

--- a/scripts/validate_extracted_content_pipeline.sh
+++ b/scripts/validate_extracted_content_pipeline.sh
@@ -4,24 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python - <<'PY'
-import json
-from pathlib import Path
-import sys
-
-manifest = Path("extracted_content_pipeline/manifest.json")
-obj = json.loads(manifest.read_text())
-status = 0
-for mapping in obj["mappings"]:
-    src = Path(mapping["source"])
-    dst = Path(mapping["target"])
-    if not dst.exists() or src.read_bytes() != dst.read_bytes():
-        print(f"OUT OF SYNC: {dst}")
-        status = 1
-
-if status:
-    print("Validation failed: run scripts/sync_extracted_content_pipeline.sh")
-    sys.exit(1)
-
-print("Validation passed: extracted_content_pipeline matches atlas_brain sources")
-PY
+bash extracted/_shared/scripts/validate_extracted.sh extracted_content_pipeline


### PR DESCRIPTION
## Summary
- Replace content-pipeline sync, validation, ASCII, and relative-import checks with compatibility wrappers over `extracted/_shared/scripts`
- Keep `audit_extracted_standalone.py` content-specific and document that distinction in the content pipeline README/status
- Normalize synced source/extracted comment punctuation so the broader shared ASCII gate can cover all manifest Python targets

## Validation
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`
- `bash scripts/run_extracted_llm_infrastructure_checks.sh`
- `python -m py_compile atlas_brain/autonomous/tasks/b2b_campaign_generation.py atlas_brain/autonomous/tasks/_blog_matching.py extracted_content_pipeline/autonomous/tasks/b2b_campaign_generation.py extracted_content_pipeline/autonomous/tasks/_blog_matching.py`