### PR TITLE
Refresh extracted product coordination docs

### DIFF
--- a/extracted/README.md
+++ b/extracted/README.md
@@ -3,7 +3,7 @@
 This directory is the coordination layer for sellable systems being extracted
 from Atlas. It does not replace the current `extracted_*` package directories
 yet. Physical package moves should happen only after active product PRs are
-merged and compatibility wrappers are planned.
+merged and compatibility wrappers are in place.
 
 ## Current Products
 
@@ -11,7 +11,7 @@ merged and compatibility wrappers are planned.
 |---|---|---|---|
 | LLM Infrastructure | `extracted_llm_infrastructure/` | Phase 2 | Standalone substrate landed; provider-level decoupling remains Phase 3. |
 | Competitive Intelligence | `extracted_competitive_intelligence/` | Phase 2 | Standalone substrate landed; selected MCP read surfaces are product-owned. |
-| Content Pipeline | `extracted_content_pipeline/` | Phase 2 in progress | Active PR work exists; do not physically move while PR #43 is active. |
+| Content Pipeline | `extracted_content_pipeline/` | Phase 2 in progress | Standalone runtime audit is clean; adapter hardening and scope trimming remain. |
 | Quality Gate | planned | Not started | ProductClaim engine and frontend approval gate candidate. |
 | Intent Router | planned | Not started | Semantic routing, memory quality, and tool registry candidate. |
 
@@ -32,8 +32,9 @@ extracted/
   intent_router/
 ```
 
-The current PR only adds the coordination layer and shared tooling. Existing
-package import paths stay unchanged.
+This directory provides the coordination layer and shared tooling. Existing
+package import paths stay unchanged until product moves are handled one at a
+time.
 
 ## Shared Tooling
 
@@ -51,5 +52,5 @@ have moved to strict extracted-only relative import resolution. Products still
 in early scaffold mode can omit the flag to match the current LLM-infrastructure
 transition behavior.
 
-Existing per-product scripts remain the CI entry points until a later migration
-switches them to call the shared scripts.
+Existing per-product scripts remain the CI entry points and delegate to the
+shared scripts.

--- a/extracted/_shared/docs/cross_product_dependency_graph.md
+++ b/extracted/_shared/docs/cross_product_dependency_graph.md
@@ -17,7 +17,8 @@ runtime import map yet; it is the source of truth for extraction direction.
 
 - Competitive Intelligence already uses extracted LLM substrate in standalone
   mode for protocols and LLM bridge wiring.
-- Content Pipeline is active in PR #43; avoid physical package moves until that
-  work lands.
+- Content Pipeline has a clean standalone runtime-import audit and now uses
+  shared extraction wrappers; avoid physical package moves until its adapters
+  and sellable workflow boundaries are narrower.
 - Shared scripts under `extracted/_shared/scripts/` are safe to use before the
   physical package consolidation.

--- a/extracted_competitive_intelligence/README.md
+++ b/extracted_competitive_intelligence/README.md
@@ -39,7 +39,9 @@ Plus 9 migrations: `095_b2b_vendor_registry.sql`, `099_displacement_edges_and_co
 
 ## What's out of scope (remaining Phase 3)
 
-- Decoupling battle-card LLM calls so they consume `extracted_llm_infrastructure/` directly (LLM-infra extraction is in PR #40)
+- Deep runtime decoupling for battle-card LLM calls; standalone mode routes the
+  LLM bridge through `extracted_llm_infrastructure/`, but task-level LLM seams
+  still need Phase 3 hardening.
 - API endpoint extraction beyond the briefing endpoints (`/b2b/win-loss`, dashboard endpoints stay in atlas_brain)
 - Full runtime exercise without `atlas_brain` on `sys.path`; this slice adds the standalone substrate and smoke coverage, but deep task modules still carry Atlas-owned domain dependencies.
 
@@ -47,7 +49,7 @@ Plus 9 migrations: `095_b2b_vendor_registry.sql`, `099_displacement_edges_and_co
 
 | Dependency | Status | Notes |
 |---|---|---|
-| **LLM Infrastructure** | extracted via PR #40 | `b2b_battle_cards.py:260` calls `pipelines.llm.call_llm_with_skill`; will rebase once PR #40 merges |
+| **LLM Infrastructure** | extracted package available | Standalone bridge delegates to `extracted_llm_infrastructure`; task-level LLM seams remain Phase 3 work |
 | **Evidence claims** | atlas-core | `services/b2b/evidence_claim_*.py` is shared with churn intel — keep central |
 | **Campaign suppression** | injectable in standalone mode | Atlas bridge remains default; standalone mode uses a configured `SuppressionPolicy` |
 | **Campaign sender (Resend)** | injectable in standalone mode | Atlas bridge remains default; standalone mode uses a configured campaign sender |
@@ -112,7 +114,10 @@ Runs five checks in sequence:
 
 The Competitive Intel platform is a distinct product with a different audience: it sells to sales / RevOps teams, not ML platform teams. Customer-facing artifacts (battle cards, vendor briefings) are fundamentally different from cost-optimization infrastructure. Keeping the scaffolds separate lets either be priced, packaged, and shipped independently.
 
-The Competitive Intel modules **consume** the LLM-infra package at runtime (battle card overlays use `call_llm_with_skill`, vendor briefings use `clean_llm_output`), so the two extractions are sequenced: LLM-infra first (PR #40), then Competitive Intel here, then a Phase 2/3 follow-up to rewire LLM imports to consume the extracted package directly.
+The Competitive Intel modules **consume** the LLM-infra package in standalone
+mode through the local bridge modules. Deep task-level runtime seams still need
+Phase 3 follow-up before the package is publishable without Atlas host
+dependencies.
 
 ## Status
 

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -1,9 +1,10 @@
 # Standalone Productization Contract
 
 The extracted package must be installable and runnable without the Atlas
-monolith. The current PR is a staging mirror, so it still contains Atlas bridge
-imports. That is acceptable for extraction traceability, but it is not the
-customer product.
+monolith. The scaffold began as a staging mirror for extraction traceability;
+the runtime import gate is now clean, but the package is not the customer
+product until the minimal adapters are hardened and copied helper scope is
+trimmed.
 
 ## Non-Negotiable Product Rule
 

--- a/extracted_llm_infrastructure/README.md
+++ b/extracted_llm_infrastructure/README.md
@@ -8,7 +8,8 @@ A byte-for-byte snapshot of the LLM-infrastructure surface inside `atlas_brain/`
 
 The scaffold is **purely additive**. Atlas continues to import from its own paths; this directory is parallel infrastructure.
 
-The pattern mirrors the content-pipeline scaffold under `extracted_content_pipeline/` (open PRs #35, #37, #38, #39).
+The pattern mirrors the content-pipeline scaffold under
+`extracted_content_pipeline/`.
 
 ## What's in scope (Phase 1)
 
@@ -30,7 +31,7 @@ The pattern mirrors the content-pipeline scaffold under `extracted_content_pipel
 
 ## What's out of scope (Phase 3)
 
-Phase 2 (standalone substrate) **landed in this PR**. Remaining work:
+Phase 2 (standalone substrate) has landed. Remaining work:
 
 - DB pool / Tracer / LLM `Protocol`-based DI seams across the scaffolded provider modules (Phase 3)
 - Replacing `isinstance(AnthropicLLM)` checks throughout `services/b2b/anthropic_batch.py` and `services/llm_router.py` (Phase 3)
@@ -45,7 +46,7 @@ Set `EXTRACTED_LLM_INFRA_STANDALONE=1` and the package's substrate
 (settings, base class, protocols, registry, db pool) loads from the
 local `_standalone/` subpackage instead of delegating to atlas_brain.
 The provider modules (`services/llm/*.py`, `services/b2b/anthropic_batch.py`,
-etc.) still import from atlas_brain in this PR — Phase 3 closes that
+etc.) still import from atlas_brain in this scaffold — Phase 3 closes that
 loop.
 
 ```bash
@@ -112,9 +113,15 @@ Phase 2 shrinks this list to zero by either (a) copying the dependency module in
 
 ## Why a separate scaffold from `extracted_content_pipeline/`?
 
-PRs #35/#37/#38/#39 already include `pipelines/llm.py` and `services/b2b/anthropic_batch.py` inside the content-pipeline scaffold as snapshotted siblings. That's intentional during the transition.
+The content-pipeline scaffold includes `pipelines/llm.py` and
+`services/b2b/anthropic_batch.py` as snapshotted siblings for transition
+traceability.
 
-The LLM-infrastructure scaffold lives separately because the LLM-infra subsystem is a **distinct sellable product** (cost optimization for teams running Claude/GPT at scale) — not a content-pipeline implementation detail. Once one of #35/#37/#38/#39 merges, a follow-up PR can rebase the content-pipeline scaffold to depend on `extracted_llm_infrastructure/` instead of carrying its own copies.
+The LLM-infrastructure scaffold lives separately because the LLM-infra subsystem
+is a **distinct sellable product** (cost optimization for teams running
+Claude/GPT at scale), not a content-pipeline implementation detail. The content
+pipeline now points its LLM-facing bridges at `extracted_llm_infrastructure/`;
+future scope trimming can remove duplicated transitional copies.
 
 ## Status
 

--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -30,7 +30,12 @@ Goal: the package's substrate (settings, base class, protocols, registry, db poo
 | Standalone smoke script + CI integration | ✅ `scripts/smoke_extracted_llm_infrastructure_standalone.py` |
 | README documents the toggle and env-var layout | ✅ |
 
-**Empirical result**: the standalone substrate landed in this PR turns out to be sufficient to unblock the import contract for all 14 provider modules. They consume the substrate transitively through the bridge stubs, so when `EXTRACTED_LLM_INFRA_STANDALONE=1` is set, every provider sees the local `_standalone/*` copies of `BaseModelService`, `LLMService` Protocol, `Message`, `ModelInfo`, `ServiceRegistry`, `llm_registry`, `settings`, and `DatabasePool`.
+**Empirical result**: the standalone substrate is sufficient to unblock the
+import contract for all 14 provider modules. They consume the substrate
+transitively through the bridge stubs, so when
+`EXTRACTED_LLM_INFRA_STANDALONE=1` is set, every provider sees the local
+`_standalone/*` copies of `BaseModelService`, `LLMService` Protocol, `Message`,
+`ModelInfo`, `ServiceRegistry`, `llm_registry`, `settings`, and `DatabasePool`.
 
 The standalone smoke (`scripts/smoke_extracted_llm_infrastructure_standalone.py`) verifies this end-to-end: it sets the env var, imports every provider, and asserts (via `__module__` walk on `AnthropicLLM.__mro__`) that providers transitively consume the standalone substrate rather than silently falling back to atlas_brain.
 


### PR DESCRIPTION
## Summary
- Remove stale PR-number references from extracted product coordination docs
- Update umbrella and dependency docs after shared wrapper consolidation landed for all three extracted packages
- Clarify current LLM/content/competitive extraction status without changing code or workflows

## Validation
- `rg -n "PR #|active PR|Active PR|current PR|Current PR|will rebase|once PR|landed in this PR|open PRs" extracted extracted_competitive_intelligence extracted_llm_infrastructure extracted_content_pipeline -g '*.md'`
- `git diff --check`