### PR TITLE
Route content pipeline notifications through VisibilitySink

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -128,7 +128,10 @@ normalizes `chat()` / `generate()` provider responses into `LLMResponse`.
 
 ## Pipeline shims
 
-`extracted_content_pipeline/pipelines/notify.py` provides a local no-op notifier so task modules can execute without Atlas pipeline services.
+`extracted_content_pipeline/pipelines/notify.py` provides a product-owned
+notification dispatcher over the `VisibilitySink` port. It remains a safe no-op
+when no sink is configured, and host apps can route emitted
+`pipeline_notification` events to ntfy, Slack, dashboards, or audit streams.
 
 Content-pipeline LLM bridge modules delegate to
 `extracted_llm_infrastructure` instead of `atlas_brain`. That keeps the content
@@ -140,6 +143,8 @@ product rather than at the monolith.
 Several small utility shims provide product-owned local behavior by default so task imports do not require Atlas service modules:
 
 - `config.py`: extracted settings from `settings.py`
+- `pipelines/notify.py`: host-visible notification dispatcher backed by the
+  `VisibilitySink` port
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -36,6 +36,9 @@
   `services.tracing`, `services.scraping.sources`, and
   `services.scraping.universal.html_cleaner`.
 - Standalone readiness audit reports 0 Atlas runtime import findings.
+- `pipelines.notify` is product-owned and dispatches through the
+  `VisibilitySink` port when configured, while staying a no-op when no host
+  visibility adapter is installed.
 
 ## Validation gates in repo
 
@@ -54,8 +57,8 @@ extracted package, not just manifest-relative import resolution.
 
 ## Remaining extraction work
 
-1. Harden minimal local adapters into customer-grade ports for notify/reasoning
-   and provider-specific LLM configuration.
+1. Harden remaining minimal local adapters into customer-grade ports for
+   reasoning and provider-specific LLM configuration.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -104,6 +104,12 @@ slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
 through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
 `CampaignDraft` rows through `CampaignRepository`.
 
+`extracted_content_pipeline/pipelines/notify.py` is the first product-owned
+visibility slice. It preserves the copied task-facing
+`send_pipeline_notification(...)` API but emits through the `VisibilitySink`
+port when a host configures one. With no sink configured it remains a safe
+no-op, so standalone task imports do not require Atlas notification services.
+
 ## Readiness Gate
 
 Run:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -192,5 +192,10 @@
       "source": "atlas_brain/autonomous/tasks/_b2b_batch_utils.py",
       "target": "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py"
     }
+  ],
+  "owned": [
+    {
+      "target": "extracted_content_pipeline/pipelines/notify.py"
+    }
   ]
 }

--- a/extracted_content_pipeline/pipelines/notify.py
+++ b/extracted_content_pipeline/pipelines/notify.py
@@ -1,7 +1,363 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from typing import Any
 
+from ..campaign_ports import VisibilitySink
 
-async def send_pipeline_notification(*args: Any, **kwargs: Any) -> None:
-    return None
+
+logger = logging.getLogger("extracted_content_pipeline.pipelines.notify")
+
+_visibility_sink: VisibilitySink | None = None
+
+
+@dataclass(frozen=True)
+class PipelineNotification:
+    """Host-visible notification event emitted by extracted pipeline tasks."""
+
+    message: str
+    title: str
+    task_name: str | None = None
+    task_id: str | None = None
+    priority: str = "default"
+    tags: str = "brain"
+    markdown: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "message": self.message,
+            "title": self.title,
+            "task_name": self.task_name,
+            "task_id": self.task_id,
+            "priority": self.priority,
+            "tags": self.tags,
+            "markdown": self.markdown,
+            "metadata": dict(self.metadata),
+        }
+
+
+def configure_pipeline_notification_sink(
+    sink: VisibilitySink | None,
+) -> VisibilitySink | None:
+    """Set the process-wide notification sink and return the previous sink."""
+
+    global _visibility_sink
+    previous = _visibility_sink
+    _visibility_sink = sink
+    return previous
+
+
+def get_pipeline_notification_sink() -> VisibilitySink | None:
+    """Return the currently configured notification sink, if any."""
+
+    return _visibility_sink
+
+
+async def send_pipeline_notification(
+    message: str,
+    task: Any,
+    *,
+    title: str | None = None,
+    default_tags: str = "brain",
+    max_chars: int = 4000,
+    parsed: Mapping[str, Any] | None = None,
+    visibility: VisibilitySink | None = None,
+) -> None:
+    """Emit a host-visible pipeline notification.
+
+    The extracted package does not own ntfy, Slack, email, or dashboard
+    delivery. A host app can configure a ``VisibilitySink`` and route this event
+    wherever it wants. With no sink configured, notifications remain a safe
+    no-op so copied Atlas task modules can run standalone.
+    """
+
+    metadata = _task_metadata(task)
+    if metadata.get("notify") is False:
+        return
+
+    sink = visibility or _visibility_sink
+    if sink is None:
+        return
+
+    task_name = _task_name(task)
+    notification = PipelineNotification(
+        message=_truncate(
+            _format_parsed(dict(parsed), message) if parsed else str(message or ""),
+            max_chars=max_chars,
+        ),
+        title=title or _default_title(task_name),
+        task_name=task_name,
+        task_id=_task_id(task),
+        priority=str(metadata.get("notify_priority") or "default"),
+        tags=str(metadata.get("notify_tags") or default_tags),
+        metadata={
+            "source": "extracted_content_pipeline",
+            "parsed": bool(parsed),
+        },
+    )
+
+    try:
+        await sink.emit("pipeline_notification", notification.as_payload())
+    except Exception:
+        logger.warning(
+            "Failed to emit pipeline notification for task %r",
+            task_name,
+            exc_info=True,
+        )
+
+
+def _task_metadata(task: Any) -> dict[str, Any]:
+    if isinstance(task, Mapping):
+        raw = task.get("metadata")
+    else:
+        raw = getattr(task, "metadata", None)
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _task_name(task: Any) -> str | None:
+    if isinstance(task, Mapping):
+        value = task.get("name")
+    else:
+        value = getattr(task, "name", None)
+    text = str(value or "").strip()
+    return text or None
+
+
+def _task_id(task: Any) -> str | None:
+    if isinstance(task, Mapping):
+        value = task.get("id") or task.get("task_id")
+    else:
+        value = getattr(task, "id", None) or getattr(task, "task_id", None)
+    text = str(value or "").strip()
+    return text or None
+
+
+def _default_title(task_name: str | None) -> str:
+    if not task_name:
+        return "Atlas: Pipeline Notification"
+    return f"Atlas: {task_name.replace('_', ' ').title()}"
+
+
+def _truncate(message: str, *, max_chars: int) -> str:
+    try:
+        limit = int(max_chars)
+    except (TypeError, ValueError):
+        limit = 4000
+    if limit <= 0:
+        return ""
+    return message[:limit]
+
+
+def _format_parsed(parsed: dict[str, Any], fallback: str) -> str:
+    """Build concise markdown from common structured pipeline payload fields."""
+
+    parts: list[str] = []
+
+    analysis = str(parsed.get("analysis_text") or "").strip()
+    if analysis:
+        parts.append(analysis)
+
+    _append_top_pain_points(parts, parsed.get("top_pain_points"))
+    _append_opportunities(parts, parsed.get("opportunities"))
+    _append_product_highlights(parts, parsed.get("product_highlights"))
+    _append_key_insights(parts, parsed.get("key_insights"))
+    _append_pressure_readings(parts, parsed.get("pressure_readings"))
+    _append_connections(parts, parsed.get("connections_found"))
+    _append_brand_vulnerability(
+        parts,
+        parsed.get("brand_vulnerability") or parsed.get("brand_scorecards"),
+    )
+    _append_competitive_flows(parts, parsed.get("competitive_flows"))
+    if not parsed.get("key_insights"):
+        _append_generic_insights(parts, parsed.get("insights"))
+    _append_recommendations(parts, parsed.get("recommendations"))
+
+    return "\n".join(parts) if parts else str(fallback or "")
+
+
+def _append_section(parts: list[str], title: str, items: list[str]) -> None:
+    if items:
+        parts.append(f"\n**{title}**\n" + "\n".join(items))
+
+
+def _append_top_pain_points(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:5]:
+        if not isinstance(item, Mapping):
+            continue
+        asin = str(item.get("asin") or "").strip()
+        issue = str(item.get("primary_issue") or "").strip()
+        score = str(item.get("avg_pain_score") or "").strip()
+        line = f"- **{asin}**: {issue}" if asin else f"- {issue}"
+        if score:
+            line += f" (pain: {score})"
+        if issue:
+            items.append(line)
+    _append_section(parts, "Top Pain Points", items)
+
+
+def _append_opportunities(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:3]:
+        if not isinstance(item, Mapping):
+            continue
+        desc = str(item.get("description") or "").strip()
+        if not desc:
+            continue
+        otype = str(item.get("type") or "").strip()
+        impact = str(item.get("estimated_impact") or "").strip()
+        line = f"- {desc}"
+        if otype or impact:
+            line += f" [{otype}{'/' + impact if impact else ''}]"
+        items.append(line)
+    _append_section(parts, "Opportunities", items)
+
+
+def _append_product_highlights(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:5]:
+        if not isinstance(item, Mapping):
+            continue
+        name = str(item.get("product_name") or item.get("asin") or "").strip()
+        complaint = str(item.get("top_complaint") or "").strip()
+        alt = str(item.get("alternative_mentioned") or "").strip()
+        if not name and not complaint:
+            continue
+        line = f"- **{name}**: {complaint}" if name else f"- {complaint}"
+        if alt:
+            line += f" -> {alt}"
+        items.append(line)
+    _append_section(parts, "Product Highlights", items)
+
+
+def _append_key_insights(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items = [_insight_line(item) for item in values[:5]]
+    _append_section(parts, "Key Insights", [item for item in items if item])
+
+
+def _append_pressure_readings(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:5]:
+        if not isinstance(item, Mapping):
+            continue
+        name = str(item.get("entity_name") or "").strip()
+        score = str(item.get("pressure_score") or "").strip()
+        traj = str(item.get("trajectory") or "").strip()
+        note = str(item.get("note") or "").strip()
+        line = f"- **{name}** {score}/10" if name else f"- {score}/10"
+        if traj:
+            line += f" ({traj})"
+        if note:
+            line += f": {note}"
+        items.append(line)
+    _append_section(parts, "Pressure Readings", items)
+
+
+def _append_connections(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:3]:
+        if isinstance(item, str) and item.strip():
+            items.append(f"- {item.strip()}")
+        elif isinstance(item, Mapping):
+            desc = str(item.get("description") or "").strip()
+            sig = str(item.get("significance") or "").strip()
+            if desc:
+                items.append(f"- {desc}{f' [{sig}]' if sig else ''}")
+    _append_section(parts, "Connections", items)
+
+
+def _append_brand_vulnerability(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:5]:
+        if not isinstance(item, Mapping):
+            continue
+        brand = str(item.get("brand") or "").strip()
+        if not brand:
+            continue
+        score = str(item.get("vulnerability_score") or item.get("health_score") or "").strip()
+        status = str(item.get("status") or "").strip()
+        liner = str(item.get("one_liner") or "").strip()
+        line = f"- **{brand}** {score}/100 vulnerability"
+        if status:
+            line += f" ({status})"
+        if liner:
+            line += f": {liner}"
+        items.append(line)
+    _append_section(parts, "Brand Vulnerability", items)
+
+
+def _append_competitive_flows(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:5]:
+        if not isinstance(item, Mapping):
+            continue
+        frm = str(item.get("from_brand") or "").strip()
+        to = str(item.get("to_brand") or "").strip()
+        if not frm and not to:
+            continue
+        reason = str(item.get("primary_reason") or "").strip()
+        count = str(item.get("count") or "").strip()
+        line = f"- {frm} -> {to}"
+        if count:
+            line += f" ({count} mentions)"
+        if reason:
+            line += f": {reason}"
+        items.append(line)
+    _append_section(parts, "Competitive Flows", items)
+
+
+def _append_generic_insights(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items = [_insight_line(item) for item in values[:5]]
+    _append_section(parts, "Insights", [item for item in items if item])
+
+
+def _append_recommendations(parts: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    items: list[str] = []
+    for item in values[:3]:
+        if isinstance(item, str) and item.strip():
+            items.append(f"- {item.strip()}")
+        elif isinstance(item, Mapping):
+            action = str(item.get("action") or "").strip()
+            urgency = str(item.get("urgency") or "").strip()
+            if action:
+                items.append(f"- {action}{f' [{urgency}]' if urgency else ''}")
+    _append_section(parts, "Recommendations", items)
+
+
+def _insight_line(item: Any) -> str | None:
+    if isinstance(item, str):
+        text = item.strip()
+        return f"- {text}" if text else None
+    if not isinstance(item, Mapping):
+        return None
+    text = str(item.get("insight") or "").strip()
+    if not text:
+        return None
+    confidence = str(item.get("confidence") or "").strip()
+    domain = str(item.get("domain") or "").strip()
+    impact = str(item.get("impact") or "").strip()
+    tags = "/".join(value for value in (domain, confidence or impact) if value)
+    return f"- {text}{f' [{tags}]' if tags else ''}"

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -13,6 +13,7 @@ pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation.py \
+  tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -37,6 +37,11 @@ def _manifest_targets() -> set[str]:
     }
 
 
+def _owned_targets() -> set[str]:
+    data = json.loads((ROOT / "extracted_content_pipeline/manifest.json").read_text())
+    return {entry["target"] for entry in data.get("owned", [])}
+
+
 def test_manifest_syncs_core_campaign_schema_migrations() -> None:
     targets = _manifest_targets()
 
@@ -66,3 +71,10 @@ def test_core_campaign_migrations_define_product_tables() -> None:
     assert "CREATE TABLE IF NOT EXISTS campaign_suppressions" in suppression_schema
     assert "CREATE TABLE IF NOT EXISTS vendor_targets" in target_schema
     assert "CREATE TABLE IF NOT EXISTS seller_targets" in seller_schema
+
+
+def test_manifest_tracks_product_owned_notify_adapter() -> None:
+    assert (
+        "extracted_content_pipeline/pipelines/notify.py"
+        in _owned_targets()
+    )

--- a/tests/test_extracted_pipeline_notify.py
+++ b/tests/test_extracted_pipeline_notify.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from extracted_content_pipeline.pipelines.notify import (
+    configure_pipeline_notification_sink,
+    get_pipeline_notification_sink,
+    send_pipeline_notification,
+)
+
+
+@dataclass
+class _Task:
+    name: str = "b2b_campaign_generation"
+    id: str = "task-1"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class _Sink:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.events: list[dict[str, Any]] = []
+
+    async def emit(self, event_type, payload):
+        if self.fail:
+            raise RuntimeError("visibility down")
+        self.events.append({"event_type": event_type, "payload": payload})
+
+
+@pytest.fixture(autouse=True)
+def _reset_sink():
+    previous = configure_pipeline_notification_sink(None)
+    yield
+    configure_pipeline_notification_sink(previous)
+
+
+@pytest.mark.asyncio
+async def test_notification_is_noop_without_configured_sink():
+    await send_pipeline_notification("hello", _Task())
+
+    assert get_pipeline_notification_sink() is None
+
+
+@pytest.mark.asyncio
+async def test_notification_emits_to_configured_visibility_sink():
+    sink = _Sink()
+    configure_pipeline_notification_sink(sink)
+
+    await send_pipeline_notification(
+        "generated campaigns",
+        _Task(metadata={"notify_priority": "high", "notify_tags": "sales,campaign"}),
+        max_chars=9,
+    )
+
+    assert sink.events == [{
+        "event_type": "pipeline_notification",
+        "payload": {
+            "message": "generated",
+            "title": "Atlas: B2B Campaign Generation",
+            "task_name": "b2b_campaign_generation",
+            "task_id": "task-1",
+            "priority": "high",
+            "tags": "sales,campaign",
+            "markdown": True,
+            "metadata": {
+                "source": "extracted_content_pipeline",
+                "parsed": False,
+            },
+        },
+    }]
+
+
+@pytest.mark.asyncio
+async def test_notification_can_use_call_scoped_visibility_sink():
+    global_sink = _Sink()
+    scoped_sink = _Sink()
+    configure_pipeline_notification_sink(global_sink)
+
+    await send_pipeline_notification("hello", _Task(), visibility=scoped_sink)
+
+    assert global_sink.events == []
+    assert scoped_sink.events[0]["payload"]["message"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_notification_respects_task_notify_opt_out():
+    sink = _Sink()
+    configure_pipeline_notification_sink(sink)
+
+    await send_pipeline_notification("hello", _Task(metadata={"notify": False}))
+
+    assert sink.events == []
+
+
+@pytest.mark.asyncio
+async def test_notification_formats_structured_payload_fields():
+    sink = _Sink()
+    configure_pipeline_notification_sink(sink)
+
+    await send_pipeline_notification(
+        "fallback",
+        _Task(name="competitive_intelligence"),
+        title="Custom title",
+        parsed={
+            "analysis_text": "Summary line.",
+            "top_pain_points": [{
+                "asin": "B001",
+                "primary_issue": "Battery complaints",
+                "avg_pain_score": 8,
+            }],
+            "competitive_flows": [{
+                "from_brand": "A",
+                "to_brand": "B",
+                "count": 4,
+                "primary_reason": "price",
+            }],
+            "recommendations": [{"action": "Inspect pricing", "urgency": "high"}],
+        },
+    )
+
+    payload = sink.events[0]["payload"]
+    assert payload["title"] == "Custom title"
+    assert payload["metadata"]["parsed"] is True
+    assert "Summary line." in payload["message"]
+    assert "**Top Pain Points**" in payload["message"]
+    assert "- **B001**: Battery complaints (pain: 8)" in payload["message"]
+    assert "**Competitive Flows**" in payload["message"]
+    assert "- A -> B (4 mentions): price" in payload["message"]
+    assert "**Recommendations**" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_notification_sink_failures_do_not_break_pipeline():
+    configure_pipeline_notification_sink(_Sink(fail=True))
+
+    await send_pipeline_notification("hello", _Task())


### PR DESCRIPTION
## Summary
- Replace the extracted content pipeline notification no-op with a product-owned dispatcher over the `VisibilitySink` port
- Preserve the copied task-facing `send_pipeline_notification(...)` API, including task metadata opt-out, default titles/tags, max length, and structured payload formatting
- Register `pipelines/notify.py` as an owned manifest entry so shared ASCII/import gates cover it
- Add focused notifier tests and include them in the extracted pipeline check runner

## Validation
- `pytest tests/test_extracted_pipeline_notify.py tests/test_extracted_campaign_manifest.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`
- `python -m py_compile extracted_content_pipeline/pipelines/notify.py tests/test_extracted_pipeline_notify.py tests/test_extracted_campaign_manifest.py`
- `git diff --check`