### PR TITLE
Add content pipeline LLM routing config

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -125,6 +125,15 @@ Set `EXTRACTED_PIPELINE_STANDALONE=1` to make the LLM bridge modules use their l
 adapter for campaign services. It satisfies the `campaign_ports.LLMClient`
 port, resolves an LLM through the extracted LLM bridge when configured, and
 normalizes `chat()` / `generate()` provider responses into `LLMResponse`.
+`PipelineLLMClientConfig` and `create_pipeline_llm_client()` let a host wire
+provider routing from explicit config, settings objects, or these environment
+variables:
+
+- `EXTRACTED_CAMPAIGN_LLM_WORKLOAD`
+- `EXTRACTED_CAMPAIGN_LLM_PREFER_CLOUD`
+- `EXTRACTED_CAMPAIGN_LLM_TRY_OPENROUTER`
+- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA`
+- `EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL`
 
 ## Pipeline shims
 
@@ -146,7 +155,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `pipelines/notify.py`: host-visible notification dispatcher backed by the
   `VisibilitySink` port
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
-  `LLMClient` port to extracted LLM infrastructure services
+  `LLMClient` port to extracted LLM infrastructure services, with product-owned
+  provider routing config
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
 - `campaign_postgres.py`: async Postgres adapters for campaign, sequence,
   suppression, and audit ports

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -21,7 +21,9 @@
   (`pipelines.llm`, `services.b2b.anthropic_batch`, `services.llm.anthropic`)
   instead of pointing directly at `atlas_brain`.
 - `campaign_llm_client.PipelineLLMClient` adapts extracted LLM infrastructure
-  services to the standalone campaign `LLMClient` port.
+  services to the standalone campaign `LLMClient` port. Its provider-routing
+  config can be built from explicit mappings, settings objects, or
+  `EXTRACTED_CAMPAIGN_LLM_*` environment variables.
 - `campaign_postgres` provides async Postgres adapters for the campaign,
   sequence, suppression, and audit ports against the copied campaign schema.
 - Small utility shims now default to local extracted implementations:
@@ -57,8 +59,8 @@ extracted package, not just manifest-relative import resolution.
 
 ## Remaining extraction work
 
-1. Harden remaining minimal local adapters into customer-grade ports for
-   reasoning and provider-specific LLM configuration.
+1. Harden remaining minimal reasoning adapters into customer-grade policy
+   modules.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -21,6 +22,74 @@ def _default_resolver(**kwargs: Any) -> Any:
     from .pipelines.llm import get_pipeline_llm
 
     return get_pipeline_llm(**kwargs)
+
+
+def _to_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+@dataclass(frozen=True)
+class PipelineLLMClientConfig:
+    """Provider routing config for the product LLM client."""
+
+    workload: str | None = "draft"
+    prefer_cloud: bool = True
+    try_openrouter: bool = True
+    auto_activate_ollama: bool = True
+    openrouter_model: str | None = None
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any]) -> "PipelineLLMClientConfig":
+        return cls(
+            workload=_optional_text(values.get("workload")) or "draft",
+            prefer_cloud=_to_bool(values.get("prefer_cloud"), True),
+            try_openrouter=_to_bool(values.get("try_openrouter"), True),
+            auto_activate_ollama=_to_bool(values.get("auto_activate_ollama"), True),
+            openrouter_model=_optional_text(values.get("openrouter_model")),
+        )
+
+    @classmethod
+    def from_settings(cls, settings_obj: Any) -> "PipelineLLMClientConfig":
+        return cls(
+            workload=_optional_text(getattr(settings_obj, "workload", None)) or "draft",
+            prefer_cloud=_to_bool(getattr(settings_obj, "prefer_cloud", None), True),
+            try_openrouter=_to_bool(getattr(settings_obj, "try_openrouter", None), True),
+            auto_activate_ollama=_to_bool(
+                getattr(settings_obj, "auto_activate_ollama", None),
+                True,
+            ),
+            openrouter_model=_optional_text(
+                getattr(settings_obj, "openrouter_model", None),
+            ),
+        )
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: Mapping[str, str] | None = None,
+        *,
+        prefix: str = "EXTRACTED_CAMPAIGN_LLM_",
+    ) -> "PipelineLLMClientConfig":
+        env = os.environ if environ is None else environ
+        return cls(
+            workload=_optional_text(env.get(f"{prefix}WORKLOAD")) or "draft",
+            prefer_cloud=_to_bool(env.get(f"{prefix}PREFER_CLOUD"), True),
+            try_openrouter=_to_bool(env.get(f"{prefix}TRY_OPENROUTER"), True),
+            auto_activate_ollama=_to_bool(
+                env.get(f"{prefix}AUTO_ACTIVATE_OLLAMA"),
+                True,
+            ),
+            openrouter_model=_optional_text(env.get(f"{prefix}OPENROUTER_MODEL")),
+        )
 
 
 @dataclass(frozen=True)
@@ -85,6 +154,29 @@ class PipelineLLMClient:
                 temperature=temperature,
             )
         raise LLMUnavailableError("Resolved LLM does not expose chat() or generate()")
+
+
+def create_pipeline_llm_client(
+    config: PipelineLLMClientConfig | Mapping[str, Any] | None = None,
+    *,
+    resolver: LLMResolver = _default_resolver,
+) -> PipelineLLMClient:
+    """Create a campaign LLM client from product-owned provider config."""
+
+    if config is None:
+        resolved = PipelineLLMClientConfig.from_env()
+    elif isinstance(config, PipelineLLMClientConfig):
+        resolved = config
+    else:
+        resolved = PipelineLLMClientConfig.from_mapping(config)
+    return PipelineLLMClient(
+        workload=resolved.workload,
+        prefer_cloud=resolved.prefer_cloud,
+        try_openrouter=resolved.try_openrouter,
+        auto_activate_ollama=resolved.auto_activate_ollama,
+        openrouter_model=resolved.openrouter_model,
+        resolver=resolver,
+    )
 
 
 def _messages_to_prompt(messages: Sequence[LLMMessage]) -> tuple[str | None, str]:

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -104,6 +104,12 @@ slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
 through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
 `CampaignDraft` rows through `CampaignRepository`.
 
+`extracted_content_pipeline/campaign_llm_client.py` is the provider-routing
+slice for LLM access. It adapts extracted LLM infrastructure services to the
+product `LLMClient` port and exposes `PipelineLLMClientConfig` so hosts can
+wire workload, OpenRouter model, and fallback behavior without importing Atlas
+settings.
+
 `extracted_content_pipeline/pipelines/notify.py` is the first product-owned
 visibility slice. It preserves the copied task-facing
 `send_pipeline_notification(...)` API but emits through the `VisibilitySink`

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -195,6 +195,12 @@
   ],
   "owned": [
     {
+      "target": "extracted_content_pipeline/campaign_llm_client.py"
+    },
+    {
+      "target": "extracted_content_pipeline/settings.py"
+    },
+    {
       "target": "extracted_content_pipeline/pipelines/notify.py"
     }
   ]

--- a/extracted_content_pipeline/settings.py
+++ b/extracted_content_pipeline/settings.py
@@ -44,4 +44,19 @@ def build_settings() -> SimpleNamespace:
         blog_post_temperature=_to_float(os.getenv("EXTRACTED_B2B_BLOG_POST_TEMPERATURE"), 0.2),
     )
 
-    return SimpleNamespace(external_data=external_data, b2b_churn=b2b_churn)
+    campaign_llm = SimpleNamespace(
+        workload=os.getenv("EXTRACTED_CAMPAIGN_LLM_WORKLOAD") or "draft",
+        prefer_cloud=_to_bool(os.getenv("EXTRACTED_CAMPAIGN_LLM_PREFER_CLOUD"), True),
+        try_openrouter=_to_bool(os.getenv("EXTRACTED_CAMPAIGN_LLM_TRY_OPENROUTER"), True),
+        auto_activate_ollama=_to_bool(
+            os.getenv("EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA"),
+            True,
+        ),
+        openrouter_model=os.getenv("EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL") or None,
+    )
+
+    return SimpleNamespace(
+        external_data=external_data,
+        b2b_churn=b2b_churn,
+        campaign_llm=campaign_llm,
+    )

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -5,8 +5,11 @@ import pytest
 from extracted_content_pipeline.campaign_llm_client import (
     LLMUnavailableError,
     PipelineLLMClient,
+    PipelineLLMClientConfig,
+    create_pipeline_llm_client,
 )
 from extracted_content_pipeline.campaign_ports import LLMMessage
+from extracted_content_pipeline.settings import build_settings
 
 
 class _ChatLLM:
@@ -131,6 +134,118 @@ async def test_pipeline_llm_client_normalizes_string_generate_response():
     assert response.content == "plain generated response"
     assert response.model is None
     assert response.raw == "plain generated response"
+
+
+def test_llm_client_config_from_mapping_parses_provider_routing_fields():
+    config = PipelineLLMClientConfig.from_mapping({
+        "workload": "campaign",
+        "prefer_cloud": "false",
+        "try_openrouter": "0",
+        "auto_activate_ollama": "yes",
+        "openrouter_model": "anthropic/claude-haiku-4-5",
+    })
+
+    assert config == PipelineLLMClientConfig(
+        workload="campaign",
+        prefer_cloud=False,
+        try_openrouter=False,
+        auto_activate_ollama=True,
+        openrouter_model="anthropic/claude-haiku-4-5",
+    )
+
+
+def test_llm_client_config_from_env_accepts_custom_prefix_and_blank_model():
+    config = PipelineLLMClientConfig.from_env(
+        {
+            "PIPE_LLM_WORKLOAD": "draft",
+            "PIPE_LLM_PREFER_CLOUD": "off",
+            "PIPE_LLM_TRY_OPENROUTER": "true",
+            "PIPE_LLM_AUTO_ACTIVATE_OLLAMA": "false",
+            "PIPE_LLM_OPENROUTER_MODEL": "  ",
+        },
+        prefix="PIPE_LLM_",
+    )
+
+    assert config == PipelineLLMClientConfig(
+        workload="draft",
+        prefer_cloud=False,
+        try_openrouter=True,
+        auto_activate_ollama=False,
+        openrouter_model=None,
+    )
+
+
+def test_llm_client_config_from_settings_namespace():
+    class _Settings:
+        workload = "campaign"
+        prefer_cloud = False
+        try_openrouter = True
+        auto_activate_ollama = False
+        openrouter_model = "openai/gpt-4o-mini"
+
+    assert PipelineLLMClientConfig.from_settings(_Settings()) == PipelineLLMClientConfig(
+        workload="campaign",
+        prefer_cloud=False,
+        try_openrouter=True,
+        auto_activate_ollama=False,
+        openrouter_model="openai/gpt-4o-mini",
+    )
+
+
+def test_build_settings_exposes_campaign_llm_provider_config(monkeypatch):
+    monkeypatch.setenv("EXTRACTED_CAMPAIGN_LLM_WORKLOAD", "campaign")
+    monkeypatch.setenv("EXTRACTED_CAMPAIGN_LLM_PREFER_CLOUD", "false")
+    monkeypatch.setenv("EXTRACTED_CAMPAIGN_LLM_TRY_OPENROUTER", "true")
+    monkeypatch.setenv("EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA", "false")
+    monkeypatch.setenv(
+        "EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL",
+        "anthropic/claude-haiku-4-5",
+    )
+
+    config = PipelineLLMClientConfig.from_settings(build_settings().campaign_llm)
+
+    assert config == PipelineLLMClientConfig(
+        workload="campaign",
+        prefer_cloud=False,
+        try_openrouter=True,
+        auto_activate_ollama=False,
+        openrouter_model="anthropic/claude-haiku-4-5",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_pipeline_llm_client_applies_config_to_resolver():
+    llm = _ChatLLM()
+    resolver_calls = []
+
+    def resolver(**kwargs):
+        resolver_calls.append(kwargs)
+        return llm
+
+    client = create_pipeline_llm_client(
+        {
+            "workload": "campaign",
+            "prefer_cloud": False,
+            "try_openrouter": False,
+            "auto_activate_ollama": False,
+            "openrouter_model": "anthropic/claude-haiku-4-5",
+        },
+        resolver=resolver,
+    )
+
+    await client.complete(
+        [LLMMessage(role="user", content="Write")],
+        max_tokens=50,
+        temperature=0.1,
+    )
+
+    assert resolver_calls == [{
+        "workload": "campaign",
+        "prefer_cloud": False,
+        "try_openrouter": False,
+        "auto_activate_ollama": False,
+        "openrouter_model": "anthropic/claude-haiku-4-5",
+    }]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -73,8 +73,9 @@ def test_core_campaign_migrations_define_product_tables() -> None:
     assert "CREATE TABLE IF NOT EXISTS seller_targets" in seller_schema
 
 
-def test_manifest_tracks_product_owned_notify_adapter() -> None:
-    assert (
-        "extracted_content_pipeline/pipelines/notify.py"
-        in _owned_targets()
-    )
+def test_manifest_tracks_product_owned_adapter_files() -> None:
+    owned = _owned_targets()
+
+    assert "extracted_content_pipeline/pipelines/notify.py" in owned
+    assert "extracted_content_pipeline/campaign_llm_client.py" in owned
+    assert "extracted_content_pipeline/settings.py" in owned


### PR DESCRIPTION
## Summary
- Add `PipelineLLMClientConfig` and `create_pipeline_llm_client()` so hosts can wire campaign LLM routing from explicit mappings, settings objects, or `EXTRACTED_CAMPAIGN_LLM_*` env vars
- Expose `settings.campaign_llm` for product-owned provider routing without importing Atlas settings
- Register `campaign_llm_client.py` and `settings.py` as owned manifest files so shared extraction gates cover them
- Update docs/status to mark provider-specific LLM config as hardened

## Validation
- `pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_campaign_manifest.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`
- `python -m py_compile extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/settings.py tests/test_extracted_campaign_llm_client.py tests/test_extracted_campaign_manifest.py`
- `git diff --check`