### PR TITLE
Harden extracted archetype reasoning adapter

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -163,7 +163,9 @@ Several small utility shims provide product-owned local behavior by default so t
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
 - `skills/registry.py`: local markdown-backed skill registry implementing
   `.get()` and product `SkillStore.get_prompt()`
-- `reasoning/archetypes.py`, `reasoning/evidence_engine.py`, and `reasoning/temporal.py`: minimal reasoning adapters for extracted report builders
+- `reasoning/archetypes.py`: product-owned deterministic churn-archetype scorer
+  for extracted report builders
+- `reasoning/evidence_engine.py` and `reasoning/temporal.py`: minimal reasoning adapters for extracted report builders
 - `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
 - `services/b2b/cache_runner.py`: local exact-cache request helpers and no-op lookup/store
 - `services/b2b/enrichment_contract.py`: local enrichment contract fallbacks

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -41,6 +41,9 @@
 - `pipelines.notify` is product-owned and dispatches through the
   `VisibilitySink` port when configured, while staying a no-op when no host
   visibility adapter is installed.
+- `reasoning.archetypes` is product-owned and provides deterministic
+  churn-archetype scoring, best-match selection, top-match filtering, and
+  falsification-condition lookup without Atlas dependencies.
 
 ## Validation gates in repo
 
@@ -59,8 +62,8 @@ extracted package, not just manifest-relative import resolution.
 
 ## Remaining extraction work
 
-1. Harden remaining minimal reasoning adapters into customer-grade policy
-   modules.
+1. Harden remaining minimal reasoning adapters (`evidence_engine`, `temporal`)
+   into customer-grade policy modules.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -116,6 +116,11 @@ visibility slice. It preserves the copied task-facing
 port when a host configures one. With no sink configured it remains a safe
 no-op, so standalone task imports do not require Atlas notification services.
 
+`extracted_content_pipeline/reasoning/archetypes.py` is the first product-owned
+reasoning policy slice. It scores vendor evidence against deterministic churn
+archetypes, returns thresholded matches, and exposes falsification conditions
+without a database, LLM, or Atlas import.
+
 ## Readiness Gate
 
 Run:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -202,6 +202,9 @@
     },
     {
       "target": "extracted_content_pipeline/pipelines/notify.py"
+    },
+    {
+      "target": "extracted_content_pipeline/reasoning/archetypes.py"
     }
   ]
 }

--- a/extracted_content_pipeline/reasoning/archetypes.py
+++ b/extracted_content_pipeline/reasoning/archetypes.py
@@ -7,11 +7,22 @@ MATCH_THRESHOLD = 0.25
 
 
 @dataclass(frozen=True)
+class SignalRule:
+    metric: str
+    direction: str
+    weight: float = 1.0
+    threshold: float | None = None
+    pain_keywords: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class ArchetypeProfile:
     name: str
     description: str = ""
     typical_risk: str = "medium"
     falsification_templates: list[str] = field(default_factory=list)
+    signals: list[SignalRule] = field(default_factory=list)
+    velocity_hints: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -24,17 +35,292 @@ class ArchetypeMatch:
 
 
 ARCHETYPES: dict[str, ArchetypeProfile] = {
-    name: ArchetypeProfile(name=name)
-    for name in (
-        "pricing_shock",
-        "feature_gap",
-        "acquisition_decay",
-        "leadership_redesign",
-        "integration_break",
-        "support_collapse",
-        "category_disruption",
-        "compliance_gap",
-    )
+    "pricing_shock": ArchetypeProfile(
+        name="pricing_shock",
+        description="Sudden pricing pressure drives churn intent and competitor mentions",
+        typical_risk="high",
+        signals=[
+            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.0),
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=2.0,
+                pain_keywords=["price", "pricing", "cost", "expensive", "renewal", "invoice"],
+            ),
+            SignalRule("competitor_count", "high", weight=1.0, threshold=3),
+            SignalRule("recommend_ratio", "low", weight=1.0, threshold=0.4),
+            SignalRule("displacement_edge_count", "high", weight=1.2, threshold=2),
+            SignalRule("positive_review_pct", "low", weight=0.8, threshold=40.0),
+        ],
+        velocity_hints={
+            "avg_urgency": "increasing",
+            "competitor_count": "increasing",
+            "recommend_ratio": "decreasing",
+        },
+        falsification_templates=[
+            "Vendor reverts to previous pricing or introduces budget tier",
+            "Positive review trend reverses for multiple consecutive weeks",
+            "Competitor count stabilizes or decreases",
+        ],
+    ),
+    "feature_gap": ArchetypeProfile(
+        name="feature_gap",
+        description="Missing capabilities create switching pressure toward feature-complete alternatives",
+        typical_risk="medium",
+        signals=[
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=2.0,
+                pain_keywords=[
+                    "missing",
+                    "lack",
+                    "need",
+                    "feature",
+                    "no support for",
+                    "doesn't have",
+                    "wish",
+                    "roadmap",
+                ],
+            ),
+            SignalRule("competitor_count", "high", weight=1.5, threshold=2),
+            SignalRule("displacement_edge_count", "high", weight=1.5, threshold=2),
+            SignalRule("pain_count", "high", weight=1.0, threshold=4),
+            SignalRule("recommend_ratio", "low", weight=0.8, threshold=0.5),
+        ],
+        velocity_hints={
+            "competitor_count": "increasing",
+            "displacement_edge_count": "increasing",
+            "pain_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor releases the missing feature",
+            "Competitor mentions decrease materially",
+            "Feature-related pain drops below sustained signal levels",
+        ],
+    ),
+    "acquisition_decay": ArchetypeProfile(
+        name="acquisition_decay",
+        description="Post-acquisition quality decline creates support and trust erosion",
+        typical_risk="high",
+        signals=[
+            SignalRule("positive_review_pct", "low", weight=1.5, threshold=35.0),
+            SignalRule("avg_urgency", "high", weight=1.2, threshold=5.5),
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=2.0,
+                pain_keywords=[
+                    "acquired",
+                    "acquisition",
+                    "buyout",
+                    "merged",
+                    "new ownership",
+                    "quality decline",
+                    "worse since",
+                ],
+            ),
+            SignalRule("recommend_ratio", "low", weight=1.0, threshold=0.35),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.6),
+        ],
+        velocity_hints={
+            "positive_review_pct": "decreasing",
+            "avg_urgency": "increasing",
+            "churn_density": "increasing",
+        },
+        falsification_templates=[
+            "Positive review percentage improves above neutral levels",
+            "Support response quality improves materially",
+            "New leadership announces and executes a quality recovery plan",
+        ],
+    ),
+    "leadership_redesign": ArchetypeProfile(
+        name="leadership_redesign",
+        description="Product redesign or leadership change disrupts existing workflows",
+        typical_risk="medium",
+        signals=[
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=2.5,
+                pain_keywords=[
+                    "redesign",
+                    "new ui",
+                    "new interface",
+                    "update",
+                    "changed layout",
+                    "new version",
+                    "ui overhaul",
+                    "workflow changed",
+                    "moved features",
+                ],
+            ),
+            SignalRule("avg_urgency", "high", weight=1.0, threshold=5.0),
+            SignalRule("pain_count", "high", weight=0.8, threshold=3),
+            SignalRule("positive_review_pct", "low", weight=1.0, threshold=45.0),
+        ],
+        velocity_hints={
+            "avg_urgency": "increasing",
+            "positive_review_pct": "decreasing",
+            "pain_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor reverts UI changes or provides a classic mode",
+            "Positive review percentage recovers above neutral levels",
+            "UI-related pain drops below sustained signal levels",
+        ],
+    ),
+    "integration_break": ArchetypeProfile(
+        name="integration_break",
+        description="API, connector, or workflow breakage creates operational switching pressure",
+        typical_risk="high",
+        signals=[
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=2.5,
+                pain_keywords=[
+                    "api",
+                    "integration",
+                    "webhook",
+                    "connector",
+                    "broke",
+                    "breaking change",
+                    "deprecated",
+                    "incompatible",
+                    "migration",
+                    "sdk",
+                ],
+            ),
+            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.5),
+            SignalRule("high_intent_company_count", "high", weight=1.2, threshold=3),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.5),
+        ],
+        velocity_hints={
+            "avg_urgency": "increasing",
+            "churn_density": "increasing",
+            "high_intent_company_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor provides backward-compatible API or migration tooling",
+            "Integration-related urgency drops below sustained signal levels",
+            "Integration-related pain mentions decline materially",
+        ],
+    ),
+    "support_collapse": ArchetypeProfile(
+        name="support_collapse",
+        description="Support quality decline creates trust erosion and retention risk",
+        typical_risk="critical",
+        signals=[
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=2.0,
+                pain_keywords=[
+                    "support",
+                    "response time",
+                    "ticket",
+                    "help desk",
+                    "no response",
+                    "slow support",
+                    "waiting",
+                    "customer service",
+                    "escalation",
+                ],
+            ),
+            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.0),
+            SignalRule("positive_review_pct", "low", weight=1.5, threshold=30.0),
+            SignalRule("recommend_ratio", "low", weight=1.2, threshold=0.3),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.7),
+        ],
+        velocity_hints={
+            "positive_review_pct": "decreasing",
+            "avg_urgency": "increasing",
+            "churn_density": "increasing",
+            "recommend_ratio": "decreasing",
+        },
+        falsification_templates=[
+            "Support response quality improves materially",
+            "Positive review percentage recovers above warning levels",
+            "Support-related complaints decline materially",
+        ],
+    ),
+    "category_disruption": ArchetypeProfile(
+        name="category_disruption",
+        description="New entrant or category narrative shifts pull buyers away from incumbents",
+        typical_risk="high",
+        signals=[
+            SignalRule("competitor_count", "high", weight=2.0, threshold=5),
+            SignalRule("displacement_edge_count", "high", weight=2.0, threshold=4),
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=1.0,
+                pain_keywords=[
+                    "alternative",
+                    "switch to",
+                    "moved to",
+                    "replaced by",
+                    "ai-native",
+                    "modern",
+                    "next-gen",
+                    "outdated",
+                ],
+            ),
+            SignalRule("high_intent_company_count", "high", weight=1.5, threshold=5),
+            SignalRule("recommend_ratio", "low", weight=0.8, threshold=0.4),
+        ],
+        velocity_hints={
+            "competitor_count": "increasing",
+            "displacement_edge_count": "increasing",
+            "high_intent_company_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor launches features that answer the category shift",
+            "Competitor count stabilizes for multiple periods",
+            "Displacement edge count declines materially",
+        ],
+    ),
+    "compliance_gap": ArchetypeProfile(
+        name="compliance_gap",
+        description="Unmet security or regulatory requirements create enterprise churn risk",
+        typical_risk="critical",
+        signals=[
+            SignalRule(
+                "top_pain",
+                "present",
+                weight=3.0,
+                pain_keywords=[
+                    "compliance",
+                    "gdpr",
+                    "hipaa",
+                    "soc2",
+                    "soc 2",
+                    "iso 27001",
+                    "fedramp",
+                    "pci",
+                    "audit",
+                    "regulation",
+                    "security",
+                    "data residency",
+                    "encryption",
+                    "certification",
+                ],
+            ),
+            SignalRule("high_intent_company_count", "high", weight=1.5, threshold=3),
+            SignalRule("avg_urgency", "high", weight=1.0, threshold=5.5),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.5),
+        ],
+        velocity_hints={
+            "high_intent_company_count": "increasing",
+            "churn_density": "increasing",
+        },
+        falsification_templates=[
+            "Vendor achieves the missing certification or compliance requirement",
+            "Compliance-related complaints drop to zero",
+            "Enterprise churn intent stabilizes",
+        ],
+    ),
 }
 
 
@@ -42,13 +328,22 @@ def score_evidence(
     evidence: dict[str, Any],
     temporal: dict[str, Any] | None = None,
 ) -> list[ArchetypeMatch]:
-    return []
+    merged: dict[str, Any] = dict(evidence or {})
+    if isinstance(temporal, dict):
+        merged.update(temporal)
+
+    matches = [_score_archetype(profile, merged) for profile in ARCHETYPES.values()]
+    matches.sort(key=lambda match: match.score, reverse=True)
+    return matches
 
 
 def best_match(
     evidence: dict[str, Any],
     temporal: dict[str, Any] | None = None,
 ) -> ArchetypeMatch | None:
+    matches = score_evidence(evidence, temporal)
+    if matches and matches[0].score >= MATCH_THRESHOLD:
+        return matches[0]
     return None
 
 
@@ -58,7 +353,10 @@ def top_matches(
     *,
     limit: int = 3,
 ) -> list[ArchetypeMatch]:
-    return []
+    if limit <= 0:
+        return []
+    matches = score_evidence(evidence, temporal)
+    return [match for match in matches[:limit] if match.score >= MATCH_THRESHOLD]
 
 
 def get_archetype(name: str) -> ArchetypeProfile | None:
@@ -74,4 +372,219 @@ def enrich_evidence_with_archetypes(
     evidence: dict[str, Any],
     temporal: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return dict(evidence or {})
+    enriched = dict(evidence or {})
+    matches = top_matches(enriched, temporal, limit=3)
+    if not matches:
+        return enriched
+    enriched["archetype_scores"] = [
+        {
+            "archetype": match.archetype,
+            "signal_score": match.score,
+            "matched_signals": list(match.matched_signals),
+            "missing_signals": list(match.missing_signals),
+            "risk_level": match.risk_level,
+        }
+        for match in matches
+    ]
+    return enriched
+
+
+def _score_archetype(profile: ArchetypeProfile, evidence: dict[str, Any]) -> ArchetypeMatch:
+    total_weight = sum(rule.weight for rule in profile.signals)
+    if total_weight <= 0:
+        return ArchetypeMatch(
+            archetype=profile.name,
+            score=0.0,
+            matched_signals=[],
+            missing_signals=[],
+            risk_level=profile.typical_risk,
+        )
+
+    weighted_score = 0.0
+    matched: list[str] = []
+    missing: list[str] = []
+    for rule in profile.signals:
+        if _evaluate_rule(rule, evidence):
+            weighted_score += rule.weight
+            matched.append(rule.metric)
+        else:
+            missing.append(rule.metric)
+
+    weighted_score += _velocity_bonus(profile, evidence)
+    weighted_score += _anomaly_bonus(profile, evidence)
+
+    max_possible = total_weight + len(profile.velocity_hints) * 0.45 + 0.5
+    score = min(weighted_score / max_possible, 1.0)
+    return ArchetypeMatch(
+        archetype=profile.name,
+        score=round(score, 3),
+        matched_signals=matched,
+        missing_signals=missing,
+        risk_level=_risk_from_score(score, profile.typical_risk),
+    )
+
+
+def _evaluate_rule(rule: SignalRule, evidence: dict[str, Any]) -> bool:
+    if rule.pain_keywords:
+        text = _evidence_text(evidence)
+        if not text:
+            return False
+        return any(keyword.lower() in text for keyword in rule.pain_keywords)
+
+    if rule.direction == "present":
+        return _has_value(evidence.get(rule.metric))
+
+    if rule.direction in {"high", "low"}:
+        value = _numeric_value(evidence.get(rule.metric))
+        if value is None:
+            return False
+        threshold = rule.threshold if rule.threshold is not None else 0.0
+        if rule.direction == "high":
+            return value >= threshold
+        return value <= threshold
+
+    if rule.direction == "increasing":
+        value = _numeric_value(evidence.get(f"velocity_{rule.metric}"))
+        return value is not None and value > 0
+    if rule.direction == "decreasing":
+        value = _numeric_value(evidence.get(f"velocity_{rule.metric}"))
+        return value is not None and value < 0
+    if rule.direction == "increasing_30d":
+        value = _numeric_value(evidence.get(f"trend_30d_{rule.metric}"))
+        return value is not None and value > 0
+    if rule.direction == "decreasing_30d":
+        value = _numeric_value(evidence.get(f"trend_30d_{rule.metric}"))
+        return value is not None and value < 0
+
+    return False
+
+
+def _velocity_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float:
+    bonus = 0.0
+    for metric, expected in profile.velocity_hints.items():
+        velocity = _numeric_value(evidence.get(f"velocity_{metric}"))
+        if velocity is None:
+            continue
+        if expected == "increasing" and velocity > 0:
+            bonus += 0.3
+        elif expected == "decreasing" and velocity < 0:
+            bonus += 0.3
+        else:
+            continue
+
+        acceleration = _numeric_value(evidence.get(f"accel_{metric}"))
+        if acceleration is None:
+            continue
+        if expected == "increasing" and acceleration > 0:
+            bonus += 0.15
+        elif expected == "decreasing" and acceleration < 0:
+            bonus += 0.15
+    return bonus
+
+
+def _anomaly_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float:
+    anomalies = evidence.get("anomalies")
+    if not isinstance(anomalies, list):
+        return 0.0
+    signal_metrics = {rule.metric for rule in profile.signals if not rule.pain_keywords}
+    bonus = 0.0
+    for anomaly in anomalies:
+        if not isinstance(anomaly, dict) or anomaly.get("metric") not in signal_metrics:
+            continue
+        z_score = _numeric_value(anomaly.get("z_score"))
+        if z_score is None:
+            continue
+        z_abs = abs(z_score)
+        if z_abs > 2.0:
+            bonus += 0.25
+        elif z_abs > 1.5:
+            bonus += 0.1
+    return min(bonus, 0.5)
+
+
+def _risk_from_score(score: float, base_risk: str) -> str:
+    if score < 0.25:
+        return "low"
+    if score < 0.45:
+        return "medium" if base_risk in {"high", "critical"} else "low"
+    if score < 0.65:
+        return "high" if base_risk == "critical" else "medium"
+    if score < 0.80:
+        return "high"
+    return "critical" if base_risk == "critical" else "high"
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _numeric_value(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip().replace(",", "")
+        if not stripped:
+            return None
+        if stripped.endswith("%"):
+            stripped = stripped[:-1]
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+_TEXT_KEY_HINTS = (
+    "category",
+    "complaint",
+    "competitor",
+    "driver",
+    "evidence",
+    "issue",
+    "pain",
+    "quote",
+    "reason",
+    "review",
+    "signal",
+    "summary",
+    "theme",
+    "weakness",
+)
+
+
+def _evidence_text(evidence: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in evidence.items():
+        key_text = str(key).lower()
+        if key in {"top_pain", "top_competitor", "pain_summary"} or any(
+            hint in key_text for hint in _TEXT_KEY_HINTS
+        ):
+            parts.extend(_flatten_text(value))
+    return " ".join(parts).lower()
+
+
+def _flatten_text(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for nested in value.values():
+            parts.extend(_flatten_text(nested))
+        return parts
+    if isinstance(value, (list, tuple, set)):
+        parts = []
+        for item in value:
+            parts.extend(_flatten_text(item))
+        return parts
+    return []

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -14,6 +14,7 @@ pytest \
   tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_pipeline_notify.py \
+  tests/test_extracted_reasoning_archetypes.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -79,3 +79,4 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/pipelines/notify.py" in owned
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
+    assert "extracted_content_pipeline/reasoning/archetypes.py" in owned

--- a/tests/test_extracted_reasoning_archetypes.py
+++ b/tests/test_extracted_reasoning_archetypes.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.reasoning.archetypes import (
+    ARCHETYPES,
+    best_match,
+    enrich_evidence_with_archetypes,
+    get_archetype,
+    get_falsification_conditions,
+    score_evidence,
+    top_matches,
+)
+
+
+def _pricing_evidence(**overrides):
+    evidence = {
+        "avg_urgency": "7.2",
+        "top_pain": "Renewal pricing jumped and the invoice became too expensive",
+        "competitor_count": 4,
+        "recommend_ratio": 0.2,
+        "displacement_edge_count": 3,
+        "positive_review_pct": "28%",
+    }
+    evidence.update(overrides)
+    return evidence
+
+
+def test_best_match_identifies_pricing_shock_from_mixed_numeric_shapes():
+    match = best_match(_pricing_evidence())
+
+    assert match is not None
+    assert match.archetype == "pricing_shock"
+    assert match.score >= 0.7
+    assert match.risk_level == "high"
+    assert set(match.matched_signals) >= {
+        "avg_urgency",
+        "top_pain",
+        "competitor_count",
+        "recommend_ratio",
+        "displacement_edge_count",
+        "positive_review_pct",
+    }
+
+
+def test_feature_gap_wins_when_missing_capability_signals_dominate():
+    evidence = {
+        "top_pain": "Customers keep asking for a missing workflow feature on the roadmap",
+        "competitor_count": 3,
+        "displacement_edge_count": 3,
+        "pain_count": 5,
+        "recommend_ratio": 0.25,
+    }
+
+    match = best_match(evidence)
+
+    assert match is not None
+    assert match.archetype == "feature_gap"
+    assert "top_pain" in match.matched_signals
+
+
+def test_keyword_matching_reads_nested_evidence_text():
+    evidence = {
+        "avg_urgency": 8,
+        "high_intent_company_count": 4,
+        "churn_density": 0.7,
+        "weakness_evidence": [
+            {
+                "best_quote": "The API connector broke after the migration",
+                "theme": "integration",
+            }
+        ],
+    }
+
+    match = best_match(evidence)
+
+    assert match is not None
+    assert match.archetype == "integration_break"
+
+
+def test_score_evidence_returns_all_archetypes_sorted():
+    matches = score_evidence(_pricing_evidence())
+
+    assert len(matches) == len(ARCHETYPES)
+    assert matches[0].score >= matches[-1].score
+    assert matches[0].archetype == "pricing_shock"
+
+
+def test_empty_or_malformed_evidence_does_not_emit_threshold_matches():
+    evidence = {
+        "avg_urgency": "not-a-number",
+        "competitor_count": None,
+        "top_pain": "   ",
+    }
+
+    assert best_match(evidence) is None
+    assert top_matches(evidence) == []
+    assert all(match.score == 0 for match in score_evidence(evidence))
+
+
+def test_top_matches_honors_limit_and_threshold():
+    matches = top_matches(_pricing_evidence(), limit=1)
+
+    assert len(matches) == 1
+    assert matches[0].archetype == "pricing_shock"
+    assert top_matches(_pricing_evidence(), limit=0) == []
+
+
+def test_temporal_velocity_increases_aligned_match_score():
+    evidence = _pricing_evidence(competitor_count=3, recommend_ratio=0.35)
+    base = next(match for match in score_evidence(evidence) if match.archetype == "pricing_shock")
+    temporal = {
+        "velocity_avg_urgency": 0.8,
+        "accel_avg_urgency": 0.2,
+        "velocity_competitor_count": 2.0,
+        "velocity_recommend_ratio": -0.1,
+    }
+
+    boosted = next(
+        match
+        for match in score_evidence(evidence, temporal)
+        if match.archetype == "pricing_shock"
+    )
+
+    assert boosted.score > base.score
+
+
+def test_anomaly_bonus_increases_matching_numeric_signal_score():
+    evidence = _pricing_evidence()
+    base = next(match for match in score_evidence(evidence) if match.archetype == "pricing_shock")
+    with_anomaly = dict(evidence)
+    with_anomaly["anomalies"] = [{"metric": "competitor_count", "z_score": "2.4"}]
+
+    boosted = next(
+        match
+        for match in score_evidence(with_anomaly)
+        if match.archetype == "pricing_shock"
+    )
+
+    assert boosted.score > base.score
+
+
+def test_enrich_evidence_adds_archetype_scores_without_mutating_input():
+    evidence = _pricing_evidence()
+
+    enriched = enrich_evidence_with_archetypes(evidence)
+
+    assert "archetype_scores" not in evidence
+    assert enriched["archetype_scores"][0]["archetype"] == "pricing_shock"
+    assert enriched["archetype_scores"][0]["signal_score"] >= 0.7
+    assert "matched_signals" in enriched["archetype_scores"][0]
+
+
+def test_enrich_evidence_leaves_no_match_payload_unannotated():
+    enriched = enrich_evidence_with_archetypes({"vendor_name": "NoSignal"})
+
+    assert enriched == {"vendor_name": "NoSignal"}
+
+
+def test_lookup_helpers_return_profiles_and_copy_falsification_lists():
+    profile = get_archetype("compliance_gap")
+    conditions = get_falsification_conditions("compliance_gap")
+
+    assert profile is not None
+    assert profile.typical_risk == "critical"
+    assert conditions
+
+    conditions.append("mutated")
+    assert "mutated" not in get_falsification_conditions("compliance_gap")
+    assert get_archetype("unknown") is None
+    assert get_falsification_conditions("unknown") == []


### PR DESCRIPTION
## Summary
- Replace the extracted archetype stub with deterministic churn-archetype scoring, thresholded best/top-match helpers, velocity/anomaly bonuses, and falsification lookup.
- Register `reasoning/archetypes.py` as product-owned and add it to extracted pipeline runner coverage.
- Add focused extracted archetype tests plus docs/status updates for the product-owned reasoning slice.

## Validation
- `python -m py_compile extracted_content_pipeline/reasoning/archetypes.py tests/test_extracted_reasoning_archetypes.py`
- `pytest tests/test_extracted_reasoning_archetypes.py tests/test_extracted_campaign_manifest.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`