### PR TITLE
Harden extracted temporal reasoning adapter

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -165,7 +165,10 @@ Several small utility shims provide product-owned local behavior by default so t
   `.get()` and product `SkillStore.get_prompt()`
 - `reasoning/archetypes.py`: product-owned deterministic churn-archetype scorer
   for extracted report builders
-- `reasoning/evidence_engine.py` and `reasoning/temporal.py`: minimal reasoning adapters for extracted report builders
+- `reasoning/temporal.py`: product-owned temporal analytics over vendor
+  snapshot rows, including velocities, trends, category baselines, and
+  anomaly serialization
+- `reasoning/evidence_engine.py`: minimal reasoning adapter for extracted report builders
 - `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
 - `services/b2b/cache_runner.py`: local exact-cache request helpers and no-op lookup/store
 - `services/b2b/enrichment_contract.py`: local enrichment contract fallbacks

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -44,6 +44,9 @@
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.
+- `reasoning.temporal` is product-owned and computes snapshot velocity,
+  acceleration, trend, category-baseline, anomaly, and recency-weight outputs
+  through a host-provided async `fetch` interface.
 
 ## Validation gates in repo
 
@@ -62,8 +65,8 @@ extracted package, not just manifest-relative import resolution.
 
 ## Remaining extraction work
 
-1. Harden remaining minimal reasoning adapters (`evidence_engine`, `temporal`)
-   into customer-grade policy modules.
+1. Harden remaining minimal reasoning adapters (`evidence_engine`) into
+   customer-grade policy modules.
 2. Trim copied helper surface to only the modules required by target sellable workflows.
 3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -121,6 +121,11 @@ reasoning policy slice. It scores vendor evidence against deterministic churn
 archetypes, returns thresholded matches, and exposes falsification conditions
 without a database, LLM, or Atlas import.
 
+`extracted_content_pipeline/reasoning/temporal.py` is the second product-owned
+reasoning policy slice. It computes velocity, acceleration, long-term trends,
+category percentiles, anomalies, recency weights, and evidence serialization
+from a host-provided async `fetch` interface instead of Atlas helper imports.
+
 ## Readiness Gate
 
 Run:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -205,6 +205,9 @@
     },
     {
       "target": "extracted_content_pipeline/reasoning/archetypes.py"
+    },
+    {
+      "target": "extracted_content_pipeline/reasoning/temporal.py"
     }
   ]
 }

--- a/extracted_content_pipeline/reasoning/temporal.py
+++ b/extracted_content_pipeline/reasoning/temporal.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
 from typing import Any
+
+MIN_DAYS_FOR_VELOCITY = 2
+MIN_DAYS_FOR_ACCELERATION = 3
+MIN_DAYS_FOR_PERCENTILES = 3
+MIN_DAYS_FOR_TREND = 14
+RECENCY_HALF_LIFE_DAYS = 14
 
 
 @dataclass(frozen=True)
@@ -55,19 +63,255 @@ class TemporalEvidence:
     insufficient_data: bool = False
 
 
+_VELOCITY_METRICS = [
+    "churn_density",
+    "avg_urgency",
+    "positive_review_pct",
+    "recommend_ratio",
+    "pain_count",
+    "competitor_count",
+    "displacement_edge_count",
+    "high_intent_company_count",
+    "support_sentiment",
+    "employee_growth_rate",
+    "new_feature_velocity",
+    "legacy_support_score",
+]
+
+
 class TemporalEngine:
+    """Standalone temporal analyzer over vendor snapshot rows.
+
+    The engine expects a pool/repository object with an async ``fetch`` method.
+    It does not import Atlas helpers; hosts can satisfy the same contract with
+    asyncpg, a repository adapter, or a test double.
+    """
+
     def __init__(self, pool: Any):
         self._pool = pool
 
     async def analyze_vendor(self, vendor_name: str) -> TemporalEvidence:
+        normalized_name = str(vendor_name or "").strip()
+        snapshots = await self._load_snapshots(normalized_name)
+
+        if len(snapshots) < MIN_DAYS_FOR_VELOCITY:
+            return TemporalEvidence(
+                vendor_name=normalized_name,
+                snapshot_days=len(snapshots),
+                insufficient_data=True,
+            )
+
+        velocities = self._compute_velocities(normalized_name, snapshots)
+        trends: list[LongTermTrend] = []
+        if len(snapshots) >= MIN_DAYS_FOR_TREND:
+            trends = self._compute_long_term_trends(normalized_name, snapshots)
+
+        baselines: list[CategoryPercentile] = []
+        anomalies: list[AnomalyScore] = []
+        latest = snapshots[-1]
+        category = str(latest.get("product_category") or "").strip()
+        if category:
+            baselines = await self._compute_percentiles(category)
+            anomalies = self._compute_anomalies(normalized_name, latest, baselines)
+
         return TemporalEvidence(
-            vendor_name=str(vendor_name or ""),
-            snapshot_days=0,
-            insufficient_data=True,
+            vendor_name=normalized_name,
+            snapshot_days=len(snapshots),
+            velocities=velocities,
+            trends=trends,
+            anomalies=anomalies,
+            category_baselines=baselines,
         )
 
     async def analyze_all_vendors(self) -> dict[str, TemporalEvidence]:
-        return {}
+        if not self._pool or not hasattr(self._pool, "fetch"):
+            return {}
+        rows = await self._pool.fetch(
+            "SELECT DISTINCT vendor_name FROM b2b_vendor_snapshots ORDER BY vendor_name"
+        )
+        results: dict[str, TemporalEvidence] = {}
+        for row in rows:
+            name = str(_row_get(row, "vendor_name") or "").strip()
+            if not name:
+                continue
+            results[name] = await self.analyze_vendor(name)
+        return results
+
+    def _compute_velocities(
+        self,
+        vendor_name: str,
+        snapshots: list[dict[str, Any]],
+    ) -> list[VendorVelocity]:
+        if len(snapshots) < MIN_DAYS_FOR_VELOCITY:
+            return []
+
+        latest = snapshots[-1]
+        previous = snapshots[-2]
+        days = _days_between(previous.get("snapshot_date"), latest.get("snapshot_date"))
+        if days <= 0:
+            return []
+
+        velocities: list[VendorVelocity] = []
+        for metric in _VELOCITY_METRICS:
+            current = _numeric_value(latest.get(metric))
+            prior = _numeric_value(previous.get(metric))
+            if current is None or prior is None:
+                continue
+
+            velocity = (current - prior) / days
+            acceleration = None
+            if len(snapshots) >= MIN_DAYS_FOR_ACCELERATION:
+                prior2 = snapshots[-3]
+                prior2_value = _numeric_value(prior2.get(metric))
+                days2 = _days_between(prior2.get("snapshot_date"), previous.get("snapshot_date"))
+                if prior2_value is not None and days2 > 0:
+                    previous_velocity = (prior - prior2_value) / days2
+                    acceleration = (velocity - previous_velocity) / days
+
+            velocities.append(
+                VendorVelocity(
+                    vendor_name=vendor_name,
+                    metric=metric,
+                    current_value=current,
+                    previous_value=prior,
+                    velocity=velocity,
+                    days_between=days,
+                    acceleration=acceleration,
+                )
+            )
+        return velocities
+
+    def _compute_long_term_trends(
+        self,
+        vendor_name: str,
+        snapshots: list[dict[str, Any]],
+    ) -> list[LongTermTrend]:
+        if len(snapshots) < MIN_DAYS_FOR_TREND:
+            return []
+
+        latest_date = _coerce_date(snapshots[-1].get("snapshot_date"))
+        if latest_date is None:
+            return []
+
+        def _window(days: int) -> list[dict[str, Any]]:
+            cutoff = latest_date - timedelta(days=days)
+            rows = []
+            for snapshot in snapshots:
+                snapshot_date = _coerce_date(snapshot.get("snapshot_date"))
+                if snapshot_date is not None and snapshot_date >= cutoff:
+                    rows.append(snapshot)
+            return rows
+
+        window_30 = _window(30)
+        window_90 = _window(90)
+        trends: list[LongTermTrend] = []
+        for metric in _VELOCITY_METRICS:
+            if _numeric_value(snapshots[-1].get(metric)) is None:
+                continue
+            slope_30 = self._calculate_slope(window_30, metric)
+            slope_90 = (
+                self._calculate_slope(window_90, metric)
+                if len(window_90) > len(window_30)
+                else None
+            )
+            if slope_30 is None and slope_90 is None:
+                continue
+            trends.append(
+                LongTermTrend(
+                    metric=metric,
+                    slope_30d=slope_30,
+                    slope_90d=slope_90,
+                    volatility=_volatility(window_30, metric),
+                    data_points=len(window_30),
+                )
+            )
+        return trends
+
+    def _calculate_slope(self, window: list[dict[str, Any]], metric: str) -> float | None:
+        if len(window) < 2:
+            return None
+
+        start = _coerce_date(window[0].get("snapshot_date"))
+        if start is None:
+            return None
+
+        x_values: list[int] = []
+        y_values: list[float] = []
+        for snapshot in window:
+            snapshot_date = _coerce_date(snapshot.get("snapshot_date"))
+            value = _numeric_value(snapshot.get(metric))
+            if snapshot_date is None or value is None:
+                continue
+            x_values.append((snapshot_date - start).days)
+            y_values.append(value)
+
+        if len(x_values) < 2:
+            return None
+
+        n = len(x_values)
+        sum_x = sum(x_values)
+        sum_y = sum(y_values)
+        sum_xy = sum(x * y for x, y in zip(x_values, y_values))
+        sum_xx = sum(x * x for x in x_values)
+        denominator = n * sum_xx - sum_x * sum_x
+        if denominator == 0:
+            return None
+        return (n * sum_xy - sum_x * sum_y) / denominator
+
+    async def _compute_percentiles(self, category: str) -> list[CategoryPercentile]:
+        if not self._pool or not hasattr(self._pool, "fetch"):
+            return []
+        rows = await self._pool.fetch(
+            """
+            SELECT s.* FROM b2b_vendor_snapshots s
+            JOIN (
+                SELECT vendor_name, MAX(snapshot_date) AS max_date
+                FROM b2b_vendor_snapshots
+                GROUP BY vendor_name
+            ) latest ON s.vendor_name = latest.vendor_name
+                AND s.snapshot_date = latest.max_date
+            WHERE s.product_category = $1
+            """,
+            category,
+        )
+        return _percentiles_from_rows(category, [dict(row) for row in rows])
+
+    def _compute_anomalies(
+        self,
+        vendor_name: str,
+        latest_snapshot: dict[str, Any],
+        baselines: list[CategoryPercentile],
+    ) -> list[AnomalyScore]:
+        baseline_by_metric = {baseline.metric: baseline for baseline in baselines}
+        anomalies: list[AnomalyScore] = []
+        for metric in _VELOCITY_METRICS:
+            value = _numeric_value(latest_snapshot.get(metric))
+            baseline = baseline_by_metric.get(metric)
+            if value is None or baseline is None:
+                continue
+            iqr = baseline.p75 - baseline.p25
+            if iqr <= 0:
+                continue
+            std_approx = iqr / 1.35
+            z_score = (value - baseline.p50) / std_approx
+            p_value = _normal_sf(abs(z_score))
+            anomalies.append(
+                AnomalyScore(
+                    vendor_name=vendor_name,
+                    metric=metric,
+                    value=value,
+                    z_score=round(z_score, 3),
+                    p_value=round(p_value, 4),
+                    is_anomaly=abs(z_score) > 2.0,
+                )
+            )
+        return anomalies
+
+    @staticmethod
+    def recency_weight(days_old: int, half_life: int = RECENCY_HALF_LIFE_DAYS) -> float:
+        if days_old <= 0:
+            return 1.0
+        return math.pow(2, -(days_old / half_life))
 
     @staticmethod
     def to_evidence_dict(te: TemporalEvidence) -> dict[str, Any]:
@@ -76,9 +320,147 @@ class TemporalEngine:
                 "temporal_status": "insufficient_data",
                 "snapshot_days": te.snapshot_days,
             }
+
         evidence: dict[str, Any] = {"snapshot_days": te.snapshot_days}
         for velocity in te.velocities:
             evidence[f"velocity_{velocity.metric}"] = round(velocity.velocity, 4)
             if velocity.acceleration is not None:
                 evidence[f"accel_{velocity.metric}"] = round(velocity.acceleration, 4)
+
+        for trend in te.trends:
+            if trend.slope_30d is not None:
+                evidence[f"trend_30d_{trend.metric}"] = round(trend.slope_30d, 4)
+            if trend.slope_90d is not None:
+                evidence[f"trend_90d_{trend.metric}"] = round(trend.slope_90d, 4)
+
+        anomalies = [
+            {
+                "metric": anomaly.metric,
+                "value": anomaly.value,
+                "z_score": anomaly.z_score,
+                "p_value": anomaly.p_value,
+            }
+            for anomaly in te.anomalies
+            if anomaly.is_anomaly
+        ]
+        if anomalies:
+            evidence["anomalies"] = anomalies
         return evidence
+
+    async def _load_snapshots(self, vendor_name: str) -> list[dict[str, Any]]:
+        if not self._pool or not hasattr(self._pool, "fetch"):
+            return []
+        rows = await self._pool.fetch(
+            """
+            SELECT * FROM b2b_vendor_snapshots
+            WHERE vendor_name = $1
+            ORDER BY snapshot_date ASC
+            """,
+            vendor_name,
+        )
+        return [dict(row) for row in rows]
+
+
+def _percentiles_from_rows(
+    category: str,
+    rows: list[dict[str, Any]],
+) -> list[CategoryPercentile]:
+    if len(rows) < MIN_DAYS_FOR_PERCENTILES:
+        return []
+
+    percentiles: list[CategoryPercentile] = []
+    for metric in _VELOCITY_METRICS:
+        values = sorted(
+            value
+            for value in (_numeric_value(row.get(metric)) for row in rows)
+            if value is not None
+        )
+        if len(values) < MIN_DAYS_FOR_PERCENTILES:
+            continue
+        n = len(values)
+        percentiles.append(
+            CategoryPercentile(
+                product_category=category,
+                metric=metric,
+                p25=values[int(n * 0.25)],
+                p50=values[int(n * 0.50)],
+                p75=values[int(n * 0.75)],
+                sample_count=n,
+            )
+        )
+    return percentiles
+
+
+def _volatility(window: list[dict[str, Any]], metric: str) -> float | None:
+    values = [
+        value
+        for value in (_numeric_value(snapshot.get(metric)) for snapshot in window)
+        if value is not None
+    ]
+    if len(values) < 2:
+        return None
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return math.sqrt(variance)
+
+
+def _days_between(start: Any, end: Any) -> int:
+    start_date = _coerce_date(start)
+    end_date = _coerce_date(end)
+    if start_date is None or end_date is None:
+        return 0
+    return (end_date - start_date).days
+
+
+def _coerce_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return datetime.fromisoformat(stripped).date()
+        except ValueError:
+            return None
+    return None
+
+
+def _numeric_value(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip().replace(",", "")
+        if not stripped:
+            return None
+        if stripped.endswith("%"):
+            stripped = stripped[:-1]
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _row_get(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    try:
+        return row[key]
+    except (KeyError, TypeError):
+        return getattr(row, key, None)
+
+
+def _normal_sf(z: float) -> float:
+    t = 1.0 / (1.0 + 0.2316419 * abs(z))
+    d = 0.3989422804014327
+    poly = t * (
+        0.319381530
+        + t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429)))
+    )
+    sf = d * math.exp(-z * z / 2) * poly
+    return sf if z >= 0 else 1.0 - sf

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -15,6 +15,7 @@ pytest \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_reasoning_archetypes.py \
+  tests/test_extracted_reasoning_temporal.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -80,3 +80,4 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
+    assert "extracted_content_pipeline/reasoning/temporal.py" in owned

--- a/tests/test_extracted_reasoning_temporal.py
+++ b/tests/test_extracted_reasoning_temporal.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from extracted_content_pipeline.reasoning.temporal import (
+    AnomalyScore,
+    CategoryPercentile,
+    LongTermTrend,
+    TemporalEngine,
+    TemporalEvidence,
+    VendorVelocity,
+)
+
+
+class _Pool:
+    def __init__(
+        self,
+        *,
+        snapshots_by_vendor=None,
+        category_rows=None,
+        vendor_rows=None,
+    ):
+        self.snapshots_by_vendor = snapshots_by_vendor or {}
+        self.category_rows = category_rows or {}
+        self.vendor_rows = vendor_rows or []
+        self.calls = []
+
+    async def fetch(self, query, *args):
+        self.calls.append((query, args))
+        if "SELECT DISTINCT vendor_name" in query:
+            return self.vendor_rows
+        if "WHERE vendor_name = $1" in query:
+            return self.snapshots_by_vendor.get(args[0], [])
+        if "WHERE s.product_category = $1" in query:
+            return self.category_rows.get(args[0], [])
+        return []
+
+
+def _snapshot(day: date, **values):
+    row = {
+        "snapshot_date": day,
+        "vendor_name": values.pop("vendor_name", "Acme"),
+        "product_category": values.pop("product_category", "CRM"),
+    }
+    row.update(values)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_analyze_vendor_returns_insufficient_data_for_missing_history():
+    pool = _Pool(snapshots_by_vendor={"Acme": [_snapshot(date(2026, 1, 1), avg_urgency=5)]})
+
+    result = await TemporalEngine(pool).analyze_vendor(" Acme ")
+
+    assert result.vendor_name == "Acme"
+    assert result.snapshot_days == 1
+    assert result.insufficient_data is True
+
+
+@pytest.mark.asyncio
+async def test_analyze_vendor_computes_velocity_acceleration_and_anomaly():
+    snapshots = [
+        _snapshot(date(2026, 1, 1), avg_urgency=3, competitor_count=1),
+        _snapshot(date(2026, 1, 8), avg_urgency=5, competitor_count=2),
+        _snapshot(date(2026, 1, 15), avg_urgency=9, competitor_count=4),
+    ]
+    category_rows = [
+        _snapshot(date(2026, 1, 15), vendor_name="A", avg_urgency=3),
+        _snapshot(date(2026, 1, 15), vendor_name="B", avg_urgency=4),
+        _snapshot(date(2026, 1, 15), vendor_name="C", avg_urgency=5),
+        _snapshot(date(2026, 1, 15), vendor_name="D", avg_urgency=6),
+        _snapshot(date(2026, 1, 15), vendor_name="Acme", avg_urgency=9),
+    ]
+    pool = _Pool(
+        snapshots_by_vendor={"Acme": snapshots},
+        category_rows={"CRM": category_rows},
+    )
+
+    result = await TemporalEngine(pool).analyze_vendor("Acme")
+    evidence = TemporalEngine.to_evidence_dict(result)
+
+    assert result.insufficient_data is False
+    assert result.snapshot_days == 3
+    assert evidence["velocity_avg_urgency"] == round((9 - 5) / 7, 4)
+    assert evidence["accel_avg_urgency"] > 0
+    assert result.category_baselines[0].product_category == "CRM"
+    assert evidence["anomalies"][0]["metric"] == "avg_urgency"
+
+
+def test_to_evidence_dict_serializes_velocity_trends_and_only_anomalies():
+    temporal = TemporalEvidence(
+        vendor_name="Acme",
+        snapshot_days=21,
+        velocities=[
+            VendorVelocity(
+                vendor_name="Acme",
+                metric="avg_urgency",
+                current_value=8,
+                previous_value=5,
+                velocity=0.5,
+                days_between=6,
+                acceleration=0.1,
+            )
+        ],
+        trends=[LongTermTrend(metric="avg_urgency", slope_30d=0.2, slope_90d=0.1)],
+        anomalies=[
+            AnomalyScore("Acme", "avg_urgency", 8, 2.4, 0.01, True),
+            AnomalyScore("Acme", "competitor_count", 4, 0.8, 0.2, False),
+        ],
+    )
+
+    evidence = TemporalEngine.to_evidence_dict(temporal)
+
+    assert evidence["velocity_avg_urgency"] == 0.5
+    assert evidence["accel_avg_urgency"] == 0.1
+    assert evidence["trend_30d_avg_urgency"] == 0.2
+    assert evidence["trend_90d_avg_urgency"] == 0.1
+    assert evidence["anomalies"] == [
+        {"metric": "avg_urgency", "value": 8, "z_score": 2.4, "p_value": 0.01}
+    ]
+
+
+def test_to_evidence_dict_marks_insufficient_data():
+    evidence = TemporalEngine.to_evidence_dict(
+        TemporalEvidence("Acme", snapshot_days=1, insufficient_data=True)
+    )
+
+    assert evidence == {"temporal_status": "insufficient_data", "snapshot_days": 1}
+
+
+def test_compute_long_term_trends_handles_date_strings_and_bad_values():
+    start = date(2026, 1, 1)
+    snapshots = [
+        _snapshot(
+            start + timedelta(days=i),
+            avg_urgency=str(3 + i),
+            churn_density="bad" if i == 5 else i,
+        )
+        for i in range(15)
+    ]
+    snapshots[-1]["snapshot_date"] = snapshots[-1]["snapshot_date"].isoformat()
+    engine = TemporalEngine(None)
+
+    trends = engine._compute_long_term_trends("Acme", snapshots)
+
+    urgency = next(trend for trend in trends if trend.metric == "avg_urgency")
+    assert urgency.slope_30d == pytest.approx(1.0)
+    assert urgency.volatility is not None
+
+
+@pytest.mark.asyncio
+async def test_compute_percentiles_uses_local_snapshot_query():
+    pool = _Pool(
+        category_rows={
+            "CRM": [
+                {"avg_urgency": 3, "competitor_count": 1},
+                {"avg_urgency": 4, "competitor_count": 2},
+                {"avg_urgency": 5, "competitor_count": 3},
+                {"avg_urgency": 6, "competitor_count": 4},
+            ]
+        }
+    )
+
+    percentiles = await TemporalEngine(pool)._compute_percentiles("CRM")
+
+    query, args = pool.calls[0]
+    assert "b2b_vendor_snapshots" in query
+    assert "s.product_category = $1" in query
+    assert args == ("CRM",)
+    assert any(item.metric == "avg_urgency" for item in percentiles)
+
+
+@pytest.mark.asyncio
+async def test_analyze_all_vendors_uses_pool_distinct_vendor_query():
+    pool = _Pool(
+        vendor_rows=[{"vendor_name": "Acme"}, {"vendor_name": "Beta"}],
+        snapshots_by_vendor={
+            "Acme": [
+                _snapshot(date(2026, 1, 1), vendor_name="Acme"),
+                _snapshot(date(2026, 1, 2), vendor_name="Acme"),
+            ],
+            "Beta": [
+                _snapshot(date(2026, 1, 1), vendor_name="Beta"),
+                _snapshot(date(2026, 1, 2), vendor_name="Beta"),
+            ],
+        },
+    )
+
+    results = await TemporalEngine(pool).analyze_all_vendors()
+
+    assert set(results) == {"Acme", "Beta"}
+    assert pool.calls[0][0].startswith("SELECT DISTINCT vendor_name")
+
+
+def test_recency_weight_uses_half_life_decay():
+    assert TemporalEngine.recency_weight(0) == 1.0
+    assert TemporalEngine.recency_weight(14) == pytest.approx(0.5)
+
+
+def test_compute_anomalies_ignores_zero_iqr_baselines():
+    engine = TemporalEngine(None)
+    anomalies = engine._compute_anomalies(
+        "Acme",
+        {"avg_urgency": 9},
+        [CategoryPercentile("CRM", "avg_urgency", p25=5, p50=5, p75=5, sample_count=3)],
+    )
+
+    assert anomalies == []


### PR DESCRIPTION
## Summary
- Replace the extracted temporal stub with a standalone pool-backed analyzer for velocities, acceleration, trends, category percentiles, anomalies, recency weights, and evidence serialization.
- Keep the public `TemporalEngine` API compatible while removing Atlas helper dependencies from the temporal reasoning path.
- Register `reasoning/temporal.py` as product-owned and add focused temporal tests to the extracted pipeline runner.

## Validation
- `python -m py_compile extracted_content_pipeline/reasoning/temporal.py tests/test_extracted_reasoning_temporal.py`
- `pytest tests/test_extracted_reasoning_temporal.py tests/test_extracted_campaign_manifest.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`