### PR TITLE
Harden extracted evidence reasoning engine

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -168,7 +168,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `reasoning/temporal.py`: product-owned temporal analytics over vendor
   snapshot rows, including velocities, trends, category baselines, and
   anomaly serialization
-- `reasoning/evidence_engine.py`: minimal reasoning adapter for extracted report builders
+- `reasoning/evidence_engine.py`: product-owned conclusion/suppression policy
+  engine with built-in rules and optional host-provided evidence maps
 - `services/__init__.py` and `services/protocols.py`: `llm_registry.get_active()` and `Message`
 - `services/b2b/cache_runner.py`: local exact-cache request helpers and no-op lookup/store
 - `services/b2b/enrichment_contract.py`: local enrichment contract fallbacks

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -47,6 +47,9 @@
 - `reasoning.temporal` is product-owned and computes snapshot velocity,
   acceleration, trend, category-baseline, anomaly, and recency-weight outputs
   through a host-provided async `fetch` interface.
+- `reasoning.evidence_engine` is product-owned and evaluates deterministic
+  conclusion gates, section suppression gates, and confidence labels from
+  built-in rules or an optional host-provided evidence map.
 
 ## Validation gates in repo
 
@@ -65,11 +68,9 @@ extracted package, not just manifest-relative import resolution.
 
 ## Remaining extraction work
 
-1. Harden remaining minimal reasoning adapters (`evidence_engine`) into
-   customer-grade policy modules.
-2. Trim copied helper surface to only the modules required by target sellable workflows.
-3. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
-4. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).
+1. Trim copied helper surface to only the modules required by target sellable workflows.
+2. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
+3. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).
 
 ## Operational note
 

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -126,6 +126,11 @@ reasoning policy slice. It computes velocity, acceleration, long-term trends,
 category percentiles, anomalies, recency weights, and evidence serialization
 from a host-provided async `fetch` interface instead of Atlas helper imports.
 
+`extracted_content_pipeline/reasoning/evidence_engine.py` is the third
+product-owned reasoning policy slice. It evaluates conclusion gates, section
+suppression gates, and confidence labels from built-in product defaults or an
+optional host-provided JSON/YAML evidence map.
+
 ## Readiness Gate
 
 Run:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -208,6 +208,9 @@
     },
     {
       "target": "extracted_content_pipeline/reasoning/temporal.py"
+    },
+    {
+      "target": "extracted_content_pipeline/reasoning/evidence_engine.py"
     }
   ]
 }

--- a/extracted_content_pipeline/reasoning/evidence_engine.py
+++ b/extracted_content_pipeline/reasoning/evidence_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -24,28 +26,313 @@ class SuppressionResult:
 
 class EvidenceEngine:
     def __init__(self, map_path: str | Path | None = None) -> None:
-        self.map_path = str(map_path or "")
-        self.map_hash = "standalone"
+        self.map_path = str(map_path or "builtin")
+        raw_rules = _load_rules(map_path)
+        self.map_hash = hashlib.sha256(
+            json.dumps(raw_rules, sort_keys=True).encode("utf-8")
+        ).hexdigest()[:16]
+        self._conclusions = raw_rules.get("conclusions", {})
+        self._suppression = raw_rules.get("suppression", {})
+        self._confidence_tiers = raw_rules.get("confidence_tiers", {})
 
     def evaluate_conclusions(
         self,
         vendor_evidence: dict[str, Any],
     ) -> list[ConclusionResult]:
-        return []
+        evidence = dict(vendor_evidence or {})
+        insufficient = self._conclusions.get("insufficient_data")
+        if insufficient and all(
+            self._check_requirement(rule, evidence)
+            for rule in insufficient.get("trigger", [])
+        ):
+            return [
+                ConclusionResult(
+                    conclusion_id="insufficient_data",
+                    met=True,
+                    confidence="insufficient",
+                    fallback_label=insufficient.get("label"),
+                    fallback_action=insufficient.get("action"),
+                )
+            ]
+
+        results: list[ConclusionResult] = []
+        for conclusion_id, spec in self._conclusions.items():
+            if conclusion_id == "insufficient_data":
+                continue
+            requirements = spec.get("requires", [])
+            met = all(self._check_requirement(rule, evidence) for rule in requirements)
+            confidence = spec.get("confidence_when_met", "medium") if met else "insufficient"
+            if met:
+                for amplifier in spec.get("amplifiers", []):
+                    if self._check_requirement(amplifier, evidence) and amplifier.get("boost_confidence"):
+                        confidence = str(amplifier.get("boost_confidence"))
+            fallback = spec.get("fallback", {}) if not met else {}
+            results.append(
+                ConclusionResult(
+                    conclusion_id=conclusion_id,
+                    met=met,
+                    confidence=confidence,
+                    fallback_label=fallback.get("label"),
+                    fallback_action=fallback.get("action"),
+                )
+            )
+        return results
 
     def evaluate_suppression(
         self,
         section: str,
         evidence: dict[str, Any],
     ) -> SuppressionResult:
+        spec = self._suppression.get(section)
+        if not spec:
+            return SuppressionResult()
+
+        evidence = dict(evidence or {})
+        for rule in spec.get("suppress_when", []):
+            if self._check_requirement(rule, evidence):
+                return SuppressionResult(
+                    suppress=True,
+                    fallback_label=spec.get("fallback_label"),
+                )
+
+        for rule in spec.get("degrade_when", []):
+            if self._check_requirement(rule, evidence):
+                return SuppressionResult(
+                    degrade=True,
+                    disclaimer=spec.get("disclaimer"),
+                )
+
         return SuppressionResult()
+
+    def get_confidence_tier(self, total_reviews: int) -> str:
+        review_count = _numeric_value(total_reviews) or 0.0
+        for tier_name in ("high", "medium", "low"):
+            tier = self._confidence_tiers.get(tier_name, {})
+            if review_count >= (_numeric_value(tier.get("min_reviews")) or 0.0):
+                return tier_name
+        return "insufficient"
+
+    def get_confidence_label(self, total_reviews: int) -> str:
+        tier_name = self.get_confidence_tier(total_reviews)
+        tier = self._confidence_tiers.get(tier_name, {})
+        return str(tier.get("label") or tier_name)
+
+    @staticmethod
+    def _resolve_field(data: dict[str, Any], field_path: str) -> Any:
+        current: Any = data
+        for part in str(field_path or "").split("."):
+            if isinstance(current, dict):
+                current = current.get(part)
+            else:
+                return None
+        return current
+
+    def _check_requirement(self, rule: dict[str, Any], evidence: dict[str, Any]) -> bool:
+        field = str(rule.get("field") or "")
+        value = self._resolve_field(evidence, field)
+        operator = rule.get("operator")
+
+        if operator in {"gte", "gt", "lte", "lt"}:
+            value_num = _numeric_value(value)
+            rule_num = _numeric_value(rule.get("value"))
+            if value_num is None or rule_num is None:
+                return False
+            if operator == "gte":
+                return value_num >= rule_num
+            if operator == "gt":
+                return value_num > rule_num
+            if operator == "lte":
+                return value_num <= rule_num
+            return value_num < rule_num
+
+        if operator == "eq":
+            return value == rule.get("value")
+        if operator == "in":
+            return value in rule.get("values", [])
+        if operator == "exists":
+            return value is not None and value != ""
+        if operator == "min_count":
+            expected = _numeric_value(rule.get("value"))
+            return (
+                isinstance(value, (list, tuple, set, dict))
+                and expected is not None
+                and len(value) >= expected
+            )
+
+        for op in ("gte", "gt", "lte", "lt", "eq"):
+            if op in rule:
+                return self._check_requirement(
+                    {"field": field, "operator": op, "value": rule[op]},
+                    evidence,
+                )
+        if "in" in rule:
+            return self._check_requirement(
+                {"field": field, "operator": "in", "values": rule["in"]},
+                evidence,
+            )
+        return False
+
+
+_DEFAULT_RULES: dict[str, Any] = {
+    "confidence_tiers": {
+        "high": {"min_reviews": 80, "label": "High confidence"},
+        "medium": {"min_reviews": 25, "label": "Medium confidence"},
+        "low": {"min_reviews": 5, "label": "Low confidence"},
+        "insufficient": {"min_reviews": 0, "label": "Insufficient evidence"},
+    },
+    "conclusions": {
+        "insufficient_data": {
+            "trigger": [{"field": "total_reviews", "operator": "lt", "value": 20}],
+            "label": "Insufficient evidence",
+            "action": "Collect more reviews before making directional claims.",
+        },
+        "pricing_crisis": {
+            "requires": [
+                {"field": "total_reviews", "operator": "gte", "value": 50},
+                {"field": "pain_distribution.pricing.count", "operator": "gte", "value": 10},
+                {"field": "pricing_phrases_total", "operator": "gte", "value": 3},
+            ],
+            "confidence_when_met": "medium",
+            "amplifiers": [
+                {
+                    "field": "pain_distribution.pricing.source_count",
+                    "operator": "gte",
+                    "value": 3,
+                    "boost_confidence": "high",
+                }
+            ],
+            "fallback": {
+                "label": "Pricing signal not established",
+                "action": "Use pain wording without claiming pricing is the primary driver.",
+            },
+        },
+        "losing_market_share": {
+            "requires": [
+                {"field": "total_reviews", "operator": "gte", "value": 50},
+                {"field": "displacement_edge.mention_count", "operator": "gte", "value": 5},
+                {
+                    "field": "displacement_edge.signal_strength",
+                    "operator": "in",
+                    "values": ["moderate", "strong"],
+                },
+            ],
+            "confidence_when_met": "medium",
+            "amplifiers": [
+                {
+                    "field": "displacement_edge.net_flow",
+                    "operator": "lte",
+                    "value": -5,
+                    "boost_confidence": "high",
+                }
+            ],
+            "fallback": {
+                "label": "Displacement signal not established",
+                "action": "Avoid share-loss framing until displacement evidence improves.",
+            },
+        },
+        "active_churn_wave": {
+            "requires": [
+                {"field": "total_reviews", "operator": "gte", "value": 40},
+                {
+                    "field": "indicator_counts.active_evaluation_language",
+                    "operator": "gte",
+                    "value": 4,
+                },
+                {
+                    "field": "indicator_counts.explicit_cancel_language",
+                    "operator": "gte",
+                    "value": 2,
+                },
+            ],
+            "confidence_when_met": "high",
+            "fallback": {
+                "label": "Active churn wave not established",
+                "action": "Frame as retention risk, not an active churn wave.",
+            },
+        },
+        "support_quality_risk": {
+            "requires": [
+                {"field": "total_reviews", "operator": "gte", "value": 40},
+                {"field": "pain_distribution.support.count", "operator": "gte", "value": 8},
+            ],
+            "confidence_when_met": "medium",
+            "fallback": {
+                "label": "Support quality risk not established",
+                "action": "Use generic dissatisfaction wording.",
+            },
+        },
+    },
+    "suppression": {
+        "executive_summary": {
+            "suppress_when": [{"field": "total_reviews", "operator": "lt", "value": 20}],
+            "degrade_when": [{"field": "total_reviews", "operator": "lt", "value": 50}],
+            "fallback_label": "Not enough evidence for an executive summary",
+            "disclaimer": "Directional summary based on a limited evidence base.",
+        },
+        "target_accounts": {
+            "suppress_when": [{"field": "named_company_count", "operator": "lte", "value": 0}],
+            "fallback_label": "No named-account evidence available",
+        },
+        "recommend_ratio": {
+            "suppress_when": [{"field": "recommend_denominator", "operator": "lt", "value": 5}],
+            "fallback_label": "Recommendation sample too small",
+        },
+    },
+}
 
 
 _engine: EvidenceEngine | None = None
+_engine_path: str | None = None
 
 
 def get_evidence_engine(map_path: str | Path | None = None) -> EvidenceEngine:
-    global _engine
-    if _engine is None or map_path is not None:
+    global _engine, _engine_path
+    resolved = str(map_path) if map_path else "builtin"
+    if _engine is None or _engine_path != resolved:
         _engine = EvidenceEngine(map_path)
+        _engine_path = resolved
     return _engine
+
+
+def reload_evidence_engine() -> EvidenceEngine:
+    global _engine, _engine_path
+    _engine = None
+    _engine_path = None
+    return get_evidence_engine()
+
+
+def _load_rules(map_path: str | Path | None) -> dict[str, Any]:
+    if map_path is None:
+        return dict(_DEFAULT_RULES)
+    path = Path(map_path)
+    raw = path.read_text()
+    if path.suffix.lower() == ".json":
+        loaded = json.loads(raw)
+    else:
+        try:
+            import yaml  # type: ignore
+        except ModuleNotFoundError:
+            loaded = json.loads(raw)
+        else:
+            loaded = yaml.safe_load(raw)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Evidence map must decode to an object: {path}")
+    return loaded
+
+
+def _numeric_value(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip().replace(",", "")
+        if not stripped:
+            return None
+        if stripped.endswith("%"):
+            stripped = stripped[:-1]
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -16,6 +16,7 @@ pytest \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_reasoning_archetypes.py \
   tests/test_extracted_reasoning_temporal.py \
+  tests/test_extracted_reasoning_evidence_engine.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -81,3 +81,4 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
+    assert "extracted_content_pipeline/reasoning/evidence_engine.py" in owned

--- a/tests/test_extracted_reasoning_evidence_engine.py
+++ b/tests/test_extracted_reasoning_evidence_engine.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+
+from extracted_content_pipeline.reasoning.evidence_engine import (
+    ConclusionResult,
+    EvidenceEngine,
+    SuppressionResult,
+    get_evidence_engine,
+)
+
+
+def test_default_engine_has_stable_builtin_metadata():
+    engine = EvidenceEngine()
+
+    assert engine.map_path == "builtin"
+    assert engine.map_hash != "standalone"
+    assert len(engine.map_hash) == 16
+
+
+def test_insufficient_data_suppresses_other_conclusions():
+    results = EvidenceEngine().evaluate_conclusions({"total_reviews": 10})
+
+    assert results == [
+        ConclusionResult(
+            conclusion_id="insufficient_data",
+            met=True,
+            confidence="insufficient",
+            fallback_label="Insufficient evidence",
+            fallback_action="Collect more reviews before making directional claims.",
+        )
+    ]
+
+
+def test_pricing_crisis_met_and_amplified_to_high_confidence():
+    evidence = {
+        "total_reviews": 120,
+        "pain_distribution": {"pricing": {"count": 18, "source_count": 4}},
+        "pricing_phrases_total": "7",
+    }
+
+    results = EvidenceEngine().evaluate_conclusions(evidence)
+    pricing = next(result for result in results if result.conclusion_id == "pricing_crisis")
+
+    assert pricing.met is True
+    assert pricing.confidence == "high"
+    assert pricing.fallback_label is None
+
+
+def test_unmet_conclusion_returns_fallback_guidance():
+    evidence = {
+        "total_reviews": 120,
+        "pain_distribution": {"pricing": {"count": 2, "source_count": 1}},
+        "pricing_phrases_total": 1,
+    }
+
+    results = EvidenceEngine().evaluate_conclusions(evidence)
+    pricing = next(result for result in results if result.conclusion_id == "pricing_crisis")
+
+    assert pricing.met is False
+    assert pricing.confidence == "insufficient"
+    assert pricing.fallback_label == "Pricing signal not established"
+
+
+def test_losing_market_share_uses_nested_in_and_numeric_requirements():
+    evidence = {
+        "total_reviews": 200,
+        "displacement_edge": {
+            "mention_count": 8,
+            "signal_strength": "strong",
+            "net_flow": -8,
+        },
+    }
+
+    results = EvidenceEngine().evaluate_conclusions(evidence)
+    market_share = next(
+        result for result in results if result.conclusion_id == "losing_market_share"
+    )
+
+    assert market_share.met is True
+    assert market_share.confidence == "high"
+
+
+def test_evaluate_suppression_suppresses_degrades_or_passes_sections():
+    engine = EvidenceEngine()
+
+    assert engine.evaluate_suppression("executive_summary", {"total_reviews": 10}) == (
+        SuppressionResult(
+            suppress=True,
+            fallback_label="Not enough evidence for an executive summary",
+        )
+    )
+    degraded = engine.evaluate_suppression("executive_summary", {"total_reviews": 35})
+    assert degraded.degrade is True
+    assert degraded.disclaimer == "Directional summary based on a limited evidence base."
+
+    assert engine.evaluate_suppression("executive_summary", {"total_reviews": 200}) == (
+        SuppressionResult()
+    )
+    assert engine.evaluate_suppression("unknown", {"total_reviews": 1}) == SuppressionResult()
+
+
+def test_confidence_tier_and_label_are_data_driven():
+    engine = EvidenceEngine()
+
+    assert engine.get_confidence_tier(100) == "high"
+    assert engine.get_confidence_tier(30) == "medium"
+    assert engine.get_confidence_tier(5) == "low"
+    assert engine.get_confidence_tier(0) == "insufficient"
+    assert engine.get_confidence_label(100) == "High confidence"
+
+
+def test_custom_json_map_path_overrides_builtin_rules(tmp_path):
+    rules = {
+        "confidence_tiers": {
+            "high": {"min_reviews": 2, "label": "custom high"},
+            "medium": {"min_reviews": 1, "label": "custom medium"},
+            "low": {"min_reviews": 0, "label": "custom low"},
+        },
+        "conclusions": {
+            "custom_claim": {
+                "requires": [
+                    {"field": "signals", "operator": "min_count", "value": 2},
+                    {"field": "metadata.ready", "operator": "eq", "value": True},
+                ],
+                "confidence_when_met": "high",
+                "fallback": {"label": "custom fallback"},
+            }
+        },
+        "suppression": {
+            "custom_section": {
+                "suppress_when": [{"field": "score", "operator": "lt", "value": 3}],
+                "fallback_label": "custom suppressed",
+            }
+        },
+    }
+    path = tmp_path / "evidence_map.json"
+    path.write_text(json.dumps(rules))
+
+    engine = EvidenceEngine(path)
+
+    result = engine.evaluate_conclusions({
+        "signals": ["a", "b"],
+        "metadata": {"ready": True},
+    })[0]
+    assert result.conclusion_id == "custom_claim"
+    assert result.met is True
+    assert result.confidence == "high"
+
+    suppressed = engine.evaluate_suppression("custom_section", {"score": "2"})
+    assert suppressed.suppress is True
+    assert suppressed.fallback_label == "custom suppressed"
+    assert engine.get_confidence_label(2) == "custom high"
+
+
+def test_get_evidence_engine_caches_by_resolved_path(tmp_path):
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+    first_path.write_text(json.dumps({"conclusions": {}, "suppression": {}}))
+    second_path.write_text(json.dumps({"conclusions": {}, "suppression": {}}))
+
+    first = get_evidence_engine(first_path)
+    again = get_evidence_engine(first_path)
+    second = get_evidence_engine(second_path)
+
+    assert first is again
+    assert second is not first


### PR DESCRIPTION
## Summary
- Replace the extracted evidence-engine stub with product-owned conclusion gating, section suppression, confidence labels, and built-in default evidence policy rules.
- Support optional host-provided JSON/YAML evidence maps while keeping the default path Atlas-free.
- Register `reasoning/evidence_engine.py` as product-owned and add focused evidence-engine tests to the extracted pipeline runner.

## Validation
- `python -m py_compile extracted_content_pipeline/reasoning/evidence_engine.py tests/test_extracted_reasoning_evidence_engine.py`
- `pytest tests/test_extracted_reasoning_evidence_engine.py tests/test_extracted_campaign_manifest.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`