### PR TITLE
Own extracted content utility helpers

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -154,6 +154,10 @@ Several small utility shims provide product-owned local behavior by default so t
 - `config.py`: extracted settings from `settings.py`
 - `pipelines/notify.py`: host-visible notification dispatcher backed by the
   `VisibilitySink` port
+- `autonomous/tasks/_execution_progress.py`,
+  `autonomous/tasks/_google_news.py`, `autonomous/tasks/_blog_ts.py`, and
+  `autonomous/tasks/_blog_deploy.py`: product-owned utility helpers used by
+  copied blog and campaign tasks
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -41,6 +41,8 @@
 - `pipelines.notify` is product-owned and dispatches through the
   `VisibilitySink` port when configured, while staying a no-op when no host
   visibility adapter is installed.
+- Small task utility helpers are product-owned rather than Atlas-synced:
+  `_execution_progress`, `_google_news`, `_blog_ts`, and `_blog_deploy`.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.
@@ -68,7 +70,9 @@ extracted package, not just manifest-relative import resolution.
 
 ## Remaining extraction work
 
-1. Trim copied helper surface to only the modules required by target sellable workflows.
+1. Continue trimming copied helper surface to only the modules required by
+   target sellable workflows. The first utility group is no longer
+   manifest-synced from Atlas.
 2. Move copied task imports and package layout toward native extracted modules instead of manifest-synced mirrors.
 3. Add focused unit tests around extraction-specific contracts (manifest sync, importability, runner smoke).
 

--- a/extracted_content_pipeline/autonomous/tasks/_blog_ts.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_ts.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import json
 import logging
 import re
+from html import escape as _escape_html
 from pathlib import Path
 
-import markdown as _md
+try:
+    import markdown as _md
+except ModuleNotFoundError:
+    _md = None
 
-_md_converter = _md.Markdown(extensions=["tables", "fenced_code", "toc"])
+_md_converter = (
+    _md.Markdown(extensions=["tables", "fenced_code", "toc"])
+    if _md is not None
+    else None
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +58,28 @@ def slug_to_var_name(slug: str) -> str:
     if var_name and var_name[0].isdigit():
         var_name = "post" + var_name[0].upper() + var_name[1:]
     return var_name
+
+
+def _render_markdown(content: str) -> str:
+    """Render markdown when available, otherwise emit safe minimal HTML."""
+    if _md_converter is not None:
+        _md_converter.reset()
+        return _md_converter.convert(content)
+
+    blocks = []
+    for raw in str(content or "").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("### "):
+            blocks.append(f"<h3>{_escape_html(line[4:])}</h3>")
+        elif line.startswith("## "):
+            blocks.append(f"<h2>{_escape_html(line[3:])}</h2>")
+        elif line.startswith("# "):
+            blocks.append(f"<h1>{_escape_html(line[2:])}</h1>")
+        else:
+            blocks.append(f"<p>{_escape_html(line)}</p>")
+    return "\n".join(blocks)
 
 
 def update_blog_index(index_path: Path, slug: str, var_name: str) -> bool:
@@ -137,9 +167,8 @@ def build_post_ts(
     """
     var_name = slug_to_var_name(slug)
     charts_str = json.dumps(charts_json, indent=2, default=str)
-    # Render markdown to HTML at deploy time so the frontend never parses markdown
-    _md_converter.reset()
-    html_content = _md_converter.convert(content)
+    # Render markdown to HTML at deploy time so the frontend never parses markdown.
+    html_content = _render_markdown(content)
     escaped_content = escape_template_literal(html_content)
     escaped_title = escape_js_single(title)
     escaped_desc = escape_js_single(description)

--- a/extracted_content_pipeline/autonomous/tasks/_execution_progress.py
+++ b/extracted_content_pipeline/autonomous/tasks/_execution_progress.py
@@ -1,4 +1,6 @@
-"""Shared helpers for reporting live autonomous task execution progress."""
+"""Product-owned helpers for reporting live task execution progress."""
+
+from __future__ import annotations
 
 from typing import Any
 from uuid import UUID

--- a/extracted_content_pipeline/autonomous/tasks/_google_news.py
+++ b/extracted_content_pipeline/autonomous/tasks/_google_news.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunsplit, u
 
 from bs4 import BeautifulSoup
 
-logger = logging.getLogger("atlas.autonomous.tasks.google_news")
+logger = logging.getLogger("extracted_content_pipeline.autonomous.tasks.google_news")
 
 _GOOGLE_NEWS_HOST = "news.google.com"
 _GOOGLE_NEWS_PATH_PREFIX = "/rss/articles/"
@@ -18,7 +18,7 @@ _GOOGLE_NEWS_DECODE_URL = (
     "?rpcids=Fbv4je"
 )
 _GOOGLE_NEWS_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (compatible; AtlasBot/1.0)",
+    "User-Agent": "Mozilla/5.0 (compatible; ExtractedContentPipelineBot/1.0)",
     "Accept": "text/html,application/xhtml+xml",
 }
 _GOOGLE_NEWS_FORM_HEADERS = {

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -116,6 +116,11 @@ visibility slice. It preserves the copied task-facing
 port when a host configures one. With no sink configured it remains a safe
 no-op, so standalone task imports do not require Atlas notification services.
 
+The first helper-surface trim moved `_execution_progress`, `_google_news`,
+`_blog_ts`, and `_blog_deploy` out of manifest sync and into product ownership.
+These are still used by copied task modules, but future changes now happen in
+the extracted product boundary instead of being pulled from Atlas.
+
 `extracted_content_pipeline/reasoning/archetypes.py` is the first product-owned
 reasoning policy slice. It scores vendor evidence against deterministic churn
 archetypes, returns thresholded matches, and exposes falsification conditions

--- a/extracted_content_pipeline/import_debt_allowlist.txt
+++ b/extracted_content_pipeline/import_debt_allowlist.txt
@@ -1,12 +1,8 @@
-._google_news
-._execution_progress
 ._b2b_shared
 ._b2b_specificity
 .b2b_campaign_generation
 ._b2b_synthesis_reader
-._blog_ts
 ._b2b_cross_vendor_synthesis
 ..visibility
-._blog_deploy
 .competitive_intelligence
 .complaint_analysis

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -121,10 +121,6 @@
       "target": "extracted_content_pipeline/storage/migrations/150_campaign_engagement_timing.sql"
     },
     {
-      "source": "atlas_brain/autonomous/tasks/_execution_progress.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_execution_progress.py"
-    },
-    {
       "source": "atlas_brain/autonomous/tasks/_b2b_shared.py",
       "target": "extracted_content_pipeline/autonomous/tasks/_b2b_shared.py"
     },
@@ -133,24 +129,12 @@
       "target": "extracted_content_pipeline/autonomous/tasks/_b2b_specificity.py"
     },
     {
-      "source": "atlas_brain/autonomous/tasks/_google_news.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_google_news.py"
-    },
-    {
       "source": "atlas_brain/autonomous/tasks/competitive_intelligence.py",
       "target": "extracted_content_pipeline/autonomous/tasks/competitive_intelligence.py"
     },
     {
       "source": "atlas_brain/autonomous/tasks/complaint_analysis.py",
       "target": "extracted_content_pipeline/autonomous/tasks/complaint_analysis.py"
-    },
-    {
-      "source": "atlas_brain/autonomous/tasks/_blog_ts.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_blog_ts.py"
-    },
-    {
-      "source": "atlas_brain/autonomous/tasks/_blog_deploy.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py"
     },
     {
       "source": "atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py",
@@ -211,6 +195,18 @@
     },
     {
       "target": "extracted_content_pipeline/reasoning/evidence_engine.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_execution_progress.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_google_news.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_blog_ts.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py"
     }
   ]
 }

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -17,6 +17,7 @@ pytest \
   tests/test_extracted_reasoning_archetypes.py \
   tests/test_extracted_reasoning_temporal.py \
   tests/test_extracted_reasoning_evidence_engine.py \
+  tests/test_extracted_product_utilities.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -42,6 +42,11 @@ def _owned_targets() -> set[str]:
     return {entry["target"] for entry in data.get("owned", [])}
 
 
+def _mapped_targets() -> set[str]:
+    data = json.loads((ROOT / "extracted_content_pipeline/manifest.json").read_text())
+    return {entry["target"] for entry in data.get("mappings", [])}
+
+
 def test_manifest_syncs_core_campaign_schema_migrations() -> None:
     targets = _manifest_targets()
 
@@ -82,3 +87,16 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
     assert "extracted_content_pipeline/reasoning/evidence_engine.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" in owned
+
+
+def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
+    mapped = _mapped_targets()
+
+    assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" not in mapped

--- a/tests/test_extracted_product_utilities.py
+++ b/tests/test_extracted_product_utilities.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from extracted_content_pipeline.autonomous.tasks import _blog_deploy, _google_news
+from extracted_content_pipeline.autonomous.tasks import _blog_ts as blog_ts_mod
+from extracted_content_pipeline.autonomous.tasks._blog_ts import (
+    build_post_ts,
+    slug_to_var_name,
+    update_blog_index,
+)
+from extracted_content_pipeline.autonomous.tasks._execution_progress import (
+    _update_execution_progress,
+    task_run_id,
+)
+from extracted_content_pipeline.storage.models import ScheduledTask
+from extracted_content_pipeline.storage.repositories import scheduled_task as repo_mod
+
+
+class _Response:
+    def __init__(self, text: str, url: str):
+        self.text = text
+        self.url = url
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _Client:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.get_calls = []
+        self.post_calls = []
+        self.closed = False
+
+    async def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self.responses.pop(0)
+
+    async def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return self.responses.pop(0)
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _Repo:
+    def __init__(self):
+        self.calls = []
+
+    async def update_execution_metadata(self, exec_id, metadata):
+        self.calls.append((exec_id, metadata))
+
+
+def test_task_run_id_prefers_scheduler_execution_id():
+    execution_id = uuid4()
+    task = ScheduledTask(
+        metadata={
+            "_execution_id": str(execution_id),
+            "run_id": "manual-run",
+        }
+    )
+
+    assert task_run_id(task) == str(execution_id)
+
+
+def test_task_run_id_falls_back_to_metadata_and_task_id():
+    assert task_run_id(ScheduledTask(metadata={"run_id": "manual-run"})) == "manual-run"
+
+    task = ScheduledTask(metadata={})
+    assert task_run_id(task) == str(task.id)
+
+
+@pytest.mark.asyncio
+async def test_update_execution_progress_writes_metadata_to_configured_repo(monkeypatch):
+    execution_id = uuid4()
+    task = ScheduledTask(metadata={"_execution_id": str(execution_id)})
+    repo = _Repo()
+    monkeypatch.setattr(repo_mod, "_scheduled_task_repo", repo)
+
+    await _update_execution_progress(
+        task,
+        stage="rendering",
+        progress_current=2,
+        progress_total=5,
+        progress_message="Building draft",
+        drafts_created=1,
+    )
+
+    assert repo.calls == [
+        (
+            execution_id,
+            {
+                "stage": "rendering",
+                "progress_current": 2,
+                "progress_total": 5,
+                "progress_message": "Building draft",
+                "drafts_created": 1,
+            },
+        )
+    ]
+
+
+def test_slug_to_var_name_handles_invalid_identifier_starts():
+    assert slug_to_var_name("2026-report") == "post2026Report"
+    assert slug_to_var_name("vendor.comparison") == "vendorComparison"
+
+
+def test_build_post_ts_escapes_content_and_emits_seo_fields():
+    _, content = build_post_ts(
+        slug="pricing-guide",
+        title="Pricing's Guide",
+        description="Dollar ${value}",
+        date_str="2026-05-01",
+        author="Canfield AI",
+        tags=["pricing"],
+        topic_type="guide",
+        charts_json=[],
+        content="## Intro\nUse ${spend} wisely.",
+        seo_title="AI pricing guide",
+        seo_description="Plan LLM spend",
+        target_keyword="AI cost monitoring",
+        secondary_keywords=["LLM cost admin"],
+        faq=[{"q": "Why?", "a": "Control spend."}],
+        related_slugs=["llm-cost-admin"],
+        cta={"label": "Audit costs"},
+    )
+
+    assert "seo_title: 'AI pricing guide'" in content
+    assert "target_keyword: 'AI cost monitoring'" in content
+    assert "secondary_keywords" in content
+    assert "content: `" in content
+    assert "\\${" in content
+    assert "Pricing\\'s Guide" in content
+
+
+def test_blog_ts_markdown_fallback_emits_safe_html(monkeypatch):
+    monkeypatch.setattr(blog_ts_mod, "_md_converter", None)
+
+    _, content = blog_ts_mod.build_post_ts(
+        slug="fallback",
+        title="Fallback",
+        description="Fallback",
+        date_str="2026-05-01",
+        author="Canfield AI",
+        tags=[],
+        topic_type="guide",
+        charts_json=[],
+        content="# Title\n<script>alert(1)</script>",
+    )
+
+    assert "<h1>Title</h1>" in content
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in content
+
+
+def test_update_blog_index_skips_dynamic_glob_index(tmp_path):
+    index = tmp_path / "index.ts"
+    original = "export const posts = import.meta.glob('./*.ts')\n"
+    index.write_text(original)
+
+    assert update_blog_index(index, "pricing-guide", "pricingGuide") is False
+    assert index.read_text() == original
+
+
+@pytest.mark.asyncio
+async def test_resolve_google_news_url_decodes_publisher_url():
+    wrapper_url = "https://news.google.com/rss/articles/test-id?hl=en-US&gl=US&ceid=US:en"
+    html = (
+        '<div data-n-a-id="test-id" data-n-a-ts="1774297014" '
+        'data-n-a-sg="sig-value"></div>'
+    )
+    batched = (
+        ")]}'\n"
+        '[["wrb.fr","Fbv4je",'
+        '"[\\"garturlres\\",\\"https://example.com/article?x\\\\u003d1\\\\u0026gaa_at\\\\u003dtoken\\",1]",'
+        'null,null,null,"generic"]]'
+    )
+    client = _Client([
+        _Response(html, wrapper_url),
+        _Response(batched, "https://news.google.com/_/DotsSplashUi/data/batchexecute"),
+    ])
+
+    resolved = await _google_news.resolve_google_news_url(wrapper_url, client=client)
+
+    assert resolved == "https://example.com/article?x=1"
+    assert client.get_calls[0][0] == wrapper_url
+    assert client.post_calls[0][0].endswith("rpcids=Fbv4je")
+
+
+@pytest.mark.asyncio
+async def test_resolve_google_news_url_returns_non_wrapper_unchanged():
+    url = "https://example.com/article"
+
+    assert await _google_news.resolve_google_news_url(url, client=_Client([])) == url
+
+
+@pytest.mark.asyncio
+async def test_auto_deploy_blog_disabled_is_safe_noop(tmp_path):
+    result = await _blog_deploy.auto_deploy_blog(
+        str(tmp_path),
+        "pricing-guide",
+        enabled=False,
+    )
+
+    assert result == {"deployed": False, "skipped": "auto_deploy disabled"}
+
+
+def test_auto_deploy_find_repo_root_returns_none_outside_git(tmp_path):
+    assert _blog_deploy._find_repo_root(str(tmp_path)) is None


### PR DESCRIPTION
## Summary
- Move `_execution_progress`, `_google_news`, `_blog_ts`, and `_blog_deploy` out of Atlas sync mappings and into extracted product ownership.
- Remove those helpers from the relative-import allowlist and keep manifest tests proving they are no longer source-synced.
- Add product utility tests covering execution progress correlation/update, blog TS rendering/index behavior, Google News wrapper decoding, and disabled blog deploy behavior.

## Validation
- `python -m py_compile extracted_content_pipeline/autonomous/tasks/_execution_progress.py extracted_content_pipeline/autonomous/tasks/_google_news.py extracted_content_pipeline/autonomous/tasks/_blog_ts.py extracted_content_pipeline/autonomous/tasks/_blog_deploy.py tests/test_extracted_product_utilities.py tests/test_extracted_campaign_manifest.py`
- `pytest tests/test_extracted_product_utilities.py tests/test_extracted_campaign_manifest.py`
- `python scripts/check_extracted_imports.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`