### PR TITLE
Own extracted batch utility helpers

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -158,6 +158,9 @@ Several small utility shims provide product-owned local behavior by default so t
   `autonomous/tasks/_google_news.py`, `autonomous/tasks/_blog_ts.py`, and
   `autonomous/tasks/_blog_deploy.py`: product-owned utility helpers used by
   copied blog and campaign tasks
+- `autonomous/tasks/_b2b_batch_utils.py`: product-owned Anthropic batch helper
+  functions for metadata gates, request fingerprints, LLM slot resolution, and
+  existing batch artifact reconciliation
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -42,7 +42,11 @@
   `VisibilitySink` port when configured, while staying a no-op when no host
   visibility adapter is installed.
 - Small task utility helpers are product-owned rather than Atlas-synced:
-  `_execution_progress`, `_google_news`, `_blog_ts`, and `_blog_deploy`.
+  `_execution_progress`, `_google_news`, `_blog_ts`, `_blog_deploy`, and
+  `_b2b_batch_utils`.
+- `_b2b_batch_utils` is product-owned and keeps Anthropic batch metadata gates,
+  request fingerprints, LLM slot resolution, and existing artifact
+  reconciliation inside the extracted boundary.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py
@@ -1,4 +1,4 @@
-"""Shared helpers for B2B Anthropic batch enablement."""
+"""Product-owned helpers for optional Anthropic batch execution."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import logging
 import os
 from typing import Any
 
-logger = logging.getLogger("atlas.autonomous.tasks._b2b_batch_utils")
+logger = logging.getLogger("extracted_content_pipeline.autonomous.tasks._b2b_batch_utils")
 
 _ANTHROPIC_BATCH_SUCCESS_STATUSES = {
     "cache_hit",
@@ -183,8 +183,10 @@ def resolve_anthropic_batch_llm(
     if not target_model:
         return batch_llm if is_anthropic_llm(batch_llm) else None
 
+    llm_settings = getattr(settings, "llm", None)
     api_key = (
-        settings.llm.anthropic_api_key
+        getattr(llm_settings, "anthropic_api_key", None)
+        or os.environ.get("EXTRACTED_LLM_ANTHROPIC_API_KEY")
         or os.environ.get("ANTHROPIC_API_KEY")
         or os.environ.get("ATLAS_LLM_ANTHROPIC_API_KEY", "")
     )
@@ -196,14 +198,24 @@ def resolve_anthropic_batch_llm(
         return batch_llm if is_anthropic_llm(batch_llm) else None
 
     slot_name = f"b2b_batch_anthropic::{target_model}"
-    existing_slot = llm_registry.get_slot(slot_name)
+    get_slot = getattr(llm_registry, "get_slot", None)
+    existing_slot = get_slot(slot_name) if callable(get_slot) else None
     if is_anthropic_llm(existing_slot):
         existing_model = anthropic_model_name(getattr(existing_slot, "model", ""))
         if existing_model == target_model:
             return existing_slot
 
+    activate_slot = getattr(llm_registry, "activate_slot", None)
+    if not callable(activate_slot):
+        logger.warning(
+            "Anthropic batch requested for %s but the configured LLM registry "
+            "does not support slot activation",
+            target_model,
+        )
+        return batch_llm if is_anthropic_llm(batch_llm) else None
+
     try:
-        return llm_registry.activate_slot(
+        return activate_slot(
             slot_name,
             "anthropic",
             model=target_model,

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -121,6 +121,12 @@ The first helper-surface trim moved `_execution_progress`, `_google_news`,
 These are still used by copied task modules, but future changes now happen in
 the extracted product boundary instead of being pulled from Atlas.
 
+`extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py` is now
+product-owned as the Anthropic batch utility boundary. It preserves the copied
+task-facing helpers for metadata flags, request fingerprints, LLM resolution,
+and existing artifact reconciliation, but resolves product environment keys and
+fails safe when a standalone host has not installed an activatable LLM registry.
+
 `extracted_content_pipeline/reasoning/archetypes.py` is the first product-owned
 reasoning policy slice. It scores vendor evidence against deterministic churn
 archetypes, returns thresholded matches, and exposes falsification conditions

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -171,10 +171,6 @@
     {
       "source": "atlas_brain/autonomous/tasks/_blog_matching.py",
       "target": "extracted_content_pipeline/autonomous/tasks/_blog_matching.py"
-    },
-    {
-      "source": "atlas_brain/autonomous/tasks/_b2b_batch_utils.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py"
     }
   ],
   "owned": [
@@ -207,6 +203,9 @@
     },
     {
       "target": "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py"
     }
   ]
 }

--- a/extracted_content_pipeline/services/b2b/anthropic_batch.py
+++ b/extracted_content_pipeline/services/b2b/anthropic_batch.py
@@ -30,5 +30,8 @@ if os.getenv("EXTRACTED_PIPELINE_STANDALONE", "0") == "1":
 
     async def mark_batch_fallback_result(*args: Any, **kwargs: Any) -> None:
         return None
+
+    async def reconcile_anthropic_message_batch(*args: Any, **kwargs: Any) -> AnthropicBatchExecution:
+        return AnthropicBatchExecution()
 else:
     from extracted_llm_infrastructure.services.b2b.anthropic_batch import *

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -18,6 +18,7 @@ pytest \
   tests/test_extracted_reasoning_temporal.py \
   tests/test_extracted_reasoning_evidence_engine.py \
   tests/test_extracted_product_utilities.py \
+  tests/test_extracted_b2b_batch_utils.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_b2b_batch_utils.py
+++ b/tests/test_extracted_b2b_batch_utils.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from extracted_content_pipeline.autonomous.tasks import _b2b_batch_utils as batch_utils
+
+
+def test_exact_stage_request_fingerprint_is_stable_and_request_sensitive() -> None:
+    first = SimpleNamespace(
+        namespace="campaign.first_attempt",
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4-5",
+        request_envelope={
+            "messages": [{"role": "user", "content": "draft"}],
+            "temperature": 0.2,
+            "max_tokens": 1000,
+        },
+    )
+    same_different_order = SimpleNamespace(
+        namespace="campaign.first_attempt",
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4-5",
+        request_envelope={
+            "max_tokens": 1000,
+            "temperature": 0.2,
+            "messages": [{"content": "draft", "role": "user"}],
+        },
+    )
+    changed = SimpleNamespace(
+        namespace="campaign.first_attempt",
+        provider="openrouter",
+        model="anthropic/claude-haiku-4-5",
+        request_envelope=first.request_envelope,
+    )
+
+    assert batch_utils.exact_stage_request_fingerprint(first) == batch_utils.exact_stage_request_fingerprint(
+        same_different_order
+    )
+    assert batch_utils.exact_stage_request_fingerprint(first) != batch_utils.exact_stage_request_fingerprint(changed)
+
+
+def test_metadata_helpers_parse_flags_and_counts() -> None:
+    metadata = {
+        "global_enabled": "yes",
+        "task_enabled": 1,
+        "min_items": "0",
+        "bad_int": "many",
+    }
+    task = SimpleNamespace(metadata=metadata)
+
+    assert batch_utils.metadata_bool(metadata, ("global_enabled",), False) is True
+    assert batch_utils.metadata_bool({"enabled": "off"}, ("enabled",), True) is False
+    assert batch_utils.anthropic_batch_requested(
+        task,
+        global_default=False,
+        task_default=False,
+        global_keys=("global_enabled",),
+        task_keys=("task_enabled",),
+    ) is True
+    assert batch_utils.anthropic_batch_min_items(
+        task,
+        default=5,
+        keys=("min_items",),
+        min_value=2,
+    ) == 2
+    assert batch_utils.metadata_int(metadata, ("bad_int",), 7, min_value=2) == 7
+
+
+def test_anthropic_model_helpers_normalize_openrouter_models() -> None:
+    llm = SimpleNamespace(name="openrouter", model="anthropic/claude-sonnet-4-5")
+
+    assert batch_utils.anthropic_model_name("anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
+    assert batch_utils.anthropic_model_name("openai/gpt-4o") is None
+    assert batch_utils.is_anthropic_llm(llm) is False
+    assert batch_utils.anthropic_model_candidates(
+        "anthropic/claude-sonnet-4-5",
+        "claude-haiku-4-5",
+        "anthropic/claude-sonnet-4-5",
+        current_llm=llm,
+    ) == ["claude-sonnet-4-5", "claude-haiku-4-5"]
+
+
+def test_resolve_anthropic_batch_llm_preserves_matching_current_llm(monkeypatch) -> None:
+    current = SimpleNamespace(name="anthropic", model="claude-sonnet-4-5")
+    monkeypatch.setenv("EXTRACTED_PIPELINE_STANDALONE", "1")
+
+    resolved = batch_utils.resolve_anthropic_batch_llm(
+        current_llm=current,
+        target_model_candidates=("claude-sonnet-4-5",),
+    )
+
+    assert resolved is current
+
+
+def test_resolve_anthropic_batch_llm_uses_extracted_env_key_and_registry_slot(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTED_PIPELINE_STANDALONE", "1")
+    monkeypatch.setenv("EXTRACTED_LLM_ANTHROPIC_API_KEY", "product-key")
+
+    from extracted_content_pipeline import services
+    from extracted_content_pipeline.pipelines import llm as llm_mod
+
+    activation = {}
+
+    class Registry:
+        def get_slot(self, slot_name):
+            activation["checked"] = slot_name
+            return None
+
+        def activate_slot(self, slot_name, provider, **kwargs):
+            activation.update(
+                {
+                    "slot_name": slot_name,
+                    "provider": provider,
+                    "model": kwargs.get("model"),
+                    "api_key": kwargs.get("api_key"),
+                }
+            )
+            return SimpleNamespace(name=provider, model=kwargs.get("model"))
+
+    monkeypatch.setattr(llm_mod, "get_pipeline_llm", lambda **_kwargs: None)
+    monkeypatch.setattr(services, "llm_registry", Registry())
+
+    resolved = batch_utils.resolve_anthropic_batch_llm(
+        target_model_candidates=("anthropic/claude-sonnet-4-5",),
+    )
+
+    assert resolved.name == "anthropic"
+    assert resolved.model == "claude-sonnet-4-5"
+    assert activation == {
+        "checked": "b2b_batch_anthropic::claude-sonnet-4-5",
+        "slot_name": "b2b_batch_anthropic::claude-sonnet-4-5",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-5",
+        "api_key": "product-key",
+    }
+
+
+def test_resolve_anthropic_batch_llm_fails_safe_without_registry_activation(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTED_PIPELINE_STANDALONE", "1")
+    monkeypatch.setenv("EXTRACTED_LLM_ANTHROPIC_API_KEY", "product-key")
+
+    from extracted_content_pipeline import services
+    from extracted_content_pipeline.pipelines import llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "get_pipeline_llm", lambda **_kwargs: None)
+    monkeypatch.setattr(services, "llm_registry", SimpleNamespace(get_active=lambda: None))
+
+    assert batch_utils.resolve_anthropic_batch_llm(
+        target_model_candidates=("claude-sonnet-4-5",),
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_returns_matching_success() -> None:
+    fingerprint = "current-request"
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "campaign-1",
+                    "batch_id": "batch-1",
+                    "status": "batch_succeeded",
+                    "response_text": json.dumps({"subject": "Hello"}),
+                    "error_text": "",
+                    "custom_id": "custom-1",
+                    "request_metadata": {"request_fingerprint": fingerprint},
+                    "batch_status": "completed",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await batch_utils.reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="campaign_generation",
+        artifact_type="campaign_first_attempt",
+        artifact_ids=["campaign-1"],
+        expected_request_fingerprints={"campaign-1": fingerprint},
+    )
+
+    assert result == {
+        "campaign-1": {
+            "state": "succeeded",
+            "status": "batch_succeeded",
+            "cached": False,
+            "response_text": json.dumps({"subject": "Hello"}),
+            "error_text": None,
+            "batch_id": "batch-1",
+            "custom_id": "custom-1",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_skips_mismatched_fingerprint() -> None:
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "campaign-1",
+                    "batch_id": "batch-1",
+                    "status": "batch_succeeded",
+                    "response_text": "draft",
+                    "error_text": "",
+                    "custom_id": "custom-1",
+                    "request_metadata": {"request_fingerprint": "stale-request"},
+                    "batch_status": "completed",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await batch_utils.reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="campaign_generation",
+        artifact_type="campaign_first_attempt",
+        artifact_ids=["campaign-1"],
+        expected_request_fingerprints={"campaign-1": "current-request"},
+    )
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_returns_pending_provider_work() -> None:
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            return_value=[
+                {
+                    "artifact_id": "campaign-1",
+                    "batch_id": "batch-1",
+                    "status": "pending",
+                    "response_text": "",
+                    "error_text": "",
+                    "custom_id": "custom-1",
+                    "request_metadata": {},
+                    "batch_status": "in_progress",
+                    "provider_batch_id": "provider-1",
+                }
+            ]
+        ),
+    )
+
+    result = await batch_utils.reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=None,
+        task_name="campaign_generation",
+        artifact_type="campaign_first_attempt",
+        artifact_ids=["campaign-1"],
+    )
+
+    assert result["campaign-1"] == {
+        "state": "pending",
+        "status": "pending",
+        "cached": False,
+        "response_text": None,
+        "error_text": None,
+        "batch_id": "batch-1",
+        "custom_id": "custom-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reconcile_existing_batch_artifacts_reconciles_in_progress_then_refetches(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTED_PIPELINE_STANDALONE", "1")
+
+    from extracted_content_pipeline.services.b2b import anthropic_batch
+
+    calls = []
+
+    async def reconcile(**kwargs):
+        calls.append(kwargs)
+
+    pool = SimpleNamespace(
+        is_initialized=True,
+        fetch=AsyncMock(
+            side_effect=[
+                [
+                    {
+                        "artifact_id": "campaign-1",
+                        "batch_id": "batch-1",
+                        "status": "pending",
+                        "response_text": "",
+                        "error_text": "",
+                        "custom_id": "custom-1",
+                        "request_metadata": {},
+                        "batch_status": "in_progress",
+                        "provider_batch_id": "provider-1",
+                    }
+                ],
+                [
+                    {
+                        "artifact_id": "campaign-1",
+                        "batch_id": "batch-1",
+                        "status": "fallback_succeeded",
+                        "response_text": "draft",
+                        "error_text": "",
+                        "custom_id": "custom-1",
+                        "request_metadata": {},
+                        "batch_status": "completed",
+                        "provider_batch_id": "provider-1",
+                    }
+                ],
+            ]
+        ),
+    )
+    llm = SimpleNamespace(name="anthropic", model="claude-sonnet-4-5")
+    monkeypatch.setattr(anthropic_batch, "reconcile_anthropic_message_batch", reconcile)
+
+    result = await batch_utils.reconcile_existing_batch_artifacts(
+        pool=pool,
+        llm=llm,
+        task_name="campaign_generation",
+        artifact_type="campaign_first_attempt",
+        artifact_ids=["campaign-1"],
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["llm"] is llm
+    assert calls[0]["local_batch_id"] == "batch-1"
+    assert pool.fetch.await_count == 2
+    assert result["campaign-1"]["state"] == "succeeded"
+    assert result["campaign-1"]["status"] == "fallback_succeeded"

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -91,6 +91,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py" in owned
 
 
 def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
@@ -100,3 +101,4 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py" not in mapped


### PR DESCRIPTION
## Summary
- Move `_b2b_batch_utils` out of manifest sync and into extracted product ownership
- Harden Anthropic batch LLM resolution for standalone settings/registry shims and add the extracted env key fallback
- Add a standalone reconcile no-op shim plus focused tests for metadata gates, fingerprints, LLM resolution, and artifact reconciliation

## Validation
- `python -m py_compile extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py extracted_content_pipeline/services/b2b/anthropic_batch.py tests/test_extracted_b2b_batch_utils.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_b2b_batch_utils.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py`
- `python scripts/check_extracted_imports.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`