### PR TITLE
Own extracted blog matching helper

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -161,6 +161,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `autonomous/tasks/_b2b_batch_utils.py`: product-owned Anthropic batch helper
   functions for metadata gates, request fingerprints, LLM slot resolution, and
   existing batch artifact reconciliation
+- `autonomous/tasks/_blog_matching.py`: product-owned campaign-to-blog matcher
+  with extracted base URL environment fallbacks
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -43,10 +43,12 @@
   visibility adapter is installed.
 - Small task utility helpers are product-owned rather than Atlas-synced:
   `_execution_progress`, `_google_news`, `_blog_ts`, `_blog_deploy`, and
-  `_b2b_batch_utils`.
+  `_b2b_batch_utils`, and `_blog_matching`.
 - `_b2b_batch_utils` is product-owned and keeps Anthropic batch metadata gates,
   request fingerprints, LLM slot resolution, and existing artifact
   reconciliation inside the extracted boundary.
+- `_blog_matching` is product-owned and matches campaign targets to generated
+  blog posts with extracted base URL configuration.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/autonomous/tasks/_blog_matching.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_matching.py
@@ -1,5 +1,5 @@
 """
-Shared blog post matching for campaign pipelines.
+Product-owned blog post matching for campaign pipelines.
 
 Fetches published blog posts relevant to a vendor/category/brand,
 returning full URLs for injection into campaign selling context.
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from typing import Any
 
-logger = logging.getLogger("atlas.autonomous.tasks._blog_matching")
+logger = logging.getLogger("extracted_content_pipeline.autonomous.tasks._blog_matching")
 
 # B2B blog topic types (b2b_blog_post_generation.py)
 _B2B_TOPIC_TYPES = (
@@ -121,6 +122,22 @@ def _normalized_post_dedupe_key(
     return f"{topic_type}:{str(row.get('title') or '').strip().lower()}"
 
 
+def _blog_base_url(pipeline: str) -> str:
+    from ...config import settings
+
+    if pipeline == "b2b":
+        configured = getattr(getattr(settings, "b2b_churn", None), "blog_base_url", None)
+        env_value = os.environ.get("EXTRACTED_B2B_BLOG_BASE_URL") or os.environ.get(
+            "EXTRACTED_BLOG_BASE_URL"
+        )
+    else:
+        configured = getattr(getattr(settings, "external_data", None), "blog_base_url", None)
+        env_value = os.environ.get("EXTRACTED_CONSUMER_BLOG_BASE_URL") or os.environ.get(
+            "EXTRACTED_BLOG_BASE_URL"
+        )
+    return str(env_value or configured or "https://example.com").rstrip("/")
+
+
 async def fetch_relevant_blog_posts(
     pool,
     *,
@@ -164,13 +181,7 @@ async def fetch_relevant_blog_posts(
         logger.warning("Unknown pipeline %r, returning empty blog list", pipeline)
         return []
 
-    # Resolve base URL from config
-    from ...config import settings
-
-    if pipeline == "b2b":
-        base_url = settings.b2b_churn.blog_base_url.rstrip("/")
-    else:
-        base_url = settings.external_data.blog_base_url.rstrip("/")
+    base_url = _blog_base_url(pipeline)
 
     # Build search terms for name matching
     search_terms: list[str] = []

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -127,6 +127,11 @@ task-facing helpers for metadata flags, request fingerprints, LLM resolution,
 and existing artifact reconciliation, but resolves product environment keys and
 fails safe when a standalone host has not installed an activatable LLM registry.
 
+`extracted_content_pipeline/autonomous/tasks/_blog_matching.py` is now
+product-owned for campaign-to-blog matching. It preserves the copied relevance
+scoring rules while resolving blog URLs from extracted settings or
+`EXTRACTED_*_BLOG_BASE_URL` environment variables instead of Atlas settings.
+
 `extracted_content_pipeline/reasoning/archetypes.py` is the first product-owned
 reasoning policy slice. It scores vendor evidence against deterministic churn
 archetypes, returns thresholded matches, and exposes falsification conditions

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -167,10 +167,6 @@
     {
       "source": "atlas_brain/autonomous/tasks/campaign_audit.py",
       "target": "extracted_content_pipeline/autonomous/tasks/campaign_audit.py"
-    },
-    {
-      "source": "atlas_brain/autonomous/tasks/_blog_matching.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_blog_matching.py"
     }
   ],
   "owned": [
@@ -206,6 +202,9 @@
     },
     {
       "target": "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_blog_matching.py"
     }
   ]
 }

--- a/extracted_content_pipeline/settings.py
+++ b/extracted_content_pipeline/settings.py
@@ -35,6 +35,9 @@ def build_settings() -> SimpleNamespace:
         blog_post_max_tokens=_to_int(os.getenv("EXTRACTED_BLOG_POST_MAX_TOKENS"), 2800),
         complaint_content_max_per_run=_to_int(os.getenv("EXTRACTED_COMPLAINT_CONTENT_MAX_PER_RUN"), 10),
         complaint_content_max_tokens=_to_int(os.getenv("EXTRACTED_COMPLAINT_CONTENT_MAX_TOKENS"), 1200),
+        blog_base_url=os.getenv("EXTRACTED_CONSUMER_BLOG_BASE_URL")
+        or os.getenv("EXTRACTED_BLOG_BASE_URL")
+        or "https://example.com",
     )
 
     b2b_churn = SimpleNamespace(
@@ -42,6 +45,9 @@ def build_settings() -> SimpleNamespace:
         blog_post_max_per_run=_to_int(os.getenv("EXTRACTED_B2B_BLOG_POST_MAX_PER_RUN"), 1),
         blog_post_max_tokens=_to_int(os.getenv("EXTRACTED_B2B_BLOG_POST_MAX_TOKENS"), 3200),
         blog_post_temperature=_to_float(os.getenv("EXTRACTED_B2B_BLOG_POST_TEMPERATURE"), 0.2),
+        blog_base_url=os.getenv("EXTRACTED_B2B_BLOG_BASE_URL")
+        or os.getenv("EXTRACTED_BLOG_BASE_URL")
+        or "https://example.com",
     )
 
     campaign_llm = SimpleNamespace(

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -19,6 +19,7 @@ pytest \
   tests/test_extracted_reasoning_evidence_engine.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \
+  tests/test_extracted_blog_matching.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_blog_matching.py
+++ b/tests/test_extracted_blog_matching.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.autonomous.tasks._blog_matching import (
+    _blog_base_url,
+    _role_topic_boosts,
+    fetch_relevant_blog_posts,
+)
+
+
+class _Pool:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def fetch(self, query, *args):
+        return self.rows
+
+
+class _CapturingPool(_Pool):
+    def __init__(self, rows):
+        super().__init__(rows)
+        self.last_query = None
+
+    async def fetch(self, query, *args):
+        self.last_query = query
+        return await super().fetch(query, *args)
+
+
+@pytest.mark.asyncio
+async def test_blog_matching_uses_extracted_b2b_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTED_B2B_BLOG_BASE_URL", "https://content.example.com/")
+    rows = [
+        {
+            "title": "Zendesk Migration Guide",
+            "slug": "zendesk-migration-guide",
+            "topic_type": "migration_guide",
+            "status": "published",
+            "tags": ["customer-support"],
+            "data_context": {},
+        }
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        vendor_name="Zendesk",
+    )
+
+    assert posts[0]["url"] == "https://content.example.com/blog/zendesk-migration-guide"
+
+
+def test_blog_base_url_falls_back_without_settings_shape(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_B2B_BLOG_BASE_URL", raising=False)
+    monkeypatch.delenv("EXTRACTED_BLOG_BASE_URL", raising=False)
+
+    assert _blog_base_url("b2b")
+
+
+@pytest.mark.asyncio
+async def test_unknown_pipeline_returns_empty_list() -> None:
+    posts = await fetch_relevant_blog_posts(
+        _Pool([]),
+        pipeline="unknown",
+        vendor_name="Zendesk",
+    )
+
+    assert posts == []
+
+
+@pytest.mark.asyncio
+async def test_alternative_vendor_matching_avoids_substring_false_positive() -> None:
+    rows = [
+        {
+            "title": "CRM Landscape 2026",
+            "slug": "crm-landscape-2026-03",
+            "topic_type": "market_landscape",
+            "tags": ["crm"],
+            "data_context": {},
+        },
+        {
+            "title": "Salesforce vs SAP",
+            "slug": "salesforce-vs-sap-2026-03",
+            "topic_type": "vendor_showdown",
+            "tags": ["crm", "comparison"],
+            "data_context": {"topic_ctx": {"vendor_a": "Salesforce", "vendor_b": "SAP"}},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        alternative_vendors=["sap"],
+        limit=5,
+    )
+
+    assert len(posts) == 1
+    assert posts[0]["title"] == "Salesforce vs SAP"
+
+
+@pytest.mark.asyncio
+async def test_alternative_vendor_matching_supports_exact_vendor_b_match() -> None:
+    rows = [
+        {
+            "title": "Cloud Vendor Showdown",
+            "slug": "cloud-vendor-showdown-2026-03",
+            "topic_type": "vendor_showdown",
+            "tags": ["cloud"],
+            "data_context": {"topic_ctx": {"vendor_b": "Google Cloud Platform"}},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        alternative_vendors=["google cloud platform"],
+        limit=3,
+    )
+
+    assert len(posts) == 1
+    assert posts[0]["topic_type"] == "vendor_showdown"
+
+
+@pytest.mark.asyncio
+async def test_blog_matching_draft_fallback_is_opt_in() -> None:
+    rows = [
+        {
+            "title": "Asana vs Monday.com",
+            "slug": "asana-vs-mondaycom-2026-03",
+            "topic_type": "vendor_showdown",
+            "status": "draft",
+            "tags": ["project-management", "comparison"],
+            "data_context": {"topic_ctx": {"vendor_a": "Asana", "vendor_b": "Monday.com"}},
+        },
+    ]
+
+    no_fallback = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        alternative_vendors=["asana"],
+        limit=3,
+    )
+    with_fallback = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        alternative_vendors=["asana"],
+        include_drafts=True,
+        limit=3,
+    )
+
+    assert no_fallback == []
+    assert len(with_fallback) == 1
+    assert with_fallback[0]["url"].endswith("/blog/asana-vs-mondaycom-2026-03")
+
+
+@pytest.mark.asyncio
+async def test_blog_matching_prefers_published_over_drafts() -> None:
+    rows = [
+        {
+            "title": "Asana vs Monday.com (Draft)",
+            "slug": "asana-vs-mondaycom-2026-03-draft",
+            "topic_type": "vendor_showdown",
+            "status": "draft",
+            "tags": ["project-management", "comparison"],
+            "data_context": {"topic_ctx": {"vendor_a": "Asana", "vendor_b": "Monday.com"}},
+        },
+        {
+            "title": "Asana vs Monday.com",
+            "slug": "asana-vs-mondaycom-2026-03",
+            "topic_type": "vendor_showdown",
+            "status": "published",
+            "tags": ["project-management", "comparison"],
+            "data_context": {"topic_ctx": {"vendor_a": "Asana", "vendor_b": "Monday.com"}},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        alternative_vendors=["asana"],
+        include_drafts=True,
+        limit=3,
+    )
+
+    assert len(posts) == 1
+    assert posts[0]["url"].endswith("/blog/asana-vs-mondaycom-2026-03")
+
+
+@pytest.mark.asyncio
+async def test_blog_matching_prefers_relevant_draft_over_unrelated_published_post() -> None:
+    rows = [
+        {
+            "title": "The Real Cost of Salesforce",
+            "slug": "real-cost-of-salesforce-2026-03",
+            "topic_type": "pricing_reality_check",
+            "status": "published",
+            "tags": ["crm", "pricing"],
+            "data_context": {"pain_distribution": "pricing"},
+        },
+        {
+            "title": "CrowdStrike vs SentinelOne",
+            "slug": "crowdstrike-vs-sentinelone-2026-03",
+            "topic_type": "vendor_showdown",
+            "status": "draft",
+            "tags": ["security", "comparison"],
+            "data_context": {"topic_ctx": {"vendor_a": "CrowdStrike", "vendor_b": "SentinelOne"}},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        vendor_name="CrowdStrike",
+        alternative_vendors=["SentinelOne"],
+        pain_categories=["pricing"],
+        include_drafts=True,
+        limit=3,
+    )
+
+    assert len(posts) == 2
+    assert posts[0]["topic_type"] == "vendor_showdown"
+    assert posts[0]["url"].endswith("/blog/crowdstrike-vs-sentinelone-2026-03")
+
+
+@pytest.mark.asyncio
+async def test_blog_matching_orders_recent_drafts_by_created_at_when_enabled() -> None:
+    pool = _CapturingPool([])
+
+    await fetch_relevant_blog_posts(
+        pool,
+        pipeline="b2b",
+        alternative_vendors=["sentinelone"],
+        include_drafts=True,
+        limit=3,
+    )
+
+    assert "COALESCE(published_at, created_at) DESC" in pool.last_query
+
+
+def test_role_topic_boosts_by_persona() -> None:
+    assert _role_topic_boosts("CFO").get("pricing_reality_check", 0) >= 3
+    assert _role_topic_boosts("CTO / Head of Engineering").get("migration_guide", 0) >= 3
+    assert _role_topic_boosts(None) == {}
+    assert _role_topic_boosts("Barista") == {}
+
+
+@pytest.mark.asyncio
+async def test_contact_role_boosts_matching_post_above_unrelated() -> None:
+    rows = [
+        {
+            "title": "Zendesk vs Freshdesk",
+            "slug": "zendesk-vs-freshdesk-2026-03",
+            "topic_type": "vendor_showdown",
+            "status": "published",
+            "tags": ["customer-support"],
+            "data_context": {"topic_ctx": {"vendor_a": "Zendesk", "vendor_b": "Freshdesk"}},
+        },
+        {
+            "title": "The Real Cost of Zendesk",
+            "slug": "real-cost-of-zendesk-2026-03",
+            "topic_type": "pricing_reality_check",
+            "status": "published",
+            "tags": ["customer-support", "pricing"],
+            "data_context": {"pain_distribution": "pricing"},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        vendor_name="Zendesk",
+        contact_role="VP Finance",
+        limit=3,
+    )
+
+    assert len(posts) == 2
+    assert posts[0]["topic_type"] == "pricing_reality_check"
+
+
+@pytest.mark.asyncio
+async def test_no_contact_role_preserves_standard_ranking() -> None:
+    rows = [
+        {
+            "title": "Zendesk Migration Guide",
+            "slug": "zendesk-migration-guide-2026-03",
+            "topic_type": "migration_guide",
+            "status": "published",
+            "tags": ["customer-support"],
+            "data_context": {},
+        },
+        {
+            "title": "Zendesk vs Freshdesk",
+            "slug": "zendesk-vs-freshdesk-2026-03",
+            "topic_type": "vendor_showdown",
+            "status": "published",
+            "tags": ["customer-support"],
+            "data_context": {"topic_ctx": {"vendor_a": "Zendesk", "vendor_b": "Freshdesk"}},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        vendor_name="Zendesk",
+        alternative_vendors=["Freshdesk"],
+        contact_role=None,
+        limit=3,
+    )
+
+    assert posts[0]["topic_type"] == "vendor_showdown"
+
+
+@pytest.mark.asyncio
+async def test_diminishing_returns_multi_pain_post_scores_higher() -> None:
+    rows = [
+        {
+            "title": "Zendesk Pricing Problems",
+            "slug": "zendesk-pricing-2026-03",
+            "topic_type": "pricing_reality_check",
+            "status": "published",
+            "tags": ["pricing", "customer-support"],
+            "data_context": {"pain_distribution": "pricing support"},
+        },
+        {
+            "title": "Zendesk Support Issues",
+            "slug": "zendesk-support-2026-03",
+            "topic_type": "churn_report",
+            "status": "published",
+            "tags": ["support", "customer-support"],
+            "data_context": {"pain_distribution": "support"},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        pain_categories=["pricing", "support"],
+        limit=3,
+    )
+
+    assert len(posts) == 2
+    assert posts[0]["url"].endswith("/blog/zendesk-pricing-2026-03")
+
+
+@pytest.mark.asyncio
+async def test_single_pain_match_without_break() -> None:
+    rows = [
+        {
+            "title": "Zendesk Migration Guide",
+            "slug": "zendesk-migration-2026-03",
+            "topic_type": "migration_guide",
+            "status": "published",
+            "tags": ["migration"],
+            "data_context": {},
+        },
+    ]
+
+    posts = await fetch_relevant_blog_posts(
+        _Pool(rows),
+        pipeline="b2b",
+        vendor_name="Zendesk",
+        pain_categories=["pricing", "support", "features", "onboarding"],
+        limit=3,
+    )
+
+    assert len(posts) == 1

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -20,6 +20,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/reasoning/temporal.py",
     "extracted_content_pipeline/reasoning/wedge_registry.py",
     "extracted_content_pipeline/config.py",
+    "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",
     "extracted_content_pipeline/skills/registry.py",
     "extracted_content_pipeline/services/__init__.py",
     "extracted_content_pipeline/services/apollo_company_overrides.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -92,6 +92,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_blog_matching.py" in owned
 
 
 def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
@@ -102,3 +103,4 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/_blog_matching.py" not in mapped


### PR DESCRIPTION
## Summary
- Move `_blog_matching` out of Atlas manifest sync and into extracted product ownership
- Replace Atlas logger/settings assumptions with extracted logger naming and product blog base URL fallbacks
- Add extracted blog matching coverage and wire it into the extracted pipeline check runner

## Validation
- `python -m py_compile extracted_content_pipeline/autonomous/tasks/_blog_matching.py extracted_content_pipeline/settings.py tests/test_extracted_blog_matching.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_blog_matching.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py`
- `python scripts/check_extracted_imports.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`