### PR TITLE
Route extracted task sequence context through product helper

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -163,6 +163,9 @@ Several small utility shims provide product-owned local behavior by default so t
   existing batch artifact reconciliation
 - `autonomous/tasks/_blog_matching.py`: product-owned campaign-to-blog matcher
   with extracted base URL environment fallbacks
+- `campaign_sequence_context.py` and
+  `autonomous/tasks/_campaign_sequence_context.py`: product-owned sequence
+  prompt/storage compaction helpers plus compatibility exports for copied tasks
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -49,6 +49,9 @@
   reconciliation inside the extracted boundary.
 - `_blog_matching` is product-owned and matches campaign targets to generated
   blog posts with extracted base URL configuration.
+- `campaign_sequence_context` is product-owned, and the copied task-local
+  `_campaign_sequence_context` module now exports that standalone
+  implementation for Atlas-compatible task imports.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py
+++ b/extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py
@@ -1,4 +1,10 @@
-"""Shared compaction helpers for campaign sequence storage and prompt assembly."""
+"""Compatibility exports for campaign sequence storage and prompt assembly.
+
+The product-owned implementation lives in
+``extracted_content_pipeline.campaign_sequence_context``. This task-local module
+keeps copied Atlas task imports stable while routing public helpers through the
+standalone implementation with explicit ``SequenceContextLimits`` defaults.
+"""
 
 from __future__ import annotations
 
@@ -419,3 +425,26 @@ def plain_text_preview(body: str, *, limit: int | None = None) -> str:
     if len(text) <= max_chars:
         return text
     return f"{text[:max_chars].rstrip()}..."
+
+
+from ...campaign_sequence_context import (  # noqa: E402
+    DEFAULT_LIMITS,
+    SequenceContextLimits,
+    compact_sequence_contexts,
+    plain_text_preview,
+    prepare_sequence_prompt_contexts,
+    prepare_sequence_storage_contexts,
+    prompt_email_body_preview_chars,
+    prompt_max_tokens,
+)
+
+__all__ = [
+    "DEFAULT_LIMITS",
+    "SequenceContextLimits",
+    "compact_sequence_contexts",
+    "plain_text_preview",
+    "prepare_sequence_prompt_contexts",
+    "prepare_sequence_storage_contexts",
+    "prompt_email_body_preview_chars",
+    "prompt_max_tokens",
+]

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -72,6 +72,9 @@ product package, and push persistence/provider concerns behind ports.
 `extracted_content_pipeline/campaign_sequence_context.py` is the second
 standalone slice. It keeps the sequence prompt/storage compaction behavior but
 replaces Atlas settings reads with explicit `SequenceContextLimits`.
+The copied task-local `_campaign_sequence_context.py` now exports this
+product-owned module so Atlas-compatible campaign task imports use the same
+standalone limits path.
 
 `extracted_content_pipeline/campaign_sender.py` is the third standalone slice.
 It keeps Resend and SES provider behavior but uses explicit provider config and

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -157,10 +157,6 @@
       "target": "extracted_content_pipeline/autonomous/tasks/_b2b_pool_compression.py"
     },
     {
-      "source": "atlas_brain/autonomous/tasks/_campaign_sequence_context.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py"
-    },
-    {
       "source": "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py",
       "target": "extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py"
     },
@@ -205,6 +201,12 @@
     },
     {
       "target": "extracted_content_pipeline/autonomous/tasks/_blog_matching.py"
+    },
+    {
+      "target": "extracted_content_pipeline/campaign_sequence_context.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py"
     }
   ]
 }

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -21,6 +21,8 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/reasoning/wedge_registry.py",
     "extracted_content_pipeline/config.py",
     "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",
+    "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py",
+    "extracted_content_pipeline/campaign_sequence_context.py",
     "extracted_content_pipeline/skills/registry.py",
     "extracted_content_pipeline/services/__init__.py",
     "extracted_content_pipeline/services/apollo_company_overrides.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -93,6 +93,8 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_blog_matching.py" in owned
+    assert "extracted_content_pipeline/campaign_sequence_context.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py" in owned
 
 
 def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
@@ -104,3 +106,5 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_blog_deploy.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_b2b_batch_utils.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_blog_matching.py" not in mapped
+    assert "extracted_content_pipeline/campaign_sequence_context.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py" not in mapped

--- a/tests/test_extracted_campaign_sequence_context.py
+++ b/tests/test_extracted_campaign_sequence_context.py
@@ -10,6 +10,17 @@ from extracted_content_pipeline.campaign_sequence_context import (
     prompt_email_body_preview_chars,
     prompt_max_tokens,
 )
+from extracted_content_pipeline.autonomous.tasks import _campaign_sequence_context as task_context
+from extracted_content_pipeline import campaign_sequence_context as product_context
+
+
+def test_task_sequence_context_exports_product_owned_helpers():
+    assert task_context.SequenceContextLimits is product_context.SequenceContextLimits
+    assert task_context.prompt_max_tokens is product_context.prompt_max_tokens
+    assert task_context.prompt_email_body_preview_chars is product_context.prompt_email_body_preview_chars
+    assert task_context.prepare_sequence_prompt_contexts is product_context.prepare_sequence_prompt_contexts
+    assert task_context.prepare_sequence_storage_contexts is product_context.prepare_sequence_storage_contexts
+    assert task_context.plain_text_preview is product_context.plain_text_preview
 
 
 def test_prepare_prompt_contexts_removes_duplicate_and_heavy_fields():


### PR DESCRIPTION
## Summary
- Move the copied task-local `_campaign_sequence_context` helper out of manifest sync and into product ownership
- Route its public exports through the existing standalone `campaign_sequence_context` implementation with explicit `SequenceContextLimits`
- Add compatibility coverage proving copied task imports resolve to the product-owned helpers

## Validation
- `python -m py_compile extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py tests/test_extracted_campaign_sequence_context.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_sequence_context.py tests/test_extracted_campaign_sequence_progression.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py`
- `python scripts/check_extracted_imports.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`