### PR TITLE
Own extracted campaign audit helper

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -166,6 +166,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `campaign_sequence_context.py` and
   `autonomous/tasks/_campaign_sequence_context.py`: product-owned sequence
   prompt/storage compaction helpers plus compatibility exports for copied tasks
+- `autonomous/tasks/campaign_audit.py`: product-owned audit-log writer for
+  campaign state changes
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -52,6 +52,8 @@
 - `campaign_sequence_context` is product-owned, and the copied task-local
   `_campaign_sequence_context` module now exports that standalone
   implementation for Atlas-compatible task imports.
+- `campaign_audit` is product-owned and writes campaign state-change audit
+  rows without importing Atlas logging or task helpers.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/autonomous/tasks/campaign_audit.py
+++ b/extracted_content_pipeline/autonomous/tasks/campaign_audit.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
-logger = logging.getLogger("atlas.autonomous.tasks.campaign_audit")
+logger = logging.getLogger("extracted_content_pipeline.autonomous.tasks.campaign_audit")
 
 
 async def log_campaign_event(

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -76,6 +76,11 @@ The copied task-local `_campaign_sequence_context.py` now exports this
 product-owned module so Atlas-compatible campaign task imports use the same
 standalone limits path.
 
+`extracted_content_pipeline/autonomous/tasks/campaign_audit.py` is product-owned
+as the copied task-facing audit writer. It keeps the small never-raise
+`log_campaign_event(...)` contract while using extracted logger naming and local
+coverage for UUID coercion, metadata serialization, and failure handling.
+
 `extracted_content_pipeline/campaign_sender.py` is the third standalone slice.
 It keeps Resend and SES provider behavior but uses explicit provider config and
 the product `SendRequest`/`SendResult` dataclasses.

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -159,10 +159,6 @@
     {
       "source": "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py",
       "target": "extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py"
-    },
-    {
-      "source": "atlas_brain/autonomous/tasks/campaign_audit.py",
-      "target": "extracted_content_pipeline/autonomous/tasks/campaign_audit.py"
     }
   ],
   "owned": [
@@ -207,6 +203,9 @@
     },
     {
       "target": "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/campaign_audit.py"
     }
   ]
 }

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -20,6 +20,7 @@ pytest \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \
   tests/test_extracted_blog_matching.py \
+  tests/test_extracted_campaign_audit.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
   tests/test_extracted_campaign_postgres.py \

--- a/tests/test_extracted_campaign_audit.py
+++ b/tests/test_extracted_campaign_audit.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from uuid import UUID, uuid4
+
+import pytest
+
+from extracted_content_pipeline.autonomous.tasks.campaign_audit import log_campaign_event
+
+
+class _Pool:
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.calls = []
+
+    async def execute(self, query, *args):
+        self.calls.append((query, args))
+        if self.fail:
+            raise RuntimeError("database unavailable")
+
+
+@pytest.mark.asyncio
+async def test_log_campaign_event_inserts_normalized_audit_row() -> None:
+    campaign_id = uuid4()
+    sequence_id = uuid4()
+    pool = _Pool()
+
+    await log_campaign_event(
+        pool,
+        event_type="sequence_sent",
+        source="scheduler",
+        campaign_id=str(campaign_id),
+        sequence_id=sequence_id,
+        step_number=2,
+        subject="Follow-up",
+        body="Body",
+        recipient_email="buyer@example.com",
+        esp_message_id="msg-1",
+        error_detail=None,
+        metadata={"variant": "A"},
+    )
+
+    assert len(pool.calls) == 1
+    query, args = pool.calls[0]
+    assert "INSERT INTO campaign_audit_log" in query
+    assert args[0] == campaign_id
+    assert isinstance(args[0], UUID)
+    assert args[1] == sequence_id
+    assert args[2:10] == (
+        "sequence_sent",
+        2,
+        "Follow-up",
+        "Body",
+        "buyer@example.com",
+        "msg-1",
+        None,
+        "scheduler",
+    )
+    assert json.loads(args[10]) == {"variant": "A"}
+
+
+@pytest.mark.asyncio
+async def test_log_campaign_event_defaults_metadata_to_empty_object() -> None:
+    pool = _Pool()
+
+    await log_campaign_event(pool, event_type="created")
+
+    _, args = pool.calls[0]
+    assert args[0] is None
+    assert args[1] is None
+    assert json.loads(args[10]) == {}
+
+
+@pytest.mark.asyncio
+async def test_log_campaign_event_never_raises_on_insert_failure() -> None:
+    pool = _Pool(fail=True)
+
+    await log_campaign_event(pool, event_type="failed", sequence_id=uuid4())
+
+    assert len(pool.calls) == 1

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -22,6 +22,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/config.py",
     "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",
     "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py",
+    "extracted_content_pipeline/autonomous/tasks/campaign_audit.py",
     "extracted_content_pipeline/campaign_sequence_context.py",
     "extracted_content_pipeline/skills/registry.py",
     "extracted_content_pipeline/services/__init__.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -95,6 +95,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_blog_matching.py" in owned
     assert "extracted_content_pipeline/campaign_sequence_context.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/campaign_audit.py" in owned
 
 
 def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
@@ -108,3 +109,4 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/autonomous/tasks/_blog_matching.py" not in mapped
     assert "extracted_content_pipeline/campaign_sequence_context.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/campaign_audit.py" not in mapped


### PR DESCRIPTION
## Summary
- Move `campaign_audit.py` out of manifest sync and into extracted product ownership
- Replace the Atlas logger namespace with extracted logger naming
- Add focused extracted tests for audit insert shape, UUID coercion, metadata JSON, and never-raise failure handling

## Validation
- `python -m py_compile extracted_content_pipeline/autonomous/tasks/campaign_audit.py tests/test_extracted_campaign_audit.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_audit.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py`
- `python scripts/check_extracted_imports.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`