### PR TITLE
Add vendor briefing standalone import seams

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/smoke_extracted_pipeline_imports.py"
       - "scripts/run_extracted_pipeline_checks.sh"
       - "tests/test_extracted_campaign_*.py"
+      - "tests/test_extracted_vendor_briefing_*.py"
   push:
     paths:
       - "extracted_content_pipeline/**"
@@ -23,6 +24,7 @@ on:
       - "scripts/smoke_extracted_pipeline_imports.py"
       - "scripts/run_extracted_pipeline_checks.sh"
       - "tests/test_extracted_campaign_*.py"
+      - "tests/test_extracted_vendor_briefing_*.py"
 
 jobs:
   extracted-checks:
@@ -41,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/extracted_content_pipeline/autonomous/tasks/campaign_suppression.py
+++ b/extracted_content_pipeline/autonomous/tasks/campaign_suppression.py
@@ -1,0 +1,111 @@
+"""Campaign suppression compatibility helpers for standalone extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class AssignmentResult:
+    assigned: bool
+    sequence_id: UUID
+    conflict_with_sequence_id: UUID | None = None
+    reason: str | None = None
+
+
+def _normalize_email(email: str | None) -> str:
+    return str(email or "").strip().lower()
+
+
+def _email_domain(email: str) -> str:
+    _, _, domain = email.partition("@")
+    return domain.strip().lower()
+
+
+async def is_suppressed(pool: Any, *, email: str) -> dict[str, Any] | None:
+    """Return an active suppression row for an email or its domain."""
+    normalized = _normalize_email(email)
+    if not normalized:
+        return None
+    row = await pool.fetchrow(
+        """
+        SELECT *
+        FROM campaign_suppressions
+        WHERE (expires_at IS NULL OR expires_at > NOW())
+          AND LOWER(email) = $1
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        normalized,
+    )
+    if row:
+        return dict(row)
+
+    domain = _email_domain(normalized)
+    if not domain:
+        return None
+    row = await pool.fetchrow(
+        """
+        SELECT *
+        FROM campaign_suppressions
+        WHERE (expires_at IS NULL OR expires_at > NOW())
+          AND LOWER(domain) = $1
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        domain,
+    )
+    return dict(row) if row else None
+
+
+async def assign_recipient_to_sequence(
+    pool: Any,
+    sequence_id: UUID | str,
+    email: str,
+) -> AssignmentResult:
+    """Assign a recipient to one active sequence unless another owns it."""
+    sid = sequence_id if isinstance(sequence_id, UUID) else UUID(str(sequence_id))
+    normalized = _normalize_email(email)
+    if not normalized:
+        return AssignmentResult(False, sid, reason="empty_email")
+
+    conflict_id = await pool.fetchval(
+        """
+        SELECT id
+        FROM campaign_sequences
+        WHERE LOWER(BTRIM(recipient_email)) = $1
+          AND status = 'active'
+          AND id != $2
+        LIMIT 1
+        """,
+        normalized,
+        sid,
+    )
+    if conflict_id:
+        return AssignmentResult(
+            False,
+            sid,
+            conflict_with_sequence_id=(
+                conflict_id if isinstance(conflict_id, UUID) else UUID(str(conflict_id))
+            ),
+            reason="recipient_already_assigned",
+        )
+
+    result = await pool.execute(
+        """
+        UPDATE campaign_sequences
+        SET recipient_email = $2,
+            updated_at = NOW()
+        WHERE id = $1
+          AND status = 'active'
+        """,
+        sid,
+        normalized,
+    )
+    return AssignmentResult(
+        str(result).upper() == "UPDATE 1",
+        sid,
+        reason=None if str(result).upper() == "UPDATE 1" else "sequence_not_active",
+    )

--- a/extracted_content_pipeline/docs/remaining_productization_audit.md
+++ b/extracted_content_pipeline/docs/remaining_productization_audit.md
@@ -22,14 +22,14 @@ EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh
 # 177 passed
 ```
 
-The current smoke import script does not import the core campaign task modules.
-Direct import of all remaining manifest-mapped Python files shows four failing
-surfaces:
+The smoke import script now includes the vendor briefing task after the PR 1
+seams made it importable. Direct import of all remaining manifest-mapped Python
+files still shows three failing surfaces:
 
 | Module | Standalone import | First blocker |
 | --- | --- | --- |
 | `autonomous.tasks.b2b_campaign_generation` | Fails | missing `services.b2b.account_opportunity_claims` |
-| `autonomous.tasks.b2b_vendor_briefing` | Fails | missing `services.campaign_sender` |
+| `autonomous.tasks.b2b_vendor_briefing` | Passes | PR 1 seams present |
 | `autonomous.tasks._b2b_pool_compression` | Fails | missing `autonomous.tasks._b2b_witnesses` |
 | `autonomous.tasks.competitive_intelligence` | Fails | missing `services.brand_registry` |
 
@@ -67,7 +67,8 @@ files remain Atlas-shaped and should not be product-owned as-is.
 - `autonomous.visibility`
 - `autonomous.tasks.campaign_suppression`
 
-`b2b_vendor_briefing.py` has these missing top-level dependencies:
+`b2b_vendor_briefing.py` had these missing top-level dependencies, now covered
+by product-owned compatibility seams:
 
 - `services.campaign_sender`
 - `services.vendor_target_selection`
@@ -107,6 +108,9 @@ into the product-owned spine in smaller slices.
 
 ### PR 1: Vendor Briefing Import Seams
 
+Status: implemented. `b2b_vendor_briefing.py` imports in standalone mode, and
+the smoke script now covers it.
+
 Goal: make `b2b_vendor_briefing.py` import in standalone mode without claiming
 the copied 3,222-line task is product-owned.
 
@@ -130,8 +134,9 @@ Acceptance criteria:
 - `EXTRACTED_PIPELINE_STANDALONE=1 python -c "import extracted_content_pipeline.autonomous.tasks.b2b_vendor_briefing"`
 - Local tests for each compatibility shim.
 
-Do not expand the smoke script yet; `b2b_campaign_generation.py` still has
-separate missing imports.
+This slice may expand the smoke script to include `b2b_vendor_briefing.py`
+once the direct import passes. Keep `b2b_campaign_generation.py` out of the
+smoke list until PR 2 handles its separate missing imports.
 
 ### PR 2: Campaign Generation Import Seams
 

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -206,6 +206,27 @@
     },
     {
       "target": "extracted_content_pipeline/autonomous/tasks/campaign_audit.py"
+    },
+    {
+      "target": "extracted_content_pipeline/services/campaign_sender.py"
+    },
+    {
+      "target": "extracted_content_pipeline/services/vendor_target_selection.py"
+    },
+    {
+      "target": "extracted_content_pipeline/services/vendor_registry.py"
+    },
+    {
+      "target": "extracted_content_pipeline/autonomous/tasks/campaign_suppression.py"
+    },
+    {
+      "target": "extracted_content_pipeline/templates/__init__.py"
+    },
+    {
+      "target": "extracted_content_pipeline/templates/email/__init__.py"
+    },
+    {
+      "target": "extracted_content_pipeline/templates/email/vendor_briefing.py"
     }
   ]
 }

--- a/extracted_content_pipeline/services/campaign_sender.py
+++ b/extracted_content_pipeline/services/campaign_sender.py
@@ -1,0 +1,101 @@
+"""Atlas-compatible sender seam backed by standalone campaign sender ports."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from ..campaign_ports import SendRequest
+from ..campaign_sender import create_campaign_sender
+from ..config import settings
+
+
+class CampaignSenderAdapter:
+    """Adapt the product sender port to Atlas' legacy keyword-call shape."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    async def send(
+        self,
+        *,
+        to: str,
+        from_email: str | None,
+        subject: str,
+        body: str,
+        tags: Sequence[Mapping[str, str]] | None = None,
+        text: str | None = None,
+        reply_to: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        **_: Any,
+    ) -> dict[str, Any]:
+        request = SendRequest(
+            campaign_id=str((metadata or {}).get("campaign_id") or "vendor_briefing"),
+            to_email=str(to),
+            from_email=from_email,
+            subject=str(subject),
+            html_body=str(body),
+            text_body=text,
+            reply_to=reply_to,
+            headers=dict(headers or {}),
+            tags=tuple(tags or ()),
+            metadata=dict(metadata or {}),
+        )
+        result = await self._inner.send(request)
+        return {
+            "id": result.message_id,
+            "provider": result.provider,
+            "raw": result.raw,
+        }
+
+
+_sender_instance: CampaignSenderAdapter | None = None
+
+
+def _sender_config_from_settings() -> tuple[str, dict[str, Any]]:
+    cfg = settings.campaign_sequence
+    sender_type = str(getattr(cfg, "sender_type", "resend") or "resend").lower()
+    if sender_type == "ses":
+        return (
+            "ses",
+            {
+                "from_email": getattr(cfg, "ses_from_email", "") or getattr(
+                    cfg,
+                    "resend_from_email",
+                    "",
+                ),
+                "region": getattr(cfg, "ses_region", "us-east-1"),
+                "access_key_id": getattr(cfg, "ses_access_key_id", "") or None,
+                "secret_access_key": getattr(cfg, "ses_secret_access_key", "") or None,
+                "configuration_set": getattr(cfg, "ses_configuration_set", "") or None,
+            },
+        )
+
+    api_key = getattr(cfg, "resend_api_key", "") or ""
+    if not api_key:
+        raise RuntimeError(
+            "EXTRACTED_CAMPAIGN_RESEND_API_KEY is required when sender_type=resend"
+        )
+    return (
+        "resend",
+        {
+            "api_key": api_key,
+            "api_url": getattr(cfg, "resend_api_url", "") or None,
+            "timeout_seconds": getattr(cfg, "sender_timeout_seconds", 30.0),
+        },
+    )
+
+
+def get_campaign_sender() -> CampaignSenderAdapter:
+    """Return the configured standalone sender behind the legacy API."""
+    global _sender_instance
+    if _sender_instance is None:
+        provider, config = _sender_config_from_settings()
+        _sender_instance = CampaignSenderAdapter(create_campaign_sender(provider, config))
+    return _sender_instance
+
+
+def reset_campaign_sender_for_tests() -> None:
+    """Clear the cached singleton between tests."""
+    global _sender_instance
+    _sender_instance = None

--- a/extracted_content_pipeline/services/vendor_registry.py
+++ b/extracted_content_pipeline/services/vendor_registry.py
@@ -3,3 +3,8 @@ from __future__ import annotations
 
 def resolve_vendor_name_cached(value: str | None) -> str:
     return str(value or "").strip()
+
+
+async def resolve_vendor_name(value: str | None) -> str:
+    """Async-compatible resolver used by copied Atlas campaign tasks."""
+    return resolve_vendor_name_cached(value)

--- a/extracted_content_pipeline/services/vendor_target_selection.py
+++ b/extracted_content_pipeline/services/vendor_target_selection.py
@@ -1,0 +1,39 @@
+"""Vendor target selection helpers for standalone campaign workflows."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def _target_key(row: Mapping[str, Any]) -> tuple[str, str]:
+    return (
+        str(row.get("company_name") or "").strip().lower(),
+        str(row.get("target_mode") or "").strip().lower(),
+    )
+
+
+def _target_priority(row: Mapping[str, Any]) -> tuple[int, int, str]:
+    freshness = str(row.get("updated_at") or row.get("created_at") or "")
+    return (
+        1 if row.get("account_id") else 0,
+        1 if row.get("contact_email") else 0,
+        freshness,
+    )
+
+
+def dedupe_vendor_target_rows(rows: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Keep the strongest row per ``(company_name, target_mode)`` pair."""
+    best_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw_row in rows:
+        row = dict(raw_row)
+        key = _target_key(row)
+        existing = best_by_key.get(key)
+        if existing is None or _target_priority(row) > _target_priority(existing):
+            best_by_key[key] = row
+    return sorted(
+        best_by_key.values(),
+        key=lambda row: (
+            str(row.get("company_name") or "").strip().lower(),
+            str(row.get("target_mode") or "").strip().lower(),
+        ),
+    )

--- a/extracted_content_pipeline/settings.py
+++ b/extracted_content_pipeline/settings.py
@@ -48,6 +48,34 @@ def build_settings() -> SimpleNamespace:
         blog_base_url=os.getenv("EXTRACTED_B2B_BLOG_BASE_URL")
         or os.getenv("EXTRACTED_BLOG_BASE_URL")
         or "https://example.com",
+        intelligence_window_days=_to_int(os.getenv("EXTRACTED_B2B_INTELLIGENCE_WINDOW_DAYS"), 30),
+        openrouter_api_key=os.getenv("EXTRACTED_OPENROUTER_API_KEY") or "",
+        briefing_analyst_model=os.getenv("EXTRACTED_VENDOR_BRIEFING_ANALYST_MODEL")
+        or "openai/gpt-4o-mini",
+        vendor_briefing_sender_name=os.getenv("EXTRACTED_VENDOR_BRIEFING_SENDER_NAME")
+        or "Atlas",
+        vendor_briefing_gate_base_url=os.getenv("EXTRACTED_VENDOR_BRIEFING_GATE_BASE_URL")
+        or "https://example.com/vendor-briefing",
+        vendor_briefing_gate_expiry_days=_to_int(
+            os.getenv("EXTRACTED_VENDOR_BRIEFING_GATE_EXPIRY_DAYS"),
+            14,
+        ),
+        vendor_briefing_max_per_batch=_to_int(
+            os.getenv("EXTRACTED_VENDOR_BRIEFING_MAX_PER_BATCH"),
+            25,
+        ),
+        vendor_briefing_cooldown_days=_to_int(
+            os.getenv("EXTRACTED_VENDOR_BRIEFING_COOLDOWN_DAYS"),
+            7,
+        ),
+        vendor_briefing_scheduled_analyst_enrichment_enabled=_to_bool(
+            os.getenv("EXTRACTED_VENDOR_BRIEFING_ANALYST_ENRICHMENT_ENABLED"),
+            False,
+        ),
+        vendor_briefing_scheduled_account_cards_reasoning_depth=os.getenv(
+            "EXTRACTED_VENDOR_BRIEFING_ACCOUNT_CARDS_REASONING_DEPTH"
+        )
+        or "standard",
     )
 
     campaign_llm = SimpleNamespace(
@@ -61,8 +89,41 @@ def build_settings() -> SimpleNamespace:
         openrouter_model=os.getenv("EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL") or None,
     )
 
+    campaign_sequence = SimpleNamespace(
+        enabled=_to_bool(os.getenv("EXTRACTED_CAMPAIGN_SEQUENCE_ENABLED"), True),
+        sender_type=os.getenv("EXTRACTED_CAMPAIGN_SEQUENCE_SENDER_TYPE")
+        or os.getenv("EXTRACTED_CAMPAIGN_SENDER_TYPE")
+        or "resend",
+        resend_api_key=os.getenv("EXTRACTED_RESEND_API_KEY")
+        or os.getenv("EXTRACTED_CAMPAIGN_RESEND_API_KEY")
+        or os.getenv("EXTRACTED_CAMPAIGN_SEQ_RESEND_API_KEY")
+        or "",
+        resend_from_email=os.getenv("EXTRACTED_RESEND_FROM_EMAIL")
+        or os.getenv("EXTRACTED_CAMPAIGN_RESEND_FROM_EMAIL")
+        or os.getenv("EXTRACTED_CAMPAIGN_SEQ_RESEND_FROM_EMAIL")
+        or "",
+        resend_api_url=os.getenv("EXTRACTED_RESEND_API_URL") or "https://api.resend.com/emails",
+        sender_timeout_seconds=_to_float(
+            os.getenv("EXTRACTED_CAMPAIGN_SENDER_TIMEOUT_SECONDS")
+            or os.getenv("EXTRACTED_CAMPAIGN_SEQ_SENDER_TIMEOUT_SECONDS"),
+            30.0,
+        ),
+        ses_region=os.getenv("EXTRACTED_SES_REGION") or "us-east-1",
+        ses_access_key_id=os.getenv("EXTRACTED_SES_ACCESS_KEY_ID") or "",
+        ses_secret_access_key=os.getenv("EXTRACTED_SES_SECRET_ACCESS_KEY") or "",
+        ses_configuration_set=os.getenv("EXTRACTED_SES_CONFIGURATION_SET") or "",
+        ses_from_email=os.getenv("EXTRACTED_SES_FROM_EMAIL") or "",
+    )
+
+    saas_auth = SimpleNamespace(
+        jwt_secret=os.getenv("EXTRACTED_VENDOR_BRIEFING_JWT_SECRET") or "dev-secret",
+        jwt_algorithm=os.getenv("EXTRACTED_VENDOR_BRIEFING_JWT_ALGORITHM") or "HS256",
+    )
+
     return SimpleNamespace(
         external_data=external_data,
         b2b_churn=b2b_churn,
         campaign_llm=campaign_llm,
+        campaign_sequence=campaign_sequence,
+        saas_auth=saas_auth,
     )

--- a/extracted_content_pipeline/templates/__init__.py
+++ b/extracted_content_pipeline/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone email/template package for extracted content pipeline."""

--- a/extracted_content_pipeline/templates/email/__init__.py
+++ b/extracted_content_pipeline/templates/email/__init__.py
@@ -1,0 +1,1 @@
+"""Email rendering templates for extracted content pipeline."""

--- a/extracted_content_pipeline/templates/email/vendor_briefing.py
+++ b/extracted_content_pipeline/templates/email/vendor_briefing.py
@@ -1,0 +1,95 @@
+"""Minimal standalone vendor briefing email renderer."""
+
+from __future__ import annotations
+
+from html import escape
+from typing import Any, Iterable
+
+
+def _text(value: Any, fallback: str = "") -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def _iter_dicts(value: Any) -> Iterable[dict[str, Any]]:
+    if not isinstance(value, list):
+        return ()
+    return (item for item in value if isinstance(item, dict))
+
+
+def _section(title: str, body: str) -> str:
+    if not body:
+        return ""
+    return f"<section><h2>{escape(title)}</h2>{body}</section>"
+
+
+def _render_pain_breakdown(briefing: dict[str, Any]) -> str:
+    rows: list[str] = []
+    for item in _iter_dicts(briefing.get("pain_breakdown")):
+        label = _text(item.get("label") or item.get("category") or item.get("pain_category"))
+        count = _text(item.get("mention_count") or item.get("count"))
+        if not label:
+            continue
+        suffix = f" ({escape(count)} mentions)" if count else ""
+        rows.append(f"<li>{escape(label)}{suffix}</li>")
+    return _section("Pain Signals", f"<ul>{''.join(rows)}</ul>" if rows else "")
+
+
+def _render_evidence(briefing: dict[str, Any]) -> str:
+    quotes: list[str] = []
+    for item in _iter_dicts(briefing.get("evidence")):
+        if item.get("phrase_verbatim") is not True:
+            continue
+        quote = _text(item.get("quote") or item.get("text") or item.get("excerpt_text"))
+        if quote:
+            quotes.append(f"<blockquote>&ldquo;{escape(quote)}&rdquo;</blockquote>")
+    return _section("What Customers Are Saying", "".join(quotes))
+
+
+def _render_named_accounts(briefing: dict[str, Any]) -> str:
+    rows: list[str] = []
+    for item in _iter_dicts(briefing.get("named_accounts")):
+        company = _text(item.get("company") or item.get("company_name"))
+        signal = _text(item.get("signal") or item.get("reason"))
+        if not company:
+            continue
+        suffix = f" - {escape(signal)}" if signal else ""
+        rows.append(f"<li><strong>{escape(company)}</strong>{suffix}</li>")
+    return _section("Named Accounts", f"<ul>{''.join(rows)}</ul>" if rows else "")
+
+
+def render_vendor_briefing_html(briefing: dict[str, Any]) -> str:
+    """Render a compact customer-facing vendor briefing HTML document."""
+    vendor = _text(
+        briefing.get("vendor_name")
+        or briefing.get("target_vendor")
+        or briefing.get("company_name"),
+        "Vendor",
+    )
+    challenger_mode = bool(briefing.get("challenger_mode"))
+    title = (
+        f"Sales Intelligence Briefing: {vendor}"
+        if challenger_mode
+        else f"Churn Intelligence Briefing: {vendor}"
+    )
+    summary = _text(
+        briefing.get("analyst_summary")
+        or briefing.get("headline")
+        or briefing.get("summary")
+    )
+    sections = [
+        _section("Summary", f"<p>{escape(summary)}</p>" if summary else ""),
+        _render_pain_breakdown(briefing),
+        _render_evidence(briefing),
+        _render_named_accounts(briefing),
+    ]
+    body = "".join(section for section in sections if section)
+    return (
+        "<!doctype html>"
+        "<html><head><meta charset=\"utf-8\">"
+        f"<title>{escape(title)}</title>"
+        "</head><body>"
+        f"<h1>{escape(title)}</h1>"
+        f"{body}"
+        "</body></html>"
+    )

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -23,6 +23,7 @@ pytest \
   tests/test_extracted_campaign_audit.py \
   tests/test_extracted_campaign_llm_client.py \
   tests/test_extracted_campaign_llm_bridge.py \
+  tests/test_extracted_vendor_briefing_seams.py \
   tests/test_extracted_campaign_postgres.py \
   tests/test_extracted_campaign_suppression.py \
   tests/test_extracted_campaign_sequence_context.py \

--- a/scripts/smoke_extracted_pipeline_imports.py
+++ b/scripts/smoke_extracted_pipeline_imports.py
@@ -15,6 +15,7 @@ MODULES = [
     "extracted_content_pipeline.autonomous.tasks.complaint_content_generation",
     "extracted_content_pipeline.autonomous.tasks.complaint_enrichment",
     "extracted_content_pipeline.autonomous.tasks.article_enrichment",
+    "extracted_content_pipeline.autonomous.tasks.b2b_vendor_briefing",
 ]
 
 

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -23,6 +23,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",
     "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py",
     "extracted_content_pipeline/autonomous/tasks/campaign_audit.py",
+    "extracted_content_pipeline/autonomous/tasks/campaign_suppression.py",
     "extracted_content_pipeline/campaign_sequence_context.py",
     "extracted_content_pipeline/skills/registry.py",
     "extracted_content_pipeline/services/__init__.py",
@@ -31,15 +32,18 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/services/b2b/cache_runner.py",
     "extracted_content_pipeline/services/b2b/enrichment_contract.py",
     "extracted_content_pipeline/services/blog_quality.py",
+    "extracted_content_pipeline/services/campaign_sender.py",
     "extracted_content_pipeline/services/company_normalization.py",
     "extracted_content_pipeline/services/protocols.py",
     "extracted_content_pipeline/services/scraping/sources.py",
     "extracted_content_pipeline/services/scraping/universal/html_cleaner.py",
     "extracted_content_pipeline/services/tracing.py",
+    "extracted_content_pipeline/services/vendor_target_selection.py",
     "extracted_content_pipeline/services/vendor_registry.py",
     "extracted_content_pipeline/storage/database.py",
     "extracted_content_pipeline/storage/models.py",
     "extracted_content_pipeline/storage/repositories/scheduled_task.py",
+    "extracted_content_pipeline/templates/email/vendor_briefing.py",
 ]
 
 

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -96,6 +96,11 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_sequence_context.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py" in owned
     assert "extracted_content_pipeline/autonomous/tasks/campaign_audit.py" in owned
+    assert "extracted_content_pipeline/services/campaign_sender.py" in owned
+    assert "extracted_content_pipeline/services/vendor_target_selection.py" in owned
+    assert "extracted_content_pipeline/services/vendor_registry.py" in owned
+    assert "extracted_content_pipeline/autonomous/tasks/campaign_suppression.py" in owned
+    assert "extracted_content_pipeline/templates/email/vendor_briefing.py" in owned
 
 
 def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
@@ -110,3 +115,8 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/campaign_sequence_context.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/campaign_audit.py" not in mapped
+    assert "extracted_content_pipeline/services/campaign_sender.py" not in mapped
+    assert "extracted_content_pipeline/services/vendor_target_selection.py" not in mapped
+    assert "extracted_content_pipeline/services/vendor_registry.py" not in mapped
+    assert "extracted_content_pipeline/autonomous/tasks/campaign_suppression.py" not in mapped
+    assert "extracted_content_pipeline/templates/email/vendor_briefing.py" not in mapped

--- a/tests/test_extracted_vendor_briefing_seams.py
+++ b/tests/test_extracted_vendor_briefing_seams.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib
+from uuid import UUID, uuid4
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
+from extracted_content_pipeline.autonomous.tasks.campaign_suppression import (
+    assign_recipient_to_sequence,
+    is_suppressed,
+)
+from extracted_content_pipeline.services.campaign_sender import CampaignSenderAdapter
+from extracted_content_pipeline.services.vendor_registry import resolve_vendor_name
+from extracted_content_pipeline.services.vendor_target_selection import (
+    dedupe_vendor_target_rows,
+)
+from extracted_content_pipeline.templates.email.vendor_briefing import (
+    render_vendor_briefing_html,
+)
+
+
+class FakeSender:
+    def __init__(self) -> None:
+        self.request: SendRequest | None = None
+
+    async def send(self, request: SendRequest) -> SendResult:
+        self.request = request
+        return SendResult(provider="fake", message_id="msg-123", raw={"ok": True})
+
+
+class FakeSuppressionPool:
+    def __init__(self, *rows: dict[str, object] | None) -> None:
+        self._rows = list(rows)
+        self.fetchrow_args: list[tuple[object, ...]] = []
+        self.fetchrow_queries: list[str] = []
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
+        self.fetchrow_queries.append(query)
+        self.fetchrow_args.append(args)
+        return self._rows.pop(0)
+
+
+class FakeAssignmentPool:
+    def __init__(self, *, conflict_id: UUID | None = None, result: str = "UPDATE 1") -> None:
+        self.conflict_id = conflict_id
+        self.result = result
+        self.executed: tuple[object, ...] | None = None
+
+    async def fetchval(self, query: str, *args: object) -> UUID | None:
+        return self.conflict_id
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.executed = args
+        return self.result
+
+
+def test_vendor_briefing_module_imports_in_standalone_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXTRACTED_PIPELINE_STANDALONE", "1")
+
+    module = importlib.import_module(
+        "extracted_content_pipeline.autonomous.tasks.b2b_vendor_briefing"
+    )
+
+    assert hasattr(module, "send_vendor_briefing")
+
+
+def test_dedupe_vendor_target_rows_keeps_best_row_per_company_and_mode() -> None:
+    rows = [
+        {
+            "company_name": "Acme",
+            "target_mode": "vendor_retention",
+            "contact_email": "",
+            "created_at": "2026-01-01",
+        },
+        {
+            "company_name": " acme ",
+            "target_mode": "vendor_retention",
+            "contact_email": "ops@example.com",
+            "created_at": "2026-01-02",
+        },
+        {
+            "company_name": "Beta",
+            "target_mode": "challenger_intel",
+            "account_id": "acct-1",
+            "created_at": "2026-01-01",
+        },
+    ]
+
+    deduped = dedupe_vendor_target_rows(rows)
+
+    assert [row["company_name"].strip() for row in deduped] == ["acme", "Beta"]
+    assert deduped[0]["contact_email"] == "ops@example.com"
+    assert deduped[1]["account_id"] == "acct-1"
+
+
+@pytest.mark.asyncio
+async def test_campaign_sender_adapter_converts_legacy_kwargs_to_send_request() -> None:
+    inner = FakeSender()
+    adapter = CampaignSenderAdapter(inner)
+
+    result = await adapter.send(
+        to="buyer@example.com",
+        from_email="Atlas <audit@example.com>",
+        subject="Briefing",
+        body="<p>Body</p>",
+        tags=[{"name": "type", "value": "vendor_briefing"}],
+        metadata={"campaign_id": "cmp-1"},
+    )
+
+    assert result == {"id": "msg-123", "provider": "fake", "raw": {"ok": True}}
+    assert inner.request == SendRequest(
+        campaign_id="cmp-1",
+        to_email="buyer@example.com",
+        from_email="Atlas <audit@example.com>",
+        subject="Briefing",
+        html_body="<p>Body</p>",
+        tags=({"name": "type", "value": "vendor_briefing"},),
+        metadata={"campaign_id": "cmp-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_suppressed_checks_email_before_domain() -> None:
+    pool = FakeSuppressionPool(None, {"domain": "example.com", "reason": "manual"})
+
+    row = await is_suppressed(pool, email=" Person@Example.com ")
+
+    assert row == {"domain": "example.com", "reason": "manual"}
+    assert pool.fetchrow_args == [("person@example.com",), ("example.com",)]
+    assert all("active" not in query.lower() for query in pool.fetchrow_queries)
+
+
+@pytest.mark.asyncio
+async def test_assign_recipient_to_sequence_reports_conflicts() -> None:
+    sequence_id = uuid4()
+    conflict_id = uuid4()
+    pool = FakeAssignmentPool(conflict_id=conflict_id)
+
+    result = await assign_recipient_to_sequence(pool, sequence_id, "buyer@example.com")
+
+    assert result.assigned is False
+    assert result.sequence_id == sequence_id
+    assert result.conflict_with_sequence_id == conflict_id
+    assert result.reason == "recipient_already_assigned"
+    assert pool.executed is None
+
+
+@pytest.mark.asyncio
+async def test_assign_recipient_to_sequence_updates_active_sequence() -> None:
+    sequence_id = UUID("11111111-1111-1111-1111-111111111111")
+    pool = FakeAssignmentPool()
+
+    result = await assign_recipient_to_sequence(pool, sequence_id, " Buyer@Example.com ")
+
+    assert result.assigned is True
+    assert result.reason is None
+    assert pool.executed == (sequence_id, "buyer@example.com")
+
+
+@pytest.mark.asyncio
+async def test_resolve_vendor_name_async_alias_uses_local_normalizer() -> None:
+    assert await resolve_vendor_name("  Acme  ") == "Acme"
+
+
+def test_render_vendor_briefing_html_escapes_and_gates_quotes() -> None:
+    html = render_vendor_briefing_html(
+        {
+            "vendor_name": "Acme <script>",
+            "analyst_summary": "Renewal risk is rising.",
+            "evidence": [
+                {"quote": "Costs jumped", "phrase_verbatim": True},
+                {"quote": "Unmarked legacy quote"},
+            ],
+        }
+    )
+
+    assert "Churn Intelligence Briefing: Acme &lt;script&gt;" in html
+    assert "Renewal risk is rising." in html
+    assert "&ldquo;Costs jumped&rdquo;" in html
+    assert "Unmarked legacy quote" not in html
+    assert "<script>" not in html


### PR DESCRIPTION
## Summary
- Add product-owned compatibility seams for vendor briefing imports: campaign sender adapter, vendor target dedupe, suppression helpers, and minimal email renderer.
- Extend extracted settings/vendor registry shims for copied vendor briefing runtime expectations.
- Add b2b_vendor_briefing to the extracted import smoke script and document PR 1 status in the productization audit.
- Update extracted CI dependencies/path filters so the new smoke target and tests run on GitHub.

## Verification
- `EXTRACTED_PIPELINE_STANDALONE=1 python -c "import extracted_content_pipeline.autonomous.tasks.b2b_vendor_briefing; print('import ok')"`
- `python -m py_compile extracted_content_pipeline/services/vendor_target_selection.py extracted_content_pipeline/services/campaign_sender.py extracted_content_pipeline/autonomous/tasks/campaign_suppression.py extracted_content_pipeline/templates/email/vendor_briefing.py extracted_content_pipeline/settings.py tests/test_extracted_vendor_briefing_seams.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_vendor_briefing_seams.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh`