### PR TITLE
Add campaign reasoning context provider boundary

### DIFF
--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -6,6 +6,8 @@
 - Primary task modules are copied and import-smokeable:
   - `blog_post_generation.py`
   - `b2b_blog_post_generation.py`
+  - `b2b_campaign_generation.py`
+  - `b2b_vendor_briefing.py`
   - `complaint_content_generation.py`
   - `complaint_enrichment.py`
   - `article_enrichment.py`
@@ -54,6 +56,15 @@
   implementation for Atlas-compatible task imports.
 - `campaign_audit` is product-owned and writes campaign state-change audit
   rows without importing Atlas logging or task helpers.
+- Vendor briefing and campaign generation import seams are product-owned:
+  `services.campaign_sender`, `services.vendor_target_selection`,
+  `autonomous.tasks.campaign_suppression`, `templates.email.vendor_briefing`,
+  `services.b2b.account_opportunity_claims`, `services.campaign_quality`,
+  `services.campaign_reasoning_context`, and `autonomous.visibility`.
+- `CampaignReasoningContextProvider` is the campaign-core boundary for
+  upstream reasoning. Hosts pass already-compressed witness/anchor/account
+  context into the generator; `_b2b_pool_compression.py` stays outside the
+  standalone campaign product.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -13,8 +13,14 @@ from .campaign_ports import (
     IntelligenceRepository,
     LLMClient,
     LLMMessage,
+    CampaignReasoningContextProvider,
     SkillStore,
     TenantScope,
+)
+from .services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
+    campaign_reasoning_context_payload,
+    normalize_campaign_reasoning_context,
 )
 
 
@@ -115,12 +121,14 @@ class CampaignGenerationService:
         campaigns: CampaignRepository,
         llm: LLMClient,
         skills: SkillStore,
+        reasoning_context: CampaignReasoningContextProvider | None = None,
         config: CampaignGenerationConfig | None = None,
     ):
         self._intelligence = intelligence
         self._campaigns = campaigns
         self._llm = llm
         self._skills = skills
+        self._reasoning_context = reasoning_context
         self._config = config or CampaignGenerationConfig()
 
     async def generate(
@@ -155,6 +163,12 @@ class CampaignGenerationService:
                 skipped += 1
                 errors.append({"reason": "missing_target_id", "opportunity": opportunity})
                 continue
+            opportunity = await self._opportunity_with_reasoning_context(
+                scope=scope,
+                target_mode=target_mode,
+                target_id=target_id,
+                opportunity=opportunity,
+            )
             try:
                 parsed = await self._generate_one(
                     prompt_template,
@@ -193,6 +207,33 @@ class CampaignGenerationService:
             saved_ids=saved_ids,
             errors=tuple(errors),
         )
+
+    async def _opportunity_with_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        target_id: str,
+        opportunity: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        base_context = normalize_campaign_reasoning_context(opportunity)
+        context = base_context
+        if self._reasoning_context is not None:
+            provided = await self._reasoning_context.read_campaign_reasoning_context(
+                scope=scope,
+                target_id=target_id,
+                target_mode=target_mode,
+                opportunity=opportunity,
+            )
+            provided_context = normalize_campaign_reasoning_context(provided)
+            if provided_context.has_content():
+                context = provided_context
+        if not context.has_content():
+            return dict(opportunity)
+        enriched = dict(opportunity)
+        enriched["reasoning_context"] = campaign_reasoning_context_payload(context)
+        enriched.update(campaign_reasoning_context_metadata(context))
+        return enriched
 
     async def _generate_one(
         self,
@@ -241,6 +282,8 @@ class CampaignGenerationService:
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},
         }
+        context = normalize_campaign_reasoning_context(opportunity)
+        metadata.update(campaign_reasoning_context_metadata(context))
         if self._config.include_source_opportunity:
             metadata["source_opportunity"] = dict(opportunity)
         return {key: value for key, value in metadata.items() if value not in (None, "", {})}

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 import json
 import re
-from typing import Any, Mapping
+from typing import Any
 
 from .campaign_ports import (
     CampaignDraft,
@@ -163,13 +164,13 @@ class CampaignGenerationService:
                 skipped += 1
                 errors.append({"reason": "missing_target_id", "opportunity": opportunity})
                 continue
-            opportunity = await self._opportunity_with_reasoning_context(
-                scope=scope,
-                target_mode=target_mode,
-                target_id=target_id,
-                opportunity=opportunity,
-            )
             try:
+                opportunity = await self._opportunity_with_reasoning_context(
+                    scope=scope,
+                    target_mode=target_mode,
+                    target_id=target_id,
+                    opportunity=opportunity,
+                )
                 parsed = await self._generate_one(
                     prompt_template,
                     opportunity=opportunity,
@@ -231,8 +232,17 @@ class CampaignGenerationService:
         if not context.has_content():
             return dict(opportunity)
         enriched = dict(opportunity)
-        enriched["reasoning_context"] = campaign_reasoning_context_payload(context)
+        payload = campaign_reasoning_context_payload(context)
         enriched.update(campaign_reasoning_context_metadata(context))
+        existing_reasoning_context = opportunity.get("reasoning_context")
+        if isinstance(existing_reasoning_context, Mapping):
+            enriched["reasoning_context"] = {
+                **dict(existing_reasoning_context),
+                "campaign_reasoning_context": payload,
+            }
+        else:
+            enriched["reasoning_context"] = payload
+        enriched["campaign_reasoning_context"] = payload
         return enriched
 
     async def _generate_one(

--- a/extracted_content_pipeline/campaign_ports.py
+++ b/extracted_content_pipeline/campaign_ports.py
@@ -50,6 +50,47 @@ class CampaignDraft:
 
 
 @dataclass(frozen=True)
+class CampaignReasoningContext:
+    """Normalized host-provided reasoning context for campaign generation."""
+
+    anchor_examples: Mapping[str, Sequence[Mapping[str, Any]]] = field(default_factory=dict)
+    witness_highlights: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    reference_ids: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    account_signals: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    timing_windows: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    proof_points: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    coverage_limits: Sequence[str] = field(default_factory=tuple)
+    scope_summary: Mapping[str, Any] = field(default_factory=dict)
+    delta_summary: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            key: value
+            for key, value in {
+                "anchor_examples": {
+                    str(label): [dict(row) for row in rows]
+                    for label, rows in self.anchor_examples.items()
+                },
+                "witness_highlights": [dict(row) for row in self.witness_highlights],
+                "reference_ids": {
+                    str(key): [str(item) for item in values]
+                    for key, values in self.reference_ids.items()
+                },
+                "account_signals": [dict(row) for row in self.account_signals],
+                "timing_windows": [dict(row) for row in self.timing_windows],
+                "proof_points": [dict(row) for row in self.proof_points],
+                "coverage_limits": [str(item) for item in self.coverage_limits],
+                "scope_summary": dict(self.scope_summary),
+                "delta_summary": dict(self.delta_summary),
+            }.items()
+            if value not in ({}, [], (), None)
+        }
+
+    def has_content(self) -> bool:
+        return bool(self.as_dict())
+
+
+@dataclass(frozen=True)
 class SendRequest:
     campaign_id: str
     to_email: str
@@ -116,6 +157,18 @@ class IntelligenceRepository(Protocol):
         vendor_name: str | None = None,
     ) -> Sequence[JsonDict]:
         """Return configured vendor/account targets."""
+
+
+class CampaignReasoningContextProvider(Protocol):
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> CampaignReasoningContext | Mapping[str, Any] | None:
+        """Return pre-compressed reasoning/witness context for one opportunity."""
 
 
 class CampaignRepository(Protocol):

--- a/extracted_content_pipeline/campaign_ports.py
+++ b/extracted_content_pipeline/campaign_ports.py
@@ -56,33 +56,42 @@ class CampaignReasoningContext:
     anchor_examples: Mapping[str, Sequence[Mapping[str, Any]]] = field(default_factory=dict)
     witness_highlights: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     reference_ids: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    top_theses: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     account_signals: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     timing_windows: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     proof_points: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     coverage_limits: Sequence[str] = field(default_factory=tuple)
+    canonical_reasoning: Mapping[str, Any] = field(default_factory=dict)
     scope_summary: Mapping[str, Any] = field(default_factory=dict)
     delta_summary: Mapping[str, Any] = field(default_factory=dict)
 
     def as_dict(self) -> JsonDict:
+        data = {
+            str(key): value
+            for key, value in self.canonical_reasoning.items()
+            if value not in (None, "", [], {})
+        }
+        data.update({
+            "anchor_examples": {
+                str(label): [dict(row) for row in rows]
+                for label, rows in self.anchor_examples.items()
+            },
+            "witness_highlights": [dict(row) for row in self.witness_highlights],
+            "reference_ids": {
+                str(key): [str(item) for item in values]
+                for key, values in self.reference_ids.items()
+            },
+            "top_theses": [dict(row) for row in self.top_theses],
+            "account_signals": [dict(row) for row in self.account_signals],
+            "timing_windows": [dict(row) for row in self.timing_windows],
+            "proof_points": [dict(row) for row in self.proof_points],
+            "coverage_limits": [str(item) for item in self.coverage_limits],
+            "scope_summary": dict(self.scope_summary),
+            "delta_summary": dict(self.delta_summary),
+        })
         return {
             key: value
-            for key, value in {
-                "anchor_examples": {
-                    str(label): [dict(row) for row in rows]
-                    for label, rows in self.anchor_examples.items()
-                },
-                "witness_highlights": [dict(row) for row in self.witness_highlights],
-                "reference_ids": {
-                    str(key): [str(item) for item in values]
-                    for key, values in self.reference_ids.items()
-                },
-                "account_signals": [dict(row) for row in self.account_signals],
-                "timing_windows": [dict(row) for row in self.timing_windows],
-                "proof_points": [dict(row) for row in self.proof_points],
-                "coverage_limits": [str(item) for item in self.coverage_limits],
-                "scope_summary": dict(self.scope_summary),
-                "delta_summary": dict(self.delta_summary),
-            }.items()
+            for key, value in data.items()
             if value not in ({}, [], (), None)
         }
 

--- a/extracted_content_pipeline/docs/remaining_productization_audit.md
+++ b/extracted_content_pipeline/docs/remaining_productization_audit.md
@@ -42,9 +42,9 @@ files remain Atlas-shaped and should not be product-owned as-is.
 | --- | ---: | --- |
 | `_b2b_shared.py` | 19,875 | Monolith; split by required product seams |
 | `b2b_blog_post_generation.py` | 9,613 | Blog product surface, not campaign-core |
-| `b2b_campaign_generation.py` | 6,043 | Campaign-core copied task; currently not importable |
-| `b2b_vendor_briefing.py` | 3,222 | Campaign/email adjacent; currently not importable |
-| `_b2b_pool_compression.py` | 2,319 | Reasoning pool; blocked on witness extraction |
+| `b2b_campaign_generation.py` | 6,043 | Campaign-core copied task; importable through product seams |
+| `b2b_vendor_briefing.py` | 3,222 | Campaign/email adjacent; importable through product seams |
+| `_b2b_pool_compression.py` | 2,319 | Upstream reasoning pool; deliberately outside campaign-core |
 | `_b2b_reasoning_contracts.py` | 1,773 | Reasoning policy; importable but large |
 | `_b2b_synthesis_reader.py` | 1,767 | Reasoning read model; importable but large |
 | `blog_post_generation.py` | 1,758 | Consumer/blog sidecar |
@@ -177,14 +177,21 @@ Acceptance criteria:
 
 ### PR 3: Pool Compression Decision
 
+Status: implemented. `_b2b_pool_compression.py` remains outside the campaign
+product boundary. The product-owned generator now accepts normalized
+host-provided reasoning context through `CampaignReasoningContextProvider`
+instead.
+
 Goal: decide whether `_b2b_pool_compression.py` is part of the sellable campaign
 product or a reasoning-product dependency.
 
-The smoke script can add campaign-core modules after PR 2, but should not add
-`_b2b_pool_compression.py` until this decision is made:
+The smoke script includes campaign-core modules after PR 2, but intentionally
+does not add `_b2b_pool_compression.py`:
 
-- `_b2b_pool_compression` only after witness extraction, or explicitly leave it
-  out with a TODO in the smoke script.
+- `_b2b_pool_compression` is upstream/host-owned reasoning infrastructure.
+- Campaign-core accepts already-compressed `anchor_examples`,
+  `witness_highlights`, `reference_ids`, `account_signals`, `timing_windows`,
+  and `proof_points` instead of importing Atlas compression internals.
 
 Options:
 
@@ -196,6 +203,19 @@ Options:
 Recommendation: option 2 unless a campaign-core test requires pool compression
 directly. It keeps the campaign product from owning the whole B2B reasoning
 stack.
+
+Implemented contract:
+
+- `campaign_ports.CampaignReasoningContext`
+- `campaign_ports.CampaignReasoningContextProvider`
+- `services.campaign_reasoning_context.normalize_campaign_reasoning_context(...)`
+- `services.campaign_reasoning_context.campaign_reasoning_context_metadata(...)`
+
+`CampaignGenerationService` can now accept an optional
+`reasoning_context=CampaignReasoningContextProvider` dependency. The provider
+receives `(scope, target_id, target_mode, opportunity)` and returns compressed
+context for the prompt and draft metadata. With no provider configured, embedded
+context already present on the opportunity row is normalized defensively.
 
 ## Explicit Deferrals
 
@@ -213,13 +233,18 @@ These remain outside the immediate campaign-core import path:
 
 ## Next Concrete Slice
 
-Start with PR 1: vendor briefing import seams. It is smaller than
-`b2b_campaign_generation.py`, exercises the same delivery-side compatibility
-surface (`campaign_sender`, suppression, template rendering), and avoids the
-campaign reasoning/claim seams until the next PR.
+With the campaign-core import path and reasoning-context boundary settled, the
+next slice should move behavior from copied Atlas task files into the
+product-owned spine instead of expanding import coverage sideways.
+
+Recommended next slice: migrate one concrete producer flow from the copied
+`b2b_campaign_generation.py` reference into `CampaignGenerationService` using
+the normalized ports:
 
 Acceptance criteria:
 
-- `EXTRACTED_PIPELINE_STANDALONE=1 python -c "import extracted_content_pipeline.autonomous.tasks.b2b_vendor_briefing"`
-- New tests for each shim's local behavior.
-- Full extracted pipeline checks still pass.
+- Use `IntelligenceRepository.read_campaign_opportunities(...)` as the source.
+- Optionally enrich with `CampaignReasoningContextProvider`.
+- Generate and persist drafts through `CampaignRepository`.
+- Keep `_b2b_pool_compression.py`, `_b2b_witnesses.py`, and `_b2b_shared.py`
+  out of the product-owned path.

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -166,6 +166,12 @@
       "target": "extracted_content_pipeline/campaign_llm_client.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_ports.py"
+    },
+    {
+      "target": "extracted_content_pipeline/campaign_generation.py"
+    },
+    {
       "target": "extracted_content_pipeline/settings.py"
     },
     {

--- a/extracted_content_pipeline/services/campaign_reasoning_context.py
+++ b/extracted_content_pipeline/services/campaign_reasoning_context.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..campaign_ports import CampaignReasoningContext
+
 
 _THESIS_LIMIT = 2
 _TIMING_WINDOW_LIMIT = 2
@@ -17,8 +19,81 @@ def _copy_list(value: Any) -> list[Any]:
     return list(value) if isinstance(value, list) else []
 
 
+def _copy_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
 def _clean_text(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _clean_mapping_list(value: Any, *, limit: int | None = None) -> tuple[dict[str, Any], ...]:
+    rows: list[dict[str, Any]] = []
+    for item in _copy_list(value):
+        if not isinstance(item, dict):
+            continue
+        row = {
+            str(key): item_value
+            for key, item_value in item.items()
+            if item_value not in (None, "", [], {})
+        }
+        if row:
+            rows.append(row)
+        if limit is not None and len(rows) >= limit:
+            break
+    return tuple(rows)
+
+
+def _clean_reference_ids(value: Any) -> dict[str, tuple[str, ...]]:
+    refs: dict[str, tuple[str, ...]] = {}
+    if not isinstance(value, dict):
+        return refs
+    for key, raw_values in value.items():
+        if isinstance(raw_values, list):
+            values = tuple(
+                _clean_text(item)
+                for item in raw_values
+                if _clean_text(item)
+            )
+        else:
+            text = _clean_text(raw_values)
+            values = (text,) if text else ()
+        if values:
+            refs[str(key)] = values
+    return refs
+
+
+def _clean_anchor_examples(value: Any) -> dict[str, tuple[dict[str, Any], ...]]:
+    anchors: dict[str, tuple[dict[str, Any], ...]] = {}
+    if not isinstance(value, dict):
+        return anchors
+    for label, rows in value.items():
+        cleaned = _clean_mapping_list(rows)
+        if cleaned:
+            anchors[_clean_text(label) or "default"] = cleaned
+    return anchors
+
+
+def _first_dict(*values: Any) -> dict[str, Any]:
+    for value in values:
+        if isinstance(value, dict) and value:
+            return value
+    return {}
+
+
+def _first_list(*values: Any) -> list[Any]:
+    for value in values:
+        if isinstance(value, list) and value:
+            return value
+    return []
+
+
+def _clean_scalar_list(value: Any) -> tuple[str, ...]:
+    return tuple(
+        _clean_text(item)
+        for item in _copy_list(value)
+        if _clean_text(item)
+    )
 
 
 def campaign_reasoning_scope_summary(
@@ -38,6 +113,102 @@ def campaign_reasoning_scope_summary(
         if value not in (None, "", [], {}):
             summary[key] = value
     return summary
+
+
+def normalize_campaign_reasoning_context(value: Any) -> CampaignReasoningContext:
+    """Normalize host-provided compressed context into the campaign contract.
+
+    Accepts already-normalized context, Atlas-style ``reasoning_*`` keys, or a
+    nested ``reasoning_context`` blob. It intentionally does not import
+    ``_b2b_pool_compression``; the host owns compression and passes the
+    resulting evidence here.
+    """
+    if isinstance(value, CampaignReasoningContext):
+        return value
+    payload = _copy_dict(value)
+    nested = _copy_dict(payload.get("reasoning_context"))
+    atom_context = _first_dict(
+        payload.get("reasoning_atom_context"),
+        nested.get("reasoning_atom_context"),
+        nested.get("atom_context"),
+        nested,
+    )
+    scope_summary = _first_dict(
+        payload.get("reasoning_scope_summary"),
+        nested.get("reasoning_scope_summary"),
+        nested.get("scope_summary"),
+    )
+    delta_summary = _first_dict(
+        payload.get("reasoning_delta_summary"),
+        nested.get("reasoning_delta_summary"),
+        nested.get("delta_summary"),
+    )
+    normalized_delta = (
+        campaign_reasoning_delta_summary(delta_summary) if delta_summary else {}
+    )
+    return CampaignReasoningContext(
+        anchor_examples=_clean_anchor_examples(
+            _first_dict(
+                payload.get("reasoning_anchor_examples"),
+                payload.get("anchor_examples"),
+                nested.get("reasoning_anchor_examples"),
+                nested.get("anchor_examples"),
+            )
+        ),
+        witness_highlights=_clean_mapping_list(
+            _first_list(
+                payload.get("reasoning_witness_highlights"),
+                payload.get("witness_highlights"),
+                nested.get("reasoning_witness_highlights"),
+                nested.get("witness_highlights"),
+            )
+        ),
+        reference_ids=_clean_reference_ids(
+            _first_dict(
+                payload.get("reasoning_reference_ids"),
+                payload.get("reference_ids"),
+                nested.get("reasoning_reference_ids"),
+                nested.get("reference_ids"),
+            )
+        ),
+        account_signals=_clean_mapping_list(atom_context.get("account_signals")),
+        timing_windows=_clean_mapping_list(atom_context.get("timing_windows")),
+        proof_points=_clean_mapping_list(atom_context.get("proof_points")),
+        coverage_limits=_clean_scalar_list(atom_context.get("coverage_limits")),
+        scope_summary=campaign_reasoning_scope_summary(scope_summary),
+        delta_summary=normalized_delta,
+    )
+
+
+def campaign_reasoning_context_payload(
+    context: CampaignReasoningContext,
+) -> dict[str, Any]:
+    """Return prompt-visible normalized context."""
+    return context.as_dict()
+
+
+def campaign_reasoning_context_metadata(
+    context: CampaignReasoningContext,
+) -> dict[str, Any]:
+    """Return storage metadata fields expected by campaign consumers."""
+    if not context.has_content():
+        return {}
+    metadata: dict[str, Any] = {"reasoning_context": context.as_dict()}
+    if context.anchor_examples:
+        metadata["reasoning_anchor_examples"] = {
+            str(label): [dict(row) for row in rows]
+            for label, rows in context.anchor_examples.items()
+        }
+    if context.witness_highlights:
+        metadata["reasoning_witness_highlights"] = [
+            dict(row) for row in context.witness_highlights
+        ]
+    if context.reference_ids:
+        metadata["reasoning_reference_ids"] = {
+            str(key): [str(item) for item in values]
+            for key, values in context.reference_ids.items()
+        }
+    return metadata
 
 
 def campaign_reasoning_atom_context(
@@ -144,7 +315,10 @@ def campaign_reasoning_delta_summary(
 
 
 __all__ = [
+    "campaign_reasoning_context_metadata",
+    "campaign_reasoning_context_payload",
     "campaign_reasoning_atom_context",
     "campaign_reasoning_delta_summary",
     "campaign_reasoning_scope_summary",
+    "normalize_campaign_reasoning_context",
 ]

--- a/extracted_content_pipeline/services/campaign_reasoning_context.py
+++ b/extracted_content_pipeline/services/campaign_reasoning_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ..campaign_ports import CampaignReasoningContext
@@ -16,11 +17,13 @@ _DELTA_ITEM_LIMIT = 3
 
 
 def _copy_list(value: Any) -> list[Any]:
-    return list(value) if isinstance(value, list) else []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return list(value)
+    return []
 
 
 def _copy_dict(value: Any) -> dict[str, Any]:
-    return dict(value) if isinstance(value, dict) else {}
+    return dict(value) if isinstance(value, Mapping) else {}
 
 
 def _clean_text(value: Any) -> str:
@@ -30,7 +33,7 @@ def _clean_text(value: Any) -> str:
 def _clean_mapping_list(value: Any, *, limit: int | None = None) -> tuple[dict[str, Any], ...]:
     rows: list[dict[str, Any]] = []
     for item in _copy_list(value):
-        if not isinstance(item, dict):
+        if not isinstance(item, Mapping):
             continue
         row = {
             str(key): item_value
@@ -46,10 +49,12 @@ def _clean_mapping_list(value: Any, *, limit: int | None = None) -> tuple[dict[s
 
 def _clean_reference_ids(value: Any) -> dict[str, tuple[str, ...]]:
     refs: dict[str, tuple[str, ...]] = {}
-    if not isinstance(value, dict):
+    if not isinstance(value, Mapping):
         return refs
     for key, raw_values in value.items():
-        if isinstance(raw_values, list):
+        if isinstance(raw_values, Sequence) and not isinstance(
+            raw_values, (str, bytes, bytearray)
+        ):
             values = tuple(
                 _clean_text(item)
                 for item in raw_values
@@ -65,7 +70,7 @@ def _clean_reference_ids(value: Any) -> dict[str, tuple[str, ...]]:
 
 def _clean_anchor_examples(value: Any) -> dict[str, tuple[dict[str, Any], ...]]:
     anchors: dict[str, tuple[dict[str, Any], ...]] = {}
-    if not isinstance(value, dict):
+    if not isinstance(value, Mapping):
         return anchors
     for label, rows in value.items():
         cleaned = _clean_mapping_list(rows)
@@ -76,15 +81,19 @@ def _clean_anchor_examples(value: Any) -> dict[str, tuple[dict[str, Any], ...]]:
 
 def _first_dict(*values: Any) -> dict[str, Any]:
     for value in values:
-        if isinstance(value, dict) and value:
-            return value
+        if isinstance(value, Mapping) and value:
+            return dict(value)
     return {}
 
 
 def _first_list(*values: Any) -> list[Any]:
     for value in values:
-        if isinstance(value, list) and value:
-            return value
+        if (
+            isinstance(value, Sequence)
+            and not isinstance(value, (str, bytes, bytearray))
+            and value
+        ):
+            return list(value)
     return []
 
 
@@ -99,7 +108,7 @@ def _clean_scalar_list(value: Any) -> tuple[str, ...]:
 def campaign_reasoning_scope_summary(
     scope_manifest: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    if not isinstance(scope_manifest, dict):
+    if not isinstance(scope_manifest, Mapping):
         return {}
     summary: dict[str, Any] = {}
     for key in (
@@ -214,7 +223,7 @@ def campaign_reasoning_context_metadata(
 def campaign_reasoning_atom_context(
     consumer_context: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    if not isinstance(consumer_context, dict):
+    if not isinstance(consumer_context, Mapping):
         return {}
     context: dict[str, Any] = {}
     theses = [
@@ -225,7 +234,7 @@ def campaign_reasoning_atom_context(
             "confidence": _clean_text(item.get("confidence")),
         }
         for item in _copy_list(consumer_context.get("theses"))[:_THESIS_LIMIT]
-        if isinstance(item, dict)
+        if isinstance(item, Mapping)
     ]
     theses = [item for item in theses if item["summary"] or item["why_now"]]
     if theses:
@@ -241,7 +250,7 @@ def campaign_reasoning_atom_context(
         for item in _copy_list(consumer_context.get("timing_windows"))[
             :_TIMING_WINDOW_LIMIT
         ]
-        if isinstance(item, dict)
+        if isinstance(item, Mapping)
     ]
     timing_windows = [item for item in timing_windows if item["anchor"]]
     if timing_windows:
@@ -256,7 +265,7 @@ def campaign_reasoning_atom_context(
         for item in _copy_list(consumer_context.get("proof_points"))[
             :_PROOF_POINT_LIMIT
         ]
-        if isinstance(item, dict)
+        if isinstance(item, Mapping)
     ]
     proof_points = [item for item in proof_points if item["label"]]
     if proof_points:
@@ -272,7 +281,7 @@ def campaign_reasoning_atom_context(
         for item in _copy_list(consumer_context.get("account_signals"))[
             :_ACCOUNT_SIGNAL_LIMIT
         ]
-        if isinstance(item, dict)
+        if isinstance(item, Mapping)
     ]
     account_signals = [
         item
@@ -287,7 +296,7 @@ def campaign_reasoning_atom_context(
         for item in _copy_list(consumer_context.get("coverage_limits"))[
             :_COVERAGE_LIMIT_LIMIT
         ]
-        if isinstance(item, dict) and _clean_text(item.get("label"))
+        if isinstance(item, Mapping) and _clean_text(item.get("label"))
     ]
     if coverage_limits:
         context["coverage_limits"] = coverage_limits
@@ -297,7 +306,7 @@ def campaign_reasoning_atom_context(
 def campaign_reasoning_delta_summary(
     reasoning_delta: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    if not isinstance(reasoning_delta, dict):
+    if not isinstance(reasoning_delta, Mapping):
         return {}
     summary: dict[str, Any] = {"changed": bool(reasoning_delta.get("changed"))}
     for key in (

--- a/extracted_content_pipeline/services/campaign_reasoning_context.py
+++ b/extracted_content_pipeline/services/campaign_reasoning_context.py
@@ -14,6 +14,14 @@ _PROOF_POINT_LIMIT = 2
 _ACCOUNT_SIGNAL_LIMIT = 2
 _COVERAGE_LIMIT_LIMIT = 3
 _DELTA_ITEM_LIMIT = 3
+_CANONICAL_REASONING_KEYS = (
+    "wedge",
+    "confidence",
+    "summary",
+    "why_now",
+    "primary_driver",
+    "recommended_action",
+)
 
 
 def _copy_list(value: Any) -> list[Any]:
@@ -105,6 +113,18 @@ def _clean_scalar_list(value: Any) -> tuple[str, ...]:
     )
 
 
+def _clean_canonical_reasoning(*values: Any) -> dict[str, Any]:
+    reasoning: dict[str, Any] = {}
+    for value in values:
+        if not isinstance(value, Mapping):
+            continue
+        for key in _CANONICAL_REASONING_KEYS:
+            item = value.get(key)
+            if item not in (None, "", [], {}):
+                reasoning[key] = item
+    return reasoning
+
+
 def campaign_reasoning_scope_summary(
     scope_manifest: dict[str, Any] | None,
 ) -> dict[str, Any]:
@@ -180,10 +200,22 @@ def normalize_campaign_reasoning_context(value: Any) -> CampaignReasoningContext
                 nested.get("reference_ids"),
             )
         ),
+        top_theses=_clean_mapping_list(
+            _first_list(
+                payload.get("reasoning_top_theses"),
+                payload.get("top_theses"),
+                nested.get("reasoning_top_theses"),
+                nested.get("top_theses"),
+                atom_context.get("top_theses"),
+                atom_context.get("theses"),
+            ),
+            limit=_THESIS_LIMIT,
+        ),
         account_signals=_clean_mapping_list(atom_context.get("account_signals")),
         timing_windows=_clean_mapping_list(atom_context.get("timing_windows")),
         proof_points=_clean_mapping_list(atom_context.get("proof_points")),
         coverage_limits=_clean_scalar_list(atom_context.get("coverage_limits")),
+        canonical_reasoning=_clean_canonical_reasoning(payload, nested, atom_context),
         scope_summary=campaign_reasoning_scope_summary(scope_summary),
         delta_summary=normalized_delta,
     )

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -10,7 +10,11 @@ from extracted_content_pipeline.campaign_generation import (
     opportunity_target_id,
     parse_campaign_draft_response,
 )
-from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
 
 
 class _Intelligence:
@@ -90,7 +94,29 @@ class _Skills:
         return self.prompts.get(name)
 
 
-def _service(opportunities, responses, *, config=None, prompts=None):
+class _ReasoningProvider:
+    def __init__(self, context):
+        self.context = context
+        self.calls = []
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        self.calls.append({
+            "scope": scope,
+            "target_id": target_id,
+            "target_mode": target_mode,
+            "opportunity": dict(opportunity),
+        })
+        return self.context
+
+
+def _service(opportunities, responses, *, config=None, prompts=None, reasoning_context=None):
     intelligence = _Intelligence(opportunities)
     campaigns = _Campaigns()
     llm = _LLM(responses)
@@ -105,6 +131,7 @@ def _service(opportunities, responses, *, config=None, prompts=None):
         campaigns=campaigns,
         llm=llm,
         skills=skills,
+        reasoning_context=reasoning_context,
         config=config,
     )
     return service, intelligence, campaigns, llm, skills
@@ -203,6 +230,50 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
     assert draft.metadata["cta"] == "Book time"
     assert draft.metadata["generation_model"] == "test-model"
     assert draft.metadata["source_opportunity"] == opportunity
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_host_reasoning_context_without_pool_compression_import():
+    scope = TenantScope(account_id="acct-1")
+    opportunity = {"id": "opp-1", "company_name": "Acme"}
+    provider = _ReasoningProvider(
+        CampaignReasoningContext(
+            anchor_examples={
+                "outlier_or_named_account": (
+                    {"witness_id": "w1", "excerpt_text": "Pricing drove evaluation."},
+                )
+            },
+            witness_highlights=(
+                {"witness_id": "w1", "excerpt_text": "Pricing drove evaluation."},
+            ),
+            reference_ids={"witness_ids": ("w1",)},
+            account_signals=({"company": "Acme", "primary_pain": "pricing"},),
+            timing_windows=({"window_type": "renewal", "anchor": "Q3"},),
+            proof_points=({"label": "pricing_mentions", "value": 12},),
+        )
+    )
+    service, _, campaigns, llm, _ = _service(
+        [opportunity],
+        ['{"subject":"Hi","body":"Body"}'],
+        reasoning_context=provider,
+    )
+
+    result = await service.generate(scope=scope, target_mode="vendor_retention")
+
+    assert result.generated == 1
+    assert provider.calls == [{
+        "scope": scope,
+        "target_id": "opp-1",
+        "target_mode": "vendor_retention",
+        "opportunity": opportunity,
+    }]
+    prompt = llm.calls[0]["messages"][0].content
+    assert "reasoning_context" in prompt
+    assert "Pricing drove evaluation." in prompt
+    draft = campaigns.saved[0]["drafts"][0]
+    assert draft.metadata["reasoning_reference_ids"] == {"witness_ids": ["w1"]}
+    assert draft.metadata["reasoning_context"]["account_signals"][0]["company"] == "Acme"
+    assert draft.metadata["source_opportunity"]["reasoning_context"]["proof_points"][0]["label"] == "pricing_mentions"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -323,6 +323,37 @@ async def test_generate_preserves_existing_canonical_reasoning_context():
 
 
 @pytest.mark.asyncio
+async def test_generate_uses_provider_canonical_reasoning_context_without_other_evidence():
+    provider = _ReasoningProvider(
+        {
+            "reasoning_context": {
+                "wedge": "renewal pressure",
+                "confidence": "high",
+                "summary": "Acme is reviewing vendors before renewal.",
+            }
+        }
+    )
+    service, _, campaigns, llm, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        ['{"subject":"Hi","body":"Body"}'],
+        reasoning_context=provider,
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert "renewal pressure" in prompt
+    assert "Acme is reviewing vendors before renewal." in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert source["reasoning_context"]["wedge"] == "renewal pressure"
+    assert source["campaign_reasoning_context"]["confidence"] == "high"
+
+
+@pytest.mark.asyncio
 async def test_generate_uses_custom_config_and_omits_source_opportunity():
     config = CampaignGenerationConfig(
         skill_name="custom",

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -113,7 +113,12 @@ class _ReasoningProvider:
             "target_mode": target_mode,
             "opportunity": dict(opportunity),
         })
-        return self.context
+        context = self.context
+        if isinstance(context, list):
+            context = context.pop(0)
+        if isinstance(context, Exception):
+            raise context
+        return context
 
 
 def _service(opportunities, responses, *, config=None, prompts=None, reasoning_context=None):
@@ -277,6 +282,47 @@ async def test_generate_uses_host_reasoning_context_without_pool_compression_imp
 
 
 @pytest.mark.asyncio
+async def test_generate_preserves_existing_canonical_reasoning_context():
+    scope = TenantScope(account_id="acct-1")
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "reasoning_context": {
+            "wedge": "renewal pressure",
+            "confidence": "high",
+            "summary": "Acme is reviewing vendors before renewal.",
+        },
+    }
+    provider = _ReasoningProvider(
+        CampaignReasoningContext(
+            witness_highlights=(
+                {"witness_id": "w1", "excerpt_text": "Pricing drove evaluation."},
+            ),
+            proof_points=({"label": "pricing_mentions", "value": 12},),
+        )
+    )
+    service, _, campaigns, llm, _ = _service(
+        [opportunity],
+        ['{"subject":"Hi","body":"Body"}'],
+        reasoning_context=provider,
+    )
+
+    result = await service.generate(scope=scope, target_mode="vendor_retention")
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert "renewal pressure" in prompt
+    assert "campaign_reasoning_context" in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert source["reasoning_context"]["wedge"] == "renewal pressure"
+    assert (
+        source["reasoning_context"]["campaign_reasoning_context"]["proof_points"][0]["label"]
+        == "pricing_mentions"
+    )
+    assert source["campaign_reasoning_context"]["witness_highlights"][0]["witness_id"] == "w1"
+
+
+@pytest.mark.asyncio
 async def test_generate_uses_custom_config_and_omits_source_opportunity():
     config = CampaignGenerationConfig(
         skill_name="custom",
@@ -340,6 +386,29 @@ async def test_generate_continues_after_llm_error():
     assert result.generated == 1
     assert result.skipped == 1
     assert result.errors == ({"target_id": "opp-1", "reason": "provider down"},)
+    assert campaigns.saved[0]["drafts"][0].target_id == "opp-2"
+
+
+@pytest.mark.asyncio
+async def test_generate_continues_after_reasoning_context_provider_error():
+    provider = _ReasoningProvider([RuntimeError("reasoning provider down"), None])
+    service, _, campaigns, llm, _ = _service(
+        [
+            {"id": "opp-1"},
+            {"id": "opp-2"},
+        ],
+        ['{"subject":"Hi","body":"Body"}'],
+        reasoning_context=provider,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="churning_company")
+
+    assert result.generated == 1
+    assert result.skipped == 1
+    assert result.errors == (
+        {"target_id": "opp-1", "reason": "reasoning provider down"},
+    )
+    assert len(llm.calls) == 1
     assert campaigns.saved[0]["drafts"][0].target_id == "opp-2"
 
 

--- a/tests/test_extracted_campaign_generation_seams.py
+++ b/tests/test_extracted_campaign_generation_seams.py
@@ -187,6 +187,53 @@ def test_normalize_campaign_reasoning_context_accepts_mapping_and_sequence_input
     assert context.coverage_limits == ("thin_account_signals",)
 
 
+def test_normalize_campaign_reasoning_context_preserves_canonical_reasoning_fields() -> None:
+    context = normalize_campaign_reasoning_context(
+        {
+            "reasoning_context": {
+                "wedge": "renewal pressure",
+                "confidence": "high",
+                "summary": "Acme is reviewing vendors before renewal.",
+            }
+        }
+    )
+
+    assert context.has_content() is True
+    assert context.as_dict()["wedge"] == "renewal pressure"
+    assert context.as_dict()["confidence"] == "high"
+    assert context.as_dict()["summary"] == "Acme is reviewing vendors before renewal."
+
+
+def test_normalize_campaign_reasoning_context_keeps_atom_top_theses() -> None:
+    context = normalize_campaign_reasoning_context(
+        {
+            "reasoning_atom_context": {
+                "top_theses": [
+                    {
+                        "wedge": "pricing pressure",
+                        "summary": "Pricing objections are rising.",
+                        "confidence": "medium",
+                    },
+                    {
+                        "wedge": "workflow risk",
+                        "summary": "Workflow gaps are visible.",
+                    },
+                    {
+                        "wedge": "third",
+                        "summary": "Should be capped.",
+                    },
+                ]
+            }
+        }
+    )
+
+    assert [item["wedge"] for item in context.top_theses] == [
+        "pricing pressure",
+        "workflow risk",
+    ]
+    assert context.as_dict()["top_theses"][0]["summary"] == "Pricing objections are rising."
+
+
 def test_campaign_reasoning_context_metadata_uses_campaign_storage_keys() -> None:
     context = normalize_campaign_reasoning_context(
         {

--- a/tests/test_extracted_campaign_generation_seams.py
+++ b/tests/test_extracted_campaign_generation_seams.py
@@ -14,9 +14,11 @@ from extracted_content_pipeline.services.b2b.account_opportunity_claims import (
 )
 from extracted_content_pipeline.services.campaign_quality import campaign_quality_revalidation
 from extracted_content_pipeline.services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
     campaign_reasoning_atom_context,
     campaign_reasoning_delta_summary,
     campaign_reasoning_scope_summary,
+    normalize_campaign_reasoning_context,
 )
 
 
@@ -104,6 +106,56 @@ def test_campaign_reasoning_context_extracts_bounded_prompt_material() -> None:
     ]
     assert context["timing_windows"][0]["anchor"] == "Q3"
     assert [item["company"] for item in context["account_signals"]] == ["Acme", "Beta"]
+
+
+def test_normalize_campaign_reasoning_context_accepts_host_compressed_fields() -> None:
+    context = normalize_campaign_reasoning_context(
+        {
+            "reasoning_anchor_examples": {
+                "named_account": [
+                    {"witness_id": "w1", "excerpt_text": "Pricing came up."},
+                    "invalid",
+                ]
+            },
+            "reasoning_witness_highlights": [
+                {"witness_id": "w1", "excerpt_text": "Pricing came up."}
+            ],
+            "reasoning_reference_ids": {"witness_ids": ["w1", ""]},
+            "reasoning_context": {
+                "account_signals": [{"company": "Acme", "primary_pain": "pricing"}],
+                "timing_windows": [{"window_type": "renewal", "anchor": "Q3"}],
+                "proof_points": [{"label": "pricing_mentions", "value": 12}],
+                "coverage_limits": ["thin_account_signals", ""],
+            },
+            "reasoning_scope_summary": {"selection_strategy": "host_compressed"},
+        }
+    )
+
+    assert context.anchor_examples["named_account"][0]["witness_id"] == "w1"
+    assert context.witness_highlights[0]["excerpt_text"] == "Pricing came up."
+    assert context.reference_ids == {"witness_ids": ("w1",)}
+    assert context.account_signals[0]["company"] == "Acme"
+    assert context.timing_windows[0]["anchor"] == "Q3"
+    assert context.proof_points[0]["label"] == "pricing_mentions"
+    assert context.coverage_limits == ("thin_account_signals",)
+    assert context.scope_summary == {"selection_strategy": "host_compressed"}
+
+
+def test_campaign_reasoning_context_metadata_uses_campaign_storage_keys() -> None:
+    context = normalize_campaign_reasoning_context(
+        {
+            "anchor_examples": {"proof": [{"witness_id": "w1"}]},
+            "witness_highlights": [{"witness_id": "w1"}],
+            "reference_ids": {"witness_ids": ["w1"]},
+        }
+    )
+
+    metadata = campaign_reasoning_context_metadata(context)
+
+    assert metadata["reasoning_anchor_examples"]["proof"][0]["witness_id"] == "w1"
+    assert metadata["reasoning_witness_highlights"][0]["witness_id"] == "w1"
+    assert metadata["reasoning_reference_ids"] == {"witness_ids": ["w1"]}
+    assert metadata["reasoning_context"]["anchor_examples"]["proof"][0]["witness_id"] == "w1"
 
 
 def test_campaign_reasoning_scope_and_delta_summaries_are_defensive() -> None:

--- a/tests/test_extracted_campaign_generation_seams.py
+++ b/tests/test_extracted_campaign_generation_seams.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections import UserDict
 from datetime import date
+from types import MappingProxyType
 
 import pytest
 
@@ -139,6 +141,50 @@ def test_normalize_campaign_reasoning_context_accepts_host_compressed_fields() -
     assert context.proof_points[0]["label"] == "pricing_mentions"
     assert context.coverage_limits == ("thin_account_signals",)
     assert context.scope_summary == {"selection_strategy": "host_compressed"}
+
+
+def test_normalize_campaign_reasoning_context_accepts_mapping_and_sequence_inputs() -> None:
+    context = normalize_campaign_reasoning_context(
+        UserDict({
+            "reasoning_anchor_examples": MappingProxyType({
+                "named_account": (
+                    MappingProxyType({
+                        "witness_id": "w1",
+                        "excerpt_text": "Pricing came up.",
+                    }),
+                )
+            }),
+            "reasoning_witness_highlights": (
+                MappingProxyType({
+                    "witness_id": "w1",
+                    "excerpt_text": "Pricing came up.",
+                }),
+            ),
+            "reasoning_reference_ids": MappingProxyType({
+                "witness_ids": ("w1", ""),
+            }),
+            "reasoning_context": MappingProxyType({
+                "account_signals": (
+                    MappingProxyType({"company": "Acme", "primary_pain": "pricing"}),
+                ),
+                "timing_windows": (
+                    MappingProxyType({"window_type": "renewal", "anchor": "Q3"}),
+                ),
+                "proof_points": (
+                    MappingProxyType({"label": "pricing_mentions", "value": 12}),
+                ),
+                "coverage_limits": ("thin_account_signals", ""),
+            }),
+        })
+    )
+
+    assert context.anchor_examples["named_account"][0]["witness_id"] == "w1"
+    assert context.witness_highlights[0]["excerpt_text"] == "Pricing came up."
+    assert context.reference_ids == {"witness_ids": ("w1",)}
+    assert context.account_signals[0]["company"] == "Acme"
+    assert context.timing_windows[0]["anchor"] == "Q3"
+    assert context.proof_points[0]["value"] == 12
+    assert context.coverage_limits == ("thin_account_signals",)
 
 
 def test_campaign_reasoning_context_metadata_uses_campaign_storage_keys() -> None:

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -19,6 +19,8 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/reasoning/evidence_engine.py",
     "extracted_content_pipeline/reasoning/temporal.py",
     "extracted_content_pipeline/reasoning/wedge_registry.py",
+    "extracted_content_pipeline/campaign_generation.py",
+    "extracted_content_pipeline/campaign_ports.py",
     "extracted_content_pipeline/config.py",
     "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",
     "extracted_content_pipeline/autonomous/tasks/_campaign_sequence_context.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -83,6 +83,8 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
 
     assert "extracted_content_pipeline/pipelines/notify.py" in owned
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
+    assert "extracted_content_pipeline/campaign_ports.py" in owned
+    assert "extracted_content_pipeline/campaign_generation.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
@@ -110,6 +112,8 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
 def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     mapped = _mapped_targets()
 
+    assert "extracted_content_pipeline/campaign_ports.py" not in mapped
+    assert "extracted_content_pipeline/campaign_generation.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" not in mapped


### PR DESCRIPTION
## Summary

Replacement for #65 because the reasoning-context work was rebased onto replacement campaign-generation PR #67, and repository rules block force-pushing the original branch.

Adds the standalone campaign-core boundary for host-provided reasoning context without pulling `_b2b_pool_compression.py` into the extracted product.

- Adds `CampaignReasoningContext` and `CampaignReasoningContextProvider` in `campaign_ports.py`.
- Adds normalization/metadata helpers for host-compressed `reasoning_*`, witness, anchor, account, timing, proof, canonical reasoning, and top-thesis context.
- Wires `CampaignGenerationService` to enrich opportunities, prompts, and draft metadata through an optional reasoning context provider.
- Preserves existing canonical `reasoning_context` fields, catches provider failures per opportunity, and accepts Mapping/Sequence provider payloads.
- Updates manifest/status/docs to record that compression remains host-owned and campaign-core consumes the normalized contract.

## Stack
- Stacked on #67 (`content-pipeline-campaign-generation-seams-review-fixes`).

## Verification
- `python -m py_compile extracted_content_pipeline/campaign_ports.py extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/services/campaign_reasoning_context.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_seams.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_seams.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py tests/test_extracted_vendor_briefing_seams.py` (`46 passed`)
- `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` (`205 passed`)