### PR TITLE
Add campaign opportunity input contract

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -97,6 +97,11 @@ shipping in the customer product.
 
 The email/campaign generation slice is mapped in `docs/email_campaign_generation_pipeline.md`, with standalone productization requirements in `docs/standalone_productization.md`.
 
+`campaign_opportunities.py` defines the customer-data contract for campaign
+generation. Hosts can pass loose opportunity rows from a CRM, warehouse, or
+vendor-intelligence feed; the product normalizes them into stable prompt and
+draft metadata fields while preserving custom columns.
+
 ## Import smoke test
 
 ```bash

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -8,6 +8,10 @@ import json
 import re
 from typing import Any
 
+from .campaign_opportunities import (
+    normalize_campaign_opportunity,
+    opportunity_target_id,
+)
 from .campaign_ports import (
     CampaignDraft,
     CampaignRepository,
@@ -100,18 +104,6 @@ def parse_campaign_draft_response(text: str) -> dict[str, Any] | None:
     return None
 
 
-def opportunity_target_id(opportunity: Mapping[str, Any]) -> str:
-    for key in ("target_id", "id", "company_id", "vendor_id", "email"):
-        value = str(opportunity.get(key) or "").strip()
-        if value:
-            return value
-    for key in ("company_name", "vendor_name", "name"):
-        value = str(opportunity.get(key) or "").strip()
-        if value:
-            return value
-    return ""
-
-
 class CampaignGenerationService:
     """Generate campaign drafts through product-owned ports."""
 
@@ -146,7 +138,7 @@ class CampaignGenerationService:
 
         requested = int(limit or self._config.limit)
         opportunities = [
-            dict(row)
+            normalize_campaign_opportunity(row, target_mode=target_mode)
             for row in await self._intelligence.read_campaign_opportunities(
                 scope=scope,
                 target_mode=target_mode,

--- a/extracted_content_pipeline/campaign_opportunities.py
+++ b/extracted_content_pipeline/campaign_opportunities.py
@@ -1,0 +1,205 @@
+"""Product-owned campaign opportunity input normalization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+_EMPTY_VALUES = (None, "", [], {})
+_TARGET_ID_KEYS = ("target_id", "id", "company_id", "vendor_id", "email")
+_TARGET_NAME_KEYS = (
+    "company_name",
+    "company",
+    "account_name",
+    "reviewer_company",
+    "customer_name",
+    "vendor_name",
+    "vendor",
+    "incumbent_vendor",
+    "current_vendor",
+    "product_name",
+    "name",
+)
+_COMPANY_KEYS = (
+    "company_name",
+    "company",
+    "account_name",
+    "reviewer_company",
+    "customer_name",
+    "name",
+)
+_VENDOR_KEYS = (
+    "vendor_name",
+    "vendor",
+    "incumbent_vendor",
+    "current_vendor",
+    "product_name",
+)
+_CONTACT_NAME_KEYS = ("contact_name", "recipient_name", "person_name", "name")
+_CONTACT_EMAIL_KEYS = ("contact_email", "recipient_email", "email")
+_CONTACT_TITLE_KEYS = ("contact_title", "recipient_title", "job_title", "title")
+_PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "primary_pain", "pain")
+_COMPETITOR_KEYS = (
+    "competitors",
+    "alternative_vendors",
+    "competitor",
+    "competing_vendor",
+)
+_EVIDENCE_KEYS = (
+    "evidence",
+    "quote_evidence",
+    "witness_highlights",
+    "reasoning_witness_highlights",
+)
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = _clean_text(row.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _clean_number(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return value
+    text = _clean_text(value)
+    if not text:
+        return None
+    try:
+        parsed = float(text)
+    except ValueError:
+        return None
+    return int(parsed) if parsed.is_integer() else parsed
+
+
+def _text_list(value: Any) -> list[str]:
+    if value in _EMPTY_VALUES:
+        return []
+    if isinstance(value, str):
+        values = value.split(",")
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        values = value
+    else:
+        values = (value,)
+    out: list[str] = []
+    for item in values:
+        text = _clean_text(item)
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _first_text_list(row: Mapping[str, Any], keys: Sequence[str]) -> list[str]:
+    for key in keys:
+        values = _text_list(row.get(key))
+        if values:
+            return values
+    return []
+
+
+def _first_non_empty(row: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = row.get(key)
+        if value not in _EMPTY_VALUES:
+            return value
+    return None
+
+
+def _drop_empty(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): value
+        for key, value in row.items()
+        if value not in _EMPTY_VALUES
+    }
+
+
+def opportunity_target_id(opportunity: Mapping[str, Any]) -> str:
+    """Return the stable target identifier for a host-provided opportunity row."""
+    for key in _TARGET_ID_KEYS:
+        value = _clean_text(opportunity.get(key))
+        if value:
+            return value
+    for key in _TARGET_NAME_KEYS:
+        value = _clean_text(opportunity.get(key))
+        if value:
+            return value
+    return ""
+
+
+def normalize_campaign_opportunity(
+    opportunity: Mapping[str, Any],
+    *,
+    target_mode: str | None = None,
+) -> dict[str, Any]:
+    """Normalize raw customer opportunity data into the campaign prompt contract.
+
+    The product accepts loose host/customer rows, but prompts and saved drafts
+    should see stable field names. Original non-empty fields are preserved so
+    customer-specific columns still reach the prompt; canonical fields are added
+    alongside them.
+    """
+    if not isinstance(opportunity, Mapping):
+        return {}
+
+    normalized = _drop_empty(opportunity)
+    target_id = opportunity_target_id(normalized)
+    if target_id:
+        normalized["target_id"] = target_id
+
+    company_name = _first_text(normalized, _COMPANY_KEYS)
+    if company_name:
+        normalized["company_name"] = company_name
+
+    vendor_name = _first_text(normalized, _VENDOR_KEYS)
+    if vendor_name:
+        normalized["vendor_name"] = vendor_name
+
+    contact_name = _first_text(normalized, _CONTACT_NAME_KEYS)
+    contact_email = _first_text(normalized, _CONTACT_EMAIL_KEYS)
+    contact_title = _first_text(normalized, _CONTACT_TITLE_KEYS)
+    if contact_name:
+        normalized["contact_name"] = contact_name
+    if contact_email:
+        normalized["contact_email"] = contact_email
+    if contact_title:
+        normalized["contact_title"] = contact_title
+
+    if target_mode:
+        normalized["target_mode"] = _clean_text(target_mode)
+
+    opportunity_score = _clean_number(normalized.get("opportunity_score"))
+    if opportunity_score is not None:
+        normalized["opportunity_score"] = opportunity_score
+
+    urgency_score = _clean_number(normalized.get("urgency_score"))
+    if urgency_score is not None:
+        normalized["urgency_score"] = urgency_score
+
+    pain_points = _first_text_list(normalized, _PAIN_KEYS)
+    if pain_points:
+        normalized["pain_points"] = pain_points
+
+    competitors = _first_text_list(normalized, _COMPETITOR_KEYS)
+    if competitors:
+        normalized["competitors"] = competitors
+
+    evidence = _first_non_empty(normalized, _EVIDENCE_KEYS)
+    if evidence not in _EMPTY_VALUES:
+        normalized["evidence"] = evidence
+
+    return normalized
+
+
+__all__ = [
+    "normalize_campaign_opportunity",
+    "opportunity_target_id",
+]

--- a/extracted_content_pipeline/campaign_opportunities.py
+++ b/extracted_content_pipeline/campaign_opportunities.py
@@ -69,7 +69,7 @@ def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
 def _clean_number(value: Any) -> int | float | None:
     if isinstance(value, bool):
         return None
-    if isinstance(value, int | float):
+    if isinstance(value, (int, float)):
         return value
     text = _clean_text(value)
     if not text:

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -112,6 +112,12 @@ slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
 through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
 `CampaignDraft` rows through `CampaignRepository`.
 
+`extracted_content_pipeline/campaign_opportunities.py` owns the host/customer
+opportunity input contract. It accepts loose customer rows, preserves custom
+fields, and adds stable prompt/storage keys (`target_id`, `company_name`,
+`vendor_name`, contact fields, scores, pain points, competitors, and evidence)
+before `CampaignGenerationService` calls reasoning providers or the LLM.
+
 `extracted_content_pipeline/campaign_llm_client.py` is the provider-routing
 slice for LLM access. It adapts extracted LLM infrastructure services to the
 product `LLMClient` port and exposes `PipelineLLMClientConfig` so hosts can

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -172,6 +172,9 @@
       "target": "extracted_content_pipeline/campaign_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_opportunities.py"
+    },
+    {
       "target": "extracted_content_pipeline/settings.py"
     },
     {

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -11,6 +11,9 @@ from extracted_content_pipeline.campaign_generation import (
     opportunity_target_id,
     parse_campaign_draft_response,
 )
+from extracted_content_pipeline.campaign_opportunities import (
+    normalize_campaign_opportunity,
+)
 from extracted_content_pipeline.campaign_ports import (
     CampaignReasoningContext,
     LLMResponse,
@@ -176,7 +179,36 @@ def test_opportunity_target_id_prefers_stable_ids_then_names():
     assert opportunity_target_id({"target_id": "target-1", "company_name": "Acme"}) == "target-1"
     assert opportunity_target_id({"id": "row-1"}) == "row-1"
     assert opportunity_target_id({"company_name": "Acme"}) == "Acme"
+    assert opportunity_target_id({"company": "Acme"}) == "Acme"
     assert opportunity_target_id({}) == ""
+
+
+def test_normalize_campaign_opportunity_adds_customer_data_contract_fields():
+    normalized = normalize_campaign_opportunity(
+        {
+            "id": "opp-1",
+            "company": " Acme ",
+            "vendor": "HubSpot",
+            "email": "buyer@example.com",
+            "title": "VP Revenue",
+            "pain_category": "pricing",
+            "competitor": "Salesforce, Zoho",
+            "opportunity_score": "84.0",
+            "custom_segment": "enterprise",
+        },
+        target_mode="vendor_retention",
+    )
+
+    assert normalized["target_id"] == "opp-1"
+    assert normalized["company_name"] == "Acme"
+    assert normalized["vendor_name"] == "HubSpot"
+    assert normalized["contact_email"] == "buyer@example.com"
+    assert normalized["contact_title"] == "VP Revenue"
+    assert normalized["target_mode"] == "vendor_retention"
+    assert normalized["pain_points"] == ["pricing"]
+    assert normalized["competitors"] == ["Salesforce", "Zoho"]
+    assert normalized["opportunity_score"] == 84
+    assert normalized["custom_segment"] == "enterprise"
 
 
 @pytest.mark.asyncio
@@ -222,6 +254,8 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
     assert llm_call["max_tokens"] == 1200
     assert llm_call["temperature"] == 0.4
     assert '"company_name":"Acme"' in llm_call["messages"][0].content
+    assert '"target_id":"opp-1"' in llm_call["messages"][0].content
+    assert '"target_mode":"churning_company"' in llm_call["messages"][0].content
     assert llm_call["metadata"] == {
         "target_mode": "churning_company",
         "target_id": "opp-1",
@@ -235,7 +269,10 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
     assert draft.body == "<p>Pricing note</p>"
     assert draft.metadata["cta"] == "Book time"
     assert draft.metadata["generation_model"] == "test-model"
-    assert draft.metadata["source_opportunity"] == opportunity
+    assert draft.metadata["source_opportunity"]["target_id"] == "opp-1"
+    assert draft.metadata["source_opportunity"]["target_mode"] == "churning_company"
+    assert draft.metadata["source_opportunity"]["company_name"] == "Acme"
+    assert draft.metadata["source_opportunity"]["pain"] == "pricing pressure"
 
 
 @pytest.mark.asyncio
@@ -267,12 +304,12 @@ async def test_generate_uses_host_reasoning_context_without_pool_compression_imp
     result = await service.generate(scope=scope, target_mode="vendor_retention")
 
     assert result.generated == 1
-    assert provider.calls == [{
-        "scope": scope,
-        "target_id": "opp-1",
-        "target_mode": "vendor_retention",
-        "opportunity": opportunity,
-    }]
+    assert provider.calls[0]["scope"] == scope
+    assert provider.calls[0]["target_id"] == "opp-1"
+    assert provider.calls[0]["target_mode"] == "vendor_retention"
+    assert provider.calls[0]["opportunity"]["target_id"] == "opp-1"
+    assert provider.calls[0]["opportunity"]["target_mode"] == "vendor_retention"
+    assert provider.calls[0]["opportunity"]["company_name"] == "Acme"
     prompt = llm.calls[0]["messages"][0].content
     assert "reasoning_context" in prompt
     assert "Pricing drove evaluation." in prompt

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -85,6 +85,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/campaign_ports.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
+    assert "extracted_content_pipeline/campaign_opportunities.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
@@ -114,6 +115,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
 
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
+    assert "extracted_content_pipeline/campaign_opportunities.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_blog_ts.py" not in mapped


### PR DESCRIPTION
Adds a product-owned campaign opportunity normalization contract for the extracted content pipeline.\n\nWhat changed:\n- New campaign_opportunities.py normalizes loose customer/host rows into stable prompt and draft metadata fields while preserving custom columns.\n- CampaignGenerationService now normalizes repository rows before reasoning-provider and LLM calls.\n- Manifest/docs updated to mark the opportunity contract as product-owned.\n- Tests cover target-id aliases, customer-field normalization, prompt/storage integration, and manifest ownership.\n\nVerification:\n- python -m py_compile extracted_content_pipeline/campaign_opportunities.py extracted_content_pipeline/campaign_generation.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_manifest.py\n- EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_manifest.py\n- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh