### PR TITLE
Add runnable campaign generation example

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -102,6 +102,25 @@ generation. Hosts can pass loose opportunity rows from a CRM, warehouse, or
 vendor-intelligence feed; the product normalizes them into stable prompt and
 draft metadata fields while preserving custom columns.
 
+## Campaign generation example
+
+Run the standalone campaign generator against the included customer-data
+payload:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py
+```
+
+Or run it against a customer JSON file and write drafts to disk:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py customer_payload.json --output campaign_drafts.json
+```
+
+The example uses in-memory product ports and an offline deterministic LLM stand
+in, so it does not need Atlas, a database, or provider credentials. It proves
+the customer-data path: JSON opportunities in, normalized campaign drafts out.
+
 ## Import smoke test
 
 ```bash

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -1,0 +1,264 @@
+"""Runnable offline campaign generation example over product ports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import json
+from typing import Any
+
+from .campaign_generation import CampaignGenerationConfig, CampaignGenerationService
+from .campaign_ports import (
+    CampaignDraft,
+    LLMMessage,
+    LLMResponse,
+    TenantScope,
+)
+
+
+_EXAMPLE_PROMPT = (
+    "You are generating one outbound campaign draft from normalized customer "
+    "opportunity data. Mode={target_mode}; opportunity={opportunity_json}"
+)
+
+
+class InMemoryIntelligenceRepository:
+    """Tiny host repository for examples and customer-data smoke tests."""
+
+    def __init__(self, opportunities: Sequence[Mapping[str, Any]]) -> None:
+        self.opportunities = [dict(row) for row in opportunities]
+        self.calls: list[dict[str, Any]] = []
+
+    async def read_campaign_opportunities(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Sequence[dict[str, Any]]:
+        self.calls.append(
+            {
+                "scope": scope,
+                "target_mode": target_mode,
+                "limit": limit,
+                "filters": dict(filters or {}),
+            }
+        )
+        return self.opportunities[:limit]
+
+    async def read_vendor_targets(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        vendor_name: str | None = None,
+    ) -> Sequence[dict[str, Any]]:  # pragma: no cover - protocol filler
+        del scope
+        del target_mode
+        del vendor_name
+        return []
+
+
+class InMemoryCampaignRepository:
+    """Capture generated drafts without requiring a database."""
+
+    def __init__(self) -> None:
+        self.drafts: list[CampaignDraft] = []
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[CampaignDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        del scope
+        start = len(self.drafts) + 1
+        self.drafts.extend(drafts)
+        return [f"draft-{index}" for index in range(start, start + len(drafts))]
+
+    async def list_due_sends(self, *, limit, now):  # pragma: no cover - protocol filler
+        del limit
+        del now
+        return []
+
+    async def mark_sent(self, *, campaign_id, result, sent_at):  # pragma: no cover
+        del campaign_id
+        del result
+        del sent_at
+
+    async def mark_cancelled(self, *, campaign_id, reason, metadata=None):  # pragma: no cover
+        del campaign_id
+        del reason
+        del metadata
+
+    async def mark_send_failed(self, *, campaign_id, error, metadata=None):  # pragma: no cover
+        del campaign_id
+        del error
+        del metadata
+
+    async def record_webhook_event(self, event):  # pragma: no cover
+        del event
+
+    async def refresh_analytics(self):  # pragma: no cover
+        return None
+
+
+class StaticCampaignSkillStore:
+    """Host skill store used by the offline example."""
+
+    def __init__(self, prompt: str = _EXAMPLE_PROMPT) -> None:
+        self.prompt = prompt
+
+    def get_prompt(self, name: str) -> str | None:
+        del name
+        return self.prompt
+
+
+class DeterministicCampaignLLM:
+    """Offline LLM stand-in that proves the product wiring end-to-end."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: Sequence[LLMMessage],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LLMResponse:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "metadata": dict(metadata or {}),
+            }
+        )
+        opportunity = _extract_opportunity_from_prompt(messages)
+        company = str(opportunity.get("company_name") or "your team")
+        vendor = str(opportunity.get("vendor_name") or "your current platform")
+        pains = opportunity.get("pain_points") or []
+        pain = str(pains[0]) if pains else "workflow friction"
+        subject = f"{company}: {pain}"[:80]
+        body = (
+            f"<p>{company} appears to be weighing {vendor} because of {pain}.</p>"
+            "<p>We can turn that signal into a focused account sequence using "
+            "your own data and approval rules.</p>"
+        )
+        return LLMResponse(
+            content=json.dumps(
+                {
+                    "subject": subject,
+                    "body": body,
+                    "cta": "Review the generated sequence",
+                    "angle_reasoning": "Offline deterministic draft from normalized opportunity data.",
+                },
+                separators=(",", ":"),
+            ),
+            model="offline-deterministic",
+            usage={"input_tokens": 0, "output_tokens": 0},
+        )
+
+
+def _extract_opportunity_from_prompt(messages: Sequence[LLMMessage]) -> dict[str, Any]:
+    content = "\n".join(str(message.content or "") for message in messages)
+    marker = "opportunity="
+    start = content.find(marker)
+    if start < 0:
+        return {}
+    payload_start = content.find("{", start + len(marker))
+    if payload_start < 0:
+        return {}
+    depth = 0
+    payload_end = -1
+    for index, char in enumerate(content[payload_start:], start=payload_start):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                payload_end = index + 1
+                break
+    if payload_end < 0:
+        return {}
+    raw = content[payload_start:payload_end]
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _scope_from_payload(payload: Mapping[str, Any]) -> TenantScope:
+    scope = payload.get("scope")
+    if not isinstance(scope, Mapping):
+        return TenantScope()
+    return TenantScope(
+        account_id=str(scope.get("account_id") or "") or None,
+        user_id=str(scope.get("user_id") or "") or None,
+        allowed_vendors=tuple(str(item) for item in scope.get("allowed_vendors") or ()),
+        roles=tuple(str(item) for item in scope.get("roles") or ()),
+    )
+
+
+def _draft_to_dict(draft: CampaignDraft, campaign_id: str) -> dict[str, Any]:
+    return {
+        "id": campaign_id,
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "channel": draft.channel,
+        "subject": draft.subject,
+        "body": draft.body,
+        "metadata": dict(draft.metadata),
+    }
+
+
+async def generate_campaign_drafts_from_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Run campaign generation from a portable JSON-compatible payload."""
+    opportunities = payload.get("opportunities")
+    if not isinstance(opportunities, Sequence) or isinstance(opportunities, (str, bytes, bytearray)):
+        raise ValueError("payload must include an opportunities array")
+    target_mode = str(payload.get("target_mode") or "vendor_retention")
+    channel = str(payload.get("channel") or "email")
+    limit = int(payload.get("limit") or len(opportunities) or 20)
+
+    intelligence = InMemoryIntelligenceRepository(
+        [row for row in opportunities if isinstance(row, Mapping)]
+    )
+    campaigns = InMemoryCampaignRepository()
+    llm = DeterministicCampaignLLM()
+    service = CampaignGenerationService(
+        intelligence=intelligence,
+        campaigns=campaigns,
+        llm=llm,
+        skills=StaticCampaignSkillStore(),
+        config=CampaignGenerationConfig(channel=channel, limit=limit),
+    )
+
+    result = await service.generate(
+        scope=_scope_from_payload(payload),
+        target_mode=target_mode,
+        limit=limit,
+        filters=payload.get("filters") if isinstance(payload.get("filters"), Mapping) else None,
+    )
+    return {
+        "result": result.as_dict(),
+        "drafts": [
+            _draft_to_dict(draft, campaign_id)
+            for draft, campaign_id in zip(campaigns.drafts, result.saved_ids, strict=False)
+        ],
+        "llm_model": "offline-deterministic",
+    }
+
+
+__all__ = [
+    "DeterministicCampaignLLM",
+    "InMemoryCampaignRepository",
+    "InMemoryIntelligenceRepository",
+    "StaticCampaignSkillStore",
+    "generate_campaign_drafts_from_payload",
+]

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -112,6 +112,11 @@ slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
 through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
 `CampaignDraft` rows through `CampaignRepository`.
 
+`extracted_content_pipeline/campaign_example.py` is the runnable product example
+for campaign generation. It wires in-memory ports, a static prompt store, and an
+offline deterministic LLM so customer opportunity JSON can be converted into
+drafts without Atlas, a database, or provider credentials.
+
 `extracted_content_pipeline/campaign_opportunities.py` owns the host/customer
 opportunity input contract. It accepts loose customer rows, preserves custom
 fields, and adds stable prompt/storage keys (`target_id`, `company_name`,

--- a/extracted_content_pipeline/examples/campaign_generation_payload.json
+++ b/extracted_content_pipeline/examples/campaign_generation_payload.json
@@ -1,0 +1,43 @@
+{
+  "scope": {
+    "account_id": "demo-account",
+    "user_id": "demo-user",
+    "allowed_vendors": ["HubSpot"],
+    "roles": ["admin"]
+  },
+  "target_mode": "vendor_retention",
+  "channel": "email",
+  "limit": 2,
+  "opportunities": [
+    {
+      "id": "opp-acme-hubspot",
+      "company": "Acme Logistics",
+      "vendor": "HubSpot",
+      "email": "revenue.ops@example.com",
+      "title": "VP Revenue Operations",
+      "pain_category": "pricing pressure",
+      "competitor": "Salesforce, Zoho",
+      "opportunity_score": 84,
+      "urgency_score": 8,
+      "custom_segment": "enterprise logistics",
+      "evidence": [
+        {
+          "quote": "The CRM cost keeps climbing as our team grows.",
+          "phrase_verbatim": true
+        }
+      ]
+    },
+    {
+      "id": "opp-northstar-crm",
+      "company": "Northstar Health",
+      "vendor": "LegacyCRM",
+      "email": "it.lead@example.com",
+      "title": "Director of IT",
+      "pain_category": "integration gaps",
+      "competitor": "Pipedrive",
+      "opportunity_score": 76,
+      "urgency_score": 7,
+      "custom_segment": "healthcare"
+    }
+  ]
+}

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -172,6 +172,9 @@
       "target": "extracted_content_pipeline/campaign_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_example.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_opportunities.py"
     },
     {

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run the extracted campaign generation product over a JSON payload."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_example import (  # noqa: E402
+    generate_campaign_drafts_from_payload,
+)
+
+
+DEFAULT_PAYLOAD = (
+    ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.json"
+)
+
+
+def _load_payload(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("campaign generation payload must be a JSON object")
+    return data
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate offline campaign drafts from customer opportunity JSON "
+            "using the extracted content pipeline ports."
+        )
+    )
+    parser.add_argument(
+        "payload",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_PAYLOAD,
+        help="Path to a campaign generation payload JSON file.",
+    )
+    parser.add_argument(
+        "--target-mode",
+        help="Override the payload target_mode.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Override the payload limit.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write generated draft JSON to this file instead of stdout.",
+    )
+    return parser.parse_args()
+
+
+async def _main() -> int:
+    args = _parse_args()
+    payload = _load_payload(args.payload)
+    if args.target_mode:
+        payload["target_mode"] = args.target_mode
+    if args.limit is not None:
+        payload["limit"] = args.limit
+
+    result = await generate_campaign_drafts_from_payload(payload)
+    output = json.dumps(result, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(f"{output}\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -14,6 +14,7 @@ pytest \
   tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation_seams.py \
   tests/test_extracted_campaign_generation.py \
+  tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_reasoning_archetypes.py \
   tests/test_extracted_reasoning_temporal.py \

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_example import (
+    generate_campaign_drafts_from_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_PAYLOAD = (
+    ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.json"
+)
+CLI = ROOT / "scripts/run_extracted_campaign_generation_example.py"
+
+
+@pytest.mark.asyncio
+async def test_example_generates_drafts_from_customer_opportunity_payload() -> None:
+    payload = {
+        "scope": {"account_id": "acct-1", "allowed_vendors": ["HubSpot"]},
+        "target_mode": "vendor_retention",
+        "limit": 1,
+        "opportunities": [
+            {
+                "id": "opp-1",
+                "company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "email": "ops@example.com",
+                "title": "VP Revenue Operations",
+                "pain_category": "pricing pressure",
+                "competitor": "Salesforce, Zoho",
+                "custom_segment": "enterprise logistics",
+            }
+        ],
+    }
+
+    result = await generate_campaign_drafts_from_payload(payload)
+
+    assert result["result"] == {
+        "requested": 1,
+        "generated": 1,
+        "skipped": 0,
+        "saved_ids": ["draft-1"],
+        "errors": [],
+    }
+    assert result["llm_model"] == "offline-deterministic"
+    draft = result["drafts"][0]
+    assert draft["id"] == "draft-1"
+    assert draft["target_id"] == "opp-1"
+    assert draft["target_mode"] == "vendor_retention"
+    assert draft["channel"] == "email"
+    assert draft["subject"] == "Acme Logistics: pricing pressure"
+    assert "Acme Logistics appears to be weighing HubSpot" in draft["body"]
+    source = draft["metadata"]["source_opportunity"]
+    assert source["company_name"] == "Acme Logistics"
+    assert source["vendor_name"] == "HubSpot"
+    assert source["contact_email"] == "ops@example.com"
+    assert source["contact_title"] == "VP Revenue Operations"
+    assert source["pain_points"] == ["pricing pressure"]
+    assert source["competitors"] == ["Salesforce", "Zoho"]
+    assert source["custom_segment"] == "enterprise logistics"
+
+
+@pytest.mark.asyncio
+async def test_example_respects_limit_and_normalizes_multiple_rows() -> None:
+    payload = json.loads(EXAMPLE_PAYLOAD.read_text(encoding="utf-8"))
+
+    result = await generate_campaign_drafts_from_payload({**payload, "limit": 1})
+
+    assert result["result"]["requested"] == 1
+    assert result["result"]["generated"] == 1
+    assert len(result["drafts"]) == 1
+    assert result["drafts"][0]["target_id"] == "opp-acme-hubspot"
+
+
+@pytest.mark.asyncio
+async def test_example_rejects_payload_without_opportunities_array() -> None:
+    with pytest.raises(ValueError, match="opportunities array"):
+        await generate_campaign_drafts_from_payload({"opportunities": "not-an-array"})
+
+
+def test_campaign_generation_example_cli_outputs_draft_json() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(CLI), str(EXAMPLE_PAYLOAD), "--limit", "1"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+
+    assert result["result"]["generated"] == 1
+    assert result["result"]["saved_ids"] == ["draft-1"]
+    assert result["drafts"][0]["target_id"] == "opp-acme-hubspot"
+    assert result["drafts"][0]["metadata"]["generation_model"] == "offline-deterministic"

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -85,6 +85,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/campaign_ports.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
+    assert "extracted_content_pipeline/campaign_example.py" in owned
     assert "extracted_content_pipeline/campaign_opportunities.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
@@ -115,6 +116,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
 
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
+    assert "extracted_content_pipeline/campaign_example.py" not in mapped
     assert "extracted_content_pipeline/campaign_opportunities.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped


### PR DESCRIPTION
## Summary
- add an offline campaign generation example over product-owned ports
- include sample customer opportunity payload and CLI runner
- document the runnable path and add it to the extracted pipeline check runner

## Verification
- python -m py_compile extracted_content_pipeline/campaign_example.py scripts/run_extracted_campaign_generation_example.py tests/test_extracted_campaign_generation_example.py
- EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_manifest.py
- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh
- python scripts/run_extracted_campaign_generation_example.py --limit 1