### PR TITLE
Allow campaign example to use pipeline LLM

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -121,6 +121,13 @@ The example uses in-memory product ports and an offline deterministic LLM stand
 in, so it does not need Atlas, a database, or provider credentials. It proves
 the customer-data path: JSON opportunities in, normalized campaign drafts out.
 
+To run the same example through the product LLM adapter, configure the
+`EXTRACTED_CAMPAIGN_LLM_*` environment variables and pass `--llm pipeline`:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py --llm pipeline
+```
+
 ## Import smoke test
 
 ```bash

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -9,8 +9,10 @@ from typing import Any
 from .campaign_generation import CampaignGenerationConfig, CampaignGenerationService
 from .campaign_ports import (
     CampaignDraft,
+    LLMClient,
     LLMMessage,
     LLMResponse,
+    SkillStore,
     TenantScope,
 )
 
@@ -215,8 +217,24 @@ def _draft_to_dict(draft: CampaignDraft, campaign_id: str) -> dict[str, Any]:
     }
 
 
+def _llm_model_label(llm: LLMClient, drafts: Sequence[CampaignDraft]) -> str:
+    for draft in drafts:
+        metadata = draft.metadata
+        model = str(metadata.get("generation_model") or "").strip()
+        if model:
+            return model
+    for attr in ("model", "model_id", "name", "openrouter_model", "workload"):
+        model = str(getattr(llm, attr, "") or "").strip()
+        if model:
+            return model
+    return llm.__class__.__name__
+
+
 async def generate_campaign_drafts_from_payload(
     payload: Mapping[str, Any],
+    *,
+    llm: LLMClient | None = None,
+    skills: SkillStore | None = None,
 ) -> dict[str, Any]:
     """Run campaign generation from a portable JSON-compatible payload."""
     opportunities = payload.get("opportunities")
@@ -230,12 +248,13 @@ async def generate_campaign_drafts_from_payload(
         [row for row in opportunities if isinstance(row, Mapping)]
     )
     campaigns = InMemoryCampaignRepository()
-    llm = DeterministicCampaignLLM()
+    llm_client = llm or DeterministicCampaignLLM()
+    skill_store = skills or StaticCampaignSkillStore()
     service = CampaignGenerationService(
         intelligence=intelligence,
         campaigns=campaigns,
-        llm=llm,
-        skills=StaticCampaignSkillStore(),
+        llm=llm_client,
+        skills=skill_store,
         config=CampaignGenerationConfig(channel=channel, limit=limit),
     )
 
@@ -251,7 +270,7 @@ async def generate_campaign_drafts_from_payload(
             _draft_to_dict(draft, campaign_id)
             for draft, campaign_id in zip(campaigns.drafts, result.saved_ids, strict=False)
         ],
-        "llm_model": "offline-deterministic",
+        "llm_model": _llm_model_label(llm_client, campaigns.drafts),
     }
 
 

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -60,7 +60,31 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         help="Write generated draft JSON to this file instead of stdout.",
     )
+    parser.add_argument(
+        "--llm",
+        choices=("offline", "pipeline"),
+        default="offline",
+        help=(
+            "Use the deterministic offline LLM or the product PipelineLLMClient "
+            "configured through EXTRACTED_CAMPAIGN_LLM_* environment variables."
+        ),
+    )
     return parser.parse_args()
+
+
+def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    if args.llm == "offline":
+        return {}
+
+    from extracted_content_pipeline.campaign_llm_client import (  # noqa: PLC0415
+        create_pipeline_llm_client,
+    )
+    from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: PLC0415
+
+    return {
+        "llm": create_pipeline_llm_client(),
+        "skills": get_skill_registry(),
+    }
 
 
 async def _main() -> int:
@@ -71,7 +95,10 @@ async def _main() -> int:
     if args.limit is not None:
         payload["limit"] = args.limit
 
-    result = await generate_campaign_drafts_from_payload(payload)
+    result = await generate_campaign_drafts_from_payload(
+        payload,
+        **_dependency_overrides(args),
+    )
     output = json.dumps(result, indent=2, sort_keys=True)
     if args.output:
         args.output.write_text(f"{output}\n", encoding="utf-8")

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -10,6 +10,7 @@ import pytest
 from extracted_content_pipeline.campaign_example import (
     generate_campaign_drafts_from_payload,
 )
+from extracted_content_pipeline.campaign_ports import LLMResponse
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -17,6 +18,31 @@ EXAMPLE_PAYLOAD = (
     ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.json"
 )
 CLI = ROOT / "scripts/run_extracted_campaign_generation_example.py"
+
+
+class _InjectedLLM:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        return LLMResponse(
+            content=json.dumps({
+                "subject": "Injected subject",
+                "body": "<p>Injected body</p>",
+            }),
+            model="injected-model",
+        )
+
+
+class _InjectedSkills:
+    def get_prompt(self, name):
+        return f"Injected prompt for {name} without payload placeholders."
 
 
 @pytest.mark.asyncio
@@ -67,6 +93,31 @@ async def test_example_generates_drafts_from_customer_opportunity_payload() -> N
 
 
 @pytest.mark.asyncio
+async def test_example_accepts_host_llm_and_skill_store_overrides() -> None:
+    llm = _InjectedLLM()
+    payload = {
+        "target_mode": "vendor_retention",
+        "limit": 1,
+        "opportunities": [
+            {"id": "opp-1", "company": "Acme Logistics", "vendor": "HubSpot"}
+        ],
+    }
+
+    result = await generate_campaign_drafts_from_payload(
+        payload,
+        llm=llm,
+        skills=_InjectedSkills(),
+    )
+
+    assert result["llm_model"] == "injected-model"
+    assert result["drafts"][0]["subject"] == "Injected subject"
+    assert "without payload placeholders" in llm.calls[0]["messages"][0].content
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "target_mode=vendor_retention" in user_prompt
+    assert '"company_name":"Acme Logistics"' in user_prompt
+
+
+@pytest.mark.asyncio
 async def test_example_respects_limit_and_normalizes_multiple_rows() -> None:
     payload = json.loads(EXAMPLE_PAYLOAD.read_text(encoding="utf-8"))
 
@@ -86,7 +137,7 @@ async def test_example_rejects_payload_without_opportunities_array() -> None:
 
 def test_campaign_generation_example_cli_outputs_draft_json() -> None:
     completed = subprocess.run(
-        [sys.executable, str(CLI), str(EXAMPLE_PAYLOAD), "--limit", "1"],
+        [sys.executable, str(CLI), str(EXAMPLE_PAYLOAD), "--limit", "1", "--llm", "offline"],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- let the campaign generation example accept host-provided LLM and skill-store ports
- add --llm offline|pipeline to the example CLI
- document how to run the example through PipelineLLMClient when EXTRACTED_CAMPAIGN_LLM_* env vars are configured

## Verification
- python -m py_compile extracted_content_pipeline/campaign_example.py scripts/run_extracted_campaign_generation_example.py tests/test_extracted_campaign_generation_example.py
- EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_llm_client.py
- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh
- python scripts/run_extracted_campaign_generation_example.py --limit 1 --llm offline