### PR TITLE
Add campaign customer data file adapter

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -102,6 +102,10 @@ generation. Hosts can pass loose opportunity rows from a CRM, warehouse, or
 vendor-intelligence feed; the product normalizes them into stable prompt and
 draft metadata fields while preserving custom columns.
 
+`campaign_customer_data.py` adds JSON/CSV file adapters and a
+`FileIntelligenceRepository` so hosts can run the generator directly from
+customer exports before wiring a database integration.
+
 ## Campaign generation example
 
 Run the standalone campaign generator against the included customer-data
@@ -115,6 +119,15 @@ Or run it against a customer JSON file and write drafts to disk:
 
 ```bash
 python scripts/run_extracted_campaign_generation_example.py customer_payload.json --output campaign_drafts.json
+```
+
+CSV exports work too. The loader normalizes common CRM/warehouse columns such
+as `company`, `vendor`, `email`, `title`, `pain_category`, `competitor`,
+`opportunity_score`, and `urgency_score`, while preserving custom columns in
+draft metadata:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py customer_opportunities.csv --format csv
 ```
 
 The example uses in-memory product ports and an offline deterministic LLM stand

--- a/extracted_content_pipeline/campaign_customer_data.py
+++ b/extracted_content_pipeline/campaign_customer_data.py
@@ -1,0 +1,316 @@
+"""Customer data adapters for standalone campaign generation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import csv
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from .campaign_opportunities import (
+    normalize_campaign_opportunity,
+    opportunity_target_id,
+)
+from .campaign_ports import TenantScope
+
+
+CustomerDataFormat = Literal["auto", "json", "csv"]
+
+
+@dataclass(frozen=True)
+class CampaignOpportunityWarning:
+    """Non-fatal customer-data warning for one loaded opportunity row."""
+
+    code: str
+    message: str
+    row_index: int | None = None
+    field: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.row_index is not None:
+            data["row_index"] = self.row_index
+        if self.field:
+            data["field"] = self.field
+        return data
+
+
+@dataclass(frozen=True)
+class CampaignOpportunityLoadResult:
+    """Normalized opportunities plus validation warnings from a customer file."""
+
+    opportunities: tuple[dict[str, Any], ...]
+    warnings: tuple[CampaignOpportunityWarning, ...] = ()
+    source: str | None = None
+
+    def warning_dicts(self) -> list[dict[str, Any]]:
+        return [warning.as_dict() for warning in self.warnings]
+
+    def as_payload(
+        self,
+        *,
+        target_mode: str = "vendor_retention",
+        channel: str = "email",
+        limit: int | None = None,
+        scope: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "target_mode": target_mode,
+            "channel": channel,
+            "limit": limit or len(self.opportunities),
+            "opportunities": [dict(row) for row in self.opportunities],
+        }
+        if scope is not None:
+            payload["scope"] = dict(scope)
+        if self.source:
+            payload["source"] = self.source
+        if self.warnings:
+            payload["opportunity_warnings"] = self.warning_dicts()
+        return payload
+
+
+def load_campaign_opportunities_from_file(
+    path: str | Path,
+    *,
+    file_format: CustomerDataFormat = "auto",
+    target_mode: str | None = None,
+) -> CampaignOpportunityLoadResult:
+    """Load customer campaign opportunities from JSON or CSV."""
+
+    source = Path(path)
+    resolved_format = _resolve_format(source, file_format)
+    if resolved_format == "csv":
+        rows = _load_csv_rows(source)
+    else:
+        rows = _load_json_rows(source)
+    result = normalize_campaign_opportunity_rows(rows, target_mode=target_mode)
+    return CampaignOpportunityLoadResult(
+        opportunities=result.opportunities,
+        warnings=result.warnings,
+        source=str(source),
+    )
+
+
+def normalize_campaign_opportunity_rows(
+    rows: Sequence[Any],
+    *,
+    target_mode: str | None = None,
+) -> CampaignOpportunityLoadResult:
+    """Normalize loose customer rows and collect non-fatal validation warnings."""
+
+    opportunities: list[dict[str, Any]] = []
+    warnings: list[CampaignOpportunityWarning] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            warnings.append(
+                CampaignOpportunityWarning(
+                    code="row_not_object",
+                    row_index=index,
+                    message="Skipped row because it is not an object.",
+                )
+            )
+            continue
+        normalized = normalize_campaign_opportunity(row, target_mode=target_mode)
+        if not normalized:
+            warnings.append(
+                CampaignOpportunityWarning(
+                    code="empty_row",
+                    row_index=index,
+                    message="Skipped row because it did not contain usable values.",
+                )
+            )
+            continue
+        opportunities.append(normalized)
+        warnings.extend(_validation_warnings(normalized, row_index=index))
+    return CampaignOpportunityLoadResult(
+        opportunities=tuple(opportunities),
+        warnings=tuple(warnings),
+    )
+
+
+@dataclass(frozen=True)
+class FileIntelligenceRepository:
+    """IntelligenceRepository backed by loaded customer opportunity rows."""
+
+    opportunities: Sequence[Mapping[str, Any]]
+    warnings: Sequence[CampaignOpportunityWarning] = ()
+    source: str | None = None
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        *,
+        file_format: CustomerDataFormat = "auto",
+        target_mode: str | None = None,
+    ) -> "FileIntelligenceRepository":
+        loaded = load_campaign_opportunities_from_file(
+            path,
+            file_format=file_format,
+            target_mode=target_mode,
+        )
+        return cls(
+            opportunities=loaded.opportunities,
+            warnings=loaded.warnings,
+            source=loaded.source,
+        )
+
+    async def read_campaign_opportunities(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Sequence[dict[str, Any]]:
+        del scope
+        rows = [
+            normalize_campaign_opportunity(row, target_mode=target_mode)
+            for row in self.opportunities
+            if _matches_filters(row, filters)
+        ]
+        return rows[:limit]
+
+    async def read_vendor_targets(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        vendor_name: str | None = None,
+    ) -> Sequence[dict[str, Any]]:  # pragma: no cover - protocol filler
+        del scope
+        del target_mode
+        del vendor_name
+        return []
+
+
+def _resolve_format(path: Path, file_format: CustomerDataFormat) -> Literal["json", "csv"]:
+    if file_format != "auto":
+        return file_format
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    if suffix in {".json", ".jsonl"}:
+        return "json"
+    raise ValueError(f"Cannot infer customer data format from file suffix: {path}")
+
+
+def _load_json_rows(path: Path) -> list[Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return list(data)
+    if not isinstance(data, Mapping):
+        raise ValueError("JSON customer data must be an object or array")
+    for key in ("opportunities", "rows", "data", "accounts", "customers"):
+        value = data.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return list(value)
+    return [dict(data)]
+
+
+def _load_csv_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames:
+            return []
+        for row in reader:
+            cleaned: dict[str, Any] = {}
+            for key, value in row.items():
+                if key is None:
+                    continue
+                cleaned_value = _coerce_csv_value(value)
+                if cleaned_value not in (None, ""):
+                    cleaned[str(key)] = cleaned_value
+            rows.append(cleaned)
+    return rows
+
+
+def _coerce_csv_value(value: Any) -> Any:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if text[0] not in "[{":
+        return text
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _validation_warnings(
+    opportunity: Mapping[str, Any],
+    *,
+    row_index: int,
+) -> list[CampaignOpportunityWarning]:
+    warnings: list[CampaignOpportunityWarning] = []
+    checks = [
+        (
+            "missing_target_id",
+            "target_id",
+            not opportunity_target_id(opportunity),
+            "Row does not contain a stable target id, email, company, or vendor.",
+        ),
+        (
+            "missing_company_name",
+            "company_name",
+            not str(opportunity.get("company_name") or "").strip(),
+            "Row does not contain a company name.",
+        ),
+        (
+            "missing_vendor_name",
+            "vendor_name",
+            not str(opportunity.get("vendor_name") or "").strip(),
+            "Row does not contain a current/incumbent vendor name.",
+        ),
+        (
+            "missing_contact_email",
+            "contact_email",
+            not str(opportunity.get("contact_email") or "").strip(),
+            "Row does not contain a contact email.",
+        ),
+    ]
+    for code, field, should_warn, message in checks:
+        if should_warn:
+            warnings.append(
+                CampaignOpportunityWarning(
+                    code=code,
+                    field=field,
+                    row_index=row_index,
+                    message=message,
+                )
+            )
+    return warnings
+
+
+def _matches_filters(
+    row: Mapping[str, Any],
+    filters: Mapping[str, Any] | None,
+) -> bool:
+    if not filters:
+        return True
+    for key, expected in filters.items():
+        if expected in (None, "", [], {}):
+            continue
+        actual = row.get(key)
+        if isinstance(expected, Sequence) and not isinstance(expected, (str, bytes, bytearray)):
+            expected_values = {str(item).strip().lower() for item in expected}
+            if str(actual or "").strip().lower() not in expected_values:
+                return False
+        elif str(actual or "").strip().lower() != str(expected).strip().lower():
+            return False
+    return True
+
+
+__all__ = [
+    "CampaignOpportunityLoadResult",
+    "CampaignOpportunityWarning",
+    "FileIntelligenceRepository",
+    "load_campaign_opportunities_from_file",
+    "normalize_campaign_opportunity_rows",
+]

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -264,7 +264,7 @@ async def generate_campaign_drafts_from_payload(
         limit=limit,
         filters=payload.get("filters") if isinstance(payload.get("filters"), Mapping) else None,
     )
-    return {
+    output = {
         "result": result.as_dict(),
         "drafts": [
             _draft_to_dict(draft, campaign_id)
@@ -272,6 +272,13 @@ async def generate_campaign_drafts_from_payload(
         ],
         "llm_model": _llm_model_label(llm_client, campaigns.drafts),
     }
+    warnings = payload.get("opportunity_warnings")
+    if isinstance(warnings, Sequence) and not isinstance(warnings, (str, bytes, bytearray)):
+        output["opportunity_warnings"] = list(warnings)
+    source = str(payload.get("source") or "").strip()
+    if source:
+        output["source"] = source
+    return output
 
 
 __all__ = [

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -117,6 +117,11 @@ for campaign generation. It wires in-memory ports, a static prompt store, and an
 offline deterministic LLM so customer opportunity JSON can be converted into
 drafts without Atlas, a database, or provider credentials.
 
+`extracted_content_pipeline/campaign_customer_data.py` is the customer-export
+adapter slice. It loads JSON or CSV opportunity rows, normalizes them through
+the product opportunity contract, returns non-fatal data-quality warnings, and
+exposes `FileIntelligenceRepository` for running generation from customer files.
+
 `extracted_content_pipeline/campaign_opportunities.py` owns the host/customer
 opportunity input contract. It accepts loose customer rows, preserves custom
 fields, and adds stable prompt/storage keys (`target_id`, `company_name`,

--- a/extracted_content_pipeline/examples/campaign_generation_payload.csv
+++ b/extracted_content_pipeline/examples/campaign_generation_payload.csv
@@ -1,0 +1,3 @@
+id,company,vendor,email,title,pain_category,competitor,opportunity_score,urgency_score,custom_segment
+opp-acme-hubspot,Acme Logistics,HubSpot,revenue.ops@example.com,VP Revenue Operations,pricing pressure,"Salesforce, Zoho",84,8,enterprise logistics
+opp-northstar-crm,Northstar Health,LegacyCRM,it.lead@example.com,Director of IT,integration gaps,Pipedrive,76,7,healthcare

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -175,6 +175,9 @@
       "target": "extracted_content_pipeline/campaign_example.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_customer_data.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_opportunities.py"
     },
     {

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -18,6 +18,9 @@ if str(ROOT) not in sys.path:
 from extracted_content_pipeline.campaign_example import (  # noqa: E402
     generate_campaign_drafts_from_payload,
 )
+from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
+    load_campaign_opportunities_from_file,
+)
 
 
 DEFAULT_PAYLOAD = (
@@ -25,10 +28,15 @@ DEFAULT_PAYLOAD = (
 )
 
 
-def _load_payload(path: Path) -> dict[str, Any]:
+def _load_payload(path: Path, *, file_format: str = "auto") -> dict[str, Any]:
+    if file_format == "csv" or (file_format == "auto" and path.suffix.lower() == ".csv"):
+        loaded = load_campaign_opportunities_from_file(path, file_format="csv")
+        return loaded.as_payload()
+
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
-        raise ValueError("campaign generation payload must be a JSON object")
+        loaded = load_campaign_opportunities_from_file(path, file_format="json")
+        return loaded.as_payload()
     return data
 
 
@@ -49,6 +57,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--target-mode",
         help="Override the payload target_mode.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("auto", "json", "csv"),
+        default="auto",
+        help="Customer data input format. Defaults to suffix-based auto detection.",
     )
     parser.add_argument(
         "--limit",
@@ -89,7 +103,7 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
 
 async def _main() -> int:
     args = _parse_args()
-    payload = _load_payload(args.payload)
+    payload = _load_payload(args.payload, file_format=args.format)
     if args.target_mode:
         payload["target_mode"] = args.target_mode
     if args.limit is not None:

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -15,6 +15,7 @@ pytest \
   tests/test_extracted_campaign_generation_seams.py \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_campaign_generation_example.py \
+  tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_reasoning_archetypes.py \
   tests/test_extracted_reasoning_temporal.py \

--- a/tests/test_extracted_campaign_customer_data.py
+++ b/tests/test_extracted_campaign_customer_data.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_customer_data import (
+    FileIntelligenceRepository,
+    load_campaign_opportunities_from_file,
+    normalize_campaign_opportunity_rows,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/run_extracted_campaign_generation_example.py"
+
+
+def test_load_campaign_opportunities_from_json_payload_preserves_custom_fields(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opportunities.json"
+    path.write_text(
+        json.dumps({
+            "opportunities": [
+                {
+                    "id": "opp-1",
+                    "company": "Acme",
+                    "vendor": "HubSpot",
+                    "email": "buyer@example.com",
+                    "title": "VP Revenue",
+                    "pain_category": "pricing",
+                    "competitor": "Salesforce, Zoho",
+                    "custom_segment": "enterprise",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_campaign_opportunities_from_file(
+        path,
+        target_mode="vendor_retention",
+    )
+
+    assert loaded.source == str(path)
+    assert loaded.warnings == ()
+    row = loaded.opportunities[0]
+    assert row["target_id"] == "opp-1"
+    assert row["company_name"] == "Acme"
+    assert row["vendor_name"] == "HubSpot"
+    assert row["contact_email"] == "buyer@example.com"
+    assert row["contact_title"] == "VP Revenue"
+    assert row["pain_points"] == ["pricing"]
+    assert row["competitors"] == ["Salesforce", "Zoho"]
+    assert row["custom_segment"] == "enterprise"
+    assert row["target_mode"] == "vendor_retention"
+
+
+def test_load_campaign_opportunities_from_csv_coerces_json_cells_and_warns(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opportunities.csv"
+    path.write_text(
+        "\n".join([
+            "id,company,vendor,email,pain_category,evidence",
+            'opp-1,Acme,HubSpot,buyer@example.com,pricing,"[{""quote"": ""Too expensive""}]"',
+            "opp-2,BetaCRM,,ops@example.com,,",
+        ]),
+        encoding="utf-8",
+    )
+
+    loaded = load_campaign_opportunities_from_file(path)
+
+    assert len(loaded.opportunities) == 2
+    assert loaded.opportunities[0]["evidence"] == [{"quote": "Too expensive"}]
+    assert loaded.opportunities[1]["company_name"] == "BetaCRM"
+    assert [warning.code for warning in loaded.warnings] == ["missing_vendor_name"]
+    assert loaded.warnings[0].row_index == 2
+
+
+def test_normalize_campaign_opportunity_rows_skips_non_object_rows() -> None:
+    loaded = normalize_campaign_opportunity_rows(
+        [
+            {"id": "opp-1", "company": "Acme", "vendor": "HubSpot"},
+            "bad-row",
+        ],
+        target_mode="vendor_retention",
+    )
+
+    assert len(loaded.opportunities) == 1
+    assert loaded.opportunities[0]["target_id"] == "opp-1"
+    assert loaded.warnings[-1].code == "row_not_object"
+    assert loaded.warnings[-1].row_index == 2
+
+
+@pytest.mark.asyncio
+async def test_file_intelligence_repository_filters_and_limits_rows(tmp_path: Path) -> None:
+    path = tmp_path / "opportunities.json"
+    path.write_text(
+        json.dumps([
+            {"id": "opp-1", "company": "Acme", "vendor": "HubSpot"},
+            {"id": "opp-2", "company": "Beta", "vendor": "Zendesk"},
+            {"id": "opp-3", "company": "Gamma", "vendor": "HubSpot"},
+        ]),
+        encoding="utf-8",
+    )
+    repo = FileIntelligenceRepository.from_file(path)
+
+    rows = await repo.read_campaign_opportunities(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+        filters={"vendor_name": "HubSpot"},
+    )
+
+    assert [row["target_id"] for row in rows] == ["opp-1"]
+    assert rows[0]["target_mode"] == "vendor_retention"
+
+
+def test_campaign_generation_cli_accepts_csv_customer_export() -> None:
+    path = ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.csv"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--format",
+            "csv",
+            "--limit",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+
+    assert result["result"]["generated"] == 1
+    assert result["source"].endswith("campaign_generation_payload.csv")
+    assert result["drafts"][0]["target_id"] == "opp-acme-hubspot"
+    assert result["drafts"][0]["metadata"]["source_opportunity"]["custom_segment"] == (
+        "enterprise logistics"
+    )
+
+
+def test_campaign_generation_cli_surfaces_customer_data_warnings(tmp_path: Path) -> None:
+    path = tmp_path / "opportunities.csv"
+    path.write_text(
+        "\n".join([
+            "id,company,vendor,email,pain_category",
+            "opp-1,Acme,,buyer@example.com,pricing",
+        ]),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(CLI), str(path), "--format", "csv"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+
+    assert result["result"]["generated"] == 1
+    assert result["opportunity_warnings"][0]["code"] == "missing_vendor_name"
+    assert result["opportunity_warnings"][0]["row_index"] == 1

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -20,6 +20,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/reasoning/temporal.py",
     "extracted_content_pipeline/reasoning/wedge_registry.py",
     "extracted_content_pipeline/campaign_generation.py",
+    "extracted_content_pipeline/campaign_customer_data.py",
     "extracted_content_pipeline/campaign_ports.py",
     "extracted_content_pipeline/config.py",
     "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -86,6 +86,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_ports.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
     assert "extracted_content_pipeline/campaign_example.py" in owned
+    assert "extracted_content_pipeline/campaign_customer_data.py" in owned
     assert "extracted_content_pipeline/campaign_opportunities.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
@@ -117,6 +118,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
     assert "extracted_content_pipeline/campaign_example.py" not in mapped
+    assert "extracted_content_pipeline/campaign_customer_data.py" not in mapped
     assert "extracted_content_pipeline/campaign_opportunities.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped


### PR DESCRIPTION
## Summary
- add campaign_customer_data.py with JSON/CSV opportunity loading, normalization, warnings, and FileIntelligenceRepository
- allow the campaign generation example CLI to read CSV customer exports
- add sample CSV payload, docs, manifest tracking, and extracted pipeline check coverage

## Verification
- python -m py_compile extracted_content_pipeline/campaign_customer_data.py extracted_content_pipeline/campaign_example.py scripts/run_extracted_campaign_generation_example.py tests/test_extracted_campaign_customer_data.py
- EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_customer_data.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py
- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh
- python scripts/run_extracted_campaign_generation_example.py extracted_content_pipeline/examples/campaign_generation_payload.csv --format csv --limit 1