### PR TITLE
Add Postgres campaign opportunity source

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -216,8 +216,9 @@ Several small utility shims provide product-owned local behavior by default so t
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
-- `campaign_postgres.py`: async Postgres adapters for campaign, sequence,
-  suppression, and audit ports
+- `campaign_postgres.py`: async Postgres adapters for intelligence,
+  campaign, sequence, suppression, and audit ports, including the product-owned
+  `campaign_opportunities` source table
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
 - `skills/registry.py`: local markdown-backed skill registry implementing
   `.get()` and product `SkillStore.get_prompt()`

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -26,8 +26,9 @@
   services to the standalone campaign `LLMClient` port. Its provider-routing
   config can be built from explicit mappings, settings objects, or
   `EXTRACTED_CAMPAIGN_LLM_*` environment variables.
-- `campaign_postgres` provides async Postgres adapters for the campaign,
-  sequence, suppression, and audit ports against the copied campaign schema.
+- `campaign_postgres` provides async Postgres adapters for the intelligence,
+  campaign, sequence, suppression, and audit ports against the copied campaign
+  schema plus the product-owned `campaign_opportunities` source table.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,

--- a/extracted_content_pipeline/campaign_postgres.py
+++ b/extracted_content_pipeline/campaign_postgres.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import json
 from typing import Any, Mapping, Sequence
 
+from .campaign_opportunities import normalize_campaign_opportunity
 from .campaign_ports import (
     CampaignDraft,
     SendResult,
@@ -56,6 +57,184 @@ def _campaign_vendor_name(draft: CampaignDraft, opportunity: Mapping[str, Any]) 
         or _clean(draft.metadata.get("vendor_name"))
         or None
     )
+
+
+def _json_mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _json_sequence(value: Any) -> list[Any]:
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return list(value)
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+def _opportunity_from_row(row: Mapping[str, Any], *, target_mode: str) -> JsonDict:
+    raw = _json_mapping(row.get("raw_payload"))
+    opportunity = dict(raw)
+    for key in (
+        "target_id",
+        "company_name",
+        "vendor_name",
+        "contact_name",
+        "contact_email",
+        "contact_title",
+        "opportunity_score",
+        "urgency_score",
+    ):
+        value = row.get(key)
+        if value not in (None, "", [], {}):
+            opportunity[key] = value
+    if row.get("pain_points") not in (None, "", [], {}):
+        opportunity["pain_points"] = _json_sequence(row.get("pain_points"))
+    if row.get("competitors") not in (None, "", [], {}):
+        opportunity["competitors"] = _json_sequence(row.get("competitors"))
+    if row.get("evidence") not in (None, "", [], {}):
+        opportunity["evidence"] = _json_sequence(row.get("evidence"))
+    if row.get("account_id"):
+        opportunity["account_id"] = row.get("account_id")
+    return normalize_campaign_opportunity(opportunity, target_mode=target_mode)
+
+
+def _safe_json_key(value: Any) -> str:
+    key = _clean(value)
+    if not key:
+        raise ValueError("filter key cannot be empty")
+    if not all(char.isalnum() or char == "_" for char in key):
+        raise ValueError(f"unsupported filter key: {key}")
+    return key
+
+
+@dataclass(frozen=True)
+class PostgresIntelligenceRepository:
+    """Async Postgres adapter for customer campaign opportunity rows."""
+
+    pool: Any
+    opportunity_table: str = "campaign_opportunities"
+    vendor_targets_table: str = "vendor_targets"
+
+    async def read_campaign_opportunities(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Sequence[JsonDict]:
+        params: list[Any] = [target_mode]
+        where = [
+            "status = 'active'",
+            "(target_mode = $1 OR target_mode IS NULL)",
+        ]
+        if scope.account_id:
+            params.append(scope.account_id)
+            where.append(f"account_id = ${len(params)}")
+        self._append_filters(where, params, filters)
+        params.append(int(limit))
+        rows = await self.pool.fetch(
+            f"""
+            SELECT
+                id, account_id, target_id, target_mode, company_name, vendor_name,
+                contact_name, contact_email, contact_title, opportunity_score,
+                urgency_score, pain_points, competitors, evidence, raw_payload
+              FROM {self._identifier(self.opportunity_table)}
+             WHERE {' AND '.join(where)}
+             ORDER BY urgency_score DESC NULLS LAST,
+                      opportunity_score DESC NULLS LAST,
+                      updated_at DESC NULLS LAST,
+                      created_at DESC NULLS LAST
+             LIMIT ${len(params)}
+            """,
+            *params,
+        )
+        return tuple(
+            _opportunity_from_row(_row_dict(row), target_mode=target_mode)
+            for row in rows
+        )
+
+    async def read_vendor_targets(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        vendor_name: str | None = None,
+    ) -> Sequence[JsonDict]:
+        del scope
+        params: list[Any] = [target_mode]
+        where = ["status = 'active'", "target_mode = $1"]
+        if vendor_name:
+            params.append(vendor_name)
+            where.append(f"LOWER(company_name) = LOWER(${len(params)})")
+        rows = await self.pool.fetch(
+            f"""
+            SELECT *
+              FROM {self._identifier(self.vendor_targets_table)}
+             WHERE {' AND '.join(where)}
+             ORDER BY company_name ASC
+            """,
+            *params,
+        )
+        return tuple(_row_dict(row) for row in rows)
+
+    def _append_filters(
+        self,
+        where: list[str],
+        params: list[Any],
+        filters: Mapping[str, Any] | None,
+    ) -> None:
+        for key, value in (filters or {}).items():
+            if value in (None, "", [], {}):
+                continue
+            if key == "vendor_name":
+                params.append(value)
+                where.append(f"LOWER(vendor_name) = LOWER(${len(params)})")
+            elif key == "company_name":
+                params.append(value)
+                where.append(f"LOWER(company_name) = LOWER(${len(params)})")
+            elif key == "contact_email":
+                params.append(value)
+                where.append(f"LOWER(contact_email) = LOWER(${len(params)})")
+            elif key == "target_id":
+                params.append(value)
+                where.append(f"target_id = ${len(params)}")
+            elif key == "min_urgency":
+                params.append(value)
+                where.append(f"urgency_score >= ${len(params)}")
+            elif key == "min_opportunity_score":
+                params.append(value)
+                where.append(f"opportunity_score >= ${len(params)}")
+            else:
+                json_key = _safe_json_key(key)
+                params.append(json_key)
+                key_position = len(params)
+                params.append(value)
+                where.append(
+                    f"LOWER(raw_payload ->> ${key_position}) = LOWER(${len(params)})"
+                )
+
+    def _identifier(self, value: str) -> str:
+        parts = value.split(".")
+        if not parts or any(not part for part in parts):
+            raise ValueError(f"invalid SQL identifier: {value}")
+        for part in parts:
+            if not all(char.isalnum() or char == "_" for char in part):
+                raise ValueError(f"invalid SQL identifier: {value}")
+        return ".".join(f'"{part}"' for part in parts)
 
 
 @dataclass(frozen=True)

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -122,6 +122,11 @@ adapter slice. It loads JSON or CSV opportunity rows, normalizes them through
 the product opportunity contract, returns non-fatal data-quality warnings, and
 exposes `FileIntelligenceRepository` for running generation from customer files.
 
+`extracted_content_pipeline/campaign_postgres.py` owns the Postgres adapter path
+for customer opportunity reads through `PostgresIntelligenceRepository`. It
+reads the product-owned `campaign_opportunities` table and normalizes rows
+through the same contract as the JSON/CSV adapters before generation.
+
 `extracted_content_pipeline/campaign_opportunities.py` owns the host/customer
 opportunity input contract. It accepts loose customer rows, preserves custom
 fields, and adds stable prompt/storage keys (`target_id`, `company_name`,

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -184,6 +184,9 @@
       "target": "extracted_content_pipeline/settings.py"
     },
     {
+      "target": "extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql"
+    },
+    {
       "target": "extracted_content_pipeline/pipelines/notify.py"
     },
     {

--- a/extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql
+++ b/extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql
@@ -1,0 +1,37 @@
+-- Product-owned customer opportunity source for standalone campaign generation.
+
+CREATE TABLE IF NOT EXISTS campaign_opportunities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT,
+    target_id TEXT NOT NULL,
+    target_mode TEXT DEFAULT 'vendor_retention',
+    company_name TEXT,
+    vendor_name TEXT,
+    contact_name TEXT,
+    contact_email TEXT,
+    contact_title TEXT,
+    opportunity_score NUMERIC,
+    urgency_score NUMERIC,
+    pain_points JSONB NOT NULL DEFAULT '[]'::jsonb,
+    competitors JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+    raw_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_opportunities_account_mode
+    ON campaign_opportunities (account_id, target_mode, status);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_opportunities_target_id
+    ON campaign_opportunities (target_id);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_opportunities_vendor
+    ON campaign_opportunities (LOWER(vendor_name));
+
+CREATE INDEX IF NOT EXISTS idx_campaign_opportunities_contact_email
+    ON campaign_opportunities (LOWER(contact_email));
+
+CREATE INDEX IF NOT EXISTS idx_campaign_opportunities_raw_payload
+    ON campaign_opportunities USING GIN(raw_payload);

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -20,6 +20,10 @@ CORE_CAMPAIGN_MIGRATIONS = {
     "150_campaign_engagement_timing.sql",
 }
 
+PRODUCT_OWNED_CAMPAIGN_MIGRATIONS = {
+    "151_campaign_opportunities.sql",
+}
+
 DEFERRED_CROSS_PRODUCT_MIGRATIONS = {
     "080_b2b_alert_baselines.sql",
     "106_score_calibration.sql",
@@ -61,6 +65,15 @@ def test_deferred_cross_product_migrations_stay_out_of_core_manifest() -> None:
     assert not (DEFERRED_CROSS_PRODUCT_MIGRATIONS & targets)
 
 
+def test_manifest_tracks_product_owned_campaign_schema_migrations() -> None:
+    owned = _owned_targets()
+
+    for migration in PRODUCT_OWNED_CAMPAIGN_MIGRATIONS:
+        target = f"extracted_content_pipeline/storage/migrations/{migration}"
+        assert target in owned
+        assert (ROOT / target).exists()
+
+
 def test_core_campaign_migrations_define_product_tables() -> None:
     migrations_dir = ROOT / "extracted_content_pipeline/storage/migrations"
 
@@ -78,6 +91,15 @@ def test_core_campaign_migrations_define_product_tables() -> None:
     assert "CREATE TABLE IF NOT EXISTS seller_targets" in seller_schema
 
 
+def test_product_owned_campaign_migrations_define_product_tables() -> None:
+    migrations_dir = ROOT / "extracted_content_pipeline/storage/migrations"
+
+    opportunity_schema = (migrations_dir / "151_campaign_opportunities.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS campaign_opportunities" in opportunity_schema
+    assert "idx_campaign_opportunities_account_mode" in opportunity_schema
+
+
 def test_manifest_tracks_product_owned_adapter_files() -> None:
     owned = _owned_targets()
 
@@ -89,6 +111,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_customer_data.py" in owned
     assert "extracted_content_pipeline/campaign_opportunities.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
+    assert "extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
     assert "extracted_content_pipeline/reasoning/evidence_engine.py" in owned

--- a/tests/test_extracted_campaign_postgres.py
+++ b/tests/test_extracted_campaign_postgres.py
@@ -15,6 +15,7 @@ from extracted_content_pipeline.campaign_postgres import (
     PostgresCampaignAuditSink,
     PostgresCampaignRepository,
     PostgresCampaignSequenceRepository,
+    PostgresIntelligenceRepository,
     PostgresSuppressionRepository,
 )
 
@@ -44,6 +45,137 @@ class _Pool:
     async def execute(self, query, *args):
         self.execute_calls.append({"query": query, "args": args})
         return "OK"
+
+
+@pytest.mark.asyncio
+async def test_intelligence_repository_reads_customer_opportunities_with_scope_and_filters():
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "row-1",
+            "account_id": "acct-1",
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "contact_email": "buyer@example.com",
+            "contact_title": "VP Revenue",
+            "opportunity_score": 84,
+            "urgency_score": 8,
+            "pain_points": ["pricing"],
+            "competitors": ["Salesforce", "Zoho"],
+            "evidence": [{"quote": "Too expensive"}],
+            "raw_payload": {
+                "custom_segment": "enterprise",
+                "source_system": "warehouse",
+            },
+        }
+    ]
+    repo = PostgresIntelligenceRepository(pool)
+
+    rows = await repo.read_campaign_opportunities(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=10,
+        filters={"vendor_name": "HubSpot", "custom_segment": "enterprise"},
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["target_id"] == "opp-1"
+    assert row["target_mode"] == "vendor_retention"
+    assert row["company_name"] == "Acme"
+    assert row["vendor_name"] == "HubSpot"
+    assert row["contact_email"] == "buyer@example.com"
+    assert row["contact_title"] == "VP Revenue"
+    assert row["pain_points"] == ["pricing"]
+    assert row["competitors"] == ["Salesforce", "Zoho"]
+    assert row["evidence"] == [{"quote": "Too expensive"}]
+    assert row["custom_segment"] == "enterprise"
+    call = pool.fetch_calls[0]
+    assert 'FROM "campaign_opportunities"' in call["query"]
+    assert "account_id = $2" in call["query"]
+    assert "LOWER(vendor_name) = LOWER($3)" in call["query"]
+    assert "LOWER(raw_payload ->> $4) = LOWER($5)" in call["query"]
+    assert call["args"] == ("vendor_retention", "acct-1", "HubSpot", "custom_segment", "enterprise", 10)
+
+
+@pytest.mark.asyncio
+async def test_intelligence_repository_accepts_json_string_payloads():
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-1",
+            "company_name": "",
+            "vendor_name": "",
+            "pain_points": '["pricing", "support"]',
+            "competitors": '["Salesforce"]',
+            "evidence": '[{"quote":"Too expensive"}]',
+            "raw_payload": json.dumps({
+                "company": "Acme",
+                "vendor": "HubSpot",
+                "email": "buyer@example.com",
+                "custom_segment": "midmarket",
+            }),
+        }
+    ]
+    repo = PostgresIntelligenceRepository(pool)
+
+    rows = await repo.read_campaign_opportunities(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=5,
+    )
+
+    assert rows[0]["company_name"] == "Acme"
+    assert rows[0]["vendor_name"] == "HubSpot"
+    assert rows[0]["contact_email"] == "buyer@example.com"
+    assert rows[0]["pain_points"] == ["pricing", "support"]
+    assert rows[0]["competitors"] == ["Salesforce"]
+    assert rows[0]["evidence"] == [{"quote": "Too expensive"}]
+    assert rows[0]["custom_segment"] == "midmarket"
+
+
+@pytest.mark.asyncio
+async def test_intelligence_repository_rejects_unsafe_table_and_filter_identifiers():
+    pool = _Pool()
+    repo = PostgresIntelligenceRepository(pool, opportunity_table="campaign_opportunities;drop")
+
+    with pytest.raises(ValueError, match="invalid SQL identifier"):
+        await repo.read_campaign_opportunities(
+            scope=TenantScope(),
+            target_mode="vendor_retention",
+            limit=5,
+        )
+
+    repo = PostgresIntelligenceRepository(pool)
+    with pytest.raises(ValueError, match="unsupported filter key"):
+        await repo.read_campaign_opportunities(
+            scope=TenantScope(),
+            target_mode="vendor_retention",
+            limit=5,
+            filters={"bad-key": "value"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_intelligence_repository_reads_vendor_targets():
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "target-1", "company_name": "Acme"}]
+    repo = PostgresIntelligenceRepository(pool)
+
+    rows = await repo.read_vendor_targets(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        vendor_name="Acme",
+    )
+
+    assert rows == ({"id": "target-1", "company_name": "Acme"},)
+    call = pool.fetch_calls[0]
+    assert 'FROM "vendor_targets"' in call["query"]
+    assert "target_mode = $1" in call["query"]
+    assert "LOWER(company_name) = LOWER($2)" in call["query"]
+    assert "account_id" not in call["query"]
+    assert call["args"] == ("vendor_retention", "Acme")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add PostgresIntelligenceRepository for reading campaign opportunities and vendor targets through product ports
- add product-owned campaign_opportunities migration for customer opportunity rows
- normalize Postgres rows through the same campaign opportunity contract as JSON/CSV adapters
- document the read-side Postgres adapter and add manifest/test coverage

## Verification
- python -m py_compile extracted_content_pipeline/campaign_postgres.py tests/test_extracted_campaign_postgres.py tests/test_extracted_campaign_manifest.py
- EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_postgres.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_manifest.py
- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh