### PR TITLE
Add Postgres campaign generation runner

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -141,6 +141,15 @@ To run the same example through the product LLM adapter, configure the
 python scripts/run_extracted_campaign_generation_example.py --llm pipeline
 ```
 
+For database-backed runs, apply the product migrations, set
+`EXTRACTED_DATABASE_URL`, and run the Postgres generation runner. It reads
+`campaign_opportunities`, generates drafts, and persists them into
+`b2b_campaigns`:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py --account-id acct_123 --limit 10
+```
+
 ## Import smoke test
 
 ```bash
@@ -219,6 +228,10 @@ Several small utility shims provide product-owned local behavior by default so t
 - `campaign_postgres.py`: async Postgres adapters for intelligence,
   campaign, sequence, suppression, and audit ports, including the product-owned
   `campaign_opportunities` source table
+- `campaign_postgres_generation.py`: product runner wiring
+  `PostgresIntelligenceRepository`, `PostgresCampaignRepository`,
+  `PipelineLLMClient`, and the local skill registry for DB-backed draft
+  generation
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
 - `skills/registry.py`: local markdown-backed skill registry implementing
   `.get()` and product `SkillStore.get_prompt()`

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -29,6 +29,9 @@
 - `campaign_postgres` provides async Postgres adapters for the intelligence,
   campaign, sequence, suppression, and audit ports against the copied campaign
   schema plus the product-owned `campaign_opportunities` source table.
+- `campaign_postgres_generation` wires the DB-backed generation path from
+  `campaign_opportunities` to saved `b2b_campaigns` drafts through product
+  ports.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,

--- a/extracted_content_pipeline/campaign_postgres_generation.py
+++ b/extracted_content_pipeline/campaign_postgres_generation.py
@@ -1,0 +1,86 @@
+"""Postgres-backed campaign draft generation runner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .campaign_generation import (
+    CampaignGenerationConfig,
+    CampaignGenerationResult,
+    CampaignGenerationService,
+)
+from .campaign_llm_client import create_pipeline_llm_client
+from .campaign_ports import (
+    CampaignReasoningContextProvider,
+    LLMClient,
+    SkillStore,
+    TenantScope,
+)
+from .campaign_postgres import (
+    PostgresCampaignRepository,
+    PostgresIntelligenceRepository,
+)
+from .skills.registry import get_skill_registry
+
+
+def tenant_scope_from_mapping(value: Mapping[str, Any] | TenantScope | None) -> TenantScope:
+    """Build a TenantScope from CLI/host-provided mapping data."""
+
+    if isinstance(value, TenantScope):
+        return value
+    if not isinstance(value, Mapping):
+        return TenantScope()
+    return TenantScope(
+        account_id=str(value.get("account_id") or "") or None,
+        user_id=str(value.get("user_id") or "") or None,
+        allowed_vendors=tuple(str(item) for item in value.get("allowed_vendors") or ()),
+        roles=tuple(str(item) for item in value.get("roles") or ()),
+    )
+
+
+async def generate_campaign_drafts_from_postgres(
+    pool: Any,
+    *,
+    scope: Mapping[str, Any] | TenantScope | None = None,
+    target_mode: str = "vendor_retention",
+    channel: str = "email",
+    limit: int = 20,
+    filters: Mapping[str, Any] | None = None,
+    llm: LLMClient | None = None,
+    skills: SkillStore | None = None,
+    reasoning_context: CampaignReasoningContextProvider | None = None,
+    config: CampaignGenerationConfig | None = None,
+    opportunity_table: str = "campaign_opportunities",
+    vendor_targets_table: str = "vendor_targets",
+) -> CampaignGenerationResult:
+    """Generate and persist campaign drafts from Postgres opportunity rows."""
+
+    generation_config = config or CampaignGenerationConfig(
+        channel=channel,
+        limit=limit,
+    )
+    service = CampaignGenerationService(
+        intelligence=PostgresIntelligenceRepository(
+            pool,
+            opportunity_table=opportunity_table,
+            vendor_targets_table=vendor_targets_table,
+        ),
+        campaigns=PostgresCampaignRepository(pool),
+        llm=llm or create_pipeline_llm_client(),
+        skills=skills or get_skill_registry(),
+        reasoning_context=reasoning_context,
+        config=generation_config,
+    )
+    return await service.generate(
+        scope=tenant_scope_from_mapping(scope),
+        target_mode=target_mode,
+        limit=limit,
+        filters=filters,
+    )
+
+
+__all__ = [
+    "generate_campaign_drafts_from_postgres",
+    "tenant_scope_from_mapping",
+]

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -112,6 +112,12 @@ slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
 through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
 `CampaignDraft` rows through `CampaignRepository`.
 
+`extracted_content_pipeline/campaign_postgres_generation.py` wires the
+database-backed product path. Hosts pass an async Postgres pool and the runner
+combines `PostgresIntelligenceRepository`, `PostgresCampaignRepository`,
+`PipelineLLMClient`, and the local skill registry to read opportunities,
+generate drafts, and save them back to Postgres.
+
 `extracted_content_pipeline/campaign_example.py` is the runnable product example
 for campaign generation. It wires in-memory ports, a static prompt store, and an
 offline deterministic LLM so customer opportunity JSON can be converted into

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -172,6 +172,9 @@
       "target": "extracted_content_pipeline/campaign_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_postgres_generation.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_example.py"
     },
     {

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Generate campaign drafts from the product Postgres opportunity table."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_example import (  # noqa: E402
+    DeterministicCampaignLLM,
+    StaticCampaignSkillStore,
+)
+from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
+    generate_campaign_drafts_from_postgres,
+)
+
+
+def _json_object(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("expected a JSON object")
+    return parsed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate campaign drafts from campaign_opportunities and persist "
+            "drafts into b2b_campaigns."
+        )
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--account-id", help="Tenant/account scope filter.")
+    parser.add_argument("--user-id", help="User id to attach to generated draft metadata.")
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--channel", default="email")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument(
+        "--filters-json",
+        help="Optional JSON object of opportunity filters.",
+    )
+    parser.add_argument(
+        "--llm",
+        choices=("pipeline", "offline"),
+        default="pipeline",
+        help="Use configured PipelineLLMClient or deterministic offline LLM.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write result JSON to this path instead of stdout.",
+    )
+    return parser.parse_args()
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - depends on host environment
+        raise RuntimeError(
+            "asyncpg is required for the Postgres runner; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    if args.llm == "pipeline":
+        return {}
+    return {
+        "llm": DeterministicCampaignLLM(),
+        "skills": StaticCampaignSkillStore(),
+    }
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        result = await generate_campaign_drafts_from_postgres(
+            pool,
+            scope={"account_id": args.account_id, "user_id": args.user_id},
+            target_mode=args.target_mode,
+            channel=args.channel,
+            limit=args.limit,
+            filters=_json_object(args.filters_json),
+            **_dependency_overrides(args),
+        )
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    output = json.dumps(result.as_dict(), indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(f"{output}\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -16,6 +16,7 @@ pytest \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
+  tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_reasoning_archetypes.py \
   tests/test_extracted_reasoning_temporal.py \

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -20,6 +20,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/reasoning/temporal.py",
     "extracted_content_pipeline/reasoning/wedge_registry.py",
     "extracted_content_pipeline/campaign_generation.py",
+    "extracted_content_pipeline/campaign_postgres_generation.py",
     "extracted_content_pipeline/campaign_customer_data.py",
     "extracted_content_pipeline/campaign_ports.py",
     "extracted_content_pipeline/config.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -107,6 +107,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/campaign_ports.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
+    assert "extracted_content_pipeline/campaign_postgres_generation.py" in owned
     assert "extracted_content_pipeline/campaign_example.py" in owned
     assert "extracted_content_pipeline/campaign_customer_data.py" in owned
     assert "extracted_content_pipeline/campaign_opportunities.py" in owned
@@ -140,6 +141,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
 
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
+    assert "extracted_content_pipeline/campaign_postgres_generation.py" not in mapped
     assert "extracted_content_pipeline/campaign_example.py" not in mapped
     assert "extracted_content_pipeline/campaign_customer_data.py" not in mapped
     assert "extracted_content_pipeline/campaign_opportunities.py" not in mapped

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
+from extracted_content_pipeline.campaign_postgres_generation import (
+    generate_campaign_drafts_from_postgres,
+    tenant_scope_from_mapping,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_postgres_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_extracted_campaign_generation_postgres",
+        ROOT / "scripts/run_extracted_campaign_generation_postgres.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    def __init__(self):
+        self.fetch_rows = []
+        self.fetchval_results = ["campaign-1"]
+        self.fetch_calls = []
+        self.fetchval_calls = []
+        self.closed = False
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+class _LLM:
+    def __init__(self):
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        return LLMResponse(
+            content=json.dumps({
+                "subject": "Acme pricing signal",
+                "body": "<p>Pricing pressure is showing up.</p>",
+                "cta": "Review the account",
+            }),
+            model="test-model",
+        )
+
+
+class _Skills:
+    def __init__(self):
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return "Mode={target_mode}; opportunity={opportunity_json}"
+
+
+@pytest.mark.asyncio
+async def test_generate_campaign_drafts_from_postgres_reads_generates_and_saves():
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "contact_email": "buyer@example.com",
+            "pain_points": ["pricing"],
+            "competitors": ["Salesforce"],
+            "raw_payload": {"custom_segment": "enterprise"},
+        }
+    ]
+    llm = _LLM()
+    skills = _Skills()
+
+    result = await generate_campaign_drafts_from_postgres(
+        pool,
+        scope={"account_id": "acct-1", "user_id": "user-1"},
+        target_mode="vendor_retention",
+        channel="email",
+        limit=5,
+        filters={"vendor_name": "HubSpot"},
+        llm=llm,
+        skills=skills,
+    )
+
+    assert result.as_dict() == {
+        "requested": 1,
+        "generated": 1,
+        "skipped": 0,
+        "saved_ids": ["campaign-1"],
+        "errors": [],
+    }
+    assert "FROM \"campaign_opportunities\"" in pool.fetch_calls[0]["query"]
+    assert pool.fetch_calls[0]["args"] == ("vendor_retention", "acct-1", "HubSpot", 5)
+    assert '"custom_segment":"enterprise"' in llm.calls[0]["messages"][0].content
+    save_call = pool.fetchval_calls[0]
+    assert "INSERT INTO b2b_campaigns" in save_call["query"]
+    assert save_call["args"][:9] == (
+        "Acme",
+        "HubSpot",
+        None,
+        "vendor_retention",
+        "email",
+        "Acme pricing signal",
+        "<p>Pricing pressure is showing up.</p>",
+        "Review the account",
+        "buyer@example.com",
+    )
+    metadata = json.loads(save_call["args"][9])
+    assert metadata["scope"] == {"account_id": "acct-1", "user_id": "user-1"}
+    assert metadata["source_opportunity"]["custom_segment"] == "enterprise"
+    assert save_call["args"][10] == "test-model"
+
+
+def test_tenant_scope_from_mapping_accepts_mapping_and_existing_scope():
+    scope = tenant_scope_from_mapping({
+        "account_id": "acct-1",
+        "user_id": "user-1",
+        "allowed_vendors": ["HubSpot"],
+        "roles": ["admin"],
+    })
+
+    assert scope == TenantScope(
+        account_id="acct-1",
+        user_id="user-1",
+        allowed_vendors=("HubSpot",),
+        roles=("admin",),
+    )
+    assert tenant_scope_from_mapping(scope) is scope
+    assert tenant_scope_from_mapping(None) == TenantScope()
+
+
+@pytest.mark.asyncio
+async def test_postgres_runner_cli_wires_pool_and_offline_dependencies(monkeypatch, capsys):
+    postgres_cli = _load_postgres_cli_module()
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "contact_email": "buyer@example.com",
+            "pain_points": ["pricing"],
+            "raw_payload": {},
+        }
+    ]
+    created_urls = []
+
+    async def create_pool(database_url):
+        created_urls.append(database_url)
+        return pool
+
+    monkeypatch.setattr(postgres_cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        postgres_cli.sys,
+        "argv",
+        [
+            "run",
+            "--database-url",
+            "postgres://example",
+            "--account-id",
+            "acct-1",
+            "--target-mode",
+            "vendor_retention",
+            "--limit",
+            "1",
+            "--llm",
+            "offline",
+        ],
+    )
+
+    exit_code = await postgres_cli._main()
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert exit_code == 0
+    assert created_urls == ["postgres://example"]
+    assert output["generated"] == 1
+    assert output["saved_ids"] == ["campaign-1"]
+    assert pool.closed is True
+
+
+@pytest.mark.asyncio
+async def test_postgres_runner_cli_requires_database_url(monkeypatch):
+    postgres_cli = _load_postgres_cli_module()
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(postgres_cli.sys, "argv", ["run"])
+
+    with pytest.raises(SystemExit, match="Missing --database-url"):
+        await postgres_cli._main()


### PR DESCRIPTION
## Summary
- add campaign_postgres_generation.py to wire PostgresIntelligenceRepository, PostgresCampaignRepository, PipelineLLMClient, and skills into one generation runner
- add a Postgres CLI that reads campaign_opportunities and persists generated drafts into b2b_campaigns
- document the database-backed generation path and add extracted pipeline test coverage

## Verification
- python -m py_compile extracted_content_pipeline/campaign_postgres_generation.py scripts/run_extracted_campaign_generation_postgres.py tests/test_extracted_campaign_postgres_generation.py
- EXTRACTED_PIPELINE_STANDALONE=1 pytest tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_postgres.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py
- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh