### PR TITLE
Add multi-channel campaign generation flow

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -130,6 +130,13 @@ draft metadata:
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.csv --format csv
 ```
 
+Generate cold-email and follow-up drafts for each opportunity by passing
+channels:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py --channels email_cold,email_followup
+```
+
 The example uses in-memory product ports and an offline deterministic LLM stand
 in, so it does not need Atlas, a database, or provider credentials. It proves
 the customer-data path: JSON opportunities in, normalized campaign drafts out.
@@ -148,6 +155,12 @@ For database-backed runs, apply the product migrations, set
 
 ```bash
 python scripts/run_extracted_campaign_generation_postgres.py --account-id acct_123 --limit 10
+```
+
+The Postgres runner accepts the same channel expansion:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py --account-id acct_123 --channels email_cold,email_followup
 ```
 
 ## Import smoke test

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -32,6 +32,10 @@
 - `campaign_postgres_generation` wires the DB-backed generation path from
   `campaign_opportunities` to saved `b2b_campaigns` drafts through product
   ports.
+- `CampaignGenerationService` supports multi-channel draft expansion through
+  product config (`channels=("email_cold", "email_followup")`), including
+  passing the generated cold-email context into follow-up prompts without
+  importing the copied Atlas campaign task.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -205,6 +205,22 @@ def _scope_from_payload(payload: Mapping[str, Any]) -> TenantScope:
     )
 
 
+def _channels_from_payload(payload: Mapping[str, Any], *, default: str) -> tuple[str, ...]:
+    raw = payload.get("channels")
+    if isinstance(raw, str):
+        values = raw.split(",")
+    elif isinstance(raw, Sequence) and not isinstance(raw, (bytes, bytearray)):
+        values = raw
+    else:
+        values = ()
+    channels = tuple(
+        str(item or "").strip()
+        for item in values
+        if str(item or "").strip()
+    )
+    return channels or (default,)
+
+
 def _draft_to_dict(draft: CampaignDraft, campaign_id: str) -> dict[str, Any]:
     return {
         "id": campaign_id,
@@ -242,6 +258,7 @@ async def generate_campaign_drafts_from_payload(
         raise ValueError("payload must include an opportunities array")
     target_mode = str(payload.get("target_mode") or "vendor_retention")
     channel = str(payload.get("channel") or "email")
+    channels = _channels_from_payload(payload, default=channel)
     limit = int(payload.get("limit") or len(opportunities) or 20)
 
     intelligence = InMemoryIntelligenceRepository(
@@ -255,7 +272,11 @@ async def generate_campaign_drafts_from_payload(
         campaigns=campaigns,
         llm=llm_client,
         skills=skill_store,
-        config=CampaignGenerationConfig(channel=channel, limit=limit),
+        config=CampaignGenerationConfig(
+            channel=channel,
+            channels=channels,
+            limit=limit,
+        ),
     )
 
     result = await service.generate(

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 import json
 import re
@@ -37,6 +37,7 @@ class CampaignGenerationConfig:
     max_tokens: int = 1200
     temperature: float = 0.4
     include_source_opportunity: bool = True
+    channels: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -150,6 +151,7 @@ class CampaignGenerationService:
         drafts: list[CampaignDraft] = []
         errors: list[dict[str, Any]] = []
         skipped = 0
+        channels = self._channels()
         for opportunity in opportunities:
             target_id = opportunity_target_id(opportunity)
             if not target_id:
@@ -163,29 +165,55 @@ class CampaignGenerationService:
                     target_id=target_id,
                     opportunity=opportunity,
                 )
-                parsed = await self._generate_one(
-                    prompt_template,
-                    opportunity=opportunity,
-                    target_mode=target_mode,
-                )
             except Exception as exc:
                 skipped += 1
                 errors.append({"target_id": target_id, "reason": str(exc)})
                 continue
-            if not parsed:
-                skipped += 1
-                errors.append({"target_id": target_id, "reason": "unparseable_response"})
-                continue
-            drafts.append(
-                CampaignDraft(
-                    target_id=target_id,
-                    target_mode=target_mode,
-                    channel=self._config.channel,
-                    subject=parsed["subject"],
-                    body=parsed["body"],
-                    metadata=self._metadata(parsed, opportunity),
+            cold_email_context: dict[str, str] | None = None
+            for channel in channels:
+                channel_opportunity = self._opportunity_for_channel(
+                    opportunity,
+                    channel=channel,
+                    cold_email_context=cold_email_context,
                 )
-            )
+                try:
+                    parsed = await self._generate_one(
+                        prompt_template,
+                        opportunity=channel_opportunity,
+                        target_mode=target_mode,
+                        channel=channel,
+                    )
+                except Exception as exc:
+                    skipped += 1
+                    errors.append({
+                        "target_id": target_id,
+                        "channel": channel,
+                        "reason": str(exc),
+                    })
+                    continue
+                if not parsed:
+                    skipped += 1
+                    errors.append({
+                        "target_id": target_id,
+                        "channel": channel,
+                        "reason": "unparseable_response",
+                    })
+                    continue
+                if channel == "email_cold":
+                    cold_email_context = {
+                        "subject": parsed["subject"],
+                        "body": parsed["body"],
+                    }
+                drafts.append(
+                    CampaignDraft(
+                        target_id=target_id,
+                        target_mode=target_mode,
+                        channel=channel,
+                        subject=parsed["subject"],
+                        body=parsed["body"],
+                        metadata=self._metadata(parsed, channel_opportunity),
+                    )
+                )
 
         saved_ids: tuple[str, ...] = ()
         if drafts:
@@ -200,6 +228,36 @@ class CampaignGenerationService:
             saved_ids=saved_ids,
             errors=tuple(errors),
         )
+
+    def _channels(self) -> tuple[str, ...]:
+        raw_value = self._config.channels or (self._config.channel,)
+        raw: Sequence[str]
+        if isinstance(raw_value, str):
+            raw = raw_value.split(",")
+        else:
+            raw = raw_value
+        channels: list[str] = []
+        for item in raw:
+            channel = str(item or "").strip()
+            if channel and channel not in channels:
+                channels.append(channel)
+        return tuple(channels or ("email",))
+
+    def _opportunity_for_channel(
+        self,
+        opportunity: Mapping[str, Any],
+        *,
+        channel: str,
+        cold_email_context: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        enriched = dict(opportunity)
+        enriched["channel"] = channel
+        if channel == "email_followup" and cold_email_context:
+            enriched["cold_email_context"] = {
+                "subject": str(cold_email_context.get("subject") or ""),
+                "body": str(cold_email_context.get("body") or ""),
+            }
+        return enriched
 
     async def _opportunity_with_reasoning_context(
         self,
@@ -244,11 +302,13 @@ class CampaignGenerationService:
         *,
         opportunity: Mapping[str, Any],
         target_mode: str,
+        channel: str,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         system_prompt = (
             prompt_template
             .replace("{target_mode}", target_mode)
+            .replace("{channel}", channel)
             .replace("{opportunity}", opportunity_json)
             .replace("{opportunity_json}", opportunity_json)
         )
@@ -260,6 +320,7 @@ class CampaignGenerationService:
                     content=(
                         "Generate one campaign draft from this normalized "
                         f"opportunity.\ntarget_mode={target_mode}\n"
+                        f"channel={channel}\n"
                         f"opportunity={opportunity_json}"
                     ),
                 ),
@@ -269,6 +330,7 @@ class CampaignGenerationService:
             metadata={
                 "target_mode": target_mode,
                 "target_id": opportunity_target_id(opportunity),
+                "channel": channel,
                 "skill_name": self._config.skill_name,
             },
         )

--- a/extracted_content_pipeline/campaign_postgres_generation.py
+++ b/extracted_content_pipeline/campaign_postgres_generation.py
@@ -45,6 +45,7 @@ async def generate_campaign_drafts_from_postgres(
     scope: Mapping[str, Any] | TenantScope | None = None,
     target_mode: str = "vendor_retention",
     channel: str = "email",
+    channels: tuple[str, ...] = (),
     limit: int = 20,
     filters: Mapping[str, Any] | None = None,
     llm: LLMClient | None = None,
@@ -58,6 +59,7 @@ async def generate_campaign_drafts_from_postgres(
 
     generation_config = config or CampaignGenerationConfig(
         channel=channel,
+        channels=channels,
         limit=limit,
     )
     service = CampaignGenerationService(

--- a/extracted_content_pipeline/docs/remaining_productization_audit.md
+++ b/extracted_content_pipeline/docs/remaining_productization_audit.md
@@ -248,3 +248,11 @@ Acceptance criteria:
 - Generate and persist drafts through `CampaignRepository`.
 - Keep `_b2b_pool_compression.py`, `_b2b_witnesses.py`, and `_b2b_shared.py`
   out of the product-owned path.
+
+Status: first slice implemented. `CampaignGenerationService` now expands one
+normalized opportunity into configured channels such as `email_cold` and
+`email_followup`, passes the generated cold-email context into the follow-up
+prompt, and saves both drafts through `CampaignRepository`. The offline
+customer-data runner and Postgres runner both expose `--channels` so the copied
+task's cold/follow-up producer shape is now available through the product-owned
+ports.

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -112,6 +112,13 @@ slice. It reads campaign opportunities through `IntelligenceRepository`, prompts
 through `SkillStore` and `LLMClient`, parses generated draft JSON, and persists
 `CampaignDraft` rows through `CampaignRepository`.
 
+The generator now owns the first concrete copied-task producer behavior:
+multi-channel expansion for one normalized opportunity. Hosts can request
+`email_cold` and `email_followup` drafts in one run, and the follow-up prompt
+receives the generated cold-email context through the product opportunity
+payload. This keeps the cold/follow-up flow inside the product-owned ports
+instead of calling the copied `b2b_campaign_generation.py` task.
+
 `extracted_content_pipeline/campaign_postgres_generation.py` wires the
 database-backed product path. Hosts pass an async Postgres pool and the runner
 combines `PostgresIntelligenceRepository`, `PostgresCampaignRepository`,

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -59,6 +59,13 @@ def _parse_args() -> argparse.Namespace:
         help="Override the payload target_mode.",
     )
     parser.add_argument(
+        "--channels",
+        help=(
+            "Comma-separated draft channels to generate per opportunity, "
+            "for example email_cold,email_followup."
+        ),
+    )
+    parser.add_argument(
         "--format",
         choices=("auto", "json", "csv"),
         default="auto",
@@ -106,6 +113,12 @@ async def _main() -> int:
     payload = _load_payload(args.payload, file_format=args.format)
     if args.target_mode:
         payload["target_mode"] = args.target_mode
+    if args.channels:
+        payload["channels"] = [
+            item.strip()
+            for item in args.channels.split(",")
+            if item.strip()
+        ]
     if args.limit is not None:
         payload["limit"] = args.limit
 

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -50,6 +50,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--user-id", help="User id to attach to generated draft metadata.")
     parser.add_argument("--target-mode", default="vendor_retention")
     parser.add_argument("--channel", default="email")
+    parser.add_argument(
+        "--channels",
+        help=(
+            "Comma-separated draft channels to generate per opportunity, "
+            "for example email_cold,email_followup."
+        ),
+    )
     parser.add_argument("--limit", type=int, default=20)
     parser.add_argument(
         "--filters-json",
@@ -99,6 +106,11 @@ async def _main() -> int:
             scope={"account_id": args.account_id, "user_id": args.user_id},
             target_mode=args.target_mode,
             channel=args.channel,
+            channels=tuple(
+                item.strip()
+                for item in str(args.channels or "").split(",")
+                if item.strip()
+            ),
             limit=args.limit,
             filters=_json_object(args.filters_json),
             **_dependency_overrides(args),

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -258,9 +258,11 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
     assert '"target_mode":"churning_company"' in llm_call["messages"][0].content
     assert '"company_name":"Acme"' in llm_call["messages"][1].content
     assert "target_mode=churning_company" in llm_call["messages"][1].content
+    assert "channel=email" in llm_call["messages"][1].content
     assert llm_call["metadata"] == {
         "target_mode": "churning_company",
         "target_id": "opp-1",
+        "channel": "email",
         "skill_name": "digest/b2b_campaign_generation",
     }
     draft = campaigns.saved[0]["drafts"][0]
@@ -273,6 +275,7 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
     assert draft.metadata["generation_model"] == "test-model"
     assert draft.metadata["source_opportunity"]["target_id"] == "opp-1"
     assert draft.metadata["source_opportunity"]["target_mode"] == "churning_company"
+    assert draft.metadata["source_opportunity"]["channel"] == "email"
     assert draft.metadata["source_opportunity"]["company_name"] == "Acme"
     assert draft.metadata["source_opportunity"]["pain"] == "pricing pressure"
 
@@ -298,9 +301,75 @@ async def test_generate_includes_opportunity_payload_when_skill_has_no_placehold
     assert "opportunity=" not in llm.calls[0]["messages"][0].content
     user_prompt = llm.calls[0]["messages"][1].content
     assert "target_mode=vendor_retention" in user_prompt
+    assert "channel=email" in user_prompt
     assert '"target_id":"opp-1"' in user_prompt
     assert '"company_name":"Acme"' in user_prompt
     assert '"target_mode":"vendor_retention"' in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_expands_configured_channels_and_passes_cold_context():
+    config = CampaignGenerationConfig(channels=("email_cold", "email_followup"))
+    service, _, campaigns, llm, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [
+            json.dumps({"subject": "Cold subject", "body": "<p>Cold body</p>"}),
+            json.dumps({"subject": "Follow-up subject", "body": "<p>Follow-up body</p>"}),
+        ],
+        config=config,
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.as_dict() == {
+        "requested": 1,
+        "generated": 2,
+        "skipped": 0,
+        "saved_ids": ["draft-1", "draft-2"],
+        "errors": [],
+    }
+    cold, followup = campaigns.saved[0]["drafts"]
+    assert cold.channel == "email_cold"
+    assert cold.subject == "Cold subject"
+    assert followup.channel == "email_followup"
+    assert followup.subject == "Follow-up subject"
+    assert cold.metadata["source_opportunity"]["channel"] == "email_cold"
+    assert followup.metadata["source_opportunity"]["channel"] == "email_followup"
+    assert followup.metadata["source_opportunity"]["cold_email_context"] == {
+        "subject": "Cold subject",
+        "body": "<p>Cold body</p>",
+    }
+    assert [call["metadata"]["channel"] for call in llm.calls] == [
+        "email_cold",
+        "email_followup",
+    ]
+    assert "channel=email_cold" in llm.calls[0]["messages"][1].content
+    assert "channel=email_followup" in llm.calls[1]["messages"][1].content
+    assert "cold_email_context" in llm.calls[1]["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_generate_accepts_comma_string_channels_defensively():
+    config = CampaignGenerationConfig(channels="email_cold,email_followup")  # type: ignore[arg-type]
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [
+            json.dumps({"subject": "Cold subject", "body": "<p>Cold body</p>"}),
+            json.dumps({"subject": "Follow-up subject", "body": "<p>Follow-up body</p>"}),
+        ],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 2
+    assert [draft.channel for draft in campaigns.saved[0]["drafts"]] == [
+        "email_cold",
+        "email_followup",
+    ]
 
 
 @pytest.mark.asyncio
@@ -521,7 +590,11 @@ async def test_generate_skips_missing_target_and_unparseable_responses():
     assert result.generated == 0
     assert result.skipped == 2
     assert result.errors[0]["reason"] == "missing_target_id"
-    assert result.errors[1] == {"target_id": "opp-2", "reason": "unparseable_response"}
+    assert result.errors[1] == {
+        "target_id": "opp-2",
+        "channel": "email",
+        "reason": "unparseable_response",
+    }
     assert campaigns.saved == []
 
 
@@ -542,7 +615,9 @@ async def test_generate_continues_after_llm_error():
 
     assert result.generated == 1
     assert result.skipped == 1
-    assert result.errors == ({"target_id": "opp-1", "reason": "provider down"},)
+    assert result.errors == (
+        {"target_id": "opp-1", "channel": "email", "reason": "provider down"},
+    )
     assert campaigns.saved[0]["drafts"][0].target_id == "opp-2"
 
 

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -118,6 +118,32 @@ async def test_example_accepts_host_llm_and_skill_store_overrides() -> None:
 
 
 @pytest.mark.asyncio
+async def test_example_generates_cold_and_followup_channels_from_payload() -> None:
+    payload = {
+        "target_mode": "vendor_retention",
+        "channels": ["email_cold", "email_followup"],
+        "limit": 1,
+        "opportunities": [
+            {"id": "opp-1", "company": "Acme Logistics", "vendor": "HubSpot"}
+        ],
+    }
+
+    result = await generate_campaign_drafts_from_payload(payload)
+
+    assert result["result"]["generated"] == 2
+    assert result["result"]["saved_ids"] == ["draft-1", "draft-2"]
+    assert [draft["channel"] for draft in result["drafts"]] == [
+        "email_cold",
+        "email_followup",
+    ]
+    followup = result["drafts"][1]
+    assert followup["metadata"]["source_opportunity"]["cold_email_context"] == {
+        "subject": result["drafts"][0]["subject"],
+        "body": result["drafts"][0]["body"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_example_respects_limit_and_normalizes_multiple_rows() -> None:
     payload = json.loads(EXAMPLE_PAYLOAD.read_text(encoding="utf-8"))
 

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -135,6 +135,44 @@ async def test_generate_campaign_drafts_from_postgres_reads_generates_and_saves(
     assert save_call["args"][10] == "test-model"
 
 
+@pytest.mark.asyncio
+async def test_generate_campaign_drafts_from_postgres_supports_channel_expansion():
+    pool = _Pool()
+    pool.fetchval_results = ["campaign-1", "campaign-2"]
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "raw_payload": {},
+        }
+    ]
+
+    result = await generate_campaign_drafts_from_postgres(
+        pool,
+        scope={"account_id": "acct-1"},
+        target_mode="vendor_retention",
+        channel="email",
+        channels=("email_cold", "email_followup"),
+        limit=1,
+        llm=_LLM(),
+        skills=_Skills(),
+    )
+
+    assert result.generated == 2
+    assert result.saved_ids == ("campaign-1", "campaign-2")
+    assert [call["args"][4] for call in pool.fetchval_calls] == [
+        "email_cold",
+        "email_followup",
+    ]
+    followup_metadata = json.loads(pool.fetchval_calls[1]["args"][9])
+    assert followup_metadata["source_opportunity"]["channel"] == "email_followup"
+    assert followup_metadata["source_opportunity"]["cold_email_context"] == {
+        "subject": "Acme pricing signal",
+        "body": "<p>Pricing pressure is showing up.</p>",
+    }
+
+
 def test_tenant_scope_from_mapping_accepts_mapping_and_existing_scope():
     scope = tenant_scope_from_mapping({
         "account_id": "acct-1",


### PR DESCRIPTION
## Summary

- Add product-owned multi-channel expansion to CampaignGenerationService
- Support cold email + follow-up generation through channels=(email_cold, email_followup)
- Pass generated cold-email context into follow-up prompts without importing the copied Atlas campaign task
- Expose --channels in the offline customer-data runner and Postgres runner
- Update extraction docs/status to mark the first copied-task producer behavior as product-owned

## Validation

- python -m py_compile extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/campaign_example.py extracted_content_pipeline/campaign_postgres_generation.py scripts/run_extracted_campaign_generation_example.py scripts/run_extracted_campaign_generation_postgres.py
- pytest tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py -q -> 29 passed
- EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh -> 241 passed, standalone audit 0 Atlas runtime imports
