### PR TITLE
Add shared reasoning core wedge registry

### DIFF
--- a/extracted_competitive_intelligence/reasoning/wedge_registry.py
+++ b/extracted_competitive_intelligence/reasoning/wedge_registry.py
@@ -1,23 +1,26 @@
-"""Phase 1 bridge: re-exports atlas_brain.reasoning.wedge_registry.
+"""Compatibility wrapper for the shared extracted reasoning wedge registry."""
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
-"""
 from __future__ import annotations
 
-import importlib as _importlib
+from extracted_reasoning_core.api import (
+    WEDGE_ENUM_VALUES,
+    Wedge,
+    WedgeMeta,
+    get_required_pools,
+    get_sales_motion,
+    get_wedge_meta,
+    validate_wedge,
+    wedge_from_archetype,
+)
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.reasoning.wedge_registry")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
 
-
-_bridge()
-del _bridge, _importlib
+__all__ = [
+    "WEDGE_ENUM_VALUES",
+    "Wedge",
+    "WedgeMeta",
+    "get_required_pools",
+    "get_sales_motion",
+    "get_wedge_meta",
+    "validate_wedge",
+    "wedge_from_archetype",
+]

--- a/extracted_content_pipeline/reasoning/wedge_registry.py
+++ b/extracted_content_pipeline/reasoning/wedge_registry.py
@@ -1,28 +1,26 @@
+"""Compatibility wrapper for the shared extracted reasoning wedge registry."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
+from extracted_reasoning_core.api import (
+    WEDGE_ENUM_VALUES,
+    Wedge,
+    WedgeMeta,
+    get_required_pools,
+    get_sales_motion,
+    get_wedge_meta,
+    validate_wedge,
+    wedge_from_archetype,
+)
 
 
-class Wedge(str, Enum):
-    PRICING = "pricing"
-    SUPPORT = "support"
-    RELIABILITY = "reliability"
-    FEATURES = "features"
-    INTEGRATIONS = "integrations"
-
-
-@dataclass
-class WedgeMeta:
-    label: str
-
-
-def get_wedge_meta(wedge: Wedge) -> WedgeMeta:
-    return WedgeMeta(label=str(wedge.value).replace("_", " ").title())
-
-
-def validate_wedge(value: str) -> str:
-    norm = str(value or "").strip().lower()
-    if norm in {w.value for w in Wedge}:
-        return norm
-    return Wedge.SUPPORT.value
+__all__ = [
+    "WEDGE_ENUM_VALUES",
+    "Wedge",
+    "WedgeMeta",
+    "get_required_pools",
+    "get_sales_motion",
+    "get_wedge_meta",
+    "validate_wedge",
+    "wedge_from_archetype",
+]

--- a/extracted_reasoning_core/__init__.py
+++ b/extracted_reasoning_core/__init__.py
@@ -1,0 +1,7 @@
+"""Extracted reasoning core public package."""
+
+from .api import *
+from .ports import *
+from .state import *
+from .tiers import *
+from .types import *

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -95,14 +95,14 @@ def build_narrative_plan(
 
 
 async def run_reasoning(
-    input: ReasoningInput,
+    reasoning_input: ReasoningInput,
     *,
     depth: ReasoningDepth = "L2",
     pack: ReasoningPack | None = None,
     ports: ReasoningPorts | None = None,
 ) -> ReasoningResult:
     """Run the shared reasoning engine."""
-    del input
+    del reasoning_input
     del depth
     del pack
     del ports
@@ -144,13 +144,13 @@ def compute_evidence_hash(evidence: Mapping[str, Any]) -> str:
 
 
 def build_semantic_cache_key(
-    input: ReasoningInput,
+    reasoning_input: ReasoningInput,
     *,
     tier: str,
     pack_name: str | None = None,
 ) -> str:
     """Build a stable semantic-cache key for a reasoning input."""
-    del input
+    del reasoning_input
     del tier
     del pack_name
     raise NotImplementedError("build_semantic_cache_key lands with semantic-cache split")

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -1,0 +1,219 @@
+"""Public API for the extracted reasoning core."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from .types import (
+    ArchetypeMatch,
+    EvidenceDecision,
+    EvidenceItem,
+    EvidencePolicy,
+    FalsificationPolicy,
+    FalsificationResult,
+    NarrativePlan,
+    OutputPolicy,
+    ReasoningDepth,
+    ReasoningInput,
+    ReasoningPack,
+    ReasoningPorts,
+    ReasoningResult,
+    TemporalEvidence,
+    ValidationReport,
+)
+from .state import ReasoningAgentState
+from .tiers import (
+    TIER_CONFIGS,
+    Tier,
+    TierConfig,
+    build_tiered_pattern_sig,
+    gather_tier_context,
+    get_tier_config,
+    needs_refresh,
+)
+from .wedge_registry import (
+    WEDGE_ENUM_VALUES,
+    Wedge,
+    WedgeMeta,
+    get_required_pools,
+    get_sales_motion,
+    get_wedge_meta,
+    validate_wedge,
+    wedge_from_archetype,
+)
+
+
+def score_archetypes(
+    evidence: Mapping[str, Any],
+    temporal: Mapping[str, Any] | None = None,
+    *,
+    limit: int = 3,
+) -> Sequence[ArchetypeMatch]:
+    """Score evidence against shared archetypes.
+
+    The implementation lands when `archetypes.py` is consolidated into the
+    core. The public name is reserved now so products can depend on the stable
+    API shape instead of importing product-local forks.
+    """
+    del evidence
+    del temporal
+    del limit
+    raise NotImplementedError("score_archetypes lands with archetype consolidation")
+
+
+def evaluate_evidence(
+    evidence: Mapping[str, Any],
+    *,
+    policy: EvidencePolicy | None = None,
+) -> EvidenceDecision:
+    """Evaluate evidence against a shared policy."""
+    del evidence
+    del policy
+    raise NotImplementedError("evaluate_evidence lands with evidence consolidation")
+
+
+def build_temporal_evidence(
+    snapshots: Sequence[Mapping[str, Any]],
+    *,
+    baselines: Mapping[str, Any] | None = None,
+) -> TemporalEvidence:
+    """Build normalized temporal evidence from snapshots."""
+    del snapshots
+    del baselines
+    raise NotImplementedError("build_temporal_evidence lands with temporal consolidation")
+
+
+def build_narrative_plan(
+    context: Mapping[str, Any],
+    *,
+    pack: ReasoningPack,
+) -> NarrativePlan:
+    """Build a product-neutral narrative plan."""
+    del context
+    del pack
+    raise NotImplementedError("build_narrative_plan lands with narrative consolidation")
+
+
+async def run_reasoning(
+    input: ReasoningInput,
+    *,
+    depth: ReasoningDepth = "L2",
+    pack: ReasoningPack | None = None,
+    ports: ReasoningPorts | None = None,
+) -> ReasoningResult:
+    """Run the shared reasoning engine."""
+    del input
+    del depth
+    del pack
+    del ports
+    raise NotImplementedError("run_reasoning lands with graph/state consolidation")
+
+
+async def continue_reasoning(
+    state: Mapping[str, Any],
+    event: Mapping[str, Any],
+    *,
+    ports: ReasoningPorts | None = None,
+) -> ReasoningResult:
+    """Continue a prior reasoning state with a new event."""
+    del state
+    del event
+    del ports
+    raise NotImplementedError("continue_reasoning lands with graph/state consolidation")
+
+
+async def check_falsification(
+    claim: Mapping[str, Any],
+    fresh_evidence: Sequence[EvidenceItem],
+    *,
+    policy: FalsificationPolicy | None = None,
+    ports: ReasoningPorts | None = None,
+) -> FalsificationResult:
+    """Check whether fresh evidence falsifies a prior claim."""
+    del claim
+    del fresh_evidence
+    del policy
+    del ports
+    raise NotImplementedError("check_falsification lands with falsification consolidation")
+
+
+def compute_evidence_hash(evidence: Mapping[str, Any]) -> str:
+    """Compute the stable reasoning evidence hash."""
+    del evidence
+    raise NotImplementedError("compute_evidence_hash lands with semantic-cache split")
+
+
+def build_semantic_cache_key(
+    input: ReasoningInput,
+    *,
+    tier: str,
+    pack_name: str | None = None,
+) -> str:
+    """Build a stable semantic-cache key for a reasoning input."""
+    del input
+    del tier
+    del pack_name
+    raise NotImplementedError("build_semantic_cache_key lands with semantic-cache split")
+
+
+def load_reasoning_pack(name: str) -> ReasoningPack:
+    """Load a named reasoning pack."""
+    del name
+    raise NotImplementedError("load_reasoning_pack lands with pack registry")
+
+
+def validate_reasoning_output(
+    result: ReasoningResult,
+    *,
+    policy: OutputPolicy | None = None,
+) -> ValidationReport:
+    """Validate a reasoned output against output policy."""
+    del result
+    del policy
+    raise NotImplementedError("validate_reasoning_output lands with validation policy")
+
+
+__all__ = [
+    "WEDGE_ENUM_VALUES",
+    "ArchetypeMatch",
+    "EvidenceDecision",
+    "EvidenceItem",
+    "EvidencePolicy",
+    "FalsificationPolicy",
+    "FalsificationResult",
+    "NarrativePlan",
+    "OutputPolicy",
+    "ReasoningDepth",
+    "ReasoningAgentState",
+    "ReasoningInput",
+    "ReasoningPack",
+    "ReasoningPorts",
+    "ReasoningResult",
+    "TemporalEvidence",
+    "ValidationReport",
+    "Wedge",
+    "WedgeMeta",
+    "TIER_CONFIGS",
+    "Tier",
+    "TierConfig",
+    "build_narrative_plan",
+    "build_semantic_cache_key",
+    "build_temporal_evidence",
+    "build_tiered_pattern_sig",
+    "check_falsification",
+    "compute_evidence_hash",
+    "evaluate_evidence",
+    "gather_tier_context",
+    "get_required_pools",
+    "get_sales_motion",
+    "get_tier_config",
+    "get_wedge_meta",
+    "load_reasoning_pack",
+    "needs_refresh",
+    "run_reasoning",
+    "score_archetypes",
+    "continue_reasoning",
+    "validate_reasoning_output",
+    "validate_wedge",
+    "wedge_from_archetype",
+]

--- a/extracted_reasoning_core/ports.py
+++ b/extracted_reasoning_core/ports.py
@@ -1,0 +1,61 @@
+"""Public ports for the extracted reasoning core."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping, Protocol, Sequence
+
+
+class LLMClient(Protocol):
+    """Provider-neutral completion port used by reasoning runners."""
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        """Return a provider completion response."""
+
+
+class SemanticCacheStore(Protocol):
+    """Port for semantic reasoning-cache storage."""
+
+    async def lookup(self, key: str) -> Mapping[str, Any] | None:
+        """Return a cached reasoning entry, if present and usable."""
+
+    async def store(self, key: str, value: Mapping[str, Any]) -> None:
+        """Persist a reasoning-cache entry."""
+
+    async def validate(self, key: str, confidence: float | None = None) -> None:
+        """Refresh validation metadata for a cached entry."""
+
+    async def invalidate(self, key: str, reason: str = "") -> None:
+        """Invalidate a cached entry."""
+
+
+class ReasoningStateStore(Protocol):
+    """Port for long-running reasoning state and continuation checkpoints."""
+
+    async def load_state(self, state_id: str) -> Mapping[str, Any] | None:
+        """Return a stored reasoning state by id."""
+
+    async def save_state(self, state_id: str, state: Mapping[str, Any]) -> None:
+        """Persist a reasoning state snapshot."""
+
+
+class Clock(Protocol):
+    """Deterministic time source for recency and cache-decay decisions."""
+
+    def now(self) -> datetime:
+        """Return the current time."""
+
+
+__all__ = [
+    "Clock",
+    "LLMClient",
+    "ReasoningStateStore",
+    "SemanticCacheStore",
+]

--- a/extracted_reasoning_core/state.py
+++ b/extracted_reasoning_core/state.py
@@ -1,0 +1,37 @@
+"""State definition for extracted reasoning runners."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, TypedDict
+
+
+class ReasoningAgentState(TypedDict, total=False):
+    """State flowing through reasoning graph nodes."""
+
+    event_id: str
+    event_type: str
+    source: str
+    entity_type: Optional[str]
+    entity_id: Optional[str]
+    payload: dict[str, Any]
+    triage_priority: str
+    triage_reasoning: str
+    needs_reasoning: bool
+    context: dict[str, Any]
+    entity_locked: bool
+    lock_holder: Optional[str]
+    queued: bool
+    reasoning_output: str
+    connections_found: list[str]
+    recommended_actions: list[dict[str, Any]]
+    rationale: str
+    planned_actions: list[dict[str, Any]]
+    action_results: list[dict[str, Any]]
+    summary: str
+    should_notify: bool
+    notification_sent: bool
+    total_input_tokens: int
+    total_output_tokens: int
+
+
+__all__ = ["ReasoningAgentState"]

--- a/extracted_reasoning_core/tiers.py
+++ b/extracted_reasoning_core/tiers.py
@@ -1,0 +1,172 @@
+"""Hierarchical abstraction tiers for extracted reasoning."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import IntEnum
+from typing import Any
+
+logger = logging.getLogger("extracted_reasoning_core.tiers")
+
+
+class Tier(IntEnum):
+    """Reasoning abstraction tiers."""
+
+    VENDOR_STATE = 1
+    VENDOR_ARCHETYPE = 2
+    CATEGORY_PATTERN = 3
+    MARKET_DYNAMICS = 4
+
+
+@dataclass(frozen=True)
+class TierConfig:
+    """Configuration for a single tier."""
+
+    tier: Tier
+    name: str
+    refresh_interval: timedelta
+    pattern_sig_prefix: str
+    description: str
+    inherits_from: tuple[Tier, ...] = field(default_factory=tuple)
+
+
+TIER_CONFIGS: dict[Tier, TierConfig] = {
+    Tier.VENDOR_STATE: TierConfig(
+        tier=Tier.VENDOR_STATE,
+        name="Vendor State",
+        refresh_interval=timedelta(days=1),
+        pattern_sig_prefix="t1",
+        description="Deterministic metrics: churn density, urgency, review counts. No LLM.",
+        inherits_from=(
+            Tier.VENDOR_ARCHETYPE,
+            Tier.CATEGORY_PATTERN,
+            Tier.MARKET_DYNAMICS,
+        ),
+    ),
+    Tier.VENDOR_ARCHETYPE: TierConfig(
+        tier=Tier.VENDOR_ARCHETYPE,
+        name="Vendor Archetype",
+        refresh_interval=timedelta(weeks=1),
+        pattern_sig_prefix="t2",
+        description="Vendor-level archetype classification with evidence graph.",
+        inherits_from=(Tier.CATEGORY_PATTERN, Tier.MARKET_DYNAMICS),
+    ),
+    Tier.CATEGORY_PATTERN: TierConfig(
+        tier=Tier.CATEGORY_PATTERN,
+        name="Category Pattern",
+        refresh_interval=timedelta(days=30),
+        pattern_sig_prefix="t3",
+        description="Category-level baselines and archetype distributions.",
+        inherits_from=(Tier.MARKET_DYNAMICS,),
+    ),
+    Tier.MARKET_DYNAMICS: TierConfig(
+        tier=Tier.MARKET_DYNAMICS,
+        name="Market Dynamics",
+        refresh_interval=timedelta(days=90),
+        pattern_sig_prefix="t4",
+        description="Market-level displacement patterns and structural shifts.",
+        inherits_from=(),
+    ),
+}
+
+
+def get_tier_config(tier: Tier) -> TierConfig:
+    """Get configuration for a tier."""
+    return TIER_CONFIGS[tier]
+
+
+def build_tiered_pattern_sig(tier: Tier, entity_name: str, evidence_hash: str) -> str:
+    """Build a pattern signature scoped to a tier."""
+    config = TIER_CONFIGS[tier]
+    safe = entity_name.lower().replace(" ", "_").replace(".", "")
+    if tier == Tier.MARKET_DYNAMICS:
+        return f"{config.pattern_sig_prefix}:market:{safe}:{evidence_hash}"
+    if tier == Tier.CATEGORY_PATTERN:
+        return f"{config.pattern_sig_prefix}:category:{safe}:{evidence_hash}"
+    return f"{config.pattern_sig_prefix}:vendor:{safe}:{evidence_hash}"
+
+
+def needs_refresh(tier: Tier, last_validated_at: datetime | None) -> bool:
+    """Check whether a cached entry for this tier needs re-reasoning."""
+    if last_validated_at is None:
+        return True
+    config = TIER_CONFIGS[tier]
+    now = datetime.now(timezone.utc)
+    if last_validated_at.tzinfo is None:
+        last_validated_at = last_validated_at.replace(tzinfo=timezone.utc)
+    return now - last_validated_at > config.refresh_interval
+
+
+async def gather_tier_context(
+    cache: Any,
+    tier: Tier,
+    vendor_name: str = "",
+    product_category: str = "",
+) -> dict[str, Any]:
+    """Gather inherited context from higher tiers through a cache port."""
+    config = TIER_CONFIGS[tier]
+    context: dict[str, Any] = {
+        "tier": tier.value,
+        "tier_name": config.name,
+    }
+    if not config.inherits_from:
+        return context
+
+    inherited_priors: list[dict[str, Any]] = []
+    for parent_tier in config.inherits_from:
+        parent_config = TIER_CONFIGS[parent_tier]
+        entries = []
+        if parent_tier == Tier.MARKET_DYNAMICS and product_category:
+            entries = await cache.lookup_for_tier(
+                "market_dynamics",
+                product_category=product_category,
+                limit=3,
+            )
+        elif parent_tier == Tier.CATEGORY_PATTERN and product_category:
+            entries = await cache.lookup_for_tier(
+                "category_pattern",
+                product_category=product_category,
+                limit=3,
+            )
+        elif parent_tier == Tier.VENDOR_ARCHETYPE and vendor_name:
+            entries = await cache.lookup_for_tier("", vendor_name=vendor_name, limit=1)
+            entries = [entry for entry in entries if entry.vendor_name != "__ecosystem__"]
+
+        for entry in entries:
+            prior = {
+                "tier": parent_tier.value,
+                "tier_name": parent_config.name,
+                "pattern": entry.pattern_sig,
+                "conclusion_type": entry.conclusion_type,
+                "confidence": entry.effective_confidence or entry.confidence,
+            }
+            conclusion = entry.conclusion
+            if isinstance(conclusion, dict):
+                for tag_key in (
+                    "market_pressure",
+                    "category_trend",
+                    "archetype",
+                    "risk_level",
+                    "displacement_direction",
+                ):
+                    if tag_key in conclusion:
+                        prior[tag_key] = conclusion[tag_key]
+            inherited_priors.append(prior)
+
+    if inherited_priors:
+        context["inherited_priors"] = inherited_priors
+        logger.debug("Tier %s gathered %d priors", config.name, len(inherited_priors))
+    return context
+
+
+__all__ = [
+    "TIER_CONFIGS",
+    "Tier",
+    "TierConfig",
+    "build_tiered_pattern_sig",
+    "gather_tier_context",
+    "get_tier_config",
+    "needs_refresh",
+]

--- a/extracted_reasoning_core/types.py
+++ b/extracted_reasoning_core/types.py
@@ -1,0 +1,153 @@
+"""Public dataclasses for the extracted reasoning core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping, Sequence
+
+from .ports import Clock, LLMClient, ReasoningStateStore, SemanticCacheStore
+from .wedge_registry import Wedge, WedgeMeta
+
+
+ReasoningDepth = Literal["L1", "L2", "L3", "L4", "L5"]
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    source_type: str
+    source_id: str
+    text: str = ""
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReasoningInput:
+    entity_id: str
+    entity_type: str
+    goal: str
+    evidence: Sequence[EvidenceItem]
+    context: Mapping[str, Any] = field(default_factory=dict)
+    pack_name: str | None = None
+
+
+@dataclass(frozen=True)
+class ReasoningResult:
+    summary: str
+    claims: Sequence[Mapping[str, Any]]
+    confidence: float
+    tier: str
+    state: Mapping[str, Any]
+    trace: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReasoningPorts:
+    llm: LLMClient | None = None
+    semantic_cache: SemanticCacheStore | None = None
+    state_store: ReasoningStateStore | None = None
+    clock: Clock | None = None
+
+
+@dataclass(frozen=True)
+class ArchetypeMatch:
+    archetype_id: str
+    label: str
+    score: float
+    evidence_hits: Sequence[str] = field(default_factory=tuple)
+    missing_evidence: Sequence[str] = field(default_factory=tuple)
+    risk_label: str = ""
+
+
+@dataclass(frozen=True)
+class EvidencePolicy:
+    required_pools: Sequence[str] = field(default_factory=tuple)
+    min_confidence: float = 0.0
+    confidence_labels: Mapping[str, float] = field(default_factory=dict)
+    suppression_rules: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvidenceDecision:
+    allowed: bool
+    confidence: float = 0.0
+    reasons: Sequence[str] = field(default_factory=tuple)
+    missing_evidence: Sequence[str] = field(default_factory=tuple)
+    trace: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TemporalEvidence:
+    velocity: Mapping[str, Any] = field(default_factory=dict)
+    trend: Mapping[str, Any] = field(default_factory=dict)
+    anomaly: Mapping[str, Any] = field(default_factory=dict)
+    recency: Mapping[str, Any] = field(default_factory=dict)
+    baselines: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class NarrativePlan:
+    claims: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    sections: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    evidence_requirements: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    state_hints: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReasoningPack:
+    name: str
+    version: str = "v1"
+    prompts: Mapping[str, str] = field(default_factory=dict)
+    policies: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FalsificationPolicy:
+    rules: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    conservative: bool = True
+
+
+@dataclass(frozen=True)
+class FalsificationResult:
+    triggered_conditions: Sequence[str] = field(default_factory=tuple)
+    non_triggered_conditions: Sequence[str] = field(default_factory=tuple)
+    should_invalidate: bool = False
+    trace: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OutputPolicy:
+    required_claim_types: Sequence[str] = field(default_factory=tuple)
+    require_citations: bool = True
+    min_confidence: float = 0.0
+    blocked_phrasing: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    passed: bool
+    blockers: Sequence[str] = field(default_factory=tuple)
+    warnings: Sequence[str] = field(default_factory=tuple)
+    repaired_fields: Mapping[str, Any] = field(default_factory=dict)
+    trace: Mapping[str, Any] = field(default_factory=dict)
+
+
+__all__ = [
+    "ArchetypeMatch",
+    "EvidenceDecision",
+    "EvidenceItem",
+    "EvidencePolicy",
+    "FalsificationPolicy",
+    "FalsificationResult",
+    "NarrativePlan",
+    "OutputPolicy",
+    "ReasoningDepth",
+    "ReasoningInput",
+    "ReasoningPack",
+    "ReasoningPorts",
+    "ReasoningResult",
+    "TemporalEvidence",
+    "ValidationReport",
+    "Wedge",
+    "WedgeMeta",
+]

--- a/extracted_reasoning_core/types.py
+++ b/extracted_reasoning_core/types.py
@@ -36,7 +36,7 @@ class ReasoningResult:
     summary: str
     claims: Sequence[Mapping[str, Any]]
     confidence: float
-    tier: str
+    tier: ReasoningDepth
     state: Mapping[str, Any]
     trace: Mapping[str, Any] = field(default_factory=dict)
 

--- a/extracted_reasoning_core/wedge_registry.py
+++ b/extracted_reasoning_core/wedge_registry.py
@@ -1,0 +1,157 @@
+"""Shared sales-oriented wedge registry for extracted reasoning products."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Sequence
+
+
+class Wedge(str, Enum):
+    """Sales-oriented wedge types."""
+
+    PRICE_SQUEEZE = "price_squeeze"
+    FEATURE_PARITY = "feature_parity"
+    SUPPORT_EROSION = "support_erosion"
+    INTEGRATION_LOCK = "integration_lock"
+    CATEGORY_SHIFT = "category_shift"
+    ACQUISITION_HANGOVER = "acquisition_hangover"
+    COMPLIANCE_EXPOSURE = "compliance_exposure"
+    UX_REGRESSION = "ux_regression"
+    SEGMENT_MISMATCH = "segment_mismatch"
+    STABLE = "stable"
+
+
+WEDGE_ENUM_VALUES: frozenset[str] = frozenset(w.value for w in Wedge)
+
+
+@dataclass(frozen=True, slots=True)
+class WedgeMeta:
+    """Metadata for a wedge type."""
+
+    wedge: Wedge
+    label: str
+    archetype_map: tuple[str, ...]
+    sales_motion: str
+    required_pools: tuple[str, ...] = field(default=("evidence_vault",))
+
+
+_WEDGE_CATALOG: tuple[WedgeMeta, ...] = (
+    WedgeMeta(
+        wedge=Wedge.PRICE_SQUEEZE,
+        label="Price Squeeze",
+        archetype_map=("pricing_shock",),
+        sales_motion="Lead with TCO comparison and hidden-cost analysis",
+        required_pools=("evidence_vault", "segment", "accounts"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.FEATURE_PARITY,
+        label="Feature Parity",
+        archetype_map=("feature_gap",),
+        sales_motion="Demo the missing capability live; anchor on workflow impact",
+        required_pools=("evidence_vault", "displacement", "segment"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.SUPPORT_EROSION,
+        label="Support Erosion",
+        archetype_map=("support_collapse",),
+        sales_motion="Offer white-glove onboarding and named CSM commitment",
+        required_pools=("evidence_vault", "temporal", "accounts"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.INTEGRATION_LOCK,
+        label="Integration Lock-in",
+        archetype_map=("integration_break",),
+        sales_motion="Show migration playbook with timeline and risk mitigation",
+        required_pools=("evidence_vault", "displacement"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.CATEGORY_SHIFT,
+        label="Category Shift",
+        archetype_map=("category_disruption",),
+        sales_motion="Position as the category leader; frame incumbent as legacy",
+        required_pools=("evidence_vault", "category", "displacement"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.ACQUISITION_HANGOVER,
+        label="Acquisition Hangover",
+        archetype_map=("acquisition_decay", "leadership_redesign"),
+        sales_motion="Exploit post-acquisition confusion and roadmap uncertainty",
+        required_pools=("evidence_vault", "temporal", "accounts"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.COMPLIANCE_EXPOSURE,
+        label="Compliance Exposure",
+        archetype_map=("compliance_gap",),
+        sales_motion="Lead with compliance matrix; urgency from regulatory deadline",
+        required_pools=("evidence_vault", "temporal"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.UX_REGRESSION,
+        label="UX Regression",
+        archetype_map=("feature_gap",),
+        sales_motion="Side-by-side UX walkthrough showing workflow friction",
+        required_pools=("evidence_vault", "segment"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.SEGMENT_MISMATCH,
+        label="Segment Mismatch",
+        archetype_map=("mixed",),
+        sales_motion="Target the underserved segment with tailored positioning",
+        required_pools=("evidence_vault", "segment", "accounts"),
+    ),
+    WedgeMeta(
+        wedge=Wedge.STABLE,
+        label="Stable",
+        archetype_map=("stable",),
+        sales_motion="Long-game nurture; monitor for trigger events",
+        required_pools=("evidence_vault",),
+    ),
+)
+
+_ARCHETYPE_TO_WEDGE: dict[str, Wedge] = {}
+for _meta in _WEDGE_CATALOG:
+    for _arch in _meta.archetype_map:
+        _ARCHETYPE_TO_WEDGE.setdefault(_arch, _meta.wedge)
+
+_WEDGE_TO_META: dict[Wedge, WedgeMeta] = {m.wedge: m for m in _WEDGE_CATALOG}
+
+
+def wedge_from_archetype(archetype: str) -> Wedge:
+    """Map a churn archetype to its sales wedge."""
+    return _ARCHETYPE_TO_WEDGE.get(archetype, Wedge.SEGMENT_MISMATCH)
+
+
+def validate_wedge(value: str) -> Wedge | None:
+    """Return the Wedge enum member if *value* is valid, else None."""
+    try:
+        return Wedge(value)
+    except ValueError:
+        return None
+
+
+def get_wedge_meta(wedge: Wedge) -> WedgeMeta:
+    """Return metadata for a wedge type."""
+    return _WEDGE_TO_META[wedge]
+
+
+def get_sales_motion(wedge: Wedge) -> str:
+    """Return the recommended sales motion for a wedge."""
+    return _WEDGE_TO_META[wedge].sales_motion
+
+
+def get_required_pools(wedge: Wedge) -> Sequence[str]:
+    """Return the pool layers required for a wedge."""
+    return _WEDGE_TO_META[wedge].required_pools
+
+
+__all__ = [
+    "WEDGE_ENUM_VALUES",
+    "Wedge",
+    "WedgeMeta",
+    "get_required_pools",
+    "get_sales_motion",
+    "get_wedge_meta",
+    "validate_wedge",
+    "wedge_from_archetype",
+]

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+import extracted_reasoning_core.api as api
+from extracted_reasoning_core.api import (
+    EvidenceItem,
+    FalsificationResult,
+    NarrativePlan,
+    OutputPolicy,
+    ReasoningInput,
+    ReasoningPack,
+    ReasoningPorts,
+    ReasoningResult,
+    TemporalEvidence,
+    ValidationReport,
+    Wedge,
+)
+
+
+def test_public_api_exports_reasoning_contract_types() -> None:
+    expected = {
+        "EvidenceItem",
+        "ReasoningInput",
+        "ReasoningResult",
+        "ReasoningPorts",
+        "ReasoningPack",
+        "ValidationReport",
+        "Wedge",
+        "score_archetypes",
+        "run_reasoning",
+        "validate_reasoning_output",
+    }
+
+    assert expected <= set(api.__all__)
+
+
+def test_reasoning_public_dataclasses_instantiate_with_defaults() -> None:
+    evidence = EvidenceItem(
+        source_type="review",
+        source_id="r1",
+        text="Pricing became too expensive after renewal",
+    )
+    reasoning_input = ReasoningInput(
+        entity_id="vendor:acme",
+        entity_type="vendor",
+        goal="build a campaign narrative",
+        evidence=(evidence,),
+        pack_name="content_pipeline",
+    )
+    result = ReasoningResult(
+        summary="Pricing pressure is the strongest wedge.",
+        claims=({"claim": "price squeeze"},),
+        confidence=0.82,
+        tier="L2",
+        state={"wedge": Wedge.PRICE_SQUEEZE.value},
+    )
+
+    assert reasoning_input.evidence == (evidence,)
+    assert result.state["wedge"] == "price_squeeze"
+    assert ReasoningPorts() == ReasoningPorts()
+    assert ReasoningPack(name="content_pipeline").version == "v1"
+    assert TemporalEvidence().velocity == {}
+    assert NarrativePlan().sections == ()
+    assert FalsificationResult().should_invalidate is False
+    assert OutputPolicy().require_citations is True
+
+
+def test_validation_report_has_explicit_terminal_verdict() -> None:
+    passed = ValidationReport(passed=True)
+    failed = ValidationReport(
+        passed=False,
+        blockers=("missing citation",),
+        warnings=("low confidence",),
+    )
+
+    assert passed.passed is True
+    assert passed.blockers == ()
+    assert failed.passed is False
+    assert failed.blockers == ("missing citation",)
+    assert failed.warnings == ("low confidence",)
+
+
+def test_stubbed_public_entry_points_fail_closed_until_consolidated() -> None:
+    evidence = EvidenceItem(source_type="review", source_id="r1")
+    reasoning_input = ReasoningInput(
+        entity_id="vendor:acme",
+        entity_type="vendor",
+        goal="test",
+        evidence=(evidence,),
+    )
+    result = ReasoningResult(
+        summary="",
+        claims=(),
+        confidence=0.0,
+        tier="L1",
+        state={},
+    )
+
+    sync_calls = [
+        lambda: api.score_archetypes({}),
+        lambda: api.evaluate_evidence({}),
+        lambda: api.build_temporal_evidence(()),
+        lambda: api.build_narrative_plan({}, pack=ReasoningPack(name="default")),
+        lambda: api.compute_evidence_hash({}),
+        lambda: api.build_semantic_cache_key(reasoning_input, tier="L1"),
+        lambda: api.load_reasoning_pack("content_pipeline"),
+        lambda: api.validate_reasoning_output(result),
+    ]
+
+    for call in sync_calls:
+        with pytest.raises(NotImplementedError):
+            call()
+
+
+@pytest.mark.asyncio
+async def test_stubbed_async_entry_points_fail_closed_until_consolidated() -> None:
+    evidence = EvidenceItem(source_type="review", source_id="r1")
+    reasoning_input = ReasoningInput(
+        entity_id="vendor:acme",
+        entity_type="vendor",
+        goal="test",
+        evidence=(evidence,),
+    )
+
+    with pytest.raises(NotImplementedError):
+        await api.run_reasoning(reasoning_input)
+
+    with pytest.raises(NotImplementedError):
+        await api.continue_reasoning({}, {})
+
+    with pytest.raises(NotImplementedError):
+        await api.check_falsification({}, (evidence,))

--- a/tests/test_extracted_reasoning_core_wedge_registry.py
+++ b/tests/test_extracted_reasoning_core_wedge_registry.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import extracted_competitive_intelligence.reasoning.wedge_registry as comp_wedges
+import extracted_content_pipeline.reasoning.wedge_registry as content_wedges
+from extracted_reasoning_core.api import (
+    WEDGE_ENUM_VALUES,
+    Wedge,
+    get_required_pools,
+    get_sales_motion,
+    get_wedge_meta,
+    validate_wedge,
+    wedge_from_archetype,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_shared_wedge_registry_exposes_full_atlas_contract() -> None:
+    assert len(WEDGE_ENUM_VALUES) == 10
+    assert WEDGE_ENUM_VALUES == {wedge.value for wedge in Wedge}
+
+    for value in WEDGE_ENUM_VALUES:
+        assert validate_wedge(value) is Wedge(value)
+
+
+def test_wedge_from_archetype_maps_known_and_unknown_shapes() -> None:
+    assert wedge_from_archetype("pricing_shock") is Wedge.PRICE_SQUEEZE
+    assert wedge_from_archetype("support_collapse") is Wedge.SUPPORT_EROSION
+    assert wedge_from_archetype("not_a_known_archetype") is Wedge.SEGMENT_MISMATCH
+
+
+def test_invalid_or_legacy_compound_wedges_do_not_validate() -> None:
+    assert validate_wedge("pricing_support") is None
+    assert validate_wedge("feature_reliability") is None
+    assert validate_wedge("support") is None
+    assert validate_wedge("") is None
+
+
+def test_wedge_metadata_helpers_return_catalog_values() -> None:
+    meta = get_wedge_meta(Wedge.PRICE_SQUEEZE)
+
+    assert meta.wedge is Wedge.PRICE_SQUEEZE
+    assert meta.label == "Price Squeeze"
+    assert "pricing_shock" in meta.archetype_map
+    assert get_sales_motion(Wedge.PRICE_SQUEEZE) == meta.sales_motion
+    assert tuple(get_required_pools(Wedge.PRICE_SQUEEZE)) == meta.required_pools
+
+
+def test_product_wedge_wrappers_reexport_shared_core_objects() -> None:
+    assert content_wedges.Wedge is Wedge
+    assert comp_wedges.Wedge is Wedge
+    assert content_wedges.WEDGE_ENUM_VALUES is WEDGE_ENUM_VALUES
+    assert comp_wedges.WEDGE_ENUM_VALUES is WEDGE_ENUM_VALUES
+    assert content_wedges.validate_wedge("price_squeeze") is Wedge.PRICE_SQUEEZE
+    assert comp_wedges.validate_wedge("price_squeeze") is Wedge.PRICE_SQUEEZE
+
+
+def test_product_wedge_wrappers_do_not_bridge_to_atlas() -> None:
+    for path in (
+        "extracted_content_pipeline/reasoning/wedge_registry.py",
+        "extracted_competitive_intelligence/reasoning/wedge_registry.py",
+    ):
+        text = _read(path)
+        assert "extracted_reasoning_core.api" in text
+        assert "atlas_brain.reasoning.wedge_registry" not in text
+        assert "importlib.import_module" not in text


### PR DESCRIPTION
## Summary

- add the first `extracted_reasoning_core` package with public API stubs, shared contract types, ports, state/tier scaffolding, and the full shared wedge registry
- migrate the content pipeline and competitive intelligence wedge modules to compatibility wrappers over `extracted_reasoning_core.api`
- add regression tests for the public contract, `ValidationReport.passed`, wedge metadata, and no-Atlas wrapper behavior

## Verification

- `python -m py_compile extracted_reasoning_core/__init__.py extracted_reasoning_core/api.py extracted_reasoning_core/ports.py extracted_reasoning_core/state.py extracted_reasoning_core/tiers.py extracted_reasoning_core/types.py extracted_reasoning_core/wedge_registry.py extracted_content_pipeline/reasoning/wedge_registry.py extracted_competitive_intelligence/reasoning/wedge_registry.py`
- `pytest tests/test_extracted_reasoning_core_wedge_registry.py tests/test_extracted_reasoning_core_api.py -q`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`
- `bash scripts/run_extracted_pipeline_checks.sh`

## Notes

This is the first code slice after the reasoning boundary audit: the API is intentionally stubbed where later consolidations will land, so products can depend on stable public names instead of reaching into internals.