### PR TITLE
Add llm_exact_cache to LLM infrastructure manifest

### DIFF
--- a/docs/extraction/COORDINATION.md
+++ b/docs/extraction/COORDINATION.md
@@ -1,6 +1,6 @@
 # Extraction Coordination
 
-Last updated: 2026-05-03T20:00Z by claude-2026-05-03-b
+Last updated: 2026-05-03T21:00Z by claude-2026-05-03-b
 
 State-of-the-world for the multi-product extraction effort. Read this end-to-end at session start before doing substantive work. Update before opening a PR, after merging one, or when a decision lands.
 
@@ -14,11 +14,11 @@ The team is one human (`@canfieldjuan`) plus AI sessions. Owner column uses GitH
 
 | Product | Phase | Most recent merged PR | Active PRs | Next milestone | Active hot zone |
 |---|---|---|---|---|---|
-| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #49 | — | Cost-closure additions (PR-A1 → A4) | none |
-| `extracted_competitive_intelligence` | 1 (scaffold) | #48 | #80 | Stabilize after #80 wedge migration | `reasoning/wedge_registry.py` |
-| `extracted_content_pipeline` | 1 → 2 (productization seams in flight) | #76 | #77, #78 | Standalone runner without `atlas_brain` on path | `campaign_generation.py`, `*_postgres_*`, `README.md`, `STATUS.md`, `docs/remaining_productization_audit.md` |
-| `extracted_reasoning_core` | 0 → 1 (kickoff) | — | #79, #80, #82 | First scaffold + wedge registry land; evidence/temporal/archetypes audit queued via #82 | `extracted_reasoning_core/**`, `docs/extraction/evidence_temporal_archetypes_audit_2026-05-03.md` |
-| `extracted_quality_gate` | not started | — | — | Boundary audit claimed by PR-B1 | `docs/extraction/quality_gate_boundary_audit_2026-05-03.md` |
+| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #49 | PR-A1 (in flight) | Cost-closure additions (PR-A1 -> A4); A1 adds `llm_exact_cache.py` + migration 251 | `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`, `extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql`, manifest, README, STATUS |
+| `extracted_competitive_intelligence` | 1 (scaffold) | #80 | — | Phase 2 standalone toggle | none |
+| `extracted_content_pipeline` | 1 -> 2 (productization seams) | #78 | — | Standalone runner without `atlas_brain` on path | none |
+| `extracted_reasoning_core` | 1 (scaffold + wedge consolidated) | #82 | — | Evidence/temporal/archetypes consolidation per merged #82 audit (PR-C1 queued) | none |
+| `extracted_quality_gate` | 1 (scaffold + product_claim core landed via #85) | #85 | — | Safety-gate split (PR-B3); blog + campaign packs (PR-B4) | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.
 
@@ -28,13 +28,7 @@ Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, s
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #77 | docs: park product strategy notes | `extracted_content_pipeline/docs/long_form_creative_backlog.md`, `extracted_content_pipeline/docs/podcast_repurposing_landing_page_strategy.md`, `extracted_content_pipeline/docs/remaining_productization_audit.md` | (unknown — confirm) | #78 on `extracted_content_pipeline/docs/remaining_productization_audit.md` |
-| #78 | Add multi-channel campaign generation flow | `extracted_content_pipeline/campaign_generation.py`, postgres runners, README, STATUS, tests | (unknown — confirm) | `extracted_content_pipeline/{campaign_generation.py, campaign_postgres_generation.py, campaign_example.py, README.md, STATUS.md, docs/remaining_productization_audit.md, docs/standalone_productization.md}`; `scripts/run_extracted_campaign_generation_*.py`; `tests/test_extracted_campaign_*.py` |
-| #79 | Document reasoning core extraction boundary | `docs/extraction/reasoning_boundary_audit_2026-05-03.md` | claude-2026-05-03 | (docs only) |
-| #80 | Add shared reasoning core wedge registry | `extracted_reasoning_core/**`, `extracted_competitive_intelligence/reasoning/wedge_registry.py`, `extracted_content_pipeline/reasoning/wedge_registry.py`, tests | claude-2026-05-03 | `extracted_reasoning_core/**`, the migrated `wedge_registry.py` files |
-| #81 | Add extraction coordination doc | `docs/extraction/COORDINATION.md` | claude-2026-05-03-b (drafted), codex-2026-05-03 (reviewed + #82 coordination update) | coordination-doc edits; claim before touching `docs/extraction/COORDINATION.md` |
-| #82 | Document reasoning evidence-temporal-archetypes consolidation | `docs/extraction/evidence_temporal_archetypes_audit_2026-05-03.md` | claude-2026-05-03 | (docs only) |
-| #83 | Document cost-closure boundary | `docs/extraction/cost_closure_audit_2026-05-03.md` + COORDINATION update | claude-2026-05-03-b | (docs only) |
+| (PR-A1, opening) | Add `llm_exact_cache` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/b2b/llm_exact_cache.py, storage/migrations/251_b2b_llm_exact_cache.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/b2b/` and `storage/migrations/` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.
 
@@ -44,14 +38,14 @@ This table is for PRs we need to coordinate around, not a mirror of `gh pr list`
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-Coord | meta | claude-2026-05-03-b | none | This doc. Establishes the mechanism. |
-| PR-A0 | `extracted_llm_infrastructure` | claude-2026-05-03-b | none | Boundary audit doc: `docs/extraction/cost_closure_audit_2026-05-03.md`. Mirrors PR #79's structure. Open as PR #83. |
-| PR-A1 | `extracted_llm_infrastructure` | unclaimed | PR-A0 | Add `services/b2b/llm_exact_cache.py` + migration `251_b2b_llm_exact_cache.sql` (rename target: `llm_exact_cache.sql`) to manifest. Update README "What's in scope" table. |
+| PR-A1 | `extracted_llm_infrastructure` | claude-2026-05-03-b | none (PR-A0 / #83 merged) | Add `services/b2b/llm_exact_cache.py` + migration `251_b2b_llm_exact_cache.sql` to manifest. Update README + STATUS. **In flight.** |
 | PR-A2 | `extracted_llm_infrastructure` | unclaimed | PR-A1 | Add `services/provider_cost_sync.py` + migration `258_provider_cost_reconciliation.sql`. Sync orchestration. |
 | PR-A3 | `extracted_llm_infrastructure` | unclaimed | PR-A1 | New code: cache-savings persistence layer + migration. Closes the "$ saved by cache" telemetry gap. |
 | PR-A4 | `extracted_llm_infrastructure` | unclaimed | PR-A2, PR-A3 | New code: drift report (local vs invoiced), budget gate, OpenAI provider adapter. May split if too large. |
-| PR-B1 | `extracted_quality_gate` | codex-2026-05-03 | (independent of A) | Boundary audit doc: `docs/extraction/quality_gate_boundary_audit_2026-05-03.md`. Mirrors PR #79. Docs only; avoid code until audit lands. |
-| PR-C1 | `extracted_reasoning_core` | unclaimed | PR #80, PR #82 | Consolidate evidence/temporal/archetypes after #82 lands: `archetypes.py`, `evidence_engine.py`, `temporal.py`, `evidence_map.yaml`, plus PR #79 contract amendment. |
+| PR-B3 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Safety-gate split: deterministic content/risk scan to core; approvals + audit log + DB to ports + Atlas adapter wrapper. |
+| PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
+| PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
+| PR-C1 | `extracted_reasoning_core` | unclaimed | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged #82 audit: `archetypes.py`, `evidence_engine.py`, `temporal.py`, `evidence_map.yaml`, plus PR #79 contract amendment. |
 
 ---
 
@@ -64,6 +58,7 @@ This table is for PRs we need to coordinate around, not a mirror of `gh pr list`
 - **2026-05-03** — `docs/extraction/COORDINATION.md` is the canonical state-of-the-world doc for extraction work. Read at session start, update at session end.
 - **2026-05-03** — Coordination protocol refinements: ISO 8601 UTC timestamps; alphabetical suffix scheme (`-b`, `-c`, …) for AI sessions colliding on a date, claimed in the same commit; unknown-owner fallback (treat as locked); tie-breaker on simultaneous claims (last write wins, loser negotiates); forgive-and-claim for missed-step recovery. CI enforcement deferred to PR-Coord-2.
 - **2026-05-03** — Active session letter aliases (A/B/C) added as conversational shorthand alongside canonical agent-date IDs (Option 2 over replacement). Aliases re-anchor each calendar day; agent-date IDs remain canonical in tables and decisions log.
+- **2026-05-03** — Post-merge cleanup: PRs #77, #78, #79, #80, #81, #82, #83, #84, #85 merged into main. Per-product state advanced for `extracted_competitive_intelligence` (#80), `extracted_content_pipeline` (#78), `extracted_reasoning_core` (#82, now Phase 1 with wedge consolidated), `extracted_quality_gate` (#85, now Phase 1 with product_claim core landed). `PR-Coord` and `PR-A0` slices retired. PR-B1 retired (merged as #84). PR-B2 retired (merged as #85).
 
 ---
 

--- a/docs/extraction/COORDINATION.md
+++ b/docs/extraction/COORDINATION.md
@@ -14,7 +14,7 @@ The team is one human (`@canfieldjuan`) plus AI sessions. Owner column uses GitH
 
 | Product | Phase | Most recent merged PR | Active PRs | Next milestone | Active hot zone |
 |---|---|---|---|---|---|
-| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #49 | PR-A1 (in flight) | Cost-closure additions (PR-A1 -> A4); A1 adds `llm_exact_cache.py` + migration 251 | `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`, `extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql`, manifest, README, STATUS |
+| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #49 | #87 | Cost-closure additions (PR-A1 -> A4); A1 adds `llm_exact_cache.py` + migration 251 | `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`, `extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql`, manifest, README, STATUS |
 | `extracted_competitive_intelligence` | 1 (scaffold) | #80 | — | Phase 2 standalone toggle | none |
 | `extracted_content_pipeline` | 1 -> 2 (productization seams) | #78 | — | Standalone runner without `atlas_brain` on path | none |
 | `extracted_reasoning_core` | 1 (scaffold + wedge consolidated) | #82 | — | Evidence/temporal/archetypes consolidation per merged #82 audit (PR-C1 queued) | none |
@@ -28,7 +28,7 @@ Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, s
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-A1, opening) | Add `llm_exact_cache` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/b2b/llm_exact_cache.py, storage/migrations/251_b2b_llm_exact_cache.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/b2b/` and `storage/migrations/` |
+| #87 | Add `llm_exact_cache` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/b2b/llm_exact_cache.py, storage/migrations/251_b2b_llm_exact_cache.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/b2b/` and `storage/migrations/` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.
 

--- a/extracted_llm_infrastructure/README.md
+++ b/extracted_llm_infrastructure/README.md
@@ -22,8 +22,10 @@ The pattern mirrors the content-pipeline scaffold under
 | `services/llm_router.py` | `atlas_brain/services/llm_router.py` | Workflow-based singleton fallback (cloud / draft / triage / reasoning) |
 | `services/llm/{anthropic,openrouter,ollama,vllm,groq,together,hybrid,cloud}.py` | `atlas_brain/services/llm/*.py` | Eight LLM provider implementations |
 | `services/tracing.py` | `atlas_brain/services/tracing.py` | FTL tracer client (token counts, cost telemetry, hierarchical spans) |
+| `services/b2b/llm_exact_cache.py` | `atlas_brain/services/b2b/llm_exact_cache.py` | Hash-keyed exact-match LLM response cache (~378 LOC); namespace + request envelope -> SHA -> response_text + usage_json. Cost-closure foundation. |
 | `storage/migrations/127_llm_usage.sql` | mig 127 | Initial llm_usage table |
 | `storage/migrations/130_reasoning_semantic_cache.sql` | mig 130 | Semantic cache + metacognition tables |
+| `storage/migrations/251_b2b_llm_exact_cache.sql` | mig 251 | b2b_llm_exact_cache table (cost-closure: cached LLM responses + usage_json) |
 | `storage/migrations/252_llm_usage_cache_breakdown.sql` | mig 252 | Cache + queue token breakdown |
 | `storage/migrations/253_llm_usage_vendor_and_run_id.sql` | mig 253 | Vendor + run_id columns |
 | `storage/migrations/255_anthropic_message_batches.sql` | mig 255 | Anthropic batch + items tables |

--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -5,8 +5,8 @@
 | Step | Status |
 |---|---|
 | Manifest of source → scaffold mappings | ✅ done |
-| Verbatim byte-snapshot of 14 Python files | ✅ done |
-| Verbatim byte-snapshot of 6 migration SQL files | ✅ done |
+| Verbatim byte-snapshot of 15 Python files | ✅ done (added `services/b2b/llm_exact_cache.py` in PR-A1) |
+| Verbatim byte-snapshot of 7 migration SQL files | ✅ done (added migration 251 in PR-A1) |
 | Package `__init__.py` files at every level | ✅ done |
 | Sync + validate scripts | ✅ done via shared tooling wrappers |
 | ASCII / smoke-import / import-debt checks | ✅ done via shared tooling wrappers |

--- a/extracted_llm_infrastructure/manifest.json
+++ b/extracted_llm_infrastructure/manifest.json
@@ -57,6 +57,10 @@
       "target": "extracted_llm_infrastructure/services/tracing.py"
     },
     {
+      "source": "atlas_brain/services/b2b/llm_exact_cache.py",
+      "target": "extracted_llm_infrastructure/services/b2b/llm_exact_cache.py"
+    },
+    {
       "source": "atlas_brain/storage/migrations/127_llm_usage.sql",
       "target": "extracted_llm_infrastructure/storage/migrations/127_llm_usage.sql"
     },
@@ -71,6 +75,10 @@
     {
       "source": "atlas_brain/storage/migrations/253_llm_usage_vendor_and_run_id.sql",
       "target": "extracted_llm_infrastructure/storage/migrations/253_llm_usage_vendor_and_run_id.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/251_b2b_llm_exact_cache.sql",
+      "target": "extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql"
     },
     {
       "source": "atlas_brain/storage/migrations/255_anthropic_message_batches.sql",

--- a/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
+++ b/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
@@ -1,0 +1,378 @@
+"""Exact-match Postgres cache for B2B/reporting LLM responses."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import math
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger("atlas.services.b2b.llm_exact_cache")
+
+CACHE_VERSION = "b2b-llm-exact-v1"
+
+
+class CacheUnavailable(RuntimeError):
+    """Raised when a cache request depends on a missing skill."""
+
+
+class B2BLLMExactCacheHit(dict):
+    """Simple dict wrapper for cached response metadata."""
+
+
+def is_b2b_llm_exact_cache_enabled() -> bool:
+    """Return whether the feature-flagged exact cache is enabled."""
+    from ...config import settings
+
+    return bool(getattr(settings.b2b_churn, "llm_exact_cache_enabled", False))
+
+
+def _normalize_maybe_json_string(value: str) -> Any:
+    stripped = value.strip()
+    if stripped and stripped[0] in "{[":
+        try:
+            return _normalize_value(json.loads(stripped))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return value
+    return value
+
+
+def _normalize_message(value: Any) -> dict[str, Any] | None:
+    role = getattr(value, "role", None)
+    content = getattr(value, "content", None)
+    if role is None and content is None:
+        return None
+
+    payload: dict[str, Any] = {
+        "role": str(role or ""),
+        "content": _normalize_value(content or ""),
+    }
+    tool_calls = getattr(value, "tool_calls", None)
+    if tool_calls:
+        payload["tool_calls"] = _normalize_value(tool_calls)
+    tool_call_id = getattr(value, "tool_call_id", None)
+    if tool_call_id:
+        payload["tool_call_id"] = str(tool_call_id)
+    return payload
+
+
+def _normalize_value(value: Any) -> Any:
+    if is_dataclass(value):
+        value = asdict(value)
+
+    msg_payload = _normalize_message(value)
+    if msg_payload is not None:
+        return msg_payload
+
+    if isinstance(value, str):
+        return _normalize_maybe_json_string(value)
+
+    if value is None or isinstance(value, (bool, int)):
+        return value
+
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+
+    if isinstance(value, set):
+        normalized = [_normalize_value(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"), default=str),
+        )
+
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [_normalize_value(item) for item in value]
+
+    return str(value)
+
+
+def canonicalize_for_cache(value: Any) -> str:
+    """Return deterministic JSON for hashing exact cache requests."""
+    normalized = _normalize_value(value)
+    return json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+
+
+def build_request_envelope(
+    *,
+    provider: str,
+    model: str,
+    messages: Any,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the normalized request envelope that drives the cache key."""
+    envelope: dict[str, Any] = {
+        "provider": str(provider or ""),
+        "model": str(model or ""),
+        "messages": _normalize_value(messages),
+        "max_tokens": int(max_tokens) if max_tokens is not None else None,
+        "temperature": float(temperature) if temperature is not None else None,
+    }
+    if response_format is not None:
+        envelope["response_format"] = _normalize_value(response_format)
+    if guided_json is not None:
+        envelope["guided_json"] = _normalize_value(guided_json)
+    if extra:
+        envelope["extra"] = _normalize_value(extra)
+    return envelope
+
+
+def llm_identity(llm: Any) -> tuple[str, str]:
+    """Return provider/model identifiers for a resolved LLM instance."""
+    if llm is None:
+        return "", ""
+    provider = str(getattr(llm, "name", "") or "")
+    model = str(
+        getattr(llm, "model", "")
+        or getattr(llm, "model_id", "")
+        or getattr(llm, "model_name", "")
+        or ""
+    )
+    return provider, model
+
+
+def compute_cache_key(namespace: str, request_envelope: dict[str, Any]) -> str:
+    """Hash cache version + namespace + canonical request envelope."""
+    raw = f"{CACHE_VERSION}:{namespace}:{canonicalize_for_cache(request_envelope)}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_skill_messages(skill_name: str, payload: Any) -> list[dict[str, str]]:
+    """Build the exact message envelope used by call_llm_with_skill()."""
+    from ...skills import get_skill_registry
+
+    skill = get_skill_registry().get(skill_name)
+    if skill is None:
+        raise CacheUnavailable(f"Skill '{skill_name}' not found")
+
+    return [
+        {"role": "system", "content": skill.content},
+        {
+            "role": "user",
+            "content": json.dumps(payload, separators=(",", ":"), default=str),
+        },
+    ]
+
+
+def build_skill_request_envelope(
+    *,
+    namespace: str,
+    skill_name: str,
+    payload: Any,
+    provider: str,
+    model: str,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: dict[str, Any] | None = None,
+    guided_json: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any], list[dict[str, str]]]:
+    """Return cache key + normalized envelope + exact skill messages."""
+    messages = build_skill_messages(skill_name, payload)
+    request_envelope = build_request_envelope(
+        provider=provider,
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        guided_json=guided_json,
+        extra={"skill_name": skill_name, **(extra or {})},
+    )
+    return compute_cache_key(namespace, request_envelope), request_envelope, messages
+
+
+def _resolve_pool(pool: Any | None) -> Any | None:
+    if pool is not None:
+        return pool
+    from ...storage.database import get_db_pool
+
+    db_pool = get_db_pool()
+    if not db_pool.is_initialized:
+        return None
+    return db_pool
+
+
+def _json_field_to_mapping(value: Any) -> dict[str, Any]:
+    """Normalize JSON/JSONB driver return values into a plain mapping."""
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+    return {}
+
+
+async def lookup_cached_text(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    pool: Any | None = None,
+) -> B2BLLMExactCacheHit | None:
+    """Return the cached text for an exact request envelope."""
+    if not namespace or not is_b2b_llm_exact_cache_enabled():
+        return None
+
+    db_pool = _resolve_pool(pool)
+    if db_pool is None:
+        return None
+
+    cache_key = compute_cache_key(namespace, request_envelope)
+    row = await db_pool.fetchrow(
+        """
+        WITH hit AS (
+            UPDATE b2b_llm_exact_cache
+            SET last_hit_at = NOW(),
+                hit_count = hit_count + 1
+            WHERE cache_key = $1
+            RETURNING cache_key, namespace, provider, model,
+                      response_text, usage_json, metadata,
+                      created_at, last_hit_at, hit_count
+        )
+        SELECT * FROM hit
+        """,
+        cache_key,
+    )
+    if row is None:
+        return None
+
+    logger.info("Exact LLM cache hit: %s", namespace)
+    return B2BLLMExactCacheHit(
+        cache_key=row["cache_key"],
+        namespace=row["namespace"],
+        provider=row["provider"],
+        model=row["model"],
+        response_text=row["response_text"],
+        usage=_json_field_to_mapping(row["usage_json"]),
+        metadata=_json_field_to_mapping(row["metadata"]),
+        created_at=row["created_at"],
+        last_hit_at=row["last_hit_at"],
+        hit_count=row["hit_count"],
+    )
+
+
+async def store_cached_text(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    provider: str,
+    model: str,
+    response_text: str,
+    usage: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> bool:
+    """Store a successful exact-match response."""
+    if (
+        not namespace
+        or not response_text
+        or not str(response_text).strip()
+        or not is_b2b_llm_exact_cache_enabled()
+    ):
+        return False
+
+    db_pool = _resolve_pool(pool)
+    if db_pool is None:
+        return False
+
+    cache_key = compute_cache_key(namespace, request_envelope)
+    metadata_json = {
+        "cache_version": CACHE_VERSION,
+        **(_normalize_value(metadata or {}) or {}),
+    }
+    await db_pool.execute(
+        """
+        INSERT INTO b2b_llm_exact_cache (
+            cache_key, namespace, provider, model, response_text, usage_json, metadata
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6::jsonb, $7::jsonb
+        )
+        ON CONFLICT (cache_key) DO UPDATE SET
+            provider = EXCLUDED.provider,
+            model = EXCLUDED.model,
+            response_text = EXCLUDED.response_text,
+            usage_json = EXCLUDED.usage_json,
+            metadata = EXCLUDED.metadata
+        """,
+        cache_key,
+        namespace,
+        str(provider or ""),
+        str(model or ""),
+        str(response_text).strip(),
+        canonicalize_for_cache(usage or {}),
+        canonicalize_for_cache(metadata_json),
+    )
+    logger.info("Stored exact LLM cache entry: %s", namespace)
+    return True
+
+
+def _run_coro_sync(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError(
+        "Synchronous exact-cache helpers cannot run inside an active event loop"
+    )
+
+
+def lookup_cached_text_sync(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    pool: Any | None = None,
+) -> B2BLLMExactCacheHit | None:
+    """Sync wrapper for exact-cache lookup."""
+    return _run_coro_sync(
+        lookup_cached_text(namespace, request_envelope, pool=pool)
+    )
+
+
+def store_cached_text_sync(
+    namespace: str,
+    request_envelope: dict[str, Any],
+    *,
+    provider: str,
+    model: str,
+    response_text: str,
+    usage: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    pool: Any | None = None,
+) -> bool:
+    """Sync wrapper for exact-cache store."""
+    return bool(
+        _run_coro_sync(
+            store_cached_text(
+                namespace,
+                request_envelope,
+                provider=provider,
+                model=model,
+                response_text=response_text,
+                usage=usage,
+                metadata=metadata,
+                pool=pool,
+            )
+        )
+    )

--- a/extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql
+++ b/extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS b2b_llm_exact_cache (
+    cache_key TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    response_text TEXT NOT NULL,
+    usage_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_hit_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    hit_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_b2b_llm_exact_cache_namespace_model
+    ON b2b_llm_exact_cache (namespace, model);
+
+CREATE INDEX IF NOT EXISTS idx_b2b_llm_exact_cache_last_hit_at
+    ON b2b_llm_exact_cache (last_hit_at DESC);


### PR DESCRIPTION
## Summary

PR-A1 in the cost-closure sequence (audit doc landed via PR #83). Pure manifest add — no code beyond what `sync_extracted.sh` produces.

- Add manifest mapping for `atlas_brain/services/b2b/llm_exact_cache.py` (378 LOC, the hash-keyed exact-match LLM response cache; namespace + request envelope -> SHA -> response_text + usage_json).
- Add manifest mapping for migration `251_b2b_llm_exact_cache.sql` (18 LOC, the table the cache writes to).
- Run `extracted/_shared/scripts/sync_extracted.sh extracted_llm_infrastructure` to materialize the byte-for-byte copies under the existing Phase 1 scaffold contract.
- Update `extracted_llm_infrastructure/README.md` "What's in scope" table with two new rows and cost-closure context.
- Update `extracted_llm_infrastructure/STATUS.md` file counts: 14 -> 15 Python files, 6 -> 7 migrations.

## Why

Per the cost-closure audit (`docs/extraction/cost_closure_audit_2026-05-03.md` from PR #83), the cost-closure pieces land INSIDE the existing `extracted_llm_infrastructure/` scaffold rather than as a separate package. PR-A1 is the smallest first slice — the exact cache itself, lift-only, no new code. PR-A2 will lift `provider_cost_sync.py` + migration 258. PR-A3 and PR-A4 introduce the new code (cache-savings persistence, drift report, budget gate, OpenAI provider adapter).

## Stacked vs flat

Base = `main` (not stacked). PR #83's audit-doc commit landed on main yesterday; PR-A1 builds directly on the merged state. The COORDINATION.md update in this PR is a post-merge cleanup pass: dropping merged PRs from the In-flight table, advancing per-product state for the four extractions whose PRs landed (#78, #80, #82, #85), retiring merged slices from the Upcoming queue, adding PR-A1 plus PR-B3/B4/B5 placeholders per PR #84's quality-gate audit sequence.

## Validation

```
$ bash extracted/_shared/scripts/sync_extracted.sh extracted_llm_infrastructure
extracted_llm_infrastructure refreshed from atlas_brain sources (22 files)

$ bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure
Validation passed: mapped files for extracted_llm_infrastructure match atlas_brain sources

$ bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure
ASCII check passed for extracted_llm_infrastructure Python files

$ python3 extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure
Import check passed for 15 extracted_llm_infrastructure module(s)
```

## Coordination

- Claimed in `docs/extraction/COORDINATION.md` under In-flight + Upcoming queue (owner `claude-2026-05-03-b`, alias A).
- No conflict with B's quality-gate work (already merged through PR #85; B's next slices are PR-B3/B4/B5 in different files) or C's reasoning work (PR-C1 still queued).
- Cross-product implication: `extracted_competitive_intelligence/services/b2b/llm_exact_cache.py` remains an unchanged Phase 1 bridge stub re-exporting `atlas_brain.services.b2b.llm_exact_cache`. The future migration to point at the extracted path is symmetrical to PR #80's wedge-registry compat-wrapper pattern, deferred per the audit.

## Follow-ups (queued in COORDINATION.md)

- PR-A2: add `services/provider_cost_sync.py` + migration 258 to manifest.
- PR-A3 (NEW CODE): cache-savings persistence + new `llm_cache_savings` migration.
- PR-A4 (NEW CODE): drift report + budget gate + OpenAI provider. May split.