### PR TITLE
Add provider_cost_sync to LLM infrastructure manifest

### DIFF
--- a/docs/extraction/COORDINATION.md
+++ b/docs/extraction/COORDINATION.md
@@ -14,7 +14,7 @@ The team is one human (`@canfieldjuan`) plus AI sessions. Owner column uses GitH
 
 | Product | Phase | Most recent merged PR | Active PRs | Next milestone | Active hot zone |
 |---|---|---|---|---|---|
-| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #87 | PR-A2 (in flight) | Cost-closure additions (PR-A2 -> A4); A2 adds `provider_cost_sync.py` + migration 258. PR-A1.5 follow-up needed for Copilot fixes that did not land in #87 (skills bridge, smoke script update, standalone config flag, STATUS detail rows). | `extracted_llm_infrastructure/services/provider_cost_sync.py`, `extracted_llm_infrastructure/storage/migrations/258_provider_cost_reconciliation.sql`, manifest, README, STATUS |
+| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #87 | #89 | Cost-closure additions (PR-A2 -> A4); A2 adds `provider_cost_sync.py` + migration 258. PR-A1.5 follow-up needed for Copilot fixes that did not land in #87 (skills bridge, smoke script update, standalone config flag, STATUS detail rows). | `extracted_llm_infrastructure/services/provider_cost_sync.py`, `extracted_llm_infrastructure/storage/migrations/258_provider_cost_reconciliation.sql`, manifest, README, STATUS |
 | `extracted_competitive_intelligence` | 1 (scaffold) | #80 | — | Phase 2 standalone toggle | none |
 | `extracted_content_pipeline` | 1 -> 2 (productization seams) | #78 | — | Standalone runner without `atlas_brain` on path | none |
 | `extracted_reasoning_core` | 1 (scaffold + wedge consolidated; PR-C1 claimed) | #82 | PR-C1 (claimed; claude-2026-05-03) | Evidence/temporal/archetypes consolidation per merged PR #82 audit | `extracted_reasoning_core/**` (api/types/archetypes/evidence_engine/evidence_map.yaml/temporal); `atlas_brain/reasoning/{evidence_engine.py, review_enrichment.py}`; `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`; `tests/test_extracted_reasoning_*.py` |
@@ -28,7 +28,7 @@ Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, s
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-A2, opening) | Add `provider_cost_sync` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/provider_cost_sync.py, storage/migrations/258_provider_cost_reconciliation.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/` and `storage/migrations/258_*` |
+| #89 | Add `provider_cost_sync` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/provider_cost_sync.py, storage/migrations/258_provider_cost_reconciliation.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/` and `storage/migrations/258_*` |
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
 _(Rows for merged PRs #77, #78, #79, #80, #81, #82, #83, #84, #85, #86, #87 dropped per session protocol step 4. Outcomes preserved in Decisions log and per-product state.)_
 

--- a/docs/extraction/COORDINATION.md
+++ b/docs/extraction/COORDINATION.md
@@ -1,6 +1,6 @@
 # Extraction Coordination
 
-Last updated: 2026-05-03T19:31Z by codex-2026-05-03
+Last updated: 2026-05-03T22:00Z by claude-2026-05-03-b
 
 State-of-the-world for the multi-product extraction effort. Read this end-to-end at session start before doing substantive work. Update before opening a PR, after merging one, or when a decision lands.
 
@@ -14,7 +14,7 @@ The team is one human (`@canfieldjuan`) plus AI sessions. Owner column uses GitH
 
 | Product | Phase | Most recent merged PR | Active PRs | Next milestone | Active hot zone |
 |---|---|---|---|---|---|
-| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #49 | #87 | Cost-closure additions (PR-A1 -> A4); A1 adds `llm_exact_cache.py` + migration 251 | `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`, `extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql`, manifest, README, STATUS |
+| `extracted_llm_infrastructure` | 2 (standalone toggle landed; Phase 3 decoupling pending) | #87 | PR-A2 (in flight) | Cost-closure additions (PR-A2 -> A4); A2 adds `provider_cost_sync.py` + migration 258. PR-A1.5 follow-up needed for Copilot fixes that did not land in #87 (skills bridge, smoke script update, standalone config flag, STATUS detail rows). | `extracted_llm_infrastructure/services/provider_cost_sync.py`, `extracted_llm_infrastructure/storage/migrations/258_provider_cost_reconciliation.sql`, manifest, README, STATUS |
 | `extracted_competitive_intelligence` | 1 (scaffold) | #80 | — | Phase 2 standalone toggle | none |
 | `extracted_content_pipeline` | 1 -> 2 (productization seams) | #78 | — | Standalone runner without `atlas_brain` on path | none |
 | `extracted_reasoning_core` | 1 (scaffold + wedge consolidated; PR-C1 claimed) | #82 | PR-C1 (claimed; claude-2026-05-03) | Evidence/temporal/archetypes consolidation per merged PR #82 audit | `extracted_reasoning_core/**` (api/types/archetypes/evidence_engine/evidence_map.yaml/temporal); `atlas_brain/reasoning/{evidence_engine.py, review_enrichment.py}`; `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`; `tests/test_extracted_reasoning_*.py` |
@@ -28,8 +28,9 @@ Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, s
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #87 | Add `llm_exact_cache` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/b2b/llm_exact_cache.py, storage/migrations/251_b2b_llm_exact_cache.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/b2b/` and `storage/migrations/` |
-_(Rows for merged PRs #77, #78, #79, #80, #81, #82, #83, #84, #85, #86 dropped per session protocol step 4. Outcomes preserved in Decisions log and per-product state.)_
+| (PR-A2, opening) | Add `provider_cost_sync` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/provider_cost_sync.py, storage/migrations/258_provider_cost_reconciliation.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/` and `storage/migrations/258_*` |
+| (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
+_(Rows for merged PRs #77, #78, #79, #80, #81, #82, #83, #84, #85, #86, #87 dropped per session protocol step 4. Outcomes preserved in Decisions log and per-product state.)_
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.
 
@@ -39,8 +40,8 @@ This table is for PRs we need to coordinate around, not a mirror of `gh pr list`
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-A1 | `extracted_llm_infrastructure` | claude-2026-05-03-b | none (PR-A0 / #83 merged) | Add `services/b2b/llm_exact_cache.py` + migration `251_b2b_llm_exact_cache.sql` to manifest. Update README + STATUS. **In flight.** |
-| PR-A2 | `extracted_llm_infrastructure` | unclaimed | PR-A1 | Add `services/provider_cost_sync.py` + migration `258_provider_cost_reconciliation.sql`. Sync orchestration. |
+| PR-A2 | `extracted_llm_infrastructure` | claude-2026-05-03-b | none (PR-A1 / #87 merged) | Add `services/provider_cost_sync.py` + migration `258_provider_cost_reconciliation.sql` to manifest. **In flight.** |
+| PR-A1.5 | `extracted_llm_infrastructure` | claude-2026-05-03-b | none | Re-apply Copilot fixes that did not land in PR #87 merge: skills bridge stub, standalone `llm_exact_cache_enabled` flag, smoke script entries, STATUS detail rows. Opening immediately after PR-A2. |
 | PR-A3 | `extracted_llm_infrastructure` | unclaimed | PR-A1 | New code: cache-savings persistence layer + migration. Closes the "$ saved by cache" telemetry gap. |
 | PR-A4 | `extracted_llm_infrastructure` | unclaimed | PR-A2, PR-A3 | New code: drift report (local vs invoiced), budget gate, OpenAI provider adapter. May split if too large. |
 | PR-B3 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Safety-gate split: deterministic content/risk scan to core; approvals + audit log + DB to ports + Atlas adapter wrapper. |

--- a/extracted_llm_infrastructure/README.md
+++ b/extracted_llm_infrastructure/README.md
@@ -23,9 +23,11 @@ The pattern mirrors the content-pipeline scaffold under
 | `services/llm/{anthropic,openrouter,ollama,vllm,groq,together,hybrid,cloud}.py` | `atlas_brain/services/llm/*.py` | Eight LLM provider implementations |
 | `services/tracing.py` | `atlas_brain/services/tracing.py` | FTL tracer client (token counts, cost telemetry, hierarchical spans) |
 | `services/b2b/llm_exact_cache.py` | `atlas_brain/services/b2b/llm_exact_cache.py` | Hash-keyed exact-match LLM response cache (~378 LOC); namespace + request envelope -> SHA -> response_text + usage_json. Cost-closure foundation. |
+| `services/provider_cost_sync.py` | `atlas_brain/services/provider_cost_sync.py` | Provider billing reconciliation (~286 LOC). Fetches OpenRouter credits + Anthropic admin daily costs, persists snapshots and daily rows for local-vs-invoiced drift reporting. |
 | `storage/migrations/127_llm_usage.sql` | mig 127 | Initial llm_usage table |
 | `storage/migrations/130_reasoning_semantic_cache.sql` | mig 130 | Semantic cache + metacognition tables |
 | `storage/migrations/251_b2b_llm_exact_cache.sql` | mig 251 | b2b_llm_exact_cache table (cost-closure: cached LLM responses + usage_json) |
+| `storage/migrations/258_provider_cost_reconciliation.sql` | mig 258 | llm_provider_usage_snapshots + llm_provider_daily_costs tables (cost-closure: invoice reconciliation) |
 | `storage/migrations/252_llm_usage_cache_breakdown.sql` | mig 252 | Cache + queue token breakdown |
 | `storage/migrations/253_llm_usage_vendor_and_run_id.sql` | mig 253 | Vendor + run_id columns |
 | `storage/migrations/255_anthropic_message_batches.sql` | mig 255 | Anthropic batch + items tables |

--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -5,8 +5,8 @@
 | Step | Status |
 |---|---|
 | Manifest of source → scaffold mappings | ✅ done |
-| Verbatim byte-snapshot of 15 Python files | ✅ done (added `services/b2b/llm_exact_cache.py` in PR-A1) |
-| Verbatim byte-snapshot of 7 migration SQL files | ✅ done (added migration 251 in PR-A1) |
+| Verbatim byte-snapshot of 16 Python files | ✅ done (added `services/b2b/llm_exact_cache.py` in PR-A1, `services/provider_cost_sync.py` in PR-A2) |
+| Verbatim byte-snapshot of 8 migration SQL files | ✅ done (added migration 251 in PR-A1, 258 in PR-A2) |
 | Package `__init__.py` files at every level | ✅ done |
 | Sync + validate scripts | ✅ done via shared tooling wrappers |
 | ASCII / smoke-import / import-debt checks | ✅ done via shared tooling wrappers |
@@ -80,9 +80,11 @@ Import contract is closed; the remaining work is **runtime** behavior when funct
 | `services/llm/hybrid.py` | ✅ | ✅ | 🔲 |
 | `services/llm/cloud.py` | ✅ | ✅ | 🔲 |
 | `services/tracing.py` | ✅ | ✅ | 🔲 |
+| `services/provider_cost_sync.py` (PR-A2) | ✅ | 🔲 (Phase 2 follow-up: standalone substrate for provider settings + db pool wrapper for snapshot/daily-cost upserts; lift uses default Atlas mode for now) | 🔲 |
 | `storage/migrations/127_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/130_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/252_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/253_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/255_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/257_*.sql` | ✅ | n/a | n/a |
+| `storage/migrations/258_*.sql` (PR-A2) | ✅ | n/a | n/a |

--- a/extracted_llm_infrastructure/manifest.json
+++ b/extracted_llm_infrastructure/manifest.json
@@ -61,6 +61,10 @@
       "target": "extracted_llm_infrastructure/services/b2b/llm_exact_cache.py"
     },
     {
+      "source": "atlas_brain/services/provider_cost_sync.py",
+      "target": "extracted_llm_infrastructure/services/provider_cost_sync.py"
+    },
+    {
       "source": "atlas_brain/storage/migrations/127_llm_usage.sql",
       "target": "extracted_llm_infrastructure/storage/migrations/127_llm_usage.sql"
     },
@@ -79,6 +83,10 @@
     {
       "source": "atlas_brain/storage/migrations/251_b2b_llm_exact_cache.sql",
       "target": "extracted_llm_infrastructure/storage/migrations/251_b2b_llm_exact_cache.sql"
+    },
+    {
+      "source": "atlas_brain/storage/migrations/258_provider_cost_reconciliation.sql",
+      "target": "extracted_llm_infrastructure/storage/migrations/258_provider_cost_reconciliation.sql"
     },
     {
       "source": "atlas_brain/storage/migrations/255_anthropic_message_batches.sql",

--- a/extracted_llm_infrastructure/services/provider_cost_sync.py
+++ b/extracted_llm_infrastructure/services/provider_cost_sync.py
@@ -1,0 +1,286 @@
+"""Provider billing sync for cost reconciliation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+from ..config import settings
+from .llm.openrouter import _resolve_openrouter_api_key
+
+logger = logging.getLogger("atlas.services.provider_cost_sync")
+
+_OPENROUTER_CREDITS_URL = "https://openrouter.ai/api/v1/credits"
+_ANTHROPIC_COST_REPORT_URL = "https://api.anthropic.com/v1/organizations/cost_report"
+_ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _safe_float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _resolve_openrouter_management_key() -> str:
+    override = str(getattr(settings.provider_cost, "openrouter_api_key", "") or "").strip()
+    if override:
+        return override
+    return _resolve_openrouter_api_key()
+
+
+def _resolve_anthropic_admin_key() -> str:
+    override = str(getattr(settings.provider_cost, "anthropic_admin_api_key", "") or "").strip()
+    if override:
+        return override
+    return str(os.environ.get("ANTHROPIC_ADMIN_API_KEY", "") or "").strip()
+
+
+async def _insert_openrouter_snapshot(
+    pool,
+    *,
+    snapshot_at: datetime,
+    total_usage_usd: float,
+    total_credits_usd: float | None,
+    raw_payload: dict[str, Any],
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO llm_provider_usage_snapshots (
+            provider,
+            snapshot_at,
+            total_usage_usd,
+            total_credits_usd,
+            raw_payload
+        )
+        VALUES ($1, $2, $3, $4, $5::jsonb)
+        """,
+        "openrouter",
+        snapshot_at,
+        total_usage_usd,
+        total_credits_usd,
+        json.dumps(raw_payload),
+    )
+
+
+async def _upsert_anthropic_daily_cost(
+    pool,
+    *,
+    cost_date: str,
+    provider_cost_usd: float,
+    currency: str,
+    raw_payload: dict[str, Any],
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO llm_provider_daily_costs (
+            provider,
+            cost_date,
+            provider_cost_usd,
+            currency,
+            source_kind,
+            raw_payload,
+            imported_at
+        )
+        VALUES ($1, $2::date, $3, $4, $5, $6::jsonb, NOW())
+        ON CONFLICT (provider, cost_date, source_kind)
+        DO UPDATE SET
+            provider_cost_usd = EXCLUDED.provider_cost_usd,
+            currency = EXCLUDED.currency,
+            raw_payload = EXCLUDED.raw_payload,
+            imported_at = NOW()
+        """,
+        "anthropic",
+        cost_date,
+        provider_cost_usd,
+        currency or "USD",
+        "anthropic_cost_report",
+        json.dumps(raw_payload),
+    )
+
+
+async def _cleanup_old_rows(pool) -> None:
+    now = datetime.now(timezone.utc)
+    snapshot_cutoff = now - timedelta(days=int(settings.provider_cost.snapshot_retention_days))
+    daily_cutoff = (now - timedelta(days=int(settings.provider_cost.daily_retention_days))).date()
+    await pool.execute(
+        """
+        DELETE FROM llm_provider_usage_snapshots
+        WHERE snapshot_at < $1
+        """,
+        snapshot_cutoff,
+    )
+    await pool.execute(
+        """
+        DELETE FROM llm_provider_daily_costs
+        WHERE cost_date < $1::date
+        """,
+        daily_cutoff,
+    )
+
+
+async def _fetch_openrouter_credits_snapshot(
+    client: httpx.AsyncClient,
+    *,
+    api_key: str,
+) -> dict[str, Any]:
+    response = await client.get(
+        _OPENROUTER_CREDITS_URL,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("data") if isinstance(payload, dict) else {}
+    if not isinstance(data, dict):
+        data = {}
+    return {
+        "provider": "openrouter",
+        "snapshot_at": datetime.now(timezone.utc),
+        "total_usage_usd": _safe_float(data.get("total_usage")),
+        "total_credits_usd": _safe_float(data.get("total_credits")) if data.get("total_credits") is not None else None,
+        "raw_payload": payload if isinstance(payload, dict) else {"raw": payload},
+    }
+
+
+async def _fetch_anthropic_daily_costs(
+    client: httpx.AsyncClient,
+    *,
+    admin_api_key: str,
+    lookback_days: int,
+) -> list[dict[str, Any]]:
+    ending_at = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    starting_at = (ending_at - timedelta(days=lookback_days)).replace(hour=0)
+    rows: dict[str, dict[str, Any]] = {}
+    page: str | None = None
+
+    while True:
+        params: dict[str, Any] = {
+            "starting_at": starting_at.isoformat().replace("+00:00", "Z"),
+            "ending_at": ending_at.isoformat().replace("+00:00", "Z"),
+            "bucket_width": "1d",
+            "limit": min(max(lookback_days, 1), 31),
+        }
+        if page:
+            params["page"] = page
+        response = await client.get(
+            _ANTHROPIC_COST_REPORT_URL,
+            params=params,
+            headers={
+                "x-api-key": admin_api_key,
+                "anthropic-version": _ANTHROPIC_VERSION,
+                "content-type": "application/json",
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data") if isinstance(payload, dict) else []
+        if not isinstance(data, list):
+            data = []
+        for bucket in data:
+            if not isinstance(bucket, dict):
+                continue
+            bucket_start = str(bucket.get("starting_at") or "").strip()
+            if not bucket_start:
+                continue
+            cost_date = bucket_start[:10]
+            results = bucket.get("results")
+            total_cost = 0.0
+            currency = "USD"
+            if isinstance(results, list):
+                for entry in results:
+                    if not isinstance(entry, dict):
+                        continue
+                    total_cost += _safe_float(entry.get("amount"))
+                    currency = str(entry.get("currency") or currency or "USD")
+            rows[cost_date] = {
+                "cost_date": cost_date,
+                "provider_cost_usd": round(total_cost, 6),
+                "currency": currency or "USD",
+                "raw_payload": bucket,
+            }
+        has_more = bool(payload.get("has_more")) if isinstance(payload, dict) else False
+        next_page = payload.get("next_page") if isinstance(payload, dict) else None
+        if not has_more or not next_page:
+            break
+        page = str(next_page)
+
+    return [rows[key] for key in sorted(rows.keys())]
+
+
+async def sync_provider_costs(*, pool, client: httpx.AsyncClient | None = None) -> dict[str, Any]:
+    """Sync provider billing totals into local reconciliation tables."""
+    cfg = settings.provider_cost
+    if not bool(cfg.enabled):
+        return {"_skip_synthesis": "Provider cost sync disabled"}
+
+    timeout = float(getattr(cfg, "sync_timeout_seconds", 20) or 20)
+    summary: dict[str, Any] = {
+        "openrouter_snapshot_written": False,
+        "anthropic_daily_rows_upserted": 0,
+        "providers_synced": [],
+        "errors": [],
+    }
+
+    async def _run(active_client: httpx.AsyncClient) -> None:
+        if bool(cfg.openrouter_enabled):
+            api_key = _resolve_openrouter_management_key()
+            if api_key:
+                try:
+                    snapshot = await _fetch_openrouter_credits_snapshot(active_client, api_key=api_key)
+                    await _insert_openrouter_snapshot(
+                        pool,
+                        snapshot_at=snapshot["snapshot_at"],
+                        total_usage_usd=snapshot["total_usage_usd"],
+                        total_credits_usd=snapshot["total_credits_usd"],
+                        raw_payload=snapshot["raw_payload"],
+                    )
+                    summary["openrouter_snapshot_written"] = True
+                    summary["providers_synced"].append("openrouter")
+                except Exception as exc:
+                    logger.warning("provider_cost_sync.openrouter_failed: %s", exc)
+                    summary["errors"].append(f"openrouter:{type(exc).__name__}")
+            else:
+                summary["errors"].append("openrouter:missing_api_key")
+
+        if bool(cfg.anthropic_enabled):
+            admin_api_key = _resolve_anthropic_admin_key()
+            if admin_api_key:
+                try:
+                    rows = await _fetch_anthropic_daily_costs(
+                        active_client,
+                        admin_api_key=admin_api_key,
+                        lookback_days=int(getattr(cfg, "anthropic_lookback_days", 7) or 7),
+                    )
+                    for row in rows:
+                        await _upsert_anthropic_daily_cost(
+                            pool,
+                            cost_date=row["cost_date"],
+                            provider_cost_usd=row["provider_cost_usd"],
+                            currency=row["currency"],
+                            raw_payload=row["raw_payload"],
+                        )
+                    if rows:
+                        summary["providers_synced"].append("anthropic")
+                    summary["anthropic_daily_rows_upserted"] = len(rows)
+                except Exception as exc:
+                    logger.warning("provider_cost_sync.anthropic_failed: %s", exc)
+                    summary["errors"].append(f"anthropic:{type(exc).__name__}")
+            else:
+                summary["errors"].append("anthropic:missing_admin_api_key")
+
+    if client is not None:
+        await _run(client)
+    else:
+        async with httpx.AsyncClient(timeout=timeout) as active_client:
+            await _run(active_client)
+
+    await _cleanup_old_rows(pool)
+
+    if not summary["providers_synced"] and not summary["openrouter_snapshot_written"] and not summary["anthropic_daily_rows_upserted"]:
+        summary["_skip_synthesis"] = "No provider cost data synced"
+    return summary

--- a/extracted_llm_infrastructure/storage/migrations/258_provider_cost_reconciliation.sql
+++ b/extracted_llm_infrastructure/storage/migrations/258_provider_cost_reconciliation.sql
@@ -1,0 +1,32 @@
+-- Storage for provider billing reconciliation.
+--
+-- OpenRouter exposes account-level cumulative usage via /api/v1/credits, so we
+-- store snapshots and derive daily deltas at query time.
+-- Anthropic exposes daily cost reports directly via the Admin API, so we store
+-- normalized daily rows separately.
+
+CREATE TABLE IF NOT EXISTS llm_provider_usage_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider TEXT NOT NULL,
+    snapshot_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    total_usage_usd NUMERIC(12, 6) NOT NULL,
+    total_credits_usd NUMERIC(12, 6),
+    raw_payload JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_provider_usage_snapshots_provider_time
+    ON llm_provider_usage_snapshots (provider, snapshot_at DESC);
+
+CREATE TABLE IF NOT EXISTS llm_provider_daily_costs (
+    provider TEXT NOT NULL,
+    cost_date DATE NOT NULL,
+    provider_cost_usd NUMERIC(12, 6) NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'USD',
+    source_kind TEXT NOT NULL,
+    raw_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (provider, cost_date, source_kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_provider_daily_costs_provider_date
+    ON llm_provider_daily_costs (provider, cost_date DESC);


### PR DESCRIPTION
## Summary

PR-A2 in the cost-closure sequence (PR #83 audit, PR #87 PR-A1). Pure manifest add — no code beyond what `sync_extracted.sh` produces.

- Add manifest mapping for `atlas_brain/services/provider_cost_sync.py` (286 LOC, OpenRouter credits + Anthropic admin daily-cost fetcher).
- Add manifest mapping for migration `258_provider_cost_reconciliation.sql` (32 LOC, the `llm_provider_usage_snapshots` + `llm_provider_daily_costs` tables).
- Sync produces byte-for-byte copies under the existing Phase 1 scaffold contract.
- Update `extracted_llm_infrastructure/README.md` and `STATUS.md` (file counts: 15->16 Python, 7->8 migrations).

## Why

`provider_cost_sync.py` + the reconciliation tables are the foundation for the differentiated cost-closure wedge per the PR-A0 audit (`docs/extraction/cost_closure_audit_2026-05-03.md`): every observability tool logs token usage; few reconcile against the provider's own billing API. With this PR landed, the extracted package owns both sides of that comparison (local `llm_usage` from the FTL tracer + OpenRouter/Anthropic invoiced amounts). The drift report (PR-A4) computes the actual delta; this PR ships the data plumbing.

## Validation

```
$ bash extracted/_shared/scripts/sync_extracted.sh extracted_llm_infrastructure
extracted_llm_infrastructure refreshed from atlas_brain sources (24 files)

$ bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure
Validation passed: mapped files for extracted_llm_infrastructure match atlas_brain sources

$ bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure
ASCII check passed for extracted_llm_infrastructure Python files

$ python3 extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure
Import check passed for 16 extracted_llm_infrastructure module(s)
```

## Coordination

- Claimed in `docs/extraction/COORDINATION.md` In-flight + Upcoming queue (owner `claude-2026-05-03-b` / alias A).
- Independent of B's quality-gate PRs (different product) and C's reasoning PRs (different files).

## Known follow-up

PR #87 (PR-A1) merged WITHOUT four Copilot review fixes that I pushed after the merge had already started: skills bridge stub for `llm_exact_cache.py:160`'s `from ...skills` import, `llm_exact_cache_enabled` field in standalone `B2BChurnSubConfig`, smoke-script entries for the new module, STATUS.md detail rows. PR-A1.5 (queued in COORDINATION) opens immediately after this PR to re-apply those.

## Follow-ups (queued in COORDINATION.md)

- PR-A1.5: re-apply Copilot fixes that missed PR #87 merge (5 files).
- PR-A3 (NEW CODE): cache-savings persistence + new `llm_cache_savings` migration.
- PR-A4 (NEW CODE): drift report + budget gate + OpenAI provider. May split.