### PR TITLE
Re-apply Copilot fixes that missed PR #87 merge

### DIFF
--- a/docs/extraction/COORDINATION.md
+++ b/docs/extraction/COORDINATION.md
@@ -1,6 +1,6 @@
 # Extraction Coordination
 
-Last updated: 2026-05-03T19:31Z by codex-2026-05-03
+Last updated: 2026-05-03T22:15Z by claude-2026-05-03-b
 
 State-of-the-world for the multi-product extraction effort. Read this end-to-end at session start before doing substantive work. Update before opening a PR, after merging one, or when a decision lands.
 
@@ -28,8 +28,8 @@ Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, s
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #87 | Add `llm_exact_cache` to LLM-infrastructure manifest | `extracted_llm_infrastructure/{manifest.json, services/b2b/llm_exact_cache.py, storage/migrations/251_b2b_llm_exact_cache.sql, README.md, STATUS.md}`; `docs/extraction/COORDINATION.md` | claude-2026-05-03-b | manifest edits or files synced into `extracted_llm_infrastructure/services/b2b/` and `storage/migrations/` |
-_(Rows for merged PRs #77, #78, #79, #80, #81, #82, #83, #84, #85, #86 dropped per session protocol step 4. Outcomes preserved in Decisions log and per-product state.)_
+| (PR-A1.5, opening) | Re-apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 listed files |
+_(Rows for merged PRs #77, #78, #79, #80, #81, #82, #83, #84, #85, #86, #87 dropped per session protocol step 4.)_
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.
 

--- a/docs/extraction/COORDINATION.md
+++ b/docs/extraction/COORDINATION.md
@@ -28,7 +28,7 @@ Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, s
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-A1.5, opening) | Re-apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 listed files |
+| #90 | Re-apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 listed files |
 _(Rows for merged PRs #77, #78, #79, #80, #81, #82, #83, #84, #85, #86, #87 dropped per session protocol step 4.)_
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -68,6 +68,8 @@ Import contract is closed; the remaining work is **runtime** behavior when funct
 | `storage/database.py` (bridge) | n/a | ✅ env-gated dispatch | n/a |
 | `services/b2b/anthropic_batch.py` | ✅ | ✅ (imports cleanly; consumes standalone substrate transitively) | 🔲 |
 | `services/b2b/cache_strategy.py` | ✅ | ✅ (pure data; no atlas imports) | n/a |
+| `services/b2b/llm_exact_cache.py` (PR-A1) | ✅ | ✅ (lazy `from ...config import settings` + `from ...storage.database import get_db_pool` route via env-gated bridges; new `from ...skills import get_skill_registry` routes via PR-A1.5 skills bridge with explicit standalone-mode error; `B2BChurnSubConfig.llm_exact_cache_enabled` flag added in PR-A1.5) | 🔲 (Phase 3: substrate skills layer or replace skill helpers with Protocol-based DI) |
+| `skills/__init__.py` (bridge, PR-A1.5) | n/a | ✅ env-gated dispatch; raises NotImplementedError in standalone mode | 🔲 |
 | `pipelines/llm.py` | ✅ | ✅ (lazy `from ..config import settings` routes to standalone) | 🔲 |
 | `reasoning/semantic_cache.py` | ✅ | ✅ (pool injected by caller; standalone DatabasePool compatible) | 🔲 |
 | `services/llm_router.py` | ✅ | ✅ (consumes standalone settings + registry) | 🔲 |
@@ -82,6 +84,7 @@ Import contract is closed; the remaining work is **runtime** behavior when funct
 | `services/tracing.py` | ✅ | ✅ | 🔲 |
 | `storage/migrations/127_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/130_*.sql` | ✅ | n/a | n/a |
+| `storage/migrations/251_*.sql` (PR-A1) | ✅ | n/a | n/a |
 | `storage/migrations/252_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/253_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/255_*.sql` | ✅ | n/a | n/a |

--- a/extracted_llm_infrastructure/_standalone/config.py
+++ b/extracted_llm_infrastructure/_standalone/config.py
@@ -168,10 +168,17 @@ class LLMSubConfig(BaseSettings):
 
 
 class B2BChurnSubConfig(BaseSettings):
-    """Slim B2B churn config -- only the LLM-batch and OpenRouter fields
-    the scaffold reads at runtime. Atlas's full ``B2BChurnConfig`` has
-    ~80 unrelated fields (billing, scrape, calibration, etc.) that the
-    LLM-infra subsystem does not touch."""
+    """Slim B2B churn config -- only the LLM-infrastructure fields the
+    scaffold reads at runtime. Atlas's full ``B2BChurnConfig`` has ~80
+    unrelated fields (billing, scrape, calibration, etc.) that the
+    LLM-infra subsystem does not touch.
+
+    Currently includes:
+
+    - OpenRouter API key
+    - Anthropic Message Batches settings (enabled / poll / timeout / min items)
+    - LLM exact-cache feature flag (``llm_exact_cache_enabled``)
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="ATLAS_B2B_CHURN_",

--- a/extracted_llm_infrastructure/_standalone/config.py
+++ b/extracted_llm_infrastructure/_standalone/config.py
@@ -184,6 +184,7 @@ class B2BChurnSubConfig(BaseSettings):
     anthropic_batch_poll_interval_seconds: float = Field(default=5.0, ge=1.0, le=60.0)
     anthropic_batch_timeout_seconds: float = Field(default=900.0, ge=30.0, le=86400.0)
     anthropic_batch_min_items: int = Field(default=2, ge=1, le=10000)
+    llm_exact_cache_enabled: bool = Field(default=False)
 
 
 class ReasoningSubConfig(BaseSettings):

--- a/extracted_llm_infrastructure/skills/__init__.py
+++ b/extracted_llm_infrastructure/skills/__init__.py
@@ -1,0 +1,36 @@
+"""Phase 2 bridge: skills entry point for the LLM-infrastructure scaffold.
+
+The exact LLM cache (`services/b2b/llm_exact_cache.py:160`) lazily imports
+`get_skill_registry` from `...skills` to build skill-message envelopes. In
+default mode that resolves to `atlas_brain.skills`. A standalone substrate
+for skills is not yet carved out -- skill prompts are owned by Atlas's
+content/competitive-intelligence pipelines and have not been classified for
+extraction yet. Phase 3 work that decouples cache helpers from skills (or
+extracts skills behind a Protocol) will replace this bridge with a proper
+substrate.
+
+Default mode (``EXTRACTED_LLM_INFRA_STANDALONE`` unset/false): re-export
+from ``atlas_brain.skills`` so the cache helpers run as a sibling of Atlas.
+
+Standalone mode (``EXTRACTED_LLM_INFRA_STANDALONE=1``): raise on access.
+The cache helpers that need skills are not callable in standalone mode
+until Phase 3 extracts (or stubs) the skills layer; lookup/store paths
+that do not call `build_skill_messages` / `build_skill_request_envelope`
+remain usable.
+"""
+
+from __future__ import annotations
+
+import os as _os
+
+if _os.environ.get("EXTRACTED_LLM_INFRA_STANDALONE") == "1":
+    def get_skill_registry(*_args, **_kwargs):  # type: ignore[no-redef]
+        raise NotImplementedError(
+            "extracted_llm_infrastructure.skills is not implemented in "
+            "standalone mode. The skills layer is owned by content/"
+            "competitive-intelligence pipelines and has not been extracted. "
+            "Phase 3 will decouple cache helpers from skills."
+        )
+else:
+    from atlas_brain.skills import *  # noqa: F401,F403
+    from atlas_brain.skills import get_skill_registry  # noqa: F401

--- a/scripts/smoke_extracted_llm_infrastructure_imports.py
+++ b/scripts/smoke_extracted_llm_infrastructure_imports.py
@@ -21,6 +21,10 @@ MODULES = [
     "extracted_llm_infrastructure.services.b2b.anthropic_batch",
     "extracted_llm_infrastructure.services.b2b.cache_strategy",
     "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
+    # llm_exact_cache lazily imports `from ...skills import
+    # get_skill_registry` inside helpers; importing the skills bridge
+    # explicitly here catches a broken bridge even if no helper runs.
+    "extracted_llm_infrastructure.skills",
     "extracted_llm_infrastructure.pipelines.llm",
     "extracted_llm_infrastructure.reasoning.semantic_cache",
     "extracted_llm_infrastructure.services.llm_router",

--- a/scripts/smoke_extracted_llm_infrastructure_imports.py
+++ b/scripts/smoke_extracted_llm_infrastructure_imports.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 MODULES = [
     "extracted_llm_infrastructure.services.b2b.anthropic_batch",
     "extracted_llm_infrastructure.services.b2b.cache_strategy",
+    "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
     "extracted_llm_infrastructure.pipelines.llm",
     "extracted_llm_infrastructure.reasoning.semantic_cache",
     "extracted_llm_infrastructure.services.llm_router",

--- a/scripts/smoke_extracted_llm_infrastructure_standalone.py
+++ b/scripts/smoke_extracted_llm_infrastructure_standalone.py
@@ -196,6 +196,7 @@ def main() -> int:
     PROVIDERS = [
         "extracted_llm_infrastructure.services.b2b.cache_strategy",
         "extracted_llm_infrastructure.services.b2b.anthropic_batch",
+        "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
         "extracted_llm_infrastructure.pipelines.llm",
         "extracted_llm_infrastructure.reasoning.semantic_cache",
         "extracted_llm_infrastructure.services.llm_router",

--- a/scripts/smoke_extracted_llm_infrastructure_standalone.py
+++ b/scripts/smoke_extracted_llm_infrastructure_standalone.py
@@ -188,6 +188,27 @@ def main() -> int:
         print(f"FAIL storage.database: {exc}")
         failed.append("storage.database")
 
+    # 6. Skills (bridge stub)
+    try:
+        from extracted_llm_infrastructure.skills import get_skill_registry
+
+        # In standalone mode the bridge MUST raise NotImplementedError.
+        # If it instead resolved silently to atlas_brain.skills (e.g.
+        # the env-gate regressed), this assertion would catch it.
+        try:
+            get_skill_registry()
+        except NotImplementedError:
+            print("OK skills (bridge raises NotImplementedError as expected)")
+        else:
+            raise AssertionError(
+                "skills bridge did not raise in standalone mode -- "
+                "the env-gate may have regressed and silently resolved "
+                "to atlas_brain.skills"
+            )
+    except Exception as exc:
+        print(f"FAIL skills: {exc}")
+        failed.append("skills")
+
     # ------------------------------------------------------------------
     # Part C: every provider module imports cleanly in standalone mode
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR-A1.5: four Copilot review fixes for `services/b2b/llm_exact_cache.py` did not land in PR #87's merge (merge timestamp preceded my fix-push commit). Re-applying off main as a separate small slice. PR-A2 (#89) stays scoped to `provider_cost_sync.py`; this PR is purely the missed Copilot follow-up.

| Fix | File | Change |
|---|---|---|
| Skills bridge stub | `extracted_llm_infrastructure/skills/__init__.py` (NEW) | Env-gated dispatch mirroring the existing 5 Phase-2 bridges. Default mode re-exports `atlas_brain.skills`; standalone mode raises NotImplementedError. Resolves the lazy `from ...skills import get_skill_registry` in `llm_exact_cache.py:160`. |
| Standalone config flag | `extracted_llm_infrastructure/_standalone/config.py` | Added `llm_exact_cache_enabled: bool = Field(default=False)` to `B2BChurnSubConfig`. The helper at `is_b2b_llm_exact_cache_enabled()` previously returned False permanently in standalone mode. |
| Smoke import coverage | `scripts/smoke_extracted_llm_infrastructure_imports.py` + `_standalone.py` | Added `extracted_llm_infrastructure.services.b2b.llm_exact_cache` to the module lists so CI exercises the new module. |
| STATUS detail rows | `extracted_llm_infrastructure/STATUS.md` | Added rows for `services/b2b/llm_exact_cache.py`, `skills/__init__.py` (bridge), and `storage/migrations/251_*.sql` to "Per-file extraction state". Counts at the top were updated in PR #87; this catches up the detail table. |

## Why these missed PR #87

I pushed these fixes shortly after the merge of #87 began. The merge took the prior commit, not the fix commit. Detected when this branch was created from `origin/main` and the four files showed the pre-fix state.

## Validation

```
$ bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure
Validation passed: mapped files for extracted_llm_infrastructure match atlas_brain sources

$ bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure
ASCII check passed for extracted_llm_infrastructure Python files

$ python3 extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure
Import check passed for 15 extracted_llm_infrastructure module(s)

$ python3 scripts/smoke_extracted_llm_infrastructure_imports.py
... 15 modules OK including llm_exact_cache ...
Import smoke passed
```

## Coordination

- Owner `claude-2026-05-03-b` (alias A); claimed in COORDINATION.md In-flight table.
- Independent of PR-A2 (#89, also in flight from same owner) -- different files, no rebase needed.
- Independent of B's quality-gate work and C's reasoning work.

## Follow-ups

After #89 (PR-A2) and this PR land, queue continues:
- PR-A3 (NEW CODE): cache-savings persistence + new `llm_cache_savings` migration.
- PR-A4 (NEW CODE): drift report + budget gate + OpenAI provider. May split.