### PR TITLE
PR-C1a: Move archetypes + evidence_map to reasoning core

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:02Z by claude-2026-05-03
+Last updated: 2026-05-03T22:03Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
+| (PR-C1, in flight) | Reasoning evidence/temporal/archetypes consolidation | NEW: `extracted_reasoning_core/{archetypes,evidence_engine,evidence_map.yaml,temporal}.py`; `atlas_brain/reasoning/review_enrichment.py`. EDIT: `atlas_brain/reasoning/evidence_engine.py` (slim); `extracted_reasoning_core/{api,types}.py`; `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` (-> wrappers); `tests/test_extracted_reasoning_core_api.py`. RENAME: `tests/test_extracted_reasoning_*.py` -> `tests/test_extracted_reasoning_core_*.py`. Audit-doc amendment to `docs/extraction/reasoning_boundary_audit_2026-05-03.md` in same commit. | claude-2026-05-03 | all listed files; especially `atlas_brain/reasoning/evidence_engine.py` and the three content_pipeline reasoning forks |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,6 @@
 # In-Flight PRs
 
-<<<<<<< HEAD
-Last updated: 2026-05-03T22:03Z by claude-2026-05-03
-=======
-Last updated: 2026-05-03T22:04Z by codex-2026-05-03
->>>>>>> origin/main
+Last updated: 2026-05-03T22:05Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 

--- a/extracted_reasoning_core/archetypes.py
+++ b/extracted_reasoning_core/archetypes.py
@@ -1,0 +1,665 @@
+"""Churn Archetype Definitions and Signal Matching.
+
+Defines 10 canonical churn archetypes with signal signatures. The scorer
+evaluates vendor evidence (including temporal data) against each
+archetype's expected signal profile and returns ranked matches.
+
+This is a pure-data pre-filter -- it does NOT call the LLM. The ranked
+scores feed into synthesis-first vendor reasoning as context, and enable
+vendor-state updates without LLM calls.
+
+Module layout:
+
+  - ``SignalRule``, ``ArchetypeProfile`` -- catalog data structures
+    (frozen dataclasses; immutable by contract).
+  - ``ARCHETYPES`` -- the canonical 10-archetype catalog.
+  - ``_ArchetypeMatchInternal`` -- rich internal scoring result. Atlas
+    callers and the in-module scoring functions return this. The public
+    contract type ``ArchetypeMatch`` lives in
+    ``extracted_reasoning_core.types`` and is produced by the public
+    ``score_archetypes`` entry point in ``extracted_reasoning_core.api``
+    via ``_to_public_match``.
+  - ``score_evidence``, ``best_match``, ``top_matches``,
+    ``enrich_evidence_with_archetypes`` -- internal helpers returning
+    ``_ArchetypeMatchInternal``. Public callers should use
+    ``extracted_reasoning_core.api.score_archetypes``.
+
+Archetypes:
+    pricing_shock       -- Sudden price increase -> complaint spike -> competitor mentions
+    feature_gap         -- Competitor launches key feature -> "missing X" reviews surge
+    acquisition_decay   -- Post-acquisition quality decline -> support complaints -> churn
+    leadership_redesign -- New VP Product -> UI overhaul -> "new interface" complaints
+    integration_break   -- API change breaks workflows -> "integration" pain spike
+    support_collapse    -- Support quality drop -> response time complaints -> trust erosion
+    category_disruption -- New entrant class (AI-native) -> incumbents lose narrative
+    compliance_gap      -- Regulatory requirement unmet -> enterprise segments leave
+    scale_up_stumble    -- High growth -> support quality / culture degrades
+    pivot_abandonment   -- Focus shifts to new segment -> legacy customer neglect
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .types import ArchetypeMatch
+
+logger = logging.getLogger("extracted_reasoning_core.archetypes")
+
+# Minimum score to consider an archetype a plausible match
+MATCH_THRESHOLD = 0.25
+
+
+@dataclass(frozen=True)
+class SignalRule:
+    """A single signal check within an archetype signature."""
+
+    metric: str        # evidence key to check
+    direction: str     # "high", "low", "increasing", "decreasing", "present"
+    weight: float = 1.0
+    threshold: float | None = None  # numeric threshold (meaning depends on direction)
+    pain_keywords: list[str] = field(default_factory=list)  # keywords to match in text fields
+
+
+@dataclass(frozen=True)
+class ArchetypeProfile:
+    """Definition of a churn archetype with its expected signal signature."""
+
+    name: str
+    description: str
+    signals: list[SignalRule]
+    typical_risk: str  # "low", "medium", "high", "critical"
+    velocity_hints: dict[str, str] = field(default_factory=dict)
+    falsification_templates: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _ArchetypeMatchInternal:
+    """Rich internal result of scoring a vendor's evidence against an archetype.
+
+    The public contract type ``ArchetypeMatch`` lives in
+    ``extracted_reasoning_core.types``; converted via ``_to_public_match``.
+    Atlas-side callers continue to consume this richer shape directly.
+    """
+
+    archetype: str
+    score: float  # 0.0-1.0 weighted match score
+    matched_signals: list[str]
+    missing_signals: list[str]
+    risk_level: str
+
+
+# ------------------------------------------------------------------
+# The 8 canonical archetypes
+# ------------------------------------------------------------------
+
+ARCHETYPES: dict[str, ArchetypeProfile] = {
+    "pricing_shock": ArchetypeProfile(
+        name="pricing_shock",
+        description="Sudden price increase -> complaint spike -> competitor mentions",
+        typical_risk="high",
+        signals=[
+            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.0),
+            SignalRule("top_pain", "present", weight=2.0,
+                       pain_keywords=["price", "pricing", "cost", "expensive", "renewal", "invoice"]),
+            SignalRule("competitor_count", "high", weight=1.0, threshold=3),
+            SignalRule("recommend_ratio", "low", weight=1.0, threshold=0.4),
+            SignalRule("displacement_edge_count", "high", weight=1.2, threshold=2),
+            SignalRule("positive_review_pct", "low", weight=0.8, threshold=40.0),
+        ],
+        velocity_hints={
+            "avg_urgency": "increasing",
+            "competitor_count": "increasing",
+            "recommend_ratio": "decreasing",
+        },
+        falsification_templates=[
+            "Vendor reverts to previous pricing or introduces budget tier",
+            "Positive review trend reversal (3+ consecutive weeks improving)",
+            "Competitor count stabilizes or decreases",
+        ],
+    ),
+    "feature_gap": ArchetypeProfile(
+        name="feature_gap",
+        description="Competitor launches key feature -> 'missing X' reviews surge",
+        typical_risk="medium",
+        signals=[
+            SignalRule("top_pain", "present", weight=2.0,
+                       pain_keywords=["missing", "lack", "need", "feature", "no support for",
+                                      "doesn't have", "wish", "roadmap"]),
+            SignalRule("competitor_count", "high", weight=1.5, threshold=2),
+            SignalRule("displacement_edge_count", "high", weight=1.5, threshold=2),
+            SignalRule("pain_count", "high", weight=1.0, threshold=4),
+            SignalRule("recommend_ratio", "low", weight=0.8, threshold=0.5),
+        ],
+        velocity_hints={
+            "competitor_count": "increasing",
+            "displacement_edge_count": "increasing",
+            "pain_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor releases the missing feature",
+            "Competitor mentions decrease by 50%+",
+            "Pain count drops below 2",
+        ],
+    ),
+    "acquisition_decay": ArchetypeProfile(
+        name="acquisition_decay",
+        description="Post-acquisition quality decline -> support complaints -> churn",
+        typical_risk="high",
+        signals=[
+            SignalRule("positive_review_pct", "low", weight=1.5, threshold=35.0),
+            SignalRule("avg_urgency", "high", weight=1.2, threshold=5.5),
+            SignalRule("top_pain", "present", weight=2.0,
+                       pain_keywords=["acquired", "acquisition", "buyout", "merged",
+                                      "new ownership", "quality decline", "worse since"]),
+            SignalRule("recommend_ratio", "low", weight=1.0, threshold=0.35),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.6),
+        ],
+        velocity_hints={
+            "positive_review_pct": "decreasing",
+            "avg_urgency": "increasing",
+            "churn_density": "increasing",
+        },
+        falsification_templates=[
+            "Positive review percentage improves above 50%",
+            "Support response time improves to < 4h average",
+            "New leadership announces quality investment plan",
+        ],
+    ),
+    "leadership_redesign": ArchetypeProfile(
+        name="leadership_redesign",
+        description="New VP Product -> UI overhaul -> 'new interface' complaints",
+        typical_risk="medium",
+        signals=[
+            SignalRule("top_pain", "present", weight=2.5,
+                       pain_keywords=["redesign", "new ui", "new interface", "update",
+                                      "changed layout", "new version", "ui overhaul",
+                                      "workflow changed", "moved features"]),
+            SignalRule("avg_urgency", "high", weight=1.0, threshold=5.0),
+            SignalRule("pain_count", "high", weight=0.8, threshold=3),
+            SignalRule("positive_review_pct", "low", weight=1.0, threshold=45.0),
+        ],
+        velocity_hints={
+            "avg_urgency": "increasing",
+            "positive_review_pct": "decreasing",
+            "pain_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor reverts UI changes or provides classic mode",
+            "Positive review pct recovers above 55%",
+            "Pain count related to UI drops below 2",
+        ],
+    ),
+    "integration_break": ArchetypeProfile(
+        name="integration_break",
+        description="API change breaks workflows -> 'integration' pain spike",
+        typical_risk="high",
+        signals=[
+            SignalRule("top_pain", "present", weight=2.5,
+                       pain_keywords=["api", "integration", "webhook", "connector",
+                                      "broke", "breaking change", "deprecated",
+                                      "incompatible", "migration", "sdk"]),
+            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.5),
+            SignalRule("high_intent_company_count", "high", weight=1.2, threshold=3),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.5),
+        ],
+        velocity_hints={
+            "avg_urgency": "increasing",
+            "churn_density": "increasing",
+            "high_intent_company_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor provides backward-compatible API or migration tooling",
+            "Urgency drops below 4.0",
+            "Integration-related pain mentions drop by 60%+",
+        ],
+    ),
+    "support_collapse": ArchetypeProfile(
+        name="support_collapse",
+        description="Support quality drop -> response time complaints -> trust erosion",
+        typical_risk="critical",
+        signals=[
+            SignalRule("top_pain", "present", weight=2.0,
+                       pain_keywords=["support", "response time", "ticket", "help desk",
+                                      "no response", "slow support", "waiting",
+                                      "customer service", "escalation"]),
+            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.0),
+            SignalRule("positive_review_pct", "low", weight=1.5, threshold=30.0),
+            SignalRule("recommend_ratio", "low", weight=1.2, threshold=0.3),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.7),
+        ],
+        velocity_hints={
+            "positive_review_pct": "decreasing",
+            "avg_urgency": "increasing",
+            "churn_density": "increasing",
+            "recommend_ratio": "decreasing",
+        },
+        falsification_templates=[
+            "Support response time improves to < 4h average",
+            "Positive review pct recovers above 45%",
+            "Support-related complaints drop by 50%+",
+        ],
+    ),
+    "category_disruption": ArchetypeProfile(
+        name="category_disruption",
+        description="New entrant class (e.g., AI-native) -> incumbents lose narrative",
+        typical_risk="high",
+        signals=[
+            SignalRule("competitor_count", "high", weight=2.0, threshold=5),
+            SignalRule("displacement_edge_count", "high", weight=2.0, threshold=4),
+            SignalRule("top_pain", "present", weight=1.0,
+                       pain_keywords=["alternative", "switch to", "moved to", "replaced by",
+                                      "ai-native", "modern", "next-gen", "outdated"]),
+            SignalRule("high_intent_company_count", "high", weight=1.5, threshold=5),
+            SignalRule("recommend_ratio", "low", weight=0.8, threshold=0.4),
+        ],
+        velocity_hints={
+            "competitor_count": "increasing",
+            "displacement_edge_count": "increasing",
+            "high_intent_company_count": "increasing",
+        },
+        falsification_templates=[
+            "Vendor launches competitive AI/modern features",
+            "Competitor count drops or stabilizes for 4+ weeks",
+            "Displacement edge count decreases by 40%+",
+        ],
+    ),
+    "compliance_gap": ArchetypeProfile(
+        name="compliance_gap",
+        description="Regulatory requirement unmet -> enterprise segments leave",
+        typical_risk="critical",
+        signals=[
+            SignalRule("top_pain", "present", weight=3.0,
+                       pain_keywords=["compliance", "gdpr", "hipaa", "soc2", "soc 2",
+                                      "iso 27001", "fedramp", "pci", "audit",
+                                      "regulation", "security", "data residency",
+                                      "encryption", "certification"]),
+            SignalRule("high_intent_company_count", "high", weight=1.5, threshold=3),
+            SignalRule("avg_urgency", "high", weight=1.0, threshold=5.5),
+            SignalRule("churn_density", "high", weight=1.0, threshold=0.5),
+        ],
+        velocity_hints={
+            "high_intent_company_count": "increasing",
+            "churn_density": "increasing",
+        },
+        falsification_templates=[
+            "Vendor achieves the missing certification/compliance requirement",
+            "Compliance-related complaints drop to zero",
+            "Enterprise churn intent stabilizes",
+        ],
+    ),
+    "scale_up_stumble": ArchetypeProfile(
+        name="scale_up_stumble",
+        description="High growth (hiring/reviews) -> support quality/culture degrades",
+        typical_risk="medium",
+        signals=[
+            SignalRule("employee_growth_rate", "high", weight=2.0, threshold=0.20),  # >20% growth
+            SignalRule("support_sentiment", "decreasing_30d", weight=1.5),
+            SignalRule("recommend_ratio", "decreasing_30d", weight=1.0),
+            SignalRule("pain_count", "high", weight=1.0, threshold=3),
+            SignalRule("top_pain", "present", weight=1.0,
+                        pain_keywords=["growing pains", "used to be better", "new reps", 
+                                       "training", "knowledge gap", "slow response"]),
+        ],
+        velocity_hints={
+            "pain_count": "increasing",
+            "recommend_ratio": "decreasing",
+        },
+        falsification_templates=[
+            "Support sentiment stabilizes for 30+ days",
+            "Hiring pace normalizes (<5% quarterly)",
+            "Training investment announced",
+        ],
+    ),
+    "pivot_abandonment": ArchetypeProfile(
+        name="pivot_abandonment",
+        description="Focus shifts to new segment/product -> legacy customer neglect",
+        typical_risk="high",
+        signals=[
+            SignalRule("new_feature_velocity", "high", weight=1.5, threshold=0.5),
+            SignalRule("legacy_support_score", "low", weight=1.5, threshold=0.4),
+            SignalRule("churn_density", "increasing_30d", weight=2.0),
+            SignalRule("top_pain", "present", weight=1.5,
+                        pain_keywords=["legacy", "ignored", "forgotten", "deprecated", 
+                                       "forced migration", "sunset", "old version"]),
+        ],
+        velocity_hints={
+            "churn_density": "increasing",
+        },
+        falsification_templates=[
+            "Vendor recommits to legacy product roadmap",
+            "Migration tools provided free of charge",
+            "Churn density stabilizes",
+        ],
+    ),
+}
+
+
+# ------------------------------------------------------------------
+# Scoring engine
+# ------------------------------------------------------------------
+
+
+def score_evidence(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+) -> list[_ArchetypeMatchInternal]:
+    """Score vendor evidence against all archetypes.
+
+    *evidence*: flat dict from b2b_vendor_snapshots (and enriched fields).
+    *temporal*: output of TemporalEngine.to_evidence_dict() -- velocity/accel/anomaly data.
+
+    Returns list of `_ArchetypeMatchInternal` sorted by score descending.
+    Public callers should use ``extracted_reasoning_core.api.score_archetypes``,
+    which returns the public ``ArchetypeMatch`` shape after conversion.
+    """
+    merged = {**evidence}
+    if temporal:
+        merged.update(temporal)
+
+    results = []
+    for name, profile in ARCHETYPES.items():
+        match = _score_archetype(profile, merged)
+        results.append(match)
+
+    results.sort(key=lambda m: m.score, reverse=True)
+    return results
+
+
+def best_match(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+) -> _ArchetypeMatchInternal | None:
+    """Return the highest-scoring archetype above threshold, or None."""
+    matches = score_evidence(evidence, temporal)
+    if matches and matches[0].score >= MATCH_THRESHOLD:
+        return matches[0]
+    return None
+
+
+def top_matches(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+    *,
+    limit: int = 3,
+) -> list[_ArchetypeMatchInternal]:
+    """Return the top N archetype matches above threshold."""
+    matches = score_evidence(evidence, temporal)
+    return [m for m in matches[:limit] if m.score >= MATCH_THRESHOLD]
+
+
+def get_archetype(name: str) -> ArchetypeProfile | None:
+    """Lookup an archetype by name."""
+    return ARCHETYPES.get(name)
+
+
+def get_falsification_conditions(archetype_name: str) -> list[str]:
+    """Get falsification condition templates for a given archetype."""
+    profile = ARCHETYPES.get(archetype_name)
+    return list(profile.falsification_templates) if profile else []
+
+
+# ------------------------------------------------------------------
+# Internal scoring
+# ------------------------------------------------------------------
+
+
+def _score_archetype(profile: ArchetypeProfile, evidence: dict[str, Any]) -> _ArchetypeMatchInternal:
+    """Score evidence against a single archetype profile."""
+    total_weight = sum(s.weight for s in profile.signals)
+    if total_weight == 0:
+        return _ArchetypeMatchInternal(
+            archetype=profile.name,
+            score=0.0,
+            matched_signals=[],
+            missing_signals=[],
+            risk_level=profile.typical_risk,
+        )
+
+    weighted_score = 0.0
+    matched = []
+    missing = []
+
+    for rule in profile.signals:
+        hit = _evaluate_rule(rule, evidence)
+        if hit:
+            weighted_score += rule.weight
+            matched.append(rule.metric)
+        else:
+            missing.append(rule.metric)
+
+    # Velocity bonus: if temporal data shows expected direction, boost score
+    velocity_bonus = _velocity_bonus(profile, evidence)
+    weighted_score += velocity_bonus
+
+    # Anomaly bonus: if z-score anomalies overlap with archetype signals
+    anomaly_bonus = _anomaly_bonus(profile, evidence)
+    weighted_score += anomaly_bonus
+
+    # Normalize to 0.0-1.0
+    max_possible = total_weight + len(profile.velocity_hints) * 0.3 + 0.5
+    score = min(weighted_score / max_possible, 1.0)
+
+    # Determine risk level from score
+    risk = _risk_from_score(score, profile.typical_risk)
+
+    return _ArchetypeMatchInternal(
+        archetype=profile.name,
+        score=round(score, 3),
+        matched_signals=matched,
+        missing_signals=missing,
+        risk_level=risk,
+    )
+
+
+def _evaluate_rule(rule: SignalRule, evidence: dict[str, Any]) -> bool:
+    """Check if a single signal rule matches the evidence."""
+    # Text-based keyword matching (for top_pain and similar text fields)
+    if rule.pain_keywords:
+        text_fields = ["top_pain", "top_competitor", "pain_summary"]
+        combined = ""
+        for f in text_fields:
+            val = evidence.get(f)
+            if val is not None:
+                combined += " " + str(val).lower()
+        # Also check list fields (pain_categories, etc.)
+        for key in evidence:
+            if "pain" in key or "complaint" in key:
+                val = evidence[key]
+                if isinstance(val, list):
+                    combined += " " + " ".join(str(v).lower() for v in val)
+        if combined.strip():
+            if any(kw in combined for kw in rule.pain_keywords):
+                return True
+        return False
+
+    if rule.direction == "present":
+        return rule.metric in evidence
+
+    # Value-based checks require the metric to be present and numeric
+    if rule.direction in ("high", "low"):
+        val = evidence.get(rule.metric)
+        if val is None:
+            return False
+        try:
+            val_f = float(val)
+        except (ValueError, TypeError):
+            return False
+
+        if rule.direction == "high":
+            return val_f >= (rule.threshold if rule.threshold is not None else 0)
+        elif rule.direction == "low":
+            return val_f <= (rule.threshold if rule.threshold is not None else float("inf"))
+
+    # Velocity/Trend checks look for derived fields
+    elif rule.direction == "increasing":
+        vel = evidence.get(f"velocity_{rule.metric}")
+        if vel is not None:
+            return float(vel) > 0
+        return False
+    elif rule.direction == "decreasing":
+        vel = evidence.get(f"velocity_{rule.metric}")
+        if vel is not None:
+            return float(vel) < 0
+        return False
+    elif rule.direction == "increasing_30d":
+        slope = evidence.get(f"trend_30d_{rule.metric}")
+        if slope is not None:
+            return float(slope) > 0
+        return False
+    elif rule.direction == "decreasing_30d":
+        slope = evidence.get(f"trend_30d_{rule.metric}")
+        if slope is not None:
+            return float(slope) < 0
+        return False
+
+    return False
+
+
+def _velocity_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float:
+    """Bonus score for velocity signals matching expected directions."""
+    bonus = 0.0
+    for metric, expected_dir in profile.velocity_hints.items():
+        vel_key = f"velocity_{metric}"
+        vel = evidence.get(vel_key)
+        if vel is None:
+            continue
+        try:
+            vel_f = float(vel)
+        except (ValueError, TypeError):
+            continue
+
+        if expected_dir == "increasing" and vel_f > 0:
+            bonus += 0.3
+        elif expected_dir == "decreasing" and vel_f < 0:
+            bonus += 0.3
+
+        # Extra bonus for acceleration in the expected direction
+        accel_key = f"accel_{metric}"
+        accel = evidence.get(accel_key)
+        if accel is not None:
+            try:
+                accel_f = float(accel)
+                if expected_dir == "increasing" and accel_f > 0:
+                    bonus += 0.15
+                elif expected_dir == "decreasing" and accel_f < 0:
+                    bonus += 0.15
+            except (ValueError, TypeError):
+                pass
+
+    return bonus
+
+
+def _anomaly_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float:
+    """Bonus if z-score anomalies align with the archetype's signal metrics."""
+    anomalies = evidence.get("anomalies")
+    if not anomalies or not isinstance(anomalies, list):
+        return 0.0
+
+    archetype_metrics = {s.metric for s in profile.signals if not s.pain_keywords}
+    bonus = 0.0
+    for anom in anomalies:
+        if not isinstance(anom, dict):
+            continue
+        metric = anom.get("metric", "")
+        if metric in archetype_metrics:
+            z = abs(anom.get("z_score", 0))
+            if z > 2.0:
+                bonus += 0.25
+            elif z > 1.5:
+                bonus += 0.1
+
+    return min(bonus, 0.5)  # cap anomaly bonus
+
+
+def _risk_from_score(score: float, base_risk: str) -> str:
+    """Derive risk level from match score and archetype's typical risk."""
+    if score < 0.25:
+        return "low"
+    if score < 0.45:
+        return "medium" if base_risk in ("high", "critical") else "low"
+    if score < 0.65:
+        return "medium" if base_risk != "critical" else "high"
+    if score < 0.80:
+        return "high"
+    return base_risk if base_risk == "critical" else "high"
+
+
+# ------------------------------------------------------------------
+# Utilities for integration
+# ------------------------------------------------------------------
+
+
+def enrich_evidence_with_archetypes(
+    evidence: dict[str, Any],
+    temporal: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Enrich evidence dict with archetype scores for LLM context.
+
+    Adds 'archetype_scores' key with top 3 matches, making the LLM's
+    classification job easier and more consistent.
+    """
+    matches = top_matches(evidence, temporal, limit=3)
+    if not matches:
+        return evidence
+
+    enriched = dict(evidence)
+    enriched["archetype_scores"] = [
+        {
+            "archetype": m.archetype,
+            "signal_score": m.score,
+            "matched_signals": m.matched_signals,
+            "missing_signals": m.missing_signals,
+            "risk_level": m.risk_level,
+        }
+        for m in matches
+    ]
+    return enriched
+
+
+# ------------------------------------------------------------------
+# Public-shape adapter
+# ------------------------------------------------------------------
+
+
+def _label_for(archetype_name: str) -> str:
+    """Derive a stable human-readable label from an archetype name.
+
+    `pricing_shock` -> `Pricing Shock`. Used by `_to_public_match` so the
+    public ArchetypeMatch.label field is populated without coupling to
+    the description string (which content packs may override)."""
+    return archetype_name.replace("_", " ").title()
+
+
+def _to_public_match(internal: _ArchetypeMatchInternal) -> ArchetypeMatch:
+    """Convert a rich internal match to the public contract type.
+
+    Atlas-internal callers continue to consume `_ArchetypeMatchInternal`
+    directly. The public boundary (extracted_reasoning_core.api.score_archetypes)
+    converts via this function so consuming products see the stable
+    public shape from `extracted_reasoning_core.types.ArchetypeMatch`.
+    """
+    return ArchetypeMatch(
+        archetype_id=internal.archetype,
+        label=_label_for(internal.archetype),
+        score=internal.score,
+        evidence_hits=tuple(internal.matched_signals),
+        missing_evidence=tuple(internal.missing_signals),
+        risk_label=internal.risk_level,
+    )
+
+
+__all__ = [
+    "ARCHETYPES",
+    "ArchetypeProfile",
+    "MATCH_THRESHOLD",
+    "SignalRule",
+    "best_match",
+    "enrich_evidence_with_archetypes",
+    "get_archetype",
+    "get_falsification_conditions",
+    "score_evidence",
+    "top_matches",
+]

--- a/extracted_reasoning_core/archetypes.py
+++ b/extracted_reasoning_core/archetypes.py
@@ -16,13 +16,17 @@ Module layout:
   - ``_ArchetypeMatchInternal`` -- rich internal scoring result. Atlas
     callers and the in-module scoring functions return this. The public
     contract type ``ArchetypeMatch`` lives in
-    ``extracted_reasoning_core.types`` and is produced by the public
-    ``score_archetypes`` entry point in ``extracted_reasoning_core.api``
-    via ``_to_public_match``.
-  - ``score_evidence``, ``best_match``, ``top_matches``,
-    ``enrich_evidence_with_archetypes`` -- internal helpers returning
-    ``_ArchetypeMatchInternal``. Public callers should use
-    ``extracted_reasoning_core.api.score_archetypes``.
+    ``extracted_reasoning_core.types``; this module provides the
+    ``_to_public_match`` adapter that produces it.
+  - ``score_evidence``, ``best_match``, ``top_matches`` -- internal
+    scoring helpers returning ``_ArchetypeMatchInternal``.
+  - ``enrich_evidence_with_archetypes`` -- internal helper that
+    returns the input evidence dict augmented with an
+    ``archetype_scores`` key (top 3 matches, serialized).
+  - The public boundary ``extracted_reasoning_core.api.score_archetypes``
+    is currently a stub raising ``NotImplementedError``; it will be
+    wired in a follow-up PR-C1 slice and will call ``score_evidence``
+    + ``_to_public_match`` to return ``Sequence[ArchetypeMatch]``.
 
 Archetypes:
     pricing_shock       -- Sudden price increase -> complaint spike -> competitor mentions
@@ -39,14 +43,10 @@ Archetypes:
 
 from __future__ import annotations
 
-import logging
-import re
 from dataclasses import dataclass, field
 from typing import Any
 
 from .types import ArchetypeMatch
-
-logger = logging.getLogger("extracted_reasoning_core.archetypes")
 
 # Minimum score to consider an archetype a plausible match
 MATCH_THRESHOLD = 0.25
@@ -92,7 +92,7 @@ class _ArchetypeMatchInternal:
 
 
 # ------------------------------------------------------------------
-# The 8 canonical archetypes
+# The 10 canonical archetypes
 # ------------------------------------------------------------------
 
 ARCHETYPES: dict[str, ArchetypeProfile] = {
@@ -493,27 +493,41 @@ def _evaluate_rule(rule: SignalRule, evidence: dict[str, Any]) -> bool:
         elif rule.direction == "low":
             return val_f <= (rule.threshold if rule.threshold is not None else float("inf"))
 
-    # Velocity/Trend checks look for derived fields
+    # Velocity/Trend checks look for derived fields. Coercion is guarded
+    # consistently with the high/low branch above: non-numeric values
+    # treated as a non-match rather than aborting scoring for the vendor.
     elif rule.direction == "increasing":
         vel = evidence.get(f"velocity_{rule.metric}")
-        if vel is not None:
+        if vel is None:
+            return False
+        try:
             return float(vel) > 0
-        return False
+        except (ValueError, TypeError):
+            return False
     elif rule.direction == "decreasing":
         vel = evidence.get(f"velocity_{rule.metric}")
-        if vel is not None:
+        if vel is None:
+            return False
+        try:
             return float(vel) < 0
-        return False
+        except (ValueError, TypeError):
+            return False
     elif rule.direction == "increasing_30d":
         slope = evidence.get(f"trend_30d_{rule.metric}")
-        if slope is not None:
+        if slope is None:
+            return False
+        try:
             return float(slope) > 0
-        return False
+        except (ValueError, TypeError):
+            return False
     elif rule.direction == "decreasing_30d":
         slope = evidence.get(f"trend_30d_{rule.metric}")
-        if slope is not None:
+        if slope is None:
+            return False
+        try:
             return float(slope) < 0
-        return False
+        except (ValueError, TypeError):
+            return False
 
     return False
 
@@ -564,12 +578,19 @@ def _anomaly_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float
         if not isinstance(anom, dict):
             continue
         metric = anom.get("metric", "")
-        if metric in archetype_metrics:
-            z = abs(anom.get("z_score", 0))
-            if z > 2.0:
-                bonus += 0.25
-            elif z > 1.5:
-                bonus += 0.1
+        if metric not in archetype_metrics:
+            continue
+        # z_score may arrive as a string from JSON payloads; coerce
+        # defensively. Skip the anomaly on conversion failure rather
+        # than aborting the bonus calculation for the vendor.
+        try:
+            z = abs(float(anom.get("z_score", 0)))
+        except (ValueError, TypeError):
+            continue
+        if z > 2.0:
+            bonus += 0.25
+        elif z > 1.5:
+            bonus += 0.1
 
     return min(bonus, 0.5)  # cap anomaly bonus
 

--- a/extracted_reasoning_core/evidence_map.yaml
+++ b/extracted_reasoning_core/evidence_map.yaml
@@ -1,0 +1,284 @@
+# Evidence Map v2 -- Deterministic evidence-to-conclusion rules
+# Editable without code changes. Consumed by evidence_engine.py.
+#
+# Two levels:
+#   enrichment:   per-review rules (run at enrichment time)
+#   conclusions:  per-vendor rules (run at report generation time)
+#   suppression:  per-section rules (run at report rendering time)
+
+version: 2
+
+# -- Per-Review Enrichment Rules ------------------------------------------
+
+enrichment:
+
+  urgency_scoring:
+    description: "Compute urgency_score (0-10) from boolean indicator flags"
+    weights:
+      # Tier A: Hard churn signals
+      intent_to_leave_signal: 2.0
+      migration_in_progress_signal: 2.5
+      explicit_cancel_language: 3.0
+      active_migration_language: 2.5
+      completed_switch_language: 3.0
+      # Tier B: Moderate signals
+      actively_evaluating_signal: 1.5
+      active_evaluation_language: 2.0
+      comparison_shopping_language: 2.0
+      named_alternative_with_reason: 2.0
+      price_pressure_language: 1.5
+      reconsideration_language: 1.5
+      # Tier C: Supporting signals
+      frustration_without_alternative: 1.5
+      dollar_amount_mentioned: 0.5
+      timeline_mentioned: 1.5
+      decision_maker_language: 1.5
+    rating_floors:
+      - max_normalized_rating: 0.2
+        min_score: 3.0
+      - max_normalized_rating: 0.4
+        min_score: 2.0
+    adjustments:
+      - condition: {field: content_type, eq: comment}
+        delta: -1.0
+    gates:
+      - condition: {field: source_weight, lte: 0.3}
+        force: 0.0
+    clamp: [0, 10]
+
+  pain_override:
+    description: "Override generic pain_category using keyword scan"
+    trigger: {field: pain_category, in: [other, general_dissatisfaction, overall_dissatisfaction]}
+    keyword_map:
+      pricing: [expensive, cost, price, pricing, budget, overpriced, overcharge, costly, fee, fees, subscription, invoice, invoiced, billing, billed, charged, charge, refund, cost increase, price increase, pay for every, paying for, paid for, invested, overpay, nickel and dime, hidden cost, hidden fee, sticker shock, renewal cost, renewal price, per seat, per user, add-on cost, upsell, price hike, price jump, not worth the price, too much money, waste of money, money pit, rates, rate increase, not transparent about, deceptive pricing, bait and switch]
+      support: [support, response time, ticket, customer service, helpdesk, wait time, unresponsive, no help, unhelpful, ignored, no response, ghosted, runaround, passed around, escalation, complaint, complaints team]
+      reliability: [downtime, outage, crash, bug, unstable, unreliable, broken, error]
+      ux: [clunky, unintuitive, confusing, ui, ux, user interface, learning curve, ugly, dated, clumsy]
+      performance: [slow, latency, performance, speed, loading, lag, timeout]
+      integration: [integration, connector, webhook, incompatible, sync, interop]
+      security: [security, breach, vulnerability, compliance, gdpr, soc2, encryption, audit]
+      onboarding: [onboarding, setup, implementation, getting started, documentation, tutorial]
+      features: [feature, missing, roadmap, functionality, capability, wishlist, lacking, calendar, scheduling, customization, workflow, template, automation, notification, dashboard, reporting, analytics, export]
+      technical_debt: [technical debt, legacy, outdated codebase, deprecated, spaghetti, refactor, tech debt]
+      contract_lock_in: [lock-in, locked in, exit cost, switching cost, vendor lock, contract trap, penalty, cancel, cancellation, terminate, termination, auto renew, automatic renewal, renewed without notice, notice period, contract term, billing dispute, runaround, unsubscribe, delete my account, close my account, deactivate, cannot cancel, won't let me cancel, impossible to cancel, trying to cancel]
+      data_migration: [data migration, export, portability, data export, migrate data, data transfer, import]
+      api_limitations: [api limit, rate limit, api limitation, missing endpoint, api documentation, throttle, api quota]
+      outcome_gap: [out of the box, only does, partial fit, does 60, does 70, does 80, not enough for our use case, had to work around, had to supplement, needed another tool, does not cover our process, poor fit for our workflow, missing business process support]
+      admin_burden: [dedicated admin, dedicated administrator, salesforce admin, consultant, consultants, consulting, requires consultants, apex, apex development, flow builder, workflow maintenance, maintain workflows, cumbersome setup, too much setup, too much configuration, admin overhead, maintenance overhead, hard to administer, needs constant maintenance, steep learning curve for admins, training investment]
+      ai_hallucination: [hallucination, hallucinates, made up answer, fabricated answer, wrong answer from ai, unsafe ai response, ai gave incorrect, ai summary was wrong, generated false]
+      integration_debt: [app exchange, appexchange, connector broke, integration broke, brittle integration, brittle connector, sync breaks, sync broke, integration maintenance, integration drift, middleware dependency, custom integration, patch integration after updates, update broke integration, after updates, constant maintenance, breaking after updates]
+    scan_fields: [specific_complaints, quotable_phrases, pricing_phrases, feature_gaps, recommendation_language]
+    fallback: overall_dissatisfaction
+
+  recommend_derivation:
+    description: "Derive would_recommend from extracted language + rating"
+    positive_patterns:
+      - "\\brecommend\\b"
+      - "\\bhighly recommend\\b"
+      - "\\bwould suggest\\b"
+      - "\\bgreat (tool|product|software|platform)\\b"
+    negative_patterns:
+      - "\\bwould not recommend\\b"
+      - "\\bcannot recommend\\b"
+      - "\\bdon'?t recommend\\b"
+      - "\\bdo not recommend\\b"
+      - "\\bnot recommend\\b"
+      - "\\bnever recommend\\b"
+      - "\\bstay away\\b"
+      - "\\bavoid\\b"
+      - "\\bnot worth\\b"
+      - "\\bwouldn'?t recommend\\b"
+      - "\\bwaste of\\b"
+    scan_field: recommendation_language
+    rating_fallback:
+      true_above: 0.7
+      false_below: 0.3
+    default: null
+
+  price_complaint_derivation:
+    description: "Derive price_complaint from Tier 1 flags + extracted phrases"
+    positive_patterns:
+      - "\\bpricing (?:is )?reasonable\\b"
+      - "\\bprice(?:s|d)? (?:is|are|was|were)? reasonable\\b"
+      - "\\b(?:cost|pricing) (?:is|was|were|seems)? fair\\b"
+      - "\\baffordable\\b"
+      - "\\bgood value\\b"
+      - "\\bworth (?:the|its) price\\b"
+      - "\\bpricing (?:works|worked) for us\\b"
+      - "\\bmet all (?:of )?our expectations\\b"
+    true_if_any:
+      - {field: "budget_signals.price_increase_mentioned", eq: true}
+      - {field: "pricing_phrases", min_count: 1}
+      - field: specific_complaints
+        contains_any: [expensive, cost, price, pricing, overpriced, overcharge, costly]
+
+  budget_authority_derivation:
+    description: "Derive has_budget_authority from role + language"
+    true_if_any:
+      - {field: "reviewer_context.role_level", in: [executive, director]}
+      - {field: "reviewer_context.decision_maker", eq: true}
+      - {field: "urgency_indicators.decision_maker_language", eq: true}
+      - {field: "budget_signals.annual_spend_estimate", not_null: true}
+      - {field: "budget_signals.price_per_seat", not_null: true}
+
+# -- Per-Vendor Conclusion Gates -------------------------------------------
+
+conclusions:
+
+  pricing_crisis:
+    description: "Vendor has a systemic pricing problem"
+    requires:
+      - field: pain_distribution.pricing.count
+        operator: gte
+        value: 15
+      - field: pain_distribution.pricing.source_count
+        operator: gte
+        value: 3
+      - field: pricing_phrases_total
+        operator: gte
+        value: 2
+    amplifiers:
+      - field: pain_distribution.pricing.rank
+        operator: lte
+        value: 2
+        boost_confidence: true
+    confidence_when_met: high
+    fallback:
+      action: show_raw
+      label: "Pricing complaints detected but below threshold for crisis classification"
+      show: pain_distribution
+
+  losing_market_share:
+    description: "Vendor is losing to a specific competitor"
+    requires:
+      - field: displacement_edge.mention_count
+        operator: gte
+        value: 5
+      - field: displacement_edge.signal_strength
+        operator: in
+        values: [strong, moderate]
+      - field: displacement_edge.explicit_switch_count
+        operator: gte
+        value: 1
+      - field: displacement_edge.net_flow
+        operator: lt
+        value: 0
+    confidence_when_met: high
+    fallback:
+      action: label
+      label: "Emerging displacement signal"
+      confidence: low
+
+  support_collapse:
+    description: "Support quality is driving churn"
+    requires:
+      - field: pain_distribution.support.count
+        operator: gte
+        value: 10
+      - field: support_escalation_rate
+        operator: gte
+        value: 0.05
+    confidence_when_met: medium
+    fallback:
+      action: suppress
+      reason: "Insufficient support-related evidence"
+
+  active_churn_wave:
+    description: "Multiple accounts actively leaving right now"
+    requires:
+      - field: indicator_counts.active_evaluation_language
+        operator: gte
+        value: 5
+      - field: indicator_counts.explicit_cancel_language
+        operator: gte
+        value: 2
+      - field: total_reviews
+        operator: gte
+        value: 50
+    confidence_when_met: high
+    fallback:
+      action: label
+      label: "Elevated churn signals but below active-wave threshold"
+      confidence: low
+
+  category_disruption:
+    description: "Vendor from outside the expected category is encroaching"
+    requires:
+      - field: cross_category_displacement.mention_count
+        operator: gte
+        value: 3
+      - field: cross_category_displacement.signal_strength
+        operator: in
+        values: [strong, moderate]
+    confidence_when_met: medium
+    fallback:
+      action: suppress
+
+  insufficient_data:
+    description: "Not enough evidence to draw any conclusion"
+    trigger:
+      - field: total_reviews
+        operator: lt
+        value: 20
+    action: suppress_all_conclusions
+    label: "Insufficient review volume for reliable analysis"
+    exceptions: [raw_pain_distribution, displacement_edges]
+
+# -- Report Section Suppression Rules --------------------------------------
+
+suppression:
+
+  executive_summary:
+    suppress_when:
+      - {field: total_reviews, lt: 20}
+    degrade_when:
+      - {field: total_reviews, lt: 50}
+      - {field: confidence, eq: low}
+    degrade_action: prepend_disclaimer
+    disclaimer: "Based on limited review volume. Interpret with caution."
+
+  target_accounts:
+    suppress_when:
+      - {field: named_company_count, eq: 0}
+    fallback_label: "No named accounts resolved. Review volume suggests anonymous churn activity."
+
+  displacement_rankings:
+    suppress_when:
+      - {field: displacement_edge_count, lt: 3}
+    degrade_when:
+      - {field: displacement_edge_count, lt: 10}
+    degrade_action: prepend_disclaimer
+    disclaimer: "Displacement data is preliminary."
+
+  recommend_ratio:
+    suppress_when:
+      - {field: recommend_denominator, lt: 10}
+    fallback_label: "Insufficient recommendation data"
+
+  timing_intelligence:
+    degrade_when:
+      - {field: quote_count, lt: 3}
+    degrade_action: prepend_disclaimer
+    disclaimer: "Timing guidance is based on limited direct evidence."
+
+  migration_proof:
+    degrade_when:
+      - {field: displacement_mention_count, lt: 3}
+    degrade_action: prepend_disclaimer
+    disclaimer: "Migration evidence is preliminary."
+
+# -- Confidence Tiers -------------------------------------------------------
+
+confidence_tiers:
+  high:
+    min_reviews: 50
+    label: "High confidence"
+  medium:
+    min_reviews: 20
+    label: "Moderate confidence"
+  low:
+    min_reviews: 1
+    label: "Low confidence -- interpret with caution"
+  insufficient:
+    max_reviews: 0
+    label: "No data"

--- a/tests/test_extracted_reasoning_core_archetypes.py
+++ b/tests/test_extracted_reasoning_core_archetypes.py
@@ -1,0 +1,184 @@
+"""Smoke tests for extracted_reasoning_core.archetypes.
+
+Locks the consolidation against regressions during the rest of PR-C1.
+The full atlas-side archetype tests will rename + redirect into this
+file's neighborhood in PR-C1k; for now this carries the minimum
+coverage needed to validate the consolidation:
+
+  - catalog loads (10 canonical archetypes)
+  - score_evidence ranks matches by score descending
+  - MATCH_THRESHOLD gate works (best_match returns None below)
+  - top_matches respects the limit + threshold
+  - _to_public_match translates field names + derives label
+  - _evaluate_rule does not crash on non-numeric velocity strings
+    (regression guard for the unguarded float() that PR #94 review
+    flagged)
+  - _anomaly_bonus tolerates string z_score values
+"""
+
+from __future__ import annotations
+
+from extracted_reasoning_core.archetypes import (
+    ARCHETYPES,
+    MATCH_THRESHOLD,
+    ArchetypeProfile,
+    SignalRule,
+    _ArchetypeMatchInternal,
+    _to_public_match,
+    best_match,
+    enrich_evidence_with_archetypes,
+    score_evidence,
+    top_matches,
+)
+from extracted_reasoning_core.types import ArchetypeMatch
+
+
+def test_catalog_has_ten_canonical_archetypes() -> None:
+    assert len(ARCHETYPES) == 10
+    expected = {
+        "pricing_shock",
+        "feature_gap",
+        "acquisition_decay",
+        "leadership_redesign",
+        "integration_break",
+        "support_collapse",
+        "category_disruption",
+        "compliance_gap",
+        "scale_up_stumble",
+        "pivot_abandonment",
+    }
+    assert set(ARCHETYPES.keys()) == expected
+    for profile in ARCHETYPES.values():
+        assert isinstance(profile, ArchetypeProfile)
+        assert profile.signals, f"{profile.name} has no signals"
+
+
+def test_score_evidence_returns_sorted_internal_matches() -> None:
+    evidence = {
+        "avg_urgency": 7.0,
+        "top_pain": "pricing too expensive after renewal",
+        "competitor_count": 4,
+        "recommend_ratio": 0.3,
+        "displacement_edge_count": 3,
+        "positive_review_pct": 35,
+    }
+    matches = score_evidence(evidence)
+
+    # one match per archetype, sorted descending
+    assert len(matches) == len(ARCHETYPES)
+    scores = [m.score for m in matches]
+    assert scores == sorted(scores, reverse=True)
+    # pricing_shock should top a pricing-flavored evidence dict
+    assert matches[0].archetype == "pricing_shock"
+    assert isinstance(matches[0], _ArchetypeMatchInternal)
+
+
+def test_best_match_respects_threshold() -> None:
+    # Empty evidence dict produces zero scores; best_match should be None.
+    assert best_match({}) is None
+
+    strong = {
+        "avg_urgency": 7.0,
+        "top_pain": "pricing too expensive",
+        "competitor_count": 4,
+        "recommend_ratio": 0.3,
+        "displacement_edge_count": 3,
+        "positive_review_pct": 35,
+    }
+    m = best_match(strong)
+    assert m is not None
+    assert m.score >= MATCH_THRESHOLD
+
+
+def test_top_matches_caps_and_thresholds() -> None:
+    strong = {
+        "avg_urgency": 7.0,
+        "top_pain": "pricing too expensive",
+        "competitor_count": 4,
+        "recommend_ratio": 0.3,
+        "displacement_edge_count": 3,
+        "positive_review_pct": 35,
+    }
+    top = top_matches(strong, limit=3)
+    assert len(top) <= 3
+    for m in top:
+        assert m.score >= MATCH_THRESHOLD
+
+
+def test_to_public_match_translates_fields() -> None:
+    internal = _ArchetypeMatchInternal(
+        archetype="pricing_shock",
+        score=0.84,
+        matched_signals=["avg_urgency", "top_pain"],
+        missing_signals=["competitor_count"],
+        risk_level="high",
+    )
+    public = _to_public_match(internal)
+    assert isinstance(public, ArchetypeMatch)
+    assert public.archetype_id == "pricing_shock"
+    assert public.label == "Pricing Shock"  # title-case derivation
+    assert public.score == 0.84
+    assert public.evidence_hits == ("avg_urgency", "top_pain")
+    assert public.missing_evidence == ("competitor_count",)
+    assert public.risk_label == "high"
+
+
+def test_evaluate_rule_tolerates_non_numeric_velocity() -> None:
+    # Regression guard: PR #94 review flagged that velocity branches
+    # of _evaluate_rule did float() without try/except. A non-numeric
+    # velocity string used to raise; now it must be a non-match.
+    evidence_with_string_velocity = {
+        "velocity_avg_urgency": "not-a-number",
+        "trend_30d_competitor_count": "n/a",
+    }
+    matches = score_evidence(evidence_with_string_velocity)
+    # All scores should compute; nothing crashed.
+    assert all(isinstance(m.score, float) for m in matches)
+
+
+def test_anomaly_bonus_tolerates_string_z_score() -> None:
+    # Regression guard: PR #94 review flagged that abs() on a string
+    # z_score raised TypeError. Confirm scoring proceeds when anomaly
+    # payloads carry stringified numerics.
+    evidence_with_string_anomaly = {
+        "avg_urgency": 7.0,
+        "anomalies": [
+            {"metric": "avg_urgency", "z_score": "2.5"},
+            {"metric": "competitor_count", "z_score": "garbage"},
+        ],
+    }
+    matches = score_evidence(evidence_with_string_anomaly)
+    assert all(isinstance(m.score, float) for m in matches)
+
+
+def test_enrich_evidence_with_archetypes_returns_dict() -> None:
+    evidence = {
+        "avg_urgency": 7.0,
+        "top_pain": "pricing",
+        "competitor_count": 4,
+        "recommend_ratio": 0.3,
+        "displacement_edge_count": 3,
+        "positive_review_pct": 35,
+    }
+    enriched = enrich_evidence_with_archetypes(evidence)
+    assert isinstance(enriched, dict)
+    # Original keys preserved
+    for k, v in evidence.items():
+        assert enriched[k] == v
+    # New key added
+    assert "archetype_scores" in enriched
+    assert isinstance(enriched["archetype_scores"], list)
+    assert len(enriched["archetype_scores"]) <= 3
+
+
+def test_signal_rule_is_immutable() -> None:
+    # frozen=True means reassignment raises; verifying the audit-
+    # documented immutability decision actually took.
+    rule = SignalRule(metric="avg_urgency", direction="high", weight=1.0)
+    try:
+        rule.weight = 2.0  # type: ignore[misc]
+    except Exception as exc:
+        # FrozenInstanceError on Python 3.10+; AttributeError on older.
+        assert exc.__class__.__name__ in {"FrozenInstanceError", "AttributeError"}
+    else:
+        raise AssertionError("frozen dataclass should reject reassignment")


### PR DESCRIPTION
## Summary

First atomic slice of PR-C1 (evidence/temporal/archetypes consolidation per merged PR #82 audit). Scope is narrowed to **archetypes + evidence_map only**; the remaining slices land as separate PRs.

## Files

- **`extracted_reasoning_core/archetypes.py`** (675 LOC, NEW)

  Atlas's `archetypes.py` moved canonical, with audit-decision tweaks:

    - `frozen=True` on `SignalRule`, `ArchetypeProfile`, and the internal match dataclass. Carries forward content_pipeline's immutability decision.
    - Atlas's `ArchetypeMatch` renamed `_ArchetypeMatchInternal`. The public `ArchetypeMatch` contract from `extracted_reasoning_core.types` stays canonical; atlas-internal callers continue to consume the rich internal shape.
    - Public adapter `_to_public_match(internal) -> ArchetypeMatch` translates fields:
      - `archetype` -> `archetype_id`
      - (derived from name) -> `label` (Title Case)
      - `matched_signals` -> `evidence_hits` (tuple)
      - `missing_signals` -> `missing_evidence` (tuple)
      - `risk_level` -> `risk_label`
    - Atlas's analyst-flavored archetype description-strings kept verbatim. content_pipeline's user-facing rewrites stay in the content_pipeline fork; they will move to a `content_review_pack` per the audit's drift-forward plan.
    - Module docstring corrected to reflect 10 canonical archetypes (atlas had 8 + 2 added; the original docstring named only 8).
    - `__all__` declared so the public surface is explicit.

- **`extracted_reasoning_core/evidence_map.yaml`** (284 LOC, NEW)

  Verbatim copy of `atlas_brain/reasoning/evidence_map.yaml`. Ships as default policy data for the slim `EvidenceEngine` that lands in a follow-up PR. Products may override via `get_evidence_engine(map_path=...)` or by injecting their own `EvidencePolicy`.

## Validation

- 10 archetypes load correctly
- `score_evidence` runs end-to-end on representative evidence
- `_to_public_match` returns a `types.ArchetypeMatch` with all field translations applied
- ASCII clean (0 non-ASCII bytes in both new files; verified)

## Not in this PR (atomic-PR boundary)

The remaining PR-C1 slices land as their own PRs after this one merges:

1. `extracted_reasoning_core/temporal.py` (with content_pipeline's defensive helpers + parameterized threshold)
2. `extracted_reasoning_core/types.py` promotion (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`)
3. `extracted_reasoning_core/evidence_engine.py` (slim conclusions+suppression core)
4. `atlas_brain/reasoning/review_enrichment.py` (NEW; carved from atlas evidence_engine)
5. `atlas_brain/reasoning/evidence_engine.py` slim
6. `extracted_reasoning_core/api.py` impl of 3 stubs
7. `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` -> re-export wrappers
8. Test renames + redirects
9. PR #79 contract amendment

## Coordination

- Owner: `claude-2026-05-03` (declared in `coordination/inflight.md` via `8bae2530`)
- Hot zone for THIS PR: `extracted_reasoning_core/{archetypes.py, evidence_map.yaml}`. The full PR-C1 hot zone declared on the in-flight row covers all subsequent slices.

## Refs

- Audit: `docs/extraction/evidence_temporal_archetypes_audit_2026-05-03.md` (merged via PR #82)
- Reasoning boundary contract: `docs/extraction/reasoning_boundary_audit_2026-05-03.md` (merged via PR #79)