### PR TITLE
Add file-backed campaign reasoning provider

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:04Z by codex-2026-05-03
+Last updated: 2026-05-03T22:05Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
+| (PR-D2, branch `codex/content-pipeline-reasoning-file-provider`) | Add file-backed AI Content Ops reasoning provider | `extracted_content_pipeline/campaign_reasoning_data.py`; `scripts/run_extracted_campaign_generation_example.py`; `extracted_content_pipeline/examples/*reasoning*`; content-pipeline docs/status; focused tests | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:05Z by codex-2026-05-03
+Last updated: 2026-05-03T22:06Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
-| (PR-D2, branch `codex/content-pipeline-reasoning-file-provider`) | Add file-backed AI Content Ops reasoning provider | `extracted_content_pipeline/campaign_reasoning_data.py`; `scripts/run_extracted_campaign_generation_example.py`; `extracted_content_pipeline/examples/*reasoning*`; content-pipeline docs/status; focused tests | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
+| #97 | Add file-backed AI Content Ops reasoning provider | `extracted_content_pipeline/campaign_reasoning_data.py`; `scripts/run_extracted_campaign_generation_example.py`; `extracted_content_pipeline/examples/*reasoning*`; content-pipeline docs/status; focused tests | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-03T22:04Z by codex-2026-05-03
+Last updated: 2026-05-03T22:05Z by codex-2026-05-03
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -13,3 +13,4 @@ Sequence reflects dependencies. Claim a slice (set Owner) before starting code s
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |
+| PR-D2 | `extracted_content_pipeline` | codex-2026-05-03 | PR-D1 / #93 (merged); avoid PR-C1 files | Add file-backed `CampaignReasoningContextProvider` so the offline example can consume buyer/host reasoning JSON through the documented handoff contract. |

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -143,6 +143,18 @@ channels:
 python scripts/run_extracted_campaign_generation_example.py --channels email_cold,email_followup
 ```
 
+Pass host-provided reasoning context without installing a reasoning engine:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
+```
+
+`campaign_reasoning_data.FileCampaignReasoningContextProvider` matches context
+rows by target id, company, email, or vendor and feeds the normalized
+`CampaignReasoningContextProvider` port documented in
+`docs/reasoning_handoff_contract.md`.
+
 The example uses in-memory product ports and an offline deterministic LLM stand
 in, so it does not need Atlas, a database, or provider credentials. It proves
 the customer-data path: JSON opportunities in, normalized campaign drafts out.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -73,6 +73,10 @@
   upstream reasoning. Hosts pass already-compressed witness/anchor/account
   context into the generator; `_b2b_pool_compression.py` stays outside the
   standalone campaign product.
+- `campaign_reasoning_data.FileCampaignReasoningContextProvider` is the
+  reference file-backed adapter for that boundary. It lets examples and hosts
+  provide precomputed reasoning JSON keyed by target id, company, email, or
+  vendor without importing a reasoning producer.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -9,6 +9,7 @@ from typing import Any
 from .campaign_generation import CampaignGenerationConfig, CampaignGenerationService
 from .campaign_ports import (
     CampaignDraft,
+    CampaignReasoningContextProvider,
     LLMClient,
     LLMMessage,
     LLMResponse,
@@ -250,6 +251,7 @@ async def generate_campaign_drafts_from_payload(
     payload: Mapping[str, Any],
     *,
     llm: LLMClient | None = None,
+    reasoning_context: CampaignReasoningContextProvider | None = None,
     skills: SkillStore | None = None,
 ) -> dict[str, Any]:
     """Run campaign generation from a portable JSON-compatible payload."""
@@ -272,6 +274,7 @@ async def generate_campaign_drafts_from_payload(
         campaigns=campaigns,
         llm=llm_client,
         skills=skill_store,
+        reasoning_context=reasoning_context,
         config=CampaignGenerationConfig(
             channel=channel,
             channels=channels,

--- a/extracted_content_pipeline/campaign_reasoning_data.py
+++ b/extracted_content_pipeline/campaign_reasoning_data.py
@@ -1,0 +1,186 @@
+"""File-backed reasoning context provider for campaign generation examples."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+from .campaign_ports import CampaignReasoningContext, TenantScope
+from .services.campaign_reasoning_context import normalize_campaign_reasoning_context
+
+
+_ROW_KEYS = ("contexts", "rows", "data", "reasoning_contexts")
+_MATCH_KEYS = {
+    "target_id",
+    "id",
+    "company",
+    "company_name",
+    "account",
+    "account_name",
+    "email",
+    "contact_email",
+    "vendor",
+    "vendor_name",
+}
+_CONTEXT_SELECTOR_KEYS = _MATCH_KEYS | {"target_mode"}
+_CONTEXT_FIELD_KEYS = {"context", "reasoning_context", "campaign_reasoning_context"}
+
+
+@dataclass(frozen=True)
+class FileCampaignReasoningContextProvider:
+    """CampaignReasoningContextProvider backed by loaded JSON rows.
+
+    This is a reference adapter for hosts that already produce reasoning
+    context outside AI Content Ops. It indexes rows by target/company/email
+    selectors and returns normalized prompt context without importing a
+    reasoning producer.
+    """
+
+    contexts: Mapping[str, CampaignReasoningContext]
+    source: str | None = None
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "FileCampaignReasoningContextProvider":
+        source = Path(path)
+        return cls.from_payload(
+            json.loads(source.read_text(encoding="utf-8")),
+            source=str(source),
+        )
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Any,
+        *,
+        source: str | None = None,
+    ) -> "FileCampaignReasoningContextProvider":
+        return cls(contexts=_index_contexts(_context_rows(payload)), source=source)
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> CampaignReasoningContext | None:
+        del scope
+        del target_mode
+        for key in _candidate_keys(target_id=target_id, opportunity=opportunity):
+            context = self.contexts.get(key)
+            if context is not None:
+                return context
+        return None
+
+
+def load_campaign_reasoning_context_provider(
+    path: str | Path,
+) -> FileCampaignReasoningContextProvider:
+    """Load a file-backed reasoning context provider from JSON."""
+
+    return FileCampaignReasoningContextProvider.from_file(path)
+
+
+def _context_rows(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        return [row for row in payload if isinstance(row, Mapping)]
+    if not isinstance(payload, Mapping):
+        raise ValueError("reasoning context JSON must be an object or array")
+
+    for key in _ROW_KEYS:
+        value = payload.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [row for row in value if isinstance(row, Mapping)]
+        if isinstance(value, Mapping):
+            return [
+                {"target_id": str(row_key), "context": row_value}
+                for row_key, row_value in value.items()
+                if isinstance(row_value, Mapping)
+            ]
+
+    if _looks_like_mapping_index(payload):
+        return [
+            {"target_id": str(row_key), "context": row_value}
+            for row_key, row_value in payload.items()
+            if isinstance(row_value, Mapping)
+        ]
+    return [payload]
+
+
+def _looks_like_mapping_index(payload: Mapping[str, Any]) -> bool:
+    if not payload:
+        return False
+    if any(key in payload for key in _CONTEXT_SELECTOR_KEYS | _CONTEXT_FIELD_KEYS):
+        return False
+    return all(isinstance(value, Mapping) for value in payload.values())
+
+
+def _index_contexts(rows: Sequence[Mapping[str, Any]]) -> dict[str, CampaignReasoningContext]:
+    indexed: dict[str, CampaignReasoningContext] = {}
+    for row in rows:
+        selectors = _row_selectors(row)
+        context = normalize_campaign_reasoning_context(_row_context(row))
+        if not selectors or not context.has_content():
+            continue
+        for selector in selectors:
+            indexed.setdefault(selector, context)
+    return indexed
+
+
+def _row_context(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = row.get("context")
+    if isinstance(nested, Mapping):
+        return nested
+    return {
+        str(key): value
+        for key, value in row.items()
+        if key not in _CONTEXT_SELECTOR_KEYS and value not in (None, "", [], {})
+    }
+
+
+def _row_selectors(row: Mapping[str, Any]) -> tuple[str, ...]:
+    values = [row.get(key) for key in _MATCH_KEYS]
+    return _clean_keys(values)
+
+
+def _candidate_keys(
+    *,
+    target_id: str,
+    opportunity: Mapping[str, Any],
+) -> tuple[str, ...]:
+    values = [
+        target_id,
+        opportunity.get("target_id"),
+        opportunity.get("id"),
+        opportunity.get("company_name"),
+        opportunity.get("company"),
+        opportunity.get("contact_email"),
+        opportunity.get("email"),
+        opportunity.get("vendor_name"),
+        opportunity.get("vendor"),
+    ]
+    return _clean_keys(values)
+
+
+def _clean_keys(values: Sequence[Any]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        for key in (text, text.lower()):
+            if key in seen:
+                continue
+            seen.add(key)
+            cleaned.append(key)
+    return tuple(cleaned)
+
+
+__all__ = [
+    "FileCampaignReasoningContextProvider",
+    "load_campaign_reasoning_context_provider",
+]

--- a/extracted_content_pipeline/docs/reasoning_handoff_contract.md
+++ b/extracted_content_pipeline/docs/reasoning_handoff_contract.md
@@ -108,6 +108,19 @@ class HostReasoningProvider:
         }
 ```
 
+## File-Backed Example Adapter
+
+`campaign_reasoning_data.FileCampaignReasoningContextProvider` is the reference
+adapter for hosts that already have reasoning output as JSON. It accepts
+context rows keyed by target id, company, email, or vendor, normalizes them into
+`CampaignReasoningContext`, and keeps AI Content Ops independent from any
+reasoning producer.
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
+```
+
 ## Integration Modes
 
 | Mode | Who produces reasoning? | Content package behavior |

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -127,7 +127,10 @@ Reasoning remains a host/product boundary for this slice. The generator accepts
 pre-compressed reasoning through `CampaignReasoningContextProvider` and
 normalizes it with `services.campaign_reasoning_context`; it must not reach into
 Atlas reasoning producers or the extracted reasoning-core internals. The
-contract is documented in `docs/reasoning_handoff_contract.md`.
+contract is documented in `docs/reasoning_handoff_contract.md`. The
+file-backed reference adapter in `campaign_reasoning_data.py` lets standalone
+examples consume host-generated reasoning JSON through that same port without
+adding a reasoning runtime dependency.
 
 `extracted_content_pipeline/campaign_postgres_generation.py` wires the
 database-backed product path. Hosts pass an async Postgres pool and the runner

--- a/extracted_content_pipeline/examples/campaign_reasoning_context.json
+++ b/extracted_content_pipeline/examples/campaign_reasoning_context.json
@@ -1,0 +1,28 @@
+{
+  "contexts": [
+    {
+      "target_id": "opp-acme-hubspot",
+      "reasoning_context": {
+        "wedge": "renewal pressure",
+        "confidence": "high",
+        "summary": "Acme is reviewing CRM costs before renewal.",
+        "key_signals": ["pricing_mentions", "renewal_window"]
+      },
+      "campaign_reasoning_context": {
+        "proof_points": [
+          {"label": "pricing_mentions", "value": 12}
+        ],
+        "timing_windows": [
+          {"window_type": "renewal", "anchor": "Q3"}
+        ],
+        "account_signals": [
+          {
+            "company": "Acme Logistics",
+            "primary_pain": "pricing pressure"
+          }
+        ],
+        "coverage_limits": ["thin_account_signals"]
+      }
+    }
+  ]
+}

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -178,6 +178,9 @@
       "target": "extracted_content_pipeline/campaign_example.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_reasoning_data.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_customer_data.py"
     },
     {

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -21,6 +21,9 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
 from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
     load_campaign_opportunities_from_file,
 )
+from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
+    load_campaign_reasoning_context_provider,
+)
 
 
 DEFAULT_PAYLOAD = (
@@ -82,6 +85,14 @@ def _parse_args() -> argparse.Namespace:
         help="Write generated draft JSON to this file instead of stdout.",
     )
     parser.add_argument(
+        "--reasoning-context",
+        type=Path,
+        help=(
+            "Optional JSON file containing host-provided reasoning context "
+            "keyed by target id, company, email, or vendor."
+        ),
+    )
+    parser.add_argument(
         "--llm",
         choices=("offline", "pipeline"),
         default="offline",
@@ -94,18 +105,24 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    if args.reasoning_context:
+        overrides["reasoning_context"] = load_campaign_reasoning_context_provider(
+            args.reasoning_context
+        )
     if args.llm == "offline":
-        return {}
+        return overrides
 
     from extracted_content_pipeline.campaign_llm_client import (  # noqa: PLC0415
         create_pipeline_llm_client,
     )
     from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: PLC0415
 
-    return {
+    overrides.update({
         "llm": create_pipeline_llm_client(),
         "skills": get_skill_registry(),
-    }
+    })
+    return overrides
 
 
 async def _main() -> int:

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -14,6 +14,7 @@ pytest \
   tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation_seams.py \
   tests/test_extracted_campaign_generation.py \
+  tests/test_extracted_campaign_reasoning_data.py \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_postgres_generation.py \

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -11,6 +11,9 @@ from extracted_content_pipeline.campaign_example import (
     generate_campaign_drafts_from_payload,
 )
 from extracted_content_pipeline.campaign_ports import LLMResponse
+from extracted_content_pipeline.campaign_reasoning_data import (
+    FileCampaignReasoningContextProvider,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -144,6 +147,42 @@ async def test_example_generates_cold_and_followup_channels_from_payload() -> No
 
 
 @pytest.mark.asyncio
+async def test_example_accepts_file_backed_reasoning_provider() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "reasoning_context": {
+                    "wedge": "renewal pressure",
+                    "confidence": "high",
+                },
+                "campaign_reasoning_context": {
+                    "proof_points": [{"label": "pricing_mentions", "value": 12}]
+                },
+            }
+        ]
+    })
+    payload = {
+        "target_mode": "vendor_retention",
+        "limit": 1,
+        "opportunities": [
+            {"id": "opp-1", "company": "Acme Logistics", "vendor": "HubSpot"}
+        ],
+    }
+
+    result = await generate_campaign_drafts_from_payload(
+        payload,
+        reasoning_context=provider,
+    )
+
+    source = result["drafts"][0]["metadata"]["source_opportunity"]
+    assert source["reasoning_context"]["wedge"] == "renewal pressure"
+    assert source["campaign_reasoning_context"]["proof_points"][0]["label"] == (
+        "pricing_mentions"
+    )
+
+
+@pytest.mark.asyncio
 async def test_example_respects_limit_and_normalizes_multiple_rows() -> None:
     payload = json.loads(EXAMPLE_PAYLOAD.read_text(encoding="utf-8"))
 
@@ -175,3 +214,42 @@ def test_campaign_generation_example_cli_outputs_draft_json() -> None:
     assert result["result"]["saved_ids"] == ["draft-1"]
     assert result["drafts"][0]["target_id"] == "opp-acme-hubspot"
     assert result["drafts"][0]["metadata"]["generation_model"] == "offline-deterministic"
+
+
+def test_campaign_generation_example_cli_accepts_reasoning_context_file(tmp_path) -> None:
+    reasoning_path = tmp_path / "reasoning.json"
+    reasoning_path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-acme-hubspot",
+                    "reasoning_context": {
+                        "wedge": "renewal pressure",
+                        "confidence": "high",
+                    },
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(EXAMPLE_PAYLOAD),
+            "--limit",
+            "1",
+            "--llm",
+            "offline",
+            "--reasoning-context",
+            str(reasoning_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+    source = result["drafts"][0]["metadata"]["source_opportunity"]
+    assert source["reasoning_context"]["wedge"] == "renewal pressure"
+    assert source["reasoning_context"]["confidence"] == "high"

--- a/tests/test_extracted_campaign_reasoning_data.py
+++ b/tests/test_extracted_campaign_reasoning_data.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_reasoning_data import (
+    FileCampaignReasoningContextProvider,
+    load_campaign_reasoning_context_provider,
+)
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_matches_target_id() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "reasoning_context": {
+                    "wedge": "renewal pressure",
+                    "confidence": "high",
+                },
+                "campaign_reasoning_context": {
+                    "proof_points": [{"label": "pricing_mentions", "value": 12}]
+                },
+            }
+        ]
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(account_id="acct-1"),
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={"company_name": "Acme"},
+    )
+
+    assert context is not None
+    assert context.as_dict()["wedge"] == "renewal pressure"
+    assert context.proof_points[0]["label"] == "pricing_mentions"
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_accepts_mapping_index() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "opp-1": {
+            "reasoning_context": {
+                "summary": "Acme is reviewing vendors before renewal."
+            }
+        }
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={},
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "Acme is reviewing vendors before renewal."
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_matches_company_fallback_case_insensitive() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "company_name": "Acme Logistics",
+                "context": {
+                    "campaign_reasoning_context": {
+                        "account_signals": [
+                            {"company": "Acme Logistics", "primary_pain": "pricing"}
+                        ]
+                    }
+                },
+            }
+        ]
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="missing-id",
+        target_mode="vendor_retention",
+        opportunity={"company_name": "acme logistics"},
+    )
+
+    assert context is not None
+    assert context.account_signals[0]["primary_pain"] == "pricing"
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_returns_none_for_missing_or_empty_context() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {"target_id": "empty", "reasoning_context": {}},
+            {"target_id": "other", "reasoning_context": {"wedge": "pricing"}},
+        ]
+    })
+
+    assert await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="empty",
+        target_mode="vendor_retention",
+        opportunity={},
+    ) is None
+    assert await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="missing",
+        target_mode="vendor_retention",
+        opportunity={},
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_does_not_match_on_target_mode_only() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_mode": "vendor_retention",
+                "reasoning_context": {"wedge": "pricing"},
+            }
+        ]
+    })
+
+    assert await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={},
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_load_file_reasoning_provider(tmp_path) -> None:
+    path = tmp_path / "reasoning.json"
+    path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "reasoning_context": {"confidence": "medium"},
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    provider = load_campaign_reasoning_context_provider(path)
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={},
+    )
+
+    assert provider.source == str(path)
+    assert context is not None
+    assert context.as_dict()["confidence"] == "medium"


### PR DESCRIPTION
Summary:
- Adds PR-D2 FileCampaignReasoningContextProvider for AI Content Ops so hosts can feed precomputed reasoning JSON through the existing campaign reasoning port.
- Wires the offline campaign example to accept a --reasoning-context JSON file and documents the handoff.
- Updates the content-pipeline manifest and validation script so the new provider and tests are covered.

Coordination:
- Claimed only extracted_content_pipeline docs/provider/example/test files.
- Avoids extracted_reasoning_core, content_pipeline reasoning internals, and LLM-infra files.

Validation:
- python -m py_compile on edited Python files
- git diff --check
- pytest tests/test_extracted_campaign_reasoning_data.py tests/test_extracted_campaign_generation_example.py
- bash scripts/run_extracted_pipeline_checks.sh (249 passed, import check 48 modules, standalone audit 0 Atlas runtime imports)