### PR TITLE
Wire Postgres campaign runner to reasoning files

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:08Z by codex-2026-05-03
+Last updated: 2026-05-03T22:09Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
-| (PR-D3, branch `codex/content-pipeline-postgres-reasoning-context`) | Wire file-backed reasoning into Postgres campaign runner | `scripts/run_extracted_campaign_generation_postgres.py`; `tests/test_extracted_campaign_postgres_generation.py`; content-pipeline docs/status if needed | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
+| #99 | Wire file-backed reasoning into Postgres campaign runner | `scripts/run_extracted_campaign_generation_postgres.py`; `tests/test_extracted_campaign_postgres_generation.py`; content-pipeline docs/status if needed | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:08Z by codex-2026-05-03
+Last updated: 2026-05-03T22:09Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -8,6 +8,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
 | #94 | PR-C1a: Move archetypes + evidence_map to reasoning core | `extracted_reasoning_core/{archetypes.py, evidence_map.yaml}`; `tests/test_extracted_reasoning_core_archetypes.py`. Subsequent PR-C1 slices (temporal, types, evidence_engine slim, review_enrichment, api, wrappers, test renames, audit amendment) will land as separate atomic PRs after this one merges. | claude-2026-05-03 | `extracted_reasoning_core/**`; the three content_pipeline reasoning forks; `atlas_brain/reasoning/evidence_engine.py` (later PR-C1 slices) |
-| (PR-D3, branch `codex/content-pipeline-postgres-reasoning-context`) | Wire file-backed reasoning into Postgres campaign runner | `scripts/run_extracted_campaign_generation_postgres.py`; `tests/test_extracted_campaign_postgres_generation.py`; content-pipeline docs/status if needed | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
+| #99 | Wire file-backed reasoning into Postgres campaign runner | `scripts/run_extracted_campaign_generation_postgres.py`; `tests/test_extracted_campaign_postgres_generation.py`; content-pipeline docs/status if needed | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:07Z by codex-2026-05-03
+Last updated: 2026-05-03T22:08Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
+| (PR-D3, branch `codex/content-pipeline-postgres-reasoning-context`) | Wire file-backed reasoning into Postgres campaign runner | `scripts/run_extracted_campaign_generation_postgres.py`; `tests/test_extracted_campaign_postgres_generation.py`; content-pipeline docs/status if needed | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:08Z by claude-2026-05-03
+Last updated: 2026-05-03T22:08Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -8,5 +8,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
 | #94 | PR-C1a: Move archetypes + evidence_map to reasoning core | `extracted_reasoning_core/{archetypes.py, evidence_map.yaml}`; `tests/test_extracted_reasoning_core_archetypes.py`. Subsequent PR-C1 slices (temporal, types, evidence_engine slim, review_enrichment, api, wrappers, test renames, audit amendment) will land as separate atomic PRs after this one merges. | claude-2026-05-03 | `extracted_reasoning_core/**`; the three content_pipeline reasoning forks; `atlas_brain/reasoning/evidence_engine.py` (later PR-C1 slices) |
+| (PR-D3, branch `codex/content-pipeline-postgres-reasoning-context`) | Wire file-backed reasoning into Postgres campaign runner | `scripts/run_extracted_campaign_generation_postgres.py`; `tests/test_extracted_campaign_postgres_generation.py`; content-pipeline docs/status if needed | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-03T22:07Z by codex-2026-05-03
+Last updated: 2026-05-03T22:08Z by codex-2026-05-03
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -13,3 +13,4 @@ Sequence reflects dependencies. Claim a slice (set Owner) before starting code s
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |
+| PR-D3 | `extracted_content_pipeline` | codex-2026-05-03 | PR-D2 / #97 (merged); avoid PR-C1 files | Wire the file-backed `CampaignReasoningContextProvider` into the Postgres campaign generation CLI so hosted/DB-backed runs can consume buyer/host reasoning JSON too. |

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -181,6 +181,14 @@ The Postgres runner accepts the same channel expansion:
 python scripts/run_extracted_campaign_generation_postgres.py --account-id acct_123 --channels email_cold,email_followup
 ```
 
+It also accepts the same host-provided reasoning JSON as the offline example:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
+```
+
 ## Import smoke test
 
 ```bash

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -77,6 +77,9 @@
   reference file-backed adapter for that boundary. It lets examples and hosts
   provide precomputed reasoning JSON keyed by target id, company, email, or
   vendor without importing a reasoning producer.
+- Both the offline and Postgres campaign generation runners can consume that
+  JSON through `--reasoning-context`, so file-backed host reasoning is available
+  on demo and DB-backed generation paths.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -23,6 +23,9 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
 from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
     generate_campaign_drafts_from_postgres,
 )
+from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
+    load_campaign_reasoning_context_provider,
+)
 
 
 def _json_object(value: str | None) -> dict[str, Any]:
@@ -63,6 +66,14 @@ def _parse_args() -> argparse.Namespace:
         help="Optional JSON object of opportunity filters.",
     )
     parser.add_argument(
+        "--reasoning-context",
+        type=Path,
+        help=(
+            "Optional JSON file containing host-provided reasoning context "
+            "keyed by target id, company, email, or vendor."
+        ),
+    )
+    parser.add_argument(
         "--llm",
         choices=("pipeline", "offline"),
         default="pipeline",
@@ -87,12 +98,18 @@ async def _create_pool(database_url: str):
 
 
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    if args.reasoning_context:
+        overrides["reasoning_context"] = load_campaign_reasoning_context_provider(
+            args.reasoning_context
+        )
     if args.llm == "pipeline":
-        return {}
-    return {
+        return overrides
+    overrides.update({
         "llm": DeterministicCampaignLLM(),
         "skills": StaticCampaignSkillStore(),
-    }
+    })
+    return overrides
 
 
 async def _main() -> int:

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -192,7 +192,11 @@ def test_tenant_scope_from_mapping_accepts_mapping_and_existing_scope():
 
 
 @pytest.mark.asyncio
-async def test_postgres_runner_cli_wires_pool_and_offline_dependencies(monkeypatch, capsys):
+async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
     postgres_cli = _load_postgres_cli_module()
     pool = _Pool()
     pool.fetch_rows = [
@@ -205,6 +209,21 @@ async def test_postgres_runner_cli_wires_pool_and_offline_dependencies(monkeypat
             "raw_payload": {},
         }
     ]
+    reasoning_path = tmp_path / "reasoning.json"
+    reasoning_path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "reasoning_context": {
+                        "wedge": "renewal pressure",
+                        "confidence": "high",
+                    },
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
     created_urls = []
 
     async def create_pool(database_url):
@@ -227,6 +246,8 @@ async def test_postgres_runner_cli_wires_pool_and_offline_dependencies(monkeypat
             "1",
             "--llm",
             "offline",
+            "--reasoning-context",
+            str(reasoning_path),
         ],
     )
 
@@ -238,6 +259,11 @@ async def test_postgres_runner_cli_wires_pool_and_offline_dependencies(monkeypat
     assert created_urls == ["postgres://example"]
     assert output["generated"] == 1
     assert output["saved_ids"] == ["campaign-1"]
+    metadata = json.loads(pool.fetchval_calls[0]["args"][9])
+    assert metadata["source_opportunity"]["reasoning_context"] == {
+        "confidence": "high",
+        "wedge": "renewal pressure",
+    }
     assert pool.closed is True
 
 


### PR DESCRIPTION
Summary:
- Adds --reasoning-context to the Postgres campaign generation runner.
- Reuses the file-backed CampaignReasoningContextProvider from PR #97 so DB-backed generation can consume host reasoning JSON.
- Updates README and STATUS, with coordination claim for PR-D3.

Coordination:
- Touches only extracted_content_pipeline runner/docs/tests and coordination rows.
- Avoids extracted_reasoning_core, content_pipeline reasoning internals, and LLM-infra files.

Validation:
- python -m py_compile scripts/run_extracted_campaign_generation_postgres.py
- git diff --check
- pytest tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_reasoning_data.py
- bash scripts/run_extracted_pipeline_checks.sh (249 passed, import check 48 modules, standalone audit 0 Atlas runtime imports)