### PR TITLE
PR-C1b: Move temporal.py to reasoning core (in progress)

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T22:10Z by codex-2026-05-03
+Last updated: 2026-05-03T22:11Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-A1.5, queued) | Apply Copilot fixes that missed PR #87 merge | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed; opening immediately after PR-A2 |
+| (PR-C1b, in flight) | Temporal consolidation -> reasoning core | NEW: `extracted_reasoning_core/temporal.py` (atlas canonical + content_pipeline's `_numeric_value` / `_row_get` defensive helpers + parameterized `MIN_DAYS_FOR_PERCENTILES` constructor arg). NEW: `tests/test_extracted_reasoning_core_temporal.py` (smoke). `extracted_content_pipeline/reasoning/temporal.py` -> wrapper conversion is a separate atomic PR (PR-C1j). | claude-2026-05-03 | `extracted_reasoning_core/temporal.py`; the content_pipeline temporal fork (we read it but do not edit in this PR); the atlas-side temporal stays untouched |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_reasoning_core/temporal.py
+++ b/extracted_reasoning_core/temporal.py
@@ -1,0 +1,610 @@
+"""Temporal Reasoning Engine.
+
+Computes time-series analytics over `b2b_vendor_snapshots`:
+
+    - Velocity: rate of change per metric (needs 2+ days)
+    - Acceleration: rate of velocity change (needs 3+ days)
+    - Rolling percentiles by category (25th / 50th / 75th)
+    - Z-score anomaly detection against category baselines
+    - Recency-weighted review scoring
+
+All outputs are pure data (no LLM) -- they feed into synthesis-first
+vendor reasoning, archetype scoring, and downstream deterministic
+builders.
+
+This module landed via PR-C1b as a consolidation of the atlas-canonical
+temporal engine and the content_pipeline fork. Documented decisions
+(per `docs/extraction/evidence_temporal_archetypes_audit_2026-05-03.md`):
+
+  - 5 dataclasses are `frozen=True` (carries content_pipeline's
+    immutability decision forward).
+  - `_numeric_value` / `_row_get` defensive helpers from
+    content_pipeline are surfaced at module scope so callers handling
+    messy snapshot payloads (strings with commas / percent signs,
+    asyncpg.Records vs plain dicts) have a single coercion point.
+  - `TemporalEngine` takes a `min_days_for_percentiles` constructor
+    argument (default = `MIN_DAYS_FOR_PERCENTILES` = 3). Atlas's prior
+    module constant declared 7 but the percentile gate was hardcoded
+    to `< 3` everywhere it was checked; the constant is the actual
+    behavior, with a knob for products that want stricter gating.
+  - The `_b2b_shared` lookup helpers used by `_compute_percentiles` /
+    `_infer_category` are imported from `atlas_brain` lazily so the
+    module loads cleanly even when atlas_brain is not on the import
+    path (degrades to empty percentiles + no inferred category in
+    that case). A future PR will replace these with a port-based
+    abstraction so reasoning core has zero atlas dependency.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any
+
+MIN_DAYS_FOR_VELOCITY = 2
+MIN_DAYS_FOR_ACCELERATION = 3
+MIN_DAYS_FOR_PERCENTILES = 3  # Was atlas's constant=7 / hardcoded gate=3; canonicalized to 3 (atlas's actual behavior)
+MIN_DAYS_FOR_TREND = 14  # Relaxed from 30 to allow shorter history
+RECENCY_HALF_LIFE_DAYS = 14
+
+
+@dataclass(frozen=True)
+class VendorVelocity:
+    """Rate-of-change metrics for a vendor."""
+
+    vendor_name: str
+    metric: str
+    current_value: float
+    previous_value: float
+    velocity: float          # change per day
+    days_between: int
+    acceleration: float | None = None  # change in velocity (needs 3+ points)
+
+
+@dataclass(frozen=True)
+class LongTermTrend:
+    """Long-term trend analysis (30-90 days)."""
+
+    metric: str
+    slope_30d: float | None = None
+    slope_90d: float | None = None
+    volatility: float | None = None  # standard deviation of changes
+    data_points: int = 0
+
+
+@dataclass(frozen=True)
+class CategoryPercentile:
+    """Rolling percentile baselines for a metric within a category."""
+
+    product_category: str
+    metric: str
+    p25: float
+    p50: float
+    p75: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class AnomalyScore:
+    """Z-score anomaly detection for a vendor metric."""
+
+    vendor_name: str
+    metric: str
+    value: float
+    z_score: float
+    p_value: float | None = None
+    is_anomaly: bool = False    # |z| > 2.0
+
+
+@dataclass(frozen=True)
+class TemporalEvidence:
+    """Complete temporal analysis for a vendor, used as evidence in reasoning."""
+
+    vendor_name: str
+    snapshot_days: int
+    velocities: list[VendorVelocity] = field(default_factory=list)
+    trends: list[LongTermTrend] = field(default_factory=list)
+    anomalies: list[AnomalyScore] = field(default_factory=list)
+    category_baselines: list[CategoryPercentile] = field(default_factory=list)
+    insufficient_data: bool = False
+
+
+# Metrics to track velocity on
+_VELOCITY_METRICS = [
+    "churn_density", "avg_urgency", "positive_review_pct",
+    "recommend_ratio", "pain_count", "competitor_count",
+    "displacement_edge_count", "high_intent_company_count",
+    "support_sentiment", "employee_growth_rate",
+    "new_feature_velocity", "legacy_support_score",
+]
+
+
+class TemporalEngine:
+    """Computes temporal analytics from `b2b_vendor_snapshots`.
+
+    `min_days_for_percentiles` controls the per-category sample-size gate
+    used by `_compute_percentiles`. Default (`MIN_DAYS_FOR_PERCENTILES` = 3)
+    matches both atlas's actual behavior and content_pipeline's wired
+    constant. Products that want stricter gating can pass a larger value
+    at construction.
+    """
+
+    def __init__(
+        self,
+        pool: Any,
+        *,
+        min_days_for_percentiles: int = MIN_DAYS_FOR_PERCENTILES,
+    ) -> None:
+        self._pool = pool
+        self._min_days_for_percentiles = int(min_days_for_percentiles)
+
+    async def analyze_vendor(self, vendor_name: str) -> TemporalEvidence:
+        """Full temporal analysis for a single vendor."""
+        snapshots = await self._load_snapshots(vendor_name)
+
+        if len(snapshots) < MIN_DAYS_FOR_VELOCITY:
+            return TemporalEvidence(
+                vendor_name=vendor_name,
+                snapshot_days=len(snapshots),
+                insufficient_data=True,
+            )
+
+        evidence = TemporalEvidence(
+            vendor_name=vendor_name,
+            snapshot_days=len(snapshots),
+        )
+
+        # Compute velocities
+        evidence.velocities = self._compute_velocities(vendor_name, snapshots)
+
+        # Compute long-term trends
+        if len(snapshots) >= MIN_DAYS_FOR_TREND:
+            evidence.trends = self._compute_long_term_trends(vendor_name, snapshots)
+
+        # Compute category baselines + anomalies
+        if len(snapshots) >= 2:
+            latest = snapshots[-1]
+            category = latest.get("product_category") or await self._infer_category(vendor_name)
+            if category:
+                evidence.category_baselines = await self._compute_percentiles(category)
+                evidence.anomalies = self._compute_anomalies(
+                    vendor_name, latest, evidence.category_baselines,
+                )
+
+        return evidence
+
+    async def analyze_all_vendors(self) -> dict[str, TemporalEvidence]:
+        """Temporal analysis for all vendors with snapshots."""
+        vendors = await self._pool.fetch(
+            "SELECT DISTINCT vendor_name FROM b2b_vendor_snapshots ORDER BY vendor_name"
+        )
+        results = {}
+        for row in vendors:
+            name = row["vendor_name"]
+            results[name] = await self.analyze_vendor(name)
+        return results
+
+    # ------------------------------------------------------------------
+    # Velocity / Acceleration
+    # ------------------------------------------------------------------
+
+    def _compute_velocities(
+        self, vendor_name: str, snapshots: list[dict],
+    ) -> list[VendorVelocity]:
+        """Compute rate-of-change for each metric between consecutive snapshots."""
+        if len(snapshots) < 2:
+            return []
+
+        velocities = []
+        latest = snapshots[-1]
+        previous = snapshots[-2]
+        days = (latest["snapshot_date"] - previous["snapshot_date"]).days
+        if days <= 0:
+            return []
+
+        for metric in _VELOCITY_METRICS:
+            curr = latest.get(metric)
+            prev = previous.get(metric)
+            if curr is None or prev is None:
+                continue
+            try:
+                curr_f = float(curr)
+                prev_f = float(prev)
+            except (ValueError, TypeError):
+                continue
+
+            velocity = (curr_f - prev_f) / days
+
+            # Acceleration if 3+ snapshots
+            accel = None
+            if len(snapshots) >= 3:
+                prev2 = snapshots[-3]
+                prev2_val = prev2.get(metric)
+                if prev2_val is not None:
+                    days2 = (previous["snapshot_date"] - prev2["snapshot_date"]).days
+                    if days2 > 0:
+                        prev_velocity = (prev_f - float(prev2_val)) / days2
+                        accel = (velocity - prev_velocity) / days
+
+            velocities.append(VendorVelocity(
+                vendor_name=vendor_name,
+                metric=metric,
+                current_value=curr_f,
+                previous_value=prev_f,
+                velocity=velocity,
+                days_between=days,
+                acceleration=accel,
+            ))
+
+        return velocities
+
+    def _compute_long_term_trends(
+        self, vendor_name: str, snapshots: list[dict],
+    ) -> list[LongTermTrend]:
+        """Compute 30-day and 90-day linear trends for key metrics."""
+        trends = []
+        if len(snapshots) < MIN_DAYS_FOR_TREND:
+            return []
+
+        latest_date = snapshots[-1]["snapshot_date"]
+        
+        # Helper to get subset of snapshots within last N days
+        def _get_window(days: int) -> list[dict]:
+            cutoff = latest_date - timedelta(days=days)
+            return [s for s in snapshots if s["snapshot_date"] >= cutoff]
+
+        window_30 = _get_window(30)
+        window_90 = _get_window(90)
+
+        for metric in _VELOCITY_METRICS:
+            # Only compute trend if metric exists in latest snapshot
+            if snapshots[-1].get(metric) is None:
+                continue
+
+            trend = LongTermTrend(metric=metric)
+            
+            # 30-day slope
+            slope_30 = self._calculate_slope(window_30, metric)
+            if slope_30 is not None:
+                trend.slope_30d = slope_30
+                trend.data_points = len(window_30)
+
+            # 90-day slope (only if we have more history than 30 days)
+            if len(window_90) > len(window_30):
+                slope_90 = self._calculate_slope(window_90, metric)
+                if slope_90 is not None:
+                    trend.slope_90d = slope_90
+
+            if trend.slope_30d is not None:
+                trends.append(trend)
+
+        return trends
+
+    def _calculate_slope(self, window: list[dict], metric: str) -> float | None:
+        """Calculate linear regression slope (change per day)."""
+        if len(window) < 2:
+            return None
+            
+        x_vals = [] # Days from start of window
+        y_vals = []
+        
+        start_date = window[0]["snapshot_date"]
+        
+        for s in window:
+            val = s.get(metric)
+            if val is not None:
+                try:
+                    y = float(val)
+                    days = (s["snapshot_date"] - start_date).days
+                    x_vals.append(days)
+                    y_vals.append(y)
+                except (ValueError, TypeError):
+                    continue
+                    
+        if len(x_vals) < 2:
+            return None
+            
+        # Simple linear regression: slope = cov(x,y) / var(x)
+        n = len(x_vals)
+        sum_x = sum(x_vals)
+        sum_y = sum(y_vals)
+        sum_xy = sum(x*y for x, y in zip(x_vals, y_vals))
+        sum_xx = sum(x*x for x in x_vals)
+        
+        denom = (n * sum_xx - sum_x * sum_x)
+        if denom == 0:
+            return None
+            
+        slope = (n * sum_xy - sum_x * sum_y) / denom
+        return slope
+
+    # ------------------------------------------------------------------
+    # Category Percentiles
+    # ------------------------------------------------------------------
+
+    async def _compute_percentiles(self, category: str) -> list[CategoryPercentile]:
+        """Compute rolling percentiles for a category from latest snapshots.
+
+        Uses atlas's `read_category_vendor_signal_rows` helper when
+        `atlas_brain` is on the import path; degrades to an empty list
+        when it is not, so the module loads cleanly outside the host.
+        A future PR will replace this lazy import with a port-based
+        abstraction so reasoning core has zero atlas dependency.
+        """
+        try:
+            from atlas_brain.autonomous.tasks._b2b_shared import (
+                read_category_vendor_signal_rows,
+            )
+        except ImportError:
+            return []
+
+        vendor_rows = await read_category_vendor_signal_rows(
+            self._pool,
+            product_category=category,
+        )
+        normalized_vendor_names = sorted(
+            {
+                str(row.get("vendor_name") or "").strip().lower()
+                for row in vendor_rows
+                if str(row.get("vendor_name") or "").strip()
+            }
+        )
+        if not normalized_vendor_names:
+            return []
+
+        rows = await self._pool.fetch(
+            """
+            SELECT s.* FROM b2b_vendor_snapshots s
+            JOIN (
+                SELECT vendor_name, MAX(snapshot_date) AS max_date
+                FROM b2b_vendor_snapshots
+                GROUP BY vendor_name
+            ) latest ON s.vendor_name = latest.vendor_name AND s.snapshot_date = latest.max_date
+            WHERE LOWER(s.vendor_name) = ANY($1::text[])
+            """,
+            normalized_vendor_names,
+        )
+
+        if len(rows) < self._min_days_for_percentiles:
+            return []
+
+        percentiles = []
+        for metric in _VELOCITY_METRICS:
+            values = []
+            for row in rows:
+                val = _row_get(row, metric)
+                num = _numeric_value(val)
+                if num is not None:
+                    values.append(num)
+            if len(values) < self._min_days_for_percentiles:
+                continue
+
+            values.sort()
+            n = len(values)
+            p25 = values[int(n * 0.25)]
+            p50 = values[int(n * 0.50)]
+            p75 = values[int(n * 0.75)]
+
+            percentiles.append(CategoryPercentile(
+                product_category=category,
+                metric=metric,
+                p25=p25,
+                p50=p50,
+                p75=p75,
+                sample_count=n,
+            ))
+
+        return percentiles
+
+    # ------------------------------------------------------------------
+    # Z-Score Anomaly Detection
+    # ------------------------------------------------------------------
+
+    def _compute_anomalies(
+        self,
+        vendor_name: str,
+        latest_snapshot: dict,
+        baselines: list[CategoryPercentile],
+    ) -> list[AnomalyScore]:
+        """Compute z-scores for vendor metrics against category baselines."""
+        anomalies = []
+        baseline_map = {b.metric: b for b in baselines}
+
+        for metric in _VELOCITY_METRICS:
+            val = latest_snapshot.get(metric)
+            baseline = baseline_map.get(metric)
+            if val is None or baseline is None:
+                continue
+
+            try:
+                val_f = float(val)
+            except (ValueError, TypeError):
+                continue
+
+            # Approximate std from IQR: std ~= IQR / 1.35
+            iqr = baseline.p75 - baseline.p25
+            if iqr <= 0:
+                continue
+            std_approx = iqr / 1.35
+            z = (val_f - baseline.p50) / std_approx
+
+            # Approximate p-value from z-score (normal CDF)
+            p_value = _normal_sf(abs(z))
+
+            anomalies.append(AnomalyScore(
+                vendor_name=vendor_name,
+                metric=metric,
+                value=val_f,
+                z_score=round(z, 3),
+                p_value=round(p_value, 4) if p_value else None,
+                is_anomaly=abs(z) > 2.0,
+            ))
+
+        return anomalies
+
+    # ------------------------------------------------------------------
+    # Recency Weighting
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def recency_weight(days_old: int, half_life: int = RECENCY_HALF_LIFE_DAYS) -> float:
+        """Exponential decay weight for review recency."""
+        if days_old <= 0:
+            return 1.0
+        return math.pow(2, -(days_old / half_life))
+
+    # ------------------------------------------------------------------
+    # Evidence serialization for synthesis/deterministic consumers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def to_evidence_dict(te: TemporalEvidence) -> dict[str, Any]:
+        """Convert temporal evidence to a dict suitable for the reasoner."""
+        if te.insufficient_data:
+            return {
+                "temporal_status": "insufficient_data",
+                "snapshot_days": te.snapshot_days,
+            }
+
+        evidence: dict[str, Any] = {"snapshot_days": te.snapshot_days}
+
+        # Velocities
+        for v in te.velocities:
+            evidence[f"velocity_{v.metric}"] = round(v.velocity, 4)
+            if v.acceleration is not None:
+                evidence[f"accel_{v.metric}"] = round(v.acceleration, 4)
+
+        # Long-term trends
+        for t in te.trends:
+            if t.slope_30d is not None:
+                evidence[f"trend_30d_{t.metric}"] = round(t.slope_30d, 4)
+            if t.slope_90d is not None:
+                evidence[f"trend_90d_{t.metric}"] = round(t.slope_90d, 4)
+
+        # Anomalies
+        anomaly_list = []
+        for a in te.anomalies:
+            if a.is_anomaly:
+                anomaly_list.append({
+                    "metric": a.metric,
+                    "value": a.value,
+                    "z_score": a.z_score,
+                    "p_value": a.p_value,
+                })
+        if anomaly_list:
+            evidence["anomalies"] = anomaly_list
+
+        return evidence
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _load_snapshots(self, vendor_name: str) -> list[dict]:
+        """Load snapshots for a vendor, ordered by date."""
+        rows = await self._pool.fetch(
+            """
+            SELECT * FROM b2b_vendor_snapshots
+            WHERE vendor_name = $1
+            ORDER BY snapshot_date ASC
+            """,
+            vendor_name,
+        )
+        return [dict(r) for r in rows]
+
+    async def _infer_category(self, vendor_name: str) -> str | None:
+        """Try to infer product category from churn signals.
+
+        Uses atlas's `read_vendor_signal_detail_exact` helper when
+        `atlas_brain` is on the import path; returns None otherwise so
+        callers degrade gracefully when reasoning core is loaded outside
+        the host. A future PR will replace this lazy import with a
+        port-based abstraction.
+        """
+        try:
+            from atlas_brain.autonomous.tasks._b2b_shared import (
+                read_vendor_signal_detail_exact,
+            )
+        except ImportError:
+            return None
+
+        row = await read_vendor_signal_detail_exact(
+            self._pool,
+            vendor_name=vendor_name,
+        )
+        return row["product_category"] if row else None
+
+
+def _normal_sf(z: float) -> float:
+    """Survival function (1 - CDF) for standard normal. Approximation."""
+    # Abramowitz & Stegun approximation
+    t = 1.0 / (1.0 + 0.2316419 * abs(z))
+    d = 0.3989422804014327  # 1/sqrt(2*pi)
+    poly = t * (0.319381530 + t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429))))
+    sf = d * math.exp(-z * z / 2) * poly
+    return sf if z >= 0 else 1.0 - sf
+
+
+# ------------------------------------------------------------------
+# Defensive value/row helpers (carried from content_pipeline fork)
+# ------------------------------------------------------------------
+
+
+def _numeric_value(value: Any) -> float | None:
+    """Coerce a possibly-messy snapshot value to a float.
+
+    Handles raw numerics, strings with thousands separators (`"1,234"`)
+    and percent suffixes (`"42%"`), and the bool-is-not-a-number trap.
+    Returns None on any conversion failure rather than raising; callers
+    use the None to skip the metric without aborting the whole vendor.
+
+    Surfaced at module scope so that any caller building snapshot
+    payloads has one canonical coercion entry point.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip().replace(",", "")
+        if not stripped:
+            return None
+        if stripped.endswith("%"):
+            stripped = stripped[:-1]
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _row_get(row: Any, key: str) -> Any:
+    """Read a key from a row regardless of its concrete shape.
+
+    Snapshot rows arrive as plain dicts in tests, asyncpg.Records in
+    production, and occasionally as objects with attribute access.
+    This helper papers over the shape difference so callers do not
+    have to branch.
+    """
+    if isinstance(row, dict):
+        return row.get(key)
+    try:
+        return row[key]
+    except (KeyError, TypeError):
+        return getattr(row, key, None)
+
+
+__all__ = [
+    "AnomalyScore",
+    "CategoryPercentile",
+    "LongTermTrend",
+    "MIN_DAYS_FOR_ACCELERATION",
+    "MIN_DAYS_FOR_PERCENTILES",
+    "MIN_DAYS_FOR_TREND",
+    "MIN_DAYS_FOR_VELOCITY",
+    "RECENCY_HALF_LIFE_DAYS",
+    "TemporalEngine",
+    "TemporalEvidence",
+    "VendorVelocity",
+]

--- a/tests/test_extracted_reasoning_core_temporal.py
+++ b/tests/test_extracted_reasoning_core_temporal.py
@@ -1,0 +1,239 @@
+"""Smoke tests for extracted_reasoning_core.temporal.
+
+Locks the consolidation against regressions during the rest of PR-C1.
+Atlas-side temporal tests will rename + redirect into this file's
+neighborhood in PR-C1k; for now this carries the minimum coverage
+needed to validate the consolidation:
+
+  - 5 dataclasses are frozen (immutability decision per audit)
+  - MIN_DAYS_FOR_PERCENTILES is the parameterizable default
+  - TemporalEngine.__init__ accepts min_days_for_percentiles kwarg
+  - _numeric_value defensively coerces messy inputs
+  - _row_get handles dicts and attribute-access shapes
+  - module loads cleanly without atlas_brain on path
+    (the lazy `_b2b_shared` import paths degrade gracefully)
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from extracted_reasoning_core.temporal import (
+    MIN_DAYS_FOR_ACCELERATION,
+    MIN_DAYS_FOR_PERCENTILES,
+    MIN_DAYS_FOR_TREND,
+    MIN_DAYS_FOR_VELOCITY,
+    RECENCY_HALF_LIFE_DAYS,
+    AnomalyScore,
+    CategoryPercentile,
+    LongTermTrend,
+    TemporalEngine,
+    TemporalEvidence,
+    VendorVelocity,
+    _numeric_value,
+    _row_get,
+)
+
+
+# ------------------------------------------------------------------
+# Constants
+# ------------------------------------------------------------------
+
+
+def test_module_constants_have_expected_defaults() -> None:
+    # MIN_DAYS_FOR_PERCENTILES canonicalized to 3 (atlas's hardcoded
+    # gate value, which is what both forks actually used at runtime).
+    assert MIN_DAYS_FOR_PERCENTILES == 3
+    assert MIN_DAYS_FOR_VELOCITY == 2
+    assert MIN_DAYS_FOR_ACCELERATION == 3
+    assert MIN_DAYS_FOR_TREND == 14
+    assert RECENCY_HALF_LIFE_DAYS == 14
+
+
+# ------------------------------------------------------------------
+# Defensive helpers
+# ------------------------------------------------------------------
+
+
+def test_numeric_value_handles_clean_numerics() -> None:
+    assert _numeric_value(1) == 1.0
+    assert _numeric_value(1.5) == 1.5
+    assert _numeric_value(0) == 0.0
+    assert _numeric_value(-3.14) == -3.14
+
+
+def test_numeric_value_strips_separators_and_percent() -> None:
+    assert _numeric_value("1,234") == 1234.0
+    assert _numeric_value("42%") == 42.0
+    assert _numeric_value("  3.14  ") == 3.14
+    assert _numeric_value("1,234.5%") == 1234.5
+
+
+def test_numeric_value_returns_none_on_garbage() -> None:
+    assert _numeric_value(None) is None
+    assert _numeric_value("") is None
+    assert _numeric_value("not-a-number") is None
+    # bool subclass of int -- explicitly excluded
+    assert _numeric_value(True) is None
+    assert _numeric_value(False) is None
+
+
+def test_row_get_handles_dict_and_object_shapes() -> None:
+    assert _row_get({"a": 1}, "a") == 1
+    assert _row_get({"a": 1}, "missing") is None
+
+    class _Row:
+        a = 5
+
+    assert _row_get(_Row(), "a") == 5
+    assert _row_get(_Row(), "missing") is None
+
+
+def test_row_get_handles_subscript_objects() -> None:
+    class _SubscriptOnly:
+        def __getitem__(self, key: str) -> int:
+            return {"x": 7}[key]
+
+    assert _row_get(_SubscriptOnly(), "x") == 7
+
+
+# ------------------------------------------------------------------
+# TemporalEngine constructor
+# ------------------------------------------------------------------
+
+
+def test_temporal_engine_default_min_days_for_percentiles() -> None:
+    engine = TemporalEngine(pool=None)
+    assert engine._min_days_for_percentiles == MIN_DAYS_FOR_PERCENTILES == 3
+
+
+def test_temporal_engine_accepts_min_days_for_percentiles_override() -> None:
+    engine = TemporalEngine(pool=None, min_days_for_percentiles=5)
+    assert engine._min_days_for_percentiles == 5
+
+    # Atlas's prior nominal "stricter" setting
+    engine_strict = TemporalEngine(pool=None, min_days_for_percentiles=7)
+    assert engine_strict._min_days_for_percentiles == 7
+
+
+def test_temporal_engine_coerces_min_days_to_int() -> None:
+    engine = TemporalEngine(pool=None, min_days_for_percentiles="4")  # type: ignore[arg-type]
+    assert engine._min_days_for_percentiles == 4
+
+
+# ------------------------------------------------------------------
+# Frozen dataclasses
+# ------------------------------------------------------------------
+
+
+def _expect_frozen_rejects_reassignment(instance: object, field_name: str) -> None:
+    """Assert that reassigning `field_name` on `instance` raises."""
+    try:
+        setattr(instance, field_name, "value-that-should-not-stick")
+    except Exception as exc:
+        assert exc.__class__.__name__ in {
+            "FrozenInstanceError",
+            "AttributeError",
+        }
+    else:
+        raise AssertionError(
+            f"frozen dataclass should reject reassignment to {field_name}"
+        )
+
+
+def test_vendor_velocity_is_frozen() -> None:
+    v = VendorVelocity(
+        vendor_name="acme",
+        metric="avg_urgency",
+        current_value=7.0,
+        previous_value=5.0,
+        velocity=0.2,
+        days_between=10,
+    )
+    _expect_frozen_rejects_reassignment(v, "velocity")
+
+
+def test_long_term_trend_is_frozen() -> None:
+    t = LongTermTrend(metric="avg_urgency", slope_30d=0.1, data_points=14)
+    _expect_frozen_rejects_reassignment(t, "slope_30d")
+
+
+def test_category_percentile_is_frozen() -> None:
+    p = CategoryPercentile(
+        product_category="crm",
+        metric="avg_urgency",
+        p25=4.0,
+        p50=5.0,
+        p75=6.0,
+        sample_count=10,
+    )
+    _expect_frozen_rejects_reassignment(p, "p50")
+
+
+def test_anomaly_score_is_frozen() -> None:
+    a = AnomalyScore(
+        vendor_name="acme",
+        metric="avg_urgency",
+        value=8.0,
+        z_score=2.5,
+        p_value=0.01,
+        is_anomaly=True,
+    )
+    _expect_frozen_rejects_reassignment(a, "z_score")
+
+
+def test_temporal_evidence_is_frozen() -> None:
+    te = TemporalEvidence(vendor_name="acme", snapshot_days=30)
+    _expect_frozen_rejects_reassignment(te, "snapshot_days")
+
+
+# ------------------------------------------------------------------
+# Engine: pure-python paths (no DB)
+# ------------------------------------------------------------------
+
+
+def _make_snapshot(d: date, **metrics: float | int | None) -> dict:
+    base = {"snapshot_date": d, "vendor_name": "acme", "product_category": "crm"}
+    base.update(metrics)
+    return base
+
+
+def test_compute_velocities_returns_empty_with_one_snapshot() -> None:
+    engine = TemporalEngine(pool=None)
+    one = [_make_snapshot(date(2026, 5, 1), avg_urgency=5.0)]
+    assert engine._compute_velocities("acme", one) == []
+
+
+def test_compute_velocities_basic_two_snapshots() -> None:
+    engine = TemporalEngine(pool=None)
+    snaps = [
+        _make_snapshot(date(2026, 5, 1), avg_urgency=5.0),
+        _make_snapshot(date(2026, 5, 5), avg_urgency=7.0),
+    ]
+    velocities = engine._compute_velocities("acme", snaps)
+    # Should produce one velocity for avg_urgency
+    by_metric = {v.metric: v for v in velocities}
+    assert "avg_urgency" in by_metric
+    v = by_metric["avg_urgency"]
+    assert v.current_value == 7.0
+    assert v.previous_value == 5.0
+    assert v.days_between == 4
+    assert v.velocity == pytest.approx((7.0 - 5.0) / 4)
+
+
+def test_recency_weight_decays_exponentially() -> None:
+    # 0 days old -> weight 1.0
+    assert TemporalEngine.recency_weight(0) == 1.0
+    # half life = 14 days -> exactly 0.5 at 14
+    assert TemporalEngine.recency_weight(14) == pytest.approx(0.5, abs=1e-9)
+    # custom half life
+    assert TemporalEngine.recency_weight(7, half_life=7) == pytest.approx(0.5, abs=1e-9)
+
+
+def test_to_evidence_dict_marks_insufficient_data() -> None:
+    te = TemporalEvidence(vendor_name="acme", snapshot_days=1, insufficient_data=True)
+    out = TemporalEngine.to_evidence_dict(te)
+    assert out["temporal_status"] == "insufficient_data"
+    assert out["snapshot_days"] == 1


### PR DESCRIPTION
## Summary

Second atomic slice of PR-C1 per PR #82's merged audit. Moves `atlas_brain/reasoning/temporal.py` into `extracted_reasoning_core/` with the documented decisions applied; ships 18 smoke tests for the new module.

PR-C1a (#94) merged the archetypes consolidation. This PR adds temporal as the next foundation layer; subsequent PR-C1 slices (types promotion, evidence_engine slim, atlas-side review_enrichment, api wiring, content_pipeline wrapper conversions, test renames, audit amendment) will land as separate atomic PRs.

## Files

- **`extracted_reasoning_core/temporal.py`** (~510 LOC, NEW)

  Atlas's `temporal.py` moved canonical, with audit-decision tweaks:

    - `frozen=True` on all 5 dataclasses (`VendorVelocity`, `LongTermTrend`, `CategoryPercentile`, `AnomalyScore`, `TemporalEvidence`). Carries content_pipeline's immutability decision forward.
    - **Defensive helpers `_numeric_value` and `_row_get` carried from content_pipeline's fork.** Surfaced at module scope so any caller has one canonical coercion entry point.
    - **`MIN_DAYS_FOR_PERCENTILES` canonicalized to 3 and parameterized via `TemporalEngine` constructor** (default = 3, products may override). Atlas's prior module constant declared 7 but the runtime gate was hardcoded `< 3` at every check site -- the canonical value matches actual behavior. Replaced both hardcoded check sites in `_compute_percentiles`.
    - **Atlas-coupled lookups wrapped in `try/except ImportError`** so the module loads cleanly without `atlas_brain` on the import path. Degrades to empty percentiles + None category when atlas_brain is absent. A future PR will replace these with port-based abstractions.
    - Internal callsites in the percentile loop now use `_numeric_value` + `_row_get` for defensive value coercion.
    - Removed unused `import logging` + module-level logger assignment (same lint cleanup that landed for archetypes in PR #94).
    - `__all__` declared.

- **`tests/test_extracted_reasoning_core_temporal.py`** (~225 LOC, NEW)

  18 smoke tests covering module constants, defensive helpers, `TemporalEngine` constructor parameter, all 5 frozen dataclasses, and pure-python engine paths (velocities, recency_weight, to_evidence_dict).

## Atlas's dead-constant finding (worth flagging)

The audit at PR #82 said "atlas=7, content_pipeline=3 are both valid for their use cases." Reality on inspection: atlas declared `MIN_DAYS_FOR_PERCENTILES = 7` at line 26 but **never read it anywhere in the file** -- the actual percentile gate was hardcoded `< 3` at lines 323 and 336. Both atlas and content_pipeline were functionally using 3; atlas just had a dead constant declaring 7. This PR canonicalizes the constant to 3 (real behavior) and parameterizes via the constructor.

## Validation

- 18/18 smoke tests pass for the new module
- 38/38 tests pass across `extracted_reasoning_core/` (archetypes + temporal + api + wedge_registry)
- Module imports cleanly without `atlas_brain` on path (verified)
- ASCII clean (0 non-ASCII bytes in both new files)
- Worktree-isolated edit (`../Atlas-prc1b`) per the established practice for coordination-doc edits

## Not in this PR (atomic-PR boundaries)

- `extracted_content_pipeline/reasoning/temporal.py` -> re-export wrapper (PR-C1j, after this + types + api wiring lands)
- `extracted_reasoning_core/types.py` rich `TemporalEvidence` promotion (PR-C1c)
- `atlas_brain/reasoning/temporal.py` is NOT touched; PR 7 / Product Migration owns the atlas-side migration.

## Coordination

- Owner: `claude-2026-05-03` (declared in `coordination/inflight.md` via `d9240684`)
- Hot zone for this PR: `extracted_reasoning_core/temporal.py`; `tests/test_extracted_reasoning_core_temporal.py`

## Refs

- Audit: `docs/extraction/evidence_temporal_archetypes_audit_2026-05-03.md` (merged via PR #82)
- Reasoning boundary contract: `docs/extraction/reasoning_boundary_audit_2026-05-03.md` (merged via PR #79)
- Prior atomic slice: PR #94 (PR-C1a, archetypes + evidence_map)