### PR TITLE
Make content skill registry configurable

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T23:32Z by codex-2026-05-03
+Last updated: 2026-05-03T23:33Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -11,6 +11,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | #96 | Add runtime budget gate (NEW CODE, PR-A4b) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/budget.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_budget.py` | claude-2026-05-03-b | `services/cost/budget.py` or its test |
 | #98 | Add OpenAI billing fetcher (NEW CODE, PR-A4c) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/openai_billing.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_openai_billing.py` | claude-2026-05-03-b | `services/cost/openai_billing.py` or its test |
 | #100 | PR-C1b: Move temporal.py to reasoning core | NEW: `extracted_reasoning_core/temporal.py` (atlas canonical + content_pipeline's `_numeric_value` / `_row_get` defensive helpers + parameterized `MIN_DAYS_FOR_PERCENTILES` constructor arg). NEW: `tests/test_extracted_reasoning_core_temporal.py` (18 smoke tests). | claude-2026-05-03 | `extracted_reasoning_core/temporal.py`; `tests/test_extracted_reasoning_core_temporal.py` |
-| (PR-D4, branch `codex/content-pipeline-configurable-skill-registry`) | Make AI Content Ops skill registry host-configurable | `extracted_content_pipeline/skills/registry.py`; campaign runner scripts; content-pipeline docs/status; focused skill/runner tests | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
+| #101 | Make AI Content Ops skill registry host-configurable | `extracted_content_pipeline/skills/registry.py`; campaign runner scripts; content-pipeline docs/status; focused skill/runner tests | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T23:31Z by claude-2026-05-03
+Last updated: 2026-05-03T23:32Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -11,5 +11,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | #96 | Add runtime budget gate (NEW CODE, PR-A4b) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/budget.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_budget.py` | claude-2026-05-03-b | `services/cost/budget.py` or its test |
 | #98 | Add OpenAI billing fetcher (NEW CODE, PR-A4c) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/openai_billing.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_openai_billing.py` | claude-2026-05-03-b | `services/cost/openai_billing.py` or its test |
 | #100 | PR-C1b: Move temporal.py to reasoning core | NEW: `extracted_reasoning_core/temporal.py` (atlas canonical + content_pipeline's `_numeric_value` / `_row_get` defensive helpers + parameterized `MIN_DAYS_FOR_PERCENTILES` constructor arg). NEW: `tests/test_extracted_reasoning_core_temporal.py` (18 smoke tests). | claude-2026-05-03 | `extracted_reasoning_core/temporal.py`; `tests/test_extracted_reasoning_core_temporal.py` |
+| (PR-D4, branch `codex/content-pipeline-configurable-skill-registry`) | Make AI Content Ops skill registry host-configurable | `extracted_content_pipeline/skills/registry.py`; campaign runner scripts; content-pipeline docs/status; focused skill/runner tests | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`, or LLM-infra files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-03T22:10Z by codex-2026-05-03
+Last updated: 2026-05-03T23:31Z by codex-2026-05-03
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -13,3 +13,4 @@ Sequence reflects dependencies. Claim a slice (set Owner) before starting code s
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |
+| PR-D4 | `extracted_content_pipeline` | codex-2026-05-03 | PR-D3 / #99 (merged); avoid PR-C1 files | Make the markdown skill registry host-configurable and wire campaign CLIs to accept customer prompt roots without importing Atlas skills. |

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -155,6 +155,16 @@ rows by target id, company, email, or vendor and feeds the normalized
 `CampaignReasoningContextProvider` port documented in
 `docs/reasoning_handoff_contract.md`.
 
+Use host-provided prompt contracts by pointing at a markdown skill directory:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  --skills-root customer_skills
+```
+
+Custom prompts with the same skill name override packaged prompts; missing
+prompts fall back to the bundled `skills/digest/*.md` files.
+
 The example uses in-memory product ports and an offline deterministic LLM stand
 in, so it does not need Atlas, a database, or provider credentials. It proves
 the customer-data path: JSON opportunities in, normalized campaign drafts out.
@@ -188,6 +198,9 @@ python scripts/run_extracted_campaign_generation_postgres.py \
   --account-id acct_123 \
   --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
 ```
+
+Use `--skills-root customer_skills` on the Postgres runner for the same
+host-prompt override behavior.
 
 ## Import smoke test
 
@@ -272,8 +285,9 @@ Several small utility shims provide product-owned local behavior by default so t
   `PipelineLLMClient`, and the local skill registry for DB-backed draft
   generation
 - `storage/repositories/scheduled_task.py`: local execution metadata updater
-- `skills/registry.py`: local markdown-backed skill registry implementing
-  `.get()` and product `SkillStore.get_prompt()`
+- `skills/registry.py`: configurable markdown-backed skill registry
+  implementing `.get()` and product `SkillStore.get_prompt()`, with optional
+  host roots that override packaged prompt contracts
 - `reasoning/archetypes.py`: product-owned deterministic churn-archetype scorer
   for extracted report builders
 - `reasoning/temporal.py`: product-owned temporal analytics over vendor

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -69,6 +69,9 @@
   `autonomous.tasks.campaign_suppression`, `templates.email.vendor_briefing`,
   `services.b2b.account_opportunity_claims`, `services.campaign_quality`,
   `services.campaign_reasoning_context`, and `autonomous.visibility`.
+- `skills.registry` is product-owned and markdown-backed. Hosts can pass a
+  custom skill root to override packaged prompt contracts while retaining
+  bundled fallback prompts.
 - `CampaignReasoningContextProvider` is the campaign-core boundary for
   upstream reasoning. Hosts pass already-compressed witness/anchor/account
   context into the generator; `_b2b_pool_compression.py` stays outside the

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -143,6 +143,10 @@ for campaign generation. It wires in-memory ports, a static prompt store, and an
 offline deterministic LLM so customer opportunity JSON can be converted into
 drafts without Atlas, a database, or provider credentials.
 
+`extracted_content_pipeline/skills/registry.py` is the product-owned prompt
+registry. It reads packaged markdown skills by default and accepts host-provided
+skill roots that override bundled prompt contracts without importing Atlas.
+
 `extracted_content_pipeline/campaign_customer_data.py` is the customer-export
 adapter slice. It loads JSON or CSV opportunity rows, normalizes them through
 the product opportunity contract, returns non-fatal data-quality warnings, and
@@ -224,7 +228,5 @@ The command must pass before this package is considered customer-usable.
 - `api/b2b_campaigns.py`, `api/seller_campaigns.py`, and
   `api/campaign_webhooks.py` need an app-factory boundary and host-provided
   auth/tenant dependencies.
-- Prompt skills are portable, but the skill registry is currently an Atlas
-  shim.
 - SQL migrations are portable only after the product owns its base schema and
   migration runner.

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -187,6 +187,12 @@
       "target": "extracted_content_pipeline/campaign_opportunities.py"
     },
     {
+      "target": "extracted_content_pipeline/skills/__init__.py"
+    },
+    {
+      "target": "extracted_content_pipeline/skills/registry.py"
+    },
+    {
       "target": "extracted_content_pipeline/settings.py"
     },
     {

--- a/extracted_content_pipeline/skills/__init__.py
+++ b/extracted_content_pipeline/skills/__init__.py
@@ -1,3 +1,3 @@
-from .registry import get_skill_registry
+from .registry import LocalSkill, LocalSkillRegistry, get_skill_registry
 
-__all__ = ["get_skill_registry"]
+__all__ = ["LocalSkill", "LocalSkillRegistry", "get_skill_registry"]

--- a/extracted_content_pipeline/skills/registry.py
+++ b/extracted_content_pipeline/skills/registry.py
@@ -1,31 +1,94 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+
+_PACKAGE_SKILL_ROOT = Path(__file__).resolve().parent
 
 
 @dataclass
 class LocalSkill:
     name: str
     content: str
+    path: Path | None = None
 
 
 class LocalSkillRegistry:
-    def __init__(self, root: Path) -> None:
-        self.root = root
+    """Markdown-backed skill registry for packaged and host-provided prompts."""
+
+    def __init__(self, roots: Path | str | Sequence[Path | str]) -> None:
+        self.roots = _normalize_roots(roots)
 
     def get(self, name: str):
-        rel = Path(*name.split("/"))
-        path = self.root / f"{rel}.md"
-        if not path.exists():
+        rel = _skill_relative_path(name)
+        if rel is None:
             return None
-        return LocalSkill(name=name, content=path.read_text(encoding="utf-8"))
+        for root in self.roots:
+            path = root / rel
+            if path.exists() and path.is_file():
+                return LocalSkill(
+                    name=_skill_name_from_path(rel),
+                    content=path.read_text(encoding="utf-8"),
+                    path=path,
+                )
+        return None
 
     def get_prompt(self, name: str) -> str | None:
         skill = self.get(name)
         return skill.content if skill else None
 
 
-def get_skill_registry():
-    root = Path(__file__).resolve().parent
-    return LocalSkillRegistry(root)
+def get_skill_registry(
+    root: Path | str | None = None,
+    *,
+    roots: Sequence[Path | str] = (),
+    include_package: bool = True,
+):
+    """Return a markdown skill registry.
+
+    Host roots are searched before the packaged skills, so customer prompt
+    contracts can override bundled prompts without replacing product code.
+    """
+
+    search_roots: list[Path | str] = []
+    if root is not None:
+        search_roots.append(root)
+    search_roots.extend(roots)
+    if include_package:
+        search_roots.append(_PACKAGE_SKILL_ROOT)
+    return LocalSkillRegistry(search_roots)
+
+
+def _normalize_roots(roots: Path | str | Sequence[Path | str]) -> tuple[Path, ...]:
+    if isinstance(roots, (str, Path)):
+        values: Sequence[Path | str] = (roots,)
+    else:
+        values = roots
+    normalized: list[Path] = []
+    for value in values:
+        path = Path(value).expanduser()
+        if path not in normalized:
+            normalized.append(path)
+    return tuple(normalized)
+
+
+def _skill_relative_path(name: Any) -> Path | None:
+    raw = str(name or "").replace("\\", "/").strip().strip("/")
+    if not raw:
+        return None
+    if raw.endswith(".md"):
+        raw = raw[:-3]
+    parts = [part for part in raw.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        return None
+    path = Path(*parts)
+    if path.is_absolute():
+        return None
+    return path.with_suffix(".md")
+
+
+def _skill_name_from_path(path: Path) -> str:
+    return path.with_suffix("").as_posix()

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -43,7 +43,7 @@ def _load_payload(path: Path, *, file_format: str = "auto") -> dict[str, Any]:
     return data
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Generate offline campaign drafts from customer opportunity JSON "
@@ -93,6 +93,14 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--skills-root",
+        type=Path,
+        help=(
+            "Optional directory of host-provided markdown skill prompts. "
+            "Custom prompts override packaged prompts with the same name."
+        ),
+    )
+    parser.add_argument(
         "--llm",
         choices=("offline", "pipeline"),
         default="offline",
@@ -101,7 +109,7 @@ def _parse_args() -> argparse.Namespace:
             "configured through EXTRACTED_CAMPAIGN_LLM_* environment variables."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
@@ -110,6 +118,10 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
         overrides["reasoning_context"] = load_campaign_reasoning_context_provider(
             args.reasoning_context
         )
+    if args.skills_root:
+        from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: PLC0415
+
+        overrides["skills"] = get_skill_registry(root=args.skills_root)
     if args.llm == "offline":
         return overrides
 
@@ -118,10 +130,8 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
     )
     from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: PLC0415
 
-    overrides.update({
-        "llm": create_pipeline_llm_client(),
-        "skills": get_skill_registry(),
-    })
+    overrides["llm"] = create_pipeline_llm_client()
+    overrides.setdefault("skills", get_skill_registry())
     return overrides
 
 

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -26,6 +26,7 @@ from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_campaign_reasoning_context_provider,
 )
+from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
 
 
 def _json_object(value: str | None) -> dict[str, Any]:
@@ -37,7 +38,7 @@ def _json_object(value: str | None) -> dict[str, Any]:
     return parsed
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Generate campaign drafts from campaign_opportunities and persist "
@@ -74,6 +75,14 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--skills-root",
+        type=Path,
+        help=(
+            "Optional directory of host-provided markdown skill prompts. "
+            "Custom prompts override packaged prompts with the same name."
+        ),
+    )
+    parser.add_argument(
         "--llm",
         choices=("pipeline", "offline"),
         default="pipeline",
@@ -84,7 +93,7 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         help="Write result JSON to this path instead of stdout.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 async def _create_pool(database_url: str):
@@ -103,12 +112,14 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
         overrides["reasoning_context"] = load_campaign_reasoning_context_provider(
             args.reasoning_context
         )
+    if args.skills_root:
+        overrides["skills"] = get_skill_registry(root=args.skills_root)
     if args.llm == "pipeline":
         return overrides
     overrides.update({
         "llm": DeterministicCampaignLLM(),
-        "skills": StaticCampaignSkillStore(),
     })
+    overrides.setdefault("skills", StaticCampaignSkillStore())
     return overrides
 
 

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -15,6 +15,7 @@ pytest \
   tests/test_extracted_campaign_generation_seams.py \
   tests/test_extracted_campaign_generation.py \
   tests/test_extracted_campaign_reasoning_data.py \
+  tests/test_extracted_campaign_skill_registry.py \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_postgres_generation.py \

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -21,6 +22,18 @@ EXAMPLE_PAYLOAD = (
     ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.json"
 )
 CLI = ROOT / "scripts/run_extracted_campaign_generation_example.py"
+
+
+def _load_example_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_extracted_campaign_generation_example",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class _InjectedLLM:
@@ -253,3 +266,21 @@ def test_campaign_generation_example_cli_accepts_reasoning_context_file(tmp_path
     source = result["drafts"][0]["metadata"]["source_opportunity"]
     assert source["reasoning_context"]["wedge"] == "renewal pressure"
     assert source["reasoning_context"]["confidence"] == "high"
+
+
+def test_campaign_generation_example_cli_accepts_skills_root(tmp_path) -> None:
+    example_cli = _load_example_cli_module()
+    skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("Custom host prompt {opportunity_json}", encoding="utf-8")
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--skills-root",
+        str(tmp_path),
+    ])
+
+    overrides = example_cli._dependency_overrides(args)
+
+    assert overrides["skills"].get_prompt("digest/b2b_campaign_generation") == (
+        "Custom host prompt {opportunity_json}"
+    )

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -30,6 +30,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/autonomous/tasks/campaign_suppression.py",
     "extracted_content_pipeline/autonomous/visibility.py",
     "extracted_content_pipeline/campaign_sequence_context.py",
+    "extracted_content_pipeline/skills/__init__.py",
     "extracted_content_pipeline/skills/registry.py",
     "extracted_content_pipeline/services/__init__.py",
     "extracted_content_pipeline/services/apollo_company_overrides.py",

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -191,6 +191,25 @@ def test_tenant_scope_from_mapping_accepts_mapping_and_existing_scope():
     assert tenant_scope_from_mapping(None) == TenantScope()
 
 
+def test_postgres_runner_cli_accepts_skills_root(tmp_path) -> None:
+    postgres_cli = _load_postgres_cli_module()
+    skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("Custom DB prompt {opportunity_json}", encoding="utf-8")
+
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--skills-root",
+        str(tmp_path),
+    ])
+    overrides = postgres_cli._dependency_overrides(args)
+
+    assert overrides["skills"].get_prompt("digest/b2b_campaign_generation") == (
+        "Custom DB prompt {opportunity_json}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
     monkeypatch,

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.skills.registry import (
+    LocalSkillRegistry,
+    get_skill_registry,
+)
+
+
+def test_local_skill_registry_reads_packaged_campaign_prompt() -> None:
+    registry = get_skill_registry()
+
+    skill = registry.get("digest/b2b_campaign_generation")
+
+    assert skill is not None
+    assert skill.name == "digest/b2b_campaign_generation"
+    assert skill.path is not None
+    assert skill.path.name == "b2b_campaign_generation.md"
+    assert registry.get_prompt("digest/b2b_campaign_generation") == skill.content
+
+
+def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:
+    skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("Custom prompt: {opportunity_json}", encoding="utf-8")
+
+    registry = get_skill_registry(root=tmp_path)
+
+    skill = registry.get("digest/b2b_campaign_generation")
+    assert skill is not None
+    assert skill.content == "Custom prompt: {opportunity_json}"
+    assert skill.path == skill_path
+
+
+def test_local_skill_registry_can_disable_packaged_fallback(tmp_path) -> None:
+    registry = get_skill_registry(root=tmp_path, include_package=False)
+
+    assert registry.get_prompt("digest/b2b_campaign_generation") is None
+
+
+def test_local_skill_registry_falls_back_to_packaged_prompt(tmp_path) -> None:
+    registry = get_skill_registry(root=tmp_path)
+
+    assert registry.get_prompt("digest/b2b_campaign_generation")
+
+
+def test_local_skill_registry_rejects_traversal_names(tmp_path) -> None:
+    registry = LocalSkillRegistry(tmp_path)
+
+    assert registry.get("../secrets") is None
+    assert registry.get("digest/../../secrets") is None
+
+
+def test_local_skill_registry_accepts_md_suffix(tmp_path) -> None:
+    skill_path = tmp_path / "digest" / "custom.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("Custom", encoding="utf-8")
+    registry = LocalSkillRegistry(tmp_path)
+
+    skill = registry.get("digest/custom.md")
+
+    assert skill is not None
+    assert skill.name == "digest/custom"
+    assert skill.content == "Custom"


### PR DESCRIPTION
Summary:
- Makes extracted_content_pipeline.skills.registry product-owned and host-configurable.
- Supports host markdown skill roots that override packaged prompts while falling back to bundled skills.
- Wires --skills-root into offline and Postgres campaign generation CLIs.
- Updates manifest, docs, and content-pipeline validation coverage.

Coordination:
- PR-D4, AI Content Ops only.
- Avoids extracted_reasoning_core, content_pipeline reasoning internals, and LLM-infra files.

Validation:
- python -m py_compile on edited Python files
- git diff --check
- pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_llm_bridge.py
- bash scripts/run_extracted_pipeline_checks.sh (257 passed, import check 50 modules, standalone audit 0 Atlas runtime imports)