### PR TITLE
PR-C1c: Promote temporal types + add evidence-result types (in progress)

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T23:31Z by claude-2026-05-03
+Last updated: 2026-05-03T23:32Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | #95 | Add drift report (NEW CODE, PR-A4a) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/drift.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_drift.py` | claude-2026-05-03-b | `services/cost/drift.py` or its test |
 | #96 | Add runtime budget gate (NEW CODE, PR-A4b) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/budget.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_budget.py` | claude-2026-05-03-b | `services/cost/budget.py` or its test |
 | #98 | Add OpenAI billing fetcher (NEW CODE, PR-A4c) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/openai_billing.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_openai_billing.py` | claude-2026-05-03-b | `services/cost/openai_billing.py` or its test |
-| #100 | PR-C1b: Move temporal.py to reasoning core | NEW: `extracted_reasoning_core/temporal.py` (atlas canonical + content_pipeline's `_numeric_value` / `_row_get` defensive helpers + parameterized `MIN_DAYS_FOR_PERCENTILES` constructor arg). NEW: `tests/test_extracted_reasoning_core_temporal.py` (18 smoke tests). | claude-2026-05-03 | `extracted_reasoning_core/temporal.py`; `tests/test_extracted_reasoning_core_temporal.py` |
+| (PR-C1c, in flight) | Promote temporal types + add evidence-result types in reasoning core | EDIT: `extracted_reasoning_core/types.py` (replace coarse `TemporalEvidence` Mapping with rich shape; add `VendorVelocity`, `LongTermTrend`, `CategoryPercentile`, `AnomalyScore`, `ConclusionResult`, `SuppressionResult` as public types). EDIT: `extracted_reasoning_core/temporal.py` (import the 5 promoted dataclasses from `.types` instead of defining locally). NEW: tests for the new public-type instantiations. | claude-2026-05-03 | `extracted_reasoning_core/{types.py, temporal.py}`; tests for those types |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_reasoning_core/temporal.py
+++ b/extracted_reasoning_core/temporal.py
@@ -38,76 +38,22 @@ temporal engine and the content_pipeline fork. Documented decisions
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any
+
+from .types import (
+    AnomalyScore,
+    CategoryPercentile,
+    LongTermTrend,
+    TemporalEvidence,
+    VendorVelocity,
+)
 
 MIN_DAYS_FOR_VELOCITY = 2
 MIN_DAYS_FOR_ACCELERATION = 3
 MIN_DAYS_FOR_PERCENTILES = 3  # Was atlas's constant=7 / hardcoded gate=3; canonicalized to 3 (atlas's actual behavior)
 MIN_DAYS_FOR_TREND = 14  # Relaxed from 30 to allow shorter history
 RECENCY_HALF_LIFE_DAYS = 14
-
-
-@dataclass(frozen=True)
-class VendorVelocity:
-    """Rate-of-change metrics for a vendor."""
-
-    vendor_name: str
-    metric: str
-    current_value: float
-    previous_value: float
-    velocity: float          # change per day
-    days_between: int
-    acceleration: float | None = None  # change in velocity (needs 3+ points)
-
-
-@dataclass(frozen=True)
-class LongTermTrend:
-    """Long-term trend analysis (30-90 days)."""
-
-    metric: str
-    slope_30d: float | None = None
-    slope_90d: float | None = None
-    volatility: float | None = None  # standard deviation of changes
-    data_points: int = 0
-
-
-@dataclass(frozen=True)
-class CategoryPercentile:
-    """Rolling percentile baselines for a metric within a category."""
-
-    product_category: str
-    metric: str
-    p25: float
-    p50: float
-    p75: float
-    sample_count: int
-
-
-@dataclass(frozen=True)
-class AnomalyScore:
-    """Z-score anomaly detection for a vendor metric."""
-
-    vendor_name: str
-    metric: str
-    value: float
-    z_score: float
-    p_value: float | None = None
-    is_anomaly: bool = False    # |z| > 2.0
-
-
-@dataclass(frozen=True)
-class TemporalEvidence:
-    """Complete temporal analysis for a vendor, used as evidence in reasoning."""
-
-    vendor_name: str
-    snapshot_days: int
-    velocities: list[VendorVelocity] = field(default_factory=list)
-    trends: list[LongTermTrend] = field(default_factory=list)
-    anomalies: list[AnomalyScore] = field(default_factory=list)
-    category_baselines: list[CategoryPercentile] = field(default_factory=list)
-    insufficient_data: bool = False
 
 
 # Metrics to track velocity on

--- a/extracted_reasoning_core/types.py
+++ b/extracted_reasoning_core/types.py
@@ -76,13 +76,104 @@ class EvidenceDecision:
     trace: Mapping[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True, slots=True)
+class ConclusionResult:
+    """Outcome of a single per-vendor conclusion rule evaluation.
+
+    Mirrors the shape `EvidenceEngine.evaluate_conclusion` returns in
+    atlas. Public so products that need the richer per-rule outcome
+    (vs the simpler `EvidenceDecision`) can consume it from the
+    canonical location.
+    """
+
+    conclusion_id: str
+    met: bool
+    confidence: str
+    fallback_label: str | None = None
+    fallback_action: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SuppressionResult:
+    """Per-section render-suppression decision.
+
+    Mirrors the shape `EvidenceEngine.evaluate_suppression` returns in
+    atlas. Public so report renderers can consume the same outcome
+    types from the canonical location.
+    """
+
+    suppress: bool = False
+    degrade: bool = False
+    disclaimer: str | None = None
+    fallback_label: str | None = None
+
+
+@dataclass(frozen=True)
+class VendorVelocity:
+    """Rate-of-change metrics for a vendor metric over a snapshot window."""
+
+    vendor_name: str
+    metric: str
+    current_value: float
+    previous_value: float
+    velocity: float          # change per day
+    days_between: int
+    acceleration: float | None = None  # change in velocity (needs 3+ points)
+
+
+@dataclass(frozen=True)
+class LongTermTrend:
+    """Long-term linear trend (30-day / 90-day slopes)."""
+
+    metric: str
+    slope_30d: float | None = None
+    slope_90d: float | None = None
+    volatility: float | None = None  # standard deviation of changes
+    data_points: int = 0
+
+
+@dataclass(frozen=True)
+class CategoryPercentile:
+    """Rolling percentile baselines for a metric within a product category."""
+
+    product_category: str
+    metric: str
+    p25: float
+    p50: float
+    p75: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class AnomalyScore:
+    """Z-score anomaly detection for a single vendor metric."""
+
+    vendor_name: str
+    metric: str
+    value: float
+    z_score: float
+    p_value: float | None = None
+    is_anomaly: bool = False    # |z| > 2.0
+
+
 @dataclass(frozen=True)
 class TemporalEvidence:
-    velocity: Mapping[str, Any] = field(default_factory=dict)
-    trend: Mapping[str, Any] = field(default_factory=dict)
-    anomaly: Mapping[str, Any] = field(default_factory=dict)
-    recency: Mapping[str, Any] = field(default_factory=dict)
-    baselines: Mapping[str, Any] = field(default_factory=dict)
+    """Complete temporal analysis for a vendor.
+
+    Promoted from PR #79's coarse `Mapping[str, Any]` placeholder to
+    the rich shape per the PR #82 audit's contract amendment. The 4
+    sub-types (`VendorVelocity`, `LongTermTrend`, `CategoryPercentile`,
+    `AnomalyScore`) are public so products can render velocity / trend
+    charts without losing type safety at the boundary.
+    """
+
+    vendor_name: str
+    snapshot_days: int
+    velocities: list[VendorVelocity] = field(default_factory=list)
+    trends: list[LongTermTrend] = field(default_factory=list)
+    anomalies: list[AnomalyScore] = field(default_factory=list)
+    category_baselines: list[CategoryPercentile] = field(default_factory=list)
+    insufficient_data: bool = False
 
 
 @dataclass(frozen=True)
@@ -133,12 +224,16 @@ class ValidationReport:
 
 
 __all__ = [
+    "AnomalyScore",
     "ArchetypeMatch",
+    "CategoryPercentile",
+    "ConclusionResult",
     "EvidenceDecision",
     "EvidenceItem",
     "EvidencePolicy",
     "FalsificationPolicy",
     "FalsificationResult",
+    "LongTermTrend",
     "NarrativePlan",
     "OutputPolicy",
     "ReasoningDepth",
@@ -146,8 +241,10 @@ __all__ = [
     "ReasoningPack",
     "ReasoningPorts",
     "ReasoningResult",
+    "SuppressionResult",
     "TemporalEvidence",
     "ValidationReport",
+    "VendorVelocity",
     "Wedge",
     "WedgeMeta",
 ]

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -60,7 +60,16 @@ def test_reasoning_public_dataclasses_instantiate_with_defaults() -> None:
     assert result.state["wedge"] == "price_squeeze"
     assert ReasoningPorts() == ReasoningPorts()
     assert ReasoningPack(name="content_pipeline").version == "v1"
-    assert TemporalEvidence().velocity == {}
+    # PR-C1c amended PR #79's TemporalEvidence from a coarse
+    # `Mapping[str, Any]` placeholder to the rich shape with the four
+    # public sub-types. The contract now requires `vendor_name` and
+    # `snapshot_days`; collections default to empty lists.
+    te = TemporalEvidence(vendor_name="acme", snapshot_days=30)
+    assert te.velocities == []
+    assert te.trends == []
+    assert te.anomalies == []
+    assert te.category_baselines == []
+    assert te.insufficient_data is False
     assert NarrativePlan().sections == ()
     assert FalsificationResult().should_invalidate is False
     assert OutputPolicy().require_citations is True

--- a/tests/test_extracted_reasoning_core_types.py
+++ b/tests/test_extracted_reasoning_core_types.py
@@ -1,0 +1,172 @@
+"""Smoke tests for the public types promoted by PR-C1c.
+
+Locks the public-contract shape for:
+
+  - `ConclusionResult` and `SuppressionResult` (newly promoted public
+    supporting types added in PR-C1c; consumed by the slim
+    `EvidenceEngine` consolidation in PR-C1d).
+  - The four temporal sub-types now exposed alongside `TemporalEvidence`
+    (`VendorVelocity`, `LongTermTrend`, `CategoryPercentile`,
+    `AnomalyScore`).
+
+The existing 18 temporal tests in
+`test_extracted_reasoning_core_temporal.py` already exercise these
+shapes through `temporal.py`; this file just nails the public-import
+path and the new evidence-result shapes that don't go through temporal.
+"""
+
+from __future__ import annotations
+
+from extracted_reasoning_core.types import (
+    AnomalyScore,
+    CategoryPercentile,
+    ConclusionResult,
+    LongTermTrend,
+    SuppressionResult,
+    TemporalEvidence,
+    VendorVelocity,
+)
+
+
+# ------------------------------------------------------------------
+# ConclusionResult / SuppressionResult (newly promoted)
+# ------------------------------------------------------------------
+
+
+def test_conclusion_result_required_fields_and_defaults() -> None:
+    result = ConclusionResult(
+        conclusion_id="urgency_threshold_breached",
+        met=True,
+        confidence="high",
+    )
+    assert result.conclusion_id == "urgency_threshold_breached"
+    assert result.met is True
+    assert result.confidence == "high"
+    assert result.fallback_label is None
+    assert result.fallback_action is None
+
+
+def test_conclusion_result_optional_fallback_fields() -> None:
+    result = ConclusionResult(
+        conclusion_id="insufficient_data",
+        met=True,
+        confidence="insufficient",
+        fallback_label="Not enough recent reviews",
+        fallback_action="suppress_section",
+    )
+    assert result.fallback_label == "Not enough recent reviews"
+    assert result.fallback_action == "suppress_section"
+
+
+def test_conclusion_result_is_frozen() -> None:
+    result = ConclusionResult(
+        conclusion_id="x", met=False, confidence="low",
+    )
+    try:
+        result.met = True  # type: ignore[misc]
+    except Exception as exc:
+        assert exc.__class__.__name__ in {"FrozenInstanceError", "AttributeError"}
+    else:
+        raise AssertionError("frozen dataclass should reject reassignment")
+
+
+def test_suppression_result_defaults() -> None:
+    result = SuppressionResult()
+    assert result.suppress is False
+    assert result.degrade is False
+    assert result.disclaimer is None
+    assert result.fallback_label is None
+
+
+def test_suppression_result_explicit_values() -> None:
+    result = SuppressionResult(
+        suppress=True,
+        degrade=False,
+        disclaimer="Insufficient data for confidence above 80%",
+        fallback_label="Limited insight",
+    )
+    assert result.suppress is True
+    assert result.disclaimer == "Insufficient data for confidence above 80%"
+
+
+def test_suppression_result_is_frozen() -> None:
+    result = SuppressionResult()
+    try:
+        result.suppress = True  # type: ignore[misc]
+    except Exception as exc:
+        assert exc.__class__.__name__ in {"FrozenInstanceError", "AttributeError"}
+    else:
+        raise AssertionError("frozen dataclass should reject reassignment")
+
+
+# ------------------------------------------------------------------
+# Temporal sub-types: public-import path
+# ------------------------------------------------------------------
+
+
+def test_temporal_subtypes_importable_from_types_module() -> None:
+    # Pure existence check; the temporal_test file already exercises
+    # behavior. This locks the public-import path that PR-C1d / api.py
+    # wiring will consume.
+    v = VendorVelocity(
+        vendor_name="acme",
+        metric="avg_urgency",
+        current_value=7.0,
+        previous_value=5.0,
+        velocity=0.2,
+        days_between=10,
+    )
+    assert v.vendor_name == "acme"
+
+    t = LongTermTrend(metric="avg_urgency", slope_30d=0.05, data_points=14)
+    assert t.metric == "avg_urgency"
+
+    p = CategoryPercentile(
+        product_category="crm",
+        metric="avg_urgency",
+        p25=4.0, p50=5.0, p75=6.0,
+        sample_count=12,
+    )
+    assert p.p50 == 5.0
+
+    a = AnomalyScore(
+        vendor_name="acme",
+        metric="avg_urgency",
+        value=8.0,
+        z_score=2.5,
+        p_value=0.01,
+        is_anomaly=True,
+    )
+    assert a.is_anomaly is True
+
+
+def test_temporal_evidence_rich_shape() -> None:
+    # Rich shape requires vendor_name + snapshot_days; collections
+    # default to empty lists. Replaces PR #79's coarse Mapping[str, Any]
+    # placeholder per the PR #82 audit's contract amendment.
+    te = TemporalEvidence(vendor_name="acme", snapshot_days=30)
+    assert te.vendor_name == "acme"
+    assert te.snapshot_days == 30
+    assert te.velocities == []
+    assert te.trends == []
+    assert te.anomalies == []
+    assert te.category_baselines == []
+    assert te.insufficient_data is False
+
+
+def test_temporal_evidence_carries_subtype_lists() -> None:
+    v = VendorVelocity(
+        vendor_name="acme",
+        metric="avg_urgency",
+        current_value=7.0,
+        previous_value=5.0,
+        velocity=0.2,
+        days_between=10,
+    )
+    te = TemporalEvidence(
+        vendor_name="acme",
+        snapshot_days=30,
+        velocities=[v],
+    )
+    assert te.velocities == [v]
+    assert isinstance(te.velocities[0], VendorVelocity)


### PR DESCRIPTION
## Status: in progress (claim landed; code coming next push)

Third atomic slice of PR-C1 per PR #82's merged audit. Promotes the temporal types from \`extracted_reasoning_core/temporal.py\` (PR #100) into the public \`extracted_reasoning_core.types\` surface, and adds the two evidence-result types (\`ConclusionResult\`, \`SuppressionResult\`) that the slim \`evidence_engine.py\` core needs in PR-C1d.

PR-C1a (#94) merged archetypes + evidence_map. PR-C1b (#100) merged temporal.py with rich dataclasses defined locally. This PR moves those rich shapes to the canonical types module so all downstream slices see one definition.

## Planned changes

- **EDIT \`extracted_reasoning_core/types.py\`**:
  - Replace the coarse \`TemporalEvidence\` (currently \`Mapping[str, Any]\` defaults per PR #79's original audit) with the rich shape from \`temporal.py\` (frozen dataclass with \`vendor_name\`, \`snapshot_days\`, \`velocities\`, \`trends\`, \`anomalies\`, \`category_baselines\`, \`insufficient_data\`).
  - Add \`VendorVelocity\`, \`LongTermTrend\`, \`CategoryPercentile\`, \`AnomalyScore\` as public supporting types (frozen).
  - Add \`ConclusionResult\` and \`SuppressionResult\` as public supporting types (frozen, slots=True; matches atlas's shape) for the slim \`EvidenceEngine\` consolidation in PR-C1d.
  - Update \`__all__\` to declare the new public surface.

- **EDIT \`extracted_reasoning_core/temporal.py\`**:
  - Remove the 5 local dataclass definitions; import from \`.types\` instead. No behavior change in \`temporal.py\`; it becomes a consumer of the canonical types rather than a duplicate definer.

- **NEW tests** for the new public-type instantiations (\`ConclusionResult\`, \`SuppressionResult\` defaults + frozen guards). The existing 18 temporal smoke tests already exercise \`TemporalEvidence\` and the 4 sub-types via \`temporal.py\`; those keep passing because the import path is the only thing changing for them.

## Audit-doc amendment (deferred)

This PR is the second amendment to PR #79's contract per PR #82's audit:

  - first amendment (PR #80 follow-up): \`reasoning_input\` rename + \`tier: ReasoningDepth\`
  - second amendment (this PR): rich \`TemporalEvidence\` + 4 sub-types + \`ConclusionResult\` + \`SuppressionResult\`

The doc-side amendment to \`docs/extraction/reasoning_boundary_audit_2026-05-03.md\` is deferred to PR-C1l per the atomic-PR refactoring of PR-C1's original single-PR plan.

## Validation plan

- All 38 existing tests across \`extracted_reasoning_core/\` continue to pass after the type-import refactor in \`temporal.py\`
- New tests for \`ConclusionResult\` + \`SuppressionResult\` instantiation + frozen guards
- ASCII clean; \`__all__\` declares the new public surface

## Coordination

- Owner: \`claude-2026-05-03\` (declared in \`coordination/inflight.md\` via this branch's first commit)
- Hot zone: \`extracted_reasoning_core/{types.py, temporal.py}\`; tests for the new public types
- Read-only on \`extracted_reasoning_core/archetypes.py\` (consumes \`ArchetypeMatch\` from \`types.py\` already; unaffected by this slice)

## Refs

- Audit: \`docs/extraction/evidence_temporal_archetypes_audit_2026-05-03.md\` (merged via PR #82); the type-collision resolution section explicitly authorizes the rich-shape promotion
- Reasoning boundary contract: \`docs/extraction/reasoning_boundary_audit_2026-05-03.md\` (merged via PR #79)
- Prior atomic slices: PR #94 (PR-C1a, archetypes + evidence_map), PR #100 (PR-C1b, temporal)