### PR TITLE
Re-apply PR-A1 Copilot fixes (PR-A1.5)

### DIFF
--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -70,6 +70,8 @@ Import contract is closed; the remaining work is **runtime** behavior when funct
 | `storage/database.py` (bridge) | n/a | ✅ env-gated dispatch | n/a |
 | `services/b2b/anthropic_batch.py` | ✅ | ✅ (imports cleanly; consumes standalone substrate transitively) | 🔲 |
 | `services/b2b/cache_strategy.py` | ✅ | ✅ (pure data; no atlas imports) | n/a |
+| `services/b2b/llm_exact_cache.py` (PR-A1) | ✅ | ✅ (lazy `from ...config import settings` + `from ...storage.database import get_db_pool` route via env-gated bridges; new `from ...skills import get_skill_registry` routes via PR-A1.5 skills bridge with explicit standalone-mode error; `B2BChurnSubConfig.llm_exact_cache_enabled` flag added in PR-A1.5) | 🔲 (Phase 3: substrate skills layer or replace skill helpers with Protocol-based DI) |
+| `skills/__init__.py` (bridge, PR-A1.5) | n/a | ✅ env-gated dispatch; raises NotImplementedError in standalone mode | 🔲 |
 | `pipelines/llm.py` | ✅ | ✅ (lazy `from ..config import settings` routes to standalone) | 🔲 |
 | `reasoning/semantic_cache.py` | ✅ | ✅ (pool injected by caller; standalone DatabasePool compatible) | 🔲 |
 | `services/llm_router.py` | ✅ | ✅ (consumes standalone settings + registry) | 🔲 |
@@ -89,6 +91,7 @@ Import contract is closed; the remaining work is **runtime** behavior when funct
 | `services/cost/drift.py` (OWNED, PR-A4a) | n/a | ✅ (asyncpg-pool-shaped; pure SQL + dataclass output, no atlas imports) | n/a |
 | `storage/migrations/127_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/130_*.sql` | ✅ | n/a | n/a |
+| `storage/migrations/251_*.sql` (PR-A1) | ✅ | n/a | n/a |
 | `storage/migrations/252_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/253_*.sql` | ✅ | n/a | n/a |
 | `storage/migrations/255_*.sql` | ✅ | n/a | n/a |

--- a/extracted_llm_infrastructure/_standalone/config.py
+++ b/extracted_llm_infrastructure/_standalone/config.py
@@ -168,10 +168,17 @@ class LLMSubConfig(BaseSettings):
 
 
 class B2BChurnSubConfig(BaseSettings):
-    """Slim B2B churn config -- only the LLM-batch and OpenRouter fields
-    the scaffold reads at runtime. Atlas's full ``B2BChurnConfig`` has
-    ~80 unrelated fields (billing, scrape, calibration, etc.) that the
-    LLM-infra subsystem does not touch."""
+    """Slim B2B churn config -- only the LLM-infrastructure fields the
+    scaffold reads at runtime. Atlas's full ``B2BChurnConfig`` has ~80
+    unrelated fields (billing, scrape, calibration, etc.) that the
+    LLM-infra subsystem does not touch.
+
+    Currently includes:
+
+    - OpenRouter API key
+    - Anthropic Message Batches settings (enabled / poll / timeout / min items)
+    - LLM exact-cache feature flag (``llm_exact_cache_enabled``)
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="ATLAS_B2B_CHURN_",

--- a/extracted_llm_infrastructure/_standalone/config.py
+++ b/extracted_llm_infrastructure/_standalone/config.py
@@ -184,6 +184,7 @@ class B2BChurnSubConfig(BaseSettings):
     anthropic_batch_poll_interval_seconds: float = Field(default=5.0, ge=1.0, le=60.0)
     anthropic_batch_timeout_seconds: float = Field(default=900.0, ge=30.0, le=86400.0)
     anthropic_batch_min_items: int = Field(default=2, ge=1, le=10000)
+    llm_exact_cache_enabled: bool = Field(default=False)
 
 
 class ReasoningSubConfig(BaseSettings):

--- a/extracted_llm_infrastructure/skills/__init__.py
+++ b/extracted_llm_infrastructure/skills/__init__.py
@@ -1,0 +1,36 @@
+"""Phase 2 bridge: skills entry point for the LLM-infrastructure scaffold.
+
+The exact LLM cache (`services/b2b/llm_exact_cache.py:160`) lazily imports
+`get_skill_registry` from `...skills` to build skill-message envelopes. In
+default mode that resolves to `atlas_brain.skills`. A standalone substrate
+for skills is not yet carved out -- skill prompts are owned by Atlas's
+content/competitive-intelligence pipelines and have not been classified for
+extraction yet. Phase 3 work that decouples cache helpers from skills (or
+extracts skills behind a Protocol) will replace this bridge with a proper
+substrate.
+
+Default mode (``EXTRACTED_LLM_INFRA_STANDALONE`` unset/false): re-export
+from ``atlas_brain.skills`` so the cache helpers run as a sibling of Atlas.
+
+Standalone mode (``EXTRACTED_LLM_INFRA_STANDALONE=1``): raise on access.
+The cache helpers that need skills are not callable in standalone mode
+until Phase 3 extracts (or stubs) the skills layer; lookup/store paths
+that do not call `build_skill_messages` / `build_skill_request_envelope`
+remain usable.
+"""
+
+from __future__ import annotations
+
+import os as _os
+
+if _os.environ.get("EXTRACTED_LLM_INFRA_STANDALONE") == "1":
+    def get_skill_registry(*_args, **_kwargs):  # type: ignore[no-redef]
+        raise NotImplementedError(
+            "extracted_llm_infrastructure.skills is not implemented in "
+            "standalone mode. The skills layer is owned by content/"
+            "competitive-intelligence pipelines and has not been extracted. "
+            "Phase 3 will decouple cache helpers from skills."
+        )
+else:
+    from atlas_brain.skills import *  # noqa: F401,F403
+    from atlas_brain.skills import get_skill_registry  # noqa: F401

--- a/scripts/smoke_extracted_llm_infrastructure_imports.py
+++ b/scripts/smoke_extracted_llm_infrastructure_imports.py
@@ -21,6 +21,10 @@ MODULES = [
     "extracted_llm_infrastructure.services.b2b.anthropic_batch",
     "extracted_llm_infrastructure.services.b2b.cache_strategy",
     "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
+    # llm_exact_cache lazily imports `from ...skills import
+    # get_skill_registry` inside helpers; importing the skills bridge
+    # explicitly here catches a broken bridge even if no helper runs.
+    "extracted_llm_infrastructure.skills",
     "extracted_llm_infrastructure.pipelines.llm",
     "extracted_llm_infrastructure.reasoning.semantic_cache",
     "extracted_llm_infrastructure.services.llm_router",

--- a/scripts/smoke_extracted_llm_infrastructure_imports.py
+++ b/scripts/smoke_extracted_llm_infrastructure_imports.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 MODULES = [
     "extracted_llm_infrastructure.services.b2b.anthropic_batch",
     "extracted_llm_infrastructure.services.b2b.cache_strategy",
+    "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
     "extracted_llm_infrastructure.pipelines.llm",
     "extracted_llm_infrastructure.reasoning.semantic_cache",
     "extracted_llm_infrastructure.services.llm_router",

--- a/scripts/smoke_extracted_llm_infrastructure_standalone.py
+++ b/scripts/smoke_extracted_llm_infrastructure_standalone.py
@@ -196,6 +196,7 @@ def main() -> int:
     PROVIDERS = [
         "extracted_llm_infrastructure.services.b2b.cache_strategy",
         "extracted_llm_infrastructure.services.b2b.anthropic_batch",
+        "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
         "extracted_llm_infrastructure.pipelines.llm",
         "extracted_llm_infrastructure.reasoning.semantic_cache",
         "extracted_llm_infrastructure.services.llm_router",

--- a/scripts/smoke_extracted_llm_infrastructure_standalone.py
+++ b/scripts/smoke_extracted_llm_infrastructure_standalone.py
@@ -188,6 +188,27 @@ def main() -> int:
         print(f"FAIL storage.database: {exc}")
         failed.append("storage.database")
 
+    # 6. Skills (bridge stub)
+    try:
+        from extracted_llm_infrastructure.skills import get_skill_registry
+
+        # In standalone mode the bridge MUST raise NotImplementedError.
+        # If it instead resolved silently to atlas_brain.skills (e.g.
+        # the env-gate regressed), this assertion would catch it.
+        try:
+            get_skill_registry()
+        except NotImplementedError:
+            print("OK skills (bridge raises NotImplementedError as expected)")
+        else:
+            raise AssertionError(
+                "skills bridge did not raise in standalone mode -- "
+                "the env-gate may have regressed and silently resolved "
+                "to atlas_brain.skills"
+            )
+    except Exception as exc:
+        print(f"FAIL skills: {exc}")
+        failed.append("skills")
+
     # ------------------------------------------------------------------
     # Part C: every provider module imports cleanly in standalone mode
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces closed [#90](https://github.com/canfieldjuan/ATLAS/pull/90), rebased fresh on main (force-push to the original branch was blocked by branch protection).

Re-applies the Copilot review fixes that landed too late to make it into the PR #87 merge. Two commits:

1. **Re-apply Copilot fixes that missed PR #87 merge** — adds `skills/__init__.py` bridge stub (env-gated; raises `NotImplementedError` in standalone mode), adds `B2BChurnSubConfig.llm_exact_cache_enabled` flag, updates STATUS.md row for `services/b2b/llm_exact_cache.py`, updates 2 smoke scripts.
2. **Address Copilot review on PR #90** — follow-up Copilot fixes on the re-apply itself.

## Validation

```
$ bash scripts/run_extracted_llm_infrastructure_checks.sh
All extracted_llm_infrastructure checks passed
Standalone smoke passed: 5 bridges + 15 provider modules + transitive-substrate check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)