### PR TITLE
Clean up coordination docs after cost-closure merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,15 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-03T23:39Z by codex-2026-05-03
+Last updated: 2026-05-03T23:55Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #90 | Re-apply Copilot fixes that missed PR #87 merge (PR-A1.5) | `extracted_llm_infrastructure/{skills/__init__.py, _standalone/config.py, STATUS.md}`; `scripts/smoke_extracted_llm_infrastructure_imports.py`; `scripts/smoke_extracted_llm_infrastructure_standalone.py` | claude-2026-05-03-b | the 5 files listed |
-| #95 | Add drift report (NEW CODE, PR-A4a) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/drift.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_drift.py` | claude-2026-05-03-b | `services/cost/drift.py` or its test |
-| #96 | Add runtime budget gate (NEW CODE, PR-A4b) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/budget.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_budget.py` | claude-2026-05-03-b | `services/cost/budget.py` or its test |
-| #98 | Add OpenAI billing fetcher (NEW CODE, PR-A4c) | `extracted_llm_infrastructure/{manifest.json, services/cost/__init__.py, services/cost/openai_billing.py, README.md, STATUS.md}`; `tests/test_extracted_llm_infrastructure_openai_billing.py` | claude-2026-05-03-b | `services/cost/openai_billing.py` or its test |
 | (PR-C1g, in flight) | PR-C1g: Wire `score_archetypes` + `build_temporal_evidence` stubs in api.py | EDIT: `extracted_reasoning_core/api.py` (impl 2 of 3 stubs; `evaluate_evidence` waits for PR-C1d's slim engine). EDIT: `tests/test_extracted_reasoning_core_api.py` (drop the 2 now-implemented stubs from the fail-closed list; add behavioral tests for the wired entry points). | claude-2026-05-03 | `extracted_reasoning_core/api.py`; `tests/test_extracted_reasoning_core_api.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,14 +1,13 @@
 # Upcoming Queue
 
-Last updated: 2026-05-03T23:39Z by codex-2026-05-03
+Last updated: 2026-05-03T23:55Z by claude-2026-05-03-b
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
+A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b #106, PR-A4c #98.
+
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-A1.5 | `extracted_llm_infrastructure` | claude-2026-05-03-b | none | Re-apply Copilot fixes that did not land in PR #87 merge: skills bridge stub, standalone `llm_exact_cache_enabled` flag, smoke script entries, STATUS detail rows. Opening immediately after PR-A2. |
-| PR-A3 | `extracted_llm_infrastructure` | unclaimed | PR-A1 / #87 (merged) | New code: cache-savings persistence layer + migration. Closes the "$ saved by cache" telemetry gap. |
-| PR-A4 | `extracted_llm_infrastructure` | unclaimed | PR-A2, PR-A3 | New code: drift report (local vs invoiced), budget gate, OpenAI provider adapter. May split if too large. |
 | PR-B3 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Safety-gate split: deterministic content/risk scan to core; approvals + audit log + DB to ports + Atlas adapter wrapper. |
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |


### PR DESCRIPTION
## Summary

Drop merged-PR rows from `coordination/inflight.md` and the now-stale
slice rows from `coordination/queue.md`. The A-series is fully merged
(PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b
#106, PR-A4c #98) so the inflight table no longer needs entries for
those, and `queue.md` should not list slices that are already in
main.

Adds a one-line summary at the top of `queue.md` listing every merged
PR in the A-series so a future session does not need to re-derive the
trail from `gh pr list --state merged`.

Per the session protocol, the row drop is owed when a PR merges;
batching the four into one commit since the merges all landed within
the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)