### PR TITLE
Add AI Content Ops host install runbook

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T00:02Z by codex-2026-05-03
+Last updated: 2026-05-04T00:03Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1d, in flight) | PR-C1d: Slim `EvidenceEngine` core (conclusions + suppression) | NEW: `extracted_reasoning_core/evidence_engine.py` (conclusions + suppression surface only; per-review enrichment stays atlas-side until PR-C1e). EDIT: `extracted_reasoning_core/api.py` (wire `evaluate_evidence` stub). NEW: `tests/test_extracted_reasoning_core_evidence_engine.py`. | claude-2026-05-03 | `extracted_reasoning_core/evidence_engine.py`; `extracted_reasoning_core/api.py`; the new evidence-engine test file |
-| (PR-D7, branch `codex/content-pipeline-install-runbook`) | Add AI Content Ops host install runbook | `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/standalone_productization.md` | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, LLM-infra files, or product code |
+| #112 | Add AI Content Ops host install runbook (PR-D7) | `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/standalone_productization.md` | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, LLM-infra files, or product code |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T00:01Z by codex-2026-05-03
+Last updated: 2026-05-04T00:02Z by codex-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1d, in flight) | PR-C1d: Slim `EvidenceEngine` core (conclusions + suppression) | NEW: `extracted_reasoning_core/evidence_engine.py` (conclusions + suppression surface only; per-review enrichment stays atlas-side until PR-C1e). EDIT: `extracted_reasoning_core/api.py` (wire `evaluate_evidence` stub). NEW: `tests/test_extracted_reasoning_core_evidence_engine.py`. | claude-2026-05-03 | `extracted_reasoning_core/evidence_engine.py`; `extracted_reasoning_core/api.py`; the new evidence-engine test file |
+| (PR-D7, branch `codex/content-pipeline-install-runbook`) | Add AI Content Ops host install runbook | `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/standalone_productization.md` | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, LLM-infra files, or product code |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T00:01Z by codex-2026-05-03
+Last updated: 2026-05-04T00:02Z by codex-2026-05-03
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -12,3 +12,4 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |
+| PR-D7 | `extracted_content_pipeline` | codex-2026-05-03 | PR-D6 / #110 (merged); avoid PR-C1 files | Add a host install/runbook doc that ties migrations, opportunity import, optional reasoning JSON, optional skill roots, and DB-backed generation into one customer path. |

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -201,6 +201,9 @@ The loader uses the same normalization contract as the offline example. It is
 append-only by default; `--replace-existing` deletes matching target ids for
 the selected account and target mode before inserting the new rows.
 
+For the full database-backed host install path, see
+`docs/host_install_runbook.md`.
+
 ```bash
 python scripts/run_extracted_campaign_generation_postgres.py --account-id acct_123 --limit 10
 ```

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -104,6 +104,9 @@
   contract documented in `docs/reasoning_handoff_contract.md`; it does not
   import Atlas synthesis, pool compression, or extracted reasoning-core
   internals.
+- `docs/host_install_runbook.md` documents the end-to-end host path for
+  database-backed installs: migrations, opportunity import, optional reasoning
+  JSON, optional skill roots, generation, and output verification.
 
 ## Validation gates in repo
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -1,0 +1,257 @@
+# AI Content Ops Host Install Runbook
+
+Date: 2026-05-04
+
+This runbook is the standalone database-backed path for the extracted AI
+Content Ops campaign product. It assumes a host application owns Postgres,
+provider credentials, tenant/auth policy, and any reasoning producer. The
+content package owns migrations, customer opportunity normalization, prompt
+lookup, generation orchestration, and draft persistence.
+
+## What This Installs
+
+The flow below gives a host app a working campaign-generation loop:
+
+1. Apply packaged SQL migrations.
+2. Load customer opportunity data from JSON or CSV.
+3. Optionally attach host-produced reasoning context.
+4. Optionally override packaged prompt skills.
+5. Generate campaign drafts through the DB-backed runner.
+6. Inspect persisted drafts in `b2b_campaigns`.
+
+It does not install an API server, auth layer, dashboard, or sender worker. Those
+remain host-owned integration points until the API/orchestration seams are
+extracted.
+
+## Prerequisites
+
+- Python environment with this repo on `PYTHONPATH`.
+- Postgres database reachable through `EXTRACTED_DATABASE_URL` or `DATABASE_URL`.
+- `asyncpg` installed in the host environment for DB-backed commands.
+- UUID generation support for `gen_random_uuid()`. On older Postgres versions,
+  enable `pgcrypto` before running migrations:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+```
+
+- LLM provider configuration if using the real product adapter:
+  `EXTRACTED_CAMPAIGN_LLM_*` environment variables.
+- No reasoning runtime is required. Reasoning is optional host input through
+  `CampaignReasoningContextProvider` or a JSON file.
+
+## Step 1: Configure Database Access
+
+Use a product-specific DSN when possible:
+
+```bash
+export EXTRACTED_DATABASE_URL="postgres://user:password@localhost:5432/content_ops"
+```
+
+If `EXTRACTED_DATABASE_URL` is not set, the migration, import, and generation
+commands fall back to `DATABASE_URL`. Use `--database-url` when the host app
+keeps AI Content Ops data in a separate database.
+
+## Step 2: Apply Migrations
+
+Preview pending migrations:
+
+```bash
+python scripts/run_extracted_content_pipeline_migrations.py --dry-run
+```
+
+Apply them:
+
+```bash
+python scripts/run_extracted_content_pipeline_migrations.py
+```
+
+The runner writes applied migration filenames and checksums to
+`content_pipeline_schema_migrations`. Re-running the command skips files already
+recorded in that table.
+
+Use a custom metadata table only if the host has a naming convention:
+
+```bash
+python scripts/run_extracted_content_pipeline_migrations.py \
+  --migration-table customer_content_pipeline_migrations
+```
+
+## Step 3: Validate Customer Data Offline
+
+Before writing to Postgres, validate the same JSON or CSV file through the file
+adapter:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  customer_opportunities.csv \
+  --format csv \
+  --channels email_cold,email_followup
+```
+
+This proves the opportunity rows can normalize into prompt-ready fields without
+requiring a database or provider credentials.
+
+Minimum useful columns:
+
+| Column | Purpose |
+|---|---|
+| `company` / `company_name` | Account or buyer name. |
+| `vendor` / `vendor_name` | Incumbent or target vendor. |
+| `email` / `contact_email` | Recipient email and stable target key. |
+| `title` / `contact_title` | Recipient role context. |
+| `pain_category` / `pain_points` | Prompt-visible customer pains. |
+| `competitor` / `competitors` | Alternative vendor context. |
+| `opportunity_score` | Ranking input. |
+| `urgency_score` | Ranking input and default ordering. |
+| `evidence` | Optional source snippets, facts, or proof rows. |
+
+Unknown columns are preserved in draft metadata and prompt context through the
+normalized opportunity payload.
+
+## Step 4: Load Opportunities Into Postgres
+
+Preview the import:
+
+```bash
+python scripts/load_extracted_campaign_opportunities.py \
+  customer_opportunities.csv \
+  --format csv \
+  --account-id acct_123 \
+  --dry-run
+```
+
+Write rows:
+
+```bash
+python scripts/load_extracted_campaign_opportunities.py \
+  customer_opportunities.csv \
+  --format csv \
+  --account-id acct_123
+```
+
+Imports are append-only by default. For repeatable test loads, replace matching
+target ids for the same account and target mode:
+
+```bash
+python scripts/load_extracted_campaign_opportunities.py \
+  customer_opportunities.csv \
+  --format csv \
+  --account-id acct_123 \
+  --replace-existing
+```
+
+`--replace-existing` only deletes rows with matching target ids inside the
+selected `account_id` and `target_mode`; it does not truncate the table.
+
+## Step 5: Add Optional Reasoning Context
+
+If a host already has account reasoning output, pass it as JSON:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
+```
+
+The file-backed reasoning adapter matches rows by target id, company, email, or
+vendor. The generator still works without this file, but output quality is lower
+because prompts only see the opportunity row.
+
+See `reasoning_handoff_contract.md` for the accepted shape and the no-direct-
+import rule. AI Content Ops consumes compressed reasoning; it does not import a
+reasoning engine.
+
+## Step 6: Add Optional Prompt Overrides
+
+Use packaged skills by default. To override copy strategy, provide a markdown
+skill root:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --skills-root customer_skills
+```
+
+Files with the same skill name override bundled prompts. Missing prompts fall
+back to `extracted_content_pipeline/skills/digest/*.md`.
+
+## Step 7: Generate Drafts
+
+Generate cold email drafts:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --limit 10
+```
+
+Generate cold email plus follow-up drafts:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --channels email_cold,email_followup \
+  --limit 10
+```
+
+The runner reads active `campaign_opportunities`, builds drafts through
+`CampaignGenerationService`, and persists them to `b2b_campaigns`.
+
+## Step 8: Verify Output
+
+Inspect imported opportunities:
+
+```sql
+SELECT target_id, company_name, vendor_name, urgency_score, updated_at
+FROM campaign_opportunities
+WHERE account_id = 'acct_123'
+ORDER BY urgency_score DESC NULLS LAST
+LIMIT 20;
+```
+
+Inspect generated drafts:
+
+```sql
+SELECT id, company_name, vendor_name, status, created_at
+FROM b2b_campaigns
+WHERE account_id = 'acct_123'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+Inspect draft metadata for source opportunity and reasoning context:
+
+```sql
+SELECT metadata
+FROM b2b_campaigns
+WHERE account_id = 'acct_123'
+ORDER BY created_at DESC
+LIMIT 1;
+```
+
+## Retry And Rollback Notes
+
+- Migrations are idempotent by filename. Re-running the migration command skips
+  recorded files.
+- Opportunity imports are append-only unless `--replace-existing` is set.
+- For test tenants, deleting rows by `account_id` is the cleanest reset:
+
+```sql
+DELETE FROM b2b_campaigns WHERE account_id = 'acct_123';
+DELETE FROM campaign_opportunities WHERE account_id = 'acct_123';
+```
+
+- If generation produces no drafts, verify active opportunities exist for the
+  same `account_id` and `target_mode`, then run with a low `--limit`.
+- If generated drafts lack buyer specificity, add reasoning JSON or richer
+  opportunity evidence before tuning prompts.
+
+## Current Limits
+
+- API routes, review queues, send workers, and dashboard auth are not part of
+  this install path yet.
+- The runbook covers campaign opportunity generation, not blog generation or
+  vendor briefing delivery.
+- Reasoning production remains host-owned. This product accepts reasoning
+  context; it does not compute long-running graph state.

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -171,6 +171,11 @@ host async pool or direct connection. The
 through `EXTRACTED_DATABASE_URL`, `DATABASE_URL`, or an explicit
 `--database-url` argument.
 
+`extracted_content_pipeline/docs/host_install_runbook.md` ties the standalone
+DB-backed path together for hosts: configure a DSN, apply migrations, validate
+and import customer opportunity data, optionally attach reasoning JSON and
+custom skill roots, run Postgres-backed generation, and verify saved drafts.
+
 `extracted_content_pipeline/campaign_opportunities.py` owns the host/customer
 opportunity input contract. It accepts loose customer rows, preserves custom
 fields, and adds stable prompt/storage keys (`target_id`, `company_name`,
@@ -243,5 +248,5 @@ The command must pass before this package is considered customer-usable.
   `api/campaign_webhooks.py` need an app-factory boundary and host-provided
   auth/tenant dependencies.
 - SQL migrations and customer opportunity imports now have product-owned
-  runners, but customer installation still needs a host-facing runbook and
+  runners and a host install runbook, but customer installation still needs
   final base-schema hardening.


### PR DESCRIPTION
## Summary
- Add a host install runbook for the database-backed AI Content Ops campaign path.
- Document the sequence from DSN setup through migrations, customer opportunity import, optional reasoning JSON, optional skill roots, Postgres generation, and output verification.
- Link the runbook from README, STATUS, and standalone productization docs.

## Coordination
- Slice: PR-D7 / AI Content Ops host install runbook.
- Avoided reasoning-core, LLM-infra, copied Atlas task mirrors, and product code.

## Validation
- bash scripts/run_extracted_pipeline_checks.sh — 273 passed, import smoke passed, Atlas runtime import findings: 0
- edited docs ASCII check — clean
