### PR TITLE
PR-B3: Split safety-gate primitives into deterministic core

### DIFF
--- a/atlas_brain/services/safety_gate.py
+++ b/atlas_brain/services/safety_gate.py
@@ -7,6 +7,11 @@ Provides four enforcement layers:
 3. Audit logging       -- immutable event log via atlas_events table
 4. Human review gate   -- block execution until a human approves
 
+The deterministic primitives (`check_content`, `assess_risk`) are owned
+by `extracted_quality_gate.safety_gate` (PR-B3) and consumed here. This
+module is the Atlas-side adapter: it adds the I/O surface (DB writes
+to `intervention_approvals` + `atlas_events`) on top of the pure core.
+
 Usage:
     from atlas_brain.services.safety_gate import SafetyGate
 
@@ -21,43 +26,63 @@ Usage:
 
 import json
 import logging
-import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from uuid import uuid4
 
+from extracted_quality_gate.safety_gate import (
+    assess_risk as _core_assess_risk,
+    check_content as _core_check_content,
+)
+from extracted_quality_gate.types import (
+    ContentScanResult,
+    RiskAssessment,
+    RiskLevel,
+)
+
 logger = logging.getLogger("atlas.services.safety_gate")
 
-# Patterns that must never appear in intervention output.
-# These catch deceptive, coercive, or identity-misrepresenting content.
-_PROHIBITED_PATTERNS: list[tuple[str, str]] = [
-    (r"\bimpersonat(?:e|ing|ion)\b", "impersonation"),
-    (r"\bfabricat(?:e|ed|ing)\s+(?:facts?|evidence|data)", "fabricated_facts"),
-    (r"\bblackmail\b", "blackmail"),
-    (r"\bextort(?:ion|ing)?\b", "extortion"),
-    (r"\bthreaten(?:s|ed|ing)?\s+(?:to\s+)?(?:harm|violence|physical)", "threat_of_harm"),
-    (r"\bmanipulat(?:e|ing)\s+(?:evidence|records|data)", "evidence_manipulation"),
-    (r"\bdoxx?(?:ing|ed)?\b", "doxxing"),
-    (r"\bphishing\b", "phishing"),
-    (r"\bsocial\s+engineer(?:ing)?\b", "social_engineering"),
-]
 
-# Compiled once at module load
-_COMPILED_PATTERNS = [
-    (re.compile(pat, re.IGNORECASE), label) for pat, label in _PROHIBITED_PATTERNS
-]
-
-_RISK_ORDER = {"LOW": 0, "MEDIUM": 1, "HIGH": 2, "CRITICAL": 3}
-
-
-def _load_safety_config() -> tuple[str, int]:
+def _load_safety_config() -> tuple[RiskLevel, int]:
     """Load safety gate settings from config (deferred to avoid circular imports)."""
     try:
         from ..config import settings
         cfg = settings.external_data
-        return cfg.safety_auto_approve_max_risk, cfg.safety_approval_expiry_hours
+        max_risk = RiskLevel(cfg.safety_auto_approve_max_risk)
+        return max_risk, cfg.safety_approval_expiry_hours
     except Exception:
-        return "MEDIUM", 72
+        return RiskLevel.MEDIUM, 72
+
+
+def _content_to_dict(result: ContentScanResult) -> dict[str, Any]:
+    """Convert a core ``ContentScanResult`` to the legacy dict shape.
+
+    Existing callers (intervention_pipeline, REST API, MCP server) read
+    the old dict format. Conversion lives here, not in the core, so the
+    core stays I/O-free.
+    """
+    return {
+        "passed": result.passed,
+        "blocked": result.blocked,
+        "flags": [
+            {
+                "pattern": flag.pattern,
+                "match": flag.match,
+                "position": flag.position,
+            }
+            for flag in result.flags
+        ],
+    }
+
+
+def _risk_to_dict(assessment: RiskAssessment) -> dict[str, Any]:
+    """Convert a core ``RiskAssessment`` to the legacy dict shape."""
+    return {
+        "risk_level": assessment.risk_level.value,
+        "risk_score": assessment.risk_score,
+        "auto_approve_eligible": assessment.auto_approve_eligible,
+        "factors": list(assessment.factors),
+    }
 
 
 class SafetyGate:
@@ -71,6 +96,10 @@ class SafetyGate:
     def check_content(self, text: str) -> dict[str, Any]:
         """Scan text for prohibited patterns.
 
+        Thin wrapper over :func:`extracted_quality_gate.safety_gate.check_content`
+        that converts the frozen-dataclass result into the dict shape
+        existing callers expect.
+
         Returns:
             {
                 "passed": bool,
@@ -78,24 +107,7 @@ class SafetyGate:
                 "flags": [{"pattern": str, "match": str, "position": int}],
             }
         """
-        if not text:
-            return {"passed": True, "blocked": False, "flags": []}
-
-        flags: list[dict[str, Any]] = []
-        for compiled, label in _COMPILED_PATTERNS:
-            for match in compiled.finditer(text):
-                flags.append({
-                    "pattern": label,
-                    "match": match.group(),
-                    "position": match.start(),
-                })
-
-        blocked = len(flags) > 0
-        return {
-            "passed": not blocked,
-            "blocked": blocked,
-            "flags": flags,
-        }
+        return _content_to_dict(_core_check_content(text))
 
     # ---- Approval Workflow ----
 
@@ -348,6 +360,12 @@ class SafetyGate:
     ) -> dict[str, Any]:
         """Assess the overall risk level for a pipeline run.
 
+        Thin wrapper over :func:`extracted_quality_gate.safety_gate.assess_risk`.
+        Converts the legacy ``content_check`` dict (if provided) back
+        into the core ``ContentScanResult`` shape, then converts the
+        resulting frozen dataclass into the dict shape existing callers
+        expect.
+
         Returns:
             {
                 "risk_level": "LOW"|"MEDIUM"|"HIGH"|"CRITICAL",
@@ -355,49 +373,36 @@ class SafetyGate:
                 "factors": [str],
             }
         """
-        factors: list[str] = []
-        risk_score = 0
-
-        # Sensor-based risk
-        sensor_level = sensor_summary.get("dominant_risk_level", "LOW")
-        risk_score += _RISK_ORDER.get(sensor_level, 0)
-        if sensor_level in ("HIGH", "CRITICAL"):
-            factors.append(f"Sensor composite: {sensor_level}")
-
-        # Pressure-based risk
-        pressure_score = pressure.get("pressure_score", 0)
-        if isinstance(pressure_score, (int, float)):
-            if pressure_score >= 8:
-                risk_score += 2
-                factors.append(f"Critical pressure: {pressure_score}/10")
-            elif pressure_score >= 6:
-                risk_score += 1
-                factors.append(f"Elevated pressure: {pressure_score}/10")
-
-        # Content filtering risk
-        if content_check and content_check.get("blocked"):
-            risk_score += 3
-            flag_labels = [f["pattern"] for f in content_check.get("flags", [])]
-            factors.append(f"Content flags: {', '.join(flag_labels)}")
-
-        # Map score to level
-        if risk_score >= 4:
-            level = "CRITICAL"
-        elif risk_score >= 3:
-            level = "HIGH"
-        elif risk_score >= 1:
-            level = "MEDIUM"
+        scan: Optional[ContentScanResult]
+        if content_check is None:
+            scan = None
         else:
-            level = "LOW"
-
-        auto_eligible = _RISK_ORDER.get(level, 0) <= _RISK_ORDER.get(self._auto_approve_max_risk, 1)
-
-        return {
-            "risk_level": level,
-            "risk_score": risk_score,
-            "auto_approve_eligible": auto_eligible,
-            "factors": factors,
-        }
+            # The wrapper produces dicts; recover a ContentScanResult by
+            # round-tripping through check_content when text would be
+            # available, but content_check here is already a scan
+            # *result*, so synthesize one. ``_core_assess_risk`` only
+            # reads ``blocked`` and the flag labels, so a minimal
+            # reconstruction is sufficient.
+            from extracted_quality_gate.types import ContentFlag
+            scan = ContentScanResult(
+                passed=bool(content_check.get("passed", True)),
+                blocked=bool(content_check.get("blocked", False)),
+                flags=tuple(
+                    ContentFlag(
+                        pattern=str(flag.get("pattern", "")),
+                        match=str(flag.get("match", "")),
+                        position=int(flag.get("position", 0)),
+                    )
+                    for flag in content_check.get("flags", [])
+                ),
+            )
+        assessment = _core_assess_risk(
+            sensor_summary=sensor_summary,
+            pressure=pressure,
+            content_check=scan,
+            auto_approve_max_risk=self._auto_approve_max_risk,
+        )
+        return _risk_to_dict(assessment)
 
     # ---- Audit Logging ----
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T00:03Z by codex-2026-05-03
+Last updated: 2026-05-04T00:35Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -8,5 +8,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 |---|---|---|---|---|
 | (PR-C1d, in flight) | PR-C1d: Slim `EvidenceEngine` core (conclusions + suppression) | NEW: `extracted_reasoning_core/evidence_engine.py` (conclusions + suppression surface only; per-review enrichment stays atlas-side until PR-C1e). EDIT: `extracted_reasoning_core/api.py` (wire `evaluate_evidence` stub). NEW: `tests/test_extracted_reasoning_core_evidence_engine.py`. | claude-2026-05-03 | `extracted_reasoning_core/evidence_engine.py`; `extracted_reasoning_core/api.py`; the new evidence-engine test file |
 | #112 | Add AI Content Ops host install runbook (PR-D7) | `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/standalone_productization.md` | codex-2026-05-03 | Do not touch `extracted_reasoning_core/**`, LLM-infra files, or product code |
+| #113 | PR-B3: Safety-gate split (deterministic core + Atlas adapter) | NEW: `extracted_quality_gate/safety_gate.py` (pure `check_content` + `assess_risk`). EDIT: `extracted_quality_gate/{__init__.py, types.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/services/safety_gate.py` (delegate pure logic to core; preserve dict-returning public API). NEW: `tests/test_extracted_quality_gate_safety_scan.py` (17 tests). | claude-2026-05-03-b | `extracted_quality_gate/safety_gate.py`; `extracted_quality_gate/types.py` (touches `RiskLevel` / `ContentScanResult` / `RiskAssessment`); `atlas_brain/services/safety_gate.py`; the new safety-scan test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -8,7 +8,7 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-B3 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Safety-gate split: deterministic content/risk scan to core; approvals + audit log + DB to ports + Atlas adapter wrapper. |
+| PR-B3 | `extracted_quality_gate` | claude-2026-05-03-b | PR-B2 / #85 (merged) | Safety-gate split: deterministic content/risk scan to core; approvals + audit log + DB to ports + Atlas adapter wrapper. |
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |

--- a/extracted_quality_gate/README.md
+++ b/extracted_quality_gate/README.md
@@ -2,7 +2,7 @@
 
 Standalone quality-gate core for AI outputs, claims, and evidence-backed render decisions.
 
-This first slice contains the product-claim contract:
+The package contains:
 
 - deterministic evidence posture derivation
 - deterministic confidence derivation
@@ -10,6 +10,7 @@ This first slice contains the product-claim contract:
 - stable product claim IDs
 - a policy registry for claim-type-specific thresholds
 - generic quality-report types and integration ports
+- deterministic safety-gate primitives (`check_content`, `assess_risk`)
 
 The package intentionally has no Atlas runtime dependency. Product-specific behavior belongs in packs or adapters layered on top of the public API.
 
@@ -21,12 +22,29 @@ from extracted_quality_gate.api import (
     build_product_claim,
     decide_render_gates,
 )
+from extracted_quality_gate.safety_gate import (
+    assess_risk,
+    check_content,
+)
 ```
 
 Products should import from:
 
 - `extracted_quality_gate.api`
+- `extracted_quality_gate.safety_gate`
 - `extracted_quality_gate.types`
 - `extracted_quality_gate.ports`
 
 Do not import from private internals when product packs are added.
+
+## Safety gate split (PR-B3)
+
+`safety_gate.py` is deterministic by construction: `check_content` is a regex scan against a stable label catalogue and `assess_risk` composes upstream signals into a `RiskAssessment`. Neither touches the database, network, or clock.
+
+The Atlas-side wrapper (`atlas_brain/services/safety_gate.py`) layers the I/O surface on top:
+
+- `intervention_approvals` table writes (request / approve / reject / list pending)
+- `atlas_events` audit-log writes
+- composite `gate_check()` that coordinates pure scan + DB writes
+
+The wrapper consumes the core via direct import; the `ApprovalStore` and `AuditLog` Protocols defined in `ports.py` describe the I/O surface for future packs that want to plug a different backend.

--- a/extracted_quality_gate/STATUS.md
+++ b/extracted_quality_gate/STATUS.md
@@ -4,7 +4,15 @@ Date: 2026-05-03
 
 ## Current Slice
 
-PR-B2 extracts the first standalone core contract:
+PR-B3: split safety-gate primitives.
+
+- Deterministic core (`safety_gate.py`) -- `check_content` + `assess_risk`
+- Atlas-side wrapper (`atlas_brain/services/safety_gate.py`) now delegates
+  the pure functions to this package; approvals + audit-log + DB writes
+  remain Atlas-side behind the existing `ApprovalStore` and `AuditLog`
+  port protocols.
+
+PR-B2 (merged via #85) is the prior slice:
 
 - `product_claim.py`
 - `api.py`
@@ -22,14 +30,17 @@ The module is deterministic and imports without Atlas.
 - Claim policy registry
 - Generic quality report types
 - Integration port protocols
+- Safety gate (deterministic core: `check_content` + `assess_risk`) -- PR-B3
 
 ## Not Yet Included
 
-- Safety gate split
-- Blog quality pack
-- Campaign quality pack
-- Witness render policy pack
-- Evidence-claim coverage pack
-- Source-quality ingest pack
+- Safety gate Atlas adapter wrapper (approvals + audit log + DB stay
+  in `atlas_brain/services/safety_gate.py`; the deterministic core
+  is now in `extracted_quality_gate/safety_gate.py` and the wrapper
+  delegates to it -- but the wrapper itself is not yet extracted)
+- Blog quality pack (PR-B4)
+- Campaign quality pack (PR-B4)
+- Witness render policy pack (PR-B5)
+- Evidence-claim coverage pack (PR-B5)
+- Source-quality ingest pack (PR-B5)
 - Memory quality pack
-- Atlas adapters

--- a/extracted_quality_gate/__init__.py
+++ b/extracted_quality_gate/__init__.py
@@ -29,12 +29,21 @@ from .api import (
     register_policy,
     reset_policy_registry,
 )
+from .safety_gate import assess_risk, check_content
+from .types import (
+    ContentFlag,
+    ContentScanResult,
+    RiskAssessment,
+    RiskLevel,
+)
 
 
 __all__ = [
     "ClaimGatePolicy",
     "ClaimScope",
     "ConfidenceLabel",
+    "ContentFlag",
+    "ContentScanResult",
     "EvidencePosture",
     "GateDecision",
     "GateFinding",
@@ -44,8 +53,12 @@ __all__ = [
     "QualityInput",
     "QualityPolicy",
     "QualityReport",
+    "RiskAssessment",
+    "RiskLevel",
     "SuppressionReason",
+    "assess_risk",
     "build_product_claim",
+    "check_content",
     "compute_claim_id",
     "decide_render_gates",
     "derive_confidence",

--- a/extracted_quality_gate/manifest.json
+++ b/extracted_quality_gate/manifest.json
@@ -16,6 +16,9 @@
       "target": "extracted_quality_gate/ports.py"
     },
     {
+      "target": "extracted_quality_gate/safety_gate.py"
+    },
+    {
       "target": "extracted_quality_gate/types.py"
     },
     {

--- a/extracted_quality_gate/safety_gate.py
+++ b/extracted_quality_gate/safety_gate.py
@@ -1,0 +1,172 @@
+"""Deterministic safety-gate scanner: content patterns + risk scoring.
+
+Owned by ``extracted_quality_gate`` (PR-B3). The two public entry
+points -- ``check_content`` and ``assess_risk`` -- are pure: no DB,
+no network, no clock. They take inputs, return frozen dataclasses,
+and are safe to call from any context (sync or async).
+
+The Atlas-side ``SafetyGate`` wrapper layers approvals, audit logging,
+and DB persistence on top of these primitives via the ``ApprovalStore``
+and ``AuditLog`` ports defined in :mod:`extracted_quality_gate.ports`.
+
+Why deterministic-first: a content/risk scan that does not touch the
+database (a) can be unit-tested without fixtures, (b) can run in a
+worker that has no DB connection (e.g. a pre-flight check at the edge),
+and (c) decouples policy evolution from persistence schema evolution.
+
+Pattern catalogue (``_PROHIBITED_PATTERNS``) is a stable, additive
+list. Adding a label is non-breaking; renaming a label IS a breaking
+change because operator dashboards key off the label string.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Mapping
+
+from .types import (
+    ContentFlag,
+    ContentScanResult,
+    RiskAssessment,
+    RiskLevel,
+)
+
+
+# Patterns that must never appear in intervention output.
+# Catches deceptive, coercive, or identity-misrepresenting content.
+# (regex, label) -- label is a stable string used in audit logs and
+# operator dashboards; renaming a label is a breaking change.
+_PROHIBITED_PATTERNS: tuple[tuple[str, str], ...] = (
+    (r"\bimpersonat(?:e|ing|ion)\b", "impersonation"),
+    (r"\bfabricat(?:e|ed|ing)\s+(?:facts?|evidence|data)", "fabricated_facts"),
+    (r"\bblackmail\b", "blackmail"),
+    (r"\bextort(?:ion|ing)?\b", "extortion"),
+    (r"\bthreaten(?:s|ed|ing)?\s+(?:to\s+)?(?:harm|violence|physical)", "threat_of_harm"),
+    (r"\bmanipulat(?:e|ing)\s+(?:evidence|records|data)", "evidence_manipulation"),
+    (r"\bdoxx?(?:ing|ed)?\b", "doxxing"),
+    (r"\bphishing\b", "phishing"),
+    (r"\bsocial\s+engineer(?:ing)?\b", "social_engineering"),
+)
+
+# Compiled once at module load. Kept private so callers cannot mutate
+# the registry between scans.
+_COMPILED_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(pat, re.IGNORECASE), label)
+    for pat, label in _PROHIBITED_PATTERNS
+)
+
+
+_RISK_ORDER: Mapping[RiskLevel, int] = {
+    RiskLevel.LOW: 0,
+    RiskLevel.MEDIUM: 1,
+    RiskLevel.HIGH: 2,
+    RiskLevel.CRITICAL: 3,
+}
+
+
+def check_content(text: str) -> ContentScanResult:
+    """Scan ``text`` for prohibited patterns.
+
+    Empty / falsy input passes by definition. The scan walks every
+    compiled pattern over the full text, so a single input can produce
+    multiple flags (e.g. a paragraph that contains both "phishing" and
+    "social engineering").
+    """
+    if not text:
+        return ContentScanResult(passed=True, blocked=False, flags=())
+
+    flags: list[ContentFlag] = []
+    for compiled, label in _COMPILED_PATTERNS:
+        for match in compiled.finditer(text):
+            flags.append(
+                ContentFlag(
+                    pattern=label,
+                    match=match.group(),
+                    position=match.start(),
+                )
+            )
+
+    blocked = bool(flags)
+    return ContentScanResult(
+        passed=not blocked,
+        blocked=blocked,
+        flags=tuple(flags),
+    )
+
+
+def assess_risk(
+    sensor_summary: Mapping[str, object] | None,
+    pressure: Mapping[str, object] | None,
+    content_check: ContentScanResult | None = None,
+    *,
+    auto_approve_max_risk: RiskLevel = RiskLevel.MEDIUM,
+) -> RiskAssessment:
+    """Compose a single ``RiskAssessment`` from upstream signals.
+
+    Inputs are loosely-typed mappings so callers do not have to convert
+    Atlas-shaped dicts into core types -- the scanner reads the
+    documented keys and ignores the rest.
+
+    Recognized keys:
+      ``sensor_summary["dominant_risk_level"]`` (str: LOW/MEDIUM/HIGH/CRITICAL)
+      ``pressure["pressure_score"]`` (numeric, 0-10 scale)
+      ``content_check`` (a :class:`ContentScanResult`; ``blocked=True``
+        adds 3 to the risk score and contributes a ``Content flags:``
+        factor with the underlying labels)
+
+    Scoring is intentionally simple and stable -- a tuned ML model
+    has no place in the deterministic core. Tune by editing constants.
+    """
+    factors: list[str] = []
+    risk_score = 0
+
+    # Sensor-based risk
+    sensor_level_raw = (sensor_summary or {}).get("dominant_risk_level", "LOW")
+    try:
+        sensor_level = RiskLevel(str(sensor_level_raw))
+    except ValueError:
+        sensor_level = RiskLevel.LOW
+    risk_score += _RISK_ORDER[sensor_level]
+    if sensor_level in (RiskLevel.HIGH, RiskLevel.CRITICAL):
+        factors.append(f"Sensor composite: {sensor_level.value}")
+
+    # Pressure-based risk
+    pressure_score = (pressure or {}).get("pressure_score", 0)
+    if isinstance(pressure_score, (int, float)):
+        if pressure_score >= 8:
+            risk_score += 2
+            factors.append(f"Critical pressure: {pressure_score}/10")
+        elif pressure_score >= 6:
+            risk_score += 1
+            factors.append(f"Elevated pressure: {pressure_score}/10")
+
+    # Content-filter risk
+    if content_check is not None and content_check.blocked:
+        risk_score += 3
+        flag_labels = [flag.pattern for flag in content_check.flags]
+        factors.append(f"Content flags: {', '.join(flag_labels)}")
+
+    # Map score -> level
+    if risk_score >= 4:
+        level = RiskLevel.CRITICAL
+    elif risk_score >= 3:
+        level = RiskLevel.HIGH
+    elif risk_score >= 1:
+        level = RiskLevel.MEDIUM
+    else:
+        level = RiskLevel.LOW
+
+    auto_eligible = _RISK_ORDER[level] <= _RISK_ORDER[auto_approve_max_risk]
+
+    return RiskAssessment(
+        risk_level=level,
+        risk_score=risk_score,
+        auto_approve_eligible=auto_eligible,
+        factors=tuple(factors),
+    )
+
+
+__all__ = [
+    "assess_risk",
+    "check_content",
+]

--- a/extracted_quality_gate/types.py
+++ b/extracted_quality_gate/types.py
@@ -25,6 +25,51 @@ class GateDecision(StrEnum):
     APPROVAL_REQUIRED = "approval_required"
 
 
+class RiskLevel(StrEnum):
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+@dataclass(frozen=True)
+class ContentFlag:
+    """One regex hit during a deterministic content scan."""
+
+    pattern: str
+    match: str
+    position: int
+
+
+@dataclass(frozen=True)
+class ContentScanResult:
+    """Result of ``check_content``: a pure scan with no I/O.
+
+    ``passed`` and ``blocked`` are inverses by construction; both are
+    surfaced so call sites can use whichever reads more naturally.
+    """
+
+    passed: bool
+    blocked: bool
+    flags: tuple[ContentFlag, ...] = ()
+
+
+@dataclass(frozen=True)
+class RiskAssessment:
+    """Result of ``assess_risk``: composite risk level + auto-approve flag.
+
+    ``factors`` is a tuple of human-readable strings explaining why the
+    assessment landed where it did (e.g. "Critical pressure: 9/10" or
+    "Content flags: doxxing, phishing"). Suitable for surfacing in an
+    operator UI.
+    """
+
+    risk_level: RiskLevel
+    risk_score: int
+    auto_approve_eligible: bool
+    factors: tuple[str, ...] = ()
+
+
 @dataclass(frozen=True)
 class GateFinding:
     code: str
@@ -77,10 +122,14 @@ class QualityInput:
 
 
 __all__ = [
+    "ContentFlag",
+    "ContentScanResult",
     "GateDecision",
     "GateFinding",
     "GateSeverity",
     "QualityInput",
     "QualityPolicy",
     "QualityReport",
+    "RiskAssessment",
+    "RiskLevel",
 ]

--- a/tests/test_extracted_quality_gate_safety_scan.py
+++ b/tests/test_extracted_quality_gate_safety_scan.py
@@ -1,0 +1,215 @@
+"""Tests for extracted_quality_gate.safety_gate.
+
+The two functions under test (`check_content`, `assess_risk`) are pure:
+no DB, no clock, no network. So these tests are pure unit tests --
+no fixtures, no mocks, no async.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from extracted_quality_gate.safety_gate import (
+    _PROHIBITED_PATTERNS,
+    assess_risk,
+    check_content,
+)
+from extracted_quality_gate.types import (
+    ContentFlag,
+    ContentScanResult,
+    RiskAssessment,
+    RiskLevel,
+)
+
+
+# ---- check_content ----
+
+
+def test_check_content_empty_passes():
+    result = check_content("")
+    assert isinstance(result, ContentScanResult)
+    assert result.passed is True
+    assert result.blocked is False
+    assert result.flags == ()
+
+
+def test_check_content_none_safe_text_passes():
+    result = check_content("Schedule a meeting next Tuesday at 2pm to review.")
+    assert result.passed is True
+    assert result.blocked is False
+    assert result.flags == ()
+
+
+def test_check_content_catches_each_known_pattern():
+    # Every label in _PROHIBITED_PATTERNS should be detectable by SOME
+    # input. Use the bare label-style word as a smoke check that the
+    # regex covers the expected stem.
+    samples = {
+        "impersonation": "We will impersonate the CFO",
+        "fabricated_facts": "instructed staff to fabricate facts about",
+        "blackmail": "engaging in blackmail of the executive",
+        "extortion": "an attempt at extortion",
+        "threat_of_harm": "threaten to harm them physically",
+        "evidence_manipulation": "manipulate evidence in the audit log",
+        "doxxing": "publish a doxxing post",
+        "phishing": "send a phishing email",
+        "social_engineering": "social engineering the help desk",
+    }
+    expected_labels = {label for _, label in _PROHIBITED_PATTERNS}
+    assert set(samples.keys()) == expected_labels, (
+        "test sample must cover every pattern label"
+    )
+    for label, text in samples.items():
+        result = check_content(text)
+        flag_labels = {flag.pattern for flag in result.flags}
+        assert label in flag_labels, f"pattern {label!r} did not flag {text!r}"
+
+
+def test_check_content_returns_position_and_match_text():
+    result = check_content("they tried to blackmail the witness")
+    assert result.blocked is True
+    assert len(result.flags) == 1
+    flag = result.flags[0]
+    assert isinstance(flag, ContentFlag)
+    assert flag.pattern == "blackmail"
+    assert flag.match.lower() == "blackmail"
+    # "blackmail" starts at column 14 in the input above
+    assert flag.position == 14
+
+
+def test_check_content_multiple_flags_in_one_input():
+    text = "We will phishing the team and use social engineering."
+    result = check_content(text)
+    assert result.blocked is True
+    flag_labels = sorted(flag.pattern for flag in result.flags)
+    assert "phishing" in flag_labels
+    assert "social_engineering" in flag_labels
+
+
+def test_check_content_is_case_insensitive():
+    assert check_content("BLACKMAIL").blocked is True
+    assert check_content("BlAcKmAiL").blocked is True
+
+
+def test_content_scan_result_is_frozen():
+    result = check_content("doxxing the witness")
+    with pytest.raises(Exception):
+        result.passed = True  # type: ignore[misc]
+    with pytest.raises(Exception):
+        result.flags = ()  # type: ignore[misc]
+
+
+# ---- assess_risk ----
+
+
+def test_assess_risk_no_signals_returns_low():
+    assessment = assess_risk(sensor_summary={}, pressure={})
+    assert isinstance(assessment, RiskAssessment)
+    assert assessment.risk_level == RiskLevel.LOW
+    assert assessment.risk_score == 0
+    assert assessment.auto_approve_eligible is True
+    assert assessment.factors == ()
+
+
+def test_assess_risk_handles_none_inputs():
+    # Calling code from the Atlas wrapper sometimes passes None when
+    # upstream stage output is missing. Don't crash.
+    assessment = assess_risk(sensor_summary=None, pressure=None)
+    assert assessment.risk_level == RiskLevel.LOW
+    assert assessment.risk_score == 0
+
+
+def test_assess_risk_unknown_sensor_level_falls_back_to_low():
+    assessment = assess_risk(
+        sensor_summary={"dominant_risk_level": "BANANAS"},
+        pressure={},
+    )
+    assert assessment.risk_level == RiskLevel.LOW
+
+
+def test_assess_risk_high_sensor_adds_factor():
+    assessment = assess_risk(
+        sensor_summary={"dominant_risk_level": "HIGH"},
+        pressure={},
+    )
+    # HIGH = +2 score -> MEDIUM band (1-2)
+    assert assessment.risk_score == 2
+    assert assessment.risk_level == RiskLevel.MEDIUM
+    assert any("Sensor composite: HIGH" in factor for factor in assessment.factors)
+
+
+def test_assess_risk_critical_pressure_pushes_to_critical():
+    assessment = assess_risk(
+        sensor_summary={"dominant_risk_level": "MEDIUM"},
+        pressure={"pressure_score": 9},
+    )
+    # MEDIUM (+1) + critical pressure (+2) = 3 -> HIGH
+    assert assessment.risk_score == 3
+    assert assessment.risk_level == RiskLevel.HIGH
+    assert any("Critical pressure: 9/10" in f for f in assessment.factors)
+
+
+def test_assess_risk_content_block_adds_three_and_lists_flags():
+    content = check_content("phishing attack")
+    assert content.blocked
+    assessment = assess_risk(
+        sensor_summary={},
+        pressure={},
+        content_check=content,
+    )
+    # blocked content alone = +3 -> HIGH
+    assert assessment.risk_score == 3
+    assert assessment.risk_level == RiskLevel.HIGH
+    assert any("Content flags: phishing" in f for f in assessment.factors)
+
+
+def test_assess_risk_combines_signals():
+    content = check_content("doxxing the witness")
+    assessment = assess_risk(
+        sensor_summary={"dominant_risk_level": "CRITICAL"},
+        pressure={"pressure_score": 9},
+        content_check=content,
+    )
+    # CRITICAL (+3) + critical pressure (+2) + blocked content (+3) = 8 -> CRITICAL
+    assert assessment.risk_score == 8
+    assert assessment.risk_level == RiskLevel.CRITICAL
+    assert assessment.auto_approve_eligible is False
+
+
+def test_assess_risk_auto_approve_threshold_is_configurable():
+    # Default threshold is MEDIUM. Tighten to LOW: a MEDIUM input
+    # should no longer auto-approve.
+    assessment = assess_risk(
+        sensor_summary={"dominant_risk_level": "MEDIUM"},
+        pressure={},
+        auto_approve_max_risk=RiskLevel.LOW,
+    )
+    assert assessment.risk_level == RiskLevel.MEDIUM
+    assert assessment.auto_approve_eligible is False
+
+    # Loosen to HIGH: HIGH input now auto-approves.
+    assessment2 = assess_risk(
+        sensor_summary={"dominant_risk_level": "HIGH"},
+        pressure={},
+        auto_approve_max_risk=RiskLevel.HIGH,
+    )
+    assert assessment2.risk_level == RiskLevel.MEDIUM  # +2 score = MEDIUM band
+    assert assessment2.auto_approve_eligible is True
+
+
+def test_assess_risk_non_numeric_pressure_score_is_ignored():
+    assessment = assess_risk(
+        sensor_summary={},
+        pressure={"pressure_score": "high"},
+    )
+    # Non-numeric -> ignored, not crashed
+    assert assessment.risk_score == 0
+    assert assessment.risk_level == RiskLevel.LOW
+
+
+def test_risk_assessment_is_frozen():
+    assessment = assess_risk(sensor_summary={}, pressure={})
+    with pytest.raises(Exception):
+        assessment.risk_level = RiskLevel.CRITICAL  # type: ignore[misc]
+    with pytest.raises(Exception):
+        assessment.factors = ()  # type: ignore[misc]


### PR DESCRIPTION
Replaces closed [#113](https://github.com/canfieldjuan/ATLAS/pull/113), rebased onto current main.

## Summary

Lifts the deterministic content-scan and risk-assessment logic out of `atlas_brain/services/safety_gate.py` into a new `extracted_quality_gate/safety_gate.py`. The Atlas-side `SafetyGate` class delegates the pure functions to the core and keeps only the I/O surface (approval-store + audit-log + DB writes).

| File | Type | Purpose |
|---|---|---|
| `extracted_quality_gate/safety_gate.py` | NEW (~140 LOC) | `check_content` + `assess_risk`. Pure functions, no DB / clock / network. |
| `extracted_quality_gate/types.py` | EDIT | Add `ContentFlag`, `ContentScanResult`, `RiskAssessment`, `RiskLevel`. |
| `extracted_quality_gate/__init__.py` | EDIT | Re-export new core symbols. |
| `extracted_quality_gate/{manifest,README,STATUS}.md` | EDIT | Document the new file. |
| `atlas_brain/services/safety_gate.py` | EDIT | Delete duplicated pattern catalogue + scoring; import from core; convert frozen dataclasses to legacy dict shape so existing callers need no changes. |
| `tests/test_extracted_quality_gate_safety_scan.py` | NEW (17 tests) | content scan + risk assessment unit tests. |

## Public API preservation

`SafetyGate.check_content` and `SafetyGate.assess_risk` still return the same dicts they always did. Existing callers (`intervention_pipeline.py:312`, `api/intelligence.py`, `mcp/intelligence_server.py`) need no changes.

## Validation

```
$ pytest tests/test_extracted_quality_gate_safety_scan.py
17 passed in 0.06s

$ pytest tests/test_extracted_quality_gate_product_claim.py tests/test_extracted_quality_gate_safety_scan.py tests/test_product_claim_contract.py
171 passed in 2.15s   # 17 new + 154 existing, no regressions
```

## Coordination

- Owner `claude-2026-05-03-b` (alias A); claimed in `coordination/queue.md` and added to `coordination/inflight.md`.
- No file overlap with C's in-flight PR-C1d or codex's PR-D7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)