### PR TITLE
Drop PR-B3 row after #114 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T00:42Z by claude-2026-05-03-b
+Last updated: 2026-05-04T00:50Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1d, in flight) | PR-C1d: Slim `EvidenceEngine` core (conclusions + suppression) | NEW: `extracted_reasoning_core/evidence_engine.py` (conclusions + suppression surface only; per-review enrichment stays atlas-side until PR-C1e). EDIT: `extracted_reasoning_core/api.py` (wire `evaluate_evidence` stub). NEW: `tests/test_extracted_reasoning_core_evidence_engine.py`. | claude-2026-05-03 | `extracted_reasoning_core/evidence_engine.py`; `extracted_reasoning_core/api.py`; the new evidence-engine test file |
-| #114 | PR-B3: Safety-gate split (deterministic core + Atlas adapter) | NEW: `extracted_quality_gate/safety_gate.py` (pure `check_content` + `assess_risk`). EDIT: `extracted_quality_gate/{__init__.py, types.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/services/safety_gate.py` (delegate pure logic to core; preserve dict-returning public API). NEW: `tests/test_extracted_quality_gate_safety_scan.py` (17 tests). | claude-2026-05-03-b | `extracted_quality_gate/safety_gate.py`; `extracted_quality_gate/types.py` (touches `RiskLevel` / `ContentScanResult` / `RiskAssessment`); `atlas_brain/services/safety_gate.py`; the new safety-scan test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,14 +1,14 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T00:04Z by codex-2026-05-03
+Last updated: 2026-05-04T00:50Z by claude-2026-05-03-b
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b #106, PR-A4c #98.
+B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split). PR-B4 / PR-B5 remain.
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-B3 | `extracted_quality_gate` | claude-2026-05-03-b | PR-B2 / #85 (merged) | Safety-gate split: deterministic content/risk scan to core; approvals + audit log + DB to ports + Atlas adapter wrapper. |
 | PR-B4 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #114 (PR-B3 safety-gate split) merged in \`f3123ef67\`.

Also updates \`queue.md\` to record PR-B3 #114 in the B-series progress line and remove the now-completed PR-B3 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)