### PR TITLE
Drop PR-B4a row after #118 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T01:10Z by claude-2026-05-03-b
+Last updated: 2026-05-04T01:20Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1h, in flight) | PR-C1h: Route `extracted_content_pipeline/reasoning/archetypes.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/archetypes.py` (drop ~590-line drifted fork; replace with thin re-export wrapper from `extracted_reasoning_core.archetypes`). Existing `tests/test_extracted_reasoning_archetypes.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/archetypes.py`; `tests/test_extracted_reasoning_archetypes.py` |
-| (PR-B4a, in flight) | PR-B4a: Blog quality pack (deterministic core + Atlas adapter) | NEW: `extracted_quality_gate/blog_pack.py` (pure `evaluate_blog_post`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` (`_apply_blog_quality_gate` delegates to pack; helper `_required_vendor_names` added). NEW: `tests/test_extracted_quality_gate_blog_pack.py` (30 tests). | claude-2026-05-03-b | `extracted_quality_gate/blog_pack.py`; `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`; the new blog-pack test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,14 +1,14 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T00:50Z by claude-2026-05-03-b
+Last updated: 2026-05-04T01:20Z by claude-2026-05-03-b
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b #106, PR-A4c #98.
-B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split). PR-B4 / PR-B5 remain.
+B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack). PR-B4b (campaign pack) and PR-B5 remain.
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-B4 | `extracted_quality_gate` | claude-2026-05-03-b | PR-B2 / #85 (merged) | Blog + campaign quality packs over the core gate contract. Splitting into PR-B4a (blog pack, this owner) and PR-B4b (campaign pack, this owner). Specificity helpers stay atlas-side until PR-B5 per advisor scoping. |
+| PR-B4b | `extracted_quality_gate` | claude-2026-05-03-b | PR-B4a / #118 (merged) | Campaign quality pack over the core gate contract. Lifts the deterministic part of `campaign_policy_audit_snapshot` (proof-term matching, tier/target_mode policy, forbidden-term scanning) into `extracted_quality_gate/campaign_pack.py`. Atlas wrapper retains the specificity-resolution + DB-fallback I/O. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #118 (PR-B4a blog quality pack) merged. Also splits the queue.md PR-B4 row into the now-completed B4a (recorded as merged) and the next slice PR-B4b (campaign pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)