### PR TITLE
PR-B4b: Lift campaign quality validators into deterministic pack

### DIFF
--- a/atlas_brain/autonomous/tasks/_b2b_specificity.py
+++ b/atlas_brain/autonomous/tasks/_b2b_specificity.py
@@ -629,16 +629,28 @@ def campaign_policy_audit_snapshot(
     require_timing_or_numeric_when_available: bool = False,
     proof_term_limit: int = 3,
 ) -> dict[str, Any]:
+    """Atlas-side adapter for campaign quality validation.
+
+    The deterministic policy validators (proof-term coverage,
+    report-tier banned language, forbidden competitor / incumbent
+    names in cold email, private-account leak) live in
+    ``extracted_quality_gate.campaign_pack.evaluate_campaign``. This
+    wrapper:
+
+      * runs the atlas-side specificity audit
+      * resolves the campaign proof-terms (caller-provided override
+        / metadata fallback / regen-from-audit)
+      * builds a ``QualityInput`` with the audit's blocking issues
+        and warnings as pass-through context
+      * calls the pack
+      * merges the pack's findings with the rest of the legacy
+        ``audit`` dict so existing callers see the same shape.
+    """
+    from extracted_quality_gate.campaign_pack import evaluate_campaign
+    from extracted_quality_gate.types import QualityInput, QualityPolicy
+
     payload = campaign if isinstance(campaign, dict) else {}
     channel = str(payload.get("channel") or "").strip()
-    target_mode = str(payload.get("target_mode") or "").strip()
-    tier = str(payload.get("tier") or "").strip()
-    metadata = payload.get("metadata")
-    if isinstance(metadata, dict):
-        if not tier:
-            tier = str(metadata.get("tier") or "").strip()
-        if not target_mode:
-            target_mode = str(metadata.get("target_mode") or "").strip()
 
     audit = specificity_audit_snapshot(
         body,
@@ -651,9 +663,8 @@ def campaign_policy_audit_snapshot(
         require_timing_or_numeric_when_available=require_timing_or_numeric_when_available,
         include_competitor_terms=channel != "email_cold",
     )
-    blocking_issues = list(audit.get("blocking_issues") or [])
-    warnings = list(audit.get("warnings") or [])
 
+    # Resolve proof terms with the same fallback chain as the legacy.
     proof_terms = _dedupe_strings(
         [str(term or "").strip() for term in (campaign_proof_terms or []) if str(term or "").strip()]
     )
@@ -672,59 +683,31 @@ def campaign_policy_audit_snapshot(
             limit=proof_term_limit,
         )
 
-    normalized_body = _normalize_text(body)
-    normalized_message = _normalize_text(" ".join(part for part in (subject, body, cta) if part))
-    normalized_report = _normalize_text(" ".join(part for part in (body, cta) if part))
-    used_proof_terms = [
-        term for term in proof_terms if _contains_term(normalized_body, term)
-    ]
+    pack_input = QualityInput(
+        artifact_type="campaign_email",
+        artifact_id=None,
+        content=body,
+        context={
+            "subject": subject,
+            "body": body,
+            "cta": cta,
+            "campaign": payload,
+            "required_proof_terms": tuple(proof_terms),
+            "anchor_examples": anchor_examples or {},
+            "witness_highlights": tuple(witness_highlights or ()),
+            "specificity_blocking_issues": tuple(audit.get("blocking_issues") or ()),
+            "specificity_warnings": tuple(audit.get("warnings") or ()),
+        },
+    )
+    pack_policy = QualityPolicy(
+        name="campaign_email",
+        thresholds={"require_anchor_support": require_anchor_support},
+    )
+    pack_report = evaluate_campaign(pack_input, policy=pack_policy)
 
-    if proof_terms and require_anchor_support and (anchor_examples or witness_highlights):
-        if not used_proof_terms:
-            blocking_issues.append("missing_exact_proof_term")
-
-    if tier.lower() == "report":
-        report_match = _REPORT_TIER_BANNED.search(normalized_report)
-        if report_match:
-            blocking_issues.append(f"report_tier_language:{report_match.group(1)}")
-
-    forbidden_label = ""
-    forbidden_terms: list[str] = []
-    if channel == "email_cold":
-        if target_mode == "vendor_retention":
-            forbidden_label = "competitor_name_in_email_cold"
-            forbidden_terms.extend(
-                _campaign_name_terms(_campaign_collection(payload, "competitors_considering"))
-            )
-            signal_summary = payload.get("signal_summary")
-            if isinstance(signal_summary, dict):
-                forbidden_terms.extend(
-                    _campaign_name_terms(signal_summary.get("competitor_distribution"))
-                )
-        elif target_mode == "challenger_intel":
-            forbidden_label = "incumbent_name_in_email_cold"
-            forbidden_terms.extend(
-                _campaign_name_terms(_campaign_collection(payload, "competitors_considering"))
-            )
-            signal_summary = payload.get("signal_summary")
-            if isinstance(signal_summary, dict):
-                forbidden_terms.extend(
-                    _campaign_name_terms(signal_summary.get("incumbents_losing"))
-                )
-            incumbent_archetypes = payload.get("incumbent_archetypes")
-            if isinstance(incumbent_archetypes, dict):
-                for rows in incumbent_archetypes.values():
-                    forbidden_terms.extend(_campaign_name_terms(rows))
-    for term in _dedupe_strings(forbidden_terms):
-        if _contains_term(normalized_message, term):
-            blocking_issues.append(f"{forbidden_label}:{term}")
-
-    for company in _campaign_private_company_terms(anchor_examples, witness_highlights):
-        if _contains_term(normalized_message, company):
-            blocking_issues.append(f"private_account_name_leak:{company}")
-
-    deduped_blockers = _dedupe_strings(blocking_issues)
-    deduped_warnings = _dedupe_strings(warnings)
+    deduped_blockers = list(pack_report.metadata.get("blocking_issues") or ())
+    deduped_warnings = list(pack_report.metadata.get("warnings") or ())
+    used_proof_terms = list(pack_report.metadata.get("used_proof_terms") or ())
     return {
         **audit,
         "status": "fail" if deduped_blockers else "pass",

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T01:10Z by claude-2026-05-03-b
+Last updated: 2026-05-04T01:30Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1h, in flight) | PR-C1h: Route `extracted_content_pipeline/reasoning/archetypes.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/archetypes.py` (drop ~590-line drifted fork; replace with thin re-export wrapper from `extracted_reasoning_core.archetypes`). Existing `tests/test_extracted_reasoning_archetypes.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/archetypes.py`; `tests/test_extracted_reasoning_archetypes.py` |
-| (PR-B4a, in flight) | PR-B4a: Blog quality pack (deterministic core + Atlas adapter) | NEW: `extracted_quality_gate/blog_pack.py` (pure `evaluate_blog_post`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` (`_apply_blog_quality_gate` delegates to pack; helper `_required_vendor_names` added). NEW: `tests/test_extracted_quality_gate_blog_pack.py` (30 tests). | claude-2026-05-03-b | `extracted_quality_gate/blog_pack.py`; `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`; the new blog-pack test file |
+| (PR-B4b, in flight) | PR-B4b: Campaign quality pack (deterministic core + Atlas adapter) | NEW: `extracted_quality_gate/campaign_pack.py` (pure `evaluate_campaign`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/autonomous/tasks/_b2b_specificity.py` (`campaign_policy_audit_snapshot` delegates to pack; legacy proof-term resolution + audit dict shape preserved). NEW: `tests/test_extracted_quality_gate_campaign_pack.py` (27 tests). | claude-2026-05-03-b | `extracted_quality_gate/campaign_pack.py`; `atlas_brain/autonomous/tasks/_b2b_specificity.py`; the new campaign-pack test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_quality_gate/README.md
+++ b/extracted_quality_gate/README.md
@@ -11,6 +11,8 @@ The package contains:
 - a policy registry for claim-type-specific thresholds
 - generic quality-report types and integration ports
 - deterministic safety-gate primitives (`check_content`, `assess_risk`)
+- deterministic blog quality pack (`evaluate_blog_post`)
+- deterministic campaign quality pack (`evaluate_campaign`)
 
 The package intentionally has no Atlas runtime dependency. Product-specific behavior belongs in packs or adapters layered on top of the public API.
 
@@ -27,12 +29,14 @@ from extracted_quality_gate.safety_gate import (
     check_content,
 )
 from extracted_quality_gate.blog_pack import evaluate_blog_post
+from extracted_quality_gate.campaign_pack import evaluate_campaign
 ```
 
 Products should import from:
 
 - `extracted_quality_gate.api`
 - `extracted_quality_gate.blog_pack`
+- `extracted_quality_gate.campaign_pack`
 - `extracted_quality_gate.safety_gate`
 - `extracted_quality_gate.types`
 - `extracted_quality_gate.ports`
@@ -74,3 +78,25 @@ The wrapper at `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py:_apply_
 sanitizes, builds the input, calls the pack, then layers the
 specificity findings on top. Public dict shape is preserved so existing
 call sites need no changes.
+
+## Campaign quality pack (PR-B4b)
+
+`campaign_pack.evaluate_campaign` is a pure validator over a
+`QualityInput` (subject, body, CTA, the campaign payload) and a
+`QualityPolicy` (currently just `require_anchor_support`). It returns
+a `QualityReport` whose `findings` enumerate every gate that fired:
+proof-term coverage (`missing_exact_proof_term`), report-tier banned
+language (`report_tier_language:<word>`), forbidden competitor name in
+cold email (`competitor_name_in_email_cold:<vendor>`), forbidden
+incumbent name in challenger-intel cold email
+(`incumbent_name_in_email_cold:<vendor>`), and private-account leak
+(`private_account_name_leak:<company>`).
+
+The atlas-side specificity audit stays in the wrapper -- the wrapper
+runs `specificity_audit_snapshot` first, passes its blocking issues
+and warnings into the pack as `context['specificity_blocking_issues']`
+/ `context['specificity_warnings']`, and the pack appends its own
+findings. The wrapper at
+`atlas_brain/autonomous/tasks/_b2b_specificity.py:campaign_policy_audit_snapshot`
+returns the same dict shape it always did, so the existing caller in
+`atlas_brain/services/campaign_quality.py` needs no changes.

--- a/extracted_quality_gate/STATUS.md
+++ b/extracted_quality_gate/STATUS.md
@@ -4,7 +4,21 @@ Date: 2026-05-03
 
 ## Current Slice
 
-PR-B4a: blog quality pack.
+PR-B4b: campaign quality pack.
+
+- Deterministic core (`campaign_pack.py`) -- `evaluate_campaign(input, *, policy)`
+  returning a `QualityReport`. Validates proof-term coverage,
+  report-tier banned language, forbidden competitor / incumbent names
+  in cold email (channel + target_mode gated), and private account-name
+  leak detection. Specificity findings are passed through from the
+  Atlas-side audit so the report carries one merged blocking-issues
+  list.
+- Atlas-side wrapper (`atlas_brain/autonomous/tasks/_b2b_specificity.py:campaign_policy_audit_snapshot`)
+  now runs the specificity audit, resolves proof terms, builds a
+  `QualityInput`/`QualityPolicy`, calls the pack, and merges the pack
+  findings with the audit dict so callers see the legacy shape.
+
+PR-B4a (merged via #118): blog quality pack.
 
 - Deterministic core (`blog_pack.py`) -- `evaluate_blog_post(input, *, policy)`
   returning a `QualityReport`. Validates word count, chart placeholders,
@@ -46,6 +60,7 @@ The module is deterministic and imports without Atlas.
 - Integration port protocols
 - Safety gate (deterministic core: `check_content` + `assess_risk`) -- PR-B3
 - Blog quality pack (deterministic core: `evaluate_blog_post`) -- PR-B4a
+- Campaign quality pack (deterministic core: `evaluate_campaign`) -- PR-B4b
 
 ## Not Yet Included
 
@@ -53,7 +68,6 @@ The module is deterministic and imports without Atlas.
   in `atlas_brain/services/safety_gate.py`; the deterministic core
   is now in `extracted_quality_gate/safety_gate.py` and the wrapper
   delegates to it -- but the wrapper itself is not yet extracted)
-- Campaign quality pack (PR-B4b)
 - Witness render policy pack (PR-B5)
 - Evidence-claim coverage pack (PR-B5)
 - Source-quality ingest pack (PR-B5)

--- a/extracted_quality_gate/__init__.py
+++ b/extracted_quality_gate/__init__.py
@@ -30,6 +30,7 @@ from .api import (
     reset_policy_registry,
 )
 from .blog_pack import evaluate_blog_post
+from .campaign_pack import evaluate_campaign
 from .safety_gate import assess_risk, check_content
 from .types import (
     ContentFlag,
@@ -61,6 +62,7 @@ __all__ = [
     "build_product_claim",
     "check_content",
     "evaluate_blog_post",
+    "evaluate_campaign",
     "compute_claim_id",
     "decide_render_gates",
     "derive_confidence",

--- a/extracted_quality_gate/campaign_pack.py
+++ b/extracted_quality_gate/campaign_pack.py
@@ -1,0 +1,425 @@
+"""Campaign quality pack: deterministic validators for outbound campaigns.
+
+Owned by ``extracted_quality_gate`` (PR-B4b). The single public entry
+point ``evaluate_campaign`` is pure: no DB, no clock, no network. It
+takes a :class:`QualityInput` (subject + body + cta in
+``content``/``context``) and a campaign payload in ``context`` and
+returns a :class:`QualityReport`.
+
+Specificity audit (witness anchor support, evidence coverage) stays
+Atlas-side -- per the PR-B5 framing, that ships as its own pack
+later. The Atlas wrapper runs ``specificity_audit_snapshot`` first
+and passes its output (blocking issues, warnings) to this pack as
+``context['specificity_blocking_issues']`` / ``context['specificity_warnings']``;
+the pack appends its own findings.
+
+Pack scope:
+
+  * Proof-term coverage: each ``required_proof_terms`` entry must
+    appear in the body (case-insensitive whole-token match). Missing
+    terms add a single ``missing_exact_proof_term`` blocker (only
+    when ``require_anchor_support`` is True and anchors / witnesses
+    are available -- otherwise enforcement falls back to specificity).
+  * Report-tier banned language: if ``campaign.tier == "report"``,
+    the body+CTA cannot use words like "dashboard", "live feed",
+    "free trial", "software", "platform" -- those are product-tier
+    language, not analyst-report language.
+  * Forbidden terms: cold-email channels cannot name
+    competitors / incumbents the recipient already knows, gated by
+    ``campaign.target_mode``. ``vendor_retention`` blocks
+    competitor names; ``challenger_intel`` blocks incumbent names.
+  * Private account name leak: anchor / witness data may surface
+    ``reviewer_company`` strings; if any of them appear in the
+    outbound message, that is a confidentiality breach.
+
+Public API:
+
+    evaluate_campaign(
+        input: QualityInput,
+        *,
+        policy: QualityPolicy | None = None,
+    ) -> QualityReport
+
+Recognised ``input.context`` keys:
+
+  * ``subject``: str
+  * ``body``: str (body markdown / plain)
+  * ``cta``: str
+  * ``campaign``: dict -- payload with ``channel``, ``target_mode``,
+    ``tier``, ``metadata``, ``signal_summary``, ``competitors_considering``,
+    ``incumbent_archetypes`` (matches the legacy ``campaign`` arg
+    of ``campaign_policy_audit_snapshot``).
+  * ``required_proof_terms``: tuple[str, ...] (caller-resolved).
+  * ``anchor_examples``: dict[str, list[dict]]
+  * ``witness_highlights``: tuple[dict, ...]
+  * ``specificity_blocking_issues``: tuple[str, ...] (from atlas-side
+    audit; the pack passes them through into the legacy report shape)
+  * ``specificity_warnings``: tuple[str, ...] (likewise)
+
+Recognised ``policy.thresholds`` keys (all optional):
+
+  * ``require_anchor_support``: bool (default True)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from .types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_REPORT_TIER_BANNED = re.compile(
+    r"\b(dashboard|live feed|free trial|software|platform)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalize_text(value: Any) -> str:
+    """Strip HTML, lowercase, collapse whitespace.
+
+    Mirrors the legacy ``_normalize_text`` in
+    ``atlas_brain.autonomous.tasks._b2b_specificity`` so the pack
+    behaves identically on the same inputs.
+    """
+    text = _HTML_TAG_RE.sub(" ", str(value or ""))
+    text = text.lower()
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _contains_term(normalized_text: str, term: str) -> bool:
+    """Whole-token match (no embedded substring matches)."""
+    clean_term = _normalize_text(term)
+    if not normalized_text or not clean_term:
+        return False
+    pattern = re.compile(
+        r"(?<![a-z0-9])" + re.escape(clean_term) + r"(?![a-z0-9])"
+    )
+    return bool(pattern.search(normalized_text))
+
+
+def _dedupe_strings(values: Sequence[str]) -> list[str]:
+    """Stable de-dup by lowercase marker. Mirrors the legacy helper."""
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        marker = str(value or "").strip().lower()
+        if not marker or marker in seen:
+            continue
+        seen.add(marker)
+        resolved.append(str(value).strip())
+    return resolved
+
+
+def _campaign_collection(payload: Mapping[str, Any], key: str) -> Any:
+    """Read ``payload[key]`` with metadata-fallback semantics."""
+    value = payload.get(key)
+    if value not in (None, "", [], {}):
+        return value
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    return None
+
+
+def _campaign_name_terms(value: Any) -> list[str]:
+    """Extract vendor / incumbent / alternative names from a payload section."""
+    terms: list[str] = []
+    seen: set[str] = set()
+    rows: list[Any] = []
+    if isinstance(value, list):
+        rows = list(value)
+    elif isinstance(value, dict):
+        rows = [value]
+
+    for row in rows:
+        name = ""
+        if isinstance(row, dict):
+            for key in ("name", "vendor_name", "incumbent_vendor", "alternative_vendor"):
+                candidate = str(row.get(key) or "").strip()
+                if candidate:
+                    name = candidate
+                    break
+        else:
+            name = str(row or "").strip()
+        marker = _normalize_text(name)
+        if not marker or marker in seen:
+            continue
+        seen.add(marker)
+        terms.append(name)
+    return terms
+
+
+def _campaign_private_company_terms(
+    anchor_examples: Mapping[str, Sequence[Mapping[str, Any]]] | None,
+    witness_highlights: Sequence[Mapping[str, Any]] | None,
+) -> list[str]:
+    """Surface private ``reviewer_company`` strings that must not leak."""
+    terms: list[str] = []
+    seen: set[str] = set()
+    rows: list[Mapping[str, Any]] = []
+    for group_rows in (anchor_examples or {}).values():
+        rows.extend(group_rows or ())
+    rows.extend(witness_highlights or ())
+    for row in rows:
+        company = str(row.get("reviewer_company") or "").strip()
+        marker = _normalize_text(company)
+        if not marker or marker in seen:
+            continue
+        seen.add(marker)
+        terms.append(company)
+    return terms
+
+
+def evaluate_campaign(
+    input: QualityInput,
+    *,
+    policy: QualityPolicy | None = None,
+) -> QualityReport:
+    """Run the deterministic campaign-quality validators.
+
+    Returns a :class:`QualityReport`. ``decision`` is:
+
+      * ``BLOCK`` when any blocker fires (proof-term gap, banned
+        report-tier word, forbidden competitor/incumbent name in
+        cold email, private company leak, or any specificity
+        blocker passed in via context).
+      * ``WARN`` when only specificity warnings flow through.
+      * ``PASS`` otherwise.
+
+    The report's ``metadata`` mirrors the legacy
+    ``campaign_policy_audit_snapshot`` dict shape so Atlas-side
+    callers can preserve their existing telemetry.
+    """
+    context = dict(input.context or {})
+    subject = str(context.get("subject") or "")
+    body = str(context.get("body") or input.content or "")
+    cta = str(context.get("cta") or "")
+    payload: Mapping[str, Any] = context.get("campaign") or {}
+
+    # Channel / target_mode / tier with metadata fallback (matches legacy)
+    channel = str(payload.get("channel") or "").strip()
+    target_mode = str(payload.get("target_mode") or "").strip()
+    tier = str(payload.get("tier") or "").strip()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        if not tier:
+            tier = str(metadata.get("tier") or "").strip()
+        if not target_mode:
+            target_mode = str(metadata.get("target_mode") or "").strip()
+
+    # Proof-term policy switch.
+    require_anchor_support = True
+    if policy is not None:
+        threshold = policy.thresholds.get("require_anchor_support")
+        if isinstance(threshold, bool):
+            require_anchor_support = threshold
+
+    findings: list[GateFinding] = []
+
+    # ---- Specificity audit pass-through (atlas computes; pack mirrors) ----
+    specificity_blockers = tuple(
+        str(issue).strip()
+        for issue in (context.get("specificity_blocking_issues") or ())
+        if str(issue or "").strip()
+    )
+    specificity_warnings = tuple(
+        str(warning).strip()
+        for warning in (context.get("specificity_warnings") or ())
+        if str(warning or "").strip()
+    )
+    for issue in specificity_blockers:
+        findings.append(
+            GateFinding(
+                code="specificity_audit_blocker",
+                message=issue,
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+    for warning in specificity_warnings:
+        findings.append(
+            GateFinding(
+                code="specificity_audit_warning",
+                message=warning,
+                severity=GateSeverity.WARNING,
+            )
+        )
+
+    # ---- Proof-term coverage ----
+    required_proof_terms = _dedupe_strings(
+        list(context.get("required_proof_terms") or ())
+    )
+    normalized_body = _normalize_text(body)
+    used_proof_terms = [
+        term for term in required_proof_terms if _contains_term(normalized_body, term)
+    ]
+    anchor_examples = context.get("anchor_examples")
+    witness_highlights = context.get("witness_highlights") or ()
+    has_anchor_or_witness = bool(anchor_examples) or bool(witness_highlights)
+    if (
+        required_proof_terms
+        and require_anchor_support
+        and has_anchor_or_witness
+        and not used_proof_terms
+    ):
+        findings.append(
+            GateFinding(
+                code="missing_exact_proof_term",
+                message="missing_exact_proof_term",
+                severity=GateSeverity.BLOCKER,
+                metadata={"required_proof_terms": tuple(required_proof_terms)},
+            )
+        )
+
+    # ---- Report-tier banned language (body + CTA only; subject is exempt) ----
+    normalized_report = _normalize_text(" ".join(part for part in (body, cta) if part))
+    if tier.lower() == "report":
+        report_match = _REPORT_TIER_BANNED.search(normalized_report)
+        if report_match:
+            findings.append(
+                GateFinding(
+                    code="report_tier_language",
+                    message=f"report_tier_language:{report_match.group(1)}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"banned_word": report_match.group(1)},
+                )
+            )
+
+    # ---- Forbidden terms in cold email ----
+    normalized_message = _normalize_text(
+        " ".join(part for part in (subject, body, cta) if part)
+    )
+    forbidden_label, forbidden_terms = _resolve_forbidden_terms(
+        channel=channel, target_mode=target_mode, payload=payload
+    )
+    for term in _dedupe_strings(forbidden_terms):
+        if _contains_term(normalized_message, term):
+            findings.append(
+                GateFinding(
+                    code=forbidden_label,
+                    message=f"{forbidden_label}:{term}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"term": term},
+                )
+            )
+
+    # ---- Private account name leak ----
+    private_terms = _campaign_private_company_terms(
+        anchor_examples if isinstance(anchor_examples, Mapping) else None,
+        witness_highlights,
+    )
+    for company in private_terms:
+        if _contains_term(normalized_message, company):
+            findings.append(
+                GateFinding(
+                    code="private_account_name_leak",
+                    message=f"private_account_name_leak:{company}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"company": company},
+                )
+            )
+
+    return _build_report(
+        findings=findings,
+        required_proof_terms=required_proof_terms,
+        used_proof_terms=used_proof_terms,
+    )
+
+
+def _resolve_forbidden_terms(
+    *,
+    channel: str,
+    target_mode: str,
+    payload: Mapping[str, Any],
+) -> tuple[str, list[str]]:
+    """Resolve the forbidden-term label + list for the (channel, target_mode) pair.
+
+    Only ``email_cold`` is gated today. ``vendor_retention`` blocks
+    competitor names; ``challenger_intel`` blocks incumbent names.
+    Other channel/target_mode combos return an empty list.
+    """
+    if channel != "email_cold":
+        return ("", [])
+
+    forbidden_terms: list[str] = []
+    if target_mode == "vendor_retention":
+        label = "competitor_name_in_email_cold"
+        forbidden_terms.extend(
+            _campaign_name_terms(_campaign_collection(payload, "competitors_considering"))
+        )
+        signal_summary = payload.get("signal_summary")
+        if isinstance(signal_summary, dict):
+            forbidden_terms.extend(
+                _campaign_name_terms(signal_summary.get("competitor_distribution"))
+            )
+        return (label, forbidden_terms)
+
+    if target_mode == "challenger_intel":
+        label = "incumbent_name_in_email_cold"
+        forbidden_terms.extend(
+            _campaign_name_terms(_campaign_collection(payload, "competitors_considering"))
+        )
+        signal_summary = payload.get("signal_summary")
+        if isinstance(signal_summary, dict):
+            forbidden_terms.extend(
+                _campaign_name_terms(signal_summary.get("incumbents_losing"))
+            )
+        incumbent_archetypes = payload.get("incumbent_archetypes")
+        if isinstance(incumbent_archetypes, dict):
+            for rows in incumbent_archetypes.values():
+                forbidden_terms.extend(_campaign_name_terms(rows))
+        return (label, forbidden_terms)
+
+    return ("", [])
+
+
+def _build_report(
+    *,
+    findings: list[GateFinding],
+    required_proof_terms: list[str],
+    used_proof_terms: list[str],
+) -> QualityReport:
+    blockers = [f for f in findings if f.severity == GateSeverity.BLOCKER]
+    warnings = [f for f in findings if f.severity == GateSeverity.WARNING]
+
+    if blockers:
+        decision = GateDecision.BLOCK
+    elif warnings:
+        decision = GateDecision.WARN
+    else:
+        decision = GateDecision.PASS
+
+    blocking_messages = _dedupe_strings([f.message for f in blockers])
+    warning_messages = _dedupe_strings([f.message for f in warnings])
+    metadata = {
+        "status": "fail" if blocking_messages else "pass",
+        "blocking_issues": tuple(blocking_messages),
+        "warnings": tuple(warning_messages),
+        "campaign_proof_terms": tuple(required_proof_terms),
+        "required_proof_terms": tuple(required_proof_terms),
+        "used_proof_terms": tuple(used_proof_terms),
+        "unused_proof_terms": tuple(
+            term for term in required_proof_terms if term not in used_proof_terms
+        ),
+        "primary_blocker": blocking_messages[0] if blocking_messages else None,
+    }
+    return QualityReport(
+        passed=not blocking_messages,
+        decision=decision,
+        findings=tuple(findings),
+        metadata=metadata,
+    )
+
+
+__all__ = [
+    "evaluate_campaign",
+]

--- a/extracted_quality_gate/manifest.json
+++ b/extracted_quality_gate/manifest.json
@@ -16,6 +16,9 @@
       "target": "extracted_quality_gate/blog_pack.py"
     },
     {
+      "target": "extracted_quality_gate/campaign_pack.py"
+    },
+    {
       "target": "extracted_quality_gate/ports.py"
     },
     {

--- a/tests/test_extracted_quality_gate_campaign_pack.py
+++ b/tests/test_extracted_quality_gate_campaign_pack.py
@@ -1,0 +1,410 @@
+"""Tests for extracted_quality_gate.campaign_pack.evaluate_campaign.
+
+The function under test is pure: no DB, no clock, no network. Pure
+unit tests, no fixtures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from extracted_quality_gate.campaign_pack import evaluate_campaign
+from extracted_quality_gate.types import (
+    GateDecision,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+def _input(
+    *,
+    subject: str = "Test subject",
+    body: str = "Test body",
+    cta: str = "Reply YES",
+    campaign: dict | None = None,
+    required_proof_terms: tuple = (),
+    anchor_examples: dict | None = None,
+    witness_highlights: tuple = (),
+    specificity_blocking_issues: tuple = (),
+    specificity_warnings: tuple = (),
+) -> QualityInput:
+    return QualityInput(
+        artifact_type="campaign_email",
+        artifact_id="test-campaign",
+        content=body,
+        context={
+            "subject": subject,
+            "body": body,
+            "cta": cta,
+            "campaign": campaign or {},
+            "required_proof_terms": required_proof_terms,
+            "anchor_examples": anchor_examples or {},
+            "witness_highlights": witness_highlights,
+            "specificity_blocking_issues": specificity_blocking_issues,
+            "specificity_warnings": specificity_warnings,
+        },
+    )
+
+
+# ---- Decision shape ----
+
+
+def test_returns_quality_report():
+    report = evaluate_campaign(_input())
+    assert isinstance(report, QualityReport)
+
+
+def test_clean_input_passes():
+    report = evaluate_campaign(_input())
+    assert report.passed is True
+    assert report.decision == GateDecision.PASS
+    assert report.findings == ()
+
+
+def test_metadata_mirrors_legacy_dict_shape():
+    report = evaluate_campaign(_input())
+    md = report.metadata
+    assert md["status"] == "pass"
+    assert md["blocking_issues"] == ()
+    assert md["warnings"] == ()
+    assert "campaign_proof_terms" in md
+    assert "required_proof_terms" in md
+    assert "used_proof_terms" in md
+    assert "unused_proof_terms" in md
+    assert md["primary_blocker"] is None
+
+
+# ---- Specificity pass-through ----
+
+
+def test_specificity_blockers_pass_through_as_blockers():
+    report = evaluate_campaign(
+        _input(specificity_blocking_issues=("missing_anchor_support",))
+    )
+    assert report.decision == GateDecision.BLOCK
+    assert "missing_anchor_support" in report.metadata["blocking_issues"]
+
+
+def test_specificity_warnings_pass_through_as_warnings():
+    report = evaluate_campaign(
+        _input(specificity_warnings=("anchor_count_below_target",))
+    )
+    assert report.decision == GateDecision.WARN
+    assert "anchor_count_below_target" in report.metadata["warnings"]
+
+
+# ---- Proof-term coverage ----
+
+
+def test_missing_required_proof_term_blocks_when_anchors_present():
+    body = "We saw improvements after switching."
+    report = evaluate_campaign(
+        _input(
+            body=body,
+            required_proof_terms=("dashboard refresh time",),
+            anchor_examples={"primary": [{"phrase": "anchor"}]},
+        )
+    )
+    assert report.decision == GateDecision.BLOCK
+    assert "missing_exact_proof_term" in report.metadata["blocking_issues"]
+
+
+def test_proof_term_present_does_not_block():
+    body = "Customers report dashboard refresh time dropped 40%."
+    report = evaluate_campaign(
+        _input(
+            body=body,
+            required_proof_terms=("dashboard refresh time",),
+            anchor_examples={"primary": [{"phrase": "anchor"}]},
+        )
+    )
+    assert "missing_exact_proof_term" not in report.metadata["blocking_issues"]
+    assert "dashboard refresh time" in report.metadata["used_proof_terms"]
+
+
+def test_no_anchors_no_witnesses_does_not_enforce_proof_terms():
+    # Without anchor_examples or witness_highlights, the proof-term gate
+    # falls back to specificity (caller's responsibility) and the pack
+    # does not block here.
+    report = evaluate_campaign(
+        _input(
+            body="Generic message",
+            required_proof_terms=("dashboard refresh time",),
+        )
+    )
+    assert "missing_exact_proof_term" not in report.metadata["blocking_issues"]
+
+
+def test_require_anchor_support_disabled_skips_proof_term_gate():
+    # Even with anchors present, policy can disable the gate.
+    policy = QualityPolicy(
+        name="campaign_email",
+        thresholds={"require_anchor_support": False},
+    )
+    report = evaluate_campaign(
+        _input(
+            body="Generic message",
+            required_proof_terms=("dashboard refresh time",),
+            anchor_examples={"primary": [{"phrase": "anchor"}]},
+        ),
+        policy=policy,
+    )
+    assert "missing_exact_proof_term" not in report.metadata["blocking_issues"]
+
+
+# ---- Report tier banned language ----
+
+
+def test_report_tier_blocks_dashboard():
+    body = "Get the dashboard your team needs to compete."
+    report = evaluate_campaign(
+        _input(body=body, campaign={"tier": "report"})
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any(b.startswith("report_tier_language:") for b in blockers)
+
+
+def test_report_tier_blocks_free_trial():
+    body = "Sign up for our free trial today."
+    report = evaluate_campaign(
+        _input(body=body, campaign={"tier": "report"})
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("free trial" in b for b in blockers)
+
+
+def test_non_report_tier_allows_dashboard():
+    body = "Get the dashboard your team needs to compete."
+    report = evaluate_campaign(
+        _input(body=body, campaign={"tier": "outreach"})
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert not any(b.startswith("report_tier_language:") for b in blockers)
+
+
+def test_subject_is_exempt_from_report_tier_check():
+    # The legacy pack only scans body+CTA, not subject.
+    report = evaluate_campaign(
+        _input(
+            subject="Your dashboard insights",
+            body="Generic insight content.",
+            cta="Reply",
+            campaign={"tier": "report"},
+        )
+    )
+    assert not any(
+        b.startswith("report_tier_language:")
+        for b in report.metadata["blocking_issues"]
+    )
+
+
+def test_tier_falls_back_to_metadata():
+    body = "Use the dashboard to monitor."
+    report = evaluate_campaign(
+        _input(body=body, campaign={"metadata": {"tier": "report"}})
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any(b.startswith("report_tier_language:") for b in blockers)
+
+
+# ---- Forbidden competitor names in cold email ----
+
+
+def test_competitor_name_in_vendor_retention_cold_email_blocks():
+    report = evaluate_campaign(
+        _input(
+            body="Your team is also evaluating Acme.",
+            campaign={
+                "channel": "email_cold",
+                "target_mode": "vendor_retention",
+                "competitors_considering": [{"vendor_name": "Acme"}],
+            },
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("competitor_name_in_email_cold" in b and "Acme" in b for b in blockers)
+
+
+def test_competitor_name_pulled_from_signal_summary():
+    report = evaluate_campaign(
+        _input(
+            body="Your team is also evaluating Acme.",
+            campaign={
+                "channel": "email_cold",
+                "target_mode": "vendor_retention",
+                "signal_summary": {
+                    "competitor_distribution": [{"vendor_name": "Acme"}]
+                },
+            },
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("competitor_name_in_email_cold" in b and "Acme" in b for b in blockers)
+
+
+def test_incumbent_name_in_challenger_intel_blocks():
+    report = evaluate_campaign(
+        _input(
+            body="Switch from Acme to a faster solution.",
+            campaign={
+                "channel": "email_cold",
+                "target_mode": "challenger_intel",
+                "signal_summary": {
+                    "incumbents_losing": [{"vendor_name": "Acme"}]
+                },
+            },
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("incumbent_name_in_email_cold" in b and "Acme" in b for b in blockers)
+
+
+def test_incumbent_pulled_from_archetypes_dict():
+    report = evaluate_campaign(
+        _input(
+            body="Switch from Acme to a faster solution.",
+            campaign={
+                "channel": "email_cold",
+                "target_mode": "challenger_intel",
+                "incumbent_archetypes": {
+                    "category_dominant": [{"name": "Acme"}],
+                },
+            },
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("incumbent_name_in_email_cold" in b and "Acme" in b for b in blockers)
+
+
+def test_warm_email_does_not_enforce_forbidden_terms():
+    # Only cold email is gated.
+    report = evaluate_campaign(
+        _input(
+            body="Your team is also evaluating Acme.",
+            campaign={
+                "channel": "email_warm",
+                "target_mode": "vendor_retention",
+                "competitors_considering": [{"vendor_name": "Acme"}],
+            },
+        )
+    )
+    assert all(
+        "competitor_name_in_email_cold" not in b
+        for b in report.metadata["blocking_issues"]
+    )
+
+
+# ---- Private account name leak ----
+
+
+def test_anchor_company_leak_blocks():
+    report = evaluate_campaign(
+        _input(
+            body="See what GhostCo's team did to fix this.",
+            anchor_examples={
+                "primary": [
+                    {
+                        "phrase": "anchor phrase",
+                        "reviewer_company": "GhostCo",
+                    }
+                ]
+            },
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("private_account_name_leak" in b and "GhostCo" in b for b in blockers)
+
+
+def test_witness_company_leak_blocks():
+    report = evaluate_campaign(
+        _input(
+            body="See what GhostCo's team did.",
+            witness_highlights=({"reviewer_company": "GhostCo"},),
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("private_account_name_leak" in b and "GhostCo" in b for b in blockers)
+
+
+def test_company_not_in_message_does_not_block():
+    report = evaluate_campaign(
+        _input(
+            body="Generic outbound copy without specific names.",
+            witness_highlights=({"reviewer_company": "GhostCo"},),
+        )
+    )
+    assert all(
+        "private_account_name_leak" not in b
+        for b in report.metadata["blocking_issues"]
+    )
+
+
+# ---- Token boundary correctness ----
+
+
+def test_contains_term_uses_token_boundaries():
+    # "Acme" should not match "Acmecorp" — whole-token match only.
+    report = evaluate_campaign(
+        _input(
+            body="We integrate with Acmecorp's API.",
+            campaign={
+                "channel": "email_cold",
+                "target_mode": "vendor_retention",
+                "competitors_considering": [{"vendor_name": "Acme"}],
+            },
+        )
+    )
+    assert all(
+        "competitor_name_in_email_cold" not in b
+        for b in report.metadata["blocking_issues"]
+    )
+
+
+# ---- HTML stripping in body normalization ----
+
+
+def test_html_tags_stripped_from_body_for_matching():
+    # The legacy normalizer strips HTML before matching.
+    report = evaluate_campaign(
+        _input(
+            body="<p>We integrate with <b>Acme</b> APIs.</p>",
+            campaign={
+                "channel": "email_cold",
+                "target_mode": "vendor_retention",
+                "competitors_considering": [{"vendor_name": "Acme"}],
+            },
+        )
+    )
+    blockers = report.metadata["blocking_issues"]
+    assert any("competitor_name_in_email_cold" in b and "Acme" in b for b in blockers)
+
+
+# ---- Decision aggregation ----
+
+
+def test_blockers_take_precedence_over_warnings():
+    report = evaluate_campaign(
+        _input(
+            specificity_blocking_issues=("hard_failure",),
+            specificity_warnings=("soft_warning",),
+        )
+    )
+    assert report.decision == GateDecision.BLOCK
+
+
+def test_only_warnings_returns_warn():
+    report = evaluate_campaign(
+        _input(specificity_warnings=("soft_warning",))
+    )
+    assert report.decision == GateDecision.WARN
+
+
+# ---- Frozen output ----
+
+
+def test_quality_report_is_frozen():
+    report = evaluate_campaign(_input())
+    with pytest.raises(Exception):
+        report.passed = False  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Completes the PR-B4 split (after PR-B4a #118). Lifts the deterministic part of `campaign_policy_audit_snapshot` into a new `extracted_quality_gate/campaign_pack.py`.

| File | Type | Purpose |
|---|---|---|
| `extracted_quality_gate/campaign_pack.py` | NEW (~330 LOC) | `evaluate_campaign(input, *, policy)` — 5 pure gates returning a `QualityReport`. |
| `extracted_quality_gate/__init__.py` | EDIT | Re-export `evaluate_campaign`. |
| `extracted_quality_gate/{manifest,README,STATUS}.md` | EDIT | Document the new pack. |
| `atlas_brain/autonomous/tasks/_b2b_specificity.py` | EDIT | `campaign_policy_audit_snapshot` runs specificity audit → resolves proof terms → builds `QualityInput` → calls pack → merges back into legacy dict. Public dict shape preserved. |
| `tests/test_extracted_quality_gate_campaign_pack.py` | NEW (27 tests) | Pure unit tests across all gates. |

## Pack scope

Pure validators in core:
- **Proof-term coverage** — `missing_exact_proof_term` blocker when `require_anchor_support` is True, anchors / witnesses are present, and the body has zero of the resolved proof terms.
- **Report-tier banned language** — when `campaign.tier == "report"`, body+CTA cannot contain `dashboard | live feed | free trial | software | platform`.
- **Forbidden competitor names in cold email** — `email_cold` + `vendor_retention` blocks competitor vendor names sourced from `competitors_considering` and `signal_summary.competitor_distribution`.
- **Forbidden incumbent names in challenger-intel cold email** — `email_cold` + `challenger_intel` blocks incumbents from `competitors_considering`, `signal_summary.incumbents_losing`, and `incumbent_archetypes` rows.
- **Private account name leak** — any `reviewer_company` from anchor or witness rows that appears in subject/body/CTA blocks.

**Stays Atlas-side** (not in pack):
- `specificity_audit_snapshot` (the witness-anchor / numeric / timing analyzer) — per PR-B5 framing, this ships as its own pack later. The wrapper passes its blocking issues + warnings into this pack as pass-through context.
- `campaign_proof_terms_from_audit` (regenerates proof terms from the audit's `signal_terms` structure) — also part of specificity territory.

## Public API preservation

`campaign_policy_audit_snapshot(...)` returns the same legacy dict shape it always did. The single call site at `atlas_brain/services/campaign_quality.py:478` needs no changes.

## Validation

```
\$ pytest tests/test_extracted_quality_gate_campaign_pack.py
27 passed in 0.06s

\$ pytest tests/test_b2b_campaign_generation.py tests/test_campaign_specificity_backfill.py tests/test_extracted_quality_gate_campaign_pack.py tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_quality_gate_safety_scan.py tests/test_extracted_quality_gate_product_claim.py tests/test_b2b_blog_quality_gate.py
238 passed in 2.39s
```

(One pre-existing failure in `tests/test_campaign_quality_service.py` involves a `_View` mock attribute and is unrelated — verified by `git stash` then re-running on main.)

## Coordination

- Owner `claude-2026-05-03-b` (alias A); claimed PR-B4b in `coordination/queue.md`.
- No file overlap with C's in-flight PR-C1h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)