### PR TITLE
docs: log reasoning state audit for AI Content Ops

### DIFF
--- a/extracted_content_pipeline/docs/reasoning_state_audit.md
+++ b/extracted_content_pipeline/docs/reasoning_state_audit.md
@@ -36,15 +36,19 @@ python scripts/audit_extracted_standalone.py --fail-on-debt
 # Atlas runtime import findings: 0
 ```
 
-The buyer-facing happy path (each step works on a fresh box with
-nothing but Postgres and Python installed):
+The buyer-facing happy path. Prerequisites: Python 3.11+, Postgres,
+plus `pip install -r requirements.txt` (the DB-backed CLIs need
+`asyncpg`). Step 4 below uses `--llm offline` so the path runs without
+external LLM credentials. To run against a real LLM, drop `--llm
+offline` and set `EXTRACTED_CAMPAIGN_LLM_*` per the host install
+runbook.
 
 ```bash
 # 1. Migrations
 export EXTRACTED_DATABASE_URL="postgres://user:pass@localhost/content_ops"
 python scripts/run_extracted_content_pipeline_migrations.py
 
-# 2. Validate offline (optional but recommended)
+# 2. Validate offline (optional but recommended; no DB required)
 python scripts/run_extracted_campaign_generation_example.py \
   customer_opportunities.csv --format csv
 
@@ -52,9 +56,10 @@ python scripts/run_extracted_campaign_generation_example.py \
 python scripts/load_extracted_campaign_opportunities.py \
   customer_opportunities.csv --format csv --account-id acct_123
 
-# 4. Generate drafts
+# 4. Generate drafts (offline LLM; swap to real LLM by removing --llm offline
+#    and configuring EXTRACTED_CAMPAIGN_LLM_*)
 python scripts/run_extracted_campaign_generation_postgres.py \
-  --account-id acct_123 --limit 10
+  --account-id acct_123 --limit 10 --llm offline
 
 # 5. Export
 python scripts/export_extracted_campaign_drafts.py \

--- a/extracted_content_pipeline/docs/reasoning_state_audit.md
+++ b/extracted_content_pipeline/docs/reasoning_state_audit.md
@@ -1,0 +1,226 @@
+# AI Content Ops — Reasoning State Audit
+
+Date: 2026-05-04
+
+This audit answers a single concrete question: **how far along is the
+extracted AI Content Ops product before a buyer can add a source and
+start reasoning over it end-to-end without atlas_brain on the path?**
+
+Scope: the primary AI Content Ops product (B2B campaign generation
+spine inside `extracted_content_pipeline/`). Not the podcast
+repurposing offer that shipped in PR #121 — that is a separate product
+with its own data flow.
+
+## TL;DR
+
+- The product is **shippable today** for buyers who either bring their
+  own reasoning input as JSON or accept a known quality penalty
+  (~60-70% specificity reduction, qualitative estimate).
+- The standalone debt audit reports **0 atlas_brain runtime imports**.
+- The reasoning *consumer* surface is complete and clean.
+- The reasoning *producer* surface does not exist in the extracted
+  package. `extracted_reasoning_core` exposes evaluator helpers
+  (`score_archetypes`, `evaluate_evidence`, `build_temporal_evidence`)
+  but its four producer-shaped functions (`run_reasoning`,
+  `continue_reasoning`, `check_falsification`, `build_narrative_plan`)
+  all raise `NotImplementedError`.
+- No branch in flight wires `extracted_reasoning_core` into the
+  content-pipeline generator.
+
+## What works today end-to-end without atlas_brain
+
+The standalone audit:
+
+```bash
+python scripts/audit_extracted_standalone.py --fail-on-debt
+# Atlas runtime import findings: 0
+```
+
+The buyer-facing happy path (each step works on a fresh box with
+nothing but Postgres and Python installed):
+
+```bash
+# 1. Migrations
+export EXTRACTED_DATABASE_URL="postgres://user:pass@localhost/content_ops"
+python scripts/run_extracted_content_pipeline_migrations.py
+
+# 2. Validate offline (optional but recommended)
+python scripts/run_extracted_campaign_generation_example.py \
+  customer_opportunities.csv --format csv
+
+# 3. Load opportunities
+python scripts/load_extracted_campaign_opportunities.py \
+  customer_opportunities.csv --format csv --account-id acct_123
+
+# 4. Generate drafts
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 --limit 10
+
+# 5. Export
+python scripts/export_extracted_campaign_drafts.py \
+  --account-id acct_123 --format csv --output drafts.csv
+```
+
+CLI inventory:
+
+| Runner | Purpose | Standalone? |
+|---|---|---|
+| `run_extracted_content_pipeline_migrations.py` | Apply schema | Yes |
+| `load_extracted_campaign_opportunities.py` | Import opportunities (JSON/CSV) | Yes |
+| `run_extracted_campaign_generation_example.py` | Offline file-driven generation | Yes |
+| `run_extracted_campaign_generation_postgres.py` | DB-backed generation | Yes (with `--llm offline` or real LLM) |
+| `export_extracted_campaign_drafts.py` | Read-only draft export | Yes |
+
+## The three reasoning layers
+
+| Layer | Purpose | Status |
+|---|---|---|
+| `CampaignReasoningContextProvider` port (`campaign_ports.py:171-180`) | Optional Protocol the host implements to inject reasoning into generation | Defined and working; reference adapter `FileCampaignReasoningContextProvider` covers the file-backed case |
+| `extracted_reasoning_core` evaluators (`api.py`) | Score / gate / compute over pre-existing reasoning state. `score_archetypes`, `evaluate_evidence`, `build_temporal_evidence` | Implemented and exported |
+| `extracted_reasoning_core` producers (`api.py`) | Generate reasoning from raw inputs. `run_reasoning`, `continue_reasoning`, `check_falsification`, `build_narrative_plan` | All four raise `NotImplementedError` |
+
+And the wiring between the layers:
+
+| Wiring | Status |
+|---|---|
+| `extracted_content_pipeline.reasoning.archetypes` re-exports `extracted_reasoning_core.archetypes` | Done |
+| `extracted_content_pipeline.reasoning.wedge_registry` re-exports `extracted_reasoning_core.api` | Done |
+| `campaign_generation.py` actually calls those evaluators | Zero call sites |
+| Adapter that packages `extracted_reasoning_core` output into a `CampaignReasoningContextProvider` instance | Does not exist |
+| Branch in flight building any of the above | None — `git branch -a \| grep -i reason` returns nothing |
+
+## What the generator expects (the input shape)
+
+`CampaignReasoningContext` (defined in `campaign_ports.py:53-100`):
+
+| Field | Cardinality | Semantic |
+|---|---|---|
+| `anchor_examples` | `Mapping[label, rows]` | Labeled evidence rows for proof anchors |
+| `witness_highlights` | up to ~5 | Quote/witness rows that ground copy |
+| `reference_ids` | `Mapping[type, ids]` | Source ids for auditability |
+| `top_theses` | up to 2 | Top strategic theses for the opportunity |
+| `account_signals` | up to 2 | Account-level buying / churn signals |
+| `timing_windows` | up to 2 | Why-now windows (renewal, anchor, urgency) |
+| `proof_points` | up to 2 | Compact metrics (label, value, interpretation) |
+| `coverage_limits` | up to 3 | Explicit caveats |
+| `canonical_reasoning` | dict | Raw reasoning fields: wedge, confidence, summary, why_now, primary_driver, recommended_action |
+| `scope_summary` | dict | Metadata about evidence scope |
+| `delta_summary` | dict | What changed since prior snapshot |
+
+Any reasoning producer that wants to plug in must produce values that
+normalize into this shape. Reference example payload:
+`extracted_content_pipeline/examples/campaign_reasoning_context.json`.
+
+## Runtime behavior under different reasoning conditions
+
+| Configuration | Behavior | Quality |
+|---|---|---|
+| `reasoning_context = None` (default) | Generator falls back to `normalize_campaign_reasoning_context` over the opportunity row itself; only fields embedded in the source data flow into the prompt | Lowest. Drafts are generic. |
+| `FileCampaignReasoningContextProvider` (file-backed) | Loads pre-baked reasoning JSON keyed by target_id / company / email / vendor; normalized and threaded into the prompt | High when the source file is well-built. Quality scales with effort the host put into producing the JSON. |
+| Custom `CampaignReasoningContextProvider` (e.g. real producer) | Provider is called once per opportunity; output normalized and threaded in | High. This is the architecturally intended path. |
+
+## What "add a source and reason over it" costs, by tier
+
+The architecture supports three honestly distinct tiers of reasoning.
+Each lands the buyer at "source in, drafts out":
+
+### Tier 1: Single-pass prompt reasoning
+
+- ~1 day of work, ~300 LOC
+- New `extracted_content_pipeline/services/single_pass_reasoning_provider.py`
+- One LLM call per opportunity that takes the source row + context and
+  produces the `CampaignReasoningContext` shape directly via a
+  structured-output prompt
+- Implements the `CampaignReasoningContextProvider` Protocol
+- Matches the single-pass pattern used elsewhere in the package
+- Quality matches what most current "AI content ops" tools actually do
+
+Trade-off: no multi-step planning, no falsification, no cache. If the
+LLM gets it wrong on the first call, the campaign draft inherits the
+mistake.
+
+### Tier 2: Implement `extracted_reasoning_core` producer stubs
+
+- ~2-3 weeks of work, ~2,000 LOC
+- Fill in `run_reasoning`, `continue_reasoning`, `check_falsification`,
+  `build_narrative_plan` in `extracted_reasoning_core/api.py`
+- Plus an adapter that packages those outputs into a
+  `CampaignReasoningContextProvider`
+- Multi-step LLM with state, falsification gating, semantic cache
+- This is what the architecture intended when the producer stubs were
+  defined
+
+Trade-off: real reasoning, but you're committing to ~3 weeks of work
+before the primary product ships meaningfully better drafts than the
+single-pass version.
+
+### Tier 3: Extract the atlas_brain producer
+
+- ~3-4 weeks of work, ~16,000 LOC + Neo4j
+- Bring `b2b_reasoning_synthesis.py` (3,903 LOC) +
+  `b2b_churn_intelligence.py` (5,779 LOC) +
+  `atlas_brain/reasoning/` (~5,000 LOC across 17 files) into the
+  extraction
+- Includes Neo4j knowledge graph, event bus orchestration, entity
+  locks, semantic cache
+- Contradicts the documented Option B decision in
+  `remaining_productization_audit.md:338-343` (reasoning is
+  host-owned)
+
+Not recommended. Captured here for completeness; the cost-benefit on
+Tier 3 only makes sense if the goal is to fold the reasoning engine
+into the content product as a single SKU.
+
+## Decision points open before sizing the next sprint
+
+These need answering before the work can be scoped concretely:
+
+1. **Which tier?** Tier 1 (1 day) or Tier 2 (2-3 weeks). Tier 3 is
+   already documented as not the chosen path.
+2. **What is "the extracted reasoning system"?** Confirmed to be
+   `extracted_reasoning_core` (the only candidate package). Whether it
+   means "fill the four NotImplementedError stubs" (Tier 2) or "use
+   the existing evaluators with a thin orchestrator" (a smaller Tier
+   1.5) is the choice that decides effort.
+3. **What source format?** CRM dump, review/complaint data, episode
+   transcripts, sales call transcripts — each needs a different
+   schema-aware extraction step in the reasoning provider's input.
+4. **Multi-step required?** If single-pass meets the product promise
+   on the landing page, Tier 1 is sufficient. If the page promises
+   "reasons over your data with multi-pass refinement," Tier 2 is
+   the floor.
+
+## Status verdict
+
+| Capability | State |
+|---|---|
+| Buyer can install the product on a fresh box | Yes |
+| Buyer can apply migrations and load opportunities without atlas_brain | Yes |
+| Buyer can generate drafts with a real LLM | Yes |
+| Buyer can generate drafts with the offline deterministic LLM | Yes |
+| Buyer can review and export drafts | Yes |
+| Buyer can supply pre-baked reasoning as JSON | Yes |
+| Buyer can supply a custom Python reasoning provider | Yes (port is defined) |
+| The product itself produces reasoning from a source | No |
+| `extracted_reasoning_core` produces reasoning from a source | No (4 stubs raise NotImplementedError) |
+
+The structural gap is **one decision and one build away** from
+"buyer plugs in a source and gets reasoned drafts": pick Tier 1 or
+Tier 2, build it, ship.
+
+## References
+
+- `extracted_content_pipeline/docs/host_install_runbook.md` — buyer-
+  facing install runbook
+- `extracted_content_pipeline/docs/reasoning_handoff_contract.md` —
+  reasoning Protocol contract for hosts
+- `extracted_content_pipeline/docs/remaining_productization_audit.md` —
+  decision Log including the Option B decision (reasoning host-owned)
+- `extracted_content_pipeline/campaign_ports.py:171-180` —
+  `CampaignReasoningContextProvider` Protocol definition
+- `extracted_content_pipeline/campaign_generation.py:262-297` —
+  `_opportunity_with_reasoning_context` (the runtime call site)
+- `extracted_reasoning_core/api.py` — evaluator + producer-stub
+  surface
+- `extracted_content_pipeline/campaign_reasoning_data.py` — file-backed
+  reference adapter


### PR DESCRIPTION
## Summary

Logs the deep audit of where the AI Content Ops product (the primary, non-podcast B2B campaign-generation product) actually stands with respect to reasoning. The audit answers a single question: **how far along is it before a buyer can add a source and start reasoning over it end-to-end without atlas_brain on the path?**

Doc-only. No code change. Captured so the answer is reachable later without re-deriving.

## Key findings

- Standalone debt audit reports `0 atlas_brain runtime imports`.
- Buyer happy path (migrate → import → generate → export) works today via 5 CLI commands. No atlas_brain on the path.
- The reasoning *consumer* surface (`CampaignReasoningContextProvider` port + `FileCampaignReasoningContextProvider` reference adapter) is complete and clean.
- The reasoning *producer* surface does not exist in the extracted package. `extracted_reasoning_core` exposes three working evaluators (`score_archetypes`, `evaluate_evidence`, `build_temporal_evidence`) but its four producer-shaped functions (`run_reasoning`, `continue_reasoning`, `check_falsification`, `build_narrative_plan`) all raise `NotImplementedError`.
- The campaign generator does not call the evaluators (zero call sites in `campaign_generation.py`).
- No branch in flight wires `extracted_reasoning_core` into content generation.

## Three tiers of "add a source and reason over it"

| Tier | Build | Cost | Trade-off |
|---|---|---|---|
| **1: Single-pass prompt reasoning** | New `services/single_pass_reasoning_provider.py` implementing the Protocol with one structured-output LLM call per opportunity | ~1 day, ~300 LOC | No multi-step, no falsification, no cache |
| **2: Implement `extracted_reasoning_core` producer stubs** | Fill the four `NotImplementedError` stubs + adapter | ~2-3 weeks, ~2,000 LOC | Real multi-step reasoning, but commits to ~3 weeks before drafts ship better than Tier 1 |
| **3: Extract `atlas_brain` producer** | Move `b2b_reasoning_synthesis.py` + `b2b_churn_intelligence.py` + `atlas_brain/reasoning/` (~16,000 LOC) plus Neo4j | ~3-4 weeks | Contradicts the documented Option B decision; not recommended |

## Decision points open

The doc names four decision points that need to be answered before the next sprint is scoped:

1. Tier 1 or Tier 2 (Tier 3 is already deferred)
2. Confirm "the extracted reasoning system" the user referenced is `extracted_reasoning_core`
3. What source format the reasoning producer needs to handle (CRM, reviews, transcripts, etc.)
4. Whether the landing-page promise requires multi-step reasoning, which decides between Tier 1 and Tier 2

## Test plan

- [x] Doc-only, no code or behavior change
- [x] Branch is purely additive

https://claude.ai/code/session_01NbZL7QHXuTkUrNX5zTxiUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbZL7QHXuTkUrNX5zTxiUs)_