### PR TITLE
Drop PR-B4b row after #120 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T01:35Z by claude-2026-05-03-b
+Last updated: 2026-05-04T01:45Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1h, in flight) | PR-C1h: Route `extracted_content_pipeline/reasoning/archetypes.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/archetypes.py` (drop ~590-line drifted fork; replace with thin re-export wrapper from `extracted_reasoning_core.archetypes`). Existing `tests/test_extracted_reasoning_archetypes.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/archetypes.py`; `tests/test_extracted_reasoning_archetypes.py` |
-| (PR-B4b, in flight) | PR-B4b: Campaign quality pack (deterministic core + Atlas adapter) | NEW: `extracted_quality_gate/campaign_pack.py` (pure `evaluate_campaign`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/autonomous/tasks/_b2b_specificity.py` (`campaign_policy_audit_snapshot` delegates to pack; legacy proof-term resolution + audit dict shape preserved). NEW: `tests/test_extracted_quality_gate_campaign_pack.py` (27 tests). | claude-2026-05-03-b | `extracted_quality_gate/campaign_pack.py`; `atlas_brain/autonomous/tasks/_b2b_specificity.py`; the new campaign-pack test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,14 +1,13 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T01:20Z by claude-2026-05-03-b
+Last updated: 2026-05-04T01:45Z by claude-2026-05-03-b
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b #106, PR-A4c #98.
-B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack). PR-B4b (campaign pack) and PR-B5 remain.
+B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack), PR-B4b #120 (campaign quality pack). PR-B4 is fully complete; PR-B5 remains.
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-B4b | `extracted_quality_gate` | claude-2026-05-03-b | PR-B4a / #118 (merged) | Campaign quality pack over the core gate contract. Lifts the deterministic part of `campaign_policy_audit_snapshot` (proof-term matching, tier/target_mode policy, forbidden-term scanning) into `extracted_quality_gate/campaign_pack.py`. Atlas wrapper retains the specificity-resolution + DB-fallback I/O. |
 | PR-B5 | `extracted_quality_gate` | unclaimed | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #120 (PR-B4b campaign quality pack) merged. PR-B4 is now fully complete (B4a #118 + B4b #120). Updates queue.md to record both merges and lists PR-B5 as the only remaining B-series slice.
