### PR TITLE
Drop PR-B5b row after #125 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T02:05Z by claude-2026-05-03-b
+Last updated: 2026-05-04T02:15Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1i, in flight) | PR-C1i: Route `extracted_content_pipeline/reasoning/evidence_engine.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/evidence_engine.py` (drop ~338-line drifted fork; replace with wrapper carrying rules as a Python dict + `from_rules(...)` route). EDIT: `extracted_reasoning_core/evidence_engine.py` (add `from_rules` classmethod, lazy yaml import + JSON suffix detection, drift-forward `_numeric_value` helper into numeric checks, `min_count`/`exists` operator parity, dual-form suppression). Existing `tests/test_extracted_reasoning_evidence_engine.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/evidence_engine.py`; `extracted_reasoning_core/evidence_engine.py`; `tests/test_extracted_reasoning_evidence_engine.py` |
-| (PR-B5b, in flight) | PR-B5b: Witness specificity pack (deterministic core + Atlas re-export) | NEW: `extracted_quality_gate/witness_pack.py` (six legacy entry points + `evaluate_witness_specificity`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/autonomous/tasks/_b2b_specificity.py` (slimmed from 755 → 216 LOC; re-exports from pack; keeps `campaign_policy_audit_snapshot`, `latest_specificity_audit`, `specificity_quality_summary`). NEW: `tests/test_extracted_quality_gate_witness_pack.py` (30 tests). | claude-2026-05-03-b | `extracted_quality_gate/witness_pack.py`; `atlas_brain/autonomous/tasks/_b2b_specificity.py`; the new witness-pack test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,13 +1,14 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T01:50Z by claude-2026-05-03-b
+Last updated: 2026-05-04T02:15Z by claude-2026-05-03-b
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b #106, PR-A4c #98.
-B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack), PR-B4b #120 (campaign quality pack). PR-B4 is fully complete; PR-B5 remains.
+B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack), PR-B4b #120 (campaign quality pack), PR-B5b #125 (witness specificity pack). PR-B5a (evidence coverage gate) and PR-B5c (source-quality pack) remain.
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-B5 | `extracted_quality_gate` | claude-2026-05-03-b | PR-B2 / #85 (merged) | B2B evidence + witness + source-quality packs. Splitting into PR-B5b (witness specificity pack — pure, starts first), PR-B5a (evidence coverage gate — async DB), PR-B5c (source-quality pack — async DB + settings). PR-B5b is the foundation other packs compose on. |
+| PR-B5a | `extracted_quality_gate` | claude-2026-05-03-b | PR-B5b / #125 (merged) | Evidence coverage gate. Lifts `audit_witness_evidence_coverage` from `atlas_brain/services/b2b/evidence_gate.py` into the pack. Async DB query stays — the pack provides the gate-shaped wrapper around it. ~350 LOC including tests. |
+| PR-B5c | `extracted_quality_gate` | claude-2026-05-03-b | PR-B5b / #125 (merged) | Source-quality pack. Composes `source_impact.py` + `witness_render_gate.py`. Async DB + settings dependency for source capability registry. ~500 LOC including tests. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #125 (PR-B5b witness specificity pack) merged. Updates queue.md to record the merge and split out the remaining B5 work into PR-B5a (evidence coverage gate) and PR-B5c (source-quality pack), both claimed by the same owner.
