### PR TITLE
Hotfix: replace literal Unicode currency in witness_pack regex with escapes

### DIFF
--- a/extracted_quality_gate/witness_pack.py
+++ b/extracted_quality_gate/witness_pack.py
@@ -64,7 +64,7 @@ from .types import (
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
 _NUMERIC_TEXT_RE = re.compile(
-    r"(?:[$€£]?\d[\d,]*(?:\.\d+)?(?:\s*(?:%|k|m|b|x))?(?:/[a-z]+)?)",
+    r"(?:[$\u20ac\u00a3]?\d[\d,]*(?:\.\d+)?(?:\s*(?:%|k|m|b|x))?(?:/[a-z]+)?)",
     re.IGNORECASE,
 )
 _TIMING_TEXT_RE = re.compile(


### PR DESCRIPTION
## Summary

Hotfix for an ASCII-rule violation introduced by PR-B5b (#125). `extracted_quality_gate/witness_pack.py:67` was shipped with literal `U+20AC` (€) and `U+00A3` (£) bytes embedded in the `_NUMERIC_TEXT_RE` regex character class:

```python
r"(?:[$€£]?\d[\d,]*..."
```

The legacy version in `atlas_brain/autonomous/tasks/_b2b_specificity.py` used escapes (`€£`); when I lifted the regex into the pack module the characters were embedded as literals. Replaced with the escape form so the file is ASCII-only:

```python
r"(?:[$€£]?\d[\d,]*..."
```

Regex semantics are identical — this is byte-level hygiene only.

## Why this matters

The repo's project memory explicitly flags Unicode-in-Python as a recurring footgun (em-dash drift in autonomous task files has bitten before). The Phase 2 ASCII verification step of the production-implementation protocol caught this on the next slice's pre-mod scan.

## Validation

```
$ python -m pytest tests/test_extracted_quality_gate_witness_pack.py
30 passed in 1.25s

$ python3 -c "with open('extracted_quality_gate/witness_pack.py','rb') as f: print('non-ascii bytes:', sum(1 for b in f.read() if b > 127))"
non-ascii bytes: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
