### PR TITLE
PR-B5a: Lift evidence coverage gate into deterministic pack

### DIFF
--- a/atlas_brain/services/b2b/evidence_gate.py
+++ b/atlas_brain/services/b2b/evidence_gate.py
@@ -1,124 +1,27 @@
 """Evidence-claim coverage gate for campaign generation (Gap 3, shadow mode).
 
-Provides audit_witness_evidence_coverage(): for a given vendor and a set of
-source_review_ids surfaced as witness anchors during campaign prompt
-assembly, returns which review_ids are backed by a valid b2b_evidence_claims
-row at the configured pain_confidence tier. Used in shadow mode to log the
-delta to campaign_audit_log (event_type='claim_gate_shadow') so we can
-measure how many campaigns *would* be gated under enforcement before
-flipping the enforce flag.
+The deterministic implementation lives in
+``extracted_quality_gate.evidence_pack`` (PR-B5a). This module is a
+thin atlas-side re-export so the existing caller path
+(``from atlas_brain.services.b2b.evidence_gate import
+audit_witness_evidence_coverage``) keeps working without changes.
 
-The pain_confidence_rank column on b2b_evidence_claims is a STORED
-generated rank: 0=strong, 1=weak, 2=none/null. Filtering by rank lets us
-treat 'strong' and 'weak' as floors without string comparisons.
+See ``extracted_quality_gate.evidence_pack`` for the contract and
+the parametric coverage thresholds the new
+``evaluate_evidence_coverage`` pack entry point exposes.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any, Iterable
-from uuid import UUID
-
-logger = logging.getLogger("atlas.services.b2b.evidence_gate")
-
-
-_PAIN_CONFIDENCE_RANK_FLOOR: dict[str, int] = {
-    "strong": 0,
-    "weak": 1,
-    "none": 2,
-}
+from extracted_quality_gate.evidence_pack import (
+    _PAIN_CONFIDENCE_RANK_FLOOR,
+    _rank_floor,
+    audit_witness_evidence_coverage,
+    evaluate_evidence_coverage,
+)
 
 
-def _rank_floor(min_pain_confidence: str) -> int:
-    """Map a pain_confidence label to the max rank that still passes the gate."""
-    return _PAIN_CONFIDENCE_RANK_FLOOR.get(
-        (min_pain_confidence or "").strip().lower(),
-        _PAIN_CONFIDENCE_RANK_FLOOR["strong"],
-    )
-
-
-async def audit_witness_evidence_coverage(
-    pool,
-    *,
-    vendor_name: str,
-    source_review_ids: Iterable[UUID | str],
-    min_pain_confidence: str = "strong",
-) -> dict[str, Any]:
-    """Report which source_review_ids have a backing valid claim at the floor.
-
-    Returns a dict:
-      - total_review_ids: count of distinct, non-empty review_ids supplied
-      - covered_review_ids: list[str] of review_ids with at least one valid
-        b2b_evidence_claims row whose pain_confidence_rank <= floor
-      - uncovered_review_ids: list[str] of supplied review_ids that did not
-        meet the floor (would be dropped under enforcement)
-      - covered_count, uncovered_count, coverage_ratio (0..1, rounded to 3 dp)
-      - min_pain_confidence: the floor applied
-      - vendor_name: echoed for audit-log convenience
-
-    Returns coverage_ratio == 1.0 with empty lists when no review_ids supplied.
-    """
-    cleaned: list[UUID] = []
-    seen: set[str] = set()
-    for rid in source_review_ids:
-        if rid is None:
-            continue
-        try:
-            uid = rid if isinstance(rid, UUID) else UUID(str(rid))
-        except (ValueError, TypeError):
-            continue
-        key = str(uid)
-        if key in seen:
-            continue
-        seen.add(key)
-        cleaned.append(uid)
-
-    total = len(cleaned)
-    floor = _rank_floor(min_pain_confidence)
-    vendor = (vendor_name or "").strip()
-
-    if not vendor or total == 0:
-        return {
-            "vendor_name": vendor,
-            "min_pain_confidence": min_pain_confidence,
-            "total_review_ids": total,
-            "covered_review_ids": [],
-            "uncovered_review_ids": [str(rid) for rid in cleaned],
-            "covered_count": 0,
-            "uncovered_count": total,
-            "coverage_ratio": 1.0 if total == 0 else 0.0,
-        }
-
-    rows = await pool.fetch(
-        """
-        SELECT DISTINCT source_review_id::text AS review_id
-        FROM b2b_evidence_claims
-        WHERE status = 'valid'
-          AND vendor_name = $1
-          AND source_review_id = ANY($2::uuid[])
-          AND pain_confidence_rank <= $3
-        """,
-        vendor,
-        cleaned,
-        floor,
-    )
-
-    covered = {row["review_id"] for row in rows}
-    covered_list = sorted(rid for rid in covered if rid)
-    uncovered_list = sorted(str(rid) for rid in cleaned if str(rid) not in covered)
-
-    coverage_ratio = (len(covered_list) / total) if total else 0.0
-
-    return {
-        "vendor_name": vendor,
-        "min_pain_confidence": min_pain_confidence,
-        "total_review_ids": total,
-        "covered_review_ids": covered_list,
-        "uncovered_review_ids": uncovered_list,
-        "covered_count": len(covered_list),
-        "uncovered_count": len(uncovered_list),
-        "coverage_ratio": round(coverage_ratio, 3),
-    }
-
-
-__all__ = ["audit_witness_evidence_coverage"]
+__all__ = [
+    "audit_witness_evidence_coverage",
+    "evaluate_evidence_coverage",
+]

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T02:15Z by claude-2026-05-03-b
+Last updated: 2026-05-04T02:25Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1i, in flight) | PR-C1i: Route `extracted_content_pipeline/reasoning/evidence_engine.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/evidence_engine.py` (drop ~338-line drifted fork; replace with wrapper carrying rules as a Python dict + `from_rules(...)` route). EDIT: `extracted_reasoning_core/evidence_engine.py` (add `from_rules` classmethod, lazy yaml import + JSON suffix detection, drift-forward `_numeric_value` helper into numeric checks, `min_count`/`exists` operator parity, dual-form suppression). Existing `tests/test_extracted_reasoning_evidence_engine.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/evidence_engine.py`; `extracted_reasoning_core/evidence_engine.py`; `tests/test_extracted_reasoning_evidence_engine.py` |
+| (PR-B5a, in flight) | PR-B5a: Evidence-coverage gate (deterministic core + Atlas re-export) | NEW: `extracted_quality_gate/evidence_pack.py` (legacy `audit_witness_evidence_coverage` + pack-contract `evaluate_evidence_coverage`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/services/b2b/evidence_gate.py` (slimmed to thin re-export). NEW: `tests/test_extracted_quality_gate_evidence_pack.py` (29 tests). | claude-2026-05-03-b | `extracted_quality_gate/evidence_pack.py`; `atlas_brain/services/b2b/evidence_gate.py`; the new evidence-pack test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_quality_gate/README.md
+++ b/extracted_quality_gate/README.md
@@ -14,6 +14,7 @@ The package contains:
 - deterministic blog quality pack (`evaluate_blog_post`)
 - deterministic campaign quality pack (`evaluate_campaign`)
 - deterministic witness specificity pack (`evaluate_witness_specificity` + 6 legacy entry points)
+- async evidence-coverage gate (`evaluate_evidence_coverage` + lifted `audit_witness_evidence_coverage`)
 
 The package intentionally has no Atlas runtime dependency. Product-specific behavior belongs in packs or adapters layered on top of the public API.
 
@@ -36,6 +37,10 @@ from extracted_quality_gate.witness_pack import (
     surface_specificity_context,
     specificity_audit_snapshot,
 )
+from extracted_quality_gate.evidence_pack import (
+    audit_witness_evidence_coverage,
+    evaluate_evidence_coverage,
+)
 ```
 
 Products should import from:
@@ -43,6 +48,7 @@ Products should import from:
 - `extracted_quality_gate.api`
 - `extracted_quality_gate.blog_pack`
 - `extracted_quality_gate.campaign_pack`
+- `extracted_quality_gate.evidence_pack`
 - `extracted_quality_gate.safety_gate`
 - `extracted_quality_gate.witness_pack`
 - `extracted_quality_gate.types`
@@ -135,3 +141,31 @@ call `evaluate_specificity_support` directly through the atlas
 re-export; future revisions can pass `evaluate_witness_specificity`
 findings through `QualityInput.context` for cleaner pack-to-pack
 composition.
+
+## Evidence-coverage gate (PR-B5a)
+
+`evidence_pack.py` ships two entry points:
+
+- `audit_witness_evidence_coverage(pool, *, vendor_name,
+  source_review_ids, min_pain_confidence, valid_status,
+  coverage_precision)` -- legacy, lifted verbatim from
+  `atlas_brain/services/b2b/evidence_gate.py`. Returns the same
+  `dict[str, Any]` shape, two new keyword args are additive
+  (default to the legacy values).
+- `evaluate_evidence_coverage(pool, input, *, policy)` -- pack
+  contract. Reads `vendor_name`, `source_review_ids`, optional
+  `min_pain_confidence` from `input.context`. Reads thresholds
+  (`coverage_block_threshold`, `coverage_warn_threshold`,
+  `min_pain_confidence`, `valid_status`, `coverage_precision`) from
+  `policy.thresholds`. Returns a `QualityReport`.
+
+The pain-confidence rank map is part of the contract
+(`b2b_evidence_claims.pain_confidence_rank` is a STORED generated
+column with values 0/1/2 for strong/weak/none) and not parametric.
+The coverage thresholds, the valid-status string, and the rounding
+precision ARE parametric.
+
+The atlas-side `atlas_brain/services/b2b/evidence_gate.py` is a
+thin re-export wrapper, so the existing shadow-mode call site in
+`atlas_brain/autonomous/tasks/b2b_campaign_generation.py` keeps
+working without change.

--- a/extracted_quality_gate/STATUS.md
+++ b/extracted_quality_gate/STATUS.md
@@ -4,7 +4,25 @@ Date: 2026-05-03
 
 ## Current Slice
 
-PR-B5b: witness specificity pack.
+PR-B5a: evidence-coverage gate.
+
+- Deterministic core (`evidence_pack.py`) -- legacy entry point
+  `audit_witness_evidence_coverage(pool, *, vendor_name, source_review_ids,
+  min_pain_confidence, valid_status, coverage_precision)` lifted
+  verbatim from `atlas_brain/services/b2b/evidence_gate.py`. The
+  three original kwargs keep their signatures and defaults; two new
+  kwargs (`valid_status`, `coverage_precision`) are additive.
+- Pack-contract entry point `evaluate_evidence_coverage(pool, input,
+  *, policy)` returns a standard `QualityReport`. Decision is driven
+  by `coverage_block_threshold` / `coverage_warn_threshold` thresholds
+  on `QualityPolicy.thresholds`; defaults preserve the current
+  shadow-mode posture (block_threshold=0.0 means never block).
+- Atlas-side `atlas_brain/services/b2b/evidence_gate.py` is a thin
+  re-export wrapper. The single existing caller in
+  `atlas_brain/autonomous/tasks/b2b_campaign_generation.py:1232`
+  continues to work without change.
+
+PR-B5b (merged via #125): witness specificity pack.
 
 - Deterministic core (`witness_pack.py`) -- six legacy entry points
   (`surface_specificity_context`, `merge_specificity_contexts`,
@@ -80,6 +98,7 @@ The module is deterministic and imports without Atlas.
 - Blog quality pack (deterministic core: `evaluate_blog_post`) -- PR-B4a
 - Campaign quality pack (deterministic core: `evaluate_campaign`) -- PR-B4b
 - Witness specificity pack (deterministic core: `evaluate_witness_specificity` + 6 legacy entry points) -- PR-B5b
+- Evidence-coverage gate (deterministic core: `evaluate_evidence_coverage` + lifted `audit_witness_evidence_coverage`) -- PR-B5a
 
 ## Not Yet Included
 
@@ -87,6 +106,5 @@ The module is deterministic and imports without Atlas.
   in `atlas_brain/services/safety_gate.py`; the deterministic core
   is now in `extracted_quality_gate/safety_gate.py` and the wrapper
   delegates to it -- but the wrapper itself is not yet extracted)
-- Evidence-claim coverage gate (PR-B5a) -- async DB query
 - Source-quality ingest pack (PR-B5c) -- async DB + settings
 - Memory quality pack

--- a/extracted_quality_gate/__init__.py
+++ b/extracted_quality_gate/__init__.py
@@ -31,6 +31,10 @@ from .api import (
 )
 from .blog_pack import evaluate_blog_post
 from .campaign_pack import evaluate_campaign
+from .evidence_pack import (
+    audit_witness_evidence_coverage,
+    evaluate_evidence_coverage,
+)
 from .safety_gate import assess_risk, check_content
 from .types import (
     ContentFlag,
@@ -68,15 +72,17 @@ __all__ = [
     "RiskLevel",
     "SuppressionReason",
     "assess_risk",
+    "audit_witness_evidence_coverage",
     "build_product_claim",
     "campaign_proof_terms_from_audit",
     "check_content",
-    "evaluate_blog_post",
-    "evaluate_campaign",
     "compute_claim_id",
     "decide_render_gates",
     "derive_confidence",
     "derive_evidence_posture",
+    "evaluate_blog_post",
+    "evaluate_campaign",
+    "evaluate_evidence_coverage",
     "evaluate_specificity_support",
     "evaluate_witness_specificity",
     "get_policy",

--- a/extracted_quality_gate/evidence_pack.py
+++ b/extracted_quality_gate/evidence_pack.py
@@ -1,0 +1,359 @@
+"""Evidence-claim coverage gate (PR-B5a).
+
+Owned by ``extracted_quality_gate``. The deterministic pieces (rank
+floor mapping, ID dedup / coercion, coverage-ratio rollup, gate
+decision) are pure. The async DB read against ``b2b_evidence_claims``
+is the only I/O step; the pack accepts a pool-shaped object the same
+way ``extracted_llm_infrastructure.services.cost.drift`` does so the
+package stays library-agnostic (the asyncpg ``Pool`` is the production
+binding; tests can pass any object exposing ``.fetch(sql, *args)``).
+
+Two API styles ship in this module:
+
+  * ``audit_witness_evidence_coverage`` -- the legacy entry point
+    lifted verbatim from
+    ``atlas_brain.services.b2b.evidence_gate``. Returns the same
+    ``dict[str, Any]`` shape so the existing caller in
+    ``atlas_brain/autonomous/tasks/b2b_campaign_generation.py:1232``
+    continues to work via the atlas-side re-export.
+  * ``evaluate_evidence_coverage(pool, input, *, policy)`` -- the
+    pack contract. Returns a ``QualityReport`` so future product
+    packs can compose against it.
+
+The deterministic pain-confidence rank map is part of the contract
+(``b2b_evidence_claims.pain_confidence_rank`` is a STORED generated
+column with values 0/1/2 for strong/weak/none) -- not parametric.
+The coverage-ratio thresholds, valid-status filter, and precision
+ARE parametric via ``QualityPolicy.thresholds``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Mapping, Sequence
+from uuid import UUID
+
+from .types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+logger = logging.getLogger("extracted_quality_gate.evidence_pack")
+
+
+# ---- Schema-fixed constants (NOT parametric -- these are the contract) ----
+
+# pain_confidence_rank is a STORED generated column on
+# b2b_evidence_claims: 0=strong, 1=weak, 2=none/null. Filtering by
+# rank lets us treat 'strong' and 'weak' as floors without string
+# comparisons. The map below is the exact contract.
+_PAIN_CONFIDENCE_RANK_FLOOR: dict[str, int] = {
+    "strong": 0,
+    "weak": 1,
+    "none": 2,
+}
+
+
+# ---- Parametric defaults (overridable via QualityPolicy.thresholds) ----
+
+_DEFAULT_MIN_PAIN_CONFIDENCE = "strong"
+_DEFAULT_VALID_STATUS = "valid"
+_DEFAULT_COVERAGE_PRECISION = 3
+# Block when coverage drops below this ratio. Default 0.0 means
+# "never block" -- matches the current shadow-mode posture in
+# atlas. Production callers tighten via policy.thresholds.
+_DEFAULT_COVERAGE_BLOCK_THRESHOLD = 0.0
+# Warn when coverage drops below this ratio (but stays above the
+# block threshold). Default 1.0 means any uncovered review yields
+# a warning.
+_DEFAULT_COVERAGE_WARN_THRESHOLD = 1.0
+
+
+def _rank_floor(min_pain_confidence: str) -> int:
+    """Map a pain_confidence label to the max rank that still passes the gate.
+
+    Unknown / empty labels fall back to the strictest floor (strong).
+    """
+    return _PAIN_CONFIDENCE_RANK_FLOOR.get(
+        (min_pain_confidence or "").strip().lower(),
+        _PAIN_CONFIDENCE_RANK_FLOOR[_DEFAULT_MIN_PAIN_CONFIDENCE],
+    )
+
+
+def _coerce_review_ids(source_review_ids: Iterable[UUID | str]) -> list[UUID]:
+    """Coerce + dedup the caller's IDs into a clean list of UUIDs.
+
+    Drops None, blank strings, malformed UUIDs, and duplicates.
+    """
+    cleaned: list[UUID] = []
+    seen: set[str] = set()
+    for rid in source_review_ids:
+        if rid is None:
+            continue
+        try:
+            uid = rid if isinstance(rid, UUID) else UUID(str(rid))
+        except (ValueError, TypeError):
+            continue
+        key = str(uid)
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(uid)
+    return cleaned
+
+
+async def audit_witness_evidence_coverage(
+    pool: Any,
+    *,
+    vendor_name: str,
+    source_review_ids: Iterable[UUID | str],
+    min_pain_confidence: str = _DEFAULT_MIN_PAIN_CONFIDENCE,
+    valid_status: str = _DEFAULT_VALID_STATUS,
+    coverage_precision: int = _DEFAULT_COVERAGE_PRECISION,
+) -> dict[str, Any]:
+    """Report which source_review_ids have a backing valid claim at the floor.
+
+    Lifted verbatim from
+    ``atlas_brain.services.b2b.evidence_gate.audit_witness_evidence_coverage``
+    (PR-B5a). The original three keyword arguments
+    (``vendor_name``, ``source_review_ids``, ``min_pain_confidence``)
+    keep their semantics and defaults so the existing caller in
+    ``atlas_brain/autonomous/tasks/b2b_campaign_generation.py``
+    continues to work via the atlas re-export. The two new arguments
+    (``valid_status``, ``coverage_precision``) are additive and
+    default to the legacy values, so they are non-breaking.
+
+    Returns a dict:
+
+      - ``vendor_name`` -- echoed for audit-log convenience
+      - ``min_pain_confidence`` -- the floor applied
+      - ``total_review_ids`` -- count of distinct, non-empty review_ids
+      - ``covered_review_ids`` -- list[str] with at least one valid
+        b2b_evidence_claims row whose pain_confidence_rank <= floor
+      - ``uncovered_review_ids`` -- list[str] that did not meet the
+        floor (would be dropped under enforcement)
+      - ``covered_count`` / ``uncovered_count``
+      - ``coverage_ratio`` -- (0..1, rounded to ``coverage_precision``)
+
+    Returns ``coverage_ratio == 1.0`` with empty lists when no
+    review_ids are supplied.
+    """
+    cleaned = _coerce_review_ids(source_review_ids)
+    total = len(cleaned)
+    floor = _rank_floor(min_pain_confidence)
+    vendor = (vendor_name or "").strip()
+
+    if not vendor or total == 0:
+        return {
+            "vendor_name": vendor,
+            "min_pain_confidence": min_pain_confidence,
+            "total_review_ids": total,
+            "covered_review_ids": [],
+            "uncovered_review_ids": [str(rid) for rid in cleaned],
+            "covered_count": 0,
+            "uncovered_count": total,
+            "coverage_ratio": 1.0 if total == 0 else 0.0,
+        }
+
+    rows = await pool.fetch(
+        """
+        SELECT DISTINCT source_review_id::text AS review_id
+        FROM b2b_evidence_claims
+        WHERE status = $1
+          AND vendor_name = $2
+          AND source_review_id = ANY($3::uuid[])
+          AND pain_confidence_rank <= $4
+        """,
+        valid_status,
+        vendor,
+        cleaned,
+        floor,
+    )
+
+    covered = {row["review_id"] for row in rows}
+    covered_list = sorted(rid for rid in covered if rid)
+    uncovered_list = sorted(str(rid) for rid in cleaned if str(rid) not in covered)
+
+    coverage_ratio = (len(covered_list) / total) if total else 0.0
+
+    return {
+        "vendor_name": vendor,
+        "min_pain_confidence": min_pain_confidence,
+        "total_review_ids": total,
+        "covered_review_ids": covered_list,
+        "uncovered_review_ids": uncovered_list,
+        "covered_count": len(covered_list),
+        "uncovered_count": len(uncovered_list),
+        "coverage_ratio": round(coverage_ratio, coverage_precision),
+    }
+
+
+# ---- Pack contract ----
+
+
+def _resolve_threshold(
+    thresholds: Mapping[str, Any] | None,
+    key: str,
+    default: Any,
+) -> Any:
+    """Read a threshold value with type-safe fallback to default."""
+    if thresholds is None:
+        return default
+    value = thresholds.get(key)
+    if value is None:
+        return default
+    return value
+
+
+def _build_quality_report(
+    audit: dict[str, Any],
+    *,
+    block_threshold: float,
+    warn_threshold: float,
+) -> QualityReport:
+    """Translate an audit dict into a typed QualityReport.
+
+    Decision rules (pure):
+      * coverage_ratio < block_threshold -> BLOCK with one
+        ``low_evidence_coverage`` finding plus per-uncovered findings
+      * coverage_ratio < warn_threshold -> WARN with per-uncovered findings
+      * otherwise -> PASS with no findings
+
+    Per-uncovered review_ids are surfaced as separate findings so an
+    operator UI can render them individually; the summary metadata
+    keeps the legacy dict shape so dashboards keep working.
+    """
+    findings: list[GateFinding] = []
+    coverage_ratio = float(audit.get("coverage_ratio", 0.0))
+    uncovered: Sequence[str] = tuple(audit.get("uncovered_review_ids") or ())
+
+    if coverage_ratio < block_threshold:
+        decision = GateDecision.BLOCK
+        severity = GateSeverity.BLOCKER
+        findings.append(
+            GateFinding(
+                code="low_evidence_coverage",
+                message=(
+                    f"low_evidence_coverage:{coverage_ratio} below "
+                    f"block_threshold:{block_threshold}"
+                ),
+                severity=GateSeverity.BLOCKER,
+                metadata={
+                    "coverage_ratio": coverage_ratio,
+                    "block_threshold": block_threshold,
+                },
+            )
+        )
+    elif coverage_ratio < warn_threshold:
+        decision = GateDecision.WARN
+        severity = GateSeverity.WARNING
+    else:
+        decision = GateDecision.PASS
+        severity = None
+
+    if severity is not None:
+        for review_id in uncovered:
+            findings.append(
+                GateFinding(
+                    code="unbacked_review",
+                    message=f"unbacked_review:{review_id}",
+                    severity=severity,
+                    metadata={"review_id": review_id},
+                )
+            )
+
+    return QualityReport(
+        passed=decision != GateDecision.BLOCK,
+        decision=decision,
+        findings=tuple(findings),
+        metadata={
+            "vendor_name": audit.get("vendor_name", ""),
+            "min_pain_confidence": audit.get("min_pain_confidence", ""),
+            "total_review_ids": int(audit.get("total_review_ids", 0)),
+            "covered_count": int(audit.get("covered_count", 0)),
+            "uncovered_count": int(audit.get("uncovered_count", 0)),
+            "coverage_ratio": coverage_ratio,
+            "covered_review_ids": tuple(audit.get("covered_review_ids") or ()),
+            "uncovered_review_ids": tuple(uncovered),
+            "block_threshold": block_threshold,
+            "warn_threshold": warn_threshold,
+        },
+    )
+
+
+async def evaluate_evidence_coverage(
+    pool: Any,
+    input: QualityInput,
+    *,
+    policy: QualityPolicy | None = None,
+) -> QualityReport:
+    """Pack-contract entry point.
+
+    Reads ``input.context``:
+      * ``vendor_name``: str -- the vendor whose claims gate this report
+      * ``source_review_ids``: Iterable[UUID | str] -- review IDs the
+        artifact references as witness anchors
+      * ``min_pain_confidence``: str (optional) -- per-call override of
+        the policy default; falls back to ``policy.thresholds["min_pain_confidence"]``
+
+    Reads ``policy.thresholds`` (all optional):
+      * ``min_pain_confidence`` (str, default ``"strong"``)
+      * ``valid_status`` (str, default ``"valid"``)
+      * ``coverage_precision`` (int, default 3)
+      * ``coverage_block_threshold`` (float, default 0.0)
+      * ``coverage_warn_threshold`` (float, default 1.0)
+
+    Returns a ``QualityReport`` whose ``metadata`` carries the same
+    fields the legacy ``audit_witness_evidence_coverage`` dict
+    produced (vendor_name, total_review_ids, covered/uncovered lists
+    + counts, coverage_ratio) plus the active block/warn thresholds.
+    """
+    context = dict(input.context or {})
+    thresholds = policy.thresholds if policy is not None else None
+
+    policy_min_pain = _resolve_threshold(
+        thresholds, "min_pain_confidence", _DEFAULT_MIN_PAIN_CONFIDENCE
+    )
+    min_pain_confidence = str(context.get("min_pain_confidence") or policy_min_pain)
+    valid_status = str(
+        _resolve_threshold(thresholds, "valid_status", _DEFAULT_VALID_STATUS)
+    )
+    coverage_precision = int(
+        _resolve_threshold(
+            thresholds, "coverage_precision", _DEFAULT_COVERAGE_PRECISION
+        )
+    )
+    block_threshold = float(
+        _resolve_threshold(
+            thresholds, "coverage_block_threshold", _DEFAULT_COVERAGE_BLOCK_THRESHOLD
+        )
+    )
+    warn_threshold = float(
+        _resolve_threshold(
+            thresholds, "coverage_warn_threshold", _DEFAULT_COVERAGE_WARN_THRESHOLD
+        )
+    )
+
+    audit = await audit_witness_evidence_coverage(
+        pool,
+        vendor_name=str(context.get("vendor_name") or ""),
+        source_review_ids=tuple(context.get("source_review_ids") or ()),
+        min_pain_confidence=min_pain_confidence,
+        valid_status=valid_status,
+        coverage_precision=coverage_precision,
+    )
+    return _build_quality_report(
+        audit,
+        block_threshold=block_threshold,
+        warn_threshold=warn_threshold,
+    )
+
+
+__all__ = [
+    "audit_witness_evidence_coverage",
+    "evaluate_evidence_coverage",
+]

--- a/extracted_quality_gate/manifest.json
+++ b/extracted_quality_gate/manifest.json
@@ -19,6 +19,9 @@
       "target": "extracted_quality_gate/campaign_pack.py"
     },
     {
+      "target": "extracted_quality_gate/evidence_pack.py"
+    },
+    {
       "target": "extracted_quality_gate/ports.py"
     },
     {

--- a/tests/test_extracted_quality_gate_evidence_pack.py
+++ b/tests/test_extracted_quality_gate_evidence_pack.py
@@ -1,0 +1,502 @@
+"""Tests for extracted_quality_gate.evidence_pack.
+
+Pure unit tests against the lifted helpers + the
+``evaluate_evidence_coverage`` pack-contract entry point. The async
+DB query is exercised against a fake pool that emulates the
+``b2b_evidence_claims`` filter so tests stay self-contained.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from extracted_quality_gate.evidence_pack import (
+    _coerce_review_ids,
+    _rank_floor,
+    audit_witness_evidence_coverage,
+    evaluate_evidence_coverage,
+)
+from extracted_quality_gate.types import (
+    GateDecision,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+class _NullPool:
+    """Pool stub that always returns no rows -- nothing covered."""
+
+    async def fetch(self, *_args: Any) -> list[dict[str, Any]]:
+        return []
+
+
+class _FakePool:
+    """Pool stub that mirrors the SQL: filter by status/vendor/IDs/rank.
+
+    Tests seed ``self.claims`` with dicts containing
+    ``status``, ``vendor_name``, ``source_review_id`` (UUID), and
+    ``pain_confidence_rank`` (int 0/1/2). ``fetch`` returns the
+    distinct review IDs that pass the filter, matching the production
+    query shape so the production SQL can change later without
+    silently desyncing tests.
+    """
+
+    def __init__(self) -> None:
+        self.claims: list[dict[str, Any]] = []
+        self.received_args: list[tuple[Any, ...]] = []
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        # Sanity-check that the production SQL keeps the shape this
+        # fake emulates. Catches accidental regressions to the schema
+        # column names or the placeholder ordering.
+        assert "FROM b2b_evidence_claims" in sql
+        assert "status = $1" in sql
+        assert "vendor_name = $2" in sql
+        assert "source_review_id = ANY($3::uuid[])" in sql
+        assert "pain_confidence_rank <= $4" in sql
+        self.received_args.append(args)
+        valid_status, vendor, ids, floor = args
+        ids_set = {str(i) for i in ids}
+        seen: set[str] = set()
+        out: list[dict[str, Any]] = []
+        for claim in self.claims:
+            if claim["status"] != valid_status:
+                continue
+            if claim["vendor_name"] != vendor:
+                continue
+            if str(claim["source_review_id"]) not in ids_set:
+                continue
+            if claim["pain_confidence_rank"] > floor:
+                continue
+            review_id = str(claim["source_review_id"])
+            if review_id in seen:
+                continue
+            seen.add(review_id)
+            out.append({"review_id": review_id})
+        return out
+
+
+# ---- _rank_floor ----
+
+
+def test_rank_floor_strong_maps_to_zero():
+    assert _rank_floor("strong") == 0
+
+
+def test_rank_floor_weak_maps_to_one():
+    assert _rank_floor("weak") == 1
+
+
+def test_rank_floor_none_maps_to_two():
+    assert _rank_floor("none") == 2
+
+
+def test_rank_floor_unknown_falls_back_to_strong():
+    assert _rank_floor("unknown") == 0
+    assert _rank_floor("") == 0
+    assert _rank_floor(None) == 0  # type: ignore[arg-type]
+
+
+def test_rank_floor_case_insensitive():
+    assert _rank_floor("STRONG") == 0
+    assert _rank_floor("Weak") == 1
+
+
+def test_rank_floor_whitespace_stripped():
+    assert _rank_floor("  strong  ") == 0
+
+
+# ---- _coerce_review_ids ----
+
+
+def test_coerce_drops_none_and_blank():
+    assert _coerce_review_ids([None, "", "   "]) == []
+
+
+def test_coerce_drops_invalid_uuids():
+    out = _coerce_review_ids(["not-a-uuid", "abc"])
+    assert out == []
+
+
+def test_coerce_dedupes_uuid_and_str_forms():
+    rid = uuid4()
+    out = _coerce_review_ids([rid, str(rid), rid])
+    assert len(out) == 1
+    assert out[0] == rid
+
+
+def test_coerce_preserves_input_order():
+    a = uuid4()
+    b = uuid4()
+    out = _coerce_review_ids([a, b])
+    assert out == [a, b]
+
+
+# ---- audit_witness_evidence_coverage (legacy entry point) ----
+
+
+@pytest.mark.asyncio
+async def test_audit_returns_full_coverage_for_empty_review_ids():
+    result = await audit_witness_evidence_coverage(
+        _NullPool(),
+        vendor_name="acme",
+        source_review_ids=[],
+    )
+    assert result["total_review_ids"] == 0
+    assert result["covered_count"] == 0
+    assert result["uncovered_count"] == 0
+    assert result["coverage_ratio"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_audit_returns_zero_coverage_for_empty_vendor():
+    rid = uuid4()
+    result = await audit_witness_evidence_coverage(
+        _NullPool(),
+        vendor_name="",
+        source_review_ids=[rid],
+    )
+    assert result["total_review_ids"] == 1
+    assert result["covered_count"] == 0
+    assert result["uncovered_count"] == 1
+    assert result["coverage_ratio"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_audit_dedups_duplicate_review_ids():
+    rid = uuid4()
+    result = await audit_witness_evidence_coverage(
+        _NullPool(),
+        vendor_name="acme",
+        source_review_ids=[rid, rid, str(rid)],
+    )
+    assert result["total_review_ids"] == 1
+
+
+@pytest.mark.asyncio
+async def test_audit_skips_invalid_uuid_strings():
+    result = await audit_witness_evidence_coverage(
+        _NullPool(),
+        vendor_name="acme",
+        source_review_ids=["not-a-uuid", None, ""],
+    )
+    assert result["total_review_ids"] == 0
+
+
+@pytest.mark.asyncio
+async def test_audit_counts_strong_backed_review_ids():
+    pool = _FakePool()
+    vendor = "vendor-x"
+    strong_rid = uuid4()
+    weak_rid = uuid4()
+    unbacked_rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": strong_rid, "pain_confidence_rank": 0},
+        {"status": "valid", "vendor_name": vendor, "source_review_id": weak_rid, "pain_confidence_rank": 1},
+    ]
+    result = await audit_witness_evidence_coverage(
+        pool,
+        vendor_name=vendor,
+        source_review_ids=[strong_rid, weak_rid, unbacked_rid],
+        min_pain_confidence="strong",
+    )
+    assert result["total_review_ids"] == 3
+    assert str(strong_rid) in result["covered_review_ids"]
+    assert str(weak_rid) not in result["covered_review_ids"]
+    assert str(unbacked_rid) not in result["covered_review_ids"]
+    assert result["covered_count"] == 1
+    assert result["uncovered_count"] == 2
+    assert result["coverage_ratio"] == round(1 / 3, 3)
+
+
+@pytest.mark.asyncio
+async def test_audit_loosened_to_weak_includes_weak_claims():
+    pool = _FakePool()
+    vendor = "vendor-y"
+    strong_rid = uuid4()
+    weak_rid = uuid4()
+    unbacked_rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": strong_rid, "pain_confidence_rank": 0},
+        {"status": "valid", "vendor_name": vendor, "source_review_id": weak_rid, "pain_confidence_rank": 1},
+    ]
+    result = await audit_witness_evidence_coverage(
+        pool,
+        vendor_name=vendor,
+        source_review_ids=[strong_rid, weak_rid, unbacked_rid],
+        min_pain_confidence="weak",
+    )
+    assert result["covered_count"] == 2
+    assert str(strong_rid) in result["covered_review_ids"]
+    assert str(weak_rid) in result["covered_review_ids"]
+
+
+@pytest.mark.asyncio
+async def test_audit_ignores_invalid_status_rows():
+    pool = _FakePool()
+    vendor = "vendor-z"
+    rid = uuid4()
+    pool.claims = [
+        {"status": "rejected", "vendor_name": vendor, "source_review_id": rid, "pain_confidence_rank": 0},
+    ]
+    result = await audit_witness_evidence_coverage(
+        pool,
+        vendor_name=vendor,
+        source_review_ids=[rid],
+        min_pain_confidence="strong",
+    )
+    assert result["covered_count"] == 0
+    assert result["uncovered_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_audit_respects_custom_valid_status():
+    pool = _FakePool()
+    vendor = "vendor-q"
+    rid = uuid4()
+    pool.claims = [
+        {"status": "approved", "vendor_name": vendor, "source_review_id": rid, "pain_confidence_rank": 0},
+    ]
+    # Override the status filter via the new keyword arg.
+    result = await audit_witness_evidence_coverage(
+        pool,
+        vendor_name=vendor,
+        source_review_ids=[rid],
+        valid_status="approved",
+    )
+    assert result["covered_count"] == 1
+    assert pool.received_args[-1][0] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_audit_respects_custom_precision():
+    pool = _FakePool()
+    vendor = "vendor-p"
+    rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": rid, "pain_confidence_rank": 0},
+    ]
+    result = await audit_witness_evidence_coverage(
+        pool,
+        vendor_name=vendor,
+        source_review_ids=[rid, uuid4(), uuid4()],
+        coverage_precision=5,
+    )
+    # coverage_ratio is 1/3 -> rounded to 5 dp
+    assert result["coverage_ratio"] == round(1 / 3, 5)
+
+
+# ---- evaluate_evidence_coverage (pack contract) ----
+
+
+def _build_input(
+    *,
+    vendor_name: str = "acme",
+    source_review_ids: tuple = (),
+    min_pain_confidence: str | None = None,
+) -> QualityInput:
+    context: dict[str, Any] = {
+        "vendor_name": vendor_name,
+        "source_review_ids": source_review_ids,
+    }
+    if min_pain_confidence is not None:
+        context["min_pain_confidence"] = min_pain_confidence
+    return QualityInput(
+        artifact_type="campaign_email",
+        artifact_id="test",
+        content=None,
+        context=context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_returns_quality_report():
+    report = await evaluate_evidence_coverage(_NullPool(), _build_input())
+    assert isinstance(report, QualityReport)
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_passes_when_no_review_ids():
+    report = await evaluate_evidence_coverage(_NullPool(), _build_input())
+    assert report.decision == GateDecision.PASS
+    assert report.findings == ()
+    assert report.metadata["coverage_ratio"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_warns_on_partial_coverage_default_thresholds():
+    # Default block_threshold=0.0 -> never blocks. warn_threshold=1.0
+    # -> any uncovered review yields warnings.
+    pool = _FakePool()
+    vendor = "vendor-w"
+    rid_covered = uuid4()
+    rid_uncovered = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": rid_covered, "pain_confidence_rank": 0},
+    ]
+    report = await evaluate_evidence_coverage(
+        pool,
+        _build_input(vendor_name=vendor, source_review_ids=(rid_covered, rid_uncovered)),
+    )
+    assert report.decision == GateDecision.WARN
+    # One per-review finding for the uncovered one.
+    warnings = [f for f in report.findings if f.severity == GateSeverity.WARNING]
+    assert len(warnings) == 1
+    assert warnings[0].code == "unbacked_review"
+    assert str(rid_uncovered) in warnings[0].message
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_blocks_when_ratio_below_block_threshold():
+    pool = _FakePool()
+    vendor = "vendor-b"
+    rid_covered = uuid4()
+    rid_uncovered_a = uuid4()
+    rid_uncovered_b = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": rid_covered, "pain_confidence_rank": 0},
+    ]
+    policy = QualityPolicy(
+        name="evidence",
+        thresholds={"coverage_block_threshold": 0.5},
+    )
+    # 1/3 coverage -> below 0.5 block threshold -> BLOCK
+    report = await evaluate_evidence_coverage(
+        pool,
+        _build_input(
+            vendor_name=vendor,
+            source_review_ids=(rid_covered, rid_uncovered_a, rid_uncovered_b),
+        ),
+        policy=policy,
+    )
+    assert report.decision == GateDecision.BLOCK
+    blockers = [f for f in report.findings if f.severity == GateSeverity.BLOCKER]
+    # One summary + per-uncovered findings.
+    assert any(f.code == "low_evidence_coverage" for f in blockers)
+    unbacked = [f for f in blockers if f.code == "unbacked_review"]
+    assert len(unbacked) == 2
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_passes_when_coverage_meets_warn_threshold():
+    pool = _FakePool()
+    vendor = "vendor-p2"
+    rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": rid, "pain_confidence_rank": 0},
+    ]
+    policy = QualityPolicy(
+        name="evidence",
+        thresholds={"coverage_warn_threshold": 0.5},
+    )
+    # 1/1 coverage = 1.0 > warn 0.5 -> PASS
+    report = await evaluate_evidence_coverage(
+        pool,
+        _build_input(vendor_name=vendor, source_review_ids=(rid,)),
+        policy=policy,
+    )
+    assert report.decision == GateDecision.PASS
+    assert report.findings == ()
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_metadata_carries_audit_dict_fields():
+    pool = _FakePool()
+    vendor = "vendor-m"
+    rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": rid, "pain_confidence_rank": 0},
+    ]
+    report = await evaluate_evidence_coverage(
+        pool,
+        _build_input(vendor_name=vendor, source_review_ids=(rid,)),
+    )
+    md = report.metadata
+    assert md["vendor_name"] == vendor
+    assert md["min_pain_confidence"] == "strong"
+    assert md["total_review_ids"] == 1
+    assert md["covered_count"] == 1
+    assert md["coverage_ratio"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_input_overrides_min_pain_confidence():
+    pool = _FakePool()
+    vendor = "vendor-o"
+    weak_rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": weak_rid, "pain_confidence_rank": 1},
+    ]
+    # default policy -> floor=strong (rank 0); weak (rank 1) excluded
+    report_default = await evaluate_evidence_coverage(
+        pool,
+        _build_input(vendor_name=vendor, source_review_ids=(weak_rid,)),
+    )
+    assert report_default.metadata["covered_count"] == 0
+
+    # input override -> floor=weak (rank 1); now included
+    report_override = await evaluate_evidence_coverage(
+        pool,
+        _build_input(
+            vendor_name=vendor,
+            source_review_ids=(weak_rid,),
+            min_pain_confidence="weak",
+        ),
+    )
+    assert report_override.metadata["covered_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_pack_contract_policy_overrides_min_pain_confidence():
+    pool = _FakePool()
+    vendor = "vendor-p3"
+    weak_rid = uuid4()
+    pool.claims = [
+        {"status": "valid", "vendor_name": vendor, "source_review_id": weak_rid, "pain_confidence_rank": 1},
+    ]
+    policy = QualityPolicy(
+        name="evidence",
+        thresholds={"min_pain_confidence": "weak"},
+    )
+    report = await evaluate_evidence_coverage(
+        pool,
+        _build_input(vendor_name=vendor, source_review_ids=(weak_rid,)),
+        policy=policy,
+    )
+    assert report.metadata["covered_count"] == 1
+
+
+def test_quality_report_is_frozen():
+    # Build a minimal report by reaching the helper directly.
+    from extracted_quality_gate.evidence_pack import _build_quality_report
+
+    audit = {
+        "vendor_name": "acme",
+        "min_pain_confidence": "strong",
+        "total_review_ids": 0,
+        "covered_review_ids": [],
+        "uncovered_review_ids": [],
+        "covered_count": 0,
+        "uncovered_count": 0,
+        "coverage_ratio": 1.0,
+    }
+    report = _build_quality_report(audit, block_threshold=0.0, warn_threshold=1.0)
+    with pytest.raises(Exception):
+        report.passed = False  # type: ignore[misc]
+
+
+# ---- Atlas re-export sanity ----
+
+
+def test_atlas_re_export_paths_match():
+    from atlas_brain.services.b2b.evidence_gate import (
+        audit_witness_evidence_coverage as atlas_audit,
+        evaluate_evidence_coverage as atlas_evaluate,
+    )
+    assert atlas_audit is audit_witness_evidence_coverage
+    assert atlas_evaluate is evaluate_evidence_coverage


### PR DESCRIPTION
## Summary

Second slice of PR-B5 (after PR-B5b #125). Lifts `audit_witness_evidence_coverage` from `atlas_brain/services/b2b/evidence_gate.py` (124 LOC) into a new `extracted_quality_gate/evidence_pack.py`. The atlas-side file becomes a thin re-export wrapper so the existing shadow-mode caller in `atlas_brain/autonomous/tasks/b2b_campaign_generation.py:1232` continues to work without modification.

| File | Type | Purpose |
|---|---|---|
| `extracted_quality_gate/evidence_pack.py` | NEW (~360 LOC) | Legacy entry point + `evaluate_evidence_coverage(pool, input, *, policy)` pack contract. |
| `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}` | EDIT | Document the new pack. |
| `atlas_brain/services/b2b/evidence_gate.py` | EDIT | Slimmed from 124 to 27 LOC; re-exports from pack. |
| `tests/test_extracted_quality_gate_evidence_pack.py` | NEW (29 tests) | Pure unit tests; FakePool emulates the SQL filter. |

## Production protocol applied (18 rules / 4 phases)

**Phase 1 (planning + discovery):** 1 production caller mapped (`b2b_campaign_generation.py:1232`); existing test file (`tests/test_evidence_gate.py`, 11 tests) inspected for contract preservation.

**Phase 2 (pre-mod validation):** ASCII scan caught a *separate* literal `€£` regression in `witness_pack.py:67` (introduced in PR-B5b #125); fixed in hotfix PR #128 before continuing this slice.

**Phase 3 (implementation):** atomic changes; no placeholders; hard-coded values audited and made parametric (`valid_status`, `coverage_precision`, `coverage_block_threshold`, `coverage_warn_threshold`, `min_pain_confidence`); schema-fixed pain-confidence rank map intentionally retained as contract (documented).

**Phase 4 (post-mod validation):** all 245 tests pass across affected suites; existing caller imports verified; signature preserved (two new kwargs are additive, default to legacy values); ASCII clean across the whole `extracted_quality_gate/` package.

## Pack contract

```python
async def evaluate_evidence_coverage(
    pool: Any,
    input: QualityInput,
    *,
    policy: QualityPolicy | None = None,
) -> QualityReport
```

`input.context` reads:
- `vendor_name`: str
- `source_review_ids`: Iterable[UUID | str]
- `min_pain_confidence`: str (optional per-call override)

`policy.thresholds` reads:
- `min_pain_confidence` (str, default `"strong"`)
- `valid_status` (str, default `"valid"`)
- `coverage_precision` (int, default 3)
- `coverage_block_threshold` (float, default 0.0 — never blocks; matches current shadow mode)
- `coverage_warn_threshold` (float, default 1.0 — any uncovered review yields a warning)

`QualityReport`:
- `decision`: BLOCK below `block_threshold`, WARN below `warn_threshold`, PASS otherwise
- `findings`: one `low_evidence_coverage` summary BLOCKER (when blocking) plus per-`review_id` findings
- `metadata`: full audit dict (vendor_name, totals, ratios, threshold values used)

## Public API preservation

`audit_witness_evidence_coverage` keeps its existing signature; the two new keyword args (`valid_status`, `coverage_precision`) default to the values the legacy hard-coded. Atlas-side import path
`from atlas_brain.services.b2b.evidence_gate import audit_witness_evidence_coverage` resolves through the re-export unchanged.

## Validation

```
$ pytest tests/test_extracted_quality_gate_evidence_pack.py
29 passed in 2.05s

$ pytest tests/test_evidence_gate.py -v
11 passed in 2.08s   # all existing tests against the re-export

$ pytest tests/test_extracted_quality_gate_*.py tests/test_evidence_gate.py tests/test_b2b_blog_quality_gate.py
245 passed in 2.49s
```

## Coordination

- Owner `claude-2026-05-03-b` (alias A); PR-B5 already claimed in `coordination/queue.md` with the three-way split note.
- Replaces evidence-coverage row in inflight.md.
- No file overlap with C's in-flight PR-C1i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
