### PR TITLE
Drop PR-B5a row after #130 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T02:30Z by claude-2026-05-03-b
+Last updated: 2026-05-04T02:35Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -8,6 +8,5 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 |---|---|---|---|---|
 | (PR-C1j, in flight) | PR-C1j: Route `extracted_content_pipeline/reasoning/temporal.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/temporal.py` (drop ~466-line drifted fork; replace with thin re-export wrapper from `extracted_reasoning_core.temporal` + `extracted_reasoning_core.types`). All temporal types/constants/`TemporalEngine` were already promoted to core in PR-C1b/PR-C1c, so no drift-forward needed. Existing `tests/test_extracted_reasoning_temporal.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/temporal.py`; `tests/test_extracted_reasoning_temporal.py` |
 | (PR-D9, in flight) | Add AI Content Ops draft review/status update path | NEW: `extracted_content_pipeline/campaign_postgres_review.py`; NEW: `scripts/review_extracted_campaign_drafts.py`; EDIT: content-pipeline docs/status/manifest/check script; NEW focused review tests | codex-2026-05-03 | Avoid `extracted_reasoning_core/**`, `extracted_content_pipeline/reasoning/**`, `extracted_content_pipeline/docs/reasoning_state_audit.md`, and `extracted_quality_gate/**` |
-| (PR-B5a, in flight) | PR-B5a: Evidence-coverage gate (deterministic core + Atlas re-export) | NEW: `extracted_quality_gate/evidence_pack.py` (legacy `audit_witness_evidence_coverage` + pack-contract `evaluate_evidence_coverage`). EDIT: `extracted_quality_gate/{__init__.py, manifest.json, README.md, STATUS.md}`. EDIT: `atlas_brain/services/b2b/evidence_gate.py` (slimmed to thin re-export). NEW: `tests/test_extracted_quality_gate_evidence_pack.py` (29 tests). | claude-2026-05-03-b | `extracted_quality_gate/evidence_pack.py`; `atlas_brain/services/b2b/evidence_gate.py`; the new evidence-pack test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,15 +1,14 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T02:20Z by codex-2026-05-03
+Last updated: 2026-05-04T02:35Z by claude-2026-05-03-b
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #87, PR-A1.5 #107, PR-A2 #89, PR-A3 #92, PR-A4a #95, PR-A4b #106, PR-A4c #98.
-B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack), PR-B4b #120 (campaign quality pack), PR-B5b #125 (witness specificity pack). PR-B5a (evidence coverage gate) and PR-B5c (source-quality pack) remain.
+B-series progress: PR-B2 #85 (product-claim core), PR-B3 #114 (safety-gate split), PR-B4a #118 (blog quality pack), PR-B4b #120 (campaign quality pack), PR-B5b #125 (witness specificity pack), PR-B5a #130 (evidence coverage gate). PR-B5c (source-quality pack) remains.
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-B5a | `extracted_quality_gate` | claude-2026-05-03-b | PR-B5b / #125 (merged) | Evidence coverage gate. Lifts `audit_witness_evidence_coverage` from `atlas_brain/services/b2b/evidence_gate.py` into the pack. Async DB query stays — the pack provides the gate-shaped wrapper around it. ~350 LOC including tests. |
 | PR-B5c | `extracted_quality_gate` | claude-2026-05-03-b | PR-B5b / #125 (merged) | Source-quality pack. Composes `source_impact.py` + `witness_render_gate.py`. Async DB + settings dependency for source capability registry. ~500 LOC including tests. |
 | PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |
 | PR-D9 | `extracted_content_pipeline` | codex-2026-05-03 | PR-D8 / #116 (merged); avoid PR-C1, PR #122, and quality-gate files | Add product-owned draft review/status update path so hosts can approve, queue, cancel, or expire generated `b2b_campaigns` rows after export. |


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #130 (PR-B5a evidence-coverage gate) merged. Updates queue.md to record the merge — only PR-B5c remains in the B-series.
