### PR TITLE
Drop PR-A5a row after #136 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T05:40Z by claude-2026-05-03-b
+Last updated: 2026-05-04T05:50Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1j, in flight) | PR-C1j: Route `extracted_content_pipeline/reasoning/temporal.py` through reasoning core wrapper | EDIT: `extracted_content_pipeline/reasoning/temporal.py` (drop ~466-line drifted fork; replace with thin re-export wrapper from `extracted_reasoning_core.temporal` + `extracted_reasoning_core.types`). EDIT: `extracted_reasoning_core/temporal.py` (fix latent frozen-dataclass mutations in `analyze_vendor` / `_compute_long_term_trends` activated by PR-C1c; drift-forward `_coerce_date` / `_days_between` / `_volatility` / `_percentiles_from_rows` helpers; replace atlas-coupled `_compute_percentiles` with self-contained SQL; drop dead `_infer_category`). Existing `tests/test_extracted_reasoning_temporal.py` keeps green against the wrapper. | claude-2026-05-03 | `extracted_content_pipeline/reasoning/temporal.py`; `extracted_reasoning_core/temporal.py`; `tests/test_extracted_reasoning_temporal.py` |
-| (PR-A5a, in flight) | PR-A5a: Phase 3 LLM-infra decoupling — extract `_convert_messages` from `AnthropicLLM` | EDIT: `atlas_brain/services/llm/anthropic.py` (add module-level `convert_messages(messages, *, cache_threshold_chars)`; collapse `AnthropicLLM._convert_messages` to a backwards-compat alias; thresh exposed as named constant `_DEFAULT_CACHE_THRESHOLD_CHARS = 1024`). EDIT: `atlas_brain/services/b2b/anthropic_batch.py` (import + use the public function instead of the private method, dropping the `# type: ignore[attr-defined]`). EDIT: `extracted_llm_infrastructure/services/{llm/anthropic.py, b2b/anthropic_batch.py, STATUS.md}` (sync). NEW: `tests/test_anthropic_convert_messages.py` (22 tests covering plain messages, system prompt extraction, cache threshold policy, tool-call/tool-result handling, method-vs-function identity, batch import identity, and output independence). | claude-2026-05-03-b | `atlas_brain/services/llm/anthropic.py`; `atlas_brain/services/b2b/anthropic_batch.py`; the synced extracted copies; the new test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #136 (PR-A5a, _convert_messages extraction, first Phase 3 LLM-infra decoupling slice) merged in 8ca261ec.