### PR TITLE
Drop PR-A5c row after #142 merge

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T06:40Z by claude-2026-05-03-b
+Last updated: 2026-05-04T06:50Z by claude-2026-05-03-b
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C1l, in flight) | PR-C1l: Document PR-C1 implementation outcomes in reasoning boundary audit | EDIT: `docs/extraction/reasoning_boundary_audit_2026-05-03.md` (append "PR-C1 Implementation Outcomes" section recording PR-C1a through PR-C1k slices, architectural deviations from the original plan, and the drift-forward pattern; mark which acceptance criteria from PR 2/PR 3 are now satisfied vs deferred to PR 4/PR 5/PR 6/PR 7). Doc-only change; no code touched. Closes the PR-C1 sequence. | claude-2026-05-03 | `docs/extraction/reasoning_boundary_audit_2026-05-03.md` |
-| (PR-A5c, in flight) | PR-A5c: Phase 3 LLM-infra decoupling — consolidate `evidence_hash` to single owner | EDIT: `atlas_brain/autonomous/tasks/_b2b_cross_vendor_synthesis.py` (drop duplicate `compute_cross_vendor_evidence_hash` body; re-export `compute_evidence_hash` from `semantic_cache` under the legacy name; add `__all__` so the public name stays exported; drop now-unused `hashlib` import). EDIT: `extracted_llm_infrastructure/STATUS.md` (mark task ✅). SYNC: `extracted_competitive_intelligence/autonomous/tasks/_b2b_cross_vendor_synthesis.py`. NEW: `tests/test_evidence_hash_consolidation.py` (11 tests pinning `is`-identity across the two names + hash stability + caller import path + `__all__` contract). Public API + signatures + behavior unchanged. | claude-2026-05-03-b | `atlas_brain/autonomous/tasks/_b2b_cross_vendor_synthesis.py`; the synced extracted_competitive_intelligence copy; the new test file |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
Per session protocol step 4: drop the in-flight row when a PR merges. PR #142 (PR-A5c, evidence_hash consolidation) merged. Phase 3 LLM-infra decoupling is now 3/5 complete.