### PR TITLE
PR-C2: Semantic cache split (PR 4 from reasoning boundary audit)

### DIFF
--- a/atlas_brain/reasoning/semantic_cache.py
+++ b/atlas_brain/reasoning/semantic_cache.py
@@ -24,11 +24,18 @@ from typing import Any, Protocol
 
 from extracted_reasoning_core.semantic_cache_keys import (
     CacheEntry,
-    STALE_THRESHOLD,
+    STALE_THRESHOLD as _CORE_STALE_THRESHOLD,
     apply_decay as _apply_decay,
     compute_evidence_hash,
     row_to_cache_entry,
 )
+
+# Re-export as a module-level name so callers doing
+# ``from atlas_brain.reasoning.semantic_cache import STALE_THRESHOLD``
+# keep working. Aliased on import to avoid the
+# ``STALE_THRESHOLD = STALE_THRESHOLD`` self-reference shadowing that
+# made the prior shape look like a no-op.
+STALE_THRESHOLD = _CORE_STALE_THRESHOLD
 
 logger = logging.getLogger("atlas.reasoning.semantic_cache")
 
@@ -67,7 +74,7 @@ class SemanticCache:
     # Re-exported as a class attribute for backward-compat with callers
     # that read ``SemanticCache.STALE_THRESHOLD``. The module-level
     # constant in core's ``semantic_cache_keys`` is the canonical home.
-    STALE_THRESHOLD = STALE_THRESHOLD
+    STALE_THRESHOLD = _CORE_STALE_THRESHOLD
 
     def __init__(self, pool: SemanticCachePool):
         """*pool*: any object exposing the ``SemanticCachePool``

--- a/atlas_brain/reasoning/semantic_cache.py
+++ b/atlas_brain/reasoning/semantic_cache.py
@@ -1,22 +1,34 @@
-"""Semantic memory cache for the stratified reasoning engine.
+"""Postgres-backed semantic cache storage for the stratified reasoning engine.
 
-Stores generalised reasoning conclusions in Postgres with confidence decay.
-Each entry represents a cached pattern conclusion (e.g. "pricing_shock for
-Vendor X") that can be recalled without re-running the LLM.
+PR-C2 (PR 4 from the reasoning boundary audit) split this module: the
+*pure* primitives (``CacheEntry``, ``compute_evidence_hash``,
+``apply_decay``, ``row_to_cache_entry``, ``STALE_THRESHOLD``) now live
+in ``extracted_reasoning_core.semantic_cache_keys``. This module owns
+the Postgres-specific storage class (``SemanticCache``) and the
+asyncpg-shaped pool Protocol it consumes. ``CacheEntry`` /
+``compute_evidence_hash`` / ``STALE_THRESHOLD`` are re-exported here
+so existing callers keep working without changing imports.
 
 Confidence decays exponentially since last validation:
     effective = confidence * 2^(-(days_since_validated / decay_half_life_days))
+
+The decay is computed by ``apply_decay`` from the core module; this
+adapter just calls it on every row read out of Postgres.
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
-import math
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Any, Mapping, Protocol
+from typing import Any, Protocol
+
+from extracted_reasoning_core.semantic_cache_keys import (
+    CacheEntry,
+    STALE_THRESHOLD,
+    apply_decay as _apply_decay,
+    compute_evidence_hash,
+    row_to_cache_entry,
+)
 
 logger = logging.getLogger("atlas.reasoning.semantic_cache")
 
@@ -33,8 +45,8 @@ class SemanticCachePool(Protocol):
 
     ``fetchrow`` and ``fetch`` return row mappings (the production
     binding returns ``asyncpg.Record`` instances that subscript like
-    dicts; ``_row_to_entry`` reads them via ``row[key]`` and accepts
-    anything that supports the ``Mapping`` protocol).
+    dicts; ``row_to_cache_entry`` reads them via ``row[key]`` and
+    accepts anything that supports the ``Mapping`` protocol).
     """
 
     async def fetchrow(self, query: str, *args: Any) -> Any: ...
@@ -42,51 +54,20 @@ class SemanticCachePool(Protocol):
     async def execute(self, query: str, *args: Any) -> Any: ...
 
 
-@dataclass
-class CacheEntry:
-    """A single cached reasoning conclusion."""
-
-    pattern_sig: str
-    pattern_class: str
-    conclusion: dict[str, Any]
-    confidence: float
-    reasoning_steps: list[dict[str, Any]] = field(default_factory=list)
-    boundary_conditions: dict[str, Any] = field(default_factory=dict)
-    falsification_conditions: list[str] = field(default_factory=list)
-    uncertainty_sources: list[str] = field(default_factory=list)
-    vendor_name: str | None = None
-    product_category: str | None = None
-    decay_half_life_days: int = 90
-    conclusion_type: str | None = None
-    evidence_hash: str | None = None
-    created_at: datetime | None = None
-    last_validated_at: datetime | None = None
-    validation_count: int = 1
-    effective_confidence: float | None = None
-
-
-def compute_evidence_hash(evidence: dict[str, Any]) -> str:
-    """SHA-256 of deterministically serialised evidence dict."""
-    raw = json.dumps(evidence, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
-
-
-def _apply_decay(confidence: float, last_validated: datetime, half_life_days: int) -> float:
-    """Return effective confidence after exponential decay."""
-    now = datetime.now(timezone.utc)
-    if last_validated.tzinfo is None:
-        last_validated = last_validated.replace(tzinfo=timezone.utc)
-    days = (now - last_validated).total_seconds() / 86400.0
-    if days <= 0 or half_life_days <= 0:
-        return confidence
-    return confidence * math.pow(2, -(days / half_life_days))
-
-
 class SemanticCache:
-    """Postgres-backed semantic memory for cached reasoning conclusions."""
+    """Postgres-backed semantic memory for cached reasoning conclusions.
 
-    # Entries with effective confidence below this are treated as stale
-    STALE_THRESHOLD = 0.5
+    Implements the ``SemanticCacheStore`` port declared in
+    ``extracted_reasoning_core.ports``: ``lookup`` / ``store`` /
+    ``validate`` / ``invalidate`` plus the read-side helpers
+    ``lookup_by_class`` / ``lookup_for_tier`` / ``get_cache_stats``
+    that callers reach for directly.
+    """
+
+    # Re-exported as a class attribute for backward-compat with callers
+    # that read ``SemanticCache.STALE_THRESHOLD``. The module-level
+    # constant in core's ``semantic_cache_keys`` is the canonical home.
+    STALE_THRESHOLD = STALE_THRESHOLD
 
     def __init__(self, pool: SemanticCachePool):
         """*pool*: any object exposing the ``SemanticCachePool``
@@ -116,7 +97,7 @@ class SemanticCache:
         if row is None:
             return None
 
-        entry = self._row_to_entry(row)
+        entry = row_to_cache_entry(row)
         eff = _apply_decay(entry.confidence, entry.last_validated_at, entry.decay_half_life_days)
         entry.effective_confidence = eff
 
@@ -256,7 +237,7 @@ class SemanticCache:
             )
         entries = []
         for row in rows:
-            e = self._row_to_entry(row)
+            e = row_to_cache_entry(row)
             e.effective_confidence = _apply_decay(e.confidence, e.last_validated_at, e.decay_half_life_days)
             entries.append(e)
         return entries
@@ -309,7 +290,7 @@ class SemanticCache:
             )
         entries = []
         for row in rows:
-            e = self._row_to_entry(row)
+            e = row_to_cache_entry(row)
             e.effective_confidence = _apply_decay(e.confidence, e.last_validated_at, e.decay_half_life_days)
             if e.effective_confidence >= self.STALE_THRESHOLD:
                 entries.append(e)
@@ -334,39 +315,8 @@ class SemanticCache:
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _row_to_entry(row: Mapping[str, Any]) -> CacheEntry:
-        """Convert a row mapping to a :class:`CacheEntry`.
-
-        Accepts any object supporting ``Mapping`` access -- typically
-        an ``asyncpg.Record`` (which subscripts like a dict) but also
-        a plain dict, which is what tests + non-asyncpg adapters
-        produce. JSONB columns may arrive either pre-decoded (asyncpg
-        with the json codec installed) or as raw strings (a vanilla
-        adapter); the body handles both shapes defensively.
-        """
-        falsification = row["falsification_conditions"]
-        if isinstance(falsification, str):
-            falsification = json.loads(falsification)
-        if isinstance(falsification, dict):
-            falsification = list(falsification.values()) if falsification else []
-
-        return CacheEntry(
-            pattern_sig=row["pattern_sig"],
-            pattern_class=row["pattern_class"],
-            vendor_name=row["vendor_name"],
-            product_category=row["product_category"],
-            conclusion=row["conclusion"] if isinstance(row["conclusion"], dict) else json.loads(row["conclusion"]),
-            confidence=row["confidence"],
-            reasoning_steps=row["reasoning_steps"] if isinstance(row["reasoning_steps"], list) else json.loads(row["reasoning_steps"]),
-            boundary_conditions=row["boundary_conditions"] if isinstance(row["boundary_conditions"], dict) else json.loads(row["boundary_conditions"]),
-            falsification_conditions=falsification if isinstance(falsification, list) else [],
-            uncertainty_sources=list(row["uncertainty_sources"]) if row["uncertainty_sources"] else [],
-            decay_half_life_days=row["decay_half_life_days"],
-            conclusion_type=row["conclusion_type"],
-            evidence_hash=row["evidence_hash"],
-            created_at=row["created_at"],
-            last_validated_at=row["last_validated_at"],
-            validation_count=row["validation_count"],
-        )
+    #
+    # Row-to-entry coercion now lives in
+    # ``extracted_reasoning_core.semantic_cache_keys.row_to_cache_entry``
+    # (PR-C2). The static method that used to live here has been
+    # removed; callers below import the function directly.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T06:30Z by claude-2026-05-03
+Last updated: 2026-05-04T07:00Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-C1l, in flight) | PR-C1l: Document PR-C1 implementation outcomes in reasoning boundary audit | EDIT: `docs/extraction/reasoning_boundary_audit_2026-05-03.md` (append "PR-C1 Implementation Outcomes" section recording PR-C1a through PR-C1k slices, architectural deviations from the original plan, and the drift-forward pattern; mark which acceptance criteria from PR 2/PR 3 are now satisfied vs deferred to PR 4/PR 5/PR 6/PR 7). Doc-only change; no code touched. Closes the PR-C1 sequence. | claude-2026-05-03 | `docs/extraction/reasoning_boundary_audit_2026-05-03.md` |
+| (PR-C2, in flight) | PR-C2: Semantic cache split (PR 4 from reasoning boundary audit) | NEW: `extracted_reasoning_core/semantic_cache_keys.py` (pure: `compute_evidence_hash`, `apply_decay`, `CacheEntry`, `STALE_THRESHOLD`, `row_to_cache_entry`). NEW: `tests/test_extracted_reasoning_core_semantic_cache_keys.py`. EDIT: `extracted_llm_infrastructure/reasoning/semantic_cache.py` (import pure code from core; keep `SemanticCachePool` Protocol + `SemanticCache` storage class). EDIT: `extracted_competitive_intelligence/reasoning/semantic_cache.py` (replace atlas bridge with explicit re-exports from core + LLM-infra; closes PR 4 acceptance criterion #3). Atlas-side migration deferred to PR 7. | claude-2026-05-03 | `extracted_reasoning_core/semantic_cache_keys.py`; `extracted_llm_infrastructure/reasoning/semantic_cache.py`; `extracted_competitive_intelligence/reasoning/semantic_cache.py`; `tests/test_extracted_reasoning_core_semantic_cache_keys.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_competitive_intelligence/reasoning/semantic_cache.py
+++ b/extracted_competitive_intelligence/reasoning/semantic_cache.py
@@ -1,23 +1,43 @@
-"""Phase 1 bridge: re-exports atlas_brain.reasoning.semantic_cache.
+"""Semantic cache surface for the competitive-intelligence package.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+PR-C2 (PR 4 from the reasoning boundary audit) closed the audit's
+acceptance criterion #3: "competitive intelligence no longer bridges
+Atlas semantic cache". This module previously did a programmatic
+``importlib`` re-export of every name from
+``atlas_brain.reasoning.semantic_cache``; it now imports from the
+canonical homes directly:
+
+  - pure primitives -> ``extracted_reasoning_core.semantic_cache_keys``
+  - Postgres storage -> ``extracted_llm_infrastructure.reasoning.semantic_cache``
+
+The public-import path (``from
+extracted_competitive_intelligence.reasoning.semantic_cache import
+SemanticCache, CacheEntry, compute_evidence_hash``) is preserved so
+existing callers in ``extracted_competitive_intelligence/autonomous/tasks/``
+keep working unchanged.
 """
+
 from __future__ import annotations
 
-import importlib as _importlib
+from extracted_llm_infrastructure.reasoning.semantic_cache import (
+    SemanticCache,
+    SemanticCachePool,
+)
+from extracted_reasoning_core.semantic_cache_keys import (
+    CacheEntry,
+    STALE_THRESHOLD,
+    apply_decay,
+    compute_evidence_hash,
+    row_to_cache_entry,
+)
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.reasoning.semantic_cache")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
 
-
-_bridge()
-del _bridge, _importlib
+__all__ = [
+    "CacheEntry",
+    "STALE_THRESHOLD",
+    "SemanticCache",
+    "SemanticCachePool",
+    "apply_decay",
+    "compute_evidence_hash",
+    "row_to_cache_entry",
+]

--- a/extracted_content_pipeline/autonomous/tasks/_b2b_cross_vendor_synthesis.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_cross_vendor_synthesis.py
@@ -11,14 +11,19 @@ downstream deterministic/reporting consumers.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import re
 from datetime import date
 from typing import Any
 
+from ...reasoning.semantic_cache import (
+    compute_evidence_hash as compute_cross_vendor_evidence_hash,
+)
+
 logger = logging.getLogger("atlas.autonomous.tasks._b2b_cross_vendor_synthesis")
+
+__all__ = ["compute_cross_vendor_evidence_hash"]
 
 
 # ---------------------------------------------------------------------------
@@ -57,12 +62,13 @@ def empty_cross_vendor_lookup() -> dict[str, dict]:
 # ---------------------------------------------------------------------------
 # Evidence hashing
 # ---------------------------------------------------------------------------
-
-def compute_cross_vendor_evidence_hash(packet: dict[str, Any]) -> str:
-    """Deterministic SHA-256 prefix from packet content."""
-    raw = json.dumps(packet, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
-
+#
+# ``compute_cross_vendor_evidence_hash`` is re-exported from
+# ``atlas_brain.reasoning.semantic_cache.compute_evidence_hash`` (PR-A5c).
+# Both names compute the same SHA-256[:16] over a JSON-canonicalised
+# dict; consolidating to a single owner keeps the hash invariants
+# (sort_keys, ``(",", ":")`` separators, ``default=str``) in one place
+# so a future tweak to canonicalisation only has to land once.
 
 # ---------------------------------------------------------------------------
 # Pool summary extraction

--- a/extracted_llm_infrastructure/reasoning/semantic_cache.py
+++ b/extracted_llm_infrastructure/reasoning/semantic_cache.py
@@ -24,11 +24,18 @@ from typing import Any, Protocol
 
 from extracted_reasoning_core.semantic_cache_keys import (
     CacheEntry,
-    STALE_THRESHOLD,
+    STALE_THRESHOLD as _CORE_STALE_THRESHOLD,
     apply_decay as _apply_decay,
     compute_evidence_hash,
     row_to_cache_entry,
 )
+
+# Re-export as a module-level name so callers doing
+# ``from atlas_brain.reasoning.semantic_cache import STALE_THRESHOLD``
+# keep working. Aliased on import to avoid the
+# ``STALE_THRESHOLD = STALE_THRESHOLD`` self-reference shadowing that
+# made the prior shape look like a no-op.
+STALE_THRESHOLD = _CORE_STALE_THRESHOLD
 
 logger = logging.getLogger("atlas.reasoning.semantic_cache")
 
@@ -67,7 +74,7 @@ class SemanticCache:
     # Re-exported as a class attribute for backward-compat with callers
     # that read ``SemanticCache.STALE_THRESHOLD``. The module-level
     # constant in core's ``semantic_cache_keys`` is the canonical home.
-    STALE_THRESHOLD = STALE_THRESHOLD
+    STALE_THRESHOLD = _CORE_STALE_THRESHOLD
 
     def __init__(self, pool: SemanticCachePool):
         """*pool*: any object exposing the ``SemanticCachePool``

--- a/extracted_llm_infrastructure/reasoning/semantic_cache.py
+++ b/extracted_llm_infrastructure/reasoning/semantic_cache.py
@@ -1,22 +1,34 @@
-"""Semantic memory cache for the stratified reasoning engine.
+"""Postgres-backed semantic cache storage for the stratified reasoning engine.
 
-Stores generalised reasoning conclusions in Postgres with confidence decay.
-Each entry represents a cached pattern conclusion (e.g. "pricing_shock for
-Vendor X") that can be recalled without re-running the LLM.
+PR-C2 (PR 4 from the reasoning boundary audit) split this module: the
+*pure* primitives (``CacheEntry``, ``compute_evidence_hash``,
+``apply_decay``, ``row_to_cache_entry``, ``STALE_THRESHOLD``) now live
+in ``extracted_reasoning_core.semantic_cache_keys``. This module owns
+the Postgres-specific storage class (``SemanticCache``) and the
+asyncpg-shaped pool Protocol it consumes. ``CacheEntry`` /
+``compute_evidence_hash`` / ``STALE_THRESHOLD`` are re-exported here
+so existing callers keep working without changing imports.
 
 Confidence decays exponentially since last validation:
     effective = confidence * 2^(-(days_since_validated / decay_half_life_days))
+
+The decay is computed by ``apply_decay`` from the core module; this
+adapter just calls it on every row read out of Postgres.
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
-import math
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Any, Mapping, Protocol
+from typing import Any, Protocol
+
+from extracted_reasoning_core.semantic_cache_keys import (
+    CacheEntry,
+    STALE_THRESHOLD,
+    apply_decay as _apply_decay,
+    compute_evidence_hash,
+    row_to_cache_entry,
+)
 
 logger = logging.getLogger("atlas.reasoning.semantic_cache")
 
@@ -33,8 +45,8 @@ class SemanticCachePool(Protocol):
 
     ``fetchrow`` and ``fetch`` return row mappings (the production
     binding returns ``asyncpg.Record`` instances that subscript like
-    dicts; ``_row_to_entry`` reads them via ``row[key]`` and accepts
-    anything that supports the ``Mapping`` protocol).
+    dicts; ``row_to_cache_entry`` reads them via ``row[key]`` and
+    accepts anything that supports the ``Mapping`` protocol).
     """
 
     async def fetchrow(self, query: str, *args: Any) -> Any: ...
@@ -42,51 +54,20 @@ class SemanticCachePool(Protocol):
     async def execute(self, query: str, *args: Any) -> Any: ...
 
 
-@dataclass
-class CacheEntry:
-    """A single cached reasoning conclusion."""
-
-    pattern_sig: str
-    pattern_class: str
-    conclusion: dict[str, Any]
-    confidence: float
-    reasoning_steps: list[dict[str, Any]] = field(default_factory=list)
-    boundary_conditions: dict[str, Any] = field(default_factory=dict)
-    falsification_conditions: list[str] = field(default_factory=list)
-    uncertainty_sources: list[str] = field(default_factory=list)
-    vendor_name: str | None = None
-    product_category: str | None = None
-    decay_half_life_days: int = 90
-    conclusion_type: str | None = None
-    evidence_hash: str | None = None
-    created_at: datetime | None = None
-    last_validated_at: datetime | None = None
-    validation_count: int = 1
-    effective_confidence: float | None = None
-
-
-def compute_evidence_hash(evidence: dict[str, Any]) -> str:
-    """SHA-256 of deterministically serialised evidence dict."""
-    raw = json.dumps(evidence, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
-
-
-def _apply_decay(confidence: float, last_validated: datetime, half_life_days: int) -> float:
-    """Return effective confidence after exponential decay."""
-    now = datetime.now(timezone.utc)
-    if last_validated.tzinfo is None:
-        last_validated = last_validated.replace(tzinfo=timezone.utc)
-    days = (now - last_validated).total_seconds() / 86400.0
-    if days <= 0 or half_life_days <= 0:
-        return confidence
-    return confidence * math.pow(2, -(days / half_life_days))
-
-
 class SemanticCache:
-    """Postgres-backed semantic memory for cached reasoning conclusions."""
+    """Postgres-backed semantic memory for cached reasoning conclusions.
 
-    # Entries with effective confidence below this are treated as stale
-    STALE_THRESHOLD = 0.5
+    Implements the ``SemanticCacheStore`` port declared in
+    ``extracted_reasoning_core.ports``: ``lookup`` / ``store`` /
+    ``validate`` / ``invalidate`` plus the read-side helpers
+    ``lookup_by_class`` / ``lookup_for_tier`` / ``get_cache_stats``
+    that callers reach for directly.
+    """
+
+    # Re-exported as a class attribute for backward-compat with callers
+    # that read ``SemanticCache.STALE_THRESHOLD``. The module-level
+    # constant in core's ``semantic_cache_keys`` is the canonical home.
+    STALE_THRESHOLD = STALE_THRESHOLD
 
     def __init__(self, pool: SemanticCachePool):
         """*pool*: any object exposing the ``SemanticCachePool``
@@ -116,7 +97,7 @@ class SemanticCache:
         if row is None:
             return None
 
-        entry = self._row_to_entry(row)
+        entry = row_to_cache_entry(row)
         eff = _apply_decay(entry.confidence, entry.last_validated_at, entry.decay_half_life_days)
         entry.effective_confidence = eff
 
@@ -256,7 +237,7 @@ class SemanticCache:
             )
         entries = []
         for row in rows:
-            e = self._row_to_entry(row)
+            e = row_to_cache_entry(row)
             e.effective_confidence = _apply_decay(e.confidence, e.last_validated_at, e.decay_half_life_days)
             entries.append(e)
         return entries
@@ -309,7 +290,7 @@ class SemanticCache:
             )
         entries = []
         for row in rows:
-            e = self._row_to_entry(row)
+            e = row_to_cache_entry(row)
             e.effective_confidence = _apply_decay(e.confidence, e.last_validated_at, e.decay_half_life_days)
             if e.effective_confidence >= self.STALE_THRESHOLD:
                 entries.append(e)
@@ -334,39 +315,8 @@ class SemanticCache:
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _row_to_entry(row: Mapping[str, Any]) -> CacheEntry:
-        """Convert a row mapping to a :class:`CacheEntry`.
-
-        Accepts any object supporting ``Mapping`` access -- typically
-        an ``asyncpg.Record`` (which subscripts like a dict) but also
-        a plain dict, which is what tests + non-asyncpg adapters
-        produce. JSONB columns may arrive either pre-decoded (asyncpg
-        with the json codec installed) or as raw strings (a vanilla
-        adapter); the body handles both shapes defensively.
-        """
-        falsification = row["falsification_conditions"]
-        if isinstance(falsification, str):
-            falsification = json.loads(falsification)
-        if isinstance(falsification, dict):
-            falsification = list(falsification.values()) if falsification else []
-
-        return CacheEntry(
-            pattern_sig=row["pattern_sig"],
-            pattern_class=row["pattern_class"],
-            vendor_name=row["vendor_name"],
-            product_category=row["product_category"],
-            conclusion=row["conclusion"] if isinstance(row["conclusion"], dict) else json.loads(row["conclusion"]),
-            confidence=row["confidence"],
-            reasoning_steps=row["reasoning_steps"] if isinstance(row["reasoning_steps"], list) else json.loads(row["reasoning_steps"]),
-            boundary_conditions=row["boundary_conditions"] if isinstance(row["boundary_conditions"], dict) else json.loads(row["boundary_conditions"]),
-            falsification_conditions=falsification if isinstance(falsification, list) else [],
-            uncertainty_sources=list(row["uncertainty_sources"]) if row["uncertainty_sources"] else [],
-            decay_half_life_days=row["decay_half_life_days"],
-            conclusion_type=row["conclusion_type"],
-            evidence_hash=row["evidence_hash"],
-            created_at=row["created_at"],
-            last_validated_at=row["last_validated_at"],
-            validation_count=row["validation_count"],
-        )
+    #
+    # Row-to-entry coercion now lives in
+    # ``extracted_reasoning_core.semantic_cache_keys.row_to_cache_entry``
+    # (PR-C2). The static method that used to live here has been
+    # removed; callers below import the function directly.

--- a/extracted_reasoning_core/semantic_cache_keys.py
+++ b/extracted_reasoning_core/semantic_cache_keys.py
@@ -1,0 +1,171 @@
+"""Pure semantic-cache primitives (PR-C2 / PR 4).
+
+Reasoning core owns the *pure* parts of semantic-cache identity and
+confidence math. Postgres-backed storage stays in
+``extracted_llm_infrastructure.reasoning.semantic_cache`` (the
+``SemanticCache`` class) behind the ``SemanticCacheStore`` port
+declared in ``extracted_reasoning_core.ports``.
+
+Public surface:
+
+  - ``STALE_THRESHOLD`` -- entries with effective confidence below this
+    are treated as stale (cache miss) by the storage adapter.
+  - ``CacheEntry`` -- the cached reasoning conclusion; pure data. The
+    storage adapter is responsible for filling ``created_at`` /
+    ``last_validated_at`` / ``effective_confidence``.
+  - ``compute_evidence_hash(evidence)`` -- SHA-256 of deterministically
+    serialised evidence dict; 16-char fingerprint that callers use to
+    invalidate cached conclusions when their underlying evidence
+    changes.
+  - ``apply_decay(confidence, last_validated, half_life_days)`` --
+    exponential decay of confidence since last validation. Reads the
+    system clock; callers wanting deterministic time should pass a
+    pre-computed decayed value or use a clock-injected wrapper.
+  - ``row_to_cache_entry(row)`` -- coerce a Postgres row mapping
+    (``asyncpg.Record`` or plain ``dict`` -- anything supporting
+    ``Mapping`` access) into a ``CacheEntry``. Handles JSONB columns
+    that arrive either pre-decoded or as raw strings, and the
+    ``falsification_conditions`` shape drift between dict and list.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+# Entries with effective confidence below this are treated as stale.
+# Storage adapters should return ``None`` from ``lookup`` when the
+# decayed confidence falls below this threshold.
+STALE_THRESHOLD = 0.5
+
+
+@dataclass
+class CacheEntry:
+    """A single cached reasoning conclusion.
+
+    ``effective_confidence`` is set by storage adapters after they
+    apply ``apply_decay`` to ``confidence`` based on
+    ``last_validated_at``; callers reading from cache should consult
+    ``effective_confidence`` rather than ``confidence`` directly.
+    """
+
+    pattern_sig: str
+    pattern_class: str
+    conclusion: dict[str, Any]
+    confidence: float
+    reasoning_steps: list[dict[str, Any]] = field(default_factory=list)
+    boundary_conditions: dict[str, Any] = field(default_factory=dict)
+    falsification_conditions: list[str] = field(default_factory=list)
+    uncertainty_sources: list[str] = field(default_factory=list)
+    vendor_name: str | None = None
+    product_category: str | None = None
+    decay_half_life_days: int = 90
+    conclusion_type: str | None = None
+    evidence_hash: str | None = None
+    created_at: datetime | None = None
+    last_validated_at: datetime | None = None
+    validation_count: int = 1
+    effective_confidence: float | None = None
+
+
+def compute_evidence_hash(evidence: dict[str, Any]) -> str:
+    """SHA-256 of deterministically serialised evidence dict.
+
+    Returns a 16-char hex fingerprint. ``sort_keys=True`` ensures dict
+    iteration order doesn't perturb the hash; ``default=str`` keeps
+    non-JSON-native values (datetimes, decimals) hashable.
+    """
+    raw = json.dumps(evidence, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def apply_decay(
+    confidence: float,
+    last_validated: datetime,
+    half_life_days: int,
+) -> float:
+    """Return effective confidence after exponential decay.
+
+    Reads the system clock (``datetime.now(timezone.utc)``); callers
+    that need deterministic time should compute the decay externally
+    rather than passing a fake clock here.
+
+    A naive ``last_validated`` (no ``tzinfo``) is assumed to be UTC.
+    Negative or zero elapsed days return ``confidence`` unchanged
+    (no decay applied); a non-positive ``half_life_days`` short-circuits
+    the same way.
+    """
+    now = datetime.now(timezone.utc)
+    if last_validated.tzinfo is None:
+        last_validated = last_validated.replace(tzinfo=timezone.utc)
+    days = (now - last_validated).total_seconds() / 86400.0
+    if days <= 0 or half_life_days <= 0:
+        return confidence
+    return confidence * math.pow(2, -(days / half_life_days))
+
+
+def row_to_cache_entry(row: Mapping[str, Any]) -> CacheEntry:
+    """Coerce a Postgres row mapping into a :class:`CacheEntry`.
+
+    Accepts any object supporting ``Mapping`` access -- typically an
+    ``asyncpg.Record`` (which subscripts like a dict) but also a plain
+    dict, which is what tests + non-asyncpg adapters produce. JSONB
+    columns may arrive either pre-decoded (asyncpg with the json codec
+    installed) or as raw strings (a vanilla adapter); the body handles
+    both shapes defensively.
+
+    Storage adapters should call this on rows from the
+    ``reasoning_semantic_cache`` table; the result is the same
+    ``CacheEntry`` shape regardless of whether the JSONB columns were
+    pre-decoded or not.
+    """
+    falsification = row["falsification_conditions"]
+    if isinstance(falsification, str):
+        falsification = json.loads(falsification)
+    if isinstance(falsification, dict):
+        falsification = list(falsification.values()) if falsification else []
+
+    conclusion = row["conclusion"]
+    if not isinstance(conclusion, dict):
+        conclusion = json.loads(conclusion)
+
+    reasoning_steps = row["reasoning_steps"]
+    if not isinstance(reasoning_steps, list):
+        reasoning_steps = json.loads(reasoning_steps)
+
+    boundary_conditions = row["boundary_conditions"]
+    if not isinstance(boundary_conditions, dict):
+        boundary_conditions = json.loads(boundary_conditions)
+
+    return CacheEntry(
+        pattern_sig=row["pattern_sig"],
+        pattern_class=row["pattern_class"],
+        vendor_name=row["vendor_name"],
+        product_category=row["product_category"],
+        conclusion=conclusion,
+        confidence=row["confidence"],
+        reasoning_steps=reasoning_steps,
+        boundary_conditions=boundary_conditions,
+        falsification_conditions=falsification if isinstance(falsification, list) else [],
+        uncertainty_sources=list(row["uncertainty_sources"]) if row["uncertainty_sources"] else [],
+        decay_half_life_days=row["decay_half_life_days"],
+        conclusion_type=row["conclusion_type"],
+        evidence_hash=row["evidence_hash"],
+        created_at=row["created_at"],
+        last_validated_at=row["last_validated_at"],
+        validation_count=row["validation_count"],
+    )
+
+
+__all__ = [
+    "CacheEntry",
+    "STALE_THRESHOLD",
+    "apply_decay",
+    "compute_evidence_hash",
+    "row_to_cache_entry",
+]

--- a/tests/test_extracted_reasoning_core_semantic_cache_keys.py
+++ b/tests/test_extracted_reasoning_core_semantic_cache_keys.py
@@ -1,0 +1,221 @@
+"""Unit tests for extracted_reasoning_core.semantic_cache_keys.
+
+Exercises the pure semantic-cache primitives (PR-C2 / PR 4):
+
+  - ``compute_evidence_hash`` determinism + key-order stability
+  - ``apply_decay`` math + edge cases (naive datetimes, non-positive
+    elapsed days, non-positive half-life)
+  - ``CacheEntry`` default-field behaviour
+  - ``row_to_cache_entry`` handles pre-decoded vs string-shaped JSONB
+    and the ``falsification_conditions`` dict-vs-list drift
+
+Storage-side concerns (Postgres queries, ``SemanticCache`` class)
+remain in the LLM infrastructure adapter and are tested separately
+(see ``tests/test_semantic_cache_decoupling.py`` for the atlas-side
+copy and the LLM-infra standalone smoke tests).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from extracted_reasoning_core.semantic_cache_keys import (
+    CacheEntry,
+    STALE_THRESHOLD,
+    apply_decay,
+    compute_evidence_hash,
+    row_to_cache_entry,
+)
+
+
+# ----------------------------------------------------------------------
+# compute_evidence_hash
+# ----------------------------------------------------------------------
+
+
+def test_compute_evidence_hash_returns_16_char_hex() -> None:
+    h = compute_evidence_hash({"vendor": "Acme", "score": 0.7})
+    assert isinstance(h, str)
+    assert len(h) == 16
+    int(h, 16)  # raises if not valid hex
+
+
+def test_compute_evidence_hash_is_key_order_stable() -> None:
+    h1 = compute_evidence_hash({"a": 1, "b": 2, "c": 3})
+    h2 = compute_evidence_hash({"c": 3, "a": 1, "b": 2})
+    assert h1 == h2
+
+
+def test_compute_evidence_hash_distinguishes_distinct_evidence() -> None:
+    h1 = compute_evidence_hash({"vendor": "Acme"})
+    h2 = compute_evidence_hash({"vendor": "Beta"})
+    assert h1 != h2
+
+
+def test_compute_evidence_hash_handles_non_json_native_values() -> None:
+    # default=str means datetimes/decimals don't crash.
+    moment = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    h = compute_evidence_hash({"validated_at": moment})
+    assert len(h) == 16
+
+
+# ----------------------------------------------------------------------
+# apply_decay
+# ----------------------------------------------------------------------
+
+
+def test_apply_decay_returns_input_for_zero_elapsed() -> None:
+    just_now = datetime.now(timezone.utc)
+    out = apply_decay(0.9, just_now, half_life_days=90)
+    # Tiny clock drift means we can't assert ==, but it must be
+    # essentially unchanged (>= 0.999 of input).
+    assert out >= 0.9 * 0.999
+
+
+def test_apply_decay_halves_at_one_half_life() -> None:
+    one_period_ago = datetime.now(timezone.utc) - timedelta(days=14)
+    out = apply_decay(0.8, one_period_ago, half_life_days=14)
+    # Allow small drift for clock skew during test execution.
+    assert 0.39 < out < 0.41
+
+
+def test_apply_decay_handles_naive_last_validated_as_utc() -> None:
+    naive_one_day_ago = datetime.utcnow() - timedelta(days=1)
+    out = apply_decay(1.0, naive_one_day_ago, half_life_days=14)
+    # 1 day at 14-day half-life: 2^(-1/14) ~= 0.952
+    assert 0.94 < out < 0.96
+
+
+def test_apply_decay_short_circuits_on_zero_half_life() -> None:
+    # A zero or negative half-life means "no decay model" -- return
+    # the raw confidence rather than dividing by zero.
+    long_ago = datetime.now(timezone.utc) - timedelta(days=365)
+    assert apply_decay(0.7, long_ago, half_life_days=0) == 0.7
+    assert apply_decay(0.7, long_ago, half_life_days=-1) == 0.7
+
+
+def test_apply_decay_returns_input_for_future_last_validated() -> None:
+    # Negative elapsed (future timestamp) is a clock-drift / data
+    # corruption case; return confidence unchanged.
+    in_the_future = datetime.now(timezone.utc) + timedelta(days=30)
+    assert apply_decay(0.6, in_the_future, half_life_days=14) == 0.6
+
+
+# ----------------------------------------------------------------------
+# CacheEntry
+# ----------------------------------------------------------------------
+
+
+def test_cache_entry_minimal_construction() -> None:
+    entry = CacheEntry(
+        pattern_sig="acme:pricing_shock:v1",
+        pattern_class="pricing_shock",
+        conclusion={"label": "Pricing Shock", "score": 0.84},
+        confidence=0.84,
+    )
+    assert entry.pattern_sig == "acme:pricing_shock:v1"
+    assert entry.reasoning_steps == []
+    assert entry.boundary_conditions == {}
+    assert entry.falsification_conditions == []
+    assert entry.uncertainty_sources == []
+    assert entry.vendor_name is None
+    assert entry.decay_half_life_days == 90
+    assert entry.validation_count == 1
+    assert entry.effective_confidence is None
+
+
+def test_cache_entry_default_lists_are_independent() -> None:
+    # Regression guard: dataclass field(default_factory=list) means
+    # each instance gets its own list -- mutation should not bleed.
+    a = CacheEntry(pattern_sig="a", pattern_class="x", conclusion={}, confidence=0.5)
+    b = CacheEntry(pattern_sig="b", pattern_class="x", conclusion={}, confidence=0.5)
+    a.reasoning_steps.append({"step": 1})
+    assert b.reasoning_steps == []
+
+
+# ----------------------------------------------------------------------
+# row_to_cache_entry
+# ----------------------------------------------------------------------
+
+
+def _base_row(**overrides) -> dict:
+    """Build a Postgres-shaped row mapping with sensible defaults."""
+    row = {
+        "pattern_sig": "vendor_x:pricing_shock:v1",
+        "pattern_class": "pricing_shock",
+        "vendor_name": "Vendor X",
+        "product_category": "billing",
+        "conclusion": {"label": "Pricing Shock", "score": 0.84},
+        "confidence": 0.84,
+        "reasoning_steps": [{"step": "evidence", "value": 0.84}],
+        "boundary_conditions": {"min_reviews": 50},
+        "falsification_conditions": ["recommend_ratio > 0.5"],
+        "uncertainty_sources": ["small_sample"],
+        "decay_half_life_days": 60,
+        "conclusion_type": "archetype",
+        "evidence_hash": "abc123def4567890",
+        "created_at": datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc),
+        "last_validated_at": datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc),
+        "validation_count": 3,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_row_to_cache_entry_handles_pre_decoded_jsonb() -> None:
+    entry = row_to_cache_entry(_base_row())
+    assert entry.pattern_sig == "vendor_x:pricing_shock:v1"
+    assert entry.conclusion == {"label": "Pricing Shock", "score": 0.84}
+    assert entry.reasoning_steps == [{"step": "evidence", "value": 0.84}]
+    assert entry.boundary_conditions == {"min_reviews": 50}
+    assert entry.falsification_conditions == ["recommend_ratio > 0.5"]
+    assert entry.uncertainty_sources == ["small_sample"]
+    assert entry.validation_count == 3
+
+
+def test_row_to_cache_entry_handles_string_shaped_jsonb() -> None:
+    # A vanilla adapter that hasn't installed the json codec returns
+    # JSONB columns as raw strings -- the coercion must handle this.
+    row = _base_row(
+        conclusion=json.dumps({"label": "Pricing Shock", "score": 0.84}),
+        reasoning_steps=json.dumps([{"step": "evidence"}]),
+        boundary_conditions=json.dumps({"min_reviews": 50}),
+        falsification_conditions=json.dumps(["recommend_ratio > 0.5"]),
+    )
+    entry = row_to_cache_entry(row)
+    assert entry.conclusion == {"label": "Pricing Shock", "score": 0.84}
+    assert entry.reasoning_steps == [{"step": "evidence"}]
+    assert entry.boundary_conditions == {"min_reviews": 50}
+    assert entry.falsification_conditions == ["recommend_ratio > 0.5"]
+
+
+def test_row_to_cache_entry_normalizes_dict_shaped_falsification() -> None:
+    # Older rows persisted falsification_conditions as a dict
+    # (label -> condition); coerce to a flat list of values.
+    row = _base_row(falsification_conditions={"a": "cond1", "b": "cond2"})
+    entry = row_to_cache_entry(row)
+    assert sorted(entry.falsification_conditions) == ["cond1", "cond2"]
+
+
+def test_row_to_cache_entry_handles_empty_falsification_dict() -> None:
+    row = _base_row(falsification_conditions={})
+    entry = row_to_cache_entry(row)
+    assert entry.falsification_conditions == []
+
+
+def test_row_to_cache_entry_handles_null_uncertainty_sources() -> None:
+    row = _base_row(uncertainty_sources=None)
+    entry = row_to_cache_entry(row)
+    assert entry.uncertainty_sources == []
+
+
+# ----------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------
+
+
+def test_stale_threshold_is_documented_value() -> None:
+    # Storage adapters depend on this constant; pin it so changes are
+    # explicit. Originally 0.5 in atlas_brain.reasoning.semantic_cache.
+    assert STALE_THRESHOLD == 0.5

--- a/tests/test_semantic_cache_decoupling.py
+++ b/tests/test_semantic_cache_decoupling.py
@@ -1,9 +1,12 @@
 """Tests for SemanticCache decoupling from asyncpg-specific assumptions.
 
-These tests exercise the parts of ``atlas_brain.reasoning.semantic_cache``
-that don't require a live Postgres: the pure helpers
-(``compute_evidence_hash``, ``_apply_decay``, ``row_to_cache_entry``) plus
-the ``SemanticCachePool`` Protocol contract. The async query methods
+These tests exercise the storage surface of
+``atlas_brain.reasoning.semantic_cache`` that doesn't require a live
+Postgres -- ``CacheEntry`` / ``SemanticCachePool`` / ``SemanticCache``
+plus the atlas-namespace ``_apply_decay`` and ``compute_evidence_hash``
+re-exports -- and the canonical ``row_to_cache_entry`` from
+``extracted_reasoning_core.semantic_cache_keys`` (PR-C2 promoted that
+helper from a private staticmethod into core). The async query methods
 are tested against a fake pool that records its inputs.
 
 The atlas ``DatabasePool`` and a raw asyncpg ``Pool`` both satisfy the

--- a/tests/test_semantic_cache_decoupling.py
+++ b/tests/test_semantic_cache_decoupling.py
@@ -2,7 +2,7 @@
 
 These tests exercise the parts of ``atlas_brain.reasoning.semantic_cache``
 that don't require a live Postgres: the pure helpers
-(``compute_evidence_hash``, ``_apply_decay``, ``_row_to_entry``) plus
+(``compute_evidence_hash``, ``_apply_decay``, ``row_to_cache_entry``) plus
 the ``SemanticCachePool`` Protocol contract. The async query methods
 are tested against a fake pool that records its inputs.
 
@@ -26,6 +26,13 @@ from atlas_brain.reasoning.semantic_cache import (
     _apply_decay,
     compute_evidence_hash,
 )
+
+# PR-C2: ``row_to_cache_entry`` was promoted from a private staticmethod
+# on ``SemanticCache`` to a public function in
+# ``extracted_reasoning_core.semantic_cache_keys``. The decoupling tests
+# below import it from the canonical home rather than reaching into
+# ``SemanticCache._row_to_entry`` (which no longer exists).
+from extracted_reasoning_core.semantic_cache_keys import row_to_cache_entry
 
 
 class _FakePool:
@@ -136,7 +143,7 @@ def test_decay_zero_half_life_returns_input():
 
 
 def test_row_to_entry_accepts_plain_dict():
-    entry = SemanticCache._row_to_entry(_row())
+    entry = row_to_cache_entry(_row())
     assert isinstance(entry, CacheEntry)
     assert entry.pattern_sig == "sig1"
     assert entry.confidence == 0.9
@@ -151,7 +158,7 @@ def test_row_to_entry_jsonb_decodes_when_string():
         boundary_conditions='{"max": 10}',
         falsification_conditions='["x"]',
     )
-    entry = SemanticCache._row_to_entry(row)
+    entry = row_to_cache_entry(row)
     assert entry.conclusion == {"k": "v"}
     assert entry.reasoning_steps == [{"step": 9}]
     assert entry.boundary_conditions == {"max": 10}
@@ -161,21 +168,21 @@ def test_row_to_entry_jsonb_decodes_when_string():
 def test_row_to_entry_jsonb_passes_through_when_dict():
     # Asyncpg shape: JSONB pre-decoded to dict.
     row = _row(conclusion={"already": "decoded"})
-    entry = SemanticCache._row_to_entry(row)
+    entry = row_to_cache_entry(row)
     assert entry.conclusion == {"already": "decoded"}
 
 
 def test_row_to_entry_falsification_dict_collapses_to_list():
     # Defensive case: caller stored a dict rather than a list.
     row = _row(falsification_conditions={"a": "x", "b": "y"})
-    entry = SemanticCache._row_to_entry(row)
+    entry = row_to_cache_entry(row)
     # Either of "x", "y" -- order is dict insertion order in Py3.7+
     assert sorted(entry.falsification_conditions) == ["x", "y"]
 
 
 def test_row_to_entry_handles_empty_uncertainty_sources():
     row = _row(uncertainty_sources=None)
-    entry = SemanticCache._row_to_entry(row)
+    entry = row_to_cache_entry(row)
     assert entry.uncertainty_sources == []
 
 


### PR DESCRIPTION
## Summary

Implements PR 4 from ``docs/extraction/reasoning_boundary_audit_2026-05-03.md``. Reasoning core now owns the *pure* semantic-cache primitives; the Postgres-backed storage class stays in the LLM infrastructure adapter behind the ``SemanticCacheStore`` port (already declared in ``extracted_reasoning_core.ports`` from prior PR-C1 work).

This is the first slice of the post-PR-C1 backlog from the audit.

## Audit acceptance criteria

1. **``compute_evidence_hash`` has one implementation** -- moved to ``extracted_reasoning_core/semantic_cache_keys.py``; atlas + LLM-infra both import it from there.
2. **LLM infrastructure owns Postgres queries** -- the ``SemanticCache`` class + ``SemanticCachePool`` Protocol stay in ``extracted_llm_infrastructure/reasoning/semantic_cache.py``.
3. **competitive intelligence no longer bridges Atlas semantic cache** -- the prior programmatic ``atlas_brain`` ``importlib`` bridge is replaced with explicit re-exports from core (pure code) + LLM-infra (storage class).
4. **cache tests cover core key derivation separately from the LLM-infra store** -- new ``tests/test_extracted_reasoning_core_semantic_cache_keys.py`` covers the pure module (17 tests); existing ``tests/test_semantic_cache_decoupling.py`` keeps testing atlas-side storage (with one import line redirected to core for the promoted ``row_to_cache_entry`` function).

## What moved into core

``extracted_reasoning_core/semantic_cache_keys.py`` (171 LOC, new):

- ``STALE_THRESHOLD = 0.5``
- ``CacheEntry`` dataclass
- ``compute_evidence_hash(evidence) -> str``
- ``apply_decay(confidence, last_validated, half_life_days) -> float`` (renamed from ``_apply_decay``; underscore-aliased back into atlas-side namespace for backward compatibility with existing imports)
- ``row_to_cache_entry(row) -> CacheEntry`` (promoted from ``SemanticCache._row_to_entry`` static method)

## What stays storage-side

``atlas_brain/reasoning/semantic_cache.py`` and ``extracted_llm_infrastructure/reasoning/semantic_cache.py`` (mirror, 322 LOC each, was 372):

- ``SemanticCachePool`` Protocol (asyncpg-shaped pool contract)
- ``SemanticCache`` class (Postgres queries: ``lookup``, ``store``, ``validate``, ``invalidate``, ``lookup_by_class``, ``lookup_for_tier``, ``get_cache_stats``)

## Audit deviation: PR 4 touched atlas-side

The audit deferred atlas-side reasoning code changes to PR 7 ("Product Migration Pass"). PR-C2 had to touch ``atlas_brain/reasoning/semantic_cache.py`` because the ``validate_extracted_llm_infrastructure.sh`` script enforces ``atlas_brain/reasoning/semantic_cache.py`` == ``extracted_llm_infrastructure/reasoning/semantic_cache.py`` at file level. The atlas-side change is purely the same edit as the LLM-infra mirror (import pure code from core, drop local copies); behavior identical. This crosses into PR 7 territory only by mechanical necessity -- the alternative was to leave the file unchanged and not implement PR 4 at all.

## Net change

- **NEW** ``extracted_reasoning_core/semantic_cache_keys.py`` -- 171 LOC pure code
- **NEW** ``tests/test_extracted_reasoning_core_semantic_cache_keys.py`` -- 17 unit tests
- **EDIT** ``atlas_brain/reasoning/semantic_cache.py`` -- 372 → 322 LOC (drops local copies of pure code)
- **EDIT** ``extracted_llm_infrastructure/reasoning/semantic_cache.py`` -- 372 → 322 LOC (mirror sync)
- **EDIT** ``extracted_competitive_intelligence/reasoning/semantic_cache.py`` -- 23 → 43 LOC (atlas bridge → explicit imports from canonical homes)
- **EDIT** ``tests/test_semantic_cache_decoupling.py`` -- 1 import line + docstring (test the promoted ``row_to_cache_entry`` from core)
- **Net LOC**: -73 across the 4 storage files; pure code consolidates from 2x duplication (atlas + LLM-infra mirror) into one canonical home

## Test plan

- [x] **17/17** new core unit tests green
- [x] **25/25** atlas-side decoupling tests green (1 import line updated)
- [x] ``bash scripts/run_extracted_llm_infrastructure_checks.sh`` green
- [x] ``bash scripts/run_extracted_pipeline_checks.sh`` green (342 tests)
- [x] ``bash scripts/run_extracted_competitive_intelligence_checks.sh`` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)