### PR TITLE
Restore legacy blocker-message format in blog_pack (fixes 3 stale failures + dead repair gate)

### DIFF
--- a/extracted_quality_gate/blog_pack.py
+++ b/extracted_quality_gate/blog_pack.py
@@ -226,10 +226,16 @@ def evaluate_blog_post(
     target_words = _threshold(policy, "target_words")
     word_count = len(body.split())
     if word_count < min_words:
+        # Legacy underscore-joined message format that downstream
+        # consumers rely on for prefix matching, e.g.
+        # ``_only_content_too_short_blockers`` in
+        # ``b2b_blog_post_generation.py`` checks
+        # ``startswith("content_too_short:")`` to gate the
+        # deterministic-repair retry path.
         findings.append(
             GateFinding(
                 code="content_too_short",
-                message=f"{word_count} words; need {min_words}",
+                message=f"content_too_short:{word_count}_words_need_{min_words}",
                 severity=GateSeverity.BLOCKER,
                 metadata={"word_count": word_count, "min_words": min_words},
             )
@@ -238,7 +244,7 @@ def evaluate_blog_post(
         findings.append(
             GateFinding(
                 code="content_below_seo_target",
-                message=f"{word_count} words below SEO target {target_words}",
+                message=f"content_below_seo_target_{target_words}_words",
                 severity=GateSeverity.WARNING,
                 metadata={"word_count": word_count, "target_words": target_words},
             )


### PR DESCRIPTION
## Summary

PR-B4a (#118) lifted blog quality validators into the deterministic pack but changed two message strings to a sentence form, breaking prefix-based consumers downstream and a deterministic-repair gate.

| Before (broken) | After (legacy format restored) |
|---|---|
| \`{N} words; need {M}\` | \`content_too_short:{N}_words_need_{M}\` |
| \`{N} words below SEO target {M}\` | \`content_below_seo_target_{M}_words\` |

## Why this matters

1. **Dead repair gate**: \`_only_content_too_short_blockers\` in \`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py:2188\` checks \`startswith(\"content_too_short:\")\` to gate the deterministic-repair retry path. Under the post-PR-B4a format that prefix never appears -- the borderline-shortfall repair loop has been silently dead since #118.

2. **3 stale test failures on main**, all in \`tests/test_b2b_blog_post_generation.py\`:
   - \`test_apply_blog_quality_gate_uses_topic_specific_min_words_for_migration_guides\`
   - \`test_apply_blog_quality_gate_keeps_higher_floor_for_vendor_showdowns\`
   - \`test_apply_blog_deterministic_repairs_adds_coverage_snapshot_for_borderline_shortfall\`

   These tests pin both the prefix and the suffix (e.g. \`endswith(\"_words_need_2000\")\`). Failed since 2026-04-XX when PR-B4a merged.

## Scope

Pure rendering fix in \`extracted_quality_gate/blog_pack.py\`. The \`GateFinding.code\` field is unchanged, so the 4 pack-side tests in \`test_extracted_quality_gate_blog_pack.py\` that assert on \`code\` are unaffected.

## Validation

\`\`\`
$ pytest tests/test_b2b_blog_post_generation.py tests/test_extracted_quality_gate_blog_pack.py -q
125 passed in 2.29s
\`\`\`

Both the previously-red 3 tests and the previously-green 122 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)