### PR TITLE
Drop OSS-publish milestones from extraction docs (extracted_* stays internal)

### DIFF
--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,15 +1,17 @@
 # Per-Product State
 
-Last updated: 2026-05-04T09:15Z by claude-2026-05-03-b
+Last updated: 2026-05-04T09:35Z by claude-2026-05-03-b
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
 | Product | Phase | Most recent merged PR | Active PRs | Next milestone | Active hot zone |
 |---|---|---|---|---|---|
-| `extracted_llm_infrastructure` | 3 (4 of 5 sub-tasks landed; only LICENSE+pyproject+PyPI publish remaining) | #150 | — | LICENSE + `pyproject.toml` + PyPI publish (needs license decision + maintainer email) | `extracted_llm_infrastructure/{LICENSE,pyproject.toml,README.md}` |
+| `extracted_llm_infrastructure` | 3 (runtime-decoupled; no OSS publish — internal refactor only) | #150 | — | Done as a decoupling refactor. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #152 | #149 (PR-C2.1 follow-up to PR-C2 by claude-2026-05-03) | Continue Phase 2 ownership of standalone-ready product surfaces | `extracted_competitive_intelligence/reasoning/semantic_cache.py` (PR-C2.1 in flight) |
 | `extracted_content_pipeline` | 1 -> 2 (productization seams) | #129 | — | Continue remaining campaign orchestration/API seams after the DB-backed review/export path landed | none |
 | `extracted_reasoning_core` | 1 (scaffold + archetypes/evidence_map moved; PR-C1 series merged through #144) | #144 | #149 (PR-C2.1 follow-up by claude-2026-05-03) | Continue temporal/types/evidence_engine/API/wrapper follow-up slices per merged PR #82 audit | `extracted_reasoning_core/**` (api/types/archetypes/evidence_engine/evidence_map.yaml/temporal); `atlas_brain/reasoning/{evidence_engine.py, review_enrichment.py}`; `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py`; `tests/test_extracted_reasoning_*.py` |
-| `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #132 | — | Open-source-grade README + LICENSE + pyproject.toml | none |
+| `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.
+
+**Note:** `extracted_*` packages are internal decoupling refactors, not OSS libraries. Per 2026-05-04 product strategy, customer-facing surfaces are paid hosted APIs (P1 Amazon Seller Intelligence, P5/P6 B2B vendor retention/lead gen). Phase 3 is the terminal extraction milestone — no LICENSE / pyproject / PyPI publish work follows.

--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -41,9 +41,9 @@ transitively through the bridge stubs, so when
 
 The standalone smoke (`scripts/smoke_extracted_llm_infrastructure_standalone.py`) verifies this end-to-end: it sets the env var, imports every provider, and asserts (via `__module__` walk on `AnthropicLLM.__mro__`) that providers transitively consume the standalone substrate rather than silently falling back to atlas_brain.
 
-## Phase 3 — Runtime decoupling 🟡 (in progress)
+## Phase 3 — Runtime decoupling ✅ (complete)
 
-Import contract is closed; the remaining work is **runtime** behavior when functions execute, not when modules load:
+Import contract is closed; runtime behavior is decoupled from `atlas_brain`-specific concrete classes.
 
 | Task | Source file referenced | Status |
 |---|---|---|
@@ -51,8 +51,8 @@ Import contract is closed; the remaining work is **runtime** behavior when funct
 | Extract `_convert_messages` from `AnthropicLLM` so batch code does not call a private method | `services/llm/anthropic.py:103+`, called from `services/b2b/anthropic_batch.py:409` | ✅ PR-A5a (module-level `convert_messages`; method preserved as backwards-compat alias; batch caller imports the public function) |
 | Decouple `SemanticCache` from Postgres (asyncpg.Record assumptions) | `reasoning/semantic_cache.py:70-339` | ✅ PR-A5b (added `SemanticCachePool` Protocol; `__init__` typed against it; `_row_to_entry` annotated as `Mapping[str, Any]`; SQL stays Postgres-specific) |
 | Move `evidence_hash` computation to a single owner | currently split between `reasoning/semantic_cache.py:47` and B2B callers | ✅ PR-A5c (`compute_cross_vendor_evidence_hash` in `_b2b_cross_vendor_synthesis.py` is now a re-export of `compute_evidence_hash` from `semantic_cache.py`; both import paths preserved; one canonical implementation) |
-| Open-source-grade README + LICENSE + pyproject.toml | scaffold root | 🔲 |
-| Publishable PyPI package | scaffold root | 🔲 |
+
+**No PyPI / open-source-grade packaging milestones.** Per 2026-05-04 product strategy, the customer-facing surface is paid hosted APIs, not OSS Python libraries. `extracted_llm_infrastructure` stays an internal decoupling refactor; its job ends at runtime decoupling.
 
 ## Per-file extraction state
 


### PR DESCRIPTION
## Summary

Per 2026-05-04 product strategy, customer-facing surfaces are paid hosted APIs (P1 Amazon Seller Intelligence, P5/P6 B2B retention/lead-gen) -- NOT open-source Python libraries. The \`extracted_*\` packages are internal decoupling refactors; they don't ship.

## Changes

- **\`extracted_llm_infrastructure/STATUS.md\`**: Phase 3 status flipped from 🟡 in progress to ✅ complete (the 4 runtime-decoupling sub-tasks are done as of PR-A5d-cleanup). Drop the trailing LICENSE/pyproject/PyPI publish rows. Add explanatory note.
- **\`docs/extraction/coordination/state.md\`**: drop OSS-publish next-milestones from \`extracted_llm_infrastructure\` and \`extracted_quality_gate\` rows; add tail note linking the policy to product strategy; bump \`extracted_quality_gate\` most-recent-PR to #154.

Doc-only. Sync invariant + standalone smoke still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)