### PR TITLE
Surface structured blocking_codes from blog quality pack (item 3 root-cause fix)

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1677,6 +1677,8 @@ def _apply_blog_quality_gate(
 
     blocking_issues: list[str] = list(pack_report.metadata.get("blocking_issues", ()))
     warnings: list[str] = list(pack_report.metadata.get("warnings", ()))
+    blocking_codes: list[str] = list(pack_report.metadata.get("blocking_codes", ()))
+    warning_codes: list[str] = list(pack_report.metadata.get("warning_codes", ()))
 
     # ---- Atlas-side specificity check (PR-B5 territory) ----
     specificity_context = surface_specificity_context(
@@ -1700,14 +1702,12 @@ def _apply_blog_quality_gate(
             include_competitor_terms=True,
             numeric_term_filter=_is_meaningful_numeric_anchor,
         )
-        blocking_issues.extend(
-            f"witness_specificity:{issue}"
-            for issue in specificity.get("blocking_issues", []) or []
-        )
-        warnings.extend(
-            f"witness_specificity:{warning}"
-            for warning in specificity.get("warnings", []) or []
-        )
+        specificity_blockers = specificity.get("blocking_issues", []) or []
+        specificity_warnings = specificity.get("warnings", []) or []
+        blocking_issues.extend(f"witness_specificity:{issue}" for issue in specificity_blockers)
+        warnings.extend(f"witness_specificity:{warning}" for warning in specificity_warnings)
+        blocking_codes.extend("witness_specificity" for _ in specificity_blockers)
+        warning_codes.extend("witness_specificity" for _ in specificity_warnings)
 
     # Recompute score with merged issues so specificity findings affect status.
     score = max(0, 100 - (18 * len(blocking_issues)) - (6 * len(warnings)))
@@ -1716,7 +1716,9 @@ def _apply_blog_quality_gate(
         "threshold": pass_score,
         "status": "pass" if (not blocking_issues and score >= pass_score) else "fail",
         "blocking_issues": blocking_issues,
+        "blocking_codes": blocking_codes,
         "warnings": warnings,
+        "warning_codes": warning_codes,
         "fixes_applied": fixes_applied,
         "quote_count": pack_report.metadata.get("quote_count", 0),
         "word_count": pack_report.metadata.get("word_count", len(body.split())),
@@ -2186,6 +2188,16 @@ def _apply_specificity_anchor_repair(
 
 
 def _only_content_too_short_blockers(report: dict[str, Any]) -> bool:
+    # Match against the structured ``blocking_codes`` surface
+    # (added 2026-05-04) so this gate cannot regress when a future
+    # refactor changes the rendered ``blocking_issues`` message
+    # format. Falls back to the legacy prefix match on
+    # ``blocking_issues`` when ``blocking_codes`` is absent (older
+    # report shapes / partial migrations).
+    codes = report.get("blocking_codes")
+    if codes is not None:
+        codes_list = [str(c) for c in codes]
+        return bool(codes_list) and all(c == "content_too_short" for c in codes_list)
     blockers = [str(issue) for issue in (report.get("blocking_issues") or [])]
     return bool(blockers) and all(issue.startswith("content_too_short:") for issue in blockers)
 

--- a/extracted_quality_gate/blog_pack.py
+++ b/extracted_quality_gate/blog_pack.py
@@ -631,8 +631,14 @@ def _build_report(
         "threshold": pass_score,
         "status": "pass" if passed else "fail",
         # Legacy-shape mirrors so the wrapper has a 1-step conversion.
+        # ``*_issues``/``warnings`` carry rendered messages; ``*_codes``
+        # carry the structured ``GateFinding.code`` values so consumers
+        # can match on a stable identifier instead of a brittle prefix
+        # in the message string.
         "blocking_issues": tuple(f.message for f in blockers),
+        "blocking_codes": tuple(f.code for f in blockers),
         "warnings": tuple(f.message for f in warnings),
+        "warning_codes": tuple(f.code for f in warnings),
         "quote_count": quote_count,
         "word_count": word_count,
         "min_words_required": min_words,

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -2153,6 +2153,78 @@ def test_apply_blog_deterministic_repairs_adds_coverage_snapshot_for_borderline_
     )
 
 
+# ---- Structured blocking_codes / _only_content_too_short_blockers (added 2026-05-04) ----
+
+
+def test_apply_blog_quality_gate_emits_blocking_codes_alongside_messages():
+    """The wrapper carries the structured ``blocking_codes`` /
+    ``warning_codes`` from the pack through to the report dict so
+    consumers can match on stable identifiers instead of message
+    prefixes.
+    """
+    blueprint = blog_mod.PostBlueprint(
+        topic_type="migration_guide",
+        slug="switch-to-zendesk-2026-04",
+        suggested_title="Switch to Zendesk",
+        tags=["helpdesk"],
+        data_context={"vendor": "Zendesk", "review_period": "2025-06 to 2026-03"},
+        sections=[],
+        charts=[],
+    )
+    content = {
+        "title": "Switch to Zendesk",
+        "content": _body_with_exact_words(800),  # well below min for migration_guide
+    }
+
+    _, report = blog_mod._apply_blog_quality_gate(blueprint, content)
+
+    assert "blocking_codes" in report
+    assert "content_too_short" in report["blocking_codes"]
+    assert len(report["blocking_codes"]) == len(report["blocking_issues"])
+
+
+def test_only_content_too_short_blockers_matches_on_codes_field():
+    """The gate function reads ``blocking_codes`` first; the legacy
+    ``startswith("content_too_short:")`` prefix check is only a
+    fallback.
+    """
+    # New shape: codes-only, message format intentionally different
+    # from the legacy prefix to prove the gate doesn't depend on it.
+    new_shape_report = {
+        "blocking_codes": ["content_too_short"],
+        "blocking_issues": ["1234 words; need 2000"],  # arbitrary message
+    }
+    assert blog_mod._only_content_too_short_blockers(new_shape_report) is True
+
+    # Mixed: any non-content_too_short code disqualifies.
+    mixed = {
+        "blocking_codes": ["content_too_short", "missing_chart_placeholder"],
+        "blocking_issues": ["doesn't matter", "doesn't matter"],
+    }
+    assert blog_mod._only_content_too_short_blockers(mixed) is False
+
+    # Empty: never matches.
+    empty = {"blocking_codes": [], "blocking_issues": []}
+    assert blog_mod._only_content_too_short_blockers(empty) is False
+
+
+def test_only_content_too_short_blockers_falls_back_to_legacy_prefix():
+    """Old report shapes (no ``blocking_codes`` field) still work
+    via the legacy prefix match. Matters for in-flight artifacts
+    that were generated before this PR landed.
+    """
+    legacy_only = {
+        "blocking_issues": ["content_too_short:1234_words_need_2000"],
+        # no blocking_codes
+    }
+    assert blog_mod._only_content_too_short_blockers(legacy_only) is True
+
+    legacy_no_match = {
+        "blocking_issues": ["missing_chart_placeholder:trend"],
+    }
+    assert blog_mod._only_content_too_short_blockers(legacy_no_match) is False
+
+
 @pytest.mark.asyncio
 async def test_assemble_and_store_forwards_run_metadata_to_canonical_row(monkeypatch):
     blueprint = blog_mod.PostBlueprint(

--- a/tests/test_extracted_quality_gate_blog_pack.py
+++ b/tests/test_extracted_quality_gate_blog_pack.py
@@ -385,3 +385,56 @@ def test_quality_report_is_frozen():
     report = evaluate_blog_post(_make_input(_LONG_GOOD_BODY))
     with pytest.raises(Exception):
         report.passed = False  # type: ignore[misc]
+
+
+# ---- Structured blocking_codes / warning_codes (added 2026-05-04) ----
+
+
+def test_metadata_exposes_blocking_codes_for_blockers():
+    """Consumers must be able to match on stable codes, not on
+    rendered message-string prefixes.
+    """
+    short_body = "Way too short for this."
+    report = evaluate_blog_post(_make_input(short_body))
+    assert "blocking_codes" in report.metadata
+    assert "content_too_short" in report.metadata["blocking_codes"]
+
+
+def test_metadata_blocking_codes_aligns_with_blocking_issues():
+    """``blocking_codes`` and ``blocking_issues`` are parallel tuples:
+    same length, same order. The pair is the contract consumers rely
+    on to find a code's message without re-running the pack.
+    """
+    short_body = "Way too short for this."
+    report = evaluate_blog_post(_make_input(short_body))
+    codes = report.metadata["blocking_codes"]
+    issues = report.metadata["blocking_issues"]
+    assert isinstance(codes, tuple)
+    assert isinstance(issues, tuple)
+    assert len(codes) == len(issues)
+
+
+def test_metadata_exposes_warning_codes_for_warnings():
+    """Same parallel-tuple contract for warnings."""
+    body_below_target = " ".join(["word"] * 1700)  # above min, below target
+    body_below_target += '\n> "It works really well for our team."\n'
+    body_below_target += '\n> "We saw real improvements."\n'
+    report = evaluate_blog_post(_make_input(body_below_target))
+    assert "warning_codes" in report.metadata
+    assert isinstance(report.metadata["warning_codes"], tuple)
+    assert len(report.metadata["warning_codes"]) == len(report.metadata["warnings"])
+    assert "content_below_seo_target" in report.metadata["warning_codes"]
+
+
+def test_blocking_codes_does_not_carry_message_substring():
+    """The whole point of the codes surface: a code is the stable
+    identifier, never an embedded substring of the rendered message.
+    A future refactor of the message format must not change the code.
+    """
+    short_body = "Way too short."
+    report = evaluate_blog_post(_make_input(short_body))
+    for code in report.metadata["blocking_codes"]:
+        # Codes are simple snake_case identifiers, never contain
+        # colons or numeric details.
+        assert ":" not in code
+        assert not any(ch.isdigit() for ch in code)


### PR DESCRIPTION
## Summary

Item 3 root-cause fix. PR #154 restored the legacy \`content_too_short:{N}_words_need_{M}\` message format so the consumer's prefix match worked again. The deeper antipattern — consumer matching against rendered message-string prefixes instead of the structured \`GateFinding.code\` — was untouched. This PR adds the missing seam.

## Changes

| File | Change |
|---|---|
| \`extracted_quality_gate/blog_pack.py\` | Emit \`blocking_codes\` + \`warning_codes\` tuples in \`QualityReport.metadata\` alongside existing \`blocking_issues\`/\`warnings\`. Parallel-tuple contract (same length, same order). |
| \`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py::_apply_blog_quality_gate\` | Carry codes from the pack through to the report dict. Merge atlas-side specificity codes (\`witness_specificity\`) using the same parallel-tuple contract. |
| \`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py::_only_content_too_short_blockers\` | Match against \`blocking_codes\` first; legacy prefix match becomes a fallback for in-flight artifacts. |

## Why this fixes the regression class, not just the symptom

\`GateFinding\` already had a stable \`code\` field. The pack just wasn't surfacing it. Consumers were forced to introspect rendered \`message\` strings, which couples their gate logic to message formatting. Any future refactor that touched the message format silently broke the gate (this is exactly what PR-B4a #118 did).

With \`blocking_codes\` exposed:
- The \`message\` field can be reformatted freely.
- A future PR can revert PR #154's format hack (\`content_too_short:{N}_words_need_{M}\` → \`{N} words; need {M}\`) and the gate keeps working.
- New code-based consumers don't have to learn the legacy prefix conventions.

## Validation

\`\`\`
$ pytest tests/test_b2b_blog_post_generation.py tests/test_extracted_quality_gate_blog_pack.py -q
132 passed in 2.42s
\`\`\`

7 new tests pin the contract:
- **Pack-side (4)**: \`blocking_codes\` presence on blockers; parallel-tuple alignment with \`blocking_issues\`; \`warning_codes\` for warnings; codes don't embed message details (no colons, no digits).
- **Consumer-side (3)**: gate matches on codes for the new shape; gate rejects mixed/empty code lists; gate falls back to legacy prefix when \`blocking_codes\` is absent.

## Scope discipline

Other consumers in \`b2b_campaign_generation.py\` and \`b2b_blog_post_generation.py\` still do prefix matching on different blocker classes (\`witness_specificity:\`, \`report_tier_language:\`, \`unsupported_data_claim:\`, \`chart_scope_ambiguity:\`, etc.). They have the same antipattern but different sources (atlas-side specificity check, not the pack). Migrating them is a follow-up — kept out of this PR to keep the change focused on item 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)