### PR TITLE
PR-C3d: Register vendor_classify prompt as a reasoning pack

### DIFF
--- a/atlas_brain/reasoning/single_pass_prompts/vendor_classify.py
+++ b/atlas_brain/reasoning/single_pass_prompts/vendor_classify.py
@@ -172,3 +172,31 @@ Output ONLY valid JSON (after optional <scratchpad> block):
 VENDOR_CLASSIFY_PROMPT_VERSION = _hashlib.sha256(
     VENDOR_CLASSIFY_SINGLE_PASS.encode()
 ).hexdigest()[:8]
+
+
+# PR-C3d: register this prompt with the shared reasoning pack registry
+# (PR-C3a / extracted_reasoning_core.pack_registry). The vendor_classify
+# pack produces archetype assignments + self-check output for the b2b
+# churn intelligence task. Atlas's autonomous tasks consume it directly,
+# and competitive_intelligence's battle card builders read the assigned
+# archetype downstream -- so owner_product captures atlas as the
+# producing host. Per the audit, the pack file moves into a product
+# package during PR 7 (Product Migration); for now the file stays
+# atlas-side.
+from extracted_reasoning_core.pack_registry import (  # noqa: E402
+    Pack as _Pack,
+    register_pack as _register_pack,
+)
+
+_register_pack(
+    _Pack(
+        name="vendor_classify",
+        version=VENDOR_CLASSIFY_PROMPT_VERSION,
+        prompts={"classify_single_pass": VENDOR_CLASSIFY_SINGLE_PASS},
+        metadata={
+            "output_artifact": "vendor_archetype_classification",
+            "owner_product": "atlas",
+            "synthesis_mode": "single_pass_with_self_check",
+        },
+    )
+)

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T10:30Z by claude-2026-05-03
+Last updated: 2026-05-04T10:50Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-C3c, in flight) | PR-C3c: Register cross-vendor battle prompts as packs | EDIT: `atlas_brain/reasoning/single_pass_prompts/cross_vendor_battle.py` (add `register_pack` for `cross_vendor_battle_single_pass`). EDIT: `atlas_brain/reasoning/single_pass_prompts/cross_vendor_battle_synthesis.py` (add `register_pack` for `cross_vendor_battle_synthesis`). EDIT: `extracted_competitive_intelligence/reasoning/single_pass_prompts/cross_vendor_battle.py` (parallel registration -- file is owned by the package per manifest, not synced from atlas; both calls idempotent against the registry). NEW: `tests/test_extracted_reasoning_core_pack_registry_cross_vendor_battle.py` (7 atlas-side integration tests). | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/cross_vendor_battle.py`; `atlas_brain/reasoning/single_pass_prompts/cross_vendor_battle_synthesis.py`; `extracted_competitive_intelligence/reasoning/single_pass_prompts/cross_vendor_battle.py`; `tests/test_extracted_reasoning_core_pack_registry_cross_vendor_battle.py` |
+| (PR-C3d, in flight) | PR-C3d: Register vendor_classify prompt as a pack | EDIT: `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py` (add module-bottom `register_pack(...)` call against the PR-C3a registry; existing `VENDOR_CLASSIFY_SINGLE_PASS` / `VENDOR_CLASSIFY_PROMPT_VERSION` exports unchanged). NEW: `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` (3 atlas-side integration tests: registration on import, owner metadata, list_packs surface). | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py`; `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py
+++ b/tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py
@@ -1,0 +1,58 @@
+"""Integration test: vendor_classify registers with the pack registry.
+
+PR-C3d -- third concrete pack slice on top of PR-C3a (registry skeleton),
+PR-C3b (battle_card_reasoning), and PR-C3c (cross_vendor_battle x2).
+
+The vendor_classify pack produces archetype assignments + self-check
+output for the b2b churn intelligence task. Atlas's autonomous tasks
+consume it directly; competitive_intelligence's battle card builders
+read the assigned archetype downstream.
+
+**Not wired into the standalone extracted-pipeline CI** for the same
+reason as the prior PR-C3* pack tests: importing the atlas-side
+prompt module transitively pulls in pydantic via
+``atlas_brain.reasoning.config``. This suite runs in the full
+atlas-side test runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from extracted_reasoning_core.pack_registry import get_pack, list_packs
+
+
+def _ensure_vendor_classify_registered():
+    from atlas_brain.reasoning.single_pass_prompts import vendor_classify
+
+    importlib.reload(vendor_classify)
+    return vendor_classify
+
+
+def test_vendor_classify_pack_registers_on_import() -> None:
+    module = _ensure_vendor_classify_registered()
+
+    pack = get_pack("vendor_classify")
+    assert pack is not None
+    assert pack.name == "vendor_classify"
+    assert len(pack.version) == 8
+    assert all(c in "0123456789abcdef" for c in pack.version)
+    assert pack.version == module.VENDOR_CLASSIFY_PROMPT_VERSION
+    assert pack.prompts["classify_single_pass"] == module.VENDOR_CLASSIFY_SINGLE_PASS
+
+
+def test_vendor_classify_pack_carries_owner_metadata() -> None:
+    _ensure_vendor_classify_registered()
+
+    pack = get_pack("vendor_classify")
+    assert pack is not None
+    assert pack.metadata["output_artifact"] == "vendor_archetype_classification"
+    assert pack.metadata["owner_product"] == "atlas"
+    assert pack.metadata["synthesis_mode"] == "single_pass_with_self_check"
+
+
+def test_vendor_classify_pack_appears_in_list_packs() -> None:
+    _ensure_vendor_classify_registered()
+
+    pack_names = [p.name for p in list_packs()]
+    assert "vendor_classify" in pack_names


### PR DESCRIPTION
## Summary

Third concrete pack slice on top of PR-C3a (#157, registry skeleton), PR-C3b (#161, ``battle_card_reasoning``), PR-C3c (#162, ``cross_vendor_battle`` x2).

The ``vendor_classify`` pack produces archetype assignments + self-check output for the b2b churn intelligence task. ``owner_product`` is ``\"atlas\"`` because atlas's autonomous tasks are the direct producer; competitive_intelligence's battle card builders read the assigned archetype downstream as a consumer.

## Single-source

Unlike ``cross_vendor_battle`` (PR-C3c, which extracted_competitive_intelligence owns), ``vendor_classify.py`` is atlas-side only. Single-source registration, no parallel call needed.

## Test plan

- [x] **3/3** new pack-registration integration tests green:
  - registers on import with correct version + content
  - carries ``owner_product: atlas`` / ``output_artifact: vendor_archetype_classification`` / ``synthesis_mode`` metadata
  - appears in ``list_packs()`` output
- [x] Combined pack-registry test suite (C3a + b + c + d): **27 tests green**
- [x] ``bash scripts/run_extracted_pipeline_checks.sh`` -- 459 green (unchanged; integration tests aren't wired into standalone CI for the same atlas→pydantic transitive-import reason as prior PR-C3* tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)