### PR TITLE
PR-C3e: Register reasoning_synthesis prompt as a reasoning pack

### DIFF
--- a/atlas_brain/reasoning/single_pass_prompts/reasoning_synthesis.py
+++ b/atlas_brain/reasoning/single_pass_prompts/reasoning_synthesis.py
@@ -300,3 +300,30 @@ Do not duplicate deterministic displacement count wrappers outside
 REASONING_SYNTHESIS_PROMPT_VERSION = _hashlib.sha256(
     REASONING_SYNTHESIS_PROMPT.encode()
 ).hexdigest()[:8]
+
+
+# PR-C3e: register this prompt with the shared reasoning pack registry
+# (PR-C3a / extracted_reasoning_core.pack_registry). The reasoning
+# synthesis pack produces consumer-neutral analytical contracts that
+# downstream consumers (battle cards, reports, blogs, campaigns)
+# translate into their own language. Per the audit, the pack file
+# moves into a product package during PR 7 (Product Migration); for
+# now the file stays atlas-side.
+from extracted_reasoning_core.pack_registry import (  # noqa: E402
+    Pack as _Pack,
+    register_pack as _register_pack,
+)
+
+_register_pack(
+    _Pack(
+        name="reasoning_synthesis",
+        version=REASONING_SYNTHESIS_PROMPT_VERSION,
+        prompts={"synthesis": REASONING_SYNTHESIS_PROMPT},
+        metadata={
+            "output_artifact": "reasoning_contracts",
+            "owner_product": "atlas",
+            "synthesis_mode": "consumer_neutral_contracts",
+            "valid_wedges": tuple(sorted(WEDGE_ENUM_VALUES)),
+        },
+    )
+)

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T10:50Z by claude-2026-05-03
+Last updated: 2026-05-04T11:00Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-C3d, in flight) | PR-C3d: Register vendor_classify prompt as a pack | EDIT: `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py` (add module-bottom `register_pack(...)` call against the PR-C3a registry; existing `VENDOR_CLASSIFY_SINGLE_PASS` / `VENDOR_CLASSIFY_PROMPT_VERSION` exports unchanged). NEW: `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` (3 atlas-side integration tests: registration on import, owner metadata, list_packs surface). | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py`; `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` |
+| (PR-C3e, in flight) | PR-C3e: Register reasoning_synthesis prompt as a pack | EDIT: `atlas_brain/reasoning/single_pass_prompts/reasoning_synthesis.py` (add module-bottom `register_pack(...)` call against the PR-C3a registry; existing `REASONING_SYNTHESIS_PROMPT` / `REASONING_SYNTHESIS_PROMPT_VERSION` exports unchanged). NEW: `tests/test_extracted_reasoning_core_pack_registry_reasoning_synthesis.py` (3 atlas-side integration tests: registration on import, owner metadata + valid_wedges, list_packs surface). Atlas-side only -- not in any extracted mirror. | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/reasoning_synthesis.py`; `tests/test_extracted_reasoning_core_pack_registry_reasoning_synthesis.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/tests/test_extracted_reasoning_core_pack_registry_reasoning_synthesis.py
+++ b/tests/test_extracted_reasoning_core_pack_registry_reasoning_synthesis.py
@@ -1,0 +1,58 @@
+"""Integration test: reasoning_synthesis registers with the pack registry.
+
+PR-C3e -- fourth concrete pack slice. The reasoning synthesis pack
+produces consumer-neutral analytical contracts that downstream
+consumers (battle cards, reports, blogs, campaigns) translate into
+their own language.
+
+**Not wired into the standalone extracted-pipeline CI** -- same
+atlas-pydantic transitive-import constraint as the prior PR-C3*
+integration tests. Runs in atlas-side full test suites.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from extracted_reasoning_core.pack_registry import get_pack, list_packs
+
+
+def _ensure_registered():
+    from atlas_brain.reasoning.single_pass_prompts import reasoning_synthesis
+
+    importlib.reload(reasoning_synthesis)
+    return reasoning_synthesis
+
+
+def test_reasoning_synthesis_pack_registers_on_import() -> None:
+    module = _ensure_registered()
+
+    pack = get_pack("reasoning_synthesis")
+    assert pack is not None
+    assert pack.name == "reasoning_synthesis"
+    assert len(pack.version) == 8
+    assert all(c in "0123456789abcdef" for c in pack.version)
+    assert pack.version == module.REASONING_SYNTHESIS_PROMPT_VERSION
+    assert pack.prompts["synthesis"] == module.REASONING_SYNTHESIS_PROMPT
+
+
+def test_reasoning_synthesis_pack_carries_owner_metadata() -> None:
+    _ensure_registered()
+
+    pack = get_pack("reasoning_synthesis")
+    assert pack is not None
+    assert pack.metadata["output_artifact"] == "reasoning_contracts"
+    assert pack.metadata["owner_product"] == "atlas"
+    assert pack.metadata["synthesis_mode"] == "consumer_neutral_contracts"
+    # valid_wedges: shared wedge_registry enum values surfaced via
+    # metadata so callers picking wedges from the synthesis output
+    # don't have to reach into wedge_registry separately.
+    assert isinstance(pack.metadata["valid_wedges"], tuple)
+    assert len(pack.metadata["valid_wedges"]) > 0
+
+
+def test_reasoning_synthesis_pack_appears_in_list() -> None:
+    _ensure_registered()
+
+    pack_names = [p.name for p in list_packs()]
+    assert "reasoning_synthesis" in pack_names


### PR DESCRIPTION
## Summary

Fourth concrete pack slice on top of PR-C3a (#157, registry skeleton), PR-C3b (#161, ``battle_card_reasoning``), PR-C3c (#162, cross-vendor battle x2), PR-C3d (#163, ``vendor_classify``).

The ``reasoning_synthesis`` pack produces consumer-neutral analytical contracts that downstream consumers (battle cards, reports, blogs, campaigns) translate into their own language. ``owner_product`` is ``\"atlas\"`` as the producing host; downstream consumers in other product families read the contracts.

Pack metadata also surfaces ``valid_wedges`` (from the shared ``wedge_registry``) so callers picking wedges from the synthesis output don't have to reach into ``wedge_registry`` separately.

Atlas-side only -- not in any extracted mirror.

## Test plan

- [x] **3/3** new pack-registration integration tests green:
  - registers on import with correct version + content
  - carries ``owner_product: atlas`` / ``output_artifact: reasoning_contracts`` / ``synthesis_mode: consumer_neutral_contracts`` / ``valid_wedges`` metadata
  - appears in ``list_packs()`` output
- [x] Combined pack-registry test suite (C3a + b + c + d + e): **30 tests green**
- [x] ``bash scripts/run_extracted_pipeline_checks.sh`` -- 459 green (unchanged; integration tests aren't wired into standalone CI for the same atlas→pydantic transitive-import reason as prior PR-C3* tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)