### PR TITLE
Resolve competitive email owned package imports

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T10:50Z by claude-2026-05-03
+Last updated: 2026-05-04T19:08Z by codex-2026-05-04
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| #166 | Competitive email package import resolves owned renderer locally | EDIT: `extracted_competitive_intelligence/templates/email/__init__.py`; `tests/test_extracted_competitive_vendor_briefing_renderer.py`. | codex-2026-05-04 | `extracted_competitive_intelligence/templates/email/__init__.py`; `tests/test_extracted_competitive_vendor_briefing_renderer.py` |
 | (PR-C3d, in flight) | PR-C3d: Register vendor_classify prompt as a pack | EDIT: `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py` (add module-bottom `register_pack(...)` call against the PR-C3a registry; existing `VENDOR_CLASSIFY_SINGLE_PASS` / `VENDOR_CLASSIFY_PROMPT_VERSION` exports unchanged). NEW: `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` (3 atlas-side integration tests: registration on import, owner metadata, list_packs surface). | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py`; `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T10:50Z by claude-2026-05-03
+Last updated: 2026-05-04T18:57Z by codex-2026-05-04
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (pending) | Competitive email package import resolves owned renderer locally | EDIT: `extracted_competitive_intelligence/templates/email/__init__.py`; `tests/test_extracted_competitive_vendor_briefing_renderer.py`. | codex-2026-05-04 | `extracted_competitive_intelligence/templates/email/__init__.py`; `tests/test_extracted_competitive_vendor_briefing_renderer.py` |
 | (PR-C3d, in flight) | PR-C3d: Register vendor_classify prompt as a pack | EDIT: `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py` (add module-bottom `register_pack(...)` call against the PR-C3a registry; existing `VENDOR_CLASSIFY_SINGLE_PASS` / `VENDOR_CLASSIFY_PROMPT_VERSION` exports unchanged). NEW: `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` (3 atlas-side integration tests: registration on import, owner metadata, list_packs surface). | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/vendor_classify.py`; `tests/test_extracted_reasoning_core_pack_registry_vendor_classify.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_competitive_intelligence/templates/email/__init__.py
+++ b/extracted_competitive_intelligence/templates/email/__init__.py
@@ -1,17 +1,14 @@
 """Phase 1 package bridge: lazily exposes names from atlas_brain.templates.email.
 
 PEP 562 ``__getattr__`` resolves ``from PACKAGE import some_name`` at
-runtime by delegating to the atlas_brain peer package's __init__
-namespace. This avoids triggering the atlas_brain peer's heavy import
-chain at scaffold-load time -- e.g., importing
+runtime. Product-owned submodules resolve from this package first; other
+names delegate to the atlas_brain peer package's __init__ namespace.
+This avoids triggering the atlas_brain peer's heavy import chain at
+scaffold-load time -- e.g., importing
 ``extracted_competitive_intelligence.services.vendor_registry`` no
 longer eagerly loads ``atlas_brain.services`` (which pulls in the
 torch/llm chain) just to satisfy a hypothetical
 ``from ...services import llm_registry`` runtime fallback.
-
-Submodule imports of the form ``from PACKAGE import submodule_name``
-are handled by Python's native import machinery from the scaffold
-filesystem; this hook only fires for non-submodule attributes.
 
 Phase 2 replaces this with a standalone implementation gated on
 EXTRACTED_COMP_INTEL_STANDALONE=1.
@@ -19,11 +16,64 @@ EXTRACTED_COMP_INTEL_STANDALONE=1.
 from __future__ import annotations
 
 import importlib
+import importlib.util
+import json
 import os
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_PRODUCT_ROOT = _PACKAGE_DIR.parents[1]
+_PACKAGE_TARGET_PREFIX = __name__.replace(".", "/") + "/"
+
+
+@lru_cache(maxsize=1)
+def _owned_submodule_names() -> frozenset[str]:
+    manifest_path = _PRODUCT_ROOT / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return frozenset()
+
+    submodules: set[str] = set()
+    for entry in manifest.get("owned", []):
+        if not isinstance(entry, dict):
+            continue
+        target = entry.get("target")
+        if not isinstance(target, str):
+            continue
+        if not target.startswith(_PACKAGE_TARGET_PREFIX):
+            continue
+        path = Path(target)
+        if path.suffix == ".py" and path.stem != "__init__":
+            submodules.add(path.stem)
+    return frozenset(submodules)
+
+
+def _load_local_submodule(name: str) -> Any | None:
+    module_name = f"{__name__}.{name}"
+    if importlib.util.find_spec(module_name) is None:
+        return None
+    return importlib.import_module(module_name)
+
+
+def _load_owned_submodule_attr(name: str) -> Any | None:
+    for submodule_name in sorted(_owned_submodule_names()):
+        submodule = importlib.import_module(f"{__name__}.{submodule_name}")
+        if hasattr(submodule, name):
+            return getattr(submodule, name)
+    return None
+
+
 def __getattr__(name: str) -> Any:
+    local_submodule = _load_local_submodule(name)
+    if local_submodule is not None:
+        return local_submodule
+    owned_attr = _load_owned_submodule_attr(name)
+    if owned_attr is not None:
+        return owned_attr
     if os.environ.get("EXTRACTED_COMP_INTEL_STANDALONE") == "1":
         raise AttributeError(
             f"module {__name__!r} has no standalone attribute {name!r}; "

--- a/tests/test_extracted_competitive_vendor_briefing_renderer.py
+++ b/tests/test_extracted_competitive_vendor_briefing_renderer.py
@@ -35,6 +35,22 @@ def _witness_rows(count: int) -> list[dict[str, object]]:
     return rows
 
 
+def test_package_level_import_resolves_owned_renderer() -> None:
+    from extracted_competitive_intelligence.templates.email import (
+        vendor_briefing as package_vendor_briefing,
+    )
+
+    assert package_vendor_briefing.__name__ == vendor_briefing.__name__
+
+
+def test_package_level_export_resolves_owned_renderer_function() -> None:
+    from extracted_competitive_intelligence.templates.email import (
+        render_vendor_briefing_html,
+    )
+
+    assert render_vendor_briefing_html.__module__ == vendor_briefing.__name__
+
+
 def test_renderer_default_witness_limit_matches_atlas_contract() -> None:
     selected = vendor_briefing._selected_reasoning_anchors(
         {"reasoning_witness_highlights": _witness_rows(WITNESS_COUNT)}


### PR DESCRIPTION
## Summary
- make the competitive email package bridge resolve local submodules before Atlas fallback
- resolve package-level exports from product-owned email modules using the existing manifest as the source of truth
- add renderer regression coverage for package-level module and function imports

## Verification
- `python -m py_compile extracted_competitive_intelligence/templates/email/__init__.py tests/test_extracted_competitive_vendor_briefing_renderer.py`
- `python -m pytest tests/test_extracted_competitive_vendor_briefing_renderer.py -q`
- `bash scripts/run_extracted_competitive_intelligence_checks.sh`
- `git diff --check`
- placeholder/conflict-marker grep on touched files
- ASCII check on changed Python files