### PR TITLE
[codex] Add AI Content Ops analytics refresh worker

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T19:06Z by codex-content-sequence-worker
+Last updated: 2026-05-04T19:09Z by codex-content-analytics-worker
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| (branch: codex/content-pipeline-next-seam) | Add AI Content Ops analytics refresh worker CLI | `extracted_content_pipeline/campaign_postgres_analytics.py`; `scripts/refresh_extracted_campaign_analytics.py`; `tests/test_extracted_campaign_postgres_analytics.py`; content-pipeline docs/status/manifest/check wiring | codex-content-analytics-worker | Avoid content-pipeline analytics refresh runner/CLI/doc wiring until this branch lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-04T19:06Z by codex-content-sequence-worker
+Last updated: 2026-05-04T19:09Z by codex-content-analytics-worker
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled; no OSS publish — internal refactor only) | #150 | — | Done as a decoupling refactor. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 1 -> 2 (productization seams) | #159 | — | Continue remaining campaign orchestration/API seams after DB-backed review/export/send/progression paths landed | none |
+| `extracted_content_pipeline` | 1 -> 2 (productization seams) | #159 | branch `codex/content-pipeline-next-seam` (analytics refresh worker by codex-content-analytics-worker) | Add DB-backed analytics refresh worker CLI after sequence progression landed | `extracted_content_pipeline/campaign_postgres_analytics.py`; `scripts/refresh_extracted_campaign_analytics.py`; `tests/test_extracted_campaign_postgres_analytics.py`; content-pipeline docs/status/manifest/check wiring |
 | `extracted_reasoning_core` | 1 (scaffold + archetypes/evidence_map moved; PR-C1 series merged through #163) | #163 | — | Continue temporal/types/evidence_engine/API/wrapper follow-up slices per merged PR #82 audit | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -250,6 +250,12 @@ python scripts/send_extracted_campaigns.py \
   --limit 10
 ```
 
+Refresh campaign analytics after send or webhook updates:
+
+```bash
+python scripts/refresh_extracted_campaign_analytics.py --json
+```
+
 Progress due sequences and queue generated follow-up drafts:
 
 ```bash
@@ -347,6 +353,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `campaign_postgres_export.py`: read-only draft export for host review flows
 - `campaign_postgres_send.py`: DB-backed queued send runner that composes the
   campaign, suppression, audit, and sender ports for host worker CLIs
+- `campaign_postgres_analytics.py`: DB-backed analytics refresh runner that
+  composes campaign and audit ports for host worker CLIs
 - `campaign_postgres_sequence_progression.py`: DB-backed due-sequence worker
   that composes the sequence, audit, LLM, and skill ports for follow-up
   generation

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -41,6 +41,9 @@
 - `campaign_postgres_send` provides a DB-backed queued send worker seam. Hosts
   inject a Resend or SES sender and reuse the product campaign, suppression,
   and audit ports to send rows already moved to `queued`.
+- `campaign_postgres_analytics` provides a DB-backed analytics refresh worker
+  seam. Hosts can refresh the packaged campaign funnel materialized view and
+  audit the result without importing Atlas scheduled-task code.
 - `campaign_postgres_sequence_progression` provides a DB-backed follow-up
   generation worker seam. Hosts reuse due `campaign_sequences` rows, packaged
   or custom sequence prompts, and the product LLM port to queue the next

--- a/extracted_content_pipeline/campaign_postgres_analytics.py
+++ b/extracted_content_pipeline/campaign_postgres_analytics.py
@@ -1,0 +1,28 @@
+"""Postgres-backed campaign analytics refresh runner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .campaign_analytics import (
+    CampaignAnalyticsRefreshResult,
+    CampaignAnalyticsRefreshService,
+)
+from .campaign_postgres import PostgresCampaignAuditSink, PostgresCampaignRepository
+
+
+async def refresh_campaign_analytics_from_postgres(
+    pool: Any,
+) -> CampaignAnalyticsRefreshResult:
+    """Refresh campaign analytics materialized views through Postgres ports."""
+
+    service = CampaignAnalyticsRefreshService(
+        campaigns=PostgresCampaignRepository(pool),
+        audit=PostgresCampaignAuditSink(pool),
+    )
+    return await service.refresh()
+
+
+__all__ = [
+    "refresh_campaign_analytics_from_postgres",
+]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -269,6 +269,12 @@ python scripts/send_extracted_campaigns.py \
   --limit 10
 ```
 
+Refresh analytics after sends or webhook ingestion:
+
+```bash
+python scripts/refresh_extracted_campaign_analytics.py --json
+```
+
 Progress due sequences and queue generated follow-up drafts:
 
 ```bash

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -180,6 +180,12 @@ worker seam. It composes `PostgresCampaignRepository`,
 `CampaignSendService` so hosts can send queued drafts through an injected
 `CampaignSender` without importing Atlas task code.
 
+`extracted_content_pipeline/campaign_postgres_analytics.py` owns the DB-backed
+analytics refresh worker seam. It composes `PostgresCampaignRepository`,
+`PostgresCampaignAuditSink`, and `CampaignAnalyticsRefreshService` so hosts can
+refresh the packaged campaign funnel materialized view without importing Atlas
+scheduled-task code.
+
 `extracted_content_pipeline/campaign_postgres_sequence_progression.py` owns the
 DB-backed sequence progression worker seam. It composes
 `PostgresCampaignSequenceRepository`, `PostgresCampaignAuditSink`, the product

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -172,7 +172,13 @@
       "target": "extracted_content_pipeline/campaign_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_analytics.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_postgres_generation.py"
+    },
+    {
+      "target": "extracted_content_pipeline/campaign_postgres_analytics.py"
     },
     {
       "target": "extracted_content_pipeline/campaign_postgres_export.py"

--- a/scripts/refresh_extracted_campaign_analytics.py
+++ b/scripts/refresh_extracted_campaign_analytics.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Refresh extracted campaign analytics materialized views."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_postgres_analytics import (  # noqa: E402
+    refresh_campaign_analytics_from_postgres,
+)
+
+
+DATABASE_URL_ENV = ("EXTRACTED_DATABASE_URL", "DATABASE_URL")
+
+
+def _env(*names: str, default: str | None = None) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Refresh campaign analytics for the extracted product database."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=_env(*DATABASE_URL_ENV),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON summary instead of a concise text summary.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to refresh campaign analytics; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+    pool = await _create_pool(args.database_url)
+    try:
+        result = await refresh_campaign_analytics_from_postgres(pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+
+    summary = result.as_dict()
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        text = "refreshed={refreshed}".format(**summary)
+        if summary.get("error"):
+            text = f"{text} error={summary['error']}"
+        print(text)
+    return 0 if result.refreshed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -22,6 +22,7 @@ pytest \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \
   tests/test_extracted_campaign_postgres_send.py \
+  tests/test_extracted_campaign_postgres_analytics.py \
   tests/test_extracted_campaign_postgres_sequence_progression.py \
   tests/test_extracted_campaign_postgres_import.py \
   tests/test_extracted_content_pipeline_migration_runner.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -113,7 +113,9 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/campaign_ports.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
+    assert "extracted_content_pipeline/campaign_analytics.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_generation.py" in owned
+    assert "extracted_content_pipeline/campaign_postgres_analytics.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_review.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_send.py" in owned
     assert "extracted_content_pipeline/campaign_example.py" in owned
@@ -151,7 +153,9 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
 
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
+    assert "extracted_content_pipeline/campaign_analytics.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_generation.py" not in mapped
+    assert "extracted_content_pipeline/campaign_postgres_analytics.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_send.py" not in mapped
     assert "extracted_content_pipeline/campaign_example.py" not in mapped
     assert "extracted_content_pipeline/campaign_customer_data.py" not in mapped

--- a/tests/test_extracted_campaign_postgres_analytics.py
+++ b/tests/test_extracted_campaign_postgres_analytics.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_analytics import CampaignAnalyticsRefreshResult
+from extracted_content_pipeline.campaign_postgres_analytics import (
+    refresh_campaign_analytics_from_postgres,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/refresh_extracted_campaign_analytics.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "refresh_extracted_campaign_analytics",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    def __init__(self, *, refresh_error: Exception | None = None) -> None:
+        self.refresh_error = refresh_error
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.closed = False
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        if "REFRESH MATERIALIZED VIEW" in str(query) and self.refresh_error:
+            raise self.refresh_error
+        return "OK"
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_postgres_analytics_refresh_runner_refreshes_and_audits_success() -> None:
+    pool = _Pool()
+
+    result = await refresh_campaign_analytics_from_postgres(pool)
+
+    assert result.as_dict() == {"refreshed": True, "error": None}
+    assert "REFRESH MATERIALIZED VIEW CONCURRENTLY campaign_funnel_stats" in (
+        pool.execute_calls[0][0]
+    )
+    audit_query, audit_args = pool.execute_calls[1]
+    assert "INSERT INTO campaign_audit_log" in audit_query
+    assert audit_args[2] == "analytics_refreshed"
+
+
+@pytest.mark.asyncio
+async def test_postgres_analytics_refresh_runner_audits_failure() -> None:
+    pool = _Pool(refresh_error=RuntimeError("view locked"))
+
+    result = await refresh_campaign_analytics_from_postgres(pool)
+
+    assert result.as_dict() == {"refreshed": False, "error": "view locked"}
+    assert "REFRESH MATERIALIZED VIEW" in pool.execute_calls[0][0]
+    audit_query, audit_args = pool.execute_calls[1]
+    assert "INSERT INTO campaign_audit_log" in audit_query
+    assert audit_args[2] == "analytics_refresh_failed"
+
+
+def test_analytics_cli_parses_env_database_url(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.setenv("EXTRACTED_DATABASE_URL", "postgres://example")
+
+    args = cli._parse_args([])
+
+    assert args.database_url == "postgres://example"
+    assert args.json is False
+
+
+@pytest.mark.asyncio
+async def test_analytics_cli_closes_pool_and_prints_json(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def fake_create_pool(database_url):
+        assert database_url == "postgres://example"
+        return pool
+
+    async def fake_refresh(received_pool):
+        assert received_pool is pool
+        return CampaignAnalyticsRefreshResult(refreshed=True)
+
+    parse_args = cli._parse_args
+    monkeypatch.setattr(cli, "_parse_args", lambda: parse_args([
+        "--database-url",
+        "postgres://example",
+        "--json",
+    ]))
+    monkeypatch.setattr(cli, "_create_pool", fake_create_pool)
+    monkeypatch.setattr(cli, "refresh_campaign_analytics_from_postgres", fake_refresh)
+
+    exit_code = await cli._main()
+
+    assert exit_code == 0
+    assert pool.closed is True
+    assert '"refreshed": true' in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_analytics_cli_returns_nonzero_on_refresh_error(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def fake_create_pool(database_url):
+        return pool
+
+    async def fake_refresh(received_pool):
+        return CampaignAnalyticsRefreshResult(refreshed=False, error="view locked")
+
+    parse_args = cli._parse_args
+    monkeypatch.setattr(cli, "_parse_args", lambda: parse_args([
+        "--database-url",
+        "postgres://example",
+    ]))
+    monkeypatch.setattr(cli, "_create_pool", fake_create_pool)
+    monkeypatch.setattr(cli, "refresh_campaign_analytics_from_postgres", fake_refresh)
+
+    exit_code = await cli._main()
+
+    assert exit_code == 1
+    assert pool.closed is True
+    assert "refreshed=False error=view locked" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add a Postgres-backed analytics refresh runner for the extracted content pipeline
- add a host-facing CLI for refreshing campaign analytics materialized views
- document the analytics worker in the runbook/status/README and wire it into the extracted pipeline gate

## Validation
- pytest tests/test_extracted_campaign_postgres_analytics.py tests/test_extracted_campaign_analytics.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_postgres.py
- bash scripts/run_extracted_pipeline_checks.sh