### PR TITLE
PR-A6a: Carve ProviderCostSubConfig into _standalone/config.py

### DIFF
--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -84,7 +84,7 @@ Import contract is closed; runtime behavior is decoupled from `atlas_brain`-spec
 | `services/llm/hybrid.py` | ✅ | ✅ | 🔲 |
 | `services/llm/cloud.py` | ✅ | ✅ | 🔲 |
 | `services/tracing.py` | ✅ | ✅ | 🔲 |
-| `services/provider_cost_sync.py` (PR-A2) | ✅ | 🔲 (Phase 2 follow-up: standalone substrate for provider settings + db pool wrapper for snapshot/daily-cost upserts; lift uses default Atlas mode for now) | 🔲 |
+| `services/provider_cost_sync.py` (PR-A2) | ✅ | ✅ (PR-A6a added `ProviderCostSubConfig` to `_standalone/config.py`; module's `settings.provider_cost.{snapshot_retention_days, daily_retention_days, openrouter_enabled, anthropic_enabled, ...}` calls now resolve under standalone mode; db pool already env-gated via `_standalone/database.py`) | n/a |
 | `services/cost/__init__.py` (OWNED, PR-A3) | n/a | ✅ (no atlas imports; owned by extraction) | n/a |
 | `services/cost/cache_savings.py` (OWNED, PR-A3) | n/a | ✅ (asyncpg-pool-shaped; runs standalone with the local DatabasePool) | n/a |
 | `services/cost/openai_billing.py` (OWNED, PR-A4c) | n/a | ✅ (httpx + asyncpg-pool-shaped; settings.provider_cost lookup with env fallback) | 🔲 (Phase 3: unify with provider_cost_sync via ProviderBillingPort Protocol) |

--- a/extracted_llm_infrastructure/_standalone/config.py
+++ b/extracted_llm_infrastructure/_standalone/config.py
@@ -8,6 +8,7 @@ works in both modes:
 
   ATLAS_LLM_*               -> settings.llm.*
   ATLAS_B2B_CHURN_*         -> settings.b2b_churn.*
+  ATLAS_PROVIDER_COST_*     -> settings.provider_cost.*
   (FTL tracing fields)      -> settings.ftl_tracing.*
 
 Sub-configs:
@@ -16,6 +17,8 @@ Sub-configs:
   - ``ReasoningSubConfig`` (just ``model``)
   - ``ModelPricingConfig`` (per-model rates + ``cost_usd`` method)
   - ``FTLTracingSubConfig`` (FTL endpoint + pricing reference)
+  - ``ProviderCostSubConfig`` (provider-billing sync surface read by
+    ``services/provider_cost_sync.py`` and ``services/cost/openai_billing.py``)
 """
 
 from __future__ import annotations
@@ -222,6 +225,37 @@ class FTLTracingSubConfig(BaseModel):
     pricing: ModelPricingConfig = Field(default_factory=ModelPricingConfig)
 
 
+class ProviderCostSubConfig(BaseSettings):
+    """Provider billing sync configuration. Fields and validators mirror
+    ``atlas_brain.config.ProviderCostConfig`` so the same
+    ``ATLAS_PROVIDER_COST_*`` env vars work in both modes.
+
+    Read by:
+      - ``services/provider_cost_sync.py`` (snapshot + daily-cost upserts;
+        consumes ``snapshot_retention_days`` / ``daily_retention_days``)
+      - ``services/cost/openai_billing.py`` (uses ``getattr(...)`` so a
+        missing optional field is tolerated; the sub-config still mirrors
+        the atlas surface for the fields atlas exposes today).
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_PROVIDER_COST_",
+        env_file=(".env", ".env.local"),
+        extra="ignore",
+    )
+
+    enabled: bool = Field(default=False)
+    interval_seconds: int = Field(default=3600, ge=300, le=86400)
+    sync_timeout_seconds: int = Field(default=20, ge=5, le=300)
+    snapshot_retention_days: int = Field(default=90, ge=7, le=730)
+    daily_retention_days: int = Field(default=365, ge=30, le=1825)
+    openrouter_enabled: bool = Field(default=True)
+    openrouter_api_key: str = Field(default="")
+    anthropic_enabled: bool = Field(default=False)
+    anthropic_admin_api_key: str = Field(default="")
+    anthropic_lookback_days: int = Field(default=7, ge=1, le=31)
+
+
 # ---------------------------------------------------------------------------
 # Top-level settings
 # ---------------------------------------------------------------------------
@@ -239,6 +273,7 @@ class LLMInfraSettings(BaseModel):
     b2b_churn: B2BChurnSubConfig = Field(default_factory=B2BChurnSubConfig)
     reasoning: ReasoningSubConfig = Field(default_factory=ReasoningSubConfig)
     ftl_tracing: FTLTracingSubConfig = Field(default_factory=FTLTracingSubConfig)
+    provider_cost: ProviderCostSubConfig = Field(default_factory=ProviderCostSubConfig)
 
 
 settings = LLMInfraSettings()

--- a/tests/test_extracted_llm_infrastructure_standalone_config.py
+++ b/tests/test_extracted_llm_infrastructure_standalone_config.py
@@ -1,0 +1,168 @@
+"""Tests for the standalone substrate's settings surface (PR-A6a).
+
+Pins the contract that ``settings.provider_cost`` is fully populated
+when the standalone toggle is on, so ``services/provider_cost_sync.py``
+and ``services/cost/openai_billing.py`` resolve their settings reads
+without falling back to atlas_brain.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from typing import Iterator
+
+import pytest
+
+
+_STANDALONE_ENV_VAR = "EXTRACTED_LLM_INFRA_STANDALONE"
+
+
+def _reload_settings_in_standalone_mode(monkeypatch, **env_overrides) -> object:
+    """Force a fresh import of the standalone settings module under
+    ``EXTRACTED_LLM_INFRA_STANDALONE=1`` plus the given env overrides.
+
+    Returns the freshly-imported ``LLMInfraSettings`` instance
+    (``settings`` global on the module).
+    """
+    monkeypatch.setenv(_STANDALONE_ENV_VAR, "1")
+    for key, value in env_overrides.items():
+        monkeypatch.setenv(key, value)
+
+    for mod_name in (
+        "extracted_llm_infrastructure._standalone.config",
+        "extracted_llm_infrastructure.config",
+    ):
+        sys.modules.pop(mod_name, None)
+
+    config_mod = importlib.import_module("extracted_llm_infrastructure.config")
+    return config_mod.settings
+
+
+@pytest.fixture
+def fresh_standalone_settings(monkeypatch) -> Iterator[object]:
+    """Yields the standalone settings global. Cleans up sys.modules
+    afterward so other tests get a fresh import too."""
+    settings = _reload_settings_in_standalone_mode(monkeypatch)
+    try:
+        yield settings
+    finally:
+        for mod_name in (
+            "extracted_llm_infrastructure._standalone.config",
+            "extracted_llm_infrastructure.config",
+        ):
+            sys.modules.pop(mod_name, None)
+
+
+# ---- Default values (mirror atlas_brain.config.ProviderCostConfig) ----
+
+
+def test_provider_cost_namespace_exists(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert hasattr(settings, "provider_cost"), (
+        "LLMInfraSettings is missing the provider_cost field"
+    )
+
+
+def test_provider_cost_enabled_default_false(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.enabled is False
+
+
+def test_provider_cost_interval_seconds_default(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.interval_seconds == 3600
+
+
+def test_provider_cost_sync_timeout_seconds_default(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.sync_timeout_seconds == 20
+
+
+def test_provider_cost_snapshot_retention_days_default(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.snapshot_retention_days == 90
+
+
+def test_provider_cost_daily_retention_days_default(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.daily_retention_days == 365
+
+
+def test_provider_cost_openrouter_enabled_default_true(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.openrouter_enabled is True
+
+
+def test_provider_cost_openrouter_api_key_default_empty(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.openrouter_api_key == ""
+
+
+def test_provider_cost_anthropic_enabled_default_false(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.anthropic_enabled is False
+
+
+def test_provider_cost_anthropic_admin_api_key_default_empty(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.anthropic_admin_api_key == ""
+
+
+def test_provider_cost_anthropic_lookback_days_default(fresh_standalone_settings):
+    settings = fresh_standalone_settings
+    assert settings.provider_cost.anthropic_lookback_days == 7
+
+
+# ---- Env-var overrides (ATLAS_PROVIDER_COST_*) ----
+
+
+def test_provider_cost_enabled_env_override(monkeypatch):
+    settings = _reload_settings_in_standalone_mode(
+        monkeypatch, ATLAS_PROVIDER_COST_ENABLED="true"
+    )
+    assert settings.provider_cost.enabled is True
+
+
+def test_provider_cost_anthropic_lookback_days_env_override(monkeypatch):
+    settings = _reload_settings_in_standalone_mode(
+        monkeypatch, ATLAS_PROVIDER_COST_ANTHROPIC_LOOKBACK_DAYS="14"
+    )
+    assert settings.provider_cost.anthropic_lookback_days == 14
+
+
+def test_provider_cost_openrouter_api_key_env_override(monkeypatch):
+    settings = _reload_settings_in_standalone_mode(
+        monkeypatch, ATLAS_PROVIDER_COST_OPENROUTER_API_KEY="sk-xxx"
+    )
+    assert settings.provider_cost.openrouter_api_key == "sk-xxx"
+
+
+# ---- provider_cost_sync.py call sites resolve in standalone mode ----
+
+
+def test_provider_cost_sync_settings_reads_resolve(monkeypatch):
+    """``services/provider_cost_sync.py`` reads
+    ``settings.provider_cost.snapshot_retention_days`` and
+    ``...daily_retention_days``. PR-A6a's whole point is that those
+    two reads no longer fall back to atlas mode."""
+    settings = _reload_settings_in_standalone_mode(monkeypatch)
+    snapshot_days = int(settings.provider_cost.snapshot_retention_days)
+    daily_days = int(settings.provider_cost.daily_retention_days)
+    assert snapshot_days == 90
+    assert daily_days == 365
+
+
+# ---- openai_billing.py getattr fallback still works ----
+
+
+def test_openai_billing_getattr_fallback_returns_default(monkeypatch):
+    """``services/cost/openai_billing.py`` uses
+    ``getattr(settings.provider_cost, "openai_admin_api_key", "")``
+    because that field is not in atlas's ProviderCostConfig today.
+    The substrate copy mirrors atlas, so the getattr fallback still
+    returns the empty default."""
+    settings = _reload_settings_in_standalone_mode(monkeypatch)
+    fallback = getattr(settings.provider_cost, "openai_admin_api_key", "") or ""
+    assert fallback == ""


### PR DESCRIPTION
## Summary

First of two PRs closing standalone-mode functional gaps in \`extracted_llm_infrastructure\` (per the approved plan at \`/home/juan-canfield/.claude/plans/cozy-exploring-hoare.md\`).

**Gap**: \`services/provider_cost_sync.py\` reads \`settings.provider_cost.{snapshot_retention_days, daily_retention_days, ...}\` but the standalone \`LLMInfraSettings\` only exposed \`llm\` / \`b2b_churn\` / \`reasoning\` / \`ftl_tracing\` namespaces. The module silently fell back to atlas mode -- STATUS.md said \"lift uses default Atlas mode for now.\"

**Fix**: \`ProviderCostSubConfig\` mirrors \`atlas_brain.config.ProviderCostConfig\` (lines 5248-5304) byte-for-byte at the type/validator level, so the same \`ATLAS_PROVIDER_COST_*\` env vars work in both modes.

## Changes

| File | Change |
|---|---|
| \`extracted_llm_infrastructure/_standalone/config.py\` | Add \`ProviderCostSubConfig(BaseSettings)\` with the 9 atlas fields. Wire as \`provider_cost\` field on \`LLMInfraSettings\`. Update header docstring. |
| \`extracted_llm_infrastructure/STATUS.md\` | Per-file table: \`services/provider_cost_sync.py\` Phase 2 column 🔲 → ✅; Phase 3 set to \`n/a\` (no further work needed). |
| \`tests/test_extracted_llm_infrastructure_standalone_config.py\` | NEW — 16 tests pin every default value, env-var override paths, and the two specific reads \`provider_cost_sync.py\` performs. |

## Why \`ProviderBillingPort\` unification is NOT in this PR

\`services/cost/openai_billing.py\` already uses \`getattr(settings.provider_cost, \"openai_admin_api_key\", \"\") or \"\"\` -- a deliberate \"field may not exist in atlas yet\" fallback. The substrate copy mirrors atlas exactly (no \`openai_admin_api_key\` field, since atlas doesn't have one), so the getattr fallback continues to work. Phase 3 unification of \`provider_cost_sync\` + \`openai_billing\` via a \`ProviderBillingPort\` Protocol is decorative and explicitly deferred per the plan.

## Validation

```
$ EXTRACTED_LLM_INFRA_STANDALONE=1 python -c \"
from extracted_llm_infrastructure.config import settings
assert settings.provider_cost.enabled is False
assert settings.provider_cost.openrouter_enabled is True
assert settings.provider_cost.anthropic_lookback_days == 7
print('OK')
\"
OK

$ ATLAS_PROVIDER_COST_ENABLED=true ATLAS_PROVIDER_COST_ANTHROPIC_LOOKBACK_DAYS=14 \\
  EXTRACTED_LLM_INFRA_STANDALONE=1 python -c \"
from extracted_llm_infrastructure.config import settings
assert settings.provider_cost.enabled is True
assert settings.provider_cost.anthropic_lookback_days == 14
print('OK')
\"
OK

$ pytest tests/test_extracted_llm_infrastructure_standalone_config.py -q
16 passed in 0.81s

$ bash scripts/run_extracted_llm_infrastructure_checks.sh
All extracted_llm_infrastructure checks passed
Standalone smoke passed: 5 bridges + 15 provider modules + transitive-substrate check
```

## Out of scope

- No atlas-side changes. Atlas mode of every bridge continues delegating to \`atlas_brain.*\` exactly as today.
- No PyPI publish (per 2026-05-04 strategy).
- Skills layer + \`llm_exact_cache.py\` standalone gap → PR-A6b (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)