### PR TITLE
PR-A6b: Port SkillRegistry substrate; close standalone skills gap

### DIFF
--- a/extracted_llm_infrastructure/STATUS.md
+++ b/extracted_llm_infrastructure/STATUS.md
@@ -70,9 +70,11 @@ Import contract is closed; runtime behavior is decoupled from `atlas_brain`-spec
 | `storage/database.py` (bridge) | n/a | ✅ env-gated dispatch | n/a |
 | `services/b2b/anthropic_batch.py` | ✅ | ✅ (imports cleanly; consumes standalone substrate transitively) | 🔲 |
 | `services/b2b/cache_strategy.py` | ✅ | ✅ (pure data; no atlas imports) | n/a |
-| `services/b2b/llm_exact_cache.py` (PR-A1) | ✅ | ✅ (lazy `from ...config import settings` + `from ...storage.database import get_db_pool` route via env-gated bridges; new `from ...skills import get_skill_registry` routes via PR-A1.5 skills bridge with explicit standalone-mode error; `B2BChurnSubConfig.llm_exact_cache_enabled` flag added in PR-A1.5) | 🔲 (Phase 3: substrate skills layer or replace skill helpers with Protocol-based DI) |
-| `skills/__init__.py` (bridge, PR-A1.5) | n/a | ✅ env-gated dispatch; raises NotImplementedError in standalone mode | 🔲 |
-| `pipelines/llm.py` | ✅ | ✅ (lazy `from ..config import settings` routes to standalone) | 🔲 |
+| `services/b2b/llm_exact_cache.py` (PR-A1) | ✅ | ✅ (lazy `from ...config import settings` + `from ...storage.database import get_db_pool` route via env-gated bridges; `from ...skills import get_skill_registry` routes via PR-A6b skills substrate; `B2BChurnSubConfig.llm_exact_cache_enabled` flag added in PR-A1.5) | ✅ (PR-A6b: skills substrate carved as owned file; `build_skill_messages` / `build_skill_request_envelope` succeed in standalone mode against the local registry) |
+| `skills/__init__.py` (bridge, PR-A1.5) | n/a | ✅ env-gated dispatch; standalone branch returns a real `SkillRegistry` (PR-A6b) | ✅ |
+| `skills/registry.py` (OWNED, PR-A6b) | n/a | ✅ standalone substrate; mirrors atlas SkillRegistry verbatim with three env-aware tweaks (default skills dir, logger name, `EXTRACTED_LLM_INFRA_SKILLS_DIR` override) | n/a |
+| `skills/markdown/.gitkeep` (OWNED, PR-A6b) | n/a | ✅ default standalone skills dir (empty by design; package ships no public skills per 2026-05-04 strategy) | n/a |
+| `pipelines/llm.py` | ✅ | ✅ (lazy `from ..config import settings` routes to standalone; lazy `from ..skills import get_skill_registry` routes to PR-A6b substrate) | ✅ |
 | `reasoning/semantic_cache.py` | ✅ | ✅ (pool injected by caller; standalone DatabasePool compatible) | 🔲 |
 | `services/llm_router.py` | ✅ | ✅ (consumes standalone settings + registry) | 🔲 |
 | `services/llm/anthropic.py` | ✅ | ✅ (transitive substrate verified by smoke check) | 🔲 |

--- a/extracted_llm_infrastructure/skills/__init__.py
+++ b/extracted_llm_infrastructure/skills/__init__.py
@@ -1,22 +1,21 @@
-"""Phase 2 bridge: skills entry point for the LLM-infrastructure scaffold.
+"""Skills entry point for the LLM-infrastructure scaffold.
 
-The exact LLM cache (`services/b2b/llm_exact_cache.py:160`) lazily imports
-`get_skill_registry` from `...skills` to build skill-message envelopes. In
-default mode that resolves to `atlas_brain.skills`. A standalone substrate
-for skills is not yet carved out -- skill prompts are owned by Atlas's
-content/competitive-intelligence pipelines and have not been classified for
-extraction yet. Phase 3 work that decouples cache helpers from skills (or
-extracts skills behind a Protocol) will replace this bridge with a proper
-substrate.
+The exact LLM cache (``services/b2b/llm_exact_cache.py:160``) and the
+LLM call pipeline (``pipelines/llm.py``) lazily import
+``get_skill_registry`` from ``...skills`` to build skill-message
+envelopes.
 
 Default mode (``EXTRACTED_LLM_INFRA_STANDALONE`` unset/false): re-export
-from ``atlas_brain.skills`` so the cache helpers run as a sibling of Atlas.
+from ``atlas_brain.skills`` so the cache helpers run as a sibling of
+Atlas and see Atlas's full skill catalog.
 
-Standalone mode (``EXTRACTED_LLM_INFRA_STANDALONE=1``): raise on access.
-The cache helpers that need skills are not callable in standalone mode
-until Phase 3 extracts (or stubs) the skills layer; lookup/store paths
-that do not call `build_skill_messages` / `build_skill_request_envelope`
-remain usable.
+Standalone mode (``EXTRACTED_LLM_INFRA_STANDALONE=1``): use the local
+``.registry`` module's ``SkillRegistry`` (PR-A6b carved this out as an
+owned substrate file). Default skills directory is
+``extracted_llm_infrastructure/skills/markdown/`` (empty by design --
+the package ships no public skills per the 2026-05-04 strategy
+decision); the ``EXTRACTED_LLM_INFRA_SKILLS_DIR`` env var lets callers
+point at an external markdown directory.
 """
 
 from __future__ import annotations
@@ -24,13 +23,7 @@ from __future__ import annotations
 import os as _os
 
 if _os.environ.get("EXTRACTED_LLM_INFRA_STANDALONE") == "1":
-    def get_skill_registry(*_args, **_kwargs):  # type: ignore[no-redef]
-        raise NotImplementedError(
-            "extracted_llm_infrastructure.skills is not implemented in "
-            "standalone mode. The skills layer is owned by content/"
-            "competitive-intelligence pipelines and has not been extracted. "
-            "Phase 3 will decouple cache helpers from skills."
-        )
+    from .registry import Skill, SkillRegistry, get_skill_registry  # noqa: F401
 else:
     from atlas_brain.skills import *  # noqa: F401,F403
     from atlas_brain.skills import get_skill_registry  # noqa: F401

--- a/extracted_llm_infrastructure/skills/markdown/.gitkeep
+++ b/extracted_llm_infrastructure/skills/markdown/.gitkeep
@@ -1,0 +1,5 @@
+# Default standalone-mode skills directory.
+# Empty by design -- per the 2026-05-04 strategy decision, the
+# extracted_llm_infrastructure package stays internal and ships no
+# skills publicly. Standalone callers either drop their own .md
+# files here or override via EXTRACTED_LLM_INFRA_SKILLS_DIR.

--- a/extracted_llm_infrastructure/skills/registry.py
+++ b/extracted_llm_infrastructure/skills/registry.py
@@ -1,0 +1,233 @@
+"""
+Standalone SkillRegistry for the extracted_llm_infrastructure package.
+
+Mirrors ``atlas_brain/skills/registry.py`` -- copied verbatim except for
+three environment-aware tweaks documented below. The public API
+(``Skill``, ``SkillRegistry``, ``get_skill_registry``) is identical so
+the env-gated bridge in ``__init__.py`` can dispatch to either copy
+without callers noticing.
+
+Tweaks vs atlas:
+
+  - ``_SKILLS_DIR`` defaults to ``Path(__file__).parent / "markdown"``
+    so the package's own ``skills/markdown/`` is the standalone default
+    (rather than the package root, which would pull in non-skill files).
+  - Logger name is ``extracted_llm_infrastructure.skills`` instead of
+    ``atlas.skills`` so log routing distinguishes the two registries
+    when both are imported in the same process during tests.
+  - ``get_skill_registry()`` honors the ``EXTRACTED_LLM_INFRA_SKILLS_DIR``
+    env var so standalone callers can point at an external markdown
+    directory without subclassing or rewiring the singleton.
+
+Skills are markdown files with optional YAML frontmatter that get
+injected into LLM prompts at runtime (e.g.,
+``services/b2b/llm_exact_cache.py::build_skill_messages`` reads
+``skill.content`` for the system message).
+
+Usage:
+    from extracted_llm_infrastructure.skills import get_skill_registry
+
+    registry = get_skill_registry()
+    skill = registry.get("email/cleaning_confirmation")
+    skills = registry.get_by_domain("email")
+    skills = registry.get_by_tag("sentiment")
+"""
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("extracted_llm_infrastructure.skills")
+
+# Skills root: extracted_llm_infrastructure/skills/markdown/.
+# An external directory can override via EXTRACTED_LLM_INFRA_SKILLS_DIR
+# (resolved at ``get_skill_registry()`` call time, not module import).
+_SKILLS_DIR = Path(__file__).parent / "markdown"
+
+
+@dataclass(frozen=True)
+class Skill:
+    """An injectable skill document parsed from a markdown file."""
+
+    name: str
+    domain: str
+    content: str
+    description: str
+    tags: tuple[str, ...]
+    version: int
+    file_path: str
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str | list[str] | int], str]:
+    """
+    Parse optional YAML-like frontmatter from markdown text.
+
+    Handles simple key: value and key: [a, b, c] syntax.
+    No PyYAML dependency required.
+
+    Returns (metadata_dict, body_text).
+    """
+    if not text.startswith("---"):
+        return {}, text
+
+    # Find closing ---
+    end_match = re.search(r"\n---\s*\n", text[3:])
+    if end_match is None:
+        return {}, text
+
+    frontmatter_str = text[3 : 3 + end_match.start()]
+    body = text[3 + end_match.end() :]
+
+    metadata: dict[str, str | list[str] | int] = {}
+    for line in frontmatter_str.strip().splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+
+        # Parse list: [a, b, c]
+        if value.startswith("[") and value.endswith("]"):
+            items = [item.strip() for item in value[1:-1].split(",")]
+            metadata[key] = [item for item in items if item]
+        # Parse integer
+        elif value.isdigit():
+            metadata[key] = int(value)
+        else:
+            metadata[key] = value
+
+    return metadata, body
+
+
+def _load_skill(file_path: Path, skills_dir: Path) -> Skill:
+    """Load a single skill from a markdown file."""
+    text = file_path.read_text(encoding="utf-8")
+    metadata, body = _parse_frontmatter(text)
+
+    # Derive defaults from file path
+    relative = file_path.relative_to(skills_dir)
+    default_name = str(relative.with_suffix(""))
+    default_domain = relative.parts[0] if len(relative.parts) > 1 else ""
+
+    name = str(metadata.get("name", default_name))
+    domain = str(metadata.get("domain", default_domain))
+    description = str(metadata.get("description", ""))
+    version = metadata.get("version", 1)
+    if not isinstance(version, int):
+        version = 1
+
+    raw_tags = metadata.get("tags", [])
+    if isinstance(raw_tags, list):
+        tags = tuple(str(t) for t in raw_tags)
+    else:
+        tags = (str(raw_tags),)
+
+    return Skill(
+        name=name,
+        domain=domain,
+        content=body.strip(),
+        description=description,
+        tags=tags,
+        version=version,
+        file_path=str(file_path),
+    )
+
+
+class SkillRegistry:
+    """
+    Discovers and loads .md skill files from the skills directory.
+
+    Lazy-loaded: skills are read from disk on first access.
+    Call reload() to re-read from disk after changes.
+    Missing directories are tolerated (load() returns 0 -- standalone
+    callers may not ship any skills by default).
+    """
+
+    def __init__(self, skills_dir: Optional[Path] = None):
+        self._skills_dir = skills_dir or _SKILLS_DIR
+        self._skills: dict[str, Skill] = {}
+        self._loaded = False
+
+    def load(self) -> int:
+        """
+        Load all .md skill files from the skills directory.
+
+        Returns the number of skills loaded. A missing directory is
+        not an error -- standalone callers may run without any
+        bundled skills.
+        """
+        self._skills.clear()
+        count = 0
+
+        if not self._skills_dir.is_dir():
+            self._loaded = True
+            logger.info(
+                "Skills directory %s does not exist; loaded 0 skills",
+                self._skills_dir,
+            )
+            return 0
+
+        for md_file in sorted(self._skills_dir.rglob("*.md")):
+            try:
+                skill = _load_skill(md_file, self._skills_dir)
+                self._skills[skill.name] = skill
+                count += 1
+                logger.debug("Loaded skill: %s", skill.name)
+            except Exception:
+                logger.exception("Failed to load skill from %s", md_file)
+
+        self._loaded = True
+        logger.info("Loaded %d skills from %s", count, self._skills_dir)
+        return count
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-load skills on first access."""
+        if not self._loaded:
+            self.load()
+
+    def reload(self) -> int:
+        """Re-read all skills from disk. Returns count loaded."""
+        self._loaded = False
+        return self.load()
+
+    def get(self, name: str) -> Optional[Skill]:
+        """Get a skill by name (e.g., 'email/cleaning_confirmation')."""
+        self._ensure_loaded()
+        return self._skills.get(name)
+
+    def get_by_domain(self, domain: str) -> list[Skill]:
+        """Get all skills in a domain (e.g., 'email')."""
+        self._ensure_loaded()
+        return [s for s in self._skills.values() if s.domain == domain]
+
+    def get_by_tag(self, tag: str) -> list[Skill]:
+        """Get all skills that have a given tag."""
+        self._ensure_loaded()
+        return [s for s in self._skills.values() if tag in s.tags]
+
+    def list_skills(self) -> list[str]:
+        """List all loaded skill names."""
+        self._ensure_loaded()
+        return sorted(self._skills.keys())
+
+
+_skill_registry: Optional[SkillRegistry] = None
+
+
+def get_skill_registry() -> SkillRegistry:
+    """Get or create the singleton SkillRegistry.
+
+    Honors the ``EXTRACTED_LLM_INFRA_SKILLS_DIR`` env var when first
+    creating the singleton: callers that need to point at an external
+    markdown directory can do so without subclassing.
+    """
+    global _skill_registry
+    if _skill_registry is None:
+        env_dir = os.environ.get("EXTRACTED_LLM_INFRA_SKILLS_DIR")
+        skills_dir = Path(env_dir) if env_dir else None
+        _skill_registry = SkillRegistry(skills_dir=skills_dir)
+    return _skill_registry

--- a/scripts/smoke_extracted_llm_infrastructure_standalone.py
+++ b/scripts/smoke_extracted_llm_infrastructure_standalone.py
@@ -188,23 +188,32 @@ def main() -> int:
         print(f"FAIL storage.database: {exc}")
         failed.append("storage.database")
 
-    # 6. Skills (bridge stub)
+    # 6. Skills (PR-A6b: bridge returns the local SkillRegistry in
+    # standalone mode; default markdown dir is empty by design but
+    # callable; env-gate must NOT silently resolve to atlas_brain.skills).
     try:
-        from extracted_llm_infrastructure.skills import get_skill_registry
+        from extracted_llm_infrastructure.skills import (
+            SkillRegistry,
+            get_skill_registry,
+        )
 
-        # In standalone mode the bridge MUST raise NotImplementedError.
-        # If it instead resolved silently to atlas_brain.skills (e.g.
-        # the env-gate regressed), this assertion would catch it.
-        try:
-            get_skill_registry()
-        except NotImplementedError:
-            print("OK skills (bridge raises NotImplementedError as expected)")
-        else:
+        registry = get_skill_registry()
+        if not isinstance(registry, SkillRegistry):
             raise AssertionError(
-                "skills bridge did not raise in standalone mode -- "
-                "the env-gate may have regressed and silently resolved "
-                "to atlas_brain.skills"
+                "skills bridge returned a non-SkillRegistry object "
+                f"({type(registry).__name__}) -- the env-gate may have "
+                "regressed and silently resolved to atlas_brain.skills"
             )
+        # Confirm the substrate copy is what we got, not atlas_brain's.
+        if not type(registry).__module__.startswith(
+            "extracted_llm_infrastructure.skills."
+        ):
+            raise AssertionError(
+                "skills bridge returned a SkillRegistry from "
+                f"{type(registry).__module__!r} -- expected the "
+                "extracted_llm_infrastructure.skills.registry module"
+            )
+        print("OK skills (PR-A6b standalone substrate active)")
     except Exception as exc:
         print(f"FAIL skills: {exc}")
         failed.append("skills")

--- a/tests/test_extracted_llm_infrastructure_skills.py
+++ b/tests/test_extracted_llm_infrastructure_skills.py
@@ -1,0 +1,198 @@
+"""Tests for the standalone skills substrate (PR-A6b).
+
+Pins the contract that ``extracted_llm_infrastructure.skills`` works
+in both modes:
+
+- Default (``EXTRACTED_LLM_INFRA_STANDALONE`` unset/false) re-exports
+  from ``atlas_brain.skills`` so the bridge sees Atlas's full skill
+  catalog. Not exercised here -- atlas-mode is covered by existing
+  ``atlas_brain.skills`` tests; this file focuses on the previously
+  broken standalone branch.
+
+- Standalone (``EXTRACTED_LLM_INFRA_STANDALONE=1``) uses the local
+  ``.registry`` module's ``SkillRegistry``. Default skills directory
+  is ``extracted_llm_infrastructure/skills/markdown/`` (empty by
+  design); the ``EXTRACTED_LLM_INFRA_SKILLS_DIR`` env var lets
+  callers point at an external markdown directory.
+
+The end-to-end test asserts that ``services.b2b.llm_exact_cache.
+build_skill_messages`` succeeds in standalone mode -- closing the
+functional gap the bridge's NotImplementedError was producing
+before this PR.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+
+_STANDALONE_ENV_VAR = "EXTRACTED_LLM_INFRA_STANDALONE"
+_SKILLS_DIR_ENV_VAR = "EXTRACTED_LLM_INFRA_SKILLS_DIR"
+
+
+def _reset_skills_modules() -> None:
+    """Drop cached imports so the env var snapshot is re-read."""
+    for mod_name in (
+        "extracted_llm_infrastructure.skills",
+        "extracted_llm_infrastructure.skills.registry",
+        "extracted_llm_infrastructure.services.b2b.llm_exact_cache",
+    ):
+        sys.modules.pop(mod_name, None)
+
+
+@pytest.fixture
+def standalone_skills(monkeypatch) -> Iterator[None]:
+    """Activate standalone mode and clean module caches afterward."""
+    monkeypatch.setenv(_STANDALONE_ENV_VAR, "1")
+    _reset_skills_modules()
+    try:
+        yield
+    finally:
+        _reset_skills_modules()
+
+
+@pytest.fixture
+def standalone_skills_with_dir(monkeypatch, tmp_path: Path) -> Iterator[Path]:
+    """Activate standalone mode pointed at a tmp markdown dir.
+
+    Yields the dir so the test can drop fixture .md files into it.
+    """
+    monkeypatch.setenv(_STANDALONE_ENV_VAR, "1")
+    monkeypatch.setenv(_SKILLS_DIR_ENV_VAR, str(tmp_path))
+    _reset_skills_modules()
+    try:
+        yield tmp_path
+    finally:
+        _reset_skills_modules()
+
+
+# ---- Bridge no longer raises in standalone mode (gap #1 closure) ----
+
+
+def test_standalone_get_skill_registry_returns_registry(standalone_skills):
+    """Pre-PR-A6b this raised NotImplementedError. After the port,
+    the bridge returns a real ``SkillRegistry``."""
+    from extracted_llm_infrastructure.skills import get_skill_registry, SkillRegistry
+
+    registry = get_skill_registry()
+    assert isinstance(registry, SkillRegistry)
+
+
+def test_standalone_default_skills_dir_is_empty(standalone_skills, monkeypatch):
+    """The package's bundled default markdown dir is empty by design.
+    A standalone caller without an override sees zero skills."""
+    monkeypatch.delenv(_SKILLS_DIR_ENV_VAR, raising=False)
+    _reset_skills_modules()
+    from extracted_llm_infrastructure.skills import get_skill_registry
+
+    registry = get_skill_registry()
+    assert registry.list_skills() == []
+
+
+def test_standalone_missing_skills_dir_does_not_raise(monkeypatch, tmp_path):
+    """If the override points at a non-existent directory, ``load()``
+    must return 0 instead of raising. Standalone callers that haven't
+    set up a skills dir yet still get a working (empty) registry."""
+    monkeypatch.setenv(_STANDALONE_ENV_VAR, "1")
+    monkeypatch.setenv(_SKILLS_DIR_ENV_VAR, str(tmp_path / "does_not_exist"))
+    _reset_skills_modules()
+
+    from extracted_llm_infrastructure.skills import get_skill_registry
+
+    registry = get_skill_registry()
+    assert registry.list_skills() == []
+
+
+# ---- EXTRACTED_LLM_INFRA_SKILLS_DIR override ----
+
+
+def test_standalone_override_dir_loads_markdown(standalone_skills_with_dir):
+    """A markdown file in the override dir is discovered and parsed."""
+    skill_file = standalone_skills_with_dir / "probe.md"
+    skill_file.write_text(
+        textwrap.dedent(
+            """\
+            ---
+            description: probe skill
+            ---
+            hello world
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    from extracted_llm_infrastructure.skills import get_skill_registry
+
+    registry = get_skill_registry()
+    assert "probe" in registry.list_skills()
+    skill = registry.get("probe")
+    assert skill is not None
+    assert skill.content.strip() == "hello world"
+    assert skill.description == "probe skill"
+
+
+def test_standalone_override_dir_supports_subdirectory_naming(
+    standalone_skills_with_dir,
+):
+    """Skill names match the path-relative naming the registry uses
+    in atlas (``email/cleaning_confirmation``)."""
+    nested_dir = standalone_skills_with_dir / "email"
+    nested_dir.mkdir()
+    (nested_dir / "cleaning_confirmation.md").write_text(
+        "Body for cleaning confirmation.",
+        encoding="utf-8",
+    )
+
+    from extracted_llm_infrastructure.skills import get_skill_registry
+
+    registry = get_skill_registry()
+    assert "email/cleaning_confirmation" in registry.list_skills()
+    skill = registry.get("email/cleaning_confirmation")
+    assert skill is not None
+    assert skill.domain == "email"
+
+
+# ---- llm_exact_cache end-to-end (gap #2 closure) ----
+
+
+def test_llm_exact_cache_build_skill_messages_works_in_standalone_mode(
+    standalone_skills_with_dir,
+):
+    """The actual functional gap PR-A6b closes: ``build_skill_messages``
+    crashed in standalone before because the skills bridge raised
+    ``NotImplementedError``. With the port in place, it loads the
+    skill content and emits the system + user messages."""
+    skill_file = standalone_skills_with_dir / "probe.md"
+    skill_file.write_text(
+        "Probe system content for the LLM.",
+        encoding="utf-8",
+    )
+
+    from extracted_llm_infrastructure.services.b2b.llm_exact_cache import (
+        build_skill_messages,
+    )
+
+    messages = build_skill_messages("probe", {"q": "hello"})
+
+    system_messages = [m for m in messages if m.get("role") == "system"]
+    user_messages = [m for m in messages if m.get("role") == "user"]
+    assert len(system_messages) == 1
+    assert len(user_messages) == 1
+    assert "Probe system content" in str(system_messages[0].get("content", ""))
+
+
+# ---- Public API surface ----
+
+
+def test_standalone_registry_exposes_atlas_compatible_api(standalone_skills):
+    """Both bridge branches must expose the same public names so
+    callers can import without conditional logic."""
+    skills_module = importlib.import_module("extracted_llm_infrastructure.skills")
+    for name in ("Skill", "SkillRegistry", "get_skill_registry"):
+        assert hasattr(skills_module, name), f"missing {name}"


### PR DESCRIPTION
## Summary

Second of two PRs closing standalone-mode functional gaps in \`extracted_llm_infrastructure\` (after PR-A6a #169). Closes gaps #1 and #2 from the audit:

- \`extracted_llm_infrastructure/skills/__init__.py\` raised \`NotImplementedError\` in standalone mode.
- \`services/b2b/llm_exact_cache.py\` and \`pipelines/llm.py\` lazy-import \`get_skill_registry\` and so crashed on first skill-aware call standalone.

After this PR, the package is **100% operational standalone** -- all functional gaps closed.

## Changes

| File | Change |
|---|---|
| \`extracted_llm_infrastructure/skills/registry.py\` | NEW (OWNED). Port of \`atlas_brain/skills/registry.py\` (193 lines, pure stdlib, zero atlas imports). Three env-aware tweaks: default skills dir is \`<package>/skills/markdown/\`; logger name is \`extracted_llm_infrastructure.skills\`; \`get_skill_registry()\` honors \`EXTRACTED_LLM_INFRA_SKILLS_DIR\` env var. \`load()\` tolerates a missing directory (returns 0 instead of raising). |
| \`extracted_llm_infrastructure/skills/markdown/.gitkeep\` | NEW. Default empty skills dir. Per the 2026-05-04 strategy decision (\`extracted_*\` stays internal), the package ships no public skills. |
| \`extracted_llm_infrastructure/skills/__init__.py\` | EDIT. Standalone branch now imports from local \`.registry\` instead of raising. Atlas branch unchanged. |
| \`scripts/smoke_extracted_llm_infrastructure_standalone.py\` | EDIT. Was asserting \"bridge MUST raise NotImplementedError\"; now asserts \"bridge MUST return a SkillRegistry from the local substrate module\" -- catches a different regression class (env-gate silently resolving to atlas_brain.skills). |
| \`extracted_llm_infrastructure/STATUS.md\` | Per-file table: \`services/b2b/llm_exact_cache.py\` Phase 3 🔲 → ✅; \`skills/__init__.py\` Phase 3 🔲 → ✅; \`pipelines/llm.py\` Phase 3 🔲 → ✅; new OWNED rows for \`skills/registry.py\` and \`skills/markdown/.gitkeep\`. |
| \`tests/test_extracted_llm_infrastructure_skills.py\` | NEW -- 7 tests pinning bridge no-longer-raises, default empty dir, missing override dir tolerated, override dir loads markdown, nested subdir naming, end-to-end \`build_skill_messages\` in standalone mode, public API surface. |

## Why port the registry rather than Protocol-DI it

Two valid Phase 3 strategies emerged from the audit (see \`/home/juan-canfield/.claude/plans/cozy-exploring-hoare.md\`):

1. **Port the substrate** (chosen): copy the 193-line registry verbatim. Zero deps, zero call-site changes, standalone mode works out of the box.
2. **Protocol-DI**: define \`SkillRegistryProtocol\`; thread it through call sites as an injectable parameter.

Strategy #1 won because the registry is **already designed to be portable** -- pure stdlib, file-system-backed, constructor accepts \`skills_dir: Optional[Path]\`. No abstraction overhead. The PR-A5d \`AnthropicBatchableLLM\` Protocol pattern was right for routing decisions (which path to take based on type); skills are substrate, not routing.

## Validation

```
$ EXTRACTED_LLM_INFRA_STANDALONE=1 python -c \"
from extracted_llm_infrastructure.skills import get_skill_registry
r = get_skill_registry()
print('default empty:', r.list_skills())
\"
default empty: []

$ EXTRACTED_LLM_INFRA_SKILLS_DIR=/tmp/test_skills EXTRACTED_LLM_INFRA_STANDALONE=1 python -c \"
from extracted_llm_infrastructure.services.b2b.llm_exact_cache import build_skill_messages
msgs = build_skill_messages('probe', {'q': 'hi'})
print(msgs)
\"
[{'role': 'system', 'content': 'hello world'}, {'role': 'user', 'content': '{\"q\":\"hi\"}'}]

$ pytest tests/test_extracted_llm_infrastructure_skills.py tests/test_extracted_llm_infrastructure_standalone_config.py -q
23 passed in 0.86s

$ bash scripts/run_extracted_llm_infrastructure_checks.sh
All extracted_llm_infrastructure checks passed
Standalone smoke passed: 5 bridges + 15 provider modules + transitive-substrate check
```

## Out of scope

- No atlas-side changes. Atlas mode of the bridge keeps re-exporting \`atlas_brain.skills\` (68 skills in atlas's catalog).
- No PyPI publish (per 2026-05-04 strategy).
- \`ProviderBillingPort\` Protocol unification deferred (decorative; not a functional gap).
- 8 prefix-matching consumers in \`b2b_blog_post_generation.py\`/\`b2b_campaign_generation.py\` -- separate follow-up; same antipattern as item 3 from the audit but different sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)