### PR TITLE
Add AI Content Ops webhook ingestion worker

### DIFF
--- a/atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py
+++ b/atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py
@@ -62,3 +62,29 @@ Return ONLY valid JSON.\
 CATEGORY_COUNCIL_SYNTHESIS_PROMPT_VERSION = _hashlib.sha256(
     CATEGORY_COUNCIL_SYNTHESIS_PROMPT.encode()
 ).hexdigest()[:8]
+
+
+# PR-C3f: register this prompt with the shared reasoning pack registry
+# (PR-C3a / extracted_reasoning_core.pack_registry). The category
+# council synthesis pack produces a market-regime assessment for a
+# product category from category dynamics, vendor evidence, and
+# ecosystem context. Per the audit, the pack file moves into a
+# product package during PR 7 (Product Migration); for now it stays
+# atlas-side.
+from extracted_reasoning_core.pack_registry import (  # noqa: E402
+    Pack as _Pack,
+    register_pack as _register_pack,
+)
+
+_register_pack(
+    _Pack(
+        name="category_council_synthesis",
+        version=CATEGORY_COUNCIL_SYNTHESIS_PROMPT_VERSION,
+        prompts={"synthesis": CATEGORY_COUNCIL_SYNTHESIS_PROMPT},
+        metadata={
+            "output_artifact": "category_market_regime",
+            "owner_product": "atlas",
+            "synthesis_mode": "structured_synthesis_v1",
+        },
+    )
+)

--- a/atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py
+++ b/atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py
@@ -61,3 +61,28 @@ Return ONLY valid JSON.\
 RESOURCE_ASYMMETRY_SYNTHESIS_PROMPT_VERSION = _hashlib.sha256(
     RESOURCE_ASYMMETRY_SYNTHESIS_PROMPT.encode()
 ).hexdigest()[:8]
+
+
+# PR-C3f: register this prompt with the shared reasoning pack registry
+# (PR-C3a / extracted_reasoning_core.pack_registry). The resource
+# asymmetry synthesis pack assesses resource divergence between two
+# vendors with similar churn pressure but different market positions.
+# Per the audit, the pack file moves into a product package during
+# PR 7 (Product Migration); for now it stays atlas-side.
+from extracted_reasoning_core.pack_registry import (  # noqa: E402
+    Pack as _Pack,
+    register_pack as _register_pack,
+)
+
+_register_pack(
+    _Pack(
+        name="resource_asymmetry_synthesis",
+        version=RESOURCE_ASYMMETRY_SYNTHESIS_PROMPT_VERSION,
+        prompts={"synthesis": RESOURCE_ASYMMETRY_SYNTHESIS_PROMPT},
+        metadata={
+            "output_artifact": "resource_asymmetry_assessment",
+            "owner_product": "competitive_intelligence",
+            "synthesis_mode": "structured_synthesis_v1",
+        },
+    )
+)

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T19:49Z by codex-2026-05-04
+Last updated: 2026-05-04T19:54Z by codex-content-webhook-worker
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | Add AI Content Ops webhook ingestion worker CLI | `extracted_content_pipeline/campaign_postgres_webhooks.py`, `scripts/ingest_extracted_campaign_webhook.py`, `tests/test_extracted_campaign_postgres_webhooks.py`, content pipeline docs/manifest/check wiring | codex-content-webhook-worker | Avoid editing DB-backed campaign webhook ingestion seams until this lands |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T19:49Z by codex-2026-05-04
+Last updated: 2026-05-04T19:50Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-C3f, in flight) | PR-C3f: Register remaining synthesis prompts as packs (closes PR-C3 sequence) | EDIT: `atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py` (add `register_pack` for `category_council_synthesis`). EDIT: `atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py` (add `register_pack` for `resource_asymmetry_synthesis`). NEW: `tests/test_extracted_reasoning_core_pack_registry_remaining_synthesis.py` (5 atlas-side integration tests). The audit's "content/campaign placeholder packs" entry has no atlas-side prompt files; deferred to PR 7 along with the migration of campaign autonomous tasks. | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py`; `atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py`; `tests/test_extracted_reasoning_core_pack_registry_remaining_synthesis.py` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,13 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T19:50Z by claude-2026-05-03
+Last updated: 2026-05-04T19:57Z by codex-content-webhook-worker
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C3f, in flight) | PR-C3f: Register remaining synthesis prompts as packs (closes PR-C3 sequence) | EDIT: `atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py` (add `register_pack` for `category_council_synthesis`). EDIT: `atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py` (add `register_pack` for `resource_asymmetry_synthesis`). NEW: `tests/test_extracted_reasoning_core_pack_registry_remaining_synthesis.py` (5 atlas-side integration tests). The audit's "content/campaign placeholder packs" entry has no atlas-side prompt files; deferred to PR 7 along with the migration of campaign autonomous tasks. | claude-2026-05-03 | `atlas_brain/reasoning/single_pass_prompts/category_council_synthesis.py`; `atlas_brain/reasoning/single_pass_prompts/resource_asymmetry_synthesis.py`; `tests/test_extracted_reasoning_core_pack_registry_remaining_synthesis.py` |
+| TBD | Add AI Content Ops webhook ingestion worker CLI | `extracted_content_pipeline/campaign_postgres_webhooks.py`, `scripts/ingest_extracted_campaign_webhook.py`, `tests/test_extracted_campaign_postgres_webhooks.py`, content pipeline docs/manifest/check wiring | codex-content-webhook-worker | Avoid editing DB-backed campaign webhook ingestion seams until this lands |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -250,6 +250,16 @@ python scripts/send_extracted_campaigns.py \
   --limit 10
 ```
 
+Ingest Resend webhook payloads into the campaign tables:
+
+```bash
+export EXTRACTED_RESEND_WEBHOOK_SECRET="whsec_..."
+python scripts/ingest_extracted_campaign_webhook.py \
+  --body-file resend-event.json \
+  --headers-json resend-headers.json \
+  --json
+```
+
 Refresh campaign analytics after send or webhook updates:
 
 ```bash
@@ -355,6 +365,9 @@ Several small utility shims provide product-owned local behavior by default so t
   campaign, suppression, audit, and sender ports for host worker CLIs
 - `campaign_postgres_analytics.py`: DB-backed analytics refresh runner that
   composes campaign and audit ports for host worker CLIs
+- `campaign_postgres_webhooks.py`: DB-backed webhook ingestion runner that
+  composes campaign, suppression, audit, and Resend verification ports for
+  host worker CLIs
 - `campaign_postgres_sequence_progression.py`: DB-backed due-sequence worker
   that composes the sequence, audit, LLM, and skill ports for follow-up
   generation

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -44,6 +44,9 @@
 - `campaign_postgres_analytics` provides a DB-backed analytics refresh worker
   seam. Hosts can refresh the packaged campaign funnel materialized view and
   audit the result without importing Atlas scheduled-task code.
+- `campaign_postgres_webhooks` provides a DB-backed webhook ingestion seam.
+  Hosts can verify Resend/Svix webhooks, record campaign engagement, apply
+  suppression policy, and audit the result without importing Atlas API code.
 - `campaign_postgres_sequence_progression` provides a DB-backed follow-up
   generation worker seam. Hosts reuse due `campaign_sequences` rows, packaged
   or custom sequence prompts, and the product LLM port to queue the next

--- a/extracted_content_pipeline/campaign_postgres_webhooks.py
+++ b/extracted_content_pipeline/campaign_postgres_webhooks.py
@@ -1,0 +1,49 @@
+"""Postgres-backed webhook ingestion runner for campaign ESP events."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .campaign_postgres import (
+    PostgresCampaignAuditSink,
+    PostgresCampaignRepository,
+    PostgresSuppressionRepository,
+)
+from .campaign_suppression import CampaignSuppressionService
+from .campaign_webhooks import (
+    CampaignWebhookIngestionConfig,
+    CampaignWebhookIngestionResult,
+    CampaignWebhookIngestionService,
+    ResendWebhookConfig,
+    ResendWebhookVerifier,
+)
+
+
+async def ingest_resend_webhook_from_postgres(
+    pool: Any,
+    *,
+    body: bytes,
+    headers: Mapping[str, str],
+    signing_secret: str = "",
+    verify_signatures: bool = True,
+    config: CampaignWebhookIngestionConfig | None = None,
+) -> CampaignWebhookIngestionResult:
+    """Verify a Resend webhook and ingest it through Postgres campaign ports."""
+    if verify_signatures and not str(signing_secret or "").strip():
+        raise ValueError(
+            "signing_secret is required when signature verification is enabled"
+        )
+
+    service = CampaignWebhookIngestionService(
+        verifier=ResendWebhookVerifier(
+            ResendWebhookConfig(
+                signing_secret=signing_secret,
+                verify_signatures=verify_signatures,
+            )
+        ),
+        campaigns=PostgresCampaignRepository(pool),
+        suppression=CampaignSuppressionService(PostgresSuppressionRepository(pool)),
+        audit=PostgresCampaignAuditSink(pool),
+        config=config,
+    )
+    return await service.ingest(body=body, headers=headers)

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -269,6 +269,17 @@ python scripts/send_extracted_campaigns.py \
   --limit 10
 ```
 
+Ingest Resend webhook events after provider delivery, open, click, bounce,
+complaint, or unsubscribe callbacks:
+
+```bash
+export EXTRACTED_RESEND_WEBHOOK_SECRET="whsec_..."
+python scripts/ingest_extracted_campaign_webhook.py \
+  --body-file resend-event.json \
+  --headers-json resend-headers.json \
+  --json
+```
+
 Refresh analytics after sends or webhook ingestion:
 
 ```bash

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -186,6 +186,12 @@ analytics refresh worker seam. It composes `PostgresCampaignRepository`,
 refresh the packaged campaign funnel materialized view without importing Atlas
 scheduled-task code.
 
+`extracted_content_pipeline/campaign_postgres_webhooks.py` owns the DB-backed
+webhook ingestion seam. It composes `PostgresCampaignRepository`,
+`PostgresSuppressionRepository`, `PostgresCampaignAuditSink`, and the Resend
+webhook verifier so hosts can record engagement, bounce, complaint, and
+unsubscribe events without importing Atlas API code.
+
 `extracted_content_pipeline/campaign_postgres_sequence_progression.py` owns the
 DB-backed sequence progression worker seam. It composes
 `PostgresCampaignSequenceRepository`, `PostgresCampaignAuditSink`, the product

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -175,10 +175,16 @@
       "target": "extracted_content_pipeline/campaign_analytics.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_webhooks.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_postgres_generation.py"
     },
     {
       "target": "extracted_content_pipeline/campaign_postgres_analytics.py"
+    },
+    {
+      "target": "extracted_content_pipeline/campaign_postgres_webhooks.py"
     },
     {
       "target": "extracted_content_pipeline/campaign_postgres_export.py"

--- a/scripts/ingest_extracted_campaign_webhook.py
+++ b/scripts/ingest_extracted_campaign_webhook.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Ingest extracted campaign ESP webhooks into Postgres."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_postgres_webhooks import (  # noqa: E402
+    ingest_resend_webhook_from_postgres,
+)
+from extracted_content_pipeline.campaign_webhooks import (  # noqa: E402
+    CampaignWebhookIngestionConfig,
+)
+
+
+DATABASE_URL_ENV = ("EXTRACTED_DATABASE_URL", "DATABASE_URL")
+RESEND_WEBHOOK_SECRET_ENV = (
+    "EXTRACTED_RESEND_WEBHOOK_SECRET",
+    "EXTRACTED_CAMPAIGN_RESEND_WEBHOOK_SECRET",
+)
+WEBHOOK_PROVIDERS = ("resend",)
+
+
+def _env(*names: str, default: str | None = None) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return int(default)
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid integer for {name}: {raw!r}") from exc
+
+
+def _parse_header_pair(value: str) -> tuple[str, str]:
+    name, sep, header_value = str(value or "").partition(":")
+    name = name.strip()
+    if not sep or not name:
+        raise argparse.ArgumentTypeError(
+            "Headers must use 'Name: value' format"
+        )
+    return name, header_value.strip()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    defaults = CampaignWebhookIngestionConfig()
+    parser = argparse.ArgumentParser(
+        description="Ingest campaign ESP webhook payloads into the extracted product database."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=_env(*DATABASE_URL_ENV),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=WEBHOOK_PROVIDERS,
+        default="resend",
+        help="Webhook provider to ingest.",
+    )
+    parser.add_argument(
+        "--body-file",
+        type=Path,
+        help="Path to the raw webhook body. Defaults to stdin.",
+    )
+    parser.add_argument(
+        "--headers-json",
+        type=Path,
+        help="Path to a JSON object containing webhook request headers.",
+    )
+    parser.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        type=_parse_header_pair,
+        help="Additional webhook header in 'Name: value' format. May repeat.",
+    )
+    parser.add_argument(
+        "--signing-secret",
+        default=_env(*RESEND_WEBHOOK_SECRET_ENV),
+        help=(
+            "Resend webhook signing secret. Defaults to "
+            "EXTRACTED_RESEND_WEBHOOK_SECRET or "
+            "EXTRACTED_CAMPAIGN_RESEND_WEBHOOK_SECRET."
+        ),
+    )
+    parser.add_argument(
+        "--skip-signature-verification",
+        action="store_true",
+        help="Skip webhook signature verification for trusted local replays.",
+    )
+    parser.add_argument(
+        "--record-unknown-events",
+        action="store_true",
+        help="Record provider events the extracted product does not handle yet.",
+    )
+    parser.add_argument(
+        "--soft-bounce-suppression-days",
+        type=int,
+        default=_env_int(
+            "EXTRACTED_CAMPAIGN_SOFT_BOUNCE_SUPPRESSION_DAYS",
+            defaults.soft_bounce_suppression_days,
+        ),
+        help="Temporary suppression length for soft bounces.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON summary instead of a concise text summary.",
+    )
+    return parser.parse_args(argv)
+
+
+def _read_body(path: Path | None) -> bytes:
+    if path is None:
+        return sys.stdin.buffer.read()
+    return path.read_bytes()
+
+
+def _read_headers(
+    headers_json: Path | None,
+    header_pairs: list[tuple[str, str]],
+) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if headers_json is not None:
+        try:
+            parsed = json.loads(headers_json.read_text())
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"Invalid --headers-json file: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise SystemExit("--headers-json must contain a JSON object")
+        headers.update({str(key): str(value) for key, value in parsed.items()})
+    for name, value in header_pairs:
+        headers[name] = value
+    return headers
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if args.provider != "resend":
+        raise SystemExit(f"Unsupported --provider: {args.provider!r}")
+    if args.soft_bounce_suppression_days <= 0:
+        raise SystemExit("--soft-bounce-suppression-days must be positive")
+    if (
+        not args.skip_signature_verification
+        and not str(args.signing_secret or "").strip()
+    ):
+        raise SystemExit(
+            "Missing --signing-secret or EXTRACTED_RESEND_WEBHOOK_SECRET; "
+            "use --skip-signature-verification only for trusted local replays"
+        )
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to ingest campaign webhooks; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main() -> int:
+    args = _parse_args()
+    _validate_args(args)
+    body = _read_body(args.body_file)
+    headers = _read_headers(args.headers_json, args.header)
+    pool = await _create_pool(args.database_url)
+    try:
+        result = await ingest_resend_webhook_from_postgres(
+            pool,
+            body=body,
+            headers=headers,
+            signing_secret=args.signing_secret or "",
+            verify_signatures=not args.skip_signature_verification,
+            config=CampaignWebhookIngestionConfig(
+                soft_bounce_suppression_days=args.soft_bounce_suppression_days,
+                record_unknown_events=args.record_unknown_events,
+            ),
+        )
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+
+    summary = result.as_dict()
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        text = "status={status}".format(**summary)
+        if summary.get("event_type"):
+            text = f"{text} event_type={summary['event_type']}"
+        if summary.get("message_id"):
+            text = f"{text} message_id={summary['message_id']}"
+        if summary.get("reason"):
+            text = f"{text} reason={summary['reason']}"
+        text = f"{text} suppressed={str(summary.get('suppressed')).lower()}"
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -23,6 +23,7 @@ pytest \
   tests/test_extracted_campaign_postgres_review.py \
   tests/test_extracted_campaign_postgres_send.py \
   tests/test_extracted_campaign_postgres_analytics.py \
+  tests/test_extracted_campaign_postgres_webhooks.py \
   tests/test_extracted_campaign_postgres_sequence_progression.py \
   tests/test_extracted_campaign_postgres_import.py \
   tests/test_extracted_content_pipeline_migration_runner.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -114,8 +114,10 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_ports.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
     assert "extracted_content_pipeline/campaign_analytics.py" in owned
+    assert "extracted_content_pipeline/campaign_webhooks.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_generation.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_analytics.py" in owned
+    assert "extracted_content_pipeline/campaign_postgres_webhooks.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_review.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_send.py" in owned
     assert "extracted_content_pipeline/campaign_example.py" in owned
@@ -154,8 +156,10 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
     assert "extracted_content_pipeline/campaign_analytics.py" not in mapped
+    assert "extracted_content_pipeline/campaign_webhooks.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_generation.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_analytics.py" not in mapped
+    assert "extracted_content_pipeline/campaign_postgres_webhooks.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_send.py" not in mapped
     assert "extracted_content_pipeline/campaign_example.py" not in mapped
     assert "extracted_content_pipeline/campaign_customer_data.py" not in mapped

--- a/tests/test_extracted_campaign_postgres_webhooks.py
+++ b/tests/test_extracted_campaign_postgres_webhooks.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_postgres_webhooks import (
+    ingest_resend_webhook_from_postgres,
+)
+from extracted_content_pipeline.campaign_webhooks import (
+    CampaignWebhookIngestionResult,
+    WebhookVerificationError,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/ingest_extracted_campaign_webhook.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "ingest_extracted_campaign_webhook",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _secret() -> str:
+    return "whsec_" + base64.b64encode(b"secret").decode("utf-8")
+
+
+def _body(event_type: str = "email.opened", **data_overrides) -> bytes:
+    data = {
+        "email_id": "email_1",
+        "to": "Buyer@Example.com",
+        "created_at": "2026-05-01T12:00:00Z",
+    }
+    data.update(data_overrides)
+    return json.dumps({"type": event_type, "data": data}).encode("utf-8")
+
+
+def _headers(body: bytes, *, secret: str | None = None, msg_id: str = "msg_1"):
+    secret_text = secret or _secret()
+    raw_secret = secret_text[6:] if secret_text.startswith("whsec_") else secret_text
+    secret_bytes = base64.b64decode(raw_secret)
+    timestamp = "1714550400"
+    to_sign = f"{msg_id}.{timestamp}.".encode("utf-8") + body
+    signature = base64.b64encode(
+        hmac.new(secret_bytes, to_sign, hashlib.sha256).digest()
+    ).decode("utf-8")
+    return {
+        "svix-id": msg_id,
+        "svix-timestamp": timestamp,
+        "svix-signature": f"v1,{signature}",
+    }
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.execute_calls: list[dict[str, object]] = []
+        self.closed = False
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return "OK"
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_postgres_webhook_runner_records_signed_open_event() -> None:
+    pool = _Pool()
+    body = _body("email.opened")
+
+    result = await ingest_resend_webhook_from_postgres(
+        pool,
+        body=body,
+        headers=_headers(body),
+        signing_secret=_secret(),
+    )
+
+    assert result.as_dict() == {
+        "status": "ok",
+        "event_type": "opened",
+        "message_id": "email_1",
+        "reason": None,
+        "suppressed": False,
+    }
+    queries = [call["query"] for call in pool.execute_calls]
+    assert any("UPDATE b2b_campaigns" in query for query in queries)
+    assert sum("INSERT INTO campaign_audit_log" in query for query in queries) == 2
+    assert pool.execute_calls[0]["args"][0] == "email_1"
+
+
+@pytest.mark.asyncio
+async def test_postgres_webhook_runner_applies_unsubscribe_suppression() -> None:
+    pool = _Pool()
+    body = _body("email.unsubscribed")
+
+    result = await ingest_resend_webhook_from_postgres(
+        pool,
+        body=body,
+        headers=_headers(body),
+        signing_secret=_secret(),
+    )
+
+    assert result.suppressed is True
+    suppression_calls = [
+        call
+        for call in pool.execute_calls
+        if "INSERT INTO campaign_suppressions" in call["query"]
+    ]
+    assert len(suppression_calls) == 1
+    assert suppression_calls[0]["args"][:3] == (
+        "buyer@example.com",
+        "unsubscribe",
+        "webhook",
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_webhook_runner_rejects_bad_signature_before_writes() -> None:
+    pool = _Pool()
+    body = _body("email.opened")
+
+    with pytest.raises(WebhookVerificationError, match="Invalid webhook signature"):
+        await ingest_resend_webhook_from_postgres(
+            pool,
+            body=body,
+            headers={},
+            signing_secret=_secret(),
+        )
+
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_postgres_webhook_runner_requires_secret_when_verifying() -> None:
+    pool = _Pool()
+
+    with pytest.raises(ValueError, match="signing_secret is required"):
+        await ingest_resend_webhook_from_postgres(
+            pool,
+            body=b"{}",
+            headers={},
+            signing_secret="",
+        )
+
+    assert pool.execute_calls == []
+
+
+def test_webhook_cli_reads_headers_json_and_overrides(tmp_path) -> None:
+    cli = _load_cli_module()
+    headers_file = tmp_path / "headers.json"
+    headers_file.write_text(json.dumps({"svix-id": "old", "x-extra": 1}))
+
+    headers = cli._read_headers(
+        headers_file,
+        [("svix-id", "new"), ("svix-signature", "v1,sig")],
+    )
+
+    assert headers == {
+        "svix-id": "new",
+        "x-extra": "1",
+        "svix-signature": "v1,sig",
+    }
+
+
+def test_webhook_cli_requires_database_url(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    args = cli._parse_args(["--signing-secret", _secret()])
+
+    with pytest.raises(SystemExit, match="Missing --database-url"):
+        cli._validate_args(args)
+
+
+def test_webhook_cli_requires_signing_secret_unless_skipped(monkeypatch) -> None:
+    cli = _load_cli_module()
+    for name in cli.RESEND_WEBHOOK_SECRET_ENV:
+        monkeypatch.delenv(name, raising=False)
+    args = cli._parse_args(["--database-url", "postgres://example"])
+
+    with pytest.raises(SystemExit, match="Missing --signing-secret"):
+        cli._validate_args(args)
+
+    skipped = cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--skip-signature-verification",
+    ])
+    cli._validate_args(skipped)
+
+
+def test_webhook_cli_rejects_invalid_soft_bounce_days() -> None:
+    cli = _load_cli_module()
+    args = cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--signing-secret",
+        _secret(),
+        "--soft-bounce-suppression-days",
+        "0",
+    ])
+
+    with pytest.raises(SystemExit, match="must be positive"):
+        cli._validate_args(args)
+
+
+@pytest.mark.asyncio
+async def test_webhook_cli_ingests_body_file_and_outputs_json(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    cli = _load_cli_module()
+    body_file = tmp_path / "body.json"
+    headers_file = tmp_path / "headers.json"
+    body_file.write_bytes(b'{"type":"email.delivered","data":{"email_id":"email_1"}}')
+    headers_file.write_text(json.dumps({"svix-id": "msg_1"}))
+    pool = _Pool()
+    calls: dict[str, object] = {}
+
+    async def create_pool(database_url):
+        calls["database_url"] = database_url
+        return pool
+
+    async def ingest(
+        pool_arg,
+        *,
+        body,
+        headers,
+        signing_secret,
+        verify_signatures,
+        config,
+    ):
+        calls["pool"] = pool_arg
+        calls["body"] = body
+        calls["headers"] = headers
+        calls["signing_secret"] = signing_secret
+        calls["verify_signatures"] = verify_signatures
+        calls["config"] = config
+        return CampaignWebhookIngestionResult(
+            status="ok",
+            event_type="delivered",
+            message_id="email_1",
+            suppressed=False,
+        )
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(cli, "ingest_resend_webhook_from_postgres", ingest)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "webhook",
+            "--database-url",
+            "postgres://example",
+            "--body-file",
+            str(body_file),
+            "--headers-json",
+            str(headers_file),
+            "--header",
+            "svix-id: msg_2",
+            "--signing-secret",
+            _secret(),
+            "--record-unknown-events",
+            "--soft-bounce-suppression-days",
+            "9",
+            "--json",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "event_type": "delivered",
+        "message_id": "email_1",
+        "reason": None,
+        "status": "ok",
+        "suppressed": False,
+    }
+    assert calls["database_url"] == "postgres://example"
+    assert calls["pool"] is pool
+    assert calls["body"] == body_file.read_bytes()
+    assert calls["headers"] == {"svix-id": "msg_2"}
+    assert calls["signing_secret"] == _secret()
+    assert calls["verify_signatures"] is True
+    assert calls["config"].record_unknown_events is True
+    assert calls["config"].soft_bounce_suppression_days == 9
+    assert pool.closed is True
+
+
+@pytest.mark.asyncio
+async def test_webhook_cli_skip_signature_passes_verify_false(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    body_file = tmp_path / "body.json"
+    body_file.write_bytes(b"{}")
+    pool = _Pool()
+    calls: dict[str, object] = {}
+
+    async def create_pool(database_url):
+        return pool
+
+    async def ingest(
+        pool_arg,
+        *,
+        body,
+        headers,
+        signing_secret,
+        verify_signatures,
+        config,
+    ):
+        calls["verify_signatures"] = verify_signatures
+        calls["signing_secret"] = signing_secret
+        return CampaignWebhookIngestionResult(status="ignored", reason="no_message_id")
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(cli, "ingest_resend_webhook_from_postgres", ingest)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "webhook",
+            "--database-url",
+            "postgres://example",
+            "--body-file",
+            str(body_file),
+            "--skip-signature-verification",
+        ],
+    )
+
+    assert await cli._main() == 0
+    assert calls == {"verify_signatures": False, "signing_secret": ""}

--- a/tests/test_extracted_reasoning_core_pack_registry_remaining_synthesis.py
+++ b/tests/test_extracted_reasoning_core_pack_registry_remaining_synthesis.py
@@ -1,0 +1,113 @@
+"""Integration tests: remaining synthesis prompts register with the pack registry.
+
+PR-C3f -- final slice of the PR-C3 sequence. Two synthesis prompts
+that weren't named in the original audit's PR 5 list but live in
+``atlas_brain/reasoning/single_pass_prompts/`` and follow the same
+single-pass synthesis pattern:
+
+  - ``category_council_synthesis`` -- market-regime assessment for a
+    product category from category dynamics + ecosystem context
+  - ``resource_asymmetry_synthesis`` -- resource divergence assessment
+    between two vendors with similar churn pressure but different
+    market positions
+
+Audit deviation note (recorded in the PR description): the audit's
+"content/campaign placeholder packs" entry turned out to have no
+corresponding atlas-side prompt files -- atlas's content/campaign
+work is in autonomous tasks (``campaign_audit``, ``blog_post_generation``,
+etc.), not in single-pass prompt modules. PR-C3f treats those as PR 7
+territory (Product Migration) where the campaign content packs
+naturally land alongside the migrated tasks.
+
+**Not wired into the standalone extracted-pipeline CI** -- same
+atlas->pydantic transitive-import constraint as prior PR-C3* tests.
+Runs in atlas-side full test suites.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from extracted_reasoning_core.pack_registry import get_pack, list_packs
+
+
+def _ensure_category_council_registered():
+    from atlas_brain.reasoning.single_pass_prompts import category_council_synthesis
+
+    importlib.reload(category_council_synthesis)
+    return category_council_synthesis
+
+
+def _ensure_resource_asymmetry_registered():
+    from atlas_brain.reasoning.single_pass_prompts import resource_asymmetry_synthesis
+
+    importlib.reload(resource_asymmetry_synthesis)
+    return resource_asymmetry_synthesis
+
+
+# ----------------------------------------------------------------------
+# category_council_synthesis
+# ----------------------------------------------------------------------
+
+
+def test_category_council_pack_registers_on_import() -> None:
+    module = _ensure_category_council_registered()
+
+    pack = get_pack("category_council_synthesis")
+    assert pack is not None
+    assert pack.name == "category_council_synthesis"
+    assert len(pack.version) == 8
+    assert all(c in "0123456789abcdef" for c in pack.version)
+    assert pack.version == module.CATEGORY_COUNCIL_SYNTHESIS_PROMPT_VERSION
+    assert pack.prompts["synthesis"] == module.CATEGORY_COUNCIL_SYNTHESIS_PROMPT
+
+
+def test_category_council_pack_carries_owner_metadata() -> None:
+    _ensure_category_council_registered()
+
+    pack = get_pack("category_council_synthesis")
+    assert pack is not None
+    assert pack.metadata["output_artifact"] == "category_market_regime"
+    assert pack.metadata["owner_product"] == "atlas"
+    assert pack.metadata["synthesis_mode"] == "structured_synthesis_v1"
+
+
+# ----------------------------------------------------------------------
+# resource_asymmetry_synthesis
+# ----------------------------------------------------------------------
+
+
+def test_resource_asymmetry_pack_registers_on_import() -> None:
+    module = _ensure_resource_asymmetry_registered()
+
+    pack = get_pack("resource_asymmetry_synthesis")
+    assert pack is not None
+    assert pack.name == "resource_asymmetry_synthesis"
+    assert len(pack.version) == 8
+    assert all(c in "0123456789abcdef" for c in pack.version)
+    assert pack.version == module.RESOURCE_ASYMMETRY_SYNTHESIS_PROMPT_VERSION
+    assert pack.prompts["synthesis"] == module.RESOURCE_ASYMMETRY_SYNTHESIS_PROMPT
+
+
+def test_resource_asymmetry_pack_carries_owner_metadata() -> None:
+    _ensure_resource_asymmetry_registered()
+
+    pack = get_pack("resource_asymmetry_synthesis")
+    assert pack is not None
+    assert pack.metadata["output_artifact"] == "resource_asymmetry_assessment"
+    assert pack.metadata["owner_product"] == "competitive_intelligence"
+    assert pack.metadata["synthesis_mode"] == "structured_synthesis_v1"
+
+
+# ----------------------------------------------------------------------
+# Combined: closes the PR-C3 sequence
+# ----------------------------------------------------------------------
+
+
+def test_both_remaining_packs_appear_in_list() -> None:
+    _ensure_category_council_registered()
+    _ensure_resource_asymmetry_registered()
+
+    pack_names = {p.name for p in list_packs()}
+    assert "category_council_synthesis" in pack_names
+    assert "resource_asymmetry_synthesis" in pack_names


### PR DESCRIPTION
## Summary
- add a Postgres-backed Resend webhook ingestion runner for the extracted content pipeline
- add a host CLI for signed webhook replay/ingestion with body/header inputs and safe signature-secret validation
- wire manifest, docs, runbook, and extracted pipeline checks with focused tests

## Verification
- pytest tests/test_extracted_campaign_postgres_webhooks.py tests/test_extracted_campaign_webhooks.py tests/test_extracted_campaign_postgres.py tests/test_extracted_campaign_manifest.py
- python -m py_compile extracted_content_pipeline/campaign_postgres_webhooks.py scripts/ingest_extracted_campaign_webhook.py tests/test_extracted_campaign_postgres_webhooks.py tests/test_extracted_campaign_manifest.py
- git diff --check
- ASCII scan on edited Python/test files
- hard-code scan: only doc/test examples surfaced, no production placeholders
- bash scripts/run_extracted_pipeline_checks.sh (485 passed, 1 warning)