### PR TITLE
PR-A6c: Wire LLM-infra pytest into CI workflow

### DIFF
--- a/.github/workflows/extracted_llm_infrastructure_checks.yml
+++ b/.github/workflows/extracted_llm_infrastructure_checks.yml
@@ -3,6 +3,7 @@ name: Extracted LLM Infrastructure Checks
 on:
   pull_request:
     paths:
+      - ".github/workflows/extracted_llm_infrastructure_checks.yml"
       - "extracted_llm_infrastructure/**"
       - "scripts/sync_extracted_llm_infrastructure.sh"
       - "scripts/validate_extracted_llm_infrastructure.sh"
@@ -11,8 +12,12 @@ on:
       - "scripts/smoke_extracted_llm_infrastructure_imports.py"
       - "scripts/smoke_extracted_llm_infrastructure_standalone.py"
       - "scripts/run_extracted_llm_infrastructure_checks.sh"
+      - "tests/test_anthropic_batchable_protocol.py"
+      - "tests/test_extracted_llm_infrastructure_standalone_config.py"
+      - "tests/test_extracted_llm_infrastructure_skills.py"
   push:
     paths:
+      - ".github/workflows/extracted_llm_infrastructure_checks.yml"
       - "extracted_llm_infrastructure/**"
       - "scripts/sync_extracted_llm_infrastructure.sh"
       - "scripts/validate_extracted_llm_infrastructure.sh"
@@ -21,6 +26,9 @@ on:
       - "scripts/smoke_extracted_llm_infrastructure_imports.py"
       - "scripts/smoke_extracted_llm_infrastructure_standalone.py"
       - "scripts/run_extracted_llm_infrastructure_checks.sh"
+      - "tests/test_anthropic_batchable_protocol.py"
+      - "tests/test_extracted_llm_infrastructure_standalone_config.py"
+      - "tests/test_extracted_llm_infrastructure_skills.py"
 
 jobs:
   extracted-llm-infra-checks:
@@ -39,10 +47,13 @@ jobs:
         # Smoke imports execute the full module body (which pulls httpx,
         # pydantic, anthropic, asyncpg, etc.). Without these, the check
         # would fail on third-party ModuleNotFoundError instead of on
-        # actual scaffold issues.
+        # actual scaffold issues. pytest + pytest-asyncio cover the
+        # PR-A5d/A6a/A6b contract pins (Protocol satisfaction, standalone
+        # ProviderCostSubConfig, standalone SkillRegistry substrate).
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
 
       - name: Run extracted LLM infrastructure checks
         run: bash scripts/run_extracted_llm_infrastructure_checks.sh

--- a/scripts/run_extracted_llm_infrastructure_checks.sh
+++ b/scripts/run_extracted_llm_infrastructure_checks.sh
@@ -17,4 +17,19 @@ python scripts/check_extracted_llm_infrastructure_imports.py
 python scripts/smoke_extracted_llm_infrastructure_imports.py
 python scripts/smoke_extracted_llm_infrastructure_standalone.py
 
+# Pytest contracts pinned by today's runtime-decoupling work:
+#  - test_anthropic_batchable_protocol.py: PR-A5d Protocol satisfaction
+#    (positive + negative cases against other LLM providers, companion
+#    guard semantics, runtime_checkable presence).
+#  - test_extracted_llm_infrastructure_standalone_config.py: PR-A6a
+#    ProviderCostSubConfig defaults + ATLAS_PROVIDER_COST_* env-overrides.
+#  - test_extracted_llm_infrastructure_skills.py: PR-A6b standalone
+#    SkillRegistry substrate + EXTRACTED_LLM_INFRA_SKILLS_DIR override
+#    + end-to-end llm_exact_cache.build_skill_messages.
+python -m pytest \
+  tests/test_anthropic_batchable_protocol.py \
+  tests/test_extracted_llm_infrastructure_standalone_config.py \
+  tests/test_extracted_llm_infrastructure_skills.py \
+  -q
+
 echo "All extracted_llm_infrastructure checks passed"


### PR DESCRIPTION
## Summary

Audit follow-up to today's PR-A5d/A6a/A6b contract work. The 35 new tests added across those PRs (12 protocol + 16 config + 7 skills) were **not running in CI** -- the \`extracted_llm_infrastructure_checks.yml\` workflow's driver only ran smoke imports + ASCII checks. A regression in any of the new contracts would have shipped undetected.

## Changes

| File | Change |
|---|---|
| \`scripts/run_extracted_llm_infrastructure_checks.sh\` | Append a \`python -m pytest ...\` invocation enumerating the three test files. Each line documents which PR's contract the file pins. |
| \`.github/workflows/extracted_llm_infrastructure_checks.yml\` | (1) Install \`pytest pytest-asyncio\` in the deps step. (2) Add the workflow file + the three test files to the \`pull_request\` and \`push\` path triggers so changes to either trigger the check. |

## Why mirror via the driver script (not a separate workflow step)

This is the established pattern in the sibling workflows:
- \`scripts/run_extracted_competitive_intelligence_checks.sh\` ends with \`python -m pytest tests/test_extracted_competitive_*.py -q\`
- \`scripts/run_extracted_pipeline_checks.sh\` runs pytest similarly

Keeping pytest in the driver means \`bash scripts/run_*.sh\` is the single source of truth for what the workflow validates -- developers running the driver locally see the same coverage as CI.

## Validation (local)

```
$ bash scripts/run_extracted_llm_infrastructure_checks.sh
...
Standalone smoke passed: 5 bridges + 15 provider modules + transitive-substrate check
35 passed, 1 warning in 2.68s
All extracted_llm_infrastructure checks passed
```

The 35 tests:
- 12 from \`test_anthropic_batchable_protocol.py\` (PR-A5d)
- 16 from \`test_extracted_llm_infrastructure_standalone_config.py\` (PR-A6a)
- 7 from \`test_extracted_llm_infrastructure_skills.py\` (PR-A6b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)