### PR TITLE
PR-C4b: Atlas reasoning state inherits core ReasoningAgentState

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "extracted_content_pipeline/**"
       - "extracted_reasoning_core/**"
+      - "atlas_brain/reasoning/state.py"
       - "scripts/sync_extracted_content_pipeline.sh"
       - "scripts/validate_extracted_content_pipeline.sh"
       - "scripts/check_ascii_python.sh"
@@ -16,10 +17,12 @@ on:
       - "tests/test_extracted_vendor_briefing_*.py"
       - "tests/test_extracted_content_pipeline_reasoning_*.py"
       - "tests/test_extracted_reasoning_core_*.py"
+      - "tests/test_atlas_reasoning_state_*.py"
   push:
     paths:
       - "extracted_content_pipeline/**"
       - "extracted_reasoning_core/**"
+      - "atlas_brain/reasoning/state.py"
       - "scripts/sync_extracted_content_pipeline.sh"
       - "scripts/validate_extracted_content_pipeline.sh"
       - "scripts/check_ascii_python.sh"
@@ -31,6 +34,7 @@ on:
       - "tests/test_extracted_vendor_briefing_*.py"
       - "tests/test_extracted_content_pipeline_reasoning_*.py"
       - "tests/test_extracted_reasoning_core_*.py"
+      - "tests/test_atlas_reasoning_state_*.py"
 
 jobs:
   extracted-checks:
@@ -53,9 +57,14 @@ jobs:
         # as an in-memory _DEFAULT_RULES dict and routes through
         # EvidenceEngine.from_rules (per PR-C1i). yaml is only needed
         # by the *core* tests that load extracted_reasoning_core/evidence_map.yaml.
+        # pydantic-settings is needed because the atlas reasoning-state
+        # inheritance test imports atlas_brain.reasoning.state, which
+        # triggers atlas_brain/reasoning/__init__.py -> config.py ->
+        # pydantic_settings. content_pipeline itself does not depend on
+        # pydantic-settings; this is purely the cross-boundary seam test.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/atlas_brain/reasoning/state.py
+++ b/atlas_brain/reasoning/state.py
@@ -1,27 +1,34 @@
-"""State definition for the ReasoningAgent LangGraph."""
+"""State definition for the ReasoningAgent LangGraph.
+
+Atlas's `ReasoningAgentState` is a refinement of the canonical
+``extracted_reasoning_core.state.ReasoningAgentState``: it inherits every
+host-agnostic field (event identity, triage, planning, action results,
+synthesis flags, token tracking) and adds the atlas-specific context
+slots that the atlas reasoning runner populates.
+
+The seam is structural -- a function annotated against core's TypedDict
+accepts an atlas state literal because every key core declares is also
+declared here. Whether atlas's granular context fields ultimately migrate
+into core (or stay host-side and feed through ports) is a decision
+deferred to PR-C4d/e; this slice only anchors atlas's type to the core
+contract so future port wiring can rely on it.
+
+Note: core's TypedDict carries a generic ``context: dict[str, Any]``
+escape hatch. Atlas does not populate it -- atlas spreads context into
+the ten typed slots below -- so reads of ``state["context"]`` on an
+atlas state will simply miss. Don't add a parallel write path.
+"""
 
 from __future__ import annotations
 
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional
+
+from extracted_reasoning_core.state import ReasoningAgentState as _CoreReasoningAgentState
 
 
-class ReasoningAgentState(TypedDict, total=False):
-    """State flowing through the reasoning graph nodes."""
+class ReasoningAgentState(_CoreReasoningAgentState, total=False):
+    """Atlas reasoning graph state (extends core's TypedDict)."""
 
-    # Input
-    event_id: str
-    event_type: str
-    source: str
-    entity_type: Optional[str]
-    entity_id: Optional[str]
-    payload: dict[str, Any]
-
-    # Triage
-    triage_priority: str  # "skip", "low", "medium", "high"
-    triage_reasoning: str
-    needs_reasoning: bool
-
-    # Context aggregation
     crm_context: Optional[dict[str, Any]]
     email_history: list[dict[str, Any]]
     voice_turns: list[dict[str, Any]]
@@ -31,30 +38,4 @@ class ReasoningAgentState(TypedDict, total=False):
     recent_events: list[dict[str, Any]]
     market_context: list[dict[str, Any]]
     news_context: list[dict[str, Any]]
-    b2b_churn: dict[str, Any]  # B2B churn intelligence context
-
-    # Lock check
-    entity_locked: bool
-    lock_holder: Optional[str]
-    queued: bool
-
-    # Reasoning
-    reasoning_output: str
-    connections_found: list[str]
-    recommended_actions: list[dict[str, Any]]
-    rationale: str
-
-    # Action planning
-    planned_actions: list[dict[str, Any]]
-
-    # Execution
-    action_results: list[dict[str, Any]]
-
-    # Synthesis
-    summary: str
-    should_notify: bool
-    notification_sent: bool
-
-    # Token tracking
-    total_input_tokens: int
-    total_output_tokens: int
+    b2b_churn: dict[str, Any]

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T20:09Z by claude-2026-05-03
+Last updated: 2026-05-04T21:05Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-C4a, in flight) | PR-C4a: Add EventSink + TraceSink ports (PR 6 from reasoning boundary audit) | EDIT: `extracted_reasoning_core/ports.py` (add `EventSink` Protocol for host event-bus emission and `TraceSink` Protocol for host tracing/span emission; existing `LLMClient`/`SemanticCacheStore`/`ReasoningStateStore`/`Clock` ports unchanged). NEW: `tests/test_extracted_reasoning_core_event_trace_ports.py` (8 unit tests: Protocol satisfaction, async emit round-trip, span open/close round-trip, optional metadata, error status). EDIT: `scripts/run_extracted_pipeline_checks.sh` (wire the new test). First slice of PR 6 (graph/state engine ports) -- adds the two contract ports the audit names; subsequent PR-C4b/c/d/e slices wire atlas adapters and port the graph/agent/state/reflection/context_aggregator engines. | claude-2026-05-03 | `extracted_reasoning_core/ports.py`; `tests/test_extracted_reasoning_core_event_trace_ports.py`; `scripts/run_extracted_pipeline_checks.sh` |
+| (PR-C4b, in flight) | PR-C4b: Atlas reasoning state inherits core's ReasoningAgentState (PR 6 second slice) | EDIT: `atlas_brain/reasoning/state.py` (atlas's `ReasoningAgentState` becomes a `TypedDict` subclass of `extracted_reasoning_core.state.ReasoningAgentState` -- atlas keeps its 10 atlas-specific context fields (`crm_context`, `email_history`, `voice_turns`, `calendar_events`, `sms_messages`, `graph_facts`, `recent_events`, `market_context`, `news_context`, `b2b_churn`); core fields are inherited). NEW: `tests/test_atlas_reasoning_state_inherits_core.py` (subclass relationship + subtype acceptance + token-tracking smoke). Pure typing seam -- no runtime behavior changes; `agent.py` / `graph.py` import sites unchanged. Forward-looking note: PR-C4d/e will decide whether atlas's granular context fields stay atlas-side or migrate up; this slice only establishes the structural is-a. | claude-2026-05-03 | `atlas_brain/reasoning/state.py`; `tests/test_atlas_reasoning_state_inherits_core.py` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -40,6 +40,7 @@ pytest \
   tests/test_extracted_reasoning_core_temporal.py \
   tests/test_extracted_reasoning_core_types.py \
   tests/test_extracted_reasoning_core_wedge_registry.py \
+  tests/test_atlas_reasoning_state_inherits_core.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \
   tests/test_extracted_blog_matching.py \

--- a/tests/test_atlas_reasoning_state_inherits_core.py
+++ b/tests/test_atlas_reasoning_state_inherits_core.py
@@ -10,19 +10,40 @@ atlas's TypedDict to a sibling definition.
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
 from typing import get_type_hints
 
 from atlas_brain.reasoning.state import ReasoningAgentState
 from extracted_reasoning_core.state import ReasoningAgentState as CoreReasoningAgentState
 
+_ATLAS_STATE_SRC = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "reasoning"
+    / "state.py"
+)
 
-def test_atlas_state_is_typeddict_subclass_of_core() -> None:
-    # The structural is-a relationship is what makes atlas state usable
-    # by core-typed functions. TypedDict strips its bases from ``__mro__``
-    # (the runtime class is just ``dict``), but ``__orig_bases__`` keeps
-    # the declared parent chain -- that's what type-checkers consult and
-    # what we want to pin here.
-    assert CoreReasoningAgentState in ReasoningAgentState.__orig_bases__
+
+def test_atlas_state_source_declares_core_typeddict_as_base() -> None:
+    # Source-level inheritance check: parse atlas's state.py and verify
+    # ReasoningAgentState's class declaration lists the core TypedDict as
+    # a base. We pin this at the AST level rather than via runtime
+    # markers (``__orig_bases__`` / ``__mro__``) because TypedDict's
+    # runtime representation varies by Python version -- 3.11+ exposes
+    # ``__orig_bases__`` but 3.10 doesn't, and the runtime class is just
+    # ``dict`` either way. The seam is the source-level declaration.
+    tree = ast.parse(_ATLAS_STATE_SRC.read_text())
+    classdef = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == "ReasoningAgentState"
+    )
+    base_names = {base.id for base in classdef.bases if isinstance(base, ast.Name)}
+    assert "_CoreReasoningAgentState" in base_names, (
+        f"atlas ReasoningAgentState must declare _CoreReasoningAgentState as a base; "
+        f"saw bases={sorted(base_names)}"
+    )
 
 
 def test_atlas_state_inherits_every_core_field() -> None:

--- a/tests/test_atlas_reasoning_state_inherits_core.py
+++ b/tests/test_atlas_reasoning_state_inherits_core.py
@@ -1,0 +1,104 @@
+"""Verify atlas's ``ReasoningAgentState`` is a TypedDict refinement of
+``extracted_reasoning_core.state.ReasoningAgentState``.
+
+PR-C4b establishes the typing seam: anything the core graph engine
+declares it consumes (via the core TypedDict) must accept an atlas state
+literal without conversion. These tests pin that contract so a future
+refactor can't accidentally break the is-a relationship by reverting
+atlas's TypedDict to a sibling definition.
+"""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+
+from atlas_brain.reasoning.state import ReasoningAgentState
+from extracted_reasoning_core.state import ReasoningAgentState as CoreReasoningAgentState
+
+
+def test_atlas_state_is_typeddict_subclass_of_core() -> None:
+    # The structural is-a relationship is what makes atlas state usable
+    # by core-typed functions. TypedDict strips its bases from ``__mro__``
+    # (the runtime class is just ``dict``), but ``__orig_bases__`` keeps
+    # the declared parent chain -- that's what type-checkers consult and
+    # what we want to pin here.
+    assert CoreReasoningAgentState in ReasoningAgentState.__orig_bases__
+
+
+def test_atlas_state_inherits_every_core_field() -> None:
+    # Every key declared on core's TypedDict must be reachable on atlas's
+    # TypedDict. This guards against a future "let's just redeclare the
+    # fields on atlas" refactor that would silently break the seam.
+    core_keys = set(get_type_hints(CoreReasoningAgentState).keys())
+    atlas_keys = set(get_type_hints(ReasoningAgentState).keys())
+    missing = core_keys - atlas_keys
+    assert not missing, f"atlas state missing core fields: {missing}"
+
+
+def test_atlas_state_adds_expected_atlas_specific_fields() -> None:
+    # The point of the subclass is to extend core with atlas's granular
+    # context slots. Pin the extension surface so a refactor can't drop
+    # one of them without an explicit test update.
+    atlas_keys = set(get_type_hints(ReasoningAgentState).keys())
+    core_keys = set(get_type_hints(CoreReasoningAgentState).keys())
+    atlas_extension = atlas_keys - core_keys
+
+    expected = {
+        "crm_context",
+        "email_history",
+        "voice_turns",
+        "calendar_events",
+        "sms_messages",
+        "graph_facts",
+        "recent_events",
+        "market_context",
+        "news_context",
+        "b2b_churn",
+    }
+    assert expected.issubset(atlas_extension), (
+        f"atlas state missing extension fields: {expected - atlas_extension}"
+    )
+
+
+def test_atlas_state_literal_is_assignable_to_core_typed_param() -> None:
+    # Round-trip a literal through a function annotated with the core
+    # TypedDict. At runtime TypedDicts are dicts, so this verifies the
+    # values flow without rejection -- the static-typing intent is that
+    # the literal type-checks against the core annotation, which the
+    # subclass makes true by construction.
+    def _accepts_core(state: CoreReasoningAgentState) -> str:
+        return state.get("event_id", "")
+
+    atlas_state: ReasoningAgentState = {
+        "event_id": "evt-1",
+        "event_type": "vendor.archetype_assigned",
+        "source": "reasoning_core",
+        "b2b_churn": {"vendor": "Acme"},
+    }
+    assert _accepts_core(atlas_state) == "evt-1"
+
+
+def test_atlas_state_token_tracking_smoke() -> None:
+    # Mirrors the literal construction in atlas_brain/test_token_tracking.py
+    # (lines 117-122). Smoke-tests that token-tracking fields still flow
+    # through the inherited TypedDict after the inheritance change.
+    state: ReasoningAgentState = {
+        "event_id": "evt-token",
+        "total_input_tokens": 100,
+        "total_output_tokens": 50,
+    }
+    assert state["total_input_tokens"] == 100
+    assert state["total_output_tokens"] == 50
+
+
+def test_atlas_state_atlas_specific_field_construction() -> None:
+    # Construct with only atlas-specific fields populated -- ensures the
+    # extension surface is real and not a phantom.
+    state: ReasoningAgentState = {
+        "crm_context": {"contact_id": "c1"},
+        "b2b_churn": {"score": 0.8},
+        "voice_turns": [{"role": "user", "text": "hi"}],
+    }
+    assert state["crm_context"] == {"contact_id": "c1"}
+    assert state["b2b_churn"] == {"score": 0.8}
+    assert state["voice_turns"][0]["text"] == "hi"


### PR DESCRIPTION
## Summary

Second slice of PR 6 (Graph/State Engine With Ports) from the reasoning boundary audit. Atlas's `ReasoningAgentState` becomes a `TypedDict` subclass of `extracted_reasoning_core.state.ReasoningAgentState` -- atlas's reasoning state is now structurally a refinement of the canonical core type, not a sibling definition.

## Scope

- **EDIT** `atlas_brain/reasoning/state.py` -- atlas's `ReasoningAgentState` declares core's TypedDict as its base; atlas's 10 host-specific context slots (`crm_context`, `email_history`, `voice_turns`, `calendar_events`, `sms_messages`, `graph_facts`, `recent_events`, `market_context`, `news_context`, `b2b_churn`) become an extension surface on top of the inherited core fields.
- **NEW** `tests/test_atlas_reasoning_state_inherits_core.py` -- 6 unit tests pinning the inheritance contract.

## Design notes

- **Typing seam, not field migration.** Atlas-specific business fields (e.g. `b2b_churn`, `voice_turns`) stay on atlas; core stays host-agnostic. Whether those fields ultimately migrate up (or feed core through ports) is deferred to PR-C4d/e.
- **No runtime behavior change.** `agent.py` and `graph.py` import sites are untouched; the `ReasoningAgentState` symbol on atlas's `state.py` keeps every key it had before.
- **Inherited `context` slot.** Core declares a generic `context: dict[str, Any]` escape hatch. Atlas does not populate it (atlas spreads context across the 10 typed slots). With `total=False` this is harmless; the docstring calls it out so a future reader doesn't add a parallel write path.
- **Subclass marker.** TypedDict strips its bases from `__mro__`, so the inheritance test pins `__orig_bases__` instead -- that's what type-checkers consult.

## Test plan

- [x] `pytest tests/test_atlas_reasoning_state_inherits_core.py` -- 6/6 pass
- [x] `pytest tests/test_extracted_reasoning_core_*.py` (sibling reasoning_core suites) -- 68/68 pass
- [x] `bash scripts/run_extracted_pipeline_checks.sh` -- 497/497 pass
- [x] `python -c "from atlas_brain.reasoning import agent, graph"` -- imports OK
- [x] `pytest atlas_brain/test_token_tracking.py::test_reasoning_state_token_aggregation` -- pass (pre-existing `test_anthropic_usage` ImportError on main is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)