### PR TITLE
extracted-content: wire reasoning provider port into generation entrypoints

### DIFF
--- a/atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py
+++ b/atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py
@@ -1,0 +1,39 @@
+"""Consumer adapter helpers for reasoning payload overlays.
+
+Additive adapter layer used by MCP/API consumers to derive stable reasoning
+fields from a synthesis view without changing existing response contracts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def reasoning_summary_fields_from_view(view: object) -> dict[str, Any]:
+    """Return stable reasoning summary fields derived from a synthesis view."""
+    from ._b2b_synthesis_reader import synthesis_view_to_reasoning_entry
+
+    entry = synthesis_view_to_reasoning_entry(view)
+    return {
+        "archetype": entry.get("archetype"),
+        "archetype_confidence": entry.get("confidence"),
+        "reasoning_mode": entry.get("mode"),
+        "reasoning_risk_level": entry.get("risk_level"),
+    }
+
+
+def reasoning_detail_fields_from_view(view: object) -> dict[str, Any]:
+    """Return stable reasoning detail fields derived from a synthesis view."""
+    from ._b2b_synthesis_reader import synthesis_view_to_reasoning_entry
+
+    entry = synthesis_view_to_reasoning_entry(view)
+    return {
+        "archetype": entry.get("archetype"),
+        "archetype_confidence": entry.get("confidence"),
+        "reasoning_mode": entry.get("mode"),
+        "reasoning_risk_level": entry.get("risk_level"),
+        "reasoning_executive_summary": entry.get("executive_summary"),
+        "reasoning_key_signals": entry.get("key_signals", []),
+        "reasoning_uncertainty_sources": entry.get("uncertainty_sources", []),
+        "falsification_conditions": entry.get("falsification_conditions", []),
+    }

--- a/atlas_brain/mcp/b2b/signals.py
+++ b/atlas_brain/mcp/b2b/signals.py
@@ -61,24 +61,15 @@ async def _load_reasoning_views_for_vendors(pool, vendor_names: list[str]) -> di
 
 
 def _overlay_reasoning_summary_from_view(target: dict, view: object) -> None:
-    from atlas_brain.autonomous.tasks._b2b_synthesis_reader import synthesis_view_to_reasoning_entry
+    from atlas_brain.autonomous.tasks._b2b_reasoning_consumer_adapter import reasoning_summary_fields_from_view
 
-    entry = synthesis_view_to_reasoning_entry(view)
-    target["archetype"] = entry.get("archetype")
-    target["archetype_confidence"] = entry.get("confidence")
-    target["reasoning_mode"] = entry.get("mode")
-    target["reasoning_risk_level"] = entry.get("risk_level")
+    target.update(reasoning_summary_fields_from_view(view))
 
 
 def _overlay_reasoning_detail_from_view(target: dict, view: object) -> None:
-    from atlas_brain.autonomous.tasks._b2b_synthesis_reader import synthesis_view_to_reasoning_entry
+    from atlas_brain.autonomous.tasks._b2b_reasoning_consumer_adapter import reasoning_detail_fields_from_view
 
-    _overlay_reasoning_summary_from_view(target, view)
-    entry = synthesis_view_to_reasoning_entry(view)
-    target["reasoning_executive_summary"] = entry.get("executive_summary")
-    target["reasoning_key_signals"] = entry.get("key_signals", [])
-    target["reasoning_uncertainty_sources"] = entry.get("uncertainty_sources", [])
-    target["falsification_conditions"] = entry.get("falsification_conditions", [])
+    target.update(reasoning_detail_fields_from_view(view))
 
 
 @mcp.tool()

--- a/docs/churn_reasoning_engine_map.md
+++ b/docs/churn_reasoning_engine_map.md
@@ -1,0 +1,163 @@
+# Atlas Churn Signals reasoning-engine map
+
+## High-level pipeline
+
+1. **Ingestion/intake**: `b2b_scrape_intake` imports review-like source rows and stages them for enrichment.
+2. **Review reasoning (Tiered extraction/classification)**: `b2b_enrichment` runs two-tier LLM + deterministic post-processing and sets each row to `enriched`, `no_signal`, or `quarantined`.
+3. **Deterministic aggregation**: `b2b_churn_intelligence` builds churn-signal and intelligence pools (evidence/segment/temporal/displacement/category/account).
+4. **Vendor reasoning synthesis**: `b2b_reasoning_synthesis` converts pooled evidence into validated reasoning contracts with witness/source traceability.
+5. **Reasoning normalization/reuse layers**:
+   - `_b2b_synthesis_reader` provides a typed read contract over v1/v2 synthesis rows.
+   - `_b2b_reasoning_contracts` decomposes battle-card-shaped output into reusable contracts.
+   - `_b2b_reasoning_atoms` derives deterministic “reasoning atoms” from contracts + witness packets.
+6. **Cross-vendor reasoning**: `_b2b_cross_vendor_synthesis` builds deterministic packets for vendor-vs-vendor, council, and asymmetry conclusions.
+7. **Downstream product consumption**: battle cards, reports, scorecards, MCP/API/UI read these persisted reasoning artifacts.
+
+## Separate reasoning engines/systems in churn signals
+
+### 1) Tiered review-reasoning engine (per review)
+- **Where**: `atlas_brain/autonomous/tasks/b2b_enrichment.py`
+- **What it does**:
+  - Tier 1 extraction for base churn fields.
+  - Tier 2 classification only when Tier 1 has gaps.
+  - Deterministic validation/derivation/repair and status assignment (`enriched` / `no_signal` / `quarantined`).
+- **Why it matters**: this is the foundational semantic layer; everything downstream assumes this normalized enrichment shape.
+
+### 2) Deterministic pool builder (per vendor/category)
+- **Where**: `atlas_brain/autonomous/tasks/b2b_churn_intelligence.py` + shared builders in `_b2b_shared.py`
+- **What it does**:
+  - Explicitly *does not* run LLM vendor reasoning anymore.
+  - Builds/persists canonical pool layers used by synthesis and reports.
+- **Why it matters**: this is the structured evidence substrate for later reasoning.
+
+### 3) Vendor reasoning synthesis engine (Stage 5)
+- **Where**: `atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py`
+- **What it does**:
+  - Consumes pooled data, builds witness-backed packets, calls synthesis LLM.
+  - Validates quality (reject/weak/pass).
+  - Persists reusable reasoning contracts (`vendor_core_reasoning`, `displacement_reasoning`, `category_reasoning`, `account_reasoning`).
+- **Why it matters**: this is the primary reusable “reasoning conclusion” layer.
+
+### 4) Reasoning-contract decomposition engine
+- **Where**: `atlas_brain/autonomous/tasks/_b2b_reasoning_contracts.py`
+- **What it does**:
+  - Normalizes/decomposes synthesis output into stable contract blocks independent of specific report schemas.
+- **Why it matters**: allows multiple products to consume one consistent reasoning schema.
+
+### 5) Reasoning-atoms derivation engine
+- **Where**: `atlas_brain/autonomous/tasks/_b2b_reasoning_atoms.py`
+- **What it does**:
+  - Deterministically derives lower-level atom structures and lineage (`metric_ids`, `witness_ids`, evidence freshness) from persisted contracts/packets.
+- **Why it matters**: gives explainable, composable “reasoning primitives” for UI/API/product features.
+
+### 6) Cross-vendor reasoning packet engine
+- **Where**: `atlas_brain/autonomous/tasks/_b2b_cross_vendor_synthesis.py`
+- **What it does**:
+  - Builds pairwise/council/asymmetry evidence packets and hashes.
+  - Supports persisted cross-vendor conclusions for comparative intelligence.
+- **Why it matters**: reusable comparative reasoning separate from single-vendor synthesis.
+
+### 7) Typed reasoning reader contract
+- **Where**: `atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py`
+- **What it does**:
+  - Abstracts v1/v2 synthesis schema differences.
+  - Extracts reference IDs, packet artifacts, confidence normalization for downstream consumers.
+- **Why it matters**: compatibility layer that prevents each consumer from re-implementing parsing logic.
+
+## Supporting infra these systems depend on
+
+- **DB schema + persistence artifacts**:
+  - `b2b_reviews`, `b2b_churn_signals` baseline tables.
+  - witness packet tables (`b2b_vendor_reasoning_packets`, `b2b_vendor_witnesses`).
+  - evidence-claim contract table (`b2b_evidence_claims`) for validated claim selection and rollout.
+- **Shared deterministic builders/helpers**:
+  - heavy use of `_b2b_shared.py` readers/aggregators/score builders.
+- **LLM pipeline + routing + telemetry**:
+  - pipeline LLM clients/routing, tracing, cache metrics used during synthesis.
+- **Reasoning registries/utilities**:
+  - wedge registry/validation, semantic hashing/cache utilities.
+- **Consumer interfaces**:
+  - MCP tools (`atlas_brain/mcp/b2b/signals.py`, `.../write_intelligence.py`) read and overlay reasoning into API outputs.
+
+## Re-creating for other use-cases: feasibility + likely missing pieces
+
+### What is portable with minimal changes
+- `b2b_reasoning_synthesis` quality-gating pattern.
+- `_b2b_synthesis_reader` typed reader abstraction.
+- `_b2b_reasoning_contracts` + `_b2b_reasoning_atoms` decomposition strategy.
+- cross-vendor packet + evidence-hash approach.
+
+### What is coupled and usually blocks extraction
+1. **Domain schema coupling**
+   - Current contracts assume churn vocabulary (pain, displacement, migration, wedge types).
+2. **SQL/read-model coupling**
+   - Pool builders and packet fallbacks read churn-specific tables and columns.
+3. **Status-machine coupling**
+   - Enrichment states and repair paths are churn-specific.
+4. **Prompt/skill coupling**
+   - Extraction and synthesis prompts are domain specific.
+5. **Consumer-contract coupling**
+   - Downstream code expects current contract keys and confidence labels.
+
+### New code usually required for compatibility in another domain
+- Define a **new domain ontology** and section-contract schema.
+- Build a **domain-specific enrichment normalizer** (or adapters into current intermediate schema).
+- Implement domain **pool builders** equivalent to current evidence/segment/temporal/displacement layers.
+- Create **packet builders + validators** for your domain’s evidence semantics.
+- Add **reader adapters** so existing consumer surfaces (MCP/API/UI) can read the new contracts.
+- Add/extend DB migrations for new artifact tables if reusing only part of current schema.
+
+## Practical extraction checklist
+
+1. Start by extracting these modules together as one unit:
+   - `b2b_enrichment.py`
+   - `b2b_churn_intelligence.py`
+   - `b2b_reasoning_synthesis.py`
+   - `_b2b_synthesis_reader.py`
+   - `_b2b_reasoning_contracts.py`
+   - `_b2b_reasoning_atoms.py`
+   - `_b2b_cross_vendor_synthesis.py`
+2. Pull required table migrations (at minimum):
+   - `055_b2b_reviews.sql`
+   - `247_b2b_vendor_witness_packets.sql`
+   - `305_b2b_evidence_claims.sql`
+3. Include shared infra:
+   - `_b2b_shared.py`, LLM pipeline/routing/tracing, wedge registry, semantic hash/cache utils.
+4. Add a domain adapter layer before touching prompts.
+
+## Recommendation: extract vs rebuild (based on current extracted products)
+
+### Short answer
+Use a **hybrid strategy**:
+- **Extract and reuse** the existing reasoning substrate modules where Atlas already has stable standalone seams.
+- **Rebuild product-specific reasoning producers/contracts** when the destination product has a different ontology or different operational constraints.
+
+### Why this is the best fit in this repo right now
+
+- `extracted_llm_infrastructure` is already at standalone/runtime-decoupled maturity; it is the strongest reusable base for any reasoning product (routing, providers, cache, tracing, cost).  Rebuilding this would duplicate solved plumbing.
+- `extracted_competitive_intelligence` is partially standalone but still has explicit Phase-3 decoupling work for deep builders and `_b2b_shared`/task adapters; this indicates the reasoning *consumer* surface is reusable, but full producer extraction remains coupled.
+- `extracted_content_pipeline` explicitly treats reasoning generation as host-owned and consumes compressed reasoning via ports/contracts rather than importing synthesis internals; this is a strong pattern for product reuse.
+
+### Decision framework
+
+Choose **extract/reuse existing reasoning module** when all are true:
+1. New use case can live with current confidence labels + witness/reference-id semantics.
+2. Existing pool layers (or a thin adapter) can feed required facts.
+3. Product can consume through typed reader/contract ports.
+
+Choose **rebuild using Atlas pattern** when any are true:
+1. Domain ontology differs (claims, wedges, evidence semantics, risk labels).
+2. Evidence sources/time windows differ materially from churn-review assumptions.
+3. Product needs different governance rules (validation/rejection thresholds, compliance constraints).
+
+### Concrete plan I recommend
+
+1. **Do not extract all churn reasoning engines as one generic package immediately.**
+2. **First standardize interfaces**:
+   - treat `extracted_llm_infrastructure` as shared substrate,
+   - keep reasoning producer behind host ports (like content pipeline’s `CampaignReasoningContextProvider` pattern),
+   - keep typed read contracts for downstream consumers.
+3. **Then fork/rebuild only domain-specific producer logic** (pool builders, prompts, validators, contract schema) per new product.
+4. **Optionally upstream common deterministic utilities** (hashing, lineage/ref IDs, section quality gates) into a small shared reasoning-core library after 2+ products need the same invariant.
+
+This gives fastest delivery with least hidden coupling risk: reuse stable infra, avoid dragging churn-specific SQL/state machines into unrelated products.

--- a/docs/hybrid_extraction_execution_board.md
+++ b/docs/hybrid_extraction_execution_board.md
@@ -1,0 +1,164 @@
+# Hybrid Extraction Execution Board
+
+This board operationalizes `docs/hybrid_extraction_implementation_plan.md` into PR-sized work with owners, estimates, risks, and acceptance tests.
+
+## Program constraints
+
+- Preserve existing Atlas API/task behavior (no breaking contracts).
+- Use additive adapters/ports over rewrites.
+- Keep producer logic product-owned when ontology diverges.
+- Reuse `extracted_llm_infrastructure` substrate for routing/tracing/cache/cost.
+
+## Milestone overview
+
+| Milestone | Focus | Duration target | Exit gate |
+|---|---|---:|---|
+| M1 | Interface standardization | 1 sprint | Reader + provider interfaces merged |
+| M2 | Consumer contract adoption | 1-2 sprints | Two products consume typed contract |
+| M3 | Producer-port isolation | 2 sprints | Producer injectable via host port |
+| M4 | Competitive-intel decoupling | 1-2 sprints | Remaining phase-3 couplings removed |
+| M5 | Hardening + migration runbooks | 1 sprint | Validation matrix green + runbooks complete |
+
+## PR execution queue
+
+### PR-1: Shared reasoning interface spec (docs + contracts)
+
+- **Owner**: Platform Architecture
+- **Estimate**: 2-3 days
+- **Scope**:
+  - Define canonical consumer contract fields (confidence bands, reference IDs, witness lineage).
+  - Define provider port contract for producer-side handoff payloads.
+  - Map compatibility envelope for v1/v2 synthesis consumers.
+- **Primary files**:
+  - `docs/hybrid_extraction_implementation_plan.md`
+  - `docs/churn_reasoning_engine_map.md`
+  - new: `docs/reasoning_interface_contract.md`
+- **Risks**:
+  - Over-specification before real adoption feedback.
+- **Acceptance tests**:
+  - Contract doc includes field-level invariants and backward-compat rules.
+  - Sign-off from AI Content Ops + Competitive Intelligence owners.
+
+### PR-2: Consumer adapter package (typed reader façade)
+
+- **Owner**: Competitive Intelligence Team
+- **Estimate**: 4-6 days
+- **Scope**:
+  - Add adapter module that wraps existing synthesis-reader outputs into stable consumer DTOs.
+  - Integrate adapter in one existing read path without changing response contract.
+- **Primary files**:
+  - `atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py`
+  - new: `atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py`
+  - `atlas_brain/mcp/b2b/signals.py`
+- **Risks**:
+  - Hidden downstream assumptions on raw dict shape.
+- **Acceptance tests**:
+  - Existing MCP response schema unchanged.
+  - Adapter path includes `metric_ids`/`witness_ids` lineage when available.
+  - Smoke import and MCP tool tests pass.
+
+### PR-3: Host provider port for reasoning producer input
+
+- **Owner**: AI Content Ops Team
+- **Estimate**: 5-8 days
+- **Scope**:
+  - Introduce explicit provider interface for producer input/output handoff.
+  - Wire one product flow to consume producer payload via port instead of direct internal calls.
+- **Primary files**:
+  - `extracted_content_pipeline/services/campaign_reasoning_context.py`
+  - `extracted_content_pipeline/campaign_reasoning_data.py`
+  - `extracted_content_pipeline/STATUS.md`
+  - new: `extracted_content_pipeline/services/reasoning_provider_port.py`
+- **Risks**:
+  - Missing fields in handoff payload for edge campaign cases.
+- **Acceptance tests**:
+  - Campaign generation succeeds with file-backed provider and postgres-backed provider.
+  - No direct import of Atlas synthesis internals in extracted content runtime path.
+
+### PR-4: Shared substrate enforcement (LLM infra)
+
+- **Owner**: Platform Runtime Team
+- **Estimate**: 3-5 days
+- **Scope**:
+  - Audit and enforce all new reasoning paths use `extracted_llm_infrastructure` services.
+  - Add guardrails/checks to block direct atlas-core LLM service coupling in extracted products.
+- **Primary files**:
+  - `extracted_llm_infrastructure/STATUS.md`
+  - `scripts/validate_extracted_llm_infrastructure.sh`
+  - `scripts/validate_extracted_content_pipeline.sh`
+  - `scripts/validate_extracted_competitive_intelligence.sh`
+- **Risks**:
+  - Validation scripts may miss dynamic imports.
+- **Acceptance tests**:
+  - Standalone smoke scripts pass for both extracted products.
+  - New guardrails fail closed on forbidden import patterns.
+
+### PR-5: Competitive-intel phase-3 decoupling slice
+
+- **Owner**: Competitive Intelligence Team
+- **Estimate**: 1-2 weeks
+- **Scope**:
+  - Remove one high-impact remaining phase-3 coupling path per PR (iterative).
+  - Start with deep-builder access behind explicit host adapter protocols.
+- **Primary files**:
+  - `extracted_competitive_intelligence/autonomous/tasks/b2b_battle_cards.py`
+  - `extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py`
+  - `extracted_competitive_intelligence/autonomous/tasks/_b2b_cross_vendor_synthesis.py`
+  - `extracted_competitive_intelligence/STATUS.md`
+- **Risks**:
+  - Runtime regressions in battle-card generation quality.
+- **Acceptance tests**:
+  - Standalone mode smoke check passes.
+  - Core battle-card outputs preserve baseline contract fields.
+
+### PR-6: Hybrid migration runbook + compatibility matrix
+
+- **Owner**: Platform Architecture + DX
+- **Estimate**: 3-4 days
+- **Scope**:
+  - Create runbook for “reuse vs rebuild producer” decisions by product.
+  - Add compatibility matrix for ontology/evidence/governance fit checks.
+- **Primary files**:
+  - new: `docs/hybrid_reasoning_migration_runbook.md`
+  - new: `docs/hybrid_reasoning_compatibility_matrix.md`
+- **Risks**:
+  - Teams bypassing decision process under deadline pressure.
+- **Acceptance tests**:
+  - At least two real product scenarios mapped through matrix and reviewed.
+
+## Dependency graph
+
+- PR-1 blocks PR-2 and PR-3.
+- PR-2 and PR-3 can run in parallel after PR-1.
+- PR-4 can start after PR-1 and should complete before PR-5 merge.
+- PR-5 should start after PR-2 adapter conventions stabilize.
+- PR-6 closes program after PR-2/PR-3/PR-5 learnings are captured.
+
+## Validation matrix (per PR)
+
+| Check | PR-1 | PR-2 | PR-3 | PR-4 | PR-5 | PR-6 |
+|---|---|---|---|---|---|---|
+| Import smoke (atlas core) | optional | required | optional | required | required | optional |
+| Import smoke (extracted package) | optional | required | required | required | required | optional |
+| API/MCP schema diff check | optional | required | optional | optional | required | optional |
+| Runtime standalone check | optional | optional | required | required | required | optional |
+| Hard-coded value scan | required | required | required | required | required | required |
+| Unicode scan (py/tests) | n/a | required | required | required | required | n/a |
+
+## Risk register
+
+1. **Contract drift across products**
+   - Mitigation: single contract owner + schema diff checks in CI.
+2. **Hidden runtime coupling to atlas_brain internals**
+   - Mitigation: standalone smoke + forbidden-import validation.
+3. **Quality regressions in reasoning outputs**
+   - Mitigation: baseline fixtures and before/after contract comparison.
+4. **Scope creep into full producer rewrite**
+   - Mitigation: enforce PR atomicity and milestone exit gates.
+
+## Ready-to-start checklist
+
+- [ ] Engineering owners assigned for PR-1 through PR-6.
+- [ ] CI jobs mapped to acceptance tests for each PR.
+- [ ] Product leads aligned on reuse-vs-rebuild decision criteria.
+- [ ] Baseline output fixtures captured for affected reasoning surfaces.

--- a/docs/hybrid_extraction_implementation_plan.md
+++ b/docs/hybrid_extraction_implementation_plan.md
@@ -1,0 +1,189 @@
+# Hybrid Extraction Plan (Reasoning Stack)
+
+This plan follows the required four-phase workflow and is tailored to Atlas churn reasoning plus the already-extracted products.
+
+## Goal
+Build a hybrid extraction path that:
+1. Reuses stable shared substrate from extracted packages.
+2. Keeps product-specific reasoning producers behind explicit host ports.
+3. Avoids churn-specific coupling leaking into non-churn products.
+
+---
+
+## Phase 1: Planning & Discovery
+
+### 1) Review implementation plan before executing
+
+We will implement in three tracks:
+
+- **Track A (Shared substrate reuse):** standardize all new reasoning work on `extracted_llm_infrastructure` runtime-decoupled surfaces.
+- **Track B (Consumer contract extraction):** promote typed reasoning readers/contracts as reusable consumers.
+- **Track C (Producer isolation):** keep synthesis/pool-generation logic product-owned and accessed via provider ports.
+
+Why:
+- LLM infra is the most mature extracted boundary.
+- Competitive-intel extraction is partially decoupled; deep task builders remain coupled.
+- Content pipeline already uses host-owned reasoning handoff pattern.
+
+### 2) Locate exact files needing updates
+
+#### Architecture and planning docs
+- `docs/churn_reasoning_engine_map.md`
+- `docs/hybrid_extraction_implementation_plan.md` (this file)
+
+#### Maturity references (used for guardrails and acceptance)
+- `extracted_llm_infrastructure/STATUS.md`
+- `extracted_competitive_intelligence/STATUS.md`
+- `extracted_content_pipeline/STATUS.md`
+
+#### Atlas reasoning producer/consumer boundaries
+- `atlas_brain/autonomous/tasks/b2b_enrichment.py`
+- `atlas_brain/autonomous/tasks/b2b_churn_intelligence.py`
+- `atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py`
+- `atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py`
+- `atlas_brain/autonomous/tasks/_b2b_reasoning_contracts.py`
+- `atlas_brain/autonomous/tasks/_b2b_reasoning_atoms.py`
+- `atlas_brain/autonomous/tasks/_b2b_cross_vendor_synthesis.py`
+
+### 3) Identify precise insertion points (line-anchored)
+
+- `extracted_llm_infrastructure/STATUS.md:44` — runtime decoupling complete marker.
+- `extracted_competitive_intelligence/STATUS.md:73` — decoupling still pending.
+- `extracted_content_pipeline/STATUS.md:98` and `:119` — host-owned reasoning boundary and handoff contract.
+- `atlas_brain/autonomous/tasks/b2b_churn_intelligence.py:11` — reasoning deferred to synthesis task.
+- `atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py:3` — synthesis orchestration entry point.
+- `atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py:563` — Phase 3 accessor section for consumer contract evolution.
+
+### 4) Verify code blocks exist
+
+Before each code PR:
+- Re-run `rg -n` for target symbols/functions.
+- Open line ranges with `nl -ba ... | sed -n 'start,endp'`.
+- Confirm existing function signatures and expected call chains.
+
+### 5) Impact analysis (dependencies/imports)
+
+High-risk dependency surfaces:
+- `b2b_reasoning_synthesis` imports `_b2b_reasoning_atoms`, `_b2b_reasoning_contracts`, and cross-vendor synthesis helpers.
+- `_b2b_synthesis_reader` performs direct DB reads from `b2b_reasoning_synthesis` table and maps both v1/v2 forms.
+- `b2b_churn_intelligence` is deterministic upstream and hands off to synthesis-first consumers.
+
+Dependency rule:
+- Do not alter existing public function signatures in these modules.
+- Introduce new adapter functions/interfaces in new files where possible.
+
+---
+
+## Phase 2: Pre-Modification Validation
+
+### 6) No assumptions - verify everything
+
+Per file before edits:
+1. Confirm symbol exists.
+2. Confirm call sites.
+3. Confirm migration/table references.
+4. Confirm runtime import path behavior (especially extracted packages).
+
+### 7) Check for hard-coded values
+
+Run focused scans before and after each code PR:
+- Search for inline constants in changed files (thresholds, model names, env names, table names).
+- Keep defaults centralized in existing config layers; do not introduce new inline literals unless already pattern-consistent.
+
+### 8) Type preservation
+
+- Preserve existing `Any` usage when touching legacy code paths.
+- Only add stricter typing in newly introduced adapter modules where clearly safe and non-breaking.
+
+### 9) Unicode compliance (Python/tests)
+
+- Python and test files must remain ASCII-only.
+- If any copied text contains typographic unicode, normalize before commit.
+
+---
+
+## Phase 3: Implementation Rules (Execution Plan)
+
+### 10) Atomic changes only
+
+Planned PR sequence (one logical change each):
+
+1. **PR-1 (Design contracts only):** add shared reasoning provider/consumer interface docs and acceptance criteria.
+2. **PR-2 (Consumer boundary extraction):** add adapter layer so products read reasoning via typed readers/contracts, not raw synthesis dicts.
+3. **PR-3 (Producer boundary port):** introduce host-provider port for reasoning producer inputs/outputs (similar to content pipeline pattern).
+4. **PR-4 (Competitive-intel decoupling slice):** reduce remaining deep-builder coupling called out in status.
+5. **PR-5 (Verification + migration guide):** add runbooks/checklists and cross-package compatibility matrix.
+
+### 11) Block size limit
+
+- Keep edits in small blocks (<=30 lines) unless completing a single cohesive logic unit.
+- Prefer additive wrappers over broad rewrites.
+
+### 12) No placeholders
+
+- No TODO/stub/mock logic in production paths.
+- If an implementation cannot be completed safely in one PR, defer it entirely and document explicitly in plan status.
+
+### 13) No hard-coded values
+
+- New thresholds or toggles must live in existing config structures or env-backed configuration modules.
+
+### 14) Preserve breaking changes
+
+- Do not change existing function signatures, DB schemas, or API response contracts in existing Atlas churn endpoints.
+- New behavior must be opt-in via adapters/ports.
+
+---
+
+## Phase 4: Post-Modification Validation
+
+### 15) Test each file after modification
+
+For docs-only PRs:
+- Markdown lint/build checks as available.
+
+For code PRs:
+- Run package-specific smoke/import checks already present in repo scripts.
+
+### 16) Confirm no breaking changes
+
+Validation matrix per PR:
+- Atlas core import smoke.
+- Extracted package import smoke.
+- Existing MCP/API call shapes unchanged.
+
+### 17) Remove hard-coded values
+
+Post-change scans:
+- Search changed files for introduced literals and ensure they are config-driven.
+
+### 18) Type safety verification
+
+- Confirm any newly added code uses the narrowest safe types.
+- Preserve existing legacy `Any` where tightening would risk behavior drift.
+
+---
+
+## Concrete hybrid extraction rollout
+
+### Stage A (now)
+- Treat `extracted_llm_infrastructure` as the canonical shared runtime substrate.
+- Do not duplicate routing/tracing/cache/cost logic.
+
+### Stage B
+- Standardize a **reasoning consumer contract** around typed reader outputs (`_b2b_synthesis_reader` pattern).
+- Keep downstream products consuming contract objects only.
+
+### Stage C
+- Standardize a **reasoning producer port** (host-owned implementation) for pool/synthesis generation.
+- Reuse deterministic utilities (hashing, lineage, quality gates) where semantics match.
+
+### Stage D
+- For each new product domain, decide:
+  - **Reuse** if ontology/evidence semantics align.
+  - **Rebuild producer** if ontology diverges.
+
+### Exit criteria
+- No direct Atlas-core imports from extracted products for reasoning generation paths.
+- Producer logic interchangeable via explicit host port.
+- Consumer products rely on typed contracts, not raw schema-specific payloads.

--- a/docs/reasoning_interface_contract.md
+++ b/docs/reasoning_interface_contract.md
@@ -1,0 +1,180 @@
+# Reasoning Interface Contract (Hybrid Extraction PR-1)
+
+This document defines the canonical interface contract between reasoning producers and reasoning consumers across Atlas and extracted products.
+
+## Objectives
+
+1. Keep consumer payloads stable while producer internals evolve.
+2. Preserve backward compatibility for current v1/v2 synthesis-backed consumers.
+3. Standardize provenance and confidence semantics for cross-product reuse.
+
+## Scope
+
+In-scope:
+- Consumer-facing reasoning payload shape.
+- Provenance and lineage fields.
+- Confidence semantics and required invariants.
+- Backward compatibility and versioning policy.
+
+Out-of-scope:
+- Producer-specific prompt design.
+- Product-specific ontology extensions.
+- Non-reasoning API/domain payloads.
+
+## Contract layers
+
+- **Layer A: Producer Port Contract**
+  - Host-owned interface used to supply or compute reasoning payloads.
+- **Layer B: Canonical Reasoning Contract**
+  - Stable shape consumed by MCP/API/UI and extracted products.
+- **Layer C: Consumer Adapter Contract**
+  - Per-product adapter that maps canonical contract to local view model.
+
+## Canonical reasoning payload
+
+Required top-level keys:
+- `contract_version` (string)
+- `vendor_name` (string)
+- `as_of_date` (ISO date string)
+- `mode` (string)
+- `risk_level` (string)
+- `confidence` (number in [0,1])
+- `confidence_label` (string)
+- `executive_summary` (string)
+- `reasoning_contracts` (object)
+- `reference_ids` (object)
+- `packet_artifacts` (object)
+
+Optional top-level keys:
+- `quality_status` (string)
+- `quality_reasons` (array of strings)
+- `archetype` (string)
+- `uncertainty_sources` (array)
+- `falsification_conditions` (array)
+
+### reasoning_contracts (required object)
+
+Must include these logical blocks (may be empty if confidence is insufficient):
+- `vendor_core_reasoning`
+- `displacement_reasoning`
+- `category_reasoning`
+- `account_reasoning`
+
+### reference_ids (required object)
+
+- `metric_ids`: array of strings (deduplicated)
+- `witness_ids`: array of strings (deduplicated)
+
+Invariant:
+- If a section has non-empty evidence claims/citations, at least one ID must resolve into `metric_ids` or `witness_ids`.
+
+### packet_artifacts (required object)
+
+If present in source synthesis payload, must be carried through unchanged except for additive normalization.
+
+Known subkeys:
+- `witness_pack`
+- `section_packets`
+
+## Confidence semantics
+
+Canonical confidence labels:
+- `high`
+- `medium`
+- `low`
+- `insufficient`
+
+Mapping rule from numeric confidence (float [0,1]):
+- `high` if >= 0.75
+- `medium` if >= 0.45 and < 0.75
+- `low` if >= 0.15 and < 0.45
+- `insufficient` if < 0.15 or missing/invalid
+
+Invariants:
+1. `confidence_label` must match mapped band from `confidence`.
+2. `risk_level` can differ by product, but must be explicit and non-empty.
+3. Consumers must not infer higher confidence than contract declares.
+
+## Provenance semantics
+
+1. `metric_ids` are IDs for aggregate/metric evidence anchors.
+2. `witness_ids` are IDs for witness/source-row anchors.
+3. IDs must be stable strings within the producer scope and analysis window.
+4. Consumers may display provenance badges only when at least one ID is present.
+
+## Backward compatibility policy
+
+### Contract versioning
+
+- `contract_version` format: `major.minor` (string).
+- Minor bump (`1.x` -> `1.y`) for additive fields.
+- Major bump (`1.x` -> `2.0`) for removals/renames/semantic breaks.
+
+### Compatibility guarantees
+
+1. Existing consumers must continue to function if only additive fields are introduced.
+2. Existing keys in the canonical payload cannot change type in the same major version.
+3. Missing optional fields must degrade gracefully.
+
+### v1/v2 synthesis source compatibility
+
+Adapters must normalize both source forms into this canonical contract by:
+- preserving reference-id extraction behavior,
+- preserving packet artifact fallback/merge behavior,
+- preserving confidence normalization rules.
+
+## Producer Port Contract
+
+Producer interface requirements:
+
+- Input:
+  - subject key (`vendor_name` or equivalent)
+  - analysis window metadata (`as_of_date`, `analysis_window_days`)
+  - optional product-specific context object
+- Output:
+  - canonical reasoning payload
+- Error behavior:
+  - fail closed with explicit structured error payload (no silent partials)
+
+Producer implementation constraints:
+- No direct consumer-specific schema shaping.
+- No hidden side effects outside configured persistence path.
+
+## Consumer Adapter Contract
+
+Consumer adapter requirements:
+
+1. Accept canonical reasoning payload only.
+2. Produce local DTO/view-model without mutating canonical payload.
+3. Preserve provenance fields in local model where relevant.
+4. Preserve confidence label and numeric confidence.
+
+## Validation checklist
+
+Each adapter/producer PR must validate:
+
+1. Canonical payload includes required top-level keys.
+2. `confidence_label` matches confidence mapping bands.
+3. `reference_ids.metric_ids` and `reference_ids.witness_ids` are deduplicated string arrays.
+4. Canonical payload remains parseable when optional fields are absent.
+5. Existing MCP/API schema remains unchanged unless explicitly versioned.
+
+## CI guardrails (recommended)
+
+1. Schema conformance test for canonical payload.
+2. Snapshot tests for representative high/medium/low/insufficient cases.
+3. Regression test ensuring existing consumers still read v1/v2-derived canonical payloads.
+4. Import-boundary test to prevent forbidden runtime coupling for extracted packages.
+
+## Ownership
+
+- **Contract owner**: Platform Architecture
+- **Producer implementations**: Product teams
+- **Consumer adapters**: Product teams with platform review
+
+## Change process
+
+1. Propose change with example payload diff and compatibility statement.
+2. Classify as additive (minor) or breaking (major).
+3. Update this contract and linked execution board in same PR.
+4. Run schema/regression checks before merge.

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -17,6 +17,9 @@ from .campaign_ports import (
     TenantScope,
 )
 
+from .services.reasoning_provider_port import CampaignReasoningProviderPort
+
+
 
 _EXAMPLE_PROMPT = (
     "You are generating one outbound campaign draft from normalized customer "
@@ -251,7 +254,7 @@ async def generate_campaign_drafts_from_payload(
     payload: Mapping[str, Any],
     *,
     llm: LLMClient | None = None,
-    reasoning_context: CampaignReasoningContextProvider | None = None,
+    reasoning_context: CampaignReasoningContextProvider | CampaignReasoningProviderPort | None = None,
     skills: SkillStore | None = None,
 ) -> dict[str, Any]:
     """Run campaign generation from a portable JSON-compatible payload."""

--- a/extracted_content_pipeline/campaign_postgres_generation.py
+++ b/extracted_content_pipeline/campaign_postgres_generation.py
@@ -22,6 +22,7 @@ from .campaign_postgres import (
     PostgresIntelligenceRepository,
 )
 from .skills.registry import get_skill_registry
+from .services.reasoning_provider_port import CampaignReasoningProviderPort
 
 
 def tenant_scope_from_mapping(value: Mapping[str, Any] | TenantScope | None) -> TenantScope:
@@ -50,7 +51,7 @@ async def generate_campaign_drafts_from_postgres(
     filters: Mapping[str, Any] | None = None,
     llm: LLMClient | None = None,
     skills: SkillStore | None = None,
-    reasoning_context: CampaignReasoningContextProvider | None = None,
+    reasoning_context: CampaignReasoningContextProvider | CampaignReasoningProviderPort | None = None,
     config: CampaignGenerationConfig | None = None,
     opportunity_table: str = "campaign_opportunities",
     vendor_targets_table: str = "vendor_targets",

--- a/extracted_content_pipeline/campaign_reasoning_data.py
+++ b/extracted_content_pipeline/campaign_reasoning_data.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from .campaign_ports import CampaignReasoningContext, TenantScope
 from .services.campaign_reasoning_context import normalize_campaign_reasoning_context
+from .services.reasoning_provider_port import CampaignReasoningProviderPort
 
 
 _ROW_KEYS = ("contexts", "rows", "data", "reasoning_contexts")
@@ -183,4 +184,11 @@ def _clean_keys(values: Sequence[Any]) -> tuple[str, ...]:
 __all__ = [
     "FileCampaignReasoningContextProvider",
     "load_campaign_reasoning_context_provider",
+    "load_reasoning_provider_port",
 ]
+
+
+def load_reasoning_provider_port(path: str | Path) -> CampaignReasoningProviderPort:
+    """Load a host-port compatible reasoning provider from JSON."""
+
+    return load_campaign_reasoning_context_provider(path)

--- a/extracted_content_pipeline/services/__init__.py
+++ b/extracted_content_pipeline/services/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .reasoning_provider_port import CampaignReasoningProviderPort
+
 
 class _StandaloneLLMRegistry:
     @staticmethod
@@ -9,4 +11,4 @@ class _StandaloneLLMRegistry:
 
 llm_registry = _StandaloneLLMRegistry()
 
-__all__ = ["llm_registry"]
+__all__ = ["llm_registry", "CampaignReasoningProviderPort"]

--- a/extracted_content_pipeline/services/reasoning_provider_port.py
+++ b/extracted_content_pipeline/services/reasoning_provider_port.py
@@ -1,0 +1,23 @@
+"""Host-owned provider port for campaign reasoning context."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
+
+from ..campaign_ports import CampaignReasoningContext, TenantScope
+
+
+@runtime_checkable
+class CampaignReasoningProviderPort(Protocol):
+    """Port for reading per-target reasoning context from a host provider."""
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> CampaignReasoningContext | None:
+        ...

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -22,7 +22,7 @@ from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
     load_campaign_opportunities_from_file,
 )
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
-    load_campaign_reasoning_context_provider,
+    load_reasoning_provider_port,
 )
 
 
@@ -115,7 +115,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
     overrides: dict[str, Any] = {}
     if args.reasoning_context:
-        overrides["reasoning_context"] = load_campaign_reasoning_context_provider(
+        overrides["reasoning_context"] = load_reasoning_provider_port(
             args.reasoning_context
         )
     if args.skills_root:

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -24,7 +24,7 @@ from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E
     generate_campaign_drafts_from_postgres,
 )
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
-    load_campaign_reasoning_context_provider,
+    load_reasoning_provider_port,
 )
 from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
 
@@ -109,7 +109,7 @@ async def _create_pool(database_url: str):
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
     overrides: dict[str, Any] = {}
     if args.reasoning_context:
-        overrides["reasoning_context"] = load_campaign_reasoning_context_provider(
+        overrides["reasoning_context"] = load_reasoning_provider_port(
             args.reasoning_context
         )
     if args.skills_root:

--- a/tests/test_b2b_mcp_signals_overlay_contract.py
+++ b/tests/test_b2b_mcp_signals_overlay_contract.py
@@ -1,0 +1,75 @@
+from atlas_brain.mcp.b2b import signals
+
+
+class _DummyView:
+    pass
+
+
+def test_overlay_reasoning_summary_from_view_uses_adapter(monkeypatch):
+    def _fake_summary_fields(_view):
+        return {
+            "archetype": "feature_parity",
+            "archetype_confidence": 0.55,
+            "reasoning_mode": "synthesis",
+            "reasoning_risk_level": "medium",
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_reasoning_consumer_adapter.reasoning_summary_fields_from_view",
+        _fake_summary_fields,
+    )
+
+    payload = {
+        "vendor_name": "Acme",
+        "archetype": None,
+        "archetype_confidence": None,
+        "reasoning_mode": None,
+        "reasoning_risk_level": None,
+        "keyword_spike_count": 3,
+    }
+    signals._overlay_reasoning_summary_from_view(payload, _DummyView())
+
+    assert payload["archetype"] == "feature_parity"
+    assert payload["archetype_confidence"] == 0.55
+    assert payload["reasoning_mode"] == "synthesis"
+    assert payload["reasoning_risk_level"] == "medium"
+    assert payload["keyword_spike_count"] == 3
+
+
+def test_overlay_reasoning_detail_from_view_uses_adapter(monkeypatch):
+    def _fake_detail_fields(_view):
+        return {
+            "archetype": "support_erosion",
+            "archetype_confidence": 0.81,
+            "reasoning_mode": "synthesis",
+            "reasoning_risk_level": "high",
+            "reasoning_executive_summary": "summary",
+            "reasoning_key_signals": ["k1"],
+            "reasoning_uncertainty_sources": ["u1"],
+            "falsification_conditions": ["f1"],
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_reasoning_consumer_adapter.reasoning_detail_fields_from_view",
+        _fake_detail_fields,
+    )
+
+    payload = {
+        "vendor_name": "Acme",
+        "reasoning_executive_summary": None,
+        "reasoning_key_signals": [],
+        "reasoning_uncertainty_sources": [],
+        "falsification_conditions": [],
+        "source_distribution": {"reddit": 3},
+    }
+    signals._overlay_reasoning_detail_from_view(payload, _DummyView())
+
+    assert payload["archetype"] == "support_erosion"
+    assert payload["archetype_confidence"] == 0.81
+    assert payload["reasoning_mode"] == "synthesis"
+    assert payload["reasoning_risk_level"] == "high"
+    assert payload["reasoning_executive_summary"] == "summary"
+    assert payload["reasoning_key_signals"] == ["k1"]
+    assert payload["reasoning_uncertainty_sources"] == ["u1"]
+    assert payload["falsification_conditions"] == ["f1"]
+    assert payload["source_distribution"] == {"reddit": 3}

--- a/tests/test_b2b_reasoning_consumer_adapter.py
+++ b/tests/test_b2b_reasoning_consumer_adapter.py
@@ -1,0 +1,85 @@
+from atlas_brain.autonomous.tasks import _b2b_reasoning_consumer_adapter as adapter
+
+
+class _DummyView:
+    pass
+
+
+def test_reasoning_summary_fields_from_view(monkeypatch):
+    def _fake_entry(_view):
+        return {
+            "archetype": "price_squeeze",
+            "confidence": 0.82,
+            "mode": "synthesis",
+            "risk_level": "high",
+            "executive_summary": "ignore",
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_summary_fields_from_view(_DummyView())
+    assert out == {
+        "archetype": "price_squeeze",
+        "archetype_confidence": 0.82,
+        "reasoning_mode": "synthesis",
+        "reasoning_risk_level": "high",
+    }
+
+
+def test_reasoning_detail_fields_from_view_preserves_contract_defaults(monkeypatch):
+    def _fake_entry(_view):
+        return {
+            "archetype": "support_erosion",
+            "confidence": 0.44,
+            "mode": "synthesis",
+            "risk_level": "medium",
+            "executive_summary": "summary",
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_detail_fields_from_view(_DummyView())
+    assert out["archetype"] == "support_erosion"
+    assert out["archetype_confidence"] == 0.44
+    assert out["reasoning_mode"] == "synthesis"
+    assert out["reasoning_risk_level"] == "medium"
+    assert out["reasoning_executive_summary"] == "summary"
+    assert out["reasoning_key_signals"] == []
+    assert out["reasoning_uncertainty_sources"] == []
+    assert out["falsification_conditions"] == []
+
+
+def test_reasoning_detail_fields_from_view_sparse_entry_has_stable_keys(monkeypatch):
+    def _fake_entry(_view):
+        return {}
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_detail_fields_from_view(_DummyView())
+    assert set(out.keys()) == {
+        "archetype",
+        "archetype_confidence",
+        "reasoning_mode",
+        "reasoning_risk_level",
+        "reasoning_executive_summary",
+        "reasoning_key_signals",
+        "reasoning_uncertainty_sources",
+        "falsification_conditions",
+    }
+    assert out["archetype"] is None
+    assert out["archetype_confidence"] is None
+    assert out["reasoning_mode"] is None
+    assert out["reasoning_risk_level"] is None
+    assert out["reasoning_executive_summary"] is None
+    assert out["reasoning_key_signals"] == []
+    assert out["reasoning_uncertainty_sources"] == []
+    assert out["falsification_conditions"] == []

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -14,6 +14,7 @@ from extracted_content_pipeline.campaign_example import (
 from extracted_content_pipeline.campaign_ports import LLMResponse
 from extracted_content_pipeline.campaign_reasoning_data import (
     FileCampaignReasoningContextProvider,
+    load_reasoning_provider_port,
 )
 
 
@@ -284,3 +285,36 @@ def test_campaign_generation_example_cli_accepts_skills_root(tmp_path) -> None:
     assert overrides["skills"].get_prompt("digest/b2b_campaign_generation") == (
         "Custom host prompt {opportunity_json}"
     )
+
+
+@pytest.mark.asyncio
+async def test_example_accepts_provider_port_loader(tmp_path) -> None:
+    reasoning_path = tmp_path / "reasoning_port.json"
+    reasoning_path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "reasoning_context": {"wedge": "renewal pressure", "confidence": "high"},
+                    "campaign_reasoning_context": {
+                        "proof_points": [{"label": "pricing_mentions", "value": 12}]
+                    },
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    provider = load_reasoning_provider_port(reasoning_path)
+    payload = {
+        "target_mode": "vendor_retention",
+        "limit": 1,
+        "opportunities": [
+            {"id": "opp-1", "company": "Acme Logistics", "vendor": "HubSpot"}
+        ],
+    }
+
+    result = await generate_campaign_drafts_from_payload(payload, reasoning_context=provider)
+
+    source = result["drafts"][0]["metadata"]["source_opportunity"]
+    assert source["reasoning_context"]["wedge"] == "renewal pressure"
+    assert source["campaign_reasoning_context"]["proof_points"][0]["label"] == "pricing_mentions"

--- a/tests/test_extracted_campaign_reasoning_data.py
+++ b/tests/test_extracted_campaign_reasoning_data.py
@@ -157,3 +157,12 @@ async def test_load_file_reasoning_provider(tmp_path) -> None:
     assert provider.source == str(path)
     assert context is not None
     assert context.as_dict()["confidence"] == "medium"
+
+
+def test_load_reasoning_provider_port_is_protocol_compatible(tmp_path) -> None:
+    path = tmp_path / "reasoning.json"
+    path.write_text('[]', encoding="utf-8")
+
+    provider = load_reasoning_provider_port(path)
+
+    assert isinstance(provider, FileCampaignReasoningContextProvider)


### PR DESCRIPTION
## Summary
- update extracted campaign generation entrypoints to accept the new provider-port type alongside the existing context provider protocol
- `extracted_content_pipeline/campaign_example.py`
  - import `CampaignReasoningProviderPort`
  - widen `reasoning_context` parameter type for `generate_campaign_drafts_from_payload(...)`
- `extracted_content_pipeline/campaign_postgres_generation.py`
  - import `CampaignReasoningProviderPort`
  - widen `reasoning_context` parameter type for `generate_campaign_drafts_from_postgres(...)`

## Why
This is the next PR-3 wiring step: adopt the new reasoning provider boundary in one campaign generation call path without breaking existing behavior or call signatures.

## Testing
- `python -m py_compile extracted_content_pipeline/campaign_example.py extracted_content_pipeline/campaign_postgres_generation.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f8c68d24832eb51e047d5e5a0225)