### PR TITLE
tests: harden reasoning adapter behavior for sparse entries (#184 rebased)

### DIFF
--- a/atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py
+++ b/atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py
@@ -23,7 +23,12 @@ def reasoning_summary_fields_from_view(view: object) -> dict[str, Any]:
 
 
 def reasoning_detail_fields_from_view(view: object) -> dict[str, Any]:
-    """Return stable reasoning detail fields derived from a synthesis view."""
+    """Return stable reasoning detail fields derived from a synthesis view.
+
+    List-valued fields are guaranteed to be lists (never None) even when the
+    upstream entry has explicit null values for those keys -- dict.get(k, [])
+    only falls back to [] when k is missing, NOT when k is present-but-null.
+    """
     from ._b2b_synthesis_reader import synthesis_view_to_reasoning_entry
 
     entry = synthesis_view_to_reasoning_entry(view)
@@ -33,7 +38,7 @@ def reasoning_detail_fields_from_view(view: object) -> dict[str, Any]:
         "reasoning_mode": entry.get("mode"),
         "reasoning_risk_level": entry.get("risk_level"),
         "reasoning_executive_summary": entry.get("executive_summary"),
-        "reasoning_key_signals": entry.get("key_signals", []),
-        "reasoning_uncertainty_sources": entry.get("uncertainty_sources", []),
-        "falsification_conditions": entry.get("falsification_conditions", []),
+        "reasoning_key_signals": entry.get("key_signals") or [],
+        "reasoning_uncertainty_sources": entry.get("uncertainty_sources") or [],
+        "falsification_conditions": entry.get("falsification_conditions") or [],
     }

--- a/extracted_content_pipeline/campaign_reasoning_data.py
+++ b/extracted_content_pipeline/campaign_reasoning_data.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from .campaign_ports import CampaignReasoningContext, TenantScope
 from .services.campaign_reasoning_context import normalize_campaign_reasoning_context
+from .services.reasoning_provider_port import CampaignReasoningProviderPort
 
 
 _ROW_KEYS = ("contexts", "rows", "data", "reasoning_contexts")
@@ -183,4 +184,11 @@ def _clean_keys(values: Sequence[Any]) -> tuple[str, ...]:
 __all__ = [
     "FileCampaignReasoningContextProvider",
     "load_campaign_reasoning_context_provider",
+    "load_reasoning_provider_port",
 ]
+
+
+def load_reasoning_provider_port(path: str | Path) -> CampaignReasoningProviderPort:
+    """Load a host-port compatible reasoning provider from JSON."""
+
+    return load_campaign_reasoning_context_provider(path)

--- a/extracted_content_pipeline/services/__init__.py
+++ b/extracted_content_pipeline/services/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .reasoning_provider_port import CampaignReasoningProviderPort
+
 
 class _StandaloneLLMRegistry:
     @staticmethod
@@ -9,4 +11,4 @@ class _StandaloneLLMRegistry:
 
 llm_registry = _StandaloneLLMRegistry()
 
-__all__ = ["llm_registry"]
+__all__ = ["llm_registry", "CampaignReasoningProviderPort"]

--- a/extracted_content_pipeline/services/reasoning_provider_port.py
+++ b/extracted_content_pipeline/services/reasoning_provider_port.py
@@ -1,0 +1,23 @@
+"""Host-owned provider port for campaign reasoning context."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
+
+from ..campaign_ports import CampaignReasoningContext, TenantScope
+
+
+@runtime_checkable
+class CampaignReasoningProviderPort(Protocol):
+    """Port for reading per-target reasoning context from a host provider."""
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> CampaignReasoningContext | None:
+        ...

--- a/tests/test_b2b_mcp_signals_overlay_contract.py
+++ b/tests/test_b2b_mcp_signals_overlay_contract.py
@@ -1,0 +1,75 @@
+from atlas_brain.mcp.b2b import signals
+
+
+class _DummyView:
+    pass
+
+
+def test_overlay_reasoning_summary_from_view_uses_adapter(monkeypatch):
+    def _fake_summary_fields(_view):
+        return {
+            "archetype": "feature_parity",
+            "archetype_confidence": 0.55,
+            "reasoning_mode": "synthesis",
+            "reasoning_risk_level": "medium",
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_reasoning_consumer_adapter.reasoning_summary_fields_from_view",
+        _fake_summary_fields,
+    )
+
+    payload = {
+        "vendor_name": "Acme",
+        "archetype": None,
+        "archetype_confidence": None,
+        "reasoning_mode": None,
+        "reasoning_risk_level": None,
+        "keyword_spike_count": 3,
+    }
+    signals._overlay_reasoning_summary_from_view(payload, _DummyView())
+
+    assert payload["archetype"] == "feature_parity"
+    assert payload["archetype_confidence"] == 0.55
+    assert payload["reasoning_mode"] == "synthesis"
+    assert payload["reasoning_risk_level"] == "medium"
+    assert payload["keyword_spike_count"] == 3
+
+
+def test_overlay_reasoning_detail_from_view_uses_adapter(monkeypatch):
+    def _fake_detail_fields(_view):
+        return {
+            "archetype": "support_erosion",
+            "archetype_confidence": 0.81,
+            "reasoning_mode": "synthesis",
+            "reasoning_risk_level": "high",
+            "reasoning_executive_summary": "summary",
+            "reasoning_key_signals": ["k1"],
+            "reasoning_uncertainty_sources": ["u1"],
+            "falsification_conditions": ["f1"],
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_reasoning_consumer_adapter.reasoning_detail_fields_from_view",
+        _fake_detail_fields,
+    )
+
+    payload = {
+        "vendor_name": "Acme",
+        "reasoning_executive_summary": None,
+        "reasoning_key_signals": [],
+        "reasoning_uncertainty_sources": [],
+        "falsification_conditions": [],
+        "source_distribution": {"reddit": 3},
+    }
+    signals._overlay_reasoning_detail_from_view(payload, _DummyView())
+
+    assert payload["archetype"] == "support_erosion"
+    assert payload["archetype_confidence"] == 0.81
+    assert payload["reasoning_mode"] == "synthesis"
+    assert payload["reasoning_risk_level"] == "high"
+    assert payload["reasoning_executive_summary"] == "summary"
+    assert payload["reasoning_key_signals"] == ["k1"]
+    assert payload["reasoning_uncertainty_sources"] == ["u1"]
+    assert payload["falsification_conditions"] == ["f1"]
+    assert payload["source_distribution"] == {"reddit": 3}

--- a/tests/test_b2b_reasoning_consumer_adapter.py
+++ b/tests/test_b2b_reasoning_consumer_adapter.py
@@ -83,3 +83,34 @@ def test_reasoning_detail_fields_from_view_sparse_entry_has_stable_keys(monkeypa
     assert out["reasoning_key_signals"] == []
     assert out["reasoning_uncertainty_sources"] == []
     assert out["falsification_conditions"] == []
+
+
+def test_reasoning_detail_fields_from_view_explicit_null_lists_stay_lists(monkeypatch):
+    """Explicit-null list fields must coerce to [] -- dict.get(k, default)
+    only uses the default when k is missing, so present-but-null upstream
+    values would otherwise leak through as None and break consumer contracts.
+    """
+    def _fake_entry(_view):
+        return {
+            "archetype": "support_erosion",
+            "confidence": 0.5,
+            "mode": "synthesis",
+            "risk_level": "medium",
+            "executive_summary": "summary",
+            "key_signals": None,
+            "uncertainty_sources": None,
+            "falsification_conditions": None,
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_detail_fields_from_view(_DummyView())
+    assert out["reasoning_key_signals"] == []
+    assert out["reasoning_uncertainty_sources"] == []
+    assert out["falsification_conditions"] == []
+    # Scalars passed through (None is acceptable for those, list contract is the concern)
+    assert out["archetype"] == "support_erosion"
+    assert out["reasoning_executive_summary"] == "summary"

--- a/tests/test_b2b_reasoning_consumer_adapter.py
+++ b/tests/test_b2b_reasoning_consumer_adapter.py
@@ -1,0 +1,85 @@
+from atlas_brain.autonomous.tasks import _b2b_reasoning_consumer_adapter as adapter
+
+
+class _DummyView:
+    pass
+
+
+def test_reasoning_summary_fields_from_view(monkeypatch):
+    def _fake_entry(_view):
+        return {
+            "archetype": "price_squeeze",
+            "confidence": 0.82,
+            "mode": "synthesis",
+            "risk_level": "high",
+            "executive_summary": "ignore",
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_summary_fields_from_view(_DummyView())
+    assert out == {
+        "archetype": "price_squeeze",
+        "archetype_confidence": 0.82,
+        "reasoning_mode": "synthesis",
+        "reasoning_risk_level": "high",
+    }
+
+
+def test_reasoning_detail_fields_from_view_preserves_contract_defaults(monkeypatch):
+    def _fake_entry(_view):
+        return {
+            "archetype": "support_erosion",
+            "confidence": 0.44,
+            "mode": "synthesis",
+            "risk_level": "medium",
+            "executive_summary": "summary",
+        }
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_detail_fields_from_view(_DummyView())
+    assert out["archetype"] == "support_erosion"
+    assert out["archetype_confidence"] == 0.44
+    assert out["reasoning_mode"] == "synthesis"
+    assert out["reasoning_risk_level"] == "medium"
+    assert out["reasoning_executive_summary"] == "summary"
+    assert out["reasoning_key_signals"] == []
+    assert out["reasoning_uncertainty_sources"] == []
+    assert out["falsification_conditions"] == []
+
+
+def test_reasoning_detail_fields_from_view_sparse_entry_has_stable_keys(monkeypatch):
+    def _fake_entry(_view):
+        return {}
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks._b2b_synthesis_reader.synthesis_view_to_reasoning_entry",
+        _fake_entry,
+    )
+
+    out = adapter.reasoning_detail_fields_from_view(_DummyView())
+    assert set(out.keys()) == {
+        "archetype",
+        "archetype_confidence",
+        "reasoning_mode",
+        "reasoning_risk_level",
+        "reasoning_executive_summary",
+        "reasoning_key_signals",
+        "reasoning_uncertainty_sources",
+        "falsification_conditions",
+    }
+    assert out["archetype"] is None
+    assert out["archetype_confidence"] is None
+    assert out["reasoning_mode"] is None
+    assert out["reasoning_risk_level"] is None
+    assert out["reasoning_executive_summary"] is None
+    assert out["reasoning_key_signals"] == []
+    assert out["reasoning_uncertainty_sources"] == []
+    assert out["falsification_conditions"] == []

--- a/tests/test_extracted_campaign_reasoning_data.py
+++ b/tests/test_extracted_campaign_reasoning_data.py
@@ -10,6 +10,9 @@ from extracted_content_pipeline.campaign_reasoning_data import (
     load_campaign_reasoning_context_provider,
     load_reasoning_provider_port,
 )
+from extracted_content_pipeline.services.reasoning_provider_port import (
+    CampaignReasoningProviderPort,
+)
 
 
 @pytest.mark.asyncio
@@ -166,4 +169,10 @@ def test_load_reasoning_provider_port_is_protocol_compatible(tmp_path) -> None:
 
     provider = load_reasoning_provider_port(path)
 
+    # Verify the loader returns the concrete File implementation AND that the
+    # implementation satisfies the runtime-checkable Protocol -- this is what
+    # the test name promises. Without the Protocol assertion, the test would
+    # still pass if FileCampaignReasoningContextProvider stopped satisfying
+    # CampaignReasoningProviderPort.
     assert isinstance(provider, FileCampaignReasoningContextProvider)
+    assert isinstance(provider, CampaignReasoningProviderPort)

--- a/tests/test_extracted_campaign_reasoning_data.py
+++ b/tests/test_extracted_campaign_reasoning_data.py
@@ -8,6 +8,7 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.campaign_reasoning_data import (
     FileCampaignReasoningContextProvider,
     load_campaign_reasoning_context_provider,
+    load_reasoning_provider_port,
 )
 
 

--- a/tests/test_extracted_campaign_reasoning_data.py
+++ b/tests/test_extracted_campaign_reasoning_data.py
@@ -157,3 +157,12 @@ async def test_load_file_reasoning_provider(tmp_path) -> None:
     assert provider.source == str(path)
     assert context is not None
     assert context.as_dict()["confidence"] == "medium"
+
+
+def test_load_reasoning_provider_port_is_protocol_compatible(tmp_path) -> None:
+    path = tmp_path / "reasoning.json"
+    path.write_text('[]', encoding="utf-8")
+
+    provider = load_reasoning_provider_port(path)
+
+    assert isinstance(provider, FileCampaignReasoningContextProvider)


### PR DESCRIPTION
## Summary

Rebased + review-fixed replacement for #184. The original PR was based on the same branch line as #178 and went DIRTY after #178 squash-merged into main. Repo rules block force-push, so a fresh branch was the cleanest path.

## What's actually in this PR (vs main)

- `atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py` (+13/-2) -- null-safety fix for explicit-null list-valued entries (Copilot review)
- `tests/test_b2b_reasoning_consumer_adapter.py` (+116) -- 4 tests covering full-entry, default-preserved, sparse-entry, and the new explicit-null path
- `tests/test_b2b_mcp_signals_overlay_contract.py` (+75) -- contract tests for the MCP overlay flow
- `extracted_content_pipeline/services/reasoning_provider_port.py` (+23) -- port groundwork for hybrid extraction
- `extracted_content_pipeline/campaign_reasoning_data.py` (+8) -- data carrier
- `extracted_content_pipeline/services/__init__.py` (+3/-1) -- export the port
- `tests/test_extracted_campaign_reasoning_data.py` (+9) -- minimal test for the new data carrier

7 files, +243/-5. No overlap with files already in main (the docs and signals.py runtime change from the original #184 were duplicates of #178's work and got correctly dropped during rebase).

## Review comments addressed

| # | Comment | Resolution |
|---|---------|------------|
| 1 | Copilot: signals.py runtime change not reflected in PR description | Dropped during rebase -- that change was already in main via #178 |
| 2 | Copilot: reasoning_interface_contract.md says canonical-only, code accepts views | Out of scope -- that doc isn't in this PR anymore (it landed via #178) |
| 3 | Copilot: tests don't cover explicit-null cases like `{"key_signals": None}` | Fixed: adapter now uses `entry.get(k) or []` for list fields; added `test_reasoning_detail_fields_from_view_explicit_null_lists_stay_lists` |

## Testing

- `pytest tests/test_b2b_reasoning_consumer_adapter.py` -- 4/4 pass locally
- All modified `.py` files ASCII-clean

Closes #184.