### PR TITLE
Add B2B campaign draft API seam

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,13 @@
 # In-Flight PRs
 
-Last updated: 2026-05-04T21:44Z by codex-content-api-webhook-worker
+Last updated: 2026-05-04T22:10Z by codex-content-b2b-api-worker
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (PR-C4b, in flight) | PR-C4b: Atlas reasoning state inherits core's ReasoningAgentState (PR 6 second slice) | EDIT: `atlas_brain/reasoning/state.py` (atlas's `ReasoningAgentState` becomes a `TypedDict` subclass of `extracted_reasoning_core.state.ReasoningAgentState` -- atlas keeps its 10 atlas-specific context fields (`crm_context`, `email_history`, `voice_turns`, `calendar_events`, `sms_messages`, `graph_facts`, `recent_events`, `market_context`, `news_context`, `b2b_churn`); core fields are inherited). NEW: `tests/test_atlas_reasoning_state_inherits_core.py` (subclass relationship + subtype acceptance + token-tracking smoke). Pure typing seam -- no runtime behavior changes; `agent.py` / `graph.py` import sites unchanged. Forward-looking note: PR-C4d/e will decide whether atlas's granular context fields stay atlas-side or migrate up; this slice only establishes the structural is-a. | claude-2026-05-03 | `atlas_brain/reasoning/state.py`; `tests/test_atlas_reasoning_state_inherits_core.py` |
+| (local, in flight) | Content pipeline B2B draft review API seam | NEW: `extracted_content_pipeline/api/b2b_campaigns.py`, `tests/test_extracted_campaign_api_b2b_campaigns.py`; EDIT: content pipeline manifest/check/docs/status/smoke wiring for host-mounted draft list/export/review routes. No Atlas API rewrites. | codex-content-b2b-api-worker | `extracted_content_pipeline/api/`; extracted content pipeline manifest/check/docs/status wiring |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -240,6 +240,28 @@ python scripts/review_extracted_campaign_drafts.py <campaign-id> --account-id ac
 python scripts/review_extracted_campaign_drafts.py <campaign-id> --account-id acct_123 --status cancelled --reason "customer rejected"
 ```
 
+Hosts with FastAPI apps can mount the same draft review/export loop through a
+router factory. The host injects its database pool, tenant scope, and auth
+dependencies:
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.b2b_campaigns import create_b2b_campaign_router
+
+
+app.include_router(
+    create_b2b_campaign_router(
+        pool_provider=get_pool,
+        scope_provider=current_tenant_scope,
+        dependencies=[Depends(require_content_ops_user)],
+    )
+)
+```
+
+This adds JSON draft listing, CSV/JSON export, and approve/queue/cancel/expire
+review routes without importing Atlas API globals.
+
 Send queued drafts through the configured provider:
 
 ```bash
@@ -403,6 +425,8 @@ Several small utility shims provide product-owned local behavior by default so t
   host worker CLIs
 - `api/campaign_webhooks.py`: optional FastAPI router factory for host-mounted
   campaign webhook and unsubscribe routes
+- `api/b2b_campaigns.py`: optional FastAPI router factory for host-mounted
+  B2B draft list/export/review routes
 - `campaign_postgres_sequence_progression.py`: DB-backed due-sequence worker
   that composes the sequence, audit, LLM, and skill ports for follow-up
   generation

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -38,6 +38,9 @@
 - `campaign_postgres_review` provides a product-owned draft review/status
   update path so hosts can approve, queue, cancel, or expire generated
   `b2b_campaigns` rows after export without handwritten SQL.
+- `api.b2b_campaigns` provides a FastAPI router factory around the draft
+  list/export/review seams. Hosts inject pool providers, tenant scope, and any
+  auth dependencies instead of importing Atlas API globals.
 - `campaign_postgres_send` provides a DB-backed queued send worker seam. Hosts
   inject a Resend or SES sender and reuse the product campaign, suppression,
   and audit ports to send rows already moved to `queued`.

--- a/extracted_content_pipeline/api/b2b_campaigns.py
+++ b/extracted_content_pipeline/api/b2b_campaigns.py
@@ -1,0 +1,256 @@
+"""FastAPI router factory for extracted B2B campaign draft review."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Body, HTTPException, Query, Response
+except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
+    APIRouter = None
+    Body = None
+    HTTPException = None
+    Query = None
+    Response = Any
+    _FASTAPI_IMPORT_ERROR: ImportError | None = exc
+else:
+    _FASTAPI_IMPORT_ERROR = None
+
+from ..campaign_ports import TenantScope
+from ..campaign_postgres_export import list_campaign_drafts
+from ..campaign_postgres_review import review_campaign_drafts
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
+
+
+def _require_fastapi() -> None:
+    if _FASTAPI_IMPORT_ERROR is None:
+        return
+    raise RuntimeError(
+        "FastAPI is required to create B2B campaign API routes. "
+        "Install fastapi in the host application environment."
+    ) from _FASTAPI_IMPORT_ERROR
+
+
+@dataclass(frozen=True)
+class B2BCampaignApiConfig:
+    """Host-owned API defaults for B2B campaign review routes."""
+
+    prefix: str = "/b2b/campaigns"
+    tags: tuple[str, ...] = ("b2b-campaigns",)
+    campaign_table: str = "b2b_campaigns"
+    default_statuses: tuple[str, ...] = ("draft",)
+    default_limit: int = 20
+    max_limit: int = 200
+    export_filename: str = "campaign_drafts.csv"
+
+    def __post_init__(self) -> None:
+        if self.default_limit < 0:
+            raise ValueError("default_limit must be non-negative")
+        if self.max_limit <= 0:
+            raise ValueError("max_limit must be positive")
+        if self.default_limit > self.max_limit:
+            raise ValueError("default_limit must be less than or equal to max_limit")
+        if not _clean(self.export_filename):
+            raise ValueError("export_filename is required")
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+async def _resolve_pool(pool_provider: PoolProvider) -> Any:
+    pool = await _maybe_await(pool_provider())
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    if getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    return pool
+
+
+async def _resolve_scope(
+    scope_provider: ScopeProvider | None,
+) -> TenantScope | Mapping[str, Any] | None:
+    if scope_provider is None:
+        return None
+    scope = await _maybe_await(scope_provider())
+    if scope is None or isinstance(scope, (TenantScope, Mapping)):
+        return scope
+    raise HTTPException(status_code=500, detail="Invalid tenant scope")
+
+
+def _parse_csv_values(
+    value: str | Sequence[str] | None,
+    *,
+    default: Sequence[str] = (),
+) -> tuple[str, ...]:
+    if value is None:
+        return tuple(default)
+    if isinstance(value, str):
+        raw_values = value.split(",")
+    else:
+        raw_values = []
+        for item in value:
+            raw_values.extend(str(item or "").split(","))
+    cleaned = tuple(item for item in (_clean(item) for item in raw_values) if item)
+    return cleaned or tuple(default)
+
+
+def _parse_payload_list(value: Any, *, default: Sequence[str] = ()) -> tuple[str, ...]:
+    if value is None:
+        return tuple(default)
+    if isinstance(value, str):
+        return _parse_csv_values(value, default=default)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return _parse_csv_values([str(item or "") for item in value], default=default)
+    return tuple(default)
+
+
+def _api_limit(value: int | None, config: B2BCampaignApiConfig) -> int:
+    limit = config.default_limit if value is None else int(value)
+    if limit < 0:
+        raise HTTPException(status_code=400, detail="limit must be non-negative")
+    return min(limit, config.max_limit)
+
+
+def _bad_request(exc: ValueError) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def create_b2b_campaign_router(
+    *,
+    pool_provider: PoolProvider,
+    scope_provider: ScopeProvider | None = None,
+    config: B2BCampaignApiConfig | None = None,
+    dependencies: Sequence[Any] | None = None,
+) -> APIRouter:
+    """Create host-mounted B2B campaign draft review routes."""
+    _require_fastapi()
+    resolved_config = config or B2BCampaignApiConfig()
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+        dependencies=list(dependencies or ()),
+    )
+
+    @router.get("/drafts")
+    async def list_drafts(
+        statuses: str | None = Query(None, description="Comma-separated statuses."),
+        target_mode: str | None = Query(None),
+        channel: str | None = Query(None),
+        vendor_name: str | None = Query(None),
+        company_name: str | None = Query(None),
+        limit: int | None = Query(None, ge=0),
+    ) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        try:
+            result = await list_campaign_drafts(
+                pool,
+                scope=scope,
+                campaign_table=resolved_config.campaign_table,
+                statuses=_parse_csv_values(
+                    statuses,
+                    default=resolved_config.default_statuses,
+                ),
+                target_mode=target_mode,
+                channel=channel,
+                vendor_name=vendor_name,
+                company_name=company_name,
+                limit=_api_limit(limit, resolved_config),
+            )
+        except ValueError as exc:
+            raise _bad_request(exc) from exc
+        return result.as_dict()
+
+    @router.get("/drafts/export", response_model=None)
+    async def export_drafts(
+        statuses: str | None = Query(None, description="Comma-separated statuses."),
+        target_mode: str | None = Query(None),
+        channel: str | None = Query(None),
+        vendor_name: str | None = Query(None),
+        company_name: str | None = Query(None),
+        limit: int | None = Query(None, ge=0),
+        format: str = Query("csv", description="csv or json"),
+    ) -> Any:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        try:
+            result = await list_campaign_drafts(
+                pool,
+                scope=scope,
+                campaign_table=resolved_config.campaign_table,
+                statuses=_parse_csv_values(
+                    statuses,
+                    default=resolved_config.default_statuses,
+                ),
+                target_mode=target_mode,
+                channel=channel,
+                vendor_name=vendor_name,
+                company_name=company_name,
+                limit=_api_limit(limit, resolved_config),
+            )
+        except ValueError as exc:
+            raise _bad_request(exc) from exc
+
+        format_name = _clean(format).lower()
+        if format_name == "json":
+            return result.as_dict()
+        if format_name != "csv":
+            raise HTTPException(status_code=400, detail="format must be csv or json")
+        return Response(
+            content=result.as_csv(),
+            media_type="text/csv",
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="{_clean(resolved_config.export_filename)}"'
+                ),
+            },
+        )
+
+    @router.post("/drafts/review")
+    async def review_drafts(
+        payload: dict[str, Any] = Body(...),
+    ) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        try:
+            result = await review_campaign_drafts(
+                pool,
+                campaign_ids=_parse_payload_list(payload.get("campaign_ids")),
+                status=_clean(payload.get("status")) or "approved",
+                scope=scope,
+                campaign_table=resolved_config.campaign_table,
+                from_statuses=_parse_payload_list(
+                    payload.get("from_statuses"),
+                    default=("draft",),
+                ),
+                from_email=_clean(payload.get("from_email")) or None,
+                reason=_clean(payload.get("reason")) or None,
+                reviewed_by=_clean(payload.get("reviewed_by")) or None,
+                metadata=payload.get("metadata")
+                if isinstance(payload.get("metadata"), Mapping)
+                else None,
+                dry_run=bool(payload.get("dry_run")),
+            )
+        except ValueError as exc:
+            raise _bad_request(exc) from exc
+        return result.as_dict()
+
+    return router
+
+
+__all__ = [
+    "B2BCampaignApiConfig",
+    "create_b2b_campaign_router",
+]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -259,6 +259,32 @@ python scripts/review_extracted_campaign_drafts.py \
   --from-email audit@customer.com
 ```
 
+Or mount the B2B draft API router in a host FastAPI app and inject tenant
+scope/auth from the host application:
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.b2b_campaigns import create_b2b_campaign_router
+
+
+app.include_router(
+    create_b2b_campaign_router(
+        pool_provider=get_pool,
+        scope_provider=current_tenant_scope,
+        dependencies=[Depends(require_content_ops_user)],
+    )
+)
+```
+
+The router exposes:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/b2b/campaigns/drafts` | List scoped drafts as JSON. |
+| `GET` | `/b2b/campaigns/drafts/export` | Export scoped drafts as CSV or JSON. |
+| `POST` | `/b2b/campaigns/drafts/review` | Approve, queue, cancel, or expire selected drafts. |
+
 Send queued drafts through the configured provider:
 
 ```bash
@@ -359,8 +385,8 @@ DELETE FROM campaign_opportunities WHERE account_id = 'acct_123';
 
 ## Current Limits
 
-- API routes, review queues, and dashboard auth are not part of this install
-  path yet.
+- Dashboard auth and long-running hosted workers are not part of this install
+  path yet. Host apps inject auth dependencies into the packaged routers.
 - The runbook covers campaign opportunity generation, not blog generation or
   vendor briefing delivery.
 - Reasoning production remains host-owned. This product accepts reasoning

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -174,6 +174,11 @@ campaign id, optional account scope, and source-status guard so hosts can move
 reviewed drafts to `approved`, `queued`, `cancelled`, or `expired` without
 writing ad hoc SQL.
 
+`extracted_content_pipeline/api/b2b_campaigns.py` owns the host-mounted FastAPI
+surface for that review loop. It exposes a router factory for draft listing,
+CSV/JSON export, and review status updates while requiring the host to inject
+pool providers, tenant scope, and auth dependencies.
+
 `extracted_content_pipeline/campaign_postgres_send.py` owns the DB-backed send
 worker seam. It composes `PostgresCampaignRepository`,
 `PostgresSuppressionRepository`, `PostgresCampaignAuditSink`, and

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -232,6 +232,9 @@
       "target": "extracted_content_pipeline/api/campaign_webhooks.py"
     },
     {
+      "target": "extracted_content_pipeline/api/b2b_campaigns.py"
+    },
+    {
       "target": "extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql"
     },
     {

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -25,6 +25,7 @@ pytest \
   tests/test_extracted_campaign_postgres_analytics.py \
   tests/test_extracted_campaign_postgres_webhooks.py \
   tests/test_extracted_campaign_api_webhooks.py \
+  tests/test_extracted_campaign_api_b2b_campaigns.py \
   tests/test_extracted_campaign_postgres_sequence_progression.py \
   tests/test_extracted_campaign_postgres_import.py \
   tests/test_extracted_content_pipeline_migration_runner.py \

--- a/scripts/smoke_extracted_pipeline_imports.py
+++ b/scripts/smoke_extracted_pipeline_imports.py
@@ -30,6 +30,7 @@ MODULES = [
     "extracted_content_pipeline.podcast_example",
     "extracted_content_pipeline.services.podcast_quality",
     "extracted_content_pipeline.api.campaign_webhooks",
+    "extracted_content_pipeline.api.b2b_campaigns",
 ]
 
 

--- a/tests/test_extracted_campaign_api_b2b_campaigns.py
+++ b/tests/test_extracted_campaign_api_b2b_campaigns.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from extracted_content_pipeline.api.b2b_campaigns import (
+    B2BCampaignApiConfig,
+    create_b2b_campaign_router,
+)
+import extracted_content_pipeline.api.b2b_campaigns as b2b_api
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+CAMPAIGN_ID = "00000000-0000-0000-0000-000000000001"
+
+
+class _Pool:
+    def __init__(self, rows=None, *, initialized: bool = True) -> None:
+        self.rows = list(rows or [])
+        self.is_initialized = initialized
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        return self.rows
+
+
+def _draft_row(**overrides):
+    row = {
+        "id": CAMPAIGN_ID,
+        "company_name": "Acme",
+        "vendor_name": "LegacyCRM",
+        "target_mode": "vendor_retention",
+        "channel": "email_cold",
+        "status": "draft",
+        "recipient_email": "buyer@example.com",
+        "subject": "Acme renewal plan",
+        "body": "Body",
+        "cta": "Review plan",
+        "llm_model": "offline",
+        "created_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
+        "metadata": {"scope": {"account_id": "acct_1"}},
+    }
+    row.update(overrides)
+    return row
+
+
+def _review_row(**overrides):
+    row = {
+        "id": CAMPAIGN_ID,
+        "previous_status": "draft",
+        "status": "approved",
+        "company_name": "Acme",
+        "vendor_name": "LegacyCRM",
+        "channel": "email_cold",
+        "recipient_email": "buyer@example.com",
+        "from_email": None,
+        "metadata": {"scope": {"account_id": "acct_1"}},
+    }
+    row.update(overrides)
+    return row
+
+
+def _client(
+    pool,
+    *,
+    scope=None,
+    config: B2BCampaignApiConfig | None = None,
+    dependencies=None,
+) -> TestClient:
+    app = FastAPI()
+
+    async def pool_provider():
+        return pool
+
+    async def scope_provider():
+        return scope
+
+    app.include_router(
+        create_b2b_campaign_router(
+            pool_provider=pool_provider,
+            scope_provider=scope_provider if scope is not None else None,
+            config=config,
+            dependencies=dependencies,
+        )
+    )
+    return TestClient(app)
+
+
+def test_b2b_campaign_router_lists_scoped_drafts() -> None:
+    pool = _Pool(rows=[_draft_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/b2b/campaigns/drafts"
+        "?statuses=draft,approved&target_mode=vendor_retention"
+        "&channel=email_cold&vendor_name=LegacyCRM&company_name=Acme&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["rows"][0]["company_name"] == "Acme"
+    query, args = pool.fetch_calls[0]
+    assert "FROM \"b2b_campaigns\"" in query
+    assert "metadata -> 'scope' ->> 'account_id' = $2" in query
+    assert args == (
+        ["draft", "approved"],
+        "acct_1",
+        "vendor_retention",
+        "email_cold",
+        "LegacyCRM",
+        "Acme",
+        5,
+    )
+
+
+def test_b2b_campaign_router_caps_export_limit_from_config() -> None:
+    pool = _Pool(rows=[_draft_row()])
+
+    response = _client(
+        pool,
+        config=B2BCampaignApiConfig(default_limit=3, max_limit=3),
+    ).get("/b2b/campaigns/drafts?limit=99")
+
+    assert response.status_code == 200
+    assert response.json()["limit"] == 3
+    assert pool.fetch_calls[0][1] == (["draft"], 3)
+
+
+def test_b2b_campaign_router_exports_csv() -> None:
+    pool = _Pool(rows=[_draft_row()])
+
+    response = _client(pool).get("/b2b/campaigns/drafts/export?format=csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "attachment; filename=\"campaign_drafts.csv\"" in (
+        response.headers["content-disposition"]
+    )
+    assert "company_name,vendor_name" in response.text
+    assert "Acme" in response.text
+
+
+def test_b2b_campaign_router_exports_json_when_requested() -> None:
+    pool = _Pool(rows=[_draft_row()])
+
+    response = _client(pool).get("/b2b/campaigns/drafts/export?format=json")
+
+    assert response.status_code == 200
+    assert response.json()["rows"][0]["vendor_name"] == "LegacyCRM"
+
+
+def test_b2b_campaign_router_rejects_unknown_export_format() -> None:
+    pool = _Pool(rows=[_draft_row()])
+
+    response = _client(pool).get("/b2b/campaigns/drafts/export?format=xlsx")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "format must be csv or json"
+
+
+def test_b2b_campaign_router_reviews_selected_drafts() -> None:
+    pool = _Pool(rows=[_review_row(status="queued", from_email="sales@example.com")])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/b2b/campaigns/drafts/review",
+        json={
+            "campaign_ids": [CAMPAIGN_ID],
+            "status": "queued",
+            "from_statuses": "draft,approved",
+            "from_email": "sales@example.com",
+            "reason": "customer approved",
+            "reviewed_by": "ops@example.com",
+            "metadata": {"review_batch": "batch_1"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated"] == 1
+    assert body["status"] == "queued"
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE \"b2b_campaigns\" AS campaign" in query
+    assert "metadata -> 'scope' ->> 'account_id' = $3" in query
+    assert args[0] == [CAMPAIGN_ID]
+    assert args[1] == ["draft", "approved"]
+    assert args[2] == "acct_1"
+    assert args[3] == "queued"
+    assert args[5] == "sales@example.com"
+
+
+def test_b2b_campaign_router_supports_dry_run_review() -> None:
+    pool = _Pool(rows=[_review_row(status="draft")])
+
+    response = _client(pool).post(
+        "/b2b/campaigns/drafts/review",
+        json={"campaign_ids": CAMPAIGN_ID, "status": "approved", "dry_run": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["dry_run"] is True
+    query, args = pool.fetch_calls[0]
+    assert "SELECT" in query
+    assert "UPDATE" not in query
+    assert args == ([CAMPAIGN_ID], ["draft"])
+
+
+def test_b2b_campaign_router_rejects_invalid_review_status() -> None:
+    pool = _Pool(rows=[_review_row()])
+
+    response = _client(pool).post(
+        "/b2b/campaigns/drafts/review",
+        json={"campaign_ids": [CAMPAIGN_ID], "status": "sent"},
+    )
+
+    assert response.status_code == 400
+    assert "unsupported review status" in response.json()["detail"]
+    assert pool.fetch_calls == []
+
+
+def test_b2b_campaign_router_requires_database() -> None:
+    response = _client(_Pool(initialized=False)).get("/b2b/campaigns/drafts")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database unavailable"
+
+
+def test_b2b_campaign_router_honors_host_dependencies() -> None:
+    pool = _Pool(rows=[_draft_row()])
+
+    def require_auth():
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    response = _client(pool, dependencies=[Depends(require_auth)]).get(
+        "/b2b/campaigns/drafts"
+    )
+
+    assert response.status_code == 403
+    assert pool.fetch_calls == []
+
+
+def test_b2b_campaign_api_config_rejects_invalid_limits() -> None:
+    with pytest.raises(ValueError, match="max_limit must be positive"):
+        B2BCampaignApiConfig(max_limit=0)
+
+    with pytest.raises(ValueError, match="default_limit must be less"):
+        B2BCampaignApiConfig(default_limit=5, max_limit=4)
+
+
+def test_b2b_campaign_router_requires_fastapi(monkeypatch) -> None:
+    monkeypatch.setattr(b2b_api, "_FASTAPI_IMPORT_ERROR", ImportError("missing"))
+
+    with pytest.raises(RuntimeError, match="FastAPI is required"):
+        create_b2b_campaign_router(pool_provider=lambda: None)

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -126,6 +126,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/api/__init__.py" in owned
     assert "extracted_content_pipeline/api/campaign_webhooks.py" in owned
+    assert "extracted_content_pipeline/api/b2b_campaigns.py" in owned
     assert "extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql" in owned
     assert "extracted_content_pipeline/storage/migrations/152_campaign_draft_export_indexes.sql" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
@@ -168,6 +169,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/campaign_opportunities.py" not in mapped
     assert "extracted_content_pipeline/api/__init__.py" not in mapped
     assert "extracted_content_pipeline/api/campaign_webhooks.py" not in mapped
+    assert "extracted_content_pipeline/api/b2b_campaigns.py" not in mapped
     assert "extracted_content_pipeline/reasoning/semantic_cache.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_execution_progress.py" not in mapped
     assert "extracted_content_pipeline/autonomous/tasks/_google_news.py" not in mapped


### PR DESCRIPTION
## Summary

Adds a host-mounted FastAPI router seam for extracted AI Content Ops B2B campaign draft review workflows.

- New `extracted_content_pipeline.api.b2b_campaigns` router factory for draft listing, CSV/JSON export, and approve/queue/cancel/expire review actions.
- Router wraps existing extracted Postgres seams: `list_campaign_drafts()` and `review_campaign_drafts()`.
- Hosts inject pool providers, optional tenant scope, and FastAPI dependencies so the extracted product does not import Atlas API globals.
- Wires the new API module into manifest ownership, import smoke, one-shot extracted checks, status, README, and host install docs.

## Validation

- `pytest tests/test_extracted_campaign_api_b2b_campaigns.py tests/test_extracted_campaign_postgres_export.py tests/test_extracted_campaign_postgres_review.py tests/test_extracted_campaign_manifest.py` -> 40 passed
- `python scripts/smoke_extracted_pipeline_imports.py` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 531 passed, standalone audit clean, ASCII/import gates clean
- `git diff --check` -> passed
- Python compile check on edited Python/test files -> passed