### PR TITLE
docs+tests: hybrid extraction scope guard + postgres CLI provider-port test

### DIFF
--- a/docs/hybrid_scope_guard.md
+++ b/docs/hybrid_scope_guard.md
@@ -1,0 +1,52 @@
+# Hybrid Extraction Scope Guard
+
+Use this checklist before opening each PR in the hybrid extraction program.
+
+## Current program scope (in)
+
+1. Reasoning consumer adapter seam for MCP/API overlays.
+2. Contract/regression tests that preserve existing response shapes.
+3. Extracted content provider-port boundary (`CampaignReasoningProviderPort`).
+4. Entry-point wiring (example/postgres scripts) to provider-port compatible loader.
+5. Documentation/runbook alignment for the above changes.
+
+## Out of scope (for current wave)
+
+1. Rewriting churn reasoning producer internals (`b2b_reasoning_synthesis`, pool compression logic).
+2. Changing existing MCP/API response contracts or task signatures.
+3. Schema migrations for new reasoning tables.
+4. Cross-product ontology redesign.
+5. LLM routing/provider behavior changes.
+
+## PR gate: drift check
+
+A PR is in-scope only if all are true:
+
+- It is directly mapped to PR-1/PR-2/PR-3 items in `docs/hybrid_extraction_execution_board.md`.
+- It is additive or narrowing-risk (tests/docs/adapter/port wiring), not behavior-changing.
+- It does not require downstream consumer contract rewrites.
+- It does not introduce new runtime dependencies outside existing extracted boundaries.
+
+## Required PR metadata
+
+Each PR description must include:
+
+1. **Execution-board mapping** (e.g., “PR-2 hardening” or “PR-3 wiring”).
+2. **Behavior-change statement** (“No behavior change” or explicit compatible delta).
+3. **Contract impact** (none/additive/breaking).
+4. **Rollback plan** (file list to revert if needed).
+
+## Stop conditions (pause and re-scope)
+
+Pause implementation and open a design note when any occurs:
+
+1. Need to alter canonical reasoning field names/types.
+2. Need to change task/API function signatures.
+3. Need to introduce new persistence artifacts.
+4. Need to import Atlas-core producer internals into extracted runtime paths.
+
+## Next in-scope steps
+
+1. PR-3 compatibility tests for Postgres runner using provider-port loader path.
+2. Optional migration note: old loader name vs new loader wrapper for host teams.
+3. Execution-board progress update with completed checkboxes only.

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -295,3 +295,28 @@ async def test_postgres_runner_cli_requires_database_url(monkeypatch):
 
     with pytest.raises(SystemExit, match="Missing --database-url"):
         await postgres_cli._main()
+
+
+def test_postgres_runner_cli_uses_provider_port_loader(tmp_path) -> None:
+    postgres_cli = _load_postgres_cli_module()
+    reasoning_path = tmp_path / "reasoning.json"
+    reasoning_path.write_text("[]", encoding="utf-8")
+
+    calls = []
+
+    def _fake_loader(path):
+        calls.append(path)
+        return "provider-port"
+
+    postgres_cli.load_reasoning_provider_port = _fake_loader
+
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--reasoning-context",
+        str(reasoning_path),
+    ])
+    overrides = postgres_cli._dependency_overrides(args)
+
+    assert calls == [reasoning_path]
+    assert overrides["reasoning_context"] == "provider-port"


### PR DESCRIPTION
## Summary

Carries the two unique additions from PR #191 onto a clean rebase of `main`. Most of #191's content already landed (provider-port wiring via #189; the consumer adapter, the doc-alignment commits, and the atlas-side overlay tests via subsequent claude branches). What remained was:

- `docs/hybrid_scope_guard.md` — a scope-and-drift checklist for the in-flight hybrid extraction program (52 lines)
- A new test in `tests/test_extracted_campaign_postgres_generation.py` asserting the postgres CLI uses the provider-port loader path (~25 lines)

This PR pulls just those two pieces in, on top of current `main`, with no merge conflicts.

## Why open a new PR instead of fixing #191

#191's diff includes a large surface (5 docs + atlas-side adapter + 2 atlas tests + extracted-content wiring) but most of it has already merged via other paths. The branch is `mergeable_state: dirty` against current main and CI is failing. Opening a clean focused PR for the residual content + closing #191 is faster than rebasing a stale Codex-Cloud branch.

## Files

- `docs/hybrid_scope_guard.md` (added, 52 lines)
- `tests/test_extracted_campaign_postgres_generation.py` (modified, +25 lines)

## Test plan

- [x] Doc + test addition only
- [x] No runtime behavior change
- [x] Targets clean main; no merge conflicts

## Closes

Supersedes #191.

https://claude.ai/code/session_01NbZL7QHXuTkUrNX5zTxiUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbZL7QHXuTkUrNX5zTxiUs)_