### PR TITLE
scripts: one-shot hybrid reasoning checks + summary runner

### DIFF
--- a/scripts/run_hybrid_reasoning_checks_and_summary.sh
+++ b/scripts/run_hybrid_reasoning_checks_and_summary.sh
@@ -7,8 +7,22 @@ cd "$ROOT_DIR"
 REPORT_PATH="${1:-artifacts/hybrid_reasoning_checks_report.json}"
 SUMMARY_PATH="${2:-artifacts/hybrid_reasoning_checks_summary.md}"
 
-./scripts/run_hybrid_reasoning_checks_with_report.py --output "$REPORT_PATH" >/dev/null
+# Ensure both parent dirs exist so positional overrides into nested
+# paths don't fail at the shell-redirect layer (the JSON runner already
+# creates its own parent, but the summary uses a shell redirect which
+# does not).
+mkdir -p "$(dirname "$REPORT_PATH")" "$(dirname "$SUMMARY_PATH")"
+
+# Capture the checks runner's exit code instead of letting set -e abort
+# the wrapper. The whole point of generating a JSON report + markdown
+# summary is to explain failures, so the summary must render even when
+# checks fail. Final exit code is propagated below.
+checks_exit=0
+./scripts/run_hybrid_reasoning_checks_with_report.py --output "$REPORT_PATH" >/dev/null || checks_exit=$?
+
 ./scripts/render_hybrid_reasoning_report_summary.py --report "$REPORT_PATH" > "$SUMMARY_PATH"
 
 echo "wrote report: $REPORT_PATH"
 echo "wrote summary: $SUMMARY_PATH"
+
+exit "$checks_exit"

--- a/scripts/run_hybrid_reasoning_checks_and_summary.sh
+++ b/scripts/run_hybrid_reasoning_checks_and_summary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+REPORT_PATH="${1:-artifacts/hybrid_reasoning_checks_report.json}"
+SUMMARY_PATH="${2:-artifacts/hybrid_reasoning_checks_summary.md}"
+
+./scripts/run_hybrid_reasoning_checks_with_report.py --output "$REPORT_PATH" >/dev/null
+./scripts/render_hybrid_reasoning_report_summary.py --report "$REPORT_PATH" > "$SUMMARY_PATH"
+
+echo "wrote report: $REPORT_PATH"
+echo "wrote summary: $SUMMARY_PATH"


### PR DESCRIPTION
## Summary

Carries the residual unique piece from codex PR #202 onto a clean rebase of `main`. #202 was the fifth duplicate from Codex task `task_e_69f8f8c68d24832eb51e047d5e5a0225` and silently **regressed six fixes** that have already shipped (test-file import bug from #189, sparse-entry guard from #184, four Copilot review fixes from #200, plus the C4b CI trigger paths from #182). Rather than rebase a stale branch through that minefield, we cherry-pick the one genuinely new file and supersede.

## Files

- `scripts/run_hybrid_reasoning_checks_and_summary.sh` (new, +x, 14 lines) — wraps `run_hybrid_reasoning_checks_with_report.py` (writes JSON report) and `render_hybrid_reasoning_report_summary.py` (renders markdown summary) into one invocation. Both outputs default to `artifacts/` (gitignored via #200), with positional overrides:
  ```
  ./scripts/run_hybrid_reasoning_checks_and_summary.sh \
      [REPORT_PATH] [SUMMARY_PATH]
  ```

## Behavior-change statement

No external behavior change. Pure script wrapper that composes existing on-`main` runners.

## Contract impact

None.

## Rollback plan

Revert this PR. Single new file.

## Why open this PR instead of merging #202

#202 reverts the following on-main fixes (verified file-by-file):

1. `tests/test_extracted_campaign_reasoning_data.py` — drops `load_reasoning_provider_port` import + `CampaignReasoningProviderPort` protocol assertion (the bug Copilot + codex P1 flagged on #191 / #199). Reverts #189.
2. `atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py` — `entry.get(k) or []` → `entry.get(k, [])` for `key_signals` / `uncertainty_sources` / `falsification_conditions`. Reverts the present-but-null hardening from #184.
3. `scripts/run_reasoning_provider_port_tests.sh` — `python -m pytest -q` → bare `pytest -q`. Reverts #200's `5502333`.
4. `scripts/run_hybrid_reasoning_checks_with_report.py` — drops `try/except (FileNotFoundError, PermissionError, OSError)` around `subprocess.run`. Reverts #200's `e536bcd`.
5. `scripts/render_hybrid_reasoning_report_summary.py` — drops repo-root-resolved default + relative-path resolution. Reverts #200's `e536bcd`.
6. `.github/workflows/extracted_pipeline_checks.yml` — removes `atlas_brain/reasoning/state.py` and `tests/test_atlas_reasoning_state_*.py` from `paths:` triggers. Reverts the C4b CI wiring from #182.

`extracted-checks` already failed on #202 (almost certainly the #1 NameError bug, since the test was reverted to the buggy version).

## Closes

Supersedes #202.

---
_Generated by [Claude Code](https://claude.ai/code/session_017k4xQ6eLxysGkgLnGv4noh)_