### PR TITLE
PR-D1: API key auth substrate for LLM Gateway

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -42,6 +42,7 @@ from .b2b_tenant_dashboard import (
 from .vendor_targets import router as vendor_targets_router
 from .consumer_dashboard import router as consumer_dashboard_router
 from .seller_campaigns import router as seller_campaigns_router
+from .api_keys import router as api_keys_router
 from .auth import router as auth_router
 from .billing import router as billing_router
 from .blog_admin import router as blog_admin_router
@@ -112,6 +113,7 @@ router.include_router(b2b_tenant_router)
 router.include_router(vendor_targets_router)
 router.include_router(consumer_dashboard_router)
 router.include_router(seller_campaigns_router)
+router.include_router(api_keys_router)
 router.include_router(auth_router)
 router.include_router(billing_router)
 router.include_router(blog_admin_router)

--- a/atlas_brain/api/api_keys.py
+++ b/atlas_brain/api/api_keys.py
@@ -1,0 +1,148 @@
+"""LLM Gateway customer API key management endpoints (PR-D1).
+
+Customer-facing CRUD for API keys (``atls_live_*``). Routes:
+
+  POST   /keys           -- create a new key (returns raw key ONCE)
+  GET    /keys           -- list active keys for the calling account
+  DELETE /keys/{key_id}  -- revoke (soft-delete) a key
+
+All routes require dashboard JWT auth (``require_auth``); customers
+issue keys from the dashboard, then use the keys themselves with
+``require_api_key`` on the LLM endpoints. Account-scoped: account A
+cannot see or revoke account B's keys.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid as _uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..auth.api_keys import (
+    APIKeyRecord,
+    DEFAULT_SCOPES,
+    insert_api_key,
+    list_api_keys,
+    revoke_api_key,
+)
+from ..auth.dependencies import AuthUser, require_auth
+from ..storage.database import get_db_pool
+
+logger = logging.getLogger("atlas.api.api_keys")
+
+router = APIRouter(prefix="/keys", tags=["api-keys"])
+
+
+# ---- Request / response schemas ------------------------------------------
+
+
+class CreateAPIKeyRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    scopes: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Optional list of scope strings. Defaults to the v1 catch-all "
+            "'llm:*' when omitted. Future versions may support fine-grained "
+            "scopes (llm:chat, llm:batch, llm:embed)."
+        ),
+    )
+
+
+class APIKeyView(BaseModel):
+    """Display-safe view -- never carries the raw key or hash."""
+
+    id: str
+    name: str
+    key_prefix: str
+    scopes: list[str]
+    last_used_at: Optional[str] = None
+    created_at: str
+    revoked_at: Optional[str] = None
+
+
+class CreateAPIKeyResponse(BaseModel):
+    """Returned exactly once at creation time. ``raw_key`` is the
+    value the customer must store; it is not recoverable later."""
+
+    raw_key: str
+    key: APIKeyView
+
+
+def _record_to_view(record: APIKeyRecord) -> APIKeyView:
+    def _fmt(value):
+        if value is None:
+            return None
+        try:
+            return value.isoformat()
+        except AttributeError:
+            return str(value)
+
+    return APIKeyView(
+        id=str(record.id),
+        name=record.name,
+        key_prefix=record.key_prefix,
+        scopes=list(record.scopes),
+        last_used_at=_fmt(record.last_used_at),
+        created_at=_fmt(record.created_at),
+        revoked_at=_fmt(record.revoked_at),
+    )
+
+
+# ---- Routes --------------------------------------------------------------
+
+
+@router.post("", response_model=CreateAPIKeyResponse, status_code=201)
+async def create_key(
+    body: CreateAPIKeyRequest,
+    user: AuthUser = Depends(require_auth),
+) -> CreateAPIKeyResponse:
+    """Mint a new API key for the calling account. The raw key is
+    returned exactly once and is not recoverable later."""
+    scopes = tuple(body.scopes) if body.scopes else DEFAULT_SCOPES
+    pool = get_db_pool()
+    result = await insert_api_key(
+        pool,
+        account_id=_uuid.UUID(user.account_id),
+        user_id=_uuid.UUID(user.user_id) if user.user_id else None,
+        name=body.name,
+        scopes=scopes,
+    )
+    return CreateAPIKeyResponse(
+        raw_key=result.raw_key,
+        key=_record_to_view(result.record),
+    )
+
+
+@router.get("", response_model=list[APIKeyView])
+async def list_keys(user: AuthUser = Depends(require_auth)) -> list[APIKeyView]:
+    """List active API keys for the calling account."""
+    pool = get_db_pool()
+    records = await list_api_keys(pool, account_id=_uuid.UUID(user.account_id))
+    return [_record_to_view(r) for r in records]
+
+
+@router.delete("/{key_id}", status_code=204)
+async def revoke_key(
+    key_id: str,
+    user: AuthUser = Depends(require_auth),
+) -> None:
+    """Revoke (soft-delete) an API key. Account-scoped -- 404 when the
+    caller does not own the key, to avoid leaking key existence across
+    accounts."""
+    try:
+        key_uuid = _uuid.UUID(key_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Key not found")
+
+    pool = get_db_pool()
+    revoked = await revoke_api_key(
+        pool,
+        key_id=key_uuid,
+        account_id=_uuid.UUID(user.account_id),
+    )
+    if not revoked:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return None

--- a/atlas_brain/auth/api_keys.py
+++ b/atlas_brain/auth/api_keys.py
@@ -1,0 +1,301 @@
+"""API key generation, hashing, and lookup for the LLM Gateway product.
+
+API keys are long-lived bearer tokens that customer scripts use to call
+the ``/api/v1/llm/*`` endpoints. They sit alongside JWT auth (for the
+dashboard) -- both resolve to the same ``AuthUser`` shape so downstream
+endpoints are auth-method agnostic.
+
+Hashing model: HMAC-SHA256(server_pepper, raw_key). The raw key is 32
+random base32 characters (~160 bits entropy) so a KDF (bcrypt / PBKDF2)
+would only add latency without security benefit. Pepper is a single
+server-wide secret in ``SaaSAuthConfig.api_key_pepper``.
+
+Format: ``atls_live_<32-base32-chars>`` so customers can pattern-match
+in their secret-scanners (GitGuardian, TruffleHog, etc.).
+
+Verification path:
+  1. Caller presents ``Authorization: Bearer atls_live_xxxxx``.
+  2. ``lookup_api_key`` narrows candidates by ``key_prefix`` (the first
+     ``KEY_PREFIX_LEN`` chars of the raw key) -- typically 0-2 rows.
+  3. HMAC-compare the candidate hash against ``HMAC-SHA256(pepper, raw)``.
+  4. Constant-time compare the two hex digests.
+  5. On match: bump ``last_used_at`` / ``last_used_ip`` and return the row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import secrets
+import uuid as _uuid
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+logger = logging.getLogger("atlas.auth.api_keys")
+
+
+KEY_LIVE_PREFIX = "atls_live_"
+KEY_BODY_LENGTH = 32  # base32 characters; 32 * 5 = 160 bits of entropy.
+KEY_PREFIX_LEN = len(KEY_LIVE_PREFIX) + 8  # store ``atls_live_`` + 8 body chars.
+DEFAULT_SCOPES = ("llm:*",)
+
+
+@dataclass(frozen=True)
+class APIKeyRecord:
+    """Subset of the api_keys row that callers handle. Never carries
+    the raw key -- raw is returned exactly once at creation time.
+    """
+
+    id: _uuid.UUID
+    account_id: _uuid.UUID
+    user_id: Optional[_uuid.UUID]
+    name: str
+    key_prefix: str
+    scopes: tuple[str, ...]
+    last_used_at: Optional[object]  # datetime; typed loose to avoid import
+    created_at: object  # datetime
+    revoked_at: Optional[object]  # datetime
+
+
+@dataclass(frozen=True)
+class APIKeyMintResult:
+    """Returned at creation time. ``raw_key`` is the value the customer
+    must store -- it is NOT recoverable after this moment."""
+
+    raw_key: str
+    record: APIKeyRecord
+
+
+# ---- Generation + hashing ------------------------------------------------
+
+
+def _base32_body(length: int) -> str:
+    """Generate ``length`` random base32 characters (lowercase a-z2-7).
+
+    Uses ``secrets.choice`` over a 32-char alphabet so each character is
+    5 bits of entropy. We strip the standard padding ``=`` because we
+    are not encoding bytes, just sampling characters.
+    """
+    alphabet = "abcdefghijklmnopqrstuvwxyz234567"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def generate_api_key() -> tuple[str, str]:
+    """Generate a fresh raw key + its prefix.
+
+    Returns ``(raw_key, key_prefix)``. Caller is responsible for
+    hashing the raw key before persisting and surfacing the raw key
+    to the customer exactly once.
+    """
+    body = _base32_body(KEY_BODY_LENGTH)
+    raw = f"{KEY_LIVE_PREFIX}{body}"
+    prefix = raw[:KEY_PREFIX_LEN]
+    return raw, prefix
+
+
+def _pepper() -> bytes:
+    """Read the API-key hashing pepper from SaaSAuthConfig.
+
+    The pepper is server-wide; a per-key salt is unnecessary because
+    the raw key already has ~160 bits of entropy. The pepper guards
+    against an attacker with read-only DB access reconstructing keys
+    -- without the pepper, the stored hash is useless to them.
+
+    Read via module-attribute access on ``..config`` so that test code
+    that reloads the config module sees the new pepper without also
+    reloading this module.
+    """
+    from .. import config as _config
+
+    pepper = getattr(_config.settings.saas_auth, "api_key_pepper", "") or ""
+    return pepper.encode("utf-8")
+
+
+def hash_api_key(raw_key: str) -> str:
+    """Hash a raw key for storage. Returns hex-encoded HMAC-SHA256."""
+    return hmac.new(_pepper(), raw_key.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def constant_time_equals(a: str, b: str) -> bool:
+    """Wrap ``hmac.compare_digest`` for str inputs. Public helper so
+    test code can assert the verify path uses constant-time comparison.
+    """
+    return hmac.compare_digest(a, b)
+
+
+def split_prefix(raw_key: str) -> str:
+    """Extract the ``key_prefix`` (lookup hint) from a raw key.
+
+    Returns the empty string when the input is too short or does not
+    start with the live prefix; callers should treat that as "no
+    candidate keys" rather than raising.
+    """
+    if not raw_key.startswith(KEY_LIVE_PREFIX):
+        return ""
+    if len(raw_key) < KEY_PREFIX_LEN:
+        return ""
+    return raw_key[:KEY_PREFIX_LEN]
+
+
+# ---- DB-backed lookup / mutation ----------------------------------------
+
+
+async def lookup_api_key(pool, raw_key: str) -> Optional[dict]:
+    """Look up the active api_keys row that matches ``raw_key``.
+
+    Returns the row as a dict (asyncpg.Record fields) when verified;
+    returns None when the key is unrecognized, revoked, or the hash
+    does not match.
+
+    The lookup is split into a prefix narrow + an HMAC compare so
+    high-throughput verification stays O(1) per request even at
+    100k keys.
+    """
+    prefix = split_prefix(raw_key)
+    if not prefix:
+        return None
+
+    rows = await pool.fetch(
+        """
+        SELECT id, account_id, user_id, name, key_prefix, key_hash, scopes,
+               last_used_at, created_at, revoked_at
+        FROM api_keys
+        WHERE key_prefix = $1
+          AND revoked_at IS NULL
+        """,
+        prefix,
+    )
+    if not rows:
+        return None
+
+    candidate_hash = hash_api_key(raw_key)
+    for row in rows:
+        if constant_time_equals(str(row["key_hash"]), candidate_hash):
+            return dict(row)
+    return None
+
+
+async def insert_api_key(
+    pool,
+    *,
+    account_id: _uuid.UUID,
+    user_id: Optional[_uuid.UUID],
+    name: str,
+    scopes: Optional[Sequence[str]] = None,
+) -> APIKeyMintResult:
+    """Create a new api_keys row and return the raw key (one-time)
+    plus the persisted record."""
+    raw_key, prefix = generate_api_key()
+    key_hash = hash_api_key(raw_key)
+    scope_values = tuple(scopes) if scopes else DEFAULT_SCOPES
+
+    row = await pool.fetchrow(
+        """
+        INSERT INTO api_keys (account_id, user_id, name, key_prefix, key_hash, scopes)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, account_id, user_id, name, key_prefix, scopes,
+                  last_used_at, created_at, revoked_at
+        """,
+        account_id,
+        user_id,
+        name,
+        prefix,
+        key_hash,
+        list(scope_values),
+    )
+    record = APIKeyRecord(
+        id=row["id"],
+        account_id=row["account_id"],
+        user_id=row["user_id"],
+        name=row["name"],
+        key_prefix=row["key_prefix"],
+        scopes=tuple(row["scopes"]),
+        last_used_at=row["last_used_at"],
+        created_at=row["created_at"],
+        revoked_at=row["revoked_at"],
+    )
+    return APIKeyMintResult(raw_key=raw_key, record=record)
+
+
+async def list_api_keys(pool, *, account_id: _uuid.UUID) -> list[APIKeyRecord]:
+    """Return all non-revoked keys for an account.
+
+    Never includes raw keys or hashes -- only display-safe fields.
+    Callers that need to show revoked keys (audit views) can filter
+    server-side; this list path is for the customer dashboard.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT id, account_id, user_id, name, key_prefix, scopes,
+               last_used_at, created_at, revoked_at
+        FROM api_keys
+        WHERE account_id = $1 AND revoked_at IS NULL
+        ORDER BY created_at DESC
+        """,
+        account_id,
+    )
+    return [
+        APIKeyRecord(
+            id=row["id"],
+            account_id=row["account_id"],
+            user_id=row["user_id"],
+            name=row["name"],
+            key_prefix=row["key_prefix"],
+            scopes=tuple(row["scopes"]),
+            last_used_at=row["last_used_at"],
+            created_at=row["created_at"],
+            revoked_at=row["revoked_at"],
+        )
+        for row in rows
+    ]
+
+
+async def revoke_api_key(
+    pool,
+    *,
+    key_id: _uuid.UUID,
+    account_id: _uuid.UUID,
+) -> bool:
+    """Soft-delete a key by setting revoked_at = NOW().
+
+    Scoped to ``account_id`` so account A cannot revoke account B's
+    keys. Returns True when a row was revoked, False when no matching
+    active key existed.
+    """
+    row = await pool.fetchrow(
+        """
+        UPDATE api_keys
+        SET revoked_at = NOW()
+        WHERE id = $1 AND account_id = $2 AND revoked_at IS NULL
+        RETURNING id
+        """,
+        key_id,
+        account_id,
+    )
+    return row is not None
+
+
+async def touch_api_key(
+    pool,
+    *,
+    key_id: _uuid.UUID,
+    client_ip: Optional[str],
+) -> None:
+    """Update last_used_at + last_used_ip on a successful auth.
+
+    Best-effort: a failure here does not block the caller. We surface
+    via logger.exception so observability catches any DB regression.
+    """
+    try:
+        await pool.execute(
+            """
+            UPDATE api_keys
+            SET last_used_at = NOW(), last_used_ip = $2
+            WHERE id = $1
+            """,
+            key_id,
+            client_ip,
+        )
+    except Exception:
+        logger.exception("api_keys.touch_failed key_id=%s", key_id)

--- a/atlas_brain/auth/dependencies.py
+++ b/atlas_brain/auth/dependencies.py
@@ -234,3 +234,88 @@ def require_b2b_plan(min_plan: str):
         return user
 
     return _check
+
+
+def _extract_api_key(request: Request) -> Optional[str]:
+    """Extract a customer API key from the Authorization header.
+
+    Customer API keys (``atls_live_*``) and JWTs both ride on the same
+    ``Authorization: Bearer ...`` header. This helper only returns
+    values that look like API keys; JWT bearer tokens fall through to
+    ``require_auth``'s extractor.
+    """
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer "):
+        return None
+    token = auth[7:].strip()
+    if not token.startswith("atls_live_"):
+        return None
+    return token
+
+
+async def require_api_key(request: Request) -> AuthUser:
+    """Authenticate via a customer-issued API key (PR-D1).
+
+    Returns an ``AuthUser`` with the same shape as ``require_auth`` so
+    downstream endpoints stay auth-method agnostic. The ``user_id``
+    field is populated from ``api_keys.user_id`` (creator audit) when
+    present, else falls back to ``account_id`` so the endpoint always
+    has a non-empty caller identity.
+
+    Raises 401 when the key is missing, malformed, revoked, or
+    unrecognized; 403 when the account is canceled or the trial
+    expired.
+    """
+    if not settings.saas_auth.enabled:
+        return _synthetic_admin()
+
+    raw_key = _extract_api_key(request)
+    if not raw_key:
+        raise HTTPException(status_code=401, detail="API key required")
+
+    from ..auth.api_keys import lookup_api_key, touch_api_key
+    from ..storage.database import get_db_pool
+
+    pool = get_db_pool()
+    row = await lookup_api_key(pool, raw_key)
+    if not row:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    account_row = await pool.fetchrow(
+        """
+        SELECT plan, plan_status, product, trial_ends_at
+        FROM saas_accounts
+        WHERE id = $1
+        """,
+        row["account_id"],
+    )
+    if not account_row:
+        raise HTTPException(status_code=401, detail="Account not found")
+
+    if account_row["plan_status"] == "canceled":
+        raise HTTPException(status_code=403, detail="Subscription canceled")
+
+    trial_ends = account_row["trial_ends_at"]
+    if account_row["plan"] in ("trial", "b2b_trial") and trial_ends:
+        te = trial_ends if trial_ends.tzinfo else trial_ends.replace(tzinfo=timezone.utc)
+        if te < datetime.now(timezone.utc):
+            raise HTTPException(status_code=403, detail="Trial expired")
+
+    creator_id = row["user_id"]
+    if creator_id is None:
+        creator_id = row["account_id"]
+
+    user = AuthUser(
+        user_id=str(creator_id),
+        account_id=str(row["account_id"]),
+        plan=account_row["plan"],
+        plan_status=account_row["plan_status"],
+        role="member",
+        product=account_row["product"] or "consumer",
+        trial_ends_at=trial_ends,
+        is_admin=False,
+    )
+
+    client_ip = request.client.host if request.client else None
+    await touch_api_key(pool, key_id=row["id"], client_ip=client_ip)
+    return user

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -81,8 +81,17 @@ class SaaSAuthConfig(BaseSettings):
     def _validate_secrets(self):
         if self.enabled and self.jwt_secret == "change-me-in-production":
             raise ValueError("ATLAS_SAAS_JWT_SECRET must be set when SaaS auth is enabled")
-        if self.enabled and self.api_key_pepper == "api-key-pepper-change-me":
-            raise ValueError("ATLAS_SAAS_API_KEY_PEPPER must be set when SaaS auth is enabled")
+        if self.enabled and (
+            not self.api_key_pepper.strip()
+            or self.api_key_pepper == "api-key-pepper-change-me"
+        ):
+            # Empty / whitespace-only peppers HMAC every key with a known
+            # secret -- functionally identical to the sentinel default.
+            # Reject all three so prod cannot ship with a known pepper.
+            raise ValueError(
+                "ATLAS_SAAS_API_KEY_PEPPER must be set to a non-empty, "
+                "non-default value when SaaS auth is enabled"
+            )
         if self.stripe_secret_key and not self.stripe_webhook_secret:
             import warnings
             warnings.warn(

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -65,10 +65,24 @@ class SaaSAuthConfig(BaseSettings):
     stripe_vendor_standard_price_id: str = Field(default="", description="Stripe Price ID for Vendor Standard ($499/mo)")
     stripe_vendor_pro_price_id: str = Field(default="", description="Stripe Price ID for Vendor Pro ($1,499/mo)")
 
+    # API key (LLM Gateway, PR-D1) -- HMAC pepper for hashing customer API keys.
+    # Pepper is server-wide; raw keys are 160-bit random so a per-key salt
+    # would only add cost. The default sentinel "api-key-pepper-change-me"
+    # is rejected when SaaS auth is enabled.
+    api_key_pepper: str = Field(
+        default="api-key-pepper-change-me",
+        description=(
+            "Server-wide pepper used to HMAC-hash customer API keys "
+            "before storage. Required when SaaS auth is enabled."
+        ),
+    )
+
     @model_validator(mode="after")
     def _validate_secrets(self):
         if self.enabled and self.jwt_secret == "change-me-in-production":
             raise ValueError("ATLAS_SAAS_JWT_SECRET must be set when SaaS auth is enabled")
+        if self.enabled and self.api_key_pepper == "api-key-pepper-change-me":
+            raise ValueError("ATLAS_SAAS_API_KEY_PEPPER must be set when SaaS auth is enabled")
         if self.stripe_secret_key and not self.stripe_webhook_secret:
             import warnings
             warnings.warn(

--- a/atlas_brain/storage/migrations/312_api_keys.sql
+++ b/atlas_brain/storage/migrations/312_api_keys.sql
@@ -1,0 +1,43 @@
+-- LLM Gateway API keys (PR-D1).
+--
+-- Long-lived bearer tokens that customer scripts use to call the
+-- /api/v1/llm/* endpoints. JWT-from-/auth/login is for the dashboard;
+-- API keys are for production scripts. Both auth methods resolve to
+-- the same AuthUser shape so downstream endpoints are auth-method
+-- agnostic.
+--
+-- Hashing model: HMAC-SHA256(server_pepper, raw_key) -> hex.
+-- raw_key is 32 random base32 characters (~160 bits entropy), so a
+-- KDF (bcrypt/PBKDF2) is unnecessary. The pepper is a server-wide
+-- secret in SaaSAuthConfig.api_key_pepper, never per-key salt.
+--
+-- key_prefix stores the first 8 chars of the raw key for fast lookup
+-- on the verify path (narrow candidate set, then HMAC-compare).
+--
+-- Soft-delete via revoked_at; never DELETE rows so audit trail
+-- (last_used_at, last_used_ip) survives revocation.
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id      UUID NOT NULL REFERENCES saas_accounts(id) ON DELETE CASCADE,
+    user_id         UUID REFERENCES saas_users(id) ON DELETE SET NULL,
+    name            VARCHAR(128) NOT NULL,
+    key_prefix      VARCHAR(24) NOT NULL,
+    key_hash        VARCHAR(128) NOT NULL,
+    scopes          TEXT[] NOT NULL DEFAULT ARRAY['llm:*'],
+    last_used_at    TIMESTAMPTZ,
+    last_used_ip    INET,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at      TIMESTAMPTZ
+);
+
+-- Lookup path: fetch active keys by account, then by prefix on verify.
+CREATE INDEX IF NOT EXISTS idx_api_keys_account_active
+    ON api_keys (account_id)
+    WHERE revoked_at IS NULL;
+
+-- Verify path narrows by prefix (~16 distinct prefixes/account in practice)
+-- then HMAC-compares full key against candidates.
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix_active
+    ON api_keys (key_prefix)
+    WHERE revoked_at IS NULL;

--- a/tests/test_auth_api_keys.py
+++ b/tests/test_auth_api_keys.py
@@ -201,3 +201,51 @@ def test_saas_auth_accepts_non_default_pepper_when_enabled(monkeypatch):
 
     importlib.reload(config_mod)
     assert config_mod.settings.saas_auth.api_key_pepper == "non-default-pepper"
+
+
+def test_saas_auth_rejects_empty_pepper_when_enabled(monkeypatch):
+    """An empty pepper HMACs every key with a known empty secret --
+    functionally identical to the sentinel default. Reject all
+    blank/whitespace values too (Codex review on PR-D1)."""
+    monkeypatch.setenv("ATLAS_SAAS_ENABLED", "true")
+    monkeypatch.setenv("ATLAS_SAAS_JWT_SECRET", "non-default-jwt")
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "")
+
+    import importlib
+    import atlas_brain.config as config_mod
+
+    with pytest.raises(Exception):
+        importlib.reload(config_mod)
+
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "post-test-pepper")
+    importlib.reload(config_mod)
+
+
+def test_saas_auth_rejects_whitespace_only_pepper_when_enabled(monkeypatch):
+    """A whitespace-only pepper is also a known secret -- ``.strip()``
+    on the validator catches both `"   "` and `"\\t\\n"`."""
+    monkeypatch.setenv("ATLAS_SAAS_ENABLED", "true")
+    monkeypatch.setenv("ATLAS_SAAS_JWT_SECRET", "non-default-jwt")
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "   ")
+
+    import importlib
+    import atlas_brain.config as config_mod
+
+    with pytest.raises(Exception):
+        importlib.reload(config_mod)
+
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "post-test-pepper")
+    importlib.reload(config_mod)
+
+
+def test_saas_auth_allows_empty_pepper_when_disabled(monkeypatch):
+    """Local-dev mode (SaaS auth disabled) does not need a real
+    pepper -- the validator only fires when ``enabled=True``."""
+    monkeypatch.setenv("ATLAS_SAAS_ENABLED", "false")
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "")
+
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+    assert config_mod.settings.saas_auth.enabled is False

--- a/tests/test_auth_api_keys.py
+++ b/tests/test_auth_api_keys.py
@@ -1,0 +1,203 @@
+"""Tests for the LLM Gateway API key auth substrate (PR-D1).
+
+Covers the pure (non-DB) helpers in ``atlas_brain.auth.api_keys``:
+generation format, hashing one-wayness, prefix extraction, constant-
+time compare. The DB-backed paths (insert/list/lookup/revoke/touch)
+plus ``require_api_key`` dependency are integration tests gated on a
+running Postgres -- they live alongside other auth integration tests
+and are skipped when no pool is available.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+from atlas_brain.auth.api_keys import (
+    DEFAULT_SCOPES,
+    KEY_BODY_LENGTH,
+    KEY_LIVE_PREFIX,
+    KEY_PREFIX_LEN,
+    constant_time_equals,
+    generate_api_key,
+    hash_api_key,
+    split_prefix,
+)
+
+
+# ---- Generation format ---------------------------------------------------
+
+
+def test_generated_key_has_live_prefix():
+    raw, _prefix = generate_api_key()
+    assert raw.startswith(KEY_LIVE_PREFIX)
+
+
+def test_generated_key_body_length():
+    raw, _prefix = generate_api_key()
+    body = raw[len(KEY_LIVE_PREFIX) :]
+    assert len(body) == KEY_BODY_LENGTH
+
+
+def test_generated_key_body_uses_lowercase_base32_alphabet():
+    raw, _prefix = generate_api_key()
+    body = raw[len(KEY_LIVE_PREFIX) :]
+    assert re.fullmatch(r"[a-z2-7]+", body), body
+
+
+def test_generated_key_prefix_matches_expected_length():
+    _raw, prefix = generate_api_key()
+    assert len(prefix) == KEY_PREFIX_LEN
+
+
+def test_generated_keys_are_unique_across_calls():
+    keys = {generate_api_key()[0] for _ in range(50)}
+    assert len(keys) == 50
+
+
+# ---- Hashing one-wayness + determinism -----------------------------------
+
+
+def test_hash_is_deterministic_for_same_input(monkeypatch):
+    """With a fixed pepper, the same raw key always hashes to the
+    same value. Deterministic hashing is required for the prefix-
+    narrow + HMAC-compare lookup pattern in ``lookup_api_key``."""
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "test-pepper-deterministic")
+
+    # Force settings to re-read by clearing the cached module
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+
+    raw = "atls_live_examplekey1234567890abcdefgh"
+    h1 = hash_api_key(raw)
+    h2 = hash_api_key(raw)
+    assert h1 == h2
+
+
+def test_hash_is_different_for_different_inputs(monkeypatch):
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "test-pepper-distinct")
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+
+    raw_a = "atls_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    raw_b = "atls_live_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    assert hash_api_key(raw_a) != hash_api_key(raw_b)
+
+
+def test_hash_changes_when_pepper_changes(monkeypatch):
+    """Same raw key + different pepper = different hash. Prevents
+    cross-environment hash reuse if the pepper rotates."""
+    raw = "atls_live_pepperrotationtestkey1234567890ab"
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "test-pepper-one")
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+    h1 = hash_api_key(raw)
+
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "test-pepper-two")
+    importlib.reload(config_mod)
+    h2 = hash_api_key(raw)
+
+    assert h1 != h2
+
+
+def test_hash_output_format_is_hex_sha256(monkeypatch):
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "test-pepper-format")
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+
+    h = hash_api_key("atls_live_anykey")
+    assert len(h) == 64
+    assert re.fullmatch(r"[0-9a-f]+", h)
+
+
+# ---- Prefix extraction --------------------------------------------------
+
+
+def test_split_prefix_returns_lookup_hint_for_well_formed_key():
+    raw, prefix = generate_api_key()
+    assert split_prefix(raw) == prefix
+
+
+def test_split_prefix_rejects_non_atlas_token():
+    """JWT-shaped tokens fall through to the JWT extractor, not the
+    API-key path. ``split_prefix`` must return the empty string for
+    them so ``lookup_api_key`` short-circuits."""
+    assert split_prefix("eyJhbGciOiJIUzI1NiJ9.fake.token") == ""
+
+
+def test_split_prefix_rejects_too_short_input():
+    assert split_prefix("atls_live_short") == ""
+
+
+def test_split_prefix_rejects_empty_input():
+    assert split_prefix("") == ""
+
+
+# ---- Constant-time compare -----------------------------------------------
+
+
+def test_constant_time_equals_matches_identical_strings():
+    assert constant_time_equals("abcdef", "abcdef") is True
+
+
+def test_constant_time_equals_rejects_different_strings():
+    assert constant_time_equals("abcdef", "abcdee") is False
+
+
+def test_constant_time_equals_rejects_different_length():
+    assert constant_time_equals("abc", "abcdef") is False
+
+
+# ---- Defaults ------------------------------------------------------------
+
+
+def test_default_scopes_is_llm_wildcard():
+    """v1 scope model. PR-D4 expands this when fine-grained scopes
+    land. The wildcard locks the default so future restriction is
+    additive."""
+    assert DEFAULT_SCOPES == ("llm:*",)
+
+
+# ---- Pepper validator (config-level) -------------------------------------
+
+
+def test_saas_auth_rejects_default_pepper_when_enabled(monkeypatch):
+    """When ``ATLAS_SAAS_ENABLED=true``, the default sentinel pepper
+    raises a ValueError -- prevents shipping prod with a known pepper."""
+    monkeypatch.setenv("ATLAS_SAAS_ENABLED", "true")
+    monkeypatch.setenv("ATLAS_SAAS_JWT_SECRET", "non-default-jwt")
+    # Leave pepper unset -> defaults to sentinel.
+    monkeypatch.delenv("ATLAS_SAAS_API_KEY_PEPPER", raising=False)
+
+    import importlib
+    import atlas_brain.config as config_mod
+
+    with pytest.raises(Exception):
+        importlib.reload(config_mod)
+
+    # Cleanup -- restore a valid environment so subsequent tests don't
+    # inherit a half-loaded module.
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "post-test-pepper")
+    importlib.reload(config_mod)
+
+
+def test_saas_auth_accepts_non_default_pepper_when_enabled(monkeypatch):
+    monkeypatch.setenv("ATLAS_SAAS_ENABLED", "true")
+    monkeypatch.setenv("ATLAS_SAAS_JWT_SECRET", "non-default-jwt")
+    monkeypatch.setenv("ATLAS_SAAS_API_KEY_PEPPER", "non-default-pepper")
+
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+    assert config_mod.settings.saas_auth.api_key_pepper == "non-default-pepper"


### PR DESCRIPTION
## Summary

First PR of the LLM Gateway MVP (per [docs/products/llm_gateway_mvp_plan.md](docs/products/llm_gateway_mvp_plan.md)). Adds the auth substrate that customer scripts will use to call the upcoming `/api/v1/llm/*` endpoints.

JWT auth (for the dashboard) stays unchanged. API keys are an **additive** auth method that resolves to the same `AuthUser` shape so downstream endpoints stay auth-method agnostic.

## Changes

| File | Type | What |
|---|---|---|
| `atlas_brain/storage/migrations/312_api_keys.sql` | NEW | `api_keys` table: id, account_id (FK CASCADE), user_id (FK SET NULL, creator audit), name, key_prefix (lookup hint), key_hash (HMAC-SHA256), scopes (default `{llm:*}`), last_used_*, created_at, revoked_at. Two partial indexes for active rows. |
| `atlas_brain/auth/api_keys.py` | NEW | Generation + hashing + DB helpers (`generate_api_key`, `hash_api_key`, `lookup_api_key`, `insert_api_key`, `list_api_keys`, `revoke_api_key`, `touch_api_key`). |
| `atlas_brain/api/api_keys.py` | NEW | FastAPI router: `POST /keys` (raw returned ONCE), `GET /keys`, `DELETE /keys/{key_id}`. Mounted at `/api/v1/keys`. Gated on dashboard JWT (`require_auth`). |
| `atlas_brain/auth/dependencies.py` | EDIT | Adds `require_api_key()` — reads `Authorization: Bearer atls_live_*`, fetches account for plan/product/trial check, returns `AuthUser` identical shape to `require_auth`. Refuses canceled subscriptions and expired trials. Best-effort `touch_api_key()`. |
| `atlas_brain/api/__init__.py` | EDIT | Imports + `include_router(api_keys_router)`. |
| `atlas_brain/config.py` | EDIT | Adds `api_key_pepper` field on `SaaSAuthConfig`. Default sentinel raises ValueError at startup when `ATLAS_SAAS_ENABLED=true` — prevents shipping prod with a known pepper. |
| `tests/test_auth_api_keys.py` | NEW (19 tests) | Generation format, hash determinism + uniqueness + pepper rotation, prefix extraction, constant-time compare, default scopes, pepper validator. |

## Format / hashing model

- API key format: `atls_live_<32-char-base32>` (~160 bits entropy). Prefix `atls_live_` lets customers' secret-scanners (GitGuardian, TruffleHog) pattern-match.
- Hash: `HMAC-SHA256(server_pepper, raw_key)`. KDF (bcrypt/PBKDF2) is unnecessary because `raw_key` is already high-entropy random.
- Pepper is server-wide (`SaaSAuthConfig.api_key_pepper`), no per-key salt.
- Verify path: prefix-narrow on `key_prefix` (typically 0-2 candidates), HMAC-compare with constant-time equals.

## API surface (PR-D4 will use these)

- `Depends(require_auth)` — dashboard, JWT only
- `Depends(require_api_key)` — production API endpoints, customer-issued key only
- Both return `AuthUser` so endpoint code is auth-method agnostic
- A future `Depends(require_auth_or_api_key)` could accept either, but PR-D1 keeps them separate to avoid hidden coupling

## Validation

```
$ pytest tests/test_auth_api_keys.py tests/test_auth_dependencies.py -q
27 passed in 1.19s

$ python -c "from atlas_brain.api import router; from atlas_brain.api.api_keys import router as r; ..."
routes registered:
  {'POST'} /keys
  {'GET'} /keys
  {'DELETE'} /keys/{key_id}
```

## Plan reference

This PR is **PR-D1** in the locked plan at `docs/products/llm_gateway_mvp_plan.md`.

Next: **PR-D2** — `llm_gateway` product + 3 plan tiers (config + PLAN_LIMITS + PLAN_RATE_LIMITS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
