### PR TITLE
M5-α: domain-agnostic reasoning protocols + typed envelope + registry

### DIFF
--- a/docs/reasoning_interface_contract.md
+++ b/docs/reasoning_interface_contract.md
@@ -178,3 +178,41 @@ Each adapter/producer PR must validate:
 2. Classify as additive (minor) or breaking (major).
 3. Update this contract and linked execution board in same PR.
 4. Run schema/regression checks before merge.
+
+## Domain-agnostic envelope (M5-alpha)
+
+The vendor-pressure-flavored canonical payload above is the v1 contract for
+the churn-reasoning domain. M5-alpha (`docs/hybrid_extraction_plan_status_2026-05-05.md`)
+introduces a domain-agnostic envelope so the same producer/consumer pattern
+can be applied to other domains (call transcripts, internal company entities,
+etc.) without rewriting the core.
+
+The envelope lives in `extracted_reasoning_core.domains`:
+
+- `ReasoningSubject` Protocol -- anything reasoning is performed over (`id`,
+  `domain`, `payload`).
+- `DomainReasoningResult[PayloadT]` -- universal core fields (`confidence`,
+  `executive_summary`, `key_signals`, `uncertainty_sources`,
+  `falsification_conditions`, `reference_ids`, etc.) plus a typed
+  `domain_payload`.
+- `ReasoningProducerPort[SubjectT, PayloadT]` and
+  `ReasoningConsumerPort[PayloadT]` -- Protocols for the producer (subject
+  in, result out) and consumer (result in, overlay-fields dict out) sides.
+- `register_domain(name, subject_type, payload_type)` -- registry so each
+  new domain ships its own typed triple without touching the core.
+
+The vendor-pressure flow (current churn reasoning) becomes one specialization
+of this envelope in M5-beta:
+
+- `domain="vendor_pressure"`, `domain_payload=VendorPressurePayload(wedge=...,
+  proof_points=..., account_signals=..., ...)`.
+- `CampaignReasoningProviderPort` becomes
+  `ReasoningProducerPort[VendorOpportunity, VendorPressurePayload]`.
+- The vendor-specific `reasoning_contracts` keys (`vendor_core_reasoning`,
+  `displacement_reasoning`, `category_reasoning`, `account_reasoning`) move
+  under `domain_payload`; the universal core stays at the envelope level.
+
+A second domain ships purely additively: define a new
+`Subject` / `Payload` / `Producer` / `Consumer` triple, call
+`register_domain`, and consumers that only need universal fields work without
+code changes.

--- a/extracted_reasoning_core/__init__.py
+++ b/extracted_reasoning_core/__init__.py
@@ -1,6 +1,7 @@
 """Extracted reasoning core public package."""
 
 from .api import *
+from .domains import *
 from .ports import *
 from .state import *
 from .tiers import *

--- a/extracted_reasoning_core/domains.py
+++ b/extracted_reasoning_core/domains.py
@@ -1,0 +1,289 @@
+"""Domain-agnostic reasoning protocols, envelope, and registry.
+
+Reasoning is performed over many kinds of subjects -- vendors under
+churn pressure, call transcripts, internal company entities, and
+whatever else a host wants to plug in. The existing ``ReasoningInput``
+and ``ReasoningResult`` types in ``extracted_reasoning_core.types``
+already use generic ``entity_id`` / ``entity_type`` fields, but two
+pieces have been missing:
+
+1.  A **typed envelope** that pairs the universal reasoning core
+    (confidence, summary, claims, lineage) with a domain-typed
+    payload, so domain-specific conclusions don't have to live in an
+    untyped ``state: Mapping[str, Any]`` bag.
+2.  **High-level Producer / Consumer Protocols** at the domain level
+    so a host can register a reasoning surface for a new domain
+    purely additively, without touching the core.
+
+This module supplies those two pieces plus a small domain registry.
+Existing types in ``extracted_reasoning_core.types`` are unchanged;
+M5-beta will refactor the vendor-pressure consumer adapter and the
+campaign provider port to be typed specializations of the protocols
+defined here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Generic,
+    NamedTuple,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
+
+from .types import ReasoningResult
+
+
+PayloadT_co = TypeVar("PayloadT_co", covariant=True)
+PayloadT = TypeVar("PayloadT")
+SubjectT_contra = TypeVar("SubjectT_contra", contravariant=True)
+
+
+@runtime_checkable
+class ReasoningSubject(Protocol):
+    """Anything reasoning is performed over.
+
+    A subject identifies *what* is being reasoned about, scoped by a
+    domain string. The ``payload`` carries domain-specific input fields
+    (e.g. opportunity row, transcript metadata, company facts) that the
+    producer needs to compute a result.
+
+    Domain conventions:
+
+    * ``"vendor_pressure"`` -- vendor under churn pressure (Atlas churn
+      reasoning, current).
+    * ``"call_transcript"`` -- a recorded conversation (future).
+    * ``"company_entity"`` -- internal company record (future).
+
+    Any class with these three attributes satisfies the protocol; this
+    is ``@runtime_checkable`` so adapter wiring can validate at startup
+    via ``isinstance(obj, ReasoningSubject)``.
+    """
+
+    id: str
+    domain: str
+    payload: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ReferenceIds:
+    """Universal evidence-lineage block.
+
+    Mirrors the ``reference_ids`` block of the canonical reasoning
+    payload from ``docs/reasoning_interface_contract.md``. Carried on
+    every result so consumers can resolve back to source evidence
+    regardless of domain.
+    """
+
+    metric_ids: tuple[str, ...] = ()
+    witness_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class DomainReasoningResult(Generic[PayloadT_co]):
+    """Domain-agnostic reasoning result with a domain-typed payload.
+
+    The fields outside ``domain_payload`` are universal across domains
+    and form a stable consumer contract: confidence, summary, signals,
+    uncertainty, falsification conditions, lineage. The
+    ``domain_payload`` carries the domain-specific conclusions
+    (wedge / displacement / account_signals for vendor pressure;
+    topics / sentiment / action_items for call transcripts; etc.).
+
+    This sits alongside ``ReasoningResult`` in ``types.py``: the
+    existing ``ReasoningResult`` keeps its untyped ``state: Mapping``
+    bag for backward compatibility; this typed envelope is the new
+    contract for anything built after M5-alpha.
+    """
+
+    subject_id: str
+    domain: str
+    confidence: float
+    domain_payload: PayloadT_co
+
+    # Optional universal fields -- present when the producer can compute
+    # them, omitted (None / empty tuple) otherwise.
+    confidence_label: str | None = None
+    as_of: str | None = None  # ISO 8601 datetime
+    executive_summary: str | None = None
+    key_signals: tuple[str, ...] = ()
+    uncertainty_sources: tuple[str, ...] = ()
+    falsification_conditions: tuple[str, ...] = ()
+    mode: str | None = None
+    risk_level: str | None = None
+    archetype: str | None = None
+    reference_ids: ReferenceIds = field(default_factory=ReferenceIds)
+
+
+@runtime_checkable
+class ReasoningProducerPort(Protocol[SubjectT_contra, PayloadT_co]):
+    """Host-owned port for producing a reasoning result for a subject.
+
+    A producer takes a fully-formed ``ReasoningSubject`` (or any
+    domain-specific subclass) and returns a ``DomainReasoningResult``
+    typed for the producer's domain payload. Returning ``None`` means
+    the producer found no reasoning to assert (e.g. insufficient
+    evidence for the contract floor); callers fall back to defaults.
+
+    The single ``produce`` method is async because real producers
+    typically do LLM calls or DB lookups. Pure-sync producers can wrap
+    in ``asyncio.to_thread`` or just declare ``async def`` and return
+    immediately -- both satisfy the protocol.
+    """
+
+    async def produce(
+        self,
+        subject: SubjectT_contra,
+        /,
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> DomainReasoningResult[PayloadT_co] | None:
+        """Compute reasoning for ``subject`` and return the typed result."""
+
+
+@runtime_checkable
+class ReasoningConsumerPort(Protocol[PayloadT]):
+    """Host-owned port for projecting a result into stable overlay fields.
+
+    Consumers are MCP tool responses, API endpoints, UI views -- any
+    surface that needs flat ``dict[str, Any]`` overlay fields rather
+    than the full envelope. The two methods mirror the
+    summary/detail split currently implemented in
+    ``atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py``;
+    M5-beta will refactor that file to be the
+    ``"vendor_pressure"`` consumer.
+    """
+
+    def to_summary_fields(
+        self,
+        result: DomainReasoningResult[PayloadT],
+    ) -> Mapping[str, Any]:
+        """Project a result into compact summary overlay fields."""
+
+    def to_detail_fields(
+        self,
+        result: DomainReasoningResult[PayloadT],
+    ) -> Mapping[str, Any]:
+        """Project a result into the full detail overlay fields."""
+
+
+class DomainDescriptor(NamedTuple):
+    """Static metadata for a registered reasoning domain."""
+
+    name: str
+    subject_type: type
+    payload_type: type
+
+
+_REGISTRY: dict[str, DomainDescriptor] = {}
+
+
+def register_domain(
+    name: str,
+    *,
+    subject_type: type,
+    payload_type: type,
+) -> DomainDescriptor:
+    """Register a reasoning domain.
+
+    Idempotent on identical re-registration -- the same ``name`` with
+    the same ``subject_type`` and ``payload_type`` is a no-op.
+    A name conflict (same name, different types) raises
+    ``ValueError`` so accidental shadowing fails closed at import
+    time. Producer and consumer instances are *not* held in the
+    registry: the descriptor is purely typing/discovery metadata, and
+    actual instances are wired by the host at startup.
+    """
+    if not name:
+        raise ValueError("domain name must be a non-empty string")
+    existing = _REGISTRY.get(name)
+    if existing is not None:
+        if (
+            existing.subject_type is subject_type
+            and existing.payload_type is payload_type
+        ):
+            return existing
+        raise ValueError(
+            f"domain {name!r} already registered with "
+            f"subject_type={existing.subject_type.__name__}, "
+            f"payload_type={existing.payload_type.__name__}; "
+            f"refusing to shadow with "
+            f"subject_type={subject_type.__name__}, "
+            f"payload_type={payload_type.__name__}"
+        )
+    descriptor = DomainDescriptor(
+        name=name,
+        subject_type=subject_type,
+        payload_type=payload_type,
+    )
+    _REGISTRY[name] = descriptor
+    return descriptor
+
+
+def get_domain(name: str) -> DomainDescriptor | None:
+    """Return the descriptor registered under ``name``, if any."""
+    return _REGISTRY.get(name)
+
+
+def list_domains() -> Sequence[DomainDescriptor]:
+    """Return all registered domain descriptors, sorted by name."""
+    return tuple(sorted(_REGISTRY.values(), key=lambda d: d.name))
+
+
+def _clear_registry_for_tests() -> None:
+    """Test-only: drop all registered domains.
+
+    Not part of the public API. Used by tests that need a clean
+    registry to validate registration semantics without depending on
+    test-execution order.
+    """
+    _REGISTRY.clear()
+
+
+def _project_universal_fields(
+    result: DomainReasoningResult[Any],
+) -> dict[str, Any]:
+    """Helper: extract the universal (non-domain) fields as a flat dict.
+
+    Useful for consumers that want to default-include the universal
+    fields and only customize the domain-specific ones. Returns a new
+    dict each call so callers can mutate it freely.
+    """
+    return {
+        "subject_id": result.subject_id,
+        "domain": result.domain,
+        "confidence": result.confidence,
+        "confidence_label": result.confidence_label,
+        "as_of": result.as_of,
+        "executive_summary": result.executive_summary,
+        "key_signals": list(result.key_signals),
+        "uncertainty_sources": list(result.uncertainty_sources),
+        "falsification_conditions": list(result.falsification_conditions),
+        "mode": result.mode,
+        "risk_level": result.risk_level,
+        "archetype": result.archetype,
+        "reference_ids": {
+            "metric_ids": list(result.reference_ids.metric_ids),
+            "witness_ids": list(result.reference_ids.witness_ids),
+        },
+    }
+
+
+# Re-export ReasoningResult so callers that want both the legacy
+# untyped result and the new typed envelope can import from one place.
+__all__ = [
+    "DomainDescriptor",
+    "DomainReasoningResult",
+    "ReasoningConsumerPort",
+    "ReasoningProducerPort",
+    "ReasoningResult",
+    "ReasoningSubject",
+    "ReferenceIds",
+    "get_domain",
+    "list_domains",
+    "register_domain",
+]

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -44,6 +44,7 @@ pytest \
   tests/test_extracted_reasoning_core_semantic_cache_keys.py \
   tests/test_extracted_reasoning_core_temporal.py \
   tests/test_extracted_reasoning_core_types.py \
+  tests/test_extracted_reasoning_core_domains.py \
   tests/test_extracted_reasoning_core_wedge_registry.py \
   tests/test_atlas_reasoning_state_inherits_core.py \
   tests/test_atlas_reasoning_port_adapters.py \

--- a/tests/test_extracted_reasoning_core_domains.py
+++ b/tests/test_extracted_reasoning_core_domains.py
@@ -1,0 +1,398 @@
+"""Tests for extracted_reasoning_core.domains.
+
+Validates the domain-agnostic reasoning protocols, the typed result
+envelope, the lineage block, and the domain registry contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from extracted_reasoning_core.domains import (
+    DomainDescriptor,
+    DomainReasoningResult,
+    ReasoningConsumerPort,
+    ReasoningProducerPort,
+    ReasoningSubject,
+    ReferenceIds,
+    _clear_registry_for_tests,
+    _project_universal_fields,
+    get_domain,
+    list_domains,
+    register_domain,
+)
+
+
+# ---------------------------------------------------------------------
+# Fixtures: tiny sample subject/payload pair for a hypothetical domain
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SamplePayload:
+    """Stand-in domain payload for tests."""
+
+    headline: str
+    score: float
+
+
+@dataclass(frozen=True)
+class _SampleSubject:
+    """Stand-in subject. Satisfies ReasoningSubject structurally."""
+
+    id: str
+    domain: str
+    payload: Mapping[str, Any]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Clear the domain registry before and after each test."""
+    _clear_registry_for_tests()
+    yield
+    _clear_registry_for_tests()
+
+
+# ---------------------------------------------------------------------
+# Subject Protocol
+# ---------------------------------------------------------------------
+
+
+def test_reasoning_subject_protocol_is_runtime_checkable() -> None:
+    subject = _SampleSubject(id="opp-1", domain="vendor_pressure", payload={"x": 1})
+    assert isinstance(subject, ReasoningSubject)
+
+
+def test_reasoning_subject_rejects_missing_attributes() -> None:
+    class _Bad:
+        id = "x"
+        # missing 'domain' and 'payload'
+
+    assert not isinstance(_Bad(), ReasoningSubject)
+
+
+# ---------------------------------------------------------------------
+# ReferenceIds + DomainReasoningResult
+# ---------------------------------------------------------------------
+
+
+def test_reference_ids_defaults_are_empty() -> None:
+    refs = ReferenceIds()
+    assert refs.metric_ids == ()
+    assert refs.witness_ids == ()
+
+
+def test_reference_ids_carries_provided_values() -> None:
+    refs = ReferenceIds(metric_ids=("m1", "m2"), witness_ids=("w1",))
+    assert refs.metric_ids == ("m1", "m2")
+    assert refs.witness_ids == ("w1",)
+
+
+def test_domain_reasoning_result_required_fields() -> None:
+    payload = _SamplePayload(headline="renewal pressure", score=0.82)
+    result: DomainReasoningResult[_SamplePayload] = DomainReasoningResult(
+        subject_id="opp-1",
+        domain="vendor_pressure",
+        confidence=0.82,
+        domain_payload=payload,
+    )
+
+    assert result.subject_id == "opp-1"
+    assert result.domain == "vendor_pressure"
+    assert result.confidence == pytest.approx(0.82)
+    assert result.domain_payload is payload
+    # Optional fields default to None / empty tuples / empty ReferenceIds
+    assert result.confidence_label is None
+    assert result.as_of is None
+    assert result.executive_summary is None
+    assert result.key_signals == ()
+    assert result.uncertainty_sources == ()
+    assert result.falsification_conditions == ()
+    assert result.mode is None
+    assert result.risk_level is None
+    assert result.archetype is None
+    assert result.reference_ids == ReferenceIds()
+
+
+def test_domain_reasoning_result_carries_optional_fields() -> None:
+    result = DomainReasoningResult(
+        subject_id="opp-1",
+        domain="vendor_pressure",
+        confidence=0.9,
+        domain_payload=_SamplePayload(headline="x", score=0.9),
+        confidence_label="high",
+        as_of="2026-05-05T00:00:00Z",
+        executive_summary="Acme is reviewing vendors before renewal.",
+        key_signals=("pricing_mentions", "exec_change"),
+        uncertainty_sources=("limited transcript coverage",),
+        falsification_conditions=("renewal signed within 7 days",),
+        mode="synthesis",
+        risk_level="high",
+        archetype="renewal_at_risk",
+        reference_ids=ReferenceIds(metric_ids=("m1",), witness_ids=("w1", "w2")),
+    )
+
+    assert result.confidence_label == "high"
+    assert result.executive_summary == "Acme is reviewing vendors before renewal."
+    assert result.key_signals == ("pricing_mentions", "exec_change")
+    assert result.uncertainty_sources == ("limited transcript coverage",)
+    assert result.falsification_conditions == ("renewal signed within 7 days",)
+    assert result.mode == "synthesis"
+    assert result.risk_level == "high"
+    assert result.archetype == "renewal_at_risk"
+    assert result.reference_ids.metric_ids == ("m1",)
+    assert result.reference_ids.witness_ids == ("w1", "w2")
+
+
+def test_domain_reasoning_result_is_frozen() -> None:
+    result = DomainReasoningResult(
+        subject_id="opp-1",
+        domain="vendor_pressure",
+        confidence=0.5,
+        domain_payload=_SamplePayload(headline="x", score=0.5),
+    )
+    with pytest.raises(Exception):
+        result.confidence = 0.99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------
+# Producer / Consumer Protocols
+# ---------------------------------------------------------------------
+
+
+class _SampleProducer:
+    """Concrete class that satisfies ReasoningProducerPort structurally."""
+
+    async def produce(
+        self,
+        subject: _SampleSubject,
+        /,
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> DomainReasoningResult[_SamplePayload] | None:
+        if subject.domain != "vendor_pressure":
+            return None
+        return DomainReasoningResult(
+            subject_id=subject.id,
+            domain=subject.domain,
+            confidence=0.7,
+            domain_payload=_SamplePayload(headline="ok", score=0.7),
+        )
+
+
+class _SampleConsumer:
+    """Concrete class that satisfies ReasoningConsumerPort structurally."""
+
+    def to_summary_fields(
+        self,
+        result: DomainReasoningResult[_SamplePayload],
+    ) -> Mapping[str, Any]:
+        return {
+            "headline": result.domain_payload.headline,
+            "confidence": result.confidence,
+        }
+
+    def to_detail_fields(
+        self,
+        result: DomainReasoningResult[_SamplePayload],
+    ) -> Mapping[str, Any]:
+        return {
+            "headline": result.domain_payload.headline,
+            "score": result.domain_payload.score,
+            "confidence": result.confidence,
+            "executive_summary": result.executive_summary,
+        }
+
+
+def test_producer_satisfies_protocol() -> None:
+    assert isinstance(_SampleProducer(), ReasoningProducerPort)
+
+
+def test_consumer_satisfies_protocol() -> None:
+    assert isinstance(_SampleConsumer(), ReasoningConsumerPort)
+
+
+@pytest.mark.asyncio
+async def test_producer_returns_none_for_other_domain() -> None:
+    producer = _SampleProducer()
+    out = await producer.produce(
+        _SampleSubject(id="t-1", domain="call_transcript", payload={}),
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_producer_returns_typed_result() -> None:
+    producer = _SampleProducer()
+    out = await producer.produce(
+        _SampleSubject(id="opp-1", domain="vendor_pressure", payload={}),
+    )
+    assert out is not None
+    assert out.subject_id == "opp-1"
+    assert out.domain_payload.score == pytest.approx(0.7)
+
+
+def test_consumer_projections_are_independent() -> None:
+    consumer = _SampleConsumer()
+    result = DomainReasoningResult(
+        subject_id="opp-1",
+        domain="vendor_pressure",
+        confidence=0.7,
+        domain_payload=_SamplePayload(headline="renewal pressure", score=0.7),
+        executive_summary="Sample summary.",
+    )
+    summary = consumer.to_summary_fields(result)
+    detail = consumer.to_detail_fields(result)
+
+    assert summary == {"headline": "renewal pressure", "confidence": 0.7}
+    assert detail["score"] == pytest.approx(0.7)
+    assert detail["executive_summary"] == "Sample summary."
+    # Detail should be a strict superset of summary's domain field.
+    assert detail["headline"] == summary["headline"]
+
+
+# ---------------------------------------------------------------------
+# Domain registry
+# ---------------------------------------------------------------------
+
+
+def test_register_domain_returns_descriptor() -> None:
+    desc = register_domain(
+        "vendor_pressure",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    assert isinstance(desc, DomainDescriptor)
+    assert desc.name == "vendor_pressure"
+    assert desc.subject_type is _SampleSubject
+    assert desc.payload_type is _SamplePayload
+
+
+def test_get_domain_returns_registered() -> None:
+    register_domain(
+        "vendor_pressure",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    desc = get_domain("vendor_pressure")
+    assert desc is not None
+    assert desc.name == "vendor_pressure"
+
+
+def test_get_domain_missing_returns_none() -> None:
+    assert get_domain("never_registered") is None
+
+
+def test_register_domain_is_idempotent_on_identical_types() -> None:
+    a = register_domain(
+        "vendor_pressure",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    b = register_domain(
+        "vendor_pressure",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    assert a == b
+
+
+def test_register_domain_conflict_raises() -> None:
+    register_domain(
+        "vendor_pressure",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+
+    @dataclass(frozen=True)
+    class _OtherPayload:
+        x: int
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_domain(
+            "vendor_pressure",
+            subject_type=_SampleSubject,
+            payload_type=_OtherPayload,
+        )
+
+
+def test_register_domain_empty_name_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        register_domain("", subject_type=_SampleSubject, payload_type=_SamplePayload)
+
+
+def test_list_domains_returns_sorted_tuple() -> None:
+    register_domain(
+        "vendor_pressure",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    register_domain(
+        "call_transcript",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    register_domain(
+        "company_entity",
+        subject_type=_SampleSubject,
+        payload_type=_SamplePayload,
+    )
+    domains = list_domains()
+    assert isinstance(domains, tuple)
+    names = [d.name for d in domains]
+    assert names == ["call_transcript", "company_entity", "vendor_pressure"]
+
+
+# ---------------------------------------------------------------------
+# Universal-field projection helper
+# ---------------------------------------------------------------------
+
+
+def test_project_universal_fields_includes_all_universal_keys() -> None:
+    result = DomainReasoningResult(
+        subject_id="opp-1",
+        domain="vendor_pressure",
+        confidence=0.7,
+        domain_payload=_SamplePayload(headline="x", score=0.7),
+        confidence_label="medium",
+        as_of="2026-05-05T00:00:00Z",
+        executive_summary="exec",
+        key_signals=("a", "b"),
+        uncertainty_sources=("u1",),
+        falsification_conditions=("f1",),
+        mode="synthesis",
+        risk_level="medium",
+        archetype="renewal_at_risk",
+        reference_ids=ReferenceIds(metric_ids=("m1",), witness_ids=("w1",)),
+    )
+    flat = _project_universal_fields(result)
+    assert flat["subject_id"] == "opp-1"
+    assert flat["domain"] == "vendor_pressure"
+    assert flat["confidence"] == pytest.approx(0.7)
+    assert flat["confidence_label"] == "medium"
+    assert flat["executive_summary"] == "exec"
+    assert flat["key_signals"] == ["a", "b"]
+    assert flat["uncertainty_sources"] == ["u1"]
+    assert flat["falsification_conditions"] == ["f1"]
+    assert flat["reference_ids"] == {"metric_ids": ["m1"], "witness_ids": ["w1"]}
+    # No domain_payload in the universal projection -- domain-specific
+    # consumers add that themselves.
+    assert "domain_payload" not in flat
+
+
+def test_project_universal_fields_returns_fresh_dict() -> None:
+    result = DomainReasoningResult(
+        subject_id="opp-1",
+        domain="vendor_pressure",
+        confidence=0.7,
+        domain_payload=_SamplePayload(headline="x", score=0.7),
+    )
+    a = _project_universal_fields(result)
+    b = _project_universal_fields(result)
+    assert a is not b
+    a["mutated"] = True
+    assert "mutated" not in b


### PR DESCRIPTION
## Summary

Implements **M5-α** from `docs/hybrid_extraction_plan_status_2026-05-05.md`. Adds the generic abstractions in `extracted_reasoning_core` that let reasoning be reused across domains (vendor pressure, call transcripts, internal company entities, etc.) without rewriting the core.

**Pure additive.** No existing call sites change, the legacy `ReasoningResult` keeps its untyped `state: Mapping` bag, the v1 canonical payload contract for vendor pressure is untouched. M5-β will refactor `_b2b_reasoning_consumer_adapter.py` and `CampaignReasoningProviderPort` to be typed specializations of the protocols defined here.

## Files

### New module: `extracted_reasoning_core/domains.py`

- **`ReasoningSubject`** Protocol — anything reasoning is performed over: `id: str`, `domain: str`, `payload: Mapping[str, Any]`. Runtime-checkable.
- **`ReferenceIds`** dataclass — universal evidence-lineage block (`metric_ids`, `witness_ids` as tuples). Mirrors the canonical payload's `reference_ids` block.
- **`DomainReasoningResult[PayloadT]`** dataclass — frozen typed envelope. Universal fields (`confidence`, `confidence_label`, `as_of`, `executive_summary`, `key_signals`, `uncertainty_sources`, `falsification_conditions`, `mode`, `risk_level`, `archetype`, `reference_ids`) plus a typed `domain_payload`.
- **`ReasoningProducerPort[SubjectT, PayloadT]`** Protocol — async `produce(subject, *, context) -> DomainReasoningResult[PayloadT] | None`.
- **`ReasoningConsumerPort[PayloadT]`** Protocol — `to_summary_fields` / `to_detail_fields` projections returning `Mapping[str, Any]`.
- **`DomainDescriptor`** NamedTuple + `register_domain` / `get_domain` / `list_domains`. Idempotent on identical re-registration; conflict raises `ValueError`; empty name raises `ValueError`. Producer/consumer instances are not held in the registry — descriptor is purely typing/discovery metadata.
- **`_project_universal_fields`** helper for consumers that want the universal subset as a flat dict.

### New tests: `tests/test_extracted_reasoning_core_domains.py` — 21 tests, all pass

- Protocol satisfaction (positive + negative for `ReasoningSubject`; Producer/Consumer satisfy via `runtime_checkable` isinstance).
- `DomainReasoningResult` required + optional + frozen.
- `ReferenceIds` defaults + provided values.
- Producer returns `None` for non-matching domain; returns typed result on match (async test).
- Consumer summary/detail projection independence.
- Registry: register / get / list-sorted / idempotent / conflict-raises / empty-name-raises. `autouse` fixture isolates the registry per test.
- `_project_universal_fields` includes all universal keys; returns a fresh dict per call.

### Wiring

- `extracted_reasoning_core/__init__.py` — re-export `domains` so the new types are available from the package root.
- `scripts/run_extracted_pipeline_checks.sh` — register the new test file alongside the other `test_extracted_reasoning_core_*` entries.
- `.github/workflows/extracted_pipeline_checks.yml` — no change needed; existing `tests/test_extracted_reasoning_core_*.py` glob already covers it.

### Doc update

`docs/reasoning_interface_contract.md` — append a "Domain-agnostic envelope (M5-alpha)" section documenting:
- the new envelope types,
- how vendor-pressure becomes one specialization of the envelope in M5-β,
- the additive path for adding a second domain (transcript, company entity, etc.).

The v1 vendor-pressure contract sections above remain the source of truth for the current churn-reasoning surface; the new section is forward-looking.

## Behavior-change statement

Zero. No existing producer or consumer code is modified. The new types live alongside the legacy `ReasoningResult`. Domain registry starts empty (no autoload).

## Contract impact

Additive. The interface-contract doc gains a new section; the existing required-keys contract is unchanged.

## Rollback plan

Revert. Single new file (`domains.py`), single new test file, one re-export line, one CI test entry, one doc-section append.

## Verification

```
$ python3 -m pytest tests/test_extracted_reasoning_core_domains.py -q
.....................                                                    [100%]
21 passed in 0.07s

$ python3 -c "from extracted_reasoning_core import (
      DomainReasoningResult, ReferenceIds, ReasoningSubject,
      ReasoningProducerPort, ReasoningConsumerPort,
      register_domain, get_domain, list_domains,
  )"
# (no output, exit 0)

$ python3 -c "from extracted_reasoning_core.domains import list_domains; print(list_domains())"
()   # registry is empty at import time -- no autoload
```

## Plan reference

`docs/hybrid_extraction_plan_status_2026-05-05.md` § "M5-α — Generic reasoning protocols in `extracted_reasoning_core/`".

## Next: M5-β

Once this lands, M5-β refactors `atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py` into a generic-universal-fields layer plus a vendor-pressure-specific layer, and re-types `CampaignReasoningProviderPort` as `ReasoningProducerPort[VendorOpportunity, VendorPressurePayload]`. No wire-shape change for current consumers; adding a second domain after that becomes purely additive.

---
_Generated by [Claude Code](https://claude.ai/code/session_017k4xQ6eLxysGkgLnGv4noh)_