### PR TITLE
PR-D2: llm_gateway product + plan tier (LLM Gateway MVP)

### DIFF
--- a/atlas_brain/api/auth.py
+++ b/atlas_brain/api/auth.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 # -- Request/Response schemas --
 
-VALID_PRODUCTS = {"consumer", "b2b_retention", "b2b_challenger"}
+VALID_PRODUCTS = {"consumer", "b2b_retention", "b2b_challenger", "llm_gateway"}
 
 
 class RegisterRequest(BaseModel):

--- a/atlas_brain/api/auth.py
+++ b/atlas_brain/api/auth.py
@@ -126,13 +126,21 @@ async def register(req: RegisterRequest):
 
     product = req.product if req.product in VALID_PRODUCTS else "consumer"
     is_b2b = product in ("b2b_retention", "b2b_challenger")
+    is_llm_gateway = product == "llm_gateway"
 
     cfg = settings.saas_auth
     trial_ends = datetime.now(timezone.utc) + timedelta(days=cfg.trial_days)
     trial_asin_limit = PLAN_LIMITS.get("trial", {}).get("asins", 5)
 
-    # B2B accounts get b2b_trial plan with 1 vendor; consumer gets trial with ASINs
-    plan = "b2b_trial" if is_b2b else "trial"
+    # Trial plan is product-specific so the corresponding require_*_plan
+    # gate accepts the new account. B2B -> b2b_trial; LLM Gateway ->
+    # llm_trial; consumer (default) -> trial.
+    if is_llm_gateway:
+        plan = "llm_trial"
+    elif is_b2b:
+        plan = "b2b_trial"
+    else:
+        plan = "trial"
     vendor_limit = 1
 
     # Use a transaction so account + user are created atomically

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -89,6 +89,10 @@ PLAN_NAME_TO_CONFIG_KEY = {
     "b2b_starter": "stripe_b2b_starter_price_id",
     "b2b_growth": "stripe_b2b_growth_price_id",
     "b2b_pro": "stripe_b2b_pro_price_id",
+    # LLM Gateway plan tiers (PR-D2)
+    "llm_starter": "stripe_llm_starter_price_id",
+    "llm_growth": "stripe_llm_growth_price_id",
+    "llm_pro": "stripe_llm_pro_price_id",
 }
 
 
@@ -147,6 +151,8 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
         v for v in [
             _cfg.stripe_starter_price_id, _cfg.stripe_growth_price_id, _cfg.stripe_pro_price_id,
             _cfg.stripe_b2b_starter_price_id, _cfg.stripe_b2b_growth_price_id, _cfg.stripe_b2b_pro_price_id,
+            # LLM Gateway plan tiers (PR-D2)
+            _cfg.stripe_llm_starter_price_id, _cfg.stripe_llm_growth_price_id, _cfg.stripe_llm_pro_price_id,
         ]
         if v
     }

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -29,6 +29,18 @@ B2B_PLAN_LIMITS = {
     "b2b_pro":     {"vendors": -1, "campaigns": True,  "reports": True, "api": True},
 }
 
+# LLM Gateway plan tiers (PR-D2). monthly_token_limit is advertised
+# here but enforced in PR-D4 against per-account llm_usage rows;
+# byok_keys_max gates how many provider API keys a customer can store
+# (PR-D5). cache_enabled / batch_enabled are feature gates for the
+# /api/v1/llm/* router.
+LLM_PLAN_LIMITS = {
+    "llm_trial":   {"monthly_token_limit": 1_000_000,   "cache_enabled": True, "batch_enabled": False, "byok_keys_max": 2},
+    "llm_starter": {"monthly_token_limit": 10_000_000,  "cache_enabled": True, "batch_enabled": True,  "byok_keys_max": 4},
+    "llm_growth":  {"monthly_token_limit": 100_000_000, "cache_enabled": True, "batch_enabled": True,  "byok_keys_max": 10},
+    "llm_pro":     {"monthly_token_limit": -1,          "cache_enabled": True, "batch_enabled": True,  "byok_keys_max": -1},
+}
+
 PRICE_TO_PLAN = {}  # populated at module init from config
 
 
@@ -50,6 +62,13 @@ def _init_price_map():
         PRICE_TO_PLAN[cfg.stripe_vendor_standard_price_id] = "vendor_standard"
     if cfg.stripe_vendor_pro_price_id:
         PRICE_TO_PLAN[cfg.stripe_vendor_pro_price_id] = "vendor_pro"
+    # LLM Gateway plan tiers (PR-D2)
+    if cfg.stripe_llm_starter_price_id:
+        PRICE_TO_PLAN[cfg.stripe_llm_starter_price_id] = "llm_starter"
+    if cfg.stripe_llm_growth_price_id:
+        PRICE_TO_PLAN[cfg.stripe_llm_growth_price_id] = "llm_growth"
+    if cfg.stripe_llm_pro_price_id:
+        PRICE_TO_PLAN[cfg.stripe_llm_pro_price_id] = "llm_pro"
 
 
 def _get_stripe():

--- a/atlas_brain/auth/dependencies.py
+++ b/atlas_brain/auth/dependencies.py
@@ -101,9 +101,10 @@ async def require_auth(request: Request) -> AuthUser:
     if row["plan_status"] == "canceled":
         raise HTTPException(status_code=403, detail="Subscription canceled")
 
-    # Check trial expiration
+    # Check trial expiration -- includes llm_trial (PR-D2) so LLM
+    # Gateway trial accounts also expire after trial_days.
     trial_ends = row["trial_ends_at"]
-    if row["plan"] in ("trial", "b2b_trial") and trial_ends:
+    if row["plan"] in ("trial", "b2b_trial", "llm_trial") and trial_ends:
         # Ensure timezone-aware comparison
         te = trial_ends if trial_ends.tzinfo else trial_ends.replace(tzinfo=timezone.utc)
         if te < datetime.now(timezone.utc):
@@ -336,8 +337,10 @@ async def require_api_key(request: Request) -> AuthUser:
     if account_row["plan_status"] == "canceled":
         raise HTTPException(status_code=403, detail="Subscription canceled")
 
+    # Trial expiration check includes llm_trial (PR-D2). Mirrors the
+    # same check in require_auth so JWT and API-key paths are consistent.
     trial_ends = account_row["trial_ends_at"]
-    if account_row["plan"] in ("trial", "b2b_trial") and trial_ends:
+    if account_row["plan"] in ("trial", "b2b_trial", "llm_trial") and trial_ends:
         te = trial_ends if trial_ends.tzinfo else trial_ends.replace(tzinfo=timezone.utc)
         if te < datetime.now(timezone.utc):
             raise HTTPException(status_code=403, detail="Trial expired")

--- a/atlas_brain/auth/dependencies.py
+++ b/atlas_brain/auth/dependencies.py
@@ -12,6 +12,7 @@ from .jwt import decode_token
 
 PLAN_ORDER = ["trial", "starter", "growth", "pro"]
 B2B_PLAN_ORDER = ["b2b_trial", "b2b_starter", "b2b_growth", "b2b_pro"]
+LLM_GATEWAY_PLAN_ORDER = ["llm_trial", "llm_starter", "llm_growth", "llm_pro"]
 
 
 @dataclass
@@ -226,6 +227,46 @@ def require_b2b_plan(min_plan: str):
                 detail="B2B product required",
             )
         user_idx = B2B_PLAN_ORDER.index(user.plan) if user.plan in B2B_PLAN_ORDER else -1
+        if user_idx < min_idx:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Plan '{min_plan}' or higher required (current: '{user.plan}')",
+            )
+        return user
+
+    return _check
+
+
+def require_llm_plan(min_plan: str):
+    """Return a dependency that enforces a minimum LLM-Gateway plan tier.
+
+    Mirrors ``require_b2b_plan``: enforces both the product binding
+    (``user.product == "llm_gateway"``) and the plan ordering. Used
+    by PR-D4's ``/api/v1/llm/*`` router to gate per-tier feature
+    access.
+    """
+    if min_plan not in LLM_GATEWAY_PLAN_ORDER:
+        raise ValueError(
+            f"Invalid LLM Gateway plan tier '{min_plan}'. Expected one of {LLM_GATEWAY_PLAN_ORDER}"
+        )
+    min_idx = LLM_GATEWAY_PLAN_ORDER.index(min_plan)
+
+    async def _check(user: AuthUser = Depends(require_auth)) -> AuthUser:
+        if user.plan_status == "past_due":
+            raise HTTPException(
+                status_code=402,
+                detail="Payment past due",
+            )
+        if user.product != "llm_gateway":
+            raise HTTPException(
+                status_code=403,
+                detail="LLM Gateway product required",
+            )
+        user_idx = (
+            LLM_GATEWAY_PLAN_ORDER.index(user.plan)
+            if user.plan in LLM_GATEWAY_PLAN_ORDER
+            else -1
+        )
         if user_idx < min_idx:
             raise HTTPException(
                 status_code=403,

--- a/atlas_brain/auth/rate_limit.py
+++ b/atlas_brain/auth/rate_limit.py
@@ -18,6 +18,13 @@ PLAN_RATE_LIMITS: dict[str, str] = {
     "starter": "100/hour",
     "growth": "1000/hour",
     "pro": "10000/hour",
+    # LLM Gateway plan tiers (PR-D2). The gateway endpoints
+    # (PR-D4) are higher-throughput than dashboard reads -- bumped
+    # an order of magnitude over consumer/B2B equivalents.
+    "llm_trial": "100/hour",
+    "llm_starter": "1000/hour",
+    "llm_growth": "10000/hour",
+    "llm_pro": "100000/hour",
 }
 
 _DEFAULT_LIMIT = "100/hour"

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -65,6 +65,13 @@ class SaaSAuthConfig(BaseSettings):
     stripe_vendor_standard_price_id: str = Field(default="", description="Stripe Price ID for Vendor Standard ($499/mo)")
     stripe_vendor_pro_price_id: str = Field(default="", description="Stripe Price ID for Vendor Pro ($1,499/mo)")
 
+    # LLM Gateway plan tiers (PR-D2). Stripe products are created
+    # operationally; the price IDs land here when ready, _init_price_map()
+    # in api/billing.py picks them up.
+    stripe_llm_starter_price_id: str = Field(default="", description="Stripe Price ID for LLM Gateway Starter plan")
+    stripe_llm_growth_price_id: str = Field(default="", description="Stripe Price ID for LLM Gateway Growth plan")
+    stripe_llm_pro_price_id: str = Field(default="", description="Stripe Price ID for LLM Gateway Pro plan")
+
     # API key (LLM Gateway, PR-D1) -- HMAC pepper for hashing customer API keys.
     # Pepper is server-wide; raw keys are 160-bit random so a per-key salt
     # would only add cost. The default sentinel "api-key-pepper-change-me"

--- a/tests/test_llm_gateway_plan_tier.py
+++ b/tests/test_llm_gateway_plan_tier.py
@@ -1,0 +1,187 @@
+"""Tests for the LLM Gateway plan tier (PR-D2).
+
+Pins the contract that ``llm_gateway`` is a first-class product with
+its own plan ordering, rate limits, and feature limits -- without
+touching the existing consumer / B2B / vendor plan tables.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---- Plan ordering -------------------------------------------------------
+
+
+def test_llm_gateway_plan_order_present():
+    from atlas_brain.auth.dependencies import LLM_GATEWAY_PLAN_ORDER
+
+    assert LLM_GATEWAY_PLAN_ORDER == [
+        "llm_trial",
+        "llm_starter",
+        "llm_growth",
+        "llm_pro",
+    ]
+
+
+def test_llm_gateway_plan_order_distinct_from_consumer():
+    """A consumer-tier user must not satisfy a require_llm_plan check
+    -- the namespaces must not overlap."""
+    from atlas_brain.auth.dependencies import (
+        LLM_GATEWAY_PLAN_ORDER,
+        PLAN_ORDER,
+        B2B_PLAN_ORDER,
+    )
+
+    assert set(LLM_GATEWAY_PLAN_ORDER).isdisjoint(set(PLAN_ORDER))
+    assert set(LLM_GATEWAY_PLAN_ORDER).isdisjoint(set(B2B_PLAN_ORDER))
+
+
+# ---- require_llm_plan -----------------------------------------------------
+
+
+def test_require_llm_plan_rejects_unknown_tier():
+    from atlas_brain.auth.dependencies import require_llm_plan
+
+    with pytest.raises(ValueError, match="Invalid LLM Gateway plan tier 'starter'"):
+        require_llm_plan("starter")
+
+
+def test_require_llm_plan_rejects_b2b_tier():
+    from atlas_brain.auth.dependencies import require_llm_plan
+
+    with pytest.raises(ValueError, match="Invalid LLM Gateway plan tier 'b2b_pro'"):
+        require_llm_plan("b2b_pro")
+
+
+def test_require_llm_plan_accepts_known_tiers():
+    from atlas_brain.auth.dependencies import (
+        LLM_GATEWAY_PLAN_ORDER,
+        require_llm_plan,
+    )
+
+    for plan in LLM_GATEWAY_PLAN_ORDER:
+        dep = require_llm_plan(plan)
+        assert callable(dep)
+
+
+# ---- VALID_PRODUCTS -------------------------------------------------------
+
+
+def test_valid_products_includes_llm_gateway():
+    from atlas_brain.api.auth import VALID_PRODUCTS
+
+    assert "llm_gateway" in VALID_PRODUCTS
+
+
+def test_valid_products_does_not_drop_existing_tiers():
+    """Adding llm_gateway must not regress the existing product set."""
+    from atlas_brain.api.auth import VALID_PRODUCTS
+
+    for existing in ("consumer", "b2b_retention", "b2b_challenger"):
+        assert existing in VALID_PRODUCTS
+
+
+# ---- PLAN_RATE_LIMITS -----------------------------------------------------
+
+
+def test_plan_rate_limits_covers_llm_tiers():
+    from atlas_brain.auth.rate_limit import PLAN_RATE_LIMITS
+
+    assert PLAN_RATE_LIMITS["llm_trial"] == "100/hour"
+    assert PLAN_RATE_LIMITS["llm_starter"] == "1000/hour"
+    assert PLAN_RATE_LIMITS["llm_growth"] == "10000/hour"
+    assert PLAN_RATE_LIMITS["llm_pro"] == "100000/hour"
+
+
+def test_plan_rate_limits_lookup_via_dynamic_limit():
+    """``_dynamic_limit`` is the slowapi callable that maps the
+    composite rate-limit key back to a rate string. It must resolve
+    LLM-Gateway plans to the right rate."""
+    from atlas_brain.auth.rate_limit import _dynamic_limit
+
+    assert _dynamic_limit("llm_starter|account-uuid") == "1000/hour"
+    assert _dynamic_limit("llm_pro|account-uuid") == "100000/hour"
+
+
+def test_plan_rate_limits_unknown_plan_falls_back():
+    """Unknown plans (e.g. legacy or future tiers) get the default
+    instead of raising -- prevents a config drift from producing 500s."""
+    from atlas_brain.auth.rate_limit import _DEFAULT_LIMIT, _dynamic_limit
+
+    assert _dynamic_limit("future_plan|x") == _DEFAULT_LIMIT
+
+
+# ---- LLM_PLAN_LIMITS ------------------------------------------------------
+
+
+def test_llm_plan_limits_shape():
+    from atlas_brain.api.billing import LLM_PLAN_LIMITS
+
+    expected_keys = {"monthly_token_limit", "cache_enabled", "batch_enabled", "byok_keys_max"}
+    for plan in ("llm_trial", "llm_starter", "llm_growth", "llm_pro"):
+        assert plan in LLM_PLAN_LIMITS
+        assert set(LLM_PLAN_LIMITS[plan].keys()) == expected_keys
+
+
+def test_llm_plan_limits_pro_is_unlimited():
+    """``-1`` is the unlimited sentinel used elsewhere in PLAN_LIMITS
+    (B2B Pro vendors=-1). Reusing the same convention here keeps
+    enforcement code simple."""
+    from atlas_brain.api.billing import LLM_PLAN_LIMITS
+
+    assert LLM_PLAN_LIMITS["llm_pro"]["monthly_token_limit"] == -1
+    assert LLM_PLAN_LIMITS["llm_pro"]["byok_keys_max"] == -1
+
+
+def test_llm_plan_limits_trial_disables_batch():
+    """Anthropic batch is the 50% cost-saver feature -- reserved for
+    paying tiers so the trial cannot abuse it for free volume."""
+    from atlas_brain.api.billing import LLM_PLAN_LIMITS
+
+    assert LLM_PLAN_LIMITS["llm_trial"]["batch_enabled"] is False
+    assert LLM_PLAN_LIMITS["llm_starter"]["batch_enabled"] is True
+    assert LLM_PLAN_LIMITS["llm_growth"]["batch_enabled"] is True
+    assert LLM_PLAN_LIMITS["llm_pro"]["batch_enabled"] is True
+
+
+def test_llm_plan_limits_token_caps_increase_monotonically():
+    """Higher-tier plans always have at-least-as-large quotas (with
+    -1 = unlimited treated as max). Catches a config-edit regression."""
+    from atlas_brain.api.billing import LLM_PLAN_LIMITS
+
+    quotas = [
+        LLM_PLAN_LIMITS[t]["monthly_token_limit"]
+        for t in ("llm_trial", "llm_starter", "llm_growth", "llm_pro")
+    ]
+    # Replace the unlimited sentinel for the comparison.
+    normalized = [10**18 if q == -1 else q for q in quotas]
+    assert normalized == sorted(normalized)
+
+
+# ---- PRICE_TO_PLAN init -------------------------------------------------
+
+
+def test_init_price_map_picks_up_llm_price_ids(monkeypatch):
+    """When the Stripe price IDs land in the env, ``_init_price_map``
+    must surface them in ``PRICE_TO_PLAN`` so checkout webhooks
+    resolve to the right plan tier."""
+    monkeypatch.setenv("ATLAS_SAAS_ENABLED", "false")
+    monkeypatch.setenv("ATLAS_SAAS_STRIPE_LLM_STARTER_PRICE_ID", "price_starter_test")
+    monkeypatch.setenv("ATLAS_SAAS_STRIPE_LLM_GROWTH_PRICE_ID", "price_growth_test")
+    monkeypatch.setenv("ATLAS_SAAS_STRIPE_LLM_PRO_PRICE_ID", "price_pro_test")
+
+    import importlib
+    import atlas_brain.config as config_mod
+
+    importlib.reload(config_mod)
+
+    import atlas_brain.api.billing as billing_mod
+
+    importlib.reload(billing_mod)
+    billing_mod.PRICE_TO_PLAN.clear()
+    billing_mod._init_price_map()
+
+    assert billing_mod.PRICE_TO_PLAN["price_starter_test"] == "llm_starter"
+    assert billing_mod.PRICE_TO_PLAN["price_growth_test"] == "llm_growth"
+    assert billing_mod.PRICE_TO_PLAN["price_pro_test"] == "llm_pro"

--- a/tests/test_llm_gateway_plan_tier.py
+++ b/tests/test_llm_gateway_plan_tier.py
@@ -185,3 +185,53 @@ def test_init_price_map_picks_up_llm_price_ids(monkeypatch):
     assert billing_mod.PRICE_TO_PLAN["price_starter_test"] == "llm_starter"
     assert billing_mod.PRICE_TO_PLAN["price_growth_test"] == "llm_growth"
     assert billing_mod.PRICE_TO_PLAN["price_pro_test"] == "llm_pro"
+
+
+# ---- Codex fixes (post-review on PR-D2) ----------------------------------
+
+
+def test_plan_name_to_config_key_covers_llm_tiers():
+    """Codex P1 #2 fix: ``create_checkout`` resolves ``plan='llm_*'``
+    via this dict. Without the mapping, customers cannot upgrade from
+    llm_trial to a paid LLM tier through the normal checkout path."""
+    from atlas_brain.api.billing import PLAN_NAME_TO_CONFIG_KEY
+
+    assert PLAN_NAME_TO_CONFIG_KEY["llm_starter"] == "stripe_llm_starter_price_id"
+    assert PLAN_NAME_TO_CONFIG_KEY["llm_growth"] == "stripe_llm_growth_price_id"
+    assert PLAN_NAME_TO_CONFIG_KEY["llm_pro"] == "stripe_llm_pro_price_id"
+
+
+def test_register_assigns_llm_trial_for_llm_gateway_product():
+    """Codex P1 #1 fix: a new account with ``product=llm_gateway``
+    must land on the ``llm_trial`` plan -- otherwise
+    ``require_llm_plan('llm_trial')`` rejects the brand-new self-serve
+    user because plan='trial' (consumer) is not in
+    LLM_GATEWAY_PLAN_ORDER. We verify the assignment logic at the
+    source-text level since the actual registration flow is DB-bound;
+    integration tests against a live Postgres are a separate fixture."""
+    import inspect
+
+    from atlas_brain.api.auth import register
+
+    src = inspect.getsource(register)
+    assert 'is_llm_gateway = product == "llm_gateway"' in src
+    assert 'plan = "llm_trial"' in src
+
+
+def test_trial_expiration_check_includes_llm_trial():
+    """Codex P2 fix: trial-expiration checks in both ``require_auth``
+    and ``require_api_key`` must include ``llm_trial`` so an expired
+    LLM trial cannot keep authenticating after ``trial_ends_at``."""
+    import inspect
+
+    from atlas_brain.auth.dependencies import require_auth, require_api_key
+
+    auth_src = inspect.getsource(require_auth)
+    api_src = inspect.getsource(require_api_key)
+
+    assert '"llm_trial"' in auth_src, (
+        "require_auth's trial-expiration check must include llm_trial"
+    )
+    assert '"llm_trial"' in api_src, (
+        "require_api_key's trial-expiration check must include llm_trial"
+    )


### PR DESCRIPTION
## Summary

Second PR of the LLM Gateway MVP (per [docs/products/llm_gateway_mvp_plan.md](docs/products/llm_gateway_mvp_plan.md)). Pure plumbing: extends the existing multi-tenant auth + billing + rate-limiter substrate to recognize a fourth product (`llm_gateway`) with its own plan ordering.

Atlas's `saas_accounts.product` field already supports `consumer / b2b_retention / b2b_challenger`; this PR adds `llm_gateway` as the fourth value alongside the helpers that gate on it. **No new tables, no migrations, no public-API signature changes.** Existing products (PLAN_ORDER, B2B_PLAN_ORDER, require_plan, require_b2b_plan) are untouched.

## Changes

| File | What |
|---|---|
| `atlas_brain/config.py` | + `stripe_llm_starter_price_id`, `stripe_llm_growth_price_id`, `stripe_llm_pro_price_id` on `SaaSAuthConfig`. Env: `ATLAS_SAAS_STRIPE_LLM_*_PRICE_ID`. |
| `atlas_brain/api/billing.py` | + `LLM_PLAN_LIMITS` dict (`monthly_token_limit`, `cache_enabled`, `batch_enabled`, `byok_keys_max`). + `_init_price_map()` picks up the 3 new IDs into `PRICE_TO_PLAN` so checkout webhooks resolve to `llm_*` plans. |
| `atlas_brain/auth/dependencies.py` | + `LLM_GATEWAY_PLAN_ORDER`. + `require_llm_plan(min_plan)` helper mirroring `require_b2b_plan` -- gates on `user.product == "llm_gateway"` + tier ordering. |
| `atlas_brain/auth/rate_limit.py` | + 4 entries in `PLAN_RATE_LIMITS` (100/hr trial → 100k/hr pro). An order of magnitude higher than consumer/B2B because gateway calls are script-driven. |
| `atlas_brain/api/auth.py` | + `"llm_gateway"` in `VALID_PRODUCTS` so `/auth/register` accepts it. |
| `tests/test_llm_gateway_plan_tier.py` | NEW (15 tests). |

## Plan tier shape

| | `llm_trial` | `llm_starter` | `llm_growth` | `llm_pro` |
|---|---|---|---|---|
| Monthly tokens | 1M | 10M | 100M | unlimited |
| Cache | ✅ | ✅ | ✅ | ✅ |
| Anthropic batch (50% disc.) | ❌ | ✅ | ✅ | ✅ |
| BYOK provider keys max | 2 | 4 | 10 | unlimited |
| Rate limit (req/hour) | 100 | 1,000 | 10,000 | 100,000 |

`monthly_token_limit` and `byok_keys_max` are advertised here but enforced in PR-D4 (against `llm_usage`) / PR-D5 (against `byok_keys`). `cache_enabled` and `batch_enabled` are feature gates the PR-D4 router will check directly.

## Why batch is reserved for paying tiers

Anthropic's Message Batches API delivers 50% off — that's our wedge feature. Reserving it for `llm_starter+` ensures the trial tier can't abuse it for free volume.

## Validation

```
$ pytest tests/test_llm_gateway_plan_tier.py tests/test_auth_dependencies.py tests/test_auth_api_keys.py -q
45 passed in 4.77s
```

15 new tests pin: plan-order shape + namespace disjoint from consumer/B2B; `require_llm_plan` rejects unknown / B2B / consumer tiers and accepts all 4 LLM tiers; `VALID_PRODUCTS` adds without dropping; `PLAN_RATE_LIMITS` resolves via `_dynamic_limit`; `LLM_PLAN_LIMITS` shape + monotonic token caps + batch-tier gating; `_init_price_map` picks up the new IDs.

## Plan reference

This PR is **PR-D2** in `docs/products/llm_gateway_mvp_plan.md`.

Next: **PR-D3** — per-account scoping on `llm_usage` + `b2b_llm_exact_cache` + `reasoning_semantic_cache` (riskiest of the series; sentinel-account approach mitigates the atlas-pipeline regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
