### PR TITLE
PR-D3: Per-account scoping on llm_usage + caches (LLM Gateway MVP)

### DIFF
--- a/atlas_brain/autonomous/tasks/ecosystem_analysis.py
+++ b/atlas_brain/autonomous/tasks/ecosystem_analysis.py
@@ -77,7 +77,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, $8
                 )
-                ON CONFLICT (pattern_sig) DO UPDATE SET
+                ON CONFLICT (pattern_sig, account_id) DO UPDATE SET
                     conclusion = EXCLUDED.conclusion,
                     confidence = EXCLUDED.confidence,
                     last_validated_at = EXCLUDED.last_validated_at,
@@ -107,7 +107,7 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, $8
                 )
-                ON CONFLICT (pattern_sig) DO UPDATE SET
+                ON CONFLICT (pattern_sig, account_id) DO UPDATE SET
                     conclusion = EXCLUDED.conclusion,
                     confidence = EXCLUDED.confidence,
                     last_validated_at = EXCLUDED.last_validated_at,

--- a/atlas_brain/reasoning/semantic_cache.py
+++ b/atlas_brain/reasoning/semantic_cache.py
@@ -303,34 +303,39 @@ class SemanticCache:
                 """
                 SELECT * FROM reasoning_semantic_cache
                 WHERE conclusion_type = $1 AND product_category = $2
-                  AND invalidated_at IS NULL
+                  AND account_id = $3 AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $3
+                LIMIT $4
                 """,
                 conclusion_type,
                 product_category,
+                self._account_id,
                 limit,
             )
         elif vendor_name:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE vendor_name = $1 AND invalidated_at IS NULL
+                WHERE vendor_name = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 vendor_name,
+                self._account_id,
                 limit,
             )
         else:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE conclusion_type = $1 AND invalidated_at IS NULL
+                WHERE conclusion_type = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 conclusion_type,
+                self._account_id,
                 limit,
             )
         entries = []
@@ -342,7 +347,11 @@ class SemanticCache:
         return entries
 
     async def get_cache_stats(self) -> dict[str, Any]:
-        """Aggregate stats for metacognition tracking."""
+        """Aggregate stats for metacognition tracking.
+
+        Scoped to ``self._account_id`` so tenant A's stats never
+        include tenant B's rows.
+        """
         row = await self._pool.fetchrow(
             """
             SELECT
@@ -351,7 +360,9 @@ class SemanticCache:
                 AVG(confidence) FILTER (WHERE invalidated_at IS NULL) AS avg_confidence,
                 AVG(validation_count) FILTER (WHERE invalidated_at IS NULL) AS avg_validations
             FROM reasoning_semantic_cache
-            """
+            WHERE account_id = $1
+            """,
+            self._account_id,
         )
         if row is None:
             return {"active": 0, "invalidated": 0, "avg_confidence": 0, "avg_validations": 0}

--- a/atlas_brain/reasoning/semantic_cache.py
+++ b/atlas_brain/reasoning/semantic_cache.py
@@ -78,14 +78,35 @@ class SemanticCache:
     # constant in core's ``semantic_cache_keys`` is the canonical home.
     STALE_THRESHOLD = _CORE_STALE_THRESHOLD
 
-    def __init__(self, pool: SemanticCachePool):
+    # Sentinel account UUID for atlas's internal pipeline (PR-D3).
+    # Atlas's existing reasoning calls write to the cache without
+    # knowing about accounts; the sentinel marks those rows so
+    # customer cache hits cannot leak across tenants.
+    SENTINEL_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+    def __init__(
+        self,
+        pool: SemanticCachePool,
+        *,
+        account_id: str = SENTINEL_ACCOUNT_ID,
+    ):
         """*pool*: any object exposing the ``SemanticCachePool``
         contract (``fetchrow`` / ``fetch`` / ``execute`` coroutine
         methods that speak Postgres dialect). The atlas
         ``DatabasePool`` wrapper and a raw asyncpg ``Pool`` both
         satisfy this Protocol.
+
+        *account_id*: scopes every read/write to the given account
+        (PR-D3). Defaults to the SENTINEL so atlas's existing
+        instantiations keep working unmodified. Customer-facing
+        callers (PR-D4 LLM Gateway router) construct a new instance
+        per request with the requesting account's UUID, so cross-
+        tenant cache hits are impossible -- the (pattern_sig,
+        account_id) UNIQUE constraint guarantees isolation at the
+        storage layer.
         """
         self._pool = pool
+        self._account_id = account_id
 
     # ------------------------------------------------------------------
     # Core operations
@@ -99,9 +120,11 @@ class SemanticCache:
         row = await self._pool.fetchrow(
             """
             SELECT * FROM reasoning_semantic_cache
-            WHERE pattern_sig = $1 AND invalidated_at IS NULL
+            WHERE pattern_sig = $1 AND account_id = $2
+              AND invalidated_at IS NULL
             """,
             pattern_sig,
+            self._account_id,
         )
         if row is None:
             return None
@@ -122,16 +145,16 @@ class SemanticCache:
         await self._pool.execute(
             """
             INSERT INTO reasoning_semantic_cache (
-                pattern_sig, pattern_class, vendor_name, product_category,
-                conclusion, confidence, reasoning_steps, boundary_conditions,
-                falsification_conditions, uncertainty_sources,
-                decay_half_life_days, conclusion_type, evidence_hash,
-                last_validated_at, validation_count
+                pattern_sig, account_id, pattern_class, vendor_name,
+                product_category, conclusion, confidence, reasoning_steps,
+                boundary_conditions, falsification_conditions,
+                uncertainty_sources, decay_half_life_days, conclusion_type,
+                evidence_hash, last_validated_at, validation_count
             ) VALUES (
-                $1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8::jsonb,
-                $9::jsonb, $10, $11, $12, $13, NOW(), 1
+                $1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9::jsonb,
+                $10::jsonb, $11, $12, $13, $14, NOW(), 1
             )
-            ON CONFLICT (pattern_sig) DO UPDATE SET
+            ON CONFLICT (pattern_sig, account_id) DO UPDATE SET
                 pattern_class = EXCLUDED.pattern_class,
                 vendor_name = EXCLUDED.vendor_name,
                 product_category = EXCLUDED.product_category,
@@ -149,6 +172,7 @@ class SemanticCache:
                 invalidated_at = NULL
             """,
             entry.pattern_sig,
+            self._account_id,
             entry.pattern_class,
             entry.vendor_name,
             entry.product_category,
@@ -172,10 +196,12 @@ class SemanticCache:
                 UPDATE reasoning_semantic_cache
                 SET last_validated_at = NOW(),
                     validation_count = validation_count + 1,
-                    confidence = $2
-                WHERE pattern_sig = $1 AND invalidated_at IS NULL
+                    confidence = $3
+                WHERE pattern_sig = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 """,
                 pattern_sig,
+                self._account_id,
                 new_confidence,
             )
         else:
@@ -184,9 +210,11 @@ class SemanticCache:
                 UPDATE reasoning_semantic_cache
                 SET last_validated_at = NOW(),
                     validation_count = validation_count + 1
-                WHERE pattern_sig = $1 AND invalidated_at IS NULL
+                WHERE pattern_sig = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 """,
                 pattern_sig,
+                self._account_id,
             )
 
     async def invalidate(self, pattern_sig: str, reason: str = "") -> None:
@@ -195,9 +223,11 @@ class SemanticCache:
             """
             UPDATE reasoning_semantic_cache
             SET invalidated_at = NOW()
-            WHERE pattern_sig = $1 AND invalidated_at IS NULL
+            WHERE pattern_sig = $1 AND account_id = $2
+              AND invalidated_at IS NULL
             """,
             pattern_sig,
+            self._account_id,
         )
         logger.info("Invalidated cache entry: %s (reason: %s)", pattern_sig, reason)
 
@@ -214,34 +244,40 @@ class SemanticCache:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE vendor_name = $1 AND invalidated_at IS NULL
+                WHERE vendor_name = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 vendor_name,
+                self._account_id,
                 limit,
             )
         elif vendor_name:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE pattern_class = $1 AND vendor_name = $2 AND invalidated_at IS NULL
+                WHERE pattern_class = $1 AND vendor_name = $2
+                  AND account_id = $3 AND invalidated_at IS NULL
                 ORDER BY confidence DESC
-                LIMIT $3
+                LIMIT $4
                 """,
                 pattern_class,
                 vendor_name,
+                self._account_id,
                 limit,
             )
         else:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE pattern_class = $1 AND invalidated_at IS NULL
+                WHERE pattern_class = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY confidence DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 pattern_class,
+                self._account_id,
                 limit,
             )
         entries = []

--- a/atlas_brain/services/b2b/llm_exact_cache.py
+++ b/atlas_brain/services/b2b/llm_exact_cache.py
@@ -225,13 +225,28 @@ def _json_field_to_mapping(value: Any) -> dict[str, Any]:
     return {}
 
 
+# Sentinel account UUID for atlas's internal pipeline calls (PR-D3).
+# Atlas's existing pipeline writes to this cache 100k+ times/month
+# without knowing about accounts; the sentinel marks those rows so
+# customer cache hits cannot leak across tenants.
+SENTINEL_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+
 async def lookup_cached_text(
     namespace: str,
     request_envelope: dict[str, Any],
     *,
     pool: Any | None = None,
+    account_id: str = SENTINEL_ACCOUNT_ID,
 ) -> B2BLLMExactCacheHit | None:
-    """Return the cached text for an exact request envelope."""
+    """Return the cached text for an exact request envelope.
+
+    ``account_id`` defaults to the SENTINEL so atlas's existing
+    pipeline keeps working unmodified. Customer-facing callers
+    (PR-D4 LLM Gateway router) pass the requesting account's UUID
+    so cross-tenant hits are impossible -- the (cache_key, account_id)
+    composite PK guarantees isolation at the storage layer.
+    """
     if not namespace or not is_b2b_llm_exact_cache_enabled():
         return None
 
@@ -246,7 +261,7 @@ async def lookup_cached_text(
             UPDATE b2b_llm_exact_cache
             SET last_hit_at = NOW(),
                 hit_count = hit_count + 1
-            WHERE cache_key = $1
+            WHERE cache_key = $1 AND account_id = $2
             RETURNING cache_key, namespace, provider, model,
                       response_text, usage_json, metadata,
                       created_at, last_hit_at, hit_count
@@ -254,6 +269,7 @@ async def lookup_cached_text(
         SELECT * FROM hit
         """,
         cache_key,
+        account_id,
     )
     if row is None:
         return None
@@ -283,8 +299,14 @@ async def store_cached_text(
     usage: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     pool: Any | None = None,
+    account_id: str = SENTINEL_ACCOUNT_ID,
 ) -> bool:
-    """Store a successful exact-match response."""
+    """Store a successful exact-match response.
+
+    ``account_id`` defaults to the SENTINEL so atlas's existing
+    pipeline keeps writing to its own cache namespace. Customer-
+    facing callers pass the requesting account's UUID.
+    """
     if (
         not namespace
         or not response_text
@@ -305,11 +327,12 @@ async def store_cached_text(
     await db_pool.execute(
         """
         INSERT INTO b2b_llm_exact_cache (
-            cache_key, namespace, provider, model, response_text, usage_json, metadata
+            cache_key, account_id, namespace, provider, model,
+            response_text, usage_json, metadata
         ) VALUES (
-            $1, $2, $3, $4, $5, $6::jsonb, $7::jsonb
+            $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb
         )
-        ON CONFLICT (cache_key) DO UPDATE SET
+        ON CONFLICT (cache_key, account_id) DO UPDATE SET
             provider = EXCLUDED.provider,
             model = EXCLUDED.model,
             response_text = EXCLUDED.response_text,
@@ -317,6 +340,7 @@ async def store_cached_text(
             metadata = EXCLUDED.metadata
         """,
         cache_key,
+        account_id,
         namespace,
         str(provider or ""),
         str(model or ""),

--- a/atlas_brain/services/tracing.py
+++ b/atlas_brain/services/tracing.py
@@ -496,6 +496,10 @@ class FTLTracingClient:
         event_type = _metadata_text_value(meta, "event_type")
         entity_type = _metadata_text_value(meta, "entity_type")
         entity_id = _metadata_text_value(meta, "entity_id")
+        # PR-D3: account_id rides in metadata (or sentinel for atlas's
+        # internal pipeline). PR-D4's LLM Gateway router will set this
+        # via metadata={"account_id": user.account_id, ...}.
+        account_id_str = _metadata_text_value(meta, "account_id")
 
         try:
             from ..storage.database import get_db_pool
@@ -503,6 +507,10 @@ class FTLTracingClient:
             pool = get_db_pool()
             if not pool.is_initialized:
                 return
+            # PR-D3: account_id read from metadata (set by PR-D4's
+            # LLM Gateway router) or sentinel for atlas's internal
+            # pipeline.
+            account_id = account_id_str or "00000000-0000-0000-0000-000000000000"
             query = """INSERT INTO llm_usage
                        (span_name, operation_type, model_name, model_provider,
                         input_tokens, output_tokens, total_tokens, cost_usd,
@@ -510,8 +518,8 @@ class FTLTracingClient:
                         tokens_per_second, billable_input_tokens, cached_tokens,
                         cache_write_tokens, api_endpoint, provider_request_id,
                         status, metadata, vendor_name, run_id, source_name,
-                        event_type, entity_type, entity_id)
-                       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)"""
+                        event_type, entity_type, entity_id, account_id)
+                       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)"""
             args = (
                 payload.get("span_name", ""),
                 payload.get("operation_type", "llm_call"),
@@ -539,6 +547,7 @@ class FTLTracingClient:
                 event_type,
                 entity_type,
                 entity_id,
+                account_id,
             )
             if use_shared_pool:
                 await pool.execute(query, *args)

--- a/atlas_brain/storage/migrations/313_llm_usage_account_scoping.sql
+++ b/atlas_brain/storage/migrations/313_llm_usage_account_scoping.sql
@@ -1,0 +1,22 @@
+-- Per-account scoping on llm_usage (PR-D3, LLM Gateway MVP).
+--
+-- Atlas's existing pipeline writes to llm_usage 100k+ times/month
+-- without knowing about accounts. The sentinel UUID
+-- '00000000-0000-0000-0000-000000000000' marks those rows as
+-- "atlas internal" so the pipeline keeps working unmodified --
+-- new INSERTs from atlas-side code that omit account_id pick up
+-- the DEFAULT and write SENTINEL.
+--
+-- Customer-facing API endpoints (PR-D4) explicitly thread
+-- account_id from require_api_key()/require_auth(), producing
+-- per-tenant usage rows. Per-account analytics (e.g., monthly
+-- token spend for billing) filter on account_id != SENTINEL or
+-- account_id = $customer_id.
+
+ALTER TABLE llm_usage
+    ADD COLUMN IF NOT EXISTS account_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000000';
+
+-- Per-account analytics: cost-by-day per account.
+CREATE INDEX IF NOT EXISTS idx_llm_usage_account_created
+    ON llm_usage (account_id, created_at DESC);

--- a/atlas_brain/storage/migrations/314_b2b_llm_exact_cache_account_scoping.sql
+++ b/atlas_brain/storage/migrations/314_b2b_llm_exact_cache_account_scoping.sql
@@ -1,0 +1,33 @@
+-- Per-account scoping on b2b_llm_exact_cache (PR-D3, LLM Gateway MVP).
+--
+-- The cache_key is a SHA256 of the canonicalized request envelope
+-- (provider/model/messages/...). Without scoping, customer A and
+-- customer B making the same request would race on the same row.
+-- Composite PK (cache_key, account_id) keeps each account in its
+-- own cache namespace.
+--
+-- Atlas's existing pipeline writes the sentinel UUID via the
+-- DEFAULT, so its cache continuity is preserved (existing rows
+-- become cache_key=X, account_id=SENTINEL).
+
+ALTER TABLE b2b_llm_exact_cache
+    ADD COLUMN IF NOT EXISTS account_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000000';
+
+-- Drop the cache_key-only PK and replace with a composite. The
+-- DROP CONSTRAINT pattern is non-destructive because the new PK
+-- covers every existing row uniquely (sentinel account_id is the
+-- same for all atlas-pipeline rows).
+ALTER TABLE b2b_llm_exact_cache
+    DROP CONSTRAINT IF EXISTS b2b_llm_exact_cache_pkey;
+
+ALTER TABLE b2b_llm_exact_cache
+    ADD CONSTRAINT b2b_llm_exact_cache_pkey
+    PRIMARY KEY (cache_key, account_id);
+
+-- Lookup pattern: WHERE cache_key = $1 AND account_id = $2.
+-- The PK index covers this directly; no extra index needed.
+
+-- Per-account analytics: rows by recency per account.
+CREATE INDEX IF NOT EXISTS idx_b2b_llm_exact_cache_account_last_hit
+    ON b2b_llm_exact_cache (account_id, last_hit_at DESC);

--- a/atlas_brain/storage/migrations/315_reasoning_semantic_cache_account_scoping.sql
+++ b/atlas_brain/storage/migrations/315_reasoning_semantic_cache_account_scoping.sql
@@ -1,0 +1,29 @@
+-- Per-account scoping on reasoning_semantic_cache (PR-D3, LLM Gateway MVP).
+--
+-- pattern_sig was UNIQUE; that becomes UNIQUE(pattern_sig, account_id)
+-- so each account has its own cache namespace. ON CONFLICT clauses
+-- in the application code update from `(pattern_sig)` to
+-- `(pattern_sig, account_id)`.
+--
+-- Atlas's existing rows get the sentinel via DEFAULT and keep
+-- their cache continuity.
+
+ALTER TABLE reasoning_semantic_cache
+    ADD COLUMN IF NOT EXISTS account_id UUID NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000000';
+
+-- Drop the pattern_sig-only UNIQUE and replace with composite.
+-- The constraint name follows Postgres convention (table_col_key);
+-- IF EXISTS guards against environments where it has been renamed.
+ALTER TABLE reasoning_semantic_cache
+    DROP CONSTRAINT IF EXISTS reasoning_semantic_cache_pattern_sig_key;
+
+ALTER TABLE reasoning_semantic_cache
+    ADD CONSTRAINT reasoning_semantic_cache_pattern_sig_account_key
+    UNIQUE (pattern_sig, account_id);
+
+-- The existing partial index idx_rsc_pattern stays; it remains
+-- useful for invalidated_at IS NULL filtering.
+CREATE INDEX IF NOT EXISTS idx_rsc_account_pattern
+    ON reasoning_semantic_cache (account_id, pattern_sig)
+    WHERE invalidated_at IS NULL;

--- a/extracted_llm_infrastructure/reasoning/semantic_cache.py
+++ b/extracted_llm_infrastructure/reasoning/semantic_cache.py
@@ -303,34 +303,39 @@ class SemanticCache:
                 """
                 SELECT * FROM reasoning_semantic_cache
                 WHERE conclusion_type = $1 AND product_category = $2
-                  AND invalidated_at IS NULL
+                  AND account_id = $3 AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $3
+                LIMIT $4
                 """,
                 conclusion_type,
                 product_category,
+                self._account_id,
                 limit,
             )
         elif vendor_name:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE vendor_name = $1 AND invalidated_at IS NULL
+                WHERE vendor_name = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 vendor_name,
+                self._account_id,
                 limit,
             )
         else:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE conclusion_type = $1 AND invalidated_at IS NULL
+                WHERE conclusion_type = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 conclusion_type,
+                self._account_id,
                 limit,
             )
         entries = []
@@ -342,7 +347,11 @@ class SemanticCache:
         return entries
 
     async def get_cache_stats(self) -> dict[str, Any]:
-        """Aggregate stats for metacognition tracking."""
+        """Aggregate stats for metacognition tracking.
+
+        Scoped to ``self._account_id`` so tenant A's stats never
+        include tenant B's rows.
+        """
         row = await self._pool.fetchrow(
             """
             SELECT
@@ -351,7 +360,9 @@ class SemanticCache:
                 AVG(confidence) FILTER (WHERE invalidated_at IS NULL) AS avg_confidence,
                 AVG(validation_count) FILTER (WHERE invalidated_at IS NULL) AS avg_validations
             FROM reasoning_semantic_cache
-            """
+            WHERE account_id = $1
+            """,
+            self._account_id,
         )
         if row is None:
             return {"active": 0, "invalidated": 0, "avg_confidence": 0, "avg_validations": 0}

--- a/extracted_llm_infrastructure/reasoning/semantic_cache.py
+++ b/extracted_llm_infrastructure/reasoning/semantic_cache.py
@@ -78,14 +78,35 @@ class SemanticCache:
     # constant in core's ``semantic_cache_keys`` is the canonical home.
     STALE_THRESHOLD = _CORE_STALE_THRESHOLD
 
-    def __init__(self, pool: SemanticCachePool):
+    # Sentinel account UUID for atlas's internal pipeline (PR-D3).
+    # Atlas's existing reasoning calls write to the cache without
+    # knowing about accounts; the sentinel marks those rows so
+    # customer cache hits cannot leak across tenants.
+    SENTINEL_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+    def __init__(
+        self,
+        pool: SemanticCachePool,
+        *,
+        account_id: str = SENTINEL_ACCOUNT_ID,
+    ):
         """*pool*: any object exposing the ``SemanticCachePool``
         contract (``fetchrow`` / ``fetch`` / ``execute`` coroutine
         methods that speak Postgres dialect). The atlas
         ``DatabasePool`` wrapper and a raw asyncpg ``Pool`` both
         satisfy this Protocol.
+
+        *account_id*: scopes every read/write to the given account
+        (PR-D3). Defaults to the SENTINEL so atlas's existing
+        instantiations keep working unmodified. Customer-facing
+        callers (PR-D4 LLM Gateway router) construct a new instance
+        per request with the requesting account's UUID, so cross-
+        tenant cache hits are impossible -- the (pattern_sig,
+        account_id) UNIQUE constraint guarantees isolation at the
+        storage layer.
         """
         self._pool = pool
+        self._account_id = account_id
 
     # ------------------------------------------------------------------
     # Core operations
@@ -99,9 +120,11 @@ class SemanticCache:
         row = await self._pool.fetchrow(
             """
             SELECT * FROM reasoning_semantic_cache
-            WHERE pattern_sig = $1 AND invalidated_at IS NULL
+            WHERE pattern_sig = $1 AND account_id = $2
+              AND invalidated_at IS NULL
             """,
             pattern_sig,
+            self._account_id,
         )
         if row is None:
             return None
@@ -122,16 +145,16 @@ class SemanticCache:
         await self._pool.execute(
             """
             INSERT INTO reasoning_semantic_cache (
-                pattern_sig, pattern_class, vendor_name, product_category,
-                conclusion, confidence, reasoning_steps, boundary_conditions,
-                falsification_conditions, uncertainty_sources,
-                decay_half_life_days, conclusion_type, evidence_hash,
-                last_validated_at, validation_count
+                pattern_sig, account_id, pattern_class, vendor_name,
+                product_category, conclusion, confidence, reasoning_steps,
+                boundary_conditions, falsification_conditions,
+                uncertainty_sources, decay_half_life_days, conclusion_type,
+                evidence_hash, last_validated_at, validation_count
             ) VALUES (
-                $1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8::jsonb,
-                $9::jsonb, $10, $11, $12, $13, NOW(), 1
+                $1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9::jsonb,
+                $10::jsonb, $11, $12, $13, $14, NOW(), 1
             )
-            ON CONFLICT (pattern_sig) DO UPDATE SET
+            ON CONFLICT (pattern_sig, account_id) DO UPDATE SET
                 pattern_class = EXCLUDED.pattern_class,
                 vendor_name = EXCLUDED.vendor_name,
                 product_category = EXCLUDED.product_category,
@@ -149,6 +172,7 @@ class SemanticCache:
                 invalidated_at = NULL
             """,
             entry.pattern_sig,
+            self._account_id,
             entry.pattern_class,
             entry.vendor_name,
             entry.product_category,
@@ -172,10 +196,12 @@ class SemanticCache:
                 UPDATE reasoning_semantic_cache
                 SET last_validated_at = NOW(),
                     validation_count = validation_count + 1,
-                    confidence = $2
-                WHERE pattern_sig = $1 AND invalidated_at IS NULL
+                    confidence = $3
+                WHERE pattern_sig = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 """,
                 pattern_sig,
+                self._account_id,
                 new_confidence,
             )
         else:
@@ -184,9 +210,11 @@ class SemanticCache:
                 UPDATE reasoning_semantic_cache
                 SET last_validated_at = NOW(),
                     validation_count = validation_count + 1
-                WHERE pattern_sig = $1 AND invalidated_at IS NULL
+                WHERE pattern_sig = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 """,
                 pattern_sig,
+                self._account_id,
             )
 
     async def invalidate(self, pattern_sig: str, reason: str = "") -> None:
@@ -195,9 +223,11 @@ class SemanticCache:
             """
             UPDATE reasoning_semantic_cache
             SET invalidated_at = NOW()
-            WHERE pattern_sig = $1 AND invalidated_at IS NULL
+            WHERE pattern_sig = $1 AND account_id = $2
+              AND invalidated_at IS NULL
             """,
             pattern_sig,
+            self._account_id,
         )
         logger.info("Invalidated cache entry: %s (reason: %s)", pattern_sig, reason)
 
@@ -214,34 +244,40 @@ class SemanticCache:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE vendor_name = $1 AND invalidated_at IS NULL
+                WHERE vendor_name = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY last_validated_at DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 vendor_name,
+                self._account_id,
                 limit,
             )
         elif vendor_name:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE pattern_class = $1 AND vendor_name = $2 AND invalidated_at IS NULL
+                WHERE pattern_class = $1 AND vendor_name = $2
+                  AND account_id = $3 AND invalidated_at IS NULL
                 ORDER BY confidence DESC
-                LIMIT $3
+                LIMIT $4
                 """,
                 pattern_class,
                 vendor_name,
+                self._account_id,
                 limit,
             )
         else:
             rows = await self._pool.fetch(
                 """
                 SELECT * FROM reasoning_semantic_cache
-                WHERE pattern_class = $1 AND invalidated_at IS NULL
+                WHERE pattern_class = $1 AND account_id = $2
+                  AND invalidated_at IS NULL
                 ORDER BY confidence DESC
-                LIMIT $2
+                LIMIT $3
                 """,
                 pattern_class,
+                self._account_id,
                 limit,
             )
         entries = []

--- a/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
+++ b/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
@@ -225,13 +225,28 @@ def _json_field_to_mapping(value: Any) -> dict[str, Any]:
     return {}
 
 
+# Sentinel account UUID for atlas's internal pipeline calls (PR-D3).
+# Atlas's existing pipeline writes to this cache 100k+ times/month
+# without knowing about accounts; the sentinel marks those rows so
+# customer cache hits cannot leak across tenants.
+SENTINEL_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+
 async def lookup_cached_text(
     namespace: str,
     request_envelope: dict[str, Any],
     *,
     pool: Any | None = None,
+    account_id: str = SENTINEL_ACCOUNT_ID,
 ) -> B2BLLMExactCacheHit | None:
-    """Return the cached text for an exact request envelope."""
+    """Return the cached text for an exact request envelope.
+
+    ``account_id`` defaults to the SENTINEL so atlas's existing
+    pipeline keeps working unmodified. Customer-facing callers
+    (PR-D4 LLM Gateway router) pass the requesting account's UUID
+    so cross-tenant hits are impossible -- the (cache_key, account_id)
+    composite PK guarantees isolation at the storage layer.
+    """
     if not namespace or not is_b2b_llm_exact_cache_enabled():
         return None
 
@@ -246,7 +261,7 @@ async def lookup_cached_text(
             UPDATE b2b_llm_exact_cache
             SET last_hit_at = NOW(),
                 hit_count = hit_count + 1
-            WHERE cache_key = $1
+            WHERE cache_key = $1 AND account_id = $2
             RETURNING cache_key, namespace, provider, model,
                       response_text, usage_json, metadata,
                       created_at, last_hit_at, hit_count
@@ -254,6 +269,7 @@ async def lookup_cached_text(
         SELECT * FROM hit
         """,
         cache_key,
+        account_id,
     )
     if row is None:
         return None
@@ -283,8 +299,14 @@ async def store_cached_text(
     usage: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     pool: Any | None = None,
+    account_id: str = SENTINEL_ACCOUNT_ID,
 ) -> bool:
-    """Store a successful exact-match response."""
+    """Store a successful exact-match response.
+
+    ``account_id`` defaults to the SENTINEL so atlas's existing
+    pipeline keeps writing to its own cache namespace. Customer-
+    facing callers pass the requesting account's UUID.
+    """
     if (
         not namespace
         or not response_text
@@ -305,11 +327,12 @@ async def store_cached_text(
     await db_pool.execute(
         """
         INSERT INTO b2b_llm_exact_cache (
-            cache_key, namespace, provider, model, response_text, usage_json, metadata
+            cache_key, account_id, namespace, provider, model,
+            response_text, usage_json, metadata
         ) VALUES (
-            $1, $2, $3, $4, $5, $6::jsonb, $7::jsonb
+            $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb
         )
-        ON CONFLICT (cache_key) DO UPDATE SET
+        ON CONFLICT (cache_key, account_id) DO UPDATE SET
             provider = EXCLUDED.provider,
             model = EXCLUDED.model,
             response_text = EXCLUDED.response_text,
@@ -317,6 +340,7 @@ async def store_cached_text(
             metadata = EXCLUDED.metadata
         """,
         cache_key,
+        account_id,
         namespace,
         str(provider or ""),
         str(model or ""),

--- a/extracted_llm_infrastructure/services/tracing.py
+++ b/extracted_llm_infrastructure/services/tracing.py
@@ -496,6 +496,10 @@ class FTLTracingClient:
         event_type = _metadata_text_value(meta, "event_type")
         entity_type = _metadata_text_value(meta, "entity_type")
         entity_id = _metadata_text_value(meta, "entity_id")
+        # PR-D3: account_id rides in metadata (or sentinel for atlas's
+        # internal pipeline). PR-D4's LLM Gateway router will set this
+        # via metadata={"account_id": user.account_id, ...}.
+        account_id_str = _metadata_text_value(meta, "account_id")
 
         try:
             from ..storage.database import get_db_pool
@@ -503,6 +507,10 @@ class FTLTracingClient:
             pool = get_db_pool()
             if not pool.is_initialized:
                 return
+            # PR-D3: account_id read from metadata (set by PR-D4's
+            # LLM Gateway router) or sentinel for atlas's internal
+            # pipeline.
+            account_id = account_id_str or "00000000-0000-0000-0000-000000000000"
             query = """INSERT INTO llm_usage
                        (span_name, operation_type, model_name, model_provider,
                         input_tokens, output_tokens, total_tokens, cost_usd,
@@ -510,8 +518,8 @@ class FTLTracingClient:
                         tokens_per_second, billable_input_tokens, cached_tokens,
                         cache_write_tokens, api_endpoint, provider_request_id,
                         status, metadata, vendor_name, run_id, source_name,
-                        event_type, entity_type, entity_id)
-                       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)"""
+                        event_type, entity_type, entity_id, account_id)
+                       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)"""
             args = (
                 payload.get("span_name", ""),
                 payload.get("operation_type", "llm_call"),
@@ -539,6 +547,7 @@ class FTLTracingClient:
                 event_type,
                 entity_type,
                 entity_id,
+                account_id,
             )
             if use_shared_pool:
                 await pool.execute(query, *args)

--- a/tests/test_account_scoping.py
+++ b/tests/test_account_scoping.py
@@ -129,6 +129,57 @@ def test_semantic_cache_lookup_by_class_filters_by_account():
     assert src.count("AND account_id =") >= 3
 
 
+def test_semantic_cache_lookup_for_tier_filters_by_account():
+    """Codex P1 fix: lookup_for_tier feeds tier-inheritance and was
+    unscoped pre-fix. All 3 branches (category-only, vendor-only,
+    conclusion_type-only) must filter on account_id."""
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.lookup_for_tier)
+    assert "self._account_id" in src
+    assert src.count("AND account_id =") >= 3
+
+
+def test_semantic_cache_get_cache_stats_filters_by_account():
+    """Codex P1 fix: get_cache_stats was unscoped. Tenant A's stats
+    cannot include tenant B's rows -- otherwise the metacognition
+    layer ingests cross-tenant counts."""
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.get_cache_stats)
+    assert "self._account_id" in src
+    assert "WHERE account_id =" in src
+
+
+def test_every_semantic_cache_query_method_scopes_by_account():
+    """Sweep guard: any new method on SemanticCache that issues SQL
+    against reasoning_semantic_cache MUST reference self._account_id.
+    Catches a future regression where someone adds a query method
+    without remembering account scoping."""
+    from atlas_brain.reasoning.semantic_cache import SemanticCache
+
+    # Methods that issue SQL against reasoning_semantic_cache -- the
+    # constructor and pure helpers (e.g. row_to_cache_entry) are
+    # excluded; this list grows as new query methods land.
+    sql_emitting_methods = (
+        "lookup",
+        "store",
+        "validate",
+        "invalidate",
+        "lookup_by_class",
+        "lookup_for_tier",
+        "get_cache_stats",
+    )
+    for name in sql_emitting_methods:
+        method = getattr(SemanticCache, name, None)
+        assert method is not None, f"SemanticCache.{name} must exist"
+        src = inspect.getsource(method)
+        assert "self._account_id" in src, (
+            f"SemanticCache.{name} issues SQL but does not scope on "
+            "self._account_id -- cross-tenant leak risk"
+        )
+
+
 # ---- llm_exact_cache: account_id kwarg + composite ON CONFLICT ----------
 
 

--- a/tests/test_account_scoping.py
+++ b/tests/test_account_scoping.py
@@ -1,0 +1,279 @@
+"""Tests for per-account scoping on llm_usage + caches (PR-D3).
+
+Pins the contract that:
+
+  - Atlas's existing pipeline (which doesn't know about accounts)
+    keeps working unmodified -- writes get the sentinel account_id
+    via the column DEFAULT and reads via the constructor default.
+  - Customer-facing callers (PR-D4 LLM Gateway router) pass an
+    explicit account_id and get an isolated cache namespace.
+  - The migration drops the cache_key/pattern_sig single-column
+    PK/UNIQUE and replaces with composite (..., account_id).
+  - The ON CONFLICT clauses target the new composite constraint.
+  - llm_usage INSERT carries account_id so per-tenant cost queries
+    work.
+
+DB-backed integration tests live alongside other auth integration
+tests and are gated on a running Postgres; this file does pure unit
++ source-text inspection so the suite stays runnable without DB.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---- Migration files exist + carry the sentinel + composite keys --------
+
+_MIG_DIR = Path(__file__).resolve().parent.parent / "atlas_brain" / "storage" / "migrations"
+
+
+def _read_migration(filename: str) -> str:
+    return (_MIG_DIR / filename).read_text(encoding="utf-8")
+
+
+def test_migration_313_adds_account_id_with_sentinel():
+    sql = _read_migration("313_llm_usage_account_scoping.sql")
+    assert "ALTER TABLE llm_usage" in sql
+    assert "ADD COLUMN IF NOT EXISTS account_id UUID NOT NULL" in sql
+    assert "'00000000-0000-0000-0000-000000000000'" in sql
+
+
+def test_migration_313_indexes_per_account_analytics():
+    sql = _read_migration("313_llm_usage_account_scoping.sql")
+    assert "idx_llm_usage_account_created" in sql
+    assert "(account_id, created_at DESC)" in sql
+
+
+def test_migration_314_replaces_cache_key_pk_with_composite():
+    sql = _read_migration("314_b2b_llm_exact_cache_account_scoping.sql")
+    assert "DROP CONSTRAINT IF EXISTS b2b_llm_exact_cache_pkey" in sql
+    assert "PRIMARY KEY (cache_key, account_id)" in sql
+    # Migration must still install the sentinel default so atlas's
+    # existing rows survive the constraint swap.
+    assert "'00000000-0000-0000-0000-000000000000'" in sql
+
+
+def test_migration_315_replaces_pattern_sig_unique_with_composite():
+    sql = _read_migration("315_reasoning_semantic_cache_account_scoping.sql")
+    assert "DROP CONSTRAINT IF EXISTS reasoning_semantic_cache_pattern_sig_key" in sql
+    assert "UNIQUE (pattern_sig, account_id)" in sql
+    assert "'00000000-0000-0000-0000-000000000000'" in sql
+
+
+# ---- SemanticCache: constructor + query SQL -------------------------------
+
+
+def test_semantic_cache_constructor_accepts_account_id_with_default():
+    """The atlas pipeline instantiates ``SemanticCache(pool)`` without
+    knowing about accounts. The default sentinel must keep that
+    working."""
+    from atlas_brain.reasoning.semantic_cache import SemanticCache
+
+    sig = inspect.signature(SemanticCache.__init__)
+    assert "account_id" in sig.parameters
+    assert (
+        sig.parameters["account_id"].default
+        == "00000000-0000-0000-0000-000000000000"
+    )
+    assert sig.parameters["account_id"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_semantic_cache_lookup_filters_by_account_id():
+    """The lookup query must scope on account_id so cross-tenant hits
+    are impossible at the storage layer."""
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.lookup)
+    assert "WHERE pattern_sig = $1 AND account_id = $2" in src
+    assert "self._account_id" in src
+
+
+def test_semantic_cache_store_uses_composite_on_conflict():
+    """The store path must target ``(pattern_sig, account_id)``. If
+    it still says ``ON CONFLICT (pattern_sig)``, the migration's
+    constraint replacement breaks it at runtime."""
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.store)
+    assert "ON CONFLICT (pattern_sig, account_id) DO UPDATE" in src
+    assert "self._account_id" in src
+
+
+def test_semantic_cache_validate_filters_by_account():
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.validate)
+    assert "AND account_id = $2" in src
+
+
+def test_semantic_cache_invalidate_filters_by_account():
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.invalidate)
+    assert "AND account_id = $2" in src
+
+
+def test_semantic_cache_lookup_by_class_filters_by_account():
+    from atlas_brain.reasoning import semantic_cache as sc_mod
+
+    src = inspect.getsource(sc_mod.SemanticCache.lookup_by_class)
+    assert "self._account_id" in src
+    # All three branches (vendor only / class+vendor / class only)
+    # must scope on account_id; verify each appears at least once.
+    assert src.count("AND account_id =") >= 3
+
+
+# ---- llm_exact_cache: account_id kwarg + composite ON CONFLICT ----------
+
+
+def test_lookup_cached_text_accepts_account_id_default_sentinel():
+    from atlas_brain.services.b2b.llm_exact_cache import lookup_cached_text
+
+    sig = inspect.signature(lookup_cached_text)
+    assert "account_id" in sig.parameters
+    assert (
+        sig.parameters["account_id"].default
+        == "00000000-0000-0000-0000-000000000000"
+    )
+
+
+def test_store_cached_text_accepts_account_id_default_sentinel():
+    from atlas_brain.services.b2b.llm_exact_cache import store_cached_text
+
+    sig = inspect.signature(store_cached_text)
+    assert "account_id" in sig.parameters
+    assert (
+        sig.parameters["account_id"].default
+        == "00000000-0000-0000-0000-000000000000"
+    )
+
+
+def test_lookup_cached_text_query_scopes_by_account_id():
+    from atlas_brain.services.b2b import llm_exact_cache as ec_mod
+
+    src = inspect.getsource(ec_mod.lookup_cached_text)
+    assert "WHERE cache_key = $1 AND account_id = $2" in src
+
+
+def test_store_cached_text_uses_composite_on_conflict():
+    from atlas_brain.services.b2b import llm_exact_cache as ec_mod
+
+    src = inspect.getsource(ec_mod.store_cached_text)
+    assert "ON CONFLICT (cache_key, account_id) DO UPDATE" in src
+    assert "INSERT INTO b2b_llm_exact_cache" in src
+    assert "account_id" in src
+
+
+# ---- llm_usage tracing INSERT -------------------------------------------
+
+
+def test_tracing_store_local_insert_includes_account_id_column():
+    """The INSERT INTO llm_usage statement must include the
+    account_id column so per-tenant cost queries (PR-D4 ``GET
+    /api/v1/llm/usage``) return the right numbers."""
+    from atlas_brain.services import tracing
+
+    src = inspect.getsource(tracing.FTLTracingClient._store_local)
+    assert "INSERT INTO llm_usage" in src
+    # Column list must include account_id
+    assert "account_id)" in src
+    # 27 placeholders (was 26 + new account_id)
+    assert "$27" in src
+
+
+def test_tracing_store_local_reads_account_id_from_metadata():
+    """Callers thread account_id via ``metadata={"account_id": ...}``;
+    the existing pattern for vendor_name / run_id / etc."""
+    from atlas_brain.services import tracing
+
+    src = inspect.getsource(tracing.FTLTracingClient._store_local)
+    assert '_metadata_text_value(meta, "account_id")' in src
+
+
+def test_tracing_store_local_falls_back_to_sentinel():
+    """When metadata lacks account_id (atlas's existing pipeline),
+    the INSERT writes the sentinel UUID."""
+    from atlas_brain.services import tracing
+
+    src = inspect.getsource(tracing.FTLTracingClient._store_local)
+    assert "00000000-0000-0000-0000-000000000000" in src
+
+
+# ---- Atlas-pipeline regression: ecosystem_analysis ON CONFLICT ----------
+
+
+def test_ecosystem_analysis_uses_composite_on_conflict():
+    """``ecosystem_analysis.py`` writes directly to
+    reasoning_semantic_cache via raw SQL (bypasses SemanticCache).
+    Migration 315 drops the pattern_sig-only UNIQUE so its ON
+    CONFLICT target must update too."""
+    from atlas_brain.autonomous.tasks import ecosystem_analysis
+
+    src = inspect.getsource(ecosystem_analysis)
+    # Must NOT contain the old single-column target...
+    assert "ON CONFLICT (pattern_sig) DO UPDATE" not in src
+    # ...but must contain the composite target (T3 + T4 INSERTs).
+    assert src.count("ON CONFLICT (pattern_sig, account_id) DO UPDATE") >= 2
+
+
+# ---- Sentinel UUID is the documented constant ---------------------------
+
+
+def test_sentinel_account_id_is_zero_uuid():
+    """The sentinel value is documented in two places (SemanticCache
+    + llm_exact_cache); both must agree on the all-zero UUID."""
+    from atlas_brain.reasoning.semantic_cache import SemanticCache
+    from atlas_brain.services.b2b.llm_exact_cache import SENTINEL_ACCOUNT_ID
+
+    assert SemanticCache.SENTINEL_ACCOUNT_ID == "00000000-0000-0000-0000-000000000000"
+    assert SENTINEL_ACCOUNT_ID == "00000000-0000-0000-0000-000000000000"
+
+
+# ---- Sync invariant: extracted copies updated ---------------------------
+
+
+def test_extracted_llm_exact_cache_synced_with_account_id():
+    """``services/b2b/llm_exact_cache.py`` is synced from atlas to
+    extracted. The extracted copy must carry the same account_id
+    threading."""
+    extracted_path = (
+        Path(__file__).resolve().parent.parent
+        / "extracted_llm_infrastructure"
+        / "services"
+        / "b2b"
+        / "llm_exact_cache.py"
+    )
+    src = extracted_path.read_text(encoding="utf-8")
+    assert "SENTINEL_ACCOUNT_ID = " in src
+    assert "WHERE cache_key = $1 AND account_id = $2" in src
+    assert "ON CONFLICT (cache_key, account_id) DO UPDATE" in src
+
+
+def test_extracted_semantic_cache_synced_with_account_id():
+    extracted_path = (
+        Path(__file__).resolve().parent.parent
+        / "extracted_llm_infrastructure"
+        / "reasoning"
+        / "semantic_cache.py"
+    )
+    src = extracted_path.read_text(encoding="utf-8")
+    assert "SENTINEL_ACCOUNT_ID = " in src
+    assert "ON CONFLICT (pattern_sig, account_id) DO UPDATE" in src
+
+
+def test_extracted_tracing_synced_with_account_id():
+    extracted_path = (
+        Path(__file__).resolve().parent.parent
+        / "extracted_llm_infrastructure"
+        / "services"
+        / "tracing.py"
+    )
+    src = extracted_path.read_text(encoding="utf-8")
+    assert "$27" in src  # the new account_id placeholder
+    assert '_metadata_text_value(meta, "account_id")' in src


### PR DESCRIPTION
## Summary

Third PR of the LLM Gateway MVP (per [docs/products/llm_gateway_mvp_plan.md](docs/products/llm_gateway_mvp_plan.md)). **Riskiest of the series** — atlas's existing pipeline writes ~100k LLM calls/month into the three affected tables.

The **sentinel UUID approach** mitigates the regression risk: atlas's pipeline keeps writing without `account_id`, the column `DEFAULT` fills in `'00000000-0000-0000-0000-000000000000'`. Customer-facing callers in PR-D4 will pass real account UUIDs. Composite `(cache_key, account_id)` PK and `(pattern_sig, account_id)` UNIQUE constraints make cross-tenant hits **impossible at the storage layer**.

## Migrations (3 NEW)

| File | What |
|---|---|
| `313_llm_usage_account_scoping.sql` | `ALTER llm_usage ADD account_id UUID NOT NULL DEFAULT sentinel` + index `(account_id, created_at DESC)` |
| `314_b2b_llm_exact_cache_account_scoping.sql` | DROP cache_key PK → ADD `(cache_key, account_id)` PK + per-account last_hit index |
| `315_reasoning_semantic_cache_account_scoping.sql` | DROP `pattern_sig` UNIQUE → ADD `(pattern_sig, account_id)` UNIQUE + partial index |

All three carry the sentinel as DEFAULT so existing rows survive non-destructively.

## Code changes (4 atlas-side files; 3 extracted_llm_infrastructure synced)

| File | What |
|---|---|
| `atlas_brain/reasoning/semantic_cache.py` | `SemanticCache.__init__` accepts `account_id` (kw-only, default sentinel). All 5 query methods (`lookup`, `store`, `validate`, `invalidate`, `lookup_by_class`) scope on `self._account_id`. `ON CONFLICT` → `(pattern_sig, account_id)`. |
| `atlas_brain/services/b2b/llm_exact_cache.py` | `lookup_cached_text` + `store_cached_text` accept `account_id` kwarg (default sentinel). `ON CONFLICT` → `(cache_key, account_id)`. Module-level `SENTINEL_ACCOUNT_ID` exported. |
| `atlas_brain/services/tracing.py` | `FTLTracingClient._store_local` reads `account_id` from metadata (existing pattern for `vendor_name` etc.); INSERT INTO llm_usage now includes the column ($27). Sentinel fallback. |
| `atlas_brain/autonomous/tasks/ecosystem_analysis.py` | 2 raw INSERTs into `reasoning_semantic_cache` had `ON CONFLICT (pattern_sig)`; both updated to `(pattern_sig, account_id)` so the migration's constraint swap doesn't break the task. |
| `extracted_llm_infrastructure/{reasoning/semantic_cache.py, services/b2b/llm_exact_cache.py, services/tracing.py}` | Synced via `sync_extracted_llm_infrastructure.sh`. |
| `tests/test_account_scoping.py` | NEW — 22 tests pinning the contract end-to-end. |

## Why no atlas-side regression

Atlas's pipeline calls `SemanticCache(pool)` — no `account_id` arg. The new keyword-only param has a default, so the call still works; queries scope on `self._account_id = SENTINEL`. Atlas's existing rows have `account_id = SENTINEL` via the migration default. Atlas's lookups continue to hit those rows. **Cache continuity is preserved.**

Customer calls in PR-D4 will instantiate `SemanticCache(pool, account_id=user.account_id)` — separate cache namespace from atlas's, no leakage in either direction.

## Validation

```
$ pytest tests/test_account_scoping.py tests/test_auth_api_keys.py \
         tests/test_auth_dependencies.py tests/test_llm_gateway_plan_tier.py -q
70 passed in 4.23s

$ bash scripts/run_extracted_llm_infrastructure_checks.sh
35 passed (smoke + ASCII + standalone substrate + contract tests)
All extracted_llm_infrastructure checks passed
```

22 new tests cover: migration content (sentinel + composite constraints); SemanticCache constructor signature + every query scoped on account_id; ON CONFLICT clauses target composite; llm_usage INSERT carries account_id; ecosystem_analysis uses composite ON CONFLICT; sync invariant — extracted copies carry the same threading.

## Rollback plan

Migrations are non-destructive:
- `ADD COLUMN` with DEFAULT covers existing rows
- Constraint swaps are reversible: recreate the single-column PK/UNIQUE if the composite needs to come out
- Sentinel UUID for atlas means cache continuity is preserved across the migration

## Plan reference

This PR is **PR-D3** in `docs/products/llm_gateway_mvp_plan.md`.

Next: **PR-D4** — `/api/v1/llm/{chat, chat_stream, batch, embed, usage}` FastAPI router wrapping the engine, scoped per-account via `require_api_key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
