### PR TITLE
PR-C4d2: reflection.py tracing-gap fix

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -8,6 +8,7 @@ on:
       - "atlas_brain/reasoning/state.py"
       - "atlas_brain/reasoning/port_adapters.py"
       - "atlas_brain/reasoning/agent.py"
+      - "atlas_brain/reasoning/reflection.py"
       - "scripts/sync_extracted_content_pipeline.sh"
       - "scripts/validate_extracted_content_pipeline.sh"
       - "scripts/check_ascii_python.sh"
@@ -22,6 +23,7 @@ on:
       - "tests/test_atlas_reasoning_state_*.py"
       - "tests/test_atlas_reasoning_port_adapters.py"
       - "tests/test_atlas_reasoning_agent_port_consumption.py"
+      - "tests/test_atlas_reasoning_reflection_tracing.py"
   push:
     paths:
       - "extracted_content_pipeline/**"
@@ -29,6 +31,7 @@ on:
       - "atlas_brain/reasoning/state.py"
       - "atlas_brain/reasoning/port_adapters.py"
       - "atlas_brain/reasoning/agent.py"
+      - "atlas_brain/reasoning/reflection.py"
       - "scripts/sync_extracted_content_pipeline.sh"
       - "scripts/validate_extracted_content_pipeline.sh"
       - "scripts/check_ascii_python.sh"
@@ -43,6 +46,7 @@ on:
       - "tests/test_atlas_reasoning_state_*.py"
       - "tests/test_atlas_reasoning_port_adapters.py"
       - "tests/test_atlas_reasoning_agent_port_consumption.py"
+      - "tests/test_atlas_reasoning_reflection_tracing.py"
 
 jobs:
   extracted-checks:

--- a/atlas_brain/reasoning/reflection.py
+++ b/atlas_brain/reasoning/reflection.py
@@ -8,19 +8,56 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from extracted_reasoning_core.types import ReasoningPorts
 
 logger = logging.getLogger("atlas.reasoning.reflection")
 
 
-async def run_reflection() -> dict[str, Any]:
+async def run_reflection(
+    ports: Optional["ReasoningPorts"] = None,
+) -> dict[str, Any]:
     """Execute a full reflection cycle.
 
     1. Run rule-based pattern detectors
     2. Feed patterns + recent events to Claude for analysis
     3. Auto-execute high-confidence recommendations
     4. Notify owner for lower-confidence findings
+
+    A ``reasoning.reflection`` span is opened for the cycle via the
+    injected ``ReasoningPorts.trace_sink`` so the cron-driven
+    reflection cycle is no longer invisible to FTL. ``ports`` defaults
+    to ``None`` for production callers; the default-builder is shared
+    with ``ReasoningAgentGraph`` (atlas's reactive entry point) so
+    tracing stays consistent across both reasoning paths. Tests inject
+    an explicit fake bundle to bypass atlas's heavy services chain.
     """
+    if ports is None:
+        from .agent import _build_default_ports
+        ports = _build_default_ports()
+
+    span = ports.trace_sink.start_span("reasoning.reflection")
+    try:
+        result = await _run_reflection_cycle(ports)
+    except Exception as exc:
+        ports.trace_sink.end_span(
+            span,
+            status="error",
+            metadata={
+                "error_message": str(exc) or type(exc).__name__,
+                "error_type": type(exc).__name__,
+            },
+        )
+        raise
+    ports.trace_sink.end_span(span, status="ok", metadata=result)
+    return result
+
+
+async def _run_reflection_cycle(ports: "ReasoningPorts") -> dict[str, Any]:
+    """Body of the reflection cycle, factored out so ``run_reflection``
+    can wrap it in a single span without indenting the whole function."""
     from .patterns import run_all_pattern_detectors
 
     # 1. Rule-based pattern detection

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T02:28Z by claude-2026-05-03
+Last updated: 2026-05-05T02:32Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-C4d2, in flight) | PR-C4d2: reflection.py tracing-gap fix | EDIT: `atlas_brain/reasoning/reflection.py` (`run_reflection` accepts `ports: ReasoningPorts \| None = None`, lazy-builds defaults via the existing `agent._build_default_ports` factory, opens a `reasoning.reflection` span via `ports.trace_sink.start_span` and closes it on success/error with counts metadata). NEW: `tests/test_atlas_reasoning_reflection_tracing.py` (sys.modules-stubbed test of span open/close + status mapping + counts metadata, mirrors PR-C4d's save/restore fixture pattern). EDIT: `scripts/run_extracted_pipeline_checks.sh` + `.github/workflows/extracted_pipeline_checks.yml` (wire test + reflection.py path). Sister slice to PR-C4d -- closes the observability gap on the cron-driven reflection cycle that PR-C4d's audit conversation surfaced. Pure additive instrumentation; existing reflection behavior unchanged. | claude-2026-05-03 | `atlas_brain/reasoning/reflection.py`; `tests/test_atlas_reasoning_reflection_tracing.py`; `scripts/run_extracted_pipeline_checks.sh`; `.github/workflows/extracted_pipeline_checks.yml` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -49,6 +49,7 @@ pytest \
   tests/test_atlas_reasoning_state_inherits_core.py \
   tests/test_atlas_reasoning_port_adapters.py \
   tests/test_atlas_reasoning_agent_port_consumption.py \
+  tests/test_atlas_reasoning_reflection_tracing.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \
   tests/test_extracted_blog_matching.py \

--- a/tests/test_atlas_reasoning_reflection_tracing.py
+++ b/tests/test_atlas_reasoning_reflection_tracing.py
@@ -1,0 +1,308 @@
+"""Verify ``run_reflection`` opens + closes a span via the TraceSink port.
+
+Atlas's cron-driven reflection cycle had zero tracing prior to this
+slice -- if the LLM call to Claude stalled or the pattern detectors
+failed, nothing surfaced in FTL. PR-C4d2 wraps the cycle in a
+``reasoning.reflection`` span so it's visible alongside the reactive
+``reasoning.process`` spans that ``ReasoningAgentGraph`` opens.
+
+These tests pin:
+
+- ``run_reflection(ports=fake)`` actually uses the injected TraceSink
+  (no fall-through to the default-builder path)
+- One ``reasoning.reflection`` span opens at the start and closes
+  exactly once with the cycle result dict packed as metadata + status
+  ``"ok"``
+- An exception inside the cycle still closes the span -- with status
+  ``"error"`` and ``error_message`` / ``error_type`` -- and re-raises
+
+Atlas's heavy chains (services / pipelines / config) plus the
+reflection-internal helpers (patterns detectors, graph helpers, the
+LLM client) are stubbed in ``sys.modules`` so the test runs in
+standalone CI without the full atlas dep stack. Stubs are restored on
+teardown (lesson from PR-C4d's Codex review -- otherwise sibling test
+files in the same pytest invocation would see this file's stubs).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Mapping
+
+import pytest
+
+
+# ----------------------------------------------------------------------
+# sys.modules stubs (installed/restored by the autouse fixture)
+# ----------------------------------------------------------------------
+
+
+_STUBBED_MODULE_NAMES = (
+    "atlas_brain.services",
+    "atlas_brain.services.tracing",
+    "atlas_brain.pipelines",
+    "atlas_brain.pipelines.llm",
+    "atlas_brain.config",
+    "atlas_brain.reasoning.patterns",
+    "atlas_brain.reasoning.graph",
+    "atlas_brain.reasoning.graph_prompts",
+)
+
+
+def _build_atlas_stubs(
+    pattern_findings: list[dict[str, Any]],
+) -> dict[str, types.ModuleType]:
+    services_pkg = types.ModuleType("atlas_brain.services")
+    services_pkg.__path__ = []
+    tracing_mod = types.ModuleType("atlas_brain.services.tracing")
+    tracing_mod.tracer = object()  # never reached; explicit ports bypass default
+
+    pipelines_pkg = types.ModuleType("atlas_brain.pipelines")
+    pipelines_pkg.__path__ = []
+    pipelines_llm_mod = types.ModuleType("atlas_brain.pipelines.llm")
+    # Default: LLM is unavailable, so reflection takes the no-LLM path
+    # and notifies on rule-based findings. Tests can override per-test.
+    pipelines_llm_mod.get_pipeline_llm = lambda **kwargs: None
+
+    config_mod = types.ModuleType("atlas_brain.config")
+
+    class _StubReasoning:
+        graph_synthesis_workload = "test"
+        max_tokens = 1024
+        temperature = 0.3
+
+    class _StubAlerts:
+        ntfy_enabled = False
+        ntfy_url = ""
+        ntfy_topic = ""
+
+    class _StubSettings:
+        reasoning = _StubReasoning()
+        alerts = _StubAlerts()
+
+    config_mod.settings = _StubSettings()
+
+    patterns_mod = types.ModuleType("atlas_brain.reasoning.patterns")
+
+    async def _fake_run_all_pattern_detectors() -> list[dict[str, Any]]:
+        return pattern_findings
+
+    patterns_mod.run_all_pattern_detectors = _fake_run_all_pattern_detectors
+
+    graph_mod = types.ModuleType("atlas_brain.reasoning.graph")
+
+    async def _fake_llm_generate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"response": '{"findings": []}', "usage": {}}
+
+    def _fake_parse_llm_json(text: str) -> dict[str, Any]:
+        import json as _json
+        return _json.loads(text)
+
+    graph_mod._llm_generate = _fake_llm_generate
+    graph_mod._parse_llm_json = _fake_parse_llm_json
+
+    graph_prompts_mod = types.ModuleType("atlas_brain.reasoning.graph_prompts")
+    graph_prompts_mod.REFLECTION_SYSTEM = "system"
+
+    return {
+        "atlas_brain.services": services_pkg,
+        "atlas_brain.services.tracing": tracing_mod,
+        "atlas_brain.pipelines": pipelines_pkg,
+        "atlas_brain.pipelines.llm": pipelines_llm_mod,
+        "atlas_brain.config": config_mod,
+        "atlas_brain.reasoning.patterns": patterns_mod,
+        "atlas_brain.reasoning.graph": graph_mod,
+        "atlas_brain.reasoning.graph_prompts": graph_prompts_mod,
+    }
+
+
+@pytest.fixture
+def install_stubs():
+    """Per-test fixture so each test can choose its own pattern findings.
+
+    Returns a callable that takes a ``pattern_findings`` list, installs
+    stubs in ``sys.modules`` (saving prior entries first), and registers
+    teardown to restore the originals.
+    """
+    saved: dict[str, types.ModuleType | None] = {}
+
+    def _install(pattern_findings: list[dict[str, Any]]) -> None:
+        for name in _STUBBED_MODULE_NAMES:
+            saved[name] = sys.modules.get(name)
+        for name, mod in _build_atlas_stubs(pattern_findings).items():
+            sys.modules[name] = mod
+
+    yield _install
+
+    for name, original in saved.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+
+# ----------------------------------------------------------------------
+# Test doubles
+# ----------------------------------------------------------------------
+
+
+class _RecordingTraceSink:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def start_span(
+        self,
+        name: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Any:
+        record = {"span": object(), "name": name, "metadata": dict(metadata) if metadata else None}
+        self.events.append(("start", record))
+        return record["span"]
+
+    def end_span(
+        self,
+        span: Any,
+        *,
+        status: str = "ok",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.events.append(
+            (
+                "end",
+                {
+                    "span": span,
+                    "status": status,
+                    "metadata": dict(metadata) if metadata else None,
+                },
+            )
+        )
+
+
+class _StubEventSink:
+    async def emit(
+        self,
+        event_type: str,
+        source: str,
+        payload: Mapping[str, Any],
+        *,
+        entity_type: str | None = None,
+        entity_id: str | None = None,
+    ) -> str:
+        return "stub-id"
+
+
+def _build_fake_ports(trace_sink: _RecordingTraceSink) -> Any:
+    from extracted_reasoning_core.types import ReasoningPorts
+
+    return ReasoningPorts(
+        event_sink=_StubEventSink(),
+        trace_sink=trace_sink,
+    )
+
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_opens_and_closes_span_with_no_findings(
+    install_stubs,
+) -> None:
+    install_stubs([])  # rule-based detectors return nothing
+    from atlas_brain.reasoning.reflection import run_reflection
+
+    trace_sink = _RecordingTraceSink()
+    result = await run_reflection(ports=_build_fake_ports(trace_sink))
+
+    assert [e[0] for e in trace_sink.events] == ["start", "end"]
+    start = trace_sink.events[0][1]
+    end = trace_sink.events[1][1]
+    assert start["name"] == "reasoning.reflection"
+    assert start["metadata"] is None  # no metadata at span start
+
+    assert end["status"] == "ok"
+    # The cycle result dict gets packed into end metadata so the
+    # span carries findings/actions/notifications counts.
+    assert end["metadata"] == {"findings": 0, "actions": 0, "notifications": 0}
+    assert result == {"findings": 0, "actions": 0, "notifications": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_packs_no_llm_path_counts_into_end_metadata(
+    install_stubs,
+) -> None:
+    # With pattern findings present but no LLM available (the stubbed
+    # get_pipeline_llm returns None), reflection notifies on every
+    # rule-based finding. The end-span metadata reflects that.
+    findings = [{"description": "stale thread"}, {"description": "drifted"}]
+    install_stubs(findings)
+    from atlas_brain.reasoning.reflection import run_reflection
+
+    trace_sink = _RecordingTraceSink()
+    result = await run_reflection(ports=_build_fake_ports(trace_sink))
+
+    end = trace_sink.events[1][1]
+    assert end["status"] == "ok"
+    assert end["metadata"] == {
+        "findings": 2,
+        "actions": 0,
+        "notifications": 2,
+    }
+    assert result == {
+        "findings": 2,
+        "actions": 0,
+        "notifications": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_closes_span_with_error_status_on_exception(
+    install_stubs,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Wire a pattern detector that raises -- the span must still close
+    # with status="error" and the exception must propagate so the
+    # autonomous task framework can surface it.
+    install_stubs([])
+
+    async def _raises() -> list[dict[str, Any]]:
+        raise RuntimeError("detector blew up")
+
+    monkeypatch.setattr(
+        sys.modules["atlas_brain.reasoning.patterns"],
+        "run_all_pattern_detectors",
+        _raises,
+    )
+    from atlas_brain.reasoning.reflection import run_reflection
+
+    trace_sink = _RecordingTraceSink()
+    with pytest.raises(RuntimeError, match="detector blew up"):
+        await run_reflection(ports=_build_fake_ports(trace_sink))
+
+    assert [e[0] for e in trace_sink.events] == ["start", "end"]
+    end = trace_sink.events[1][1]
+    assert end["status"] == "error"
+    assert end["metadata"]["error_message"] == "detector blew up"
+    assert end["metadata"]["error_type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_explicit_ports_bypass_default_builder(install_stubs) -> None:
+    # If the default-builder path were taken, run_reflection would import
+    # ``from .agent import _build_default_ports`` and that would in turn
+    # trigger ``atlas_brain.services.tracing.tracer`` -- our stub provides
+    # a no-op tracer so it'd technically succeed, but the point is
+    # structural: the explicit ports we pass must be the ones used.
+    install_stubs([])
+    from atlas_brain.reasoning.reflection import run_reflection
+
+    trace_sink = _RecordingTraceSink()
+    fake_ports = _build_fake_ports(trace_sink)
+    await run_reflection(ports=fake_ports)
+
+    # If the explicit bundle were ignored, our recording trace_sink
+    # would never see the events.
+    assert len(trace_sink.events) == 2


### PR DESCRIPTION
## Summary

Sister slice to PR-C4d. Atlas's cron-driven reflection cycle (`run_reflection` in `atlas_brain/reasoning/reflection.py`) had zero tracing — if the LLM call to Claude stalled or pattern detectors failed, nothing surfaced in FTL. Closes the observability gap that PR-C4d's audit conversation flagged.

## Wiring

- `run_reflection` accepts `ports: ReasoningPorts | None = None`. Production callers (`autonomous/tasks/reasoning_reflection.py`) keep the no-arg invocation; the function lazy-builds defaults via the existing `agent._build_default_ports` factory so tracing stays consistent with `ReasoningAgentGraph`'s reactive entry point.
- The cycle body factors out into `_run_reflection_cycle` so the span wrap stays a single try/except at the public entry.
- Span name `reasoning.reflection`. End-span metadata carries the cycle result dict (findings/llm_findings/actions/notifications).
- Failure path closes `status="error"` with `error_message`/`error_type` metadata (the `AtlasTraceSink` lifts those into atlas tracer kwargs per PR-C4d) and re-raises so the autonomous task framework surfaces the failure.

## Tests (4, all passing locally)

| test | covers |
|---|---|
| `test_run_reflection_opens_and_closes_span_with_no_findings` | empty pattern run path |
| `test_run_reflection_packs_no_llm_path_counts_into_end_metadata` | rule-based + no LLM path |
| `test_run_reflection_closes_span_with_error_status_on_exception` | exception in detector → span closed with `error` + raised |
| `test_explicit_ports_bypass_default_builder` | DI path is honored |

Test layout mirrors PR-C4d's pattern: `sys.modules` stubs for atlas heavy chain (services / pipelines / config) + reflection-internal helpers (patterns / graph / graph_prompts), with the lesson from Codex's PR-C4d review applied — per-test save/restore via fixture so sibling tests in the same pytest invocation don't see leftover stubs.

## CI wired from first commit (PR-C4b lesson)

- `atlas_brain/reasoning/reflection.py` + the new test added to both `pull_request` and `push` `paths:` filters.
- New test appended to `scripts/run_extracted_pipeline_checks.sh`.

## Test plan

- [x] `pytest tests/test_atlas_reasoning_reflection_tracing.py` → 4/4
- [x] `bash scripts/run_extracted_pipeline_checks.sh` → 606 passed (was 602 before)
- [ ] CI green on the 3.10 runner

## Out of scope

- **Event emission for findings** (e.g. `reasoning.reflection_completed`) — speculative, no consumer yet. Skipped per CLAUDE.md "don't add features beyond what the task requires."
- **Inner-step child spans** (rule-based vs LLM analysis vs action execution) — single span per reflection cycle is sufficient observability for now.
- **PR-C4e (graph engine into core)** — the audit's planned next step. Will be sized + queued separately after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)