### PR TITLE
M5-γ: call_transcript domain — second-domain proof-of-life

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -8,6 +8,7 @@ on:
       - "atlas_brain/reasoning/state.py"
       - "atlas_brain/reasoning/port_adapters.py"
       - "atlas_brain/reasoning/vendor_pressure.py"
+      - "atlas_brain/reasoning/call_transcript.py"
       - "atlas_brain/reasoning/agent.py"
       - "atlas_brain/reasoning/reflection.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
@@ -26,6 +27,7 @@ on:
       - "tests/test_atlas_reasoning_state_*.py"
       - "tests/test_atlas_reasoning_port_adapters.py"
       - "tests/test_atlas_reasoning_vendor_pressure.py"
+      - "tests/test_atlas_reasoning_call_transcript.py"
       - "tests/test_atlas_reasoning_agent_port_consumption.py"
       - "tests/test_atlas_reasoning_reflection_tracing.py"
   push:
@@ -35,6 +37,7 @@ on:
       - "atlas_brain/reasoning/state.py"
       - "atlas_brain/reasoning/port_adapters.py"
       - "atlas_brain/reasoning/vendor_pressure.py"
+      - "atlas_brain/reasoning/call_transcript.py"
       - "atlas_brain/reasoning/agent.py"
       - "atlas_brain/reasoning/reflection.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
@@ -53,6 +56,7 @@ on:
       - "tests/test_atlas_reasoning_state_*.py"
       - "tests/test_atlas_reasoning_port_adapters.py"
       - "tests/test_atlas_reasoning_vendor_pressure.py"
+      - "tests/test_atlas_reasoning_call_transcript.py"
       - "tests/test_atlas_reasoning_agent_port_consumption.py"
       - "tests/test_atlas_reasoning_reflection_tracing.py"
 

--- a/atlas_brain/reasoning/call_transcript.py
+++ b/atlas_brain/reasoning/call_transcript.py
@@ -113,12 +113,36 @@ def call_transcript_result_from_entry(
             return ()
         return tuple(str(item) for item in raw if item is not None)
 
-    metric_ids = entry.get("metric_ids") or []
-    witness_ids = entry.get("witness_ids") or []
-    if not isinstance(metric_ids, list):
-        metric_ids = []
-    if not isinstance(witness_ids, list):
-        witness_ids = []
+    # Lineage: prefer the canonical nested ``reference_ids`` object
+    # (matches the synthesis-payload shape across the codebase); fall
+    # back to top-level ``metric_ids`` / ``witness_ids`` keys so a
+    # producer using the flatter pattern still round-trips.
+    ref_ids_raw = entry.get("reference_ids")
+    if isinstance(ref_ids_raw, Mapping):
+        metric_raw = ref_ids_raw.get("metric_ids") or []
+        witness_raw = ref_ids_raw.get("witness_ids") or []
+    else:
+        metric_raw = entry.get("metric_ids") or []
+        witness_raw = entry.get("witness_ids") or []
+
+    def _normalize_ids(raw: Any) -> tuple[str, ...]:
+        """Coerce to str, strip whitespace, drop None/empty.
+
+        Lineage IDs are referenced for resolution downstream; whitespace
+        IDs and empty strings are pure noise that downstream lookups
+        would silently miss-match against, so we filter them out at the
+        envelope boundary.
+        """
+        if not isinstance(raw, list):
+            return ()
+        out: list[str] = []
+        for item in raw:
+            if item is None:
+                continue
+            normalized = str(item).strip()
+            if normalized:
+                out.append(normalized)
+        return tuple(out)
 
     return DomainReasoningResult(
         subject_id=subject_id,
@@ -138,8 +162,8 @@ def call_transcript_result_from_entry(
         risk_level=entry.get("risk_level"),
         archetype=entry.get("archetype"),
         reference_ids=ReferenceIds(
-            metric_ids=tuple(str(m) for m in metric_ids if m is not None),
-            witness_ids=tuple(str(w) for w in witness_ids if w is not None),
+            metric_ids=_normalize_ids(metric_raw),
+            witness_ids=_normalize_ids(witness_raw),
         ),
     )
 

--- a/atlas_brain/reasoning/call_transcript.py
+++ b/atlas_brain/reasoning/call_transcript.py
@@ -1,0 +1,221 @@
+"""Call-transcript reasoning domain — second-domain proof-of-life.
+
+This module demonstrates that the typed-envelope abstraction shipped in
+M5-alpha (#211) and validated by the vendor-pressure specialization in
+M5-beta (#215) is genuinely domain-agnostic. ``call_transcript`` is a
+second concrete domain registered against the same
+``DomainReasoningResult`` envelope and the same producer/consumer
+Protocols, with **zero changes** to ``extracted_reasoning_core``.
+
+Pattern parity with ``vendor_pressure``:
+
+    vendor_pressure                    call_transcript
+    ---------------                    ---------------
+    VendorOpportunitySubject           CallTranscriptSubject
+    VendorPressurePayload              CallTranscriptPayload
+    vendor_pressure_result_from_entry  call_transcript_result_from_entry
+    VendorPressureConsumer             CallTranscriptConsumer
+
+Both register through the same ``register_domain`` entry point and emit
+the same envelope type; only the domain-specific ``domain_payload``
+shape and the consumer field-name mapping differ.
+
+Scope: this is a *proof-of-life* slice, not a full production wiring.
+It proves the abstraction generalizes; it does not pull transcripts
+from any real source. A future product PR can build a producer that
+takes a real transcript -> ``call_transcript_result_from_entry`` ->
+overlay fields on a transcript-detail API/UI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from extracted_reasoning_core.domains import (
+    DomainReasoningResult,
+    ReasoningConsumerPort,
+    ReferenceIds,
+    register_domain,
+)
+
+
+@dataclass(frozen=True)
+class CallTranscriptSubject:
+    """A recorded conversation that reasoning runs against.
+
+    Satisfies ``extracted_reasoning_core.domains.ReasoningSubject``
+    structurally (``id`` / ``domain`` / ``payload``). The ``payload``
+    carries call-shaped metadata (call leg ids, participant emails,
+    duration, source provider, etc.) that the producer needs.
+    """
+
+    id: str
+    domain: str = "call_transcript"
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CallTranscriptPayload:
+    """Call-transcript-specific payload carried in ``domain_payload``.
+
+    Universal fields (confidence, executive_summary, key_signals,
+    falsification_conditions, ...) live on the envelope itself. This
+    payload is for transcript semantics that don't fit a universal
+    slot:
+
+    - ``topics`` -- ranked list of conversation topics surfaced.
+    - ``sentiment`` -- categorical sentiment label
+      (``"positive"`` / ``"neutral"`` / ``"negative"`` / ``None``).
+    - ``action_items`` -- explicit follow-ups extracted from the call.
+    - ``participants`` -- normalized participant identifiers (emails,
+      phone numbers, internal user ids) the conversation involved.
+
+    A vendor-pressure consumer would never read these; a transcript
+    consumer never reads ``wedge``. That separation is the point of
+    the typed envelope.
+    """
+
+    topics: tuple[str, ...] = ()
+    sentiment: str | None = None
+    action_items: tuple[str, ...] = ()
+    participants: tuple[str, ...] = ()
+
+
+def call_transcript_result_from_entry(
+    entry: Mapping[str, Any] | None,
+    *,
+    subject_id: str = "",
+) -> DomainReasoningResult[CallTranscriptPayload]:
+    """Build a typed reasoning result from a flat transcript-entry dict.
+
+    Mirrors :func:`atlas_brain.reasoning.vendor_pressure.vendor_pressure_result_from_entry`
+    -- pure dict-in / envelope-out conversion that tests can drive
+    directly with synthetic entries.
+
+    Universal envelope fields (``confidence``, ``executive_summary``,
+    ``key_signals``, ``uncertainty_sources``, ``falsification_conditions``,
+    ``mode``, ``risk_level``, ``archetype``, ``reference_ids``) are
+    populated from same-named keys in ``entry`` when present. The
+    domain-specific ``CallTranscriptPayload`` is built from
+    ``topics`` / ``sentiment`` / ``action_items`` / ``participants``
+    keys.
+
+    A ``None`` or empty entry produces a result with ``confidence=None``
+    and empty-tuple list fields, matching the envelope's sparse contract.
+    """
+    entry = entry or {}
+
+    def _as_tuple(key: str) -> tuple[str, ...]:
+        raw = entry.get(key) or []
+        if not isinstance(raw, list):
+            return ()
+        return tuple(str(item) for item in raw if item is not None)
+
+    metric_ids = entry.get("metric_ids") or []
+    witness_ids = entry.get("witness_ids") or []
+    if not isinstance(metric_ids, list):
+        metric_ids = []
+    if not isinstance(witness_ids, list):
+        witness_ids = []
+
+    return DomainReasoningResult(
+        subject_id=subject_id,
+        domain="call_transcript",
+        confidence=entry.get("confidence"),
+        domain_payload=CallTranscriptPayload(
+            topics=_as_tuple("topics"),
+            sentiment=entry.get("sentiment"),
+            action_items=_as_tuple("action_items"),
+            participants=_as_tuple("participants"),
+        ),
+        executive_summary=entry.get("executive_summary"),
+        key_signals=_as_tuple("key_signals"),
+        uncertainty_sources=_as_tuple("uncertainty_sources"),
+        falsification_conditions=_as_tuple("falsification_conditions"),
+        mode=entry.get("mode"),
+        risk_level=entry.get("risk_level"),
+        archetype=entry.get("archetype"),
+        reference_ids=ReferenceIds(
+            metric_ids=tuple(str(m) for m in metric_ids if m is not None),
+            witness_ids=tuple(str(w) for w in witness_ids if w is not None),
+        ),
+    )
+
+
+class CallTranscriptConsumer:
+    """Consumer adapter for the ``"call_transcript"`` domain.
+
+    Satisfies ``ReasoningConsumerPort[CallTranscriptPayload]``. Projects
+    the typed envelope into flat overlay dicts suitable for an
+    MCP/API/UI surface that wants to render transcript reasoning. The
+    field-name mapping is independent of the vendor-pressure consumer
+    -- a transcript-detail API exposes ``transcript_topics``, not
+    ``archetype``; ``transcript_sentiment``, not ``reasoning_risk_level``.
+
+    Field-name mapping from envelope -> overlay output:
+
+        envelope.confidence                  -> ``transcript_confidence``
+        envelope.confidence_label            -> ``transcript_confidence_label``
+        envelope.executive_summary           -> ``transcript_summary``
+        envelope.key_signals                 -> ``transcript_key_signals``
+        envelope.uncertainty_sources         -> ``transcript_uncertainty_sources``
+        envelope.falsification_conditions    -> ``transcript_falsification_conditions``
+        envelope.archetype                   -> ``transcript_archetype``
+        envelope.domain_payload.topics       -> ``transcript_topics``
+        envelope.domain_payload.sentiment    -> ``transcript_sentiment``
+        envelope.domain_payload.action_items -> ``transcript_action_items``
+        envelope.domain_payload.participants -> ``transcript_participants``
+
+    Summary returns the four most-quoted fields for a list view; detail
+    returns the full set for a transcript-detail view.
+    """
+
+    def to_summary_fields(
+        self,
+        result: DomainReasoningResult[CallTranscriptPayload],
+    ) -> Mapping[str, Any]:
+        return {
+            "transcript_archetype": result.archetype,
+            "transcript_confidence": result.confidence,
+            "transcript_sentiment": result.domain_payload.sentiment,
+            "transcript_topics": list(result.domain_payload.topics),
+        }
+
+    def to_detail_fields(
+        self,
+        result: DomainReasoningResult[CallTranscriptPayload],
+    ) -> Mapping[str, Any]:
+        return {
+            "transcript_archetype": result.archetype,
+            "transcript_confidence": result.confidence,
+            "transcript_confidence_label": result.confidence_label,
+            "transcript_summary": result.executive_summary,
+            "transcript_topics": list(result.domain_payload.topics),
+            "transcript_sentiment": result.domain_payload.sentiment,
+            "transcript_action_items": list(result.domain_payload.action_items),
+            "transcript_participants": list(result.domain_payload.participants),
+            "transcript_key_signals": list(result.key_signals),
+            "transcript_uncertainty_sources": list(result.uncertainty_sources),
+            "transcript_falsification_conditions": list(
+                result.falsification_conditions
+            ),
+        }
+
+
+# Module-import side effect: register the domain. Idempotent on
+# identical re-registration; conflict raises.
+register_domain(
+    "call_transcript",
+    subject_type=CallTranscriptSubject,
+    payload_type=CallTranscriptPayload,
+)
+
+
+__all__ = [
+    "CallTranscriptConsumer",
+    "CallTranscriptPayload",
+    "CallTranscriptSubject",
+    "call_transcript_result_from_entry",
+]

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -49,6 +49,7 @@ pytest \
   tests/test_atlas_reasoning_state_inherits_core.py \
   tests/test_atlas_reasoning_port_adapters.py \
   tests/test_atlas_reasoning_vendor_pressure.py \
+  tests/test_atlas_reasoning_call_transcript.py \
   tests/test_atlas_reasoning_agent_port_consumption.py \
   tests/test_atlas_reasoning_reflection_tracing.py \
   tests/test_extracted_product_utilities.py \

--- a/tests/test_atlas_reasoning_call_transcript.py
+++ b/tests/test_atlas_reasoning_call_transcript.py
@@ -187,16 +187,74 @@ def test_result_handles_explicit_null_lists() -> None:
     assert result.reference_ids.witness_ids == ()
 
 
-def test_result_drops_non_string_list_items() -> None:
-    """Defensive: producer might pass non-string items; coerce or skip."""
+def test_result_coerces_non_string_list_items_and_drops_none() -> None:
+    """Defensive coercion: ``None`` items are filtered, non-strings are
+    coerced via ``str()`` (e.g. ``42`` -> ``"42"``).
+
+    Domain-payload lists keep the same shape as their producer (so
+    integers in ``topics`` survive as their stringified form). Lineage
+    IDs go through a tighter ``_normalize_ids`` path that additionally
+    strips whitespace and drops empties — see
+    :func:`test_lineage_ids_normalize_and_filter_empty`.
+    """
     entry = {
         "topics": ["renewal", None, 42, "pricing"],
         "metric_ids": [None, "real_metric_id"],
     }
     result = call_transcript_result_from_entry(entry)
-    # None gets filtered; non-string is coerced via str()
     assert result.domain_payload.topics == ("renewal", "42", "pricing")
     assert result.reference_ids.metric_ids == ("real_metric_id",)
+
+
+def test_lineage_ids_strip_whitespace_and_drop_empty() -> None:
+    """Lineage IDs are normalized: whitespace stripped, empties dropped.
+
+    Unlike domain-payload lists (which preserve coerced strings even if
+    short or padded), lineage IDs feed downstream lookups; whitespace
+    or empty IDs would silently miss-match, so the envelope filters
+    them at the boundary.
+    """
+    entry = {
+        "metric_ids": ["  m1  ", "", "   ", None, "m2"],
+        "witness_ids": ["w1", "  w2", ""],
+    }
+    result = call_transcript_result_from_entry(entry)
+    assert result.reference_ids.metric_ids == ("m1", "m2")
+    assert result.reference_ids.witness_ids == ("w1", "w2")
+
+
+def test_lineage_prefers_nested_reference_ids_object() -> None:
+    """When the entry carries a nested ``reference_ids`` object (the
+    canonical synthesis-payload shape), the builder reads from there
+    and the top-level ``metric_ids``/``witness_ids`` fallback is
+    ignored.
+    """
+    entry = {
+        "reference_ids": {
+            "metric_ids": ["nested_m1", "nested_m2"],
+            "witness_ids": ["nested_w1"],
+        },
+        # Top-level keys are present but should be ignored when the
+        # nested object exists.
+        "metric_ids": ["top_level_m_should_be_ignored"],
+        "witness_ids": ["top_level_w_should_be_ignored"],
+    }
+    result = call_transcript_result_from_entry(entry)
+    assert result.reference_ids.metric_ids == ("nested_m1", "nested_m2")
+    assert result.reference_ids.witness_ids == ("nested_w1",)
+
+
+def test_lineage_falls_back_to_top_level_when_nested_absent() -> None:
+    """Without a nested ``reference_ids`` object, the flat shape used
+    by the vendor-pressure-style entry path still round-trips.
+    """
+    entry = {
+        "metric_ids": ["flat_m1"],
+        "witness_ids": ["flat_w1"],
+    }
+    result = call_transcript_result_from_entry(entry)
+    assert result.reference_ids.metric_ids == ("flat_m1",)
+    assert result.reference_ids.witness_ids == ("flat_w1",)
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_atlas_reasoning_call_transcript.py
+++ b/tests/test_atlas_reasoning_call_transcript.py
@@ -1,0 +1,336 @@
+"""Tests for the call-transcript reasoning domain (M5-gamma).
+
+Validates that the typed-envelope abstraction generalizes to a second
+domain — ``call_transcript`` registers, builds, and projects without
+touching ``extracted_reasoning_core`` or ``vendor_pressure``. Also
+demonstrates **coexistence**: both domains live in the registry at
+once and their consumers project to entirely different overlay-field
+sets from envelopes of the same Python type.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atlas_brain.reasoning.call_transcript import (
+    CallTranscriptConsumer,
+    CallTranscriptPayload,
+    CallTranscriptSubject,
+    call_transcript_result_from_entry,
+)
+from atlas_brain.reasoning.vendor_pressure import (
+    VendorOpportunitySubject,
+    VendorPressureConsumer,
+    VendorPressurePayload,
+    vendor_pressure_result_from_entry,
+)
+from extracted_reasoning_core.domains import (
+    DomainReasoningResult,
+    ReasoningConsumerPort,
+    ReasoningSubject,
+    get_domain,
+    list_domains,
+)
+
+
+# ---------------------------------------------------------------------
+# Subject / payload basic shape
+# ---------------------------------------------------------------------
+
+
+def test_call_transcript_subject_satisfies_reasoning_subject_protocol() -> None:
+    subject = CallTranscriptSubject(
+        id="call-42",
+        payload={
+            "duration_seconds": 1820,
+            "participants": ["alice@example.com", "bob@acme.com"],
+        },
+    )
+    assert isinstance(subject, ReasoningSubject)
+    assert subject.id == "call-42"
+    assert subject.domain == "call_transcript"
+    assert subject.payload["duration_seconds"] == 1820
+
+
+def test_call_transcript_payload_default() -> None:
+    payload = CallTranscriptPayload()
+    assert payload.topics == ()
+    assert payload.sentiment is None
+    assert payload.action_items == ()
+    assert payload.participants == ()
+
+
+def test_call_transcript_payload_with_values() -> None:
+    payload = CallTranscriptPayload(
+        topics=("renewal", "pricing"),
+        sentiment="negative",
+        action_items=("send proposal",),
+        participants=("alice@example.com",),
+    )
+    assert payload.topics == ("renewal", "pricing")
+    assert payload.sentiment == "negative"
+
+
+# ---------------------------------------------------------------------
+# Domain registration (module import side effect)
+# ---------------------------------------------------------------------
+
+
+def test_call_transcript_domain_is_registered() -> None:
+    desc = get_domain("call_transcript")
+    assert desc is not None
+    assert desc.name == "call_transcript"
+    assert desc.subject_type is CallTranscriptSubject
+    assert desc.payload_type is CallTranscriptPayload
+
+
+def test_both_domains_coexist_in_registry() -> None:
+    """The whole point of the abstraction: vendor_pressure + call_transcript
+    coexist in the same registry, identified by ``domain`` string."""
+    names = {d.name for d in list_domains()}
+    assert {"vendor_pressure", "call_transcript"}.issubset(names)
+
+
+# ---------------------------------------------------------------------
+# Builder: full + sparse + lineage
+# ---------------------------------------------------------------------
+
+
+def test_result_from_full_entry() -> None:
+    entry = {
+        "archetype": "renewal_at_risk",
+        "confidence": 0.74,
+        "mode": "synthesis",
+        "risk_level": "high",
+        "executive_summary": "Customer asked twice about pricing flexibility.",
+        "key_signals": ["pricing_pushback", "competitor_mention"],
+        "uncertainty_sources": ["only one decision-maker on the call"],
+        "falsification_conditions": ["renewal signed within 14 days"],
+        "topics": ["renewal", "pricing", "competition"],
+        "sentiment": "negative",
+        "action_items": ["send pricing comparison", "schedule follow-up"],
+        "participants": ["alice@example.com", "bob@acme.com"],
+        "metric_ids": ["price_mentions", "exec_change"],
+        "witness_ids": ["transcript-42-segment-7"],
+    }
+
+    result = call_transcript_result_from_entry(entry, subject_id="call-42")
+
+    assert isinstance(result, DomainReasoningResult)
+    assert result.subject_id == "call-42"
+    assert result.domain == "call_transcript"
+    assert result.confidence == pytest.approx(0.74)
+    assert result.archetype == "renewal_at_risk"
+    assert result.executive_summary == "Customer asked twice about pricing flexibility."
+    assert result.key_signals == ("pricing_pushback", "competitor_mention")
+    assert result.uncertainty_sources == ("only one decision-maker on the call",)
+    assert result.falsification_conditions == ("renewal signed within 14 days",)
+    # Domain payload carries the call-specific shape
+    assert result.domain_payload.topics == ("renewal", "pricing", "competition")
+    assert result.domain_payload.sentiment == "negative"
+    assert result.domain_payload.action_items == (
+        "send pricing comparison",
+        "schedule follow-up",
+    )
+    assert result.domain_payload.participants == (
+        "alice@example.com",
+        "bob@acme.com",
+    )
+    # Lineage round-trips through the envelope
+    assert result.reference_ids.metric_ids == ("price_mentions", "exec_change")
+    assert result.reference_ids.witness_ids == ("transcript-42-segment-7",)
+
+
+def test_result_from_empty_entry_is_sparse() -> None:
+    result = call_transcript_result_from_entry({})
+
+    assert result.subject_id == ""
+    assert result.domain == "call_transcript"
+    assert result.confidence is None
+    assert result.archetype is None
+    assert result.executive_summary is None
+    assert result.key_signals == ()
+    assert result.uncertainty_sources == ()
+    assert result.falsification_conditions == ()
+    assert result.domain_payload.topics == ()
+    assert result.domain_payload.sentiment is None
+    assert result.domain_payload.action_items == ()
+    assert result.domain_payload.participants == ()
+    assert result.reference_ids.metric_ids == ()
+    assert result.reference_ids.witness_ids == ()
+
+
+def test_result_from_none_entry_is_sparse() -> None:
+    result = call_transcript_result_from_entry(None)
+    assert result.confidence is None
+    assert result.domain_payload.topics == ()
+
+
+def test_result_handles_explicit_null_lists() -> None:
+    """Producer dict may set list keys to explicit None; envelope still
+    gets empty tuples (mirrors the PR #184 sparse-entry guard pattern
+    used in vendor_pressure)."""
+    entry = {
+        "topics": None,
+        "action_items": None,
+        "participants": None,
+        "key_signals": None,
+        "metric_ids": None,
+        "witness_ids": None,
+    }
+    result = call_transcript_result_from_entry(entry)
+    assert result.domain_payload.topics == ()
+    assert result.domain_payload.action_items == ()
+    assert result.domain_payload.participants == ()
+    assert result.key_signals == ()
+    assert result.reference_ids.metric_ids == ()
+    assert result.reference_ids.witness_ids == ()
+
+
+def test_result_drops_non_string_list_items() -> None:
+    """Defensive: producer might pass non-string items; coerce or skip."""
+    entry = {
+        "topics": ["renewal", None, 42, "pricing"],
+        "metric_ids": [None, "real_metric_id"],
+    }
+    result = call_transcript_result_from_entry(entry)
+    # None gets filtered; non-string is coerced via str()
+    assert result.domain_payload.topics == ("renewal", "42", "pricing")
+    assert result.reference_ids.metric_ids == ("real_metric_id",)
+
+
+# ---------------------------------------------------------------------
+# CallTranscriptConsumer projection
+# ---------------------------------------------------------------------
+
+
+def test_consumer_satisfies_reasoning_consumer_port() -> None:
+    assert isinstance(CallTranscriptConsumer(), ReasoningConsumerPort)
+
+
+def _full_result() -> DomainReasoningResult[CallTranscriptPayload]:
+    return DomainReasoningResult(
+        subject_id="call-42",
+        domain="call_transcript",
+        confidence=0.74,
+        domain_payload=CallTranscriptPayload(
+            topics=("renewal", "pricing"),
+            sentiment="negative",
+            action_items=("send proposal",),
+            participants=("alice@example.com",),
+        ),
+        confidence_label="medium",
+        executive_summary="exec",
+        key_signals=("a",),
+        uncertainty_sources=("u1",),
+        falsification_conditions=("f1",),
+        archetype="renewal_at_risk",
+    )
+
+
+def test_consumer_summary_projection() -> None:
+    out = CallTranscriptConsumer().to_summary_fields(_full_result())
+    assert out == {
+        "transcript_archetype": "renewal_at_risk",
+        "transcript_confidence": 0.74,
+        "transcript_sentiment": "negative",
+        "transcript_topics": ["renewal", "pricing"],
+    }
+
+
+def test_consumer_detail_projection() -> None:
+    out = CallTranscriptConsumer().to_detail_fields(_full_result())
+    assert out == {
+        "transcript_archetype": "renewal_at_risk",
+        "transcript_confidence": 0.74,
+        "transcript_confidence_label": "medium",
+        "transcript_summary": "exec",
+        "transcript_topics": ["renewal", "pricing"],
+        "transcript_sentiment": "negative",
+        "transcript_action_items": ["send proposal"],
+        "transcript_participants": ["alice@example.com"],
+        "transcript_key_signals": ["a"],
+        "transcript_uncertainty_sources": ["u1"],
+        "transcript_falsification_conditions": ["f1"],
+    }
+
+
+def test_consumer_sparse_result_keeps_stable_keys() -> None:
+    sparse = DomainReasoningResult(
+        subject_id="",
+        domain="call_transcript",
+        confidence=None,
+        domain_payload=CallTranscriptPayload(),
+    )
+    consumer = CallTranscriptConsumer()
+    summary = consumer.to_summary_fields(sparse)
+    detail = consumer.to_detail_fields(sparse)
+
+    assert summary == {
+        "transcript_archetype": None,
+        "transcript_confidence": None,
+        "transcript_sentiment": None,
+        "transcript_topics": [],
+    }
+    assert set(detail.keys()) == {
+        "transcript_archetype",
+        "transcript_confidence",
+        "transcript_confidence_label",
+        "transcript_summary",
+        "transcript_topics",
+        "transcript_sentiment",
+        "transcript_action_items",
+        "transcript_participants",
+        "transcript_key_signals",
+        "transcript_uncertainty_sources",
+        "transcript_falsification_conditions",
+    }
+
+
+# ---------------------------------------------------------------------
+# Domain isolation: vendor-pressure and call-transcript don't bleed
+# ---------------------------------------------------------------------
+
+
+def test_consumers_project_to_disjoint_field_sets() -> None:
+    """Belt-and-suspenders proof that the typed envelope keeps domains
+    isolated: a vendor-pressure consumer and a call-transcript consumer
+    fed isomorphic envelopes produce overlay dicts with disjoint keys.
+
+    This is the value of the abstraction in one test: an MCP/API
+    surface can pick the right consumer for its domain without any
+    coordination between the two domain modules.
+    """
+    vp_result = vendor_pressure_result_from_entry(
+        {
+            "archetype": "price_squeeze",
+            "confidence": 0.82,
+            "mode": "synthesis",
+            "risk_level": "high",
+        }
+    )
+    tx_result = call_transcript_result_from_entry(
+        {
+            "archetype": "renewal_at_risk",
+            "confidence": 0.74,
+            "topics": ["renewal"],
+        }
+    )
+
+    vp_summary = VendorPressureConsumer().to_summary_fields(vp_result)
+    tx_summary = CallTranscriptConsumer().to_summary_fields(tx_result)
+
+    # No key overlap between the two summaries
+    assert set(vp_summary.keys()).isdisjoint(set(tx_summary.keys()))
+
+
+def test_subject_protocol_satisfied_by_both_subject_types() -> None:
+    """Both subject types satisfy the same Protocol — that's how a
+    generic dispatcher could route to either domain producer without
+    knowing about either dataclass concretely."""
+    subjects = (
+        VendorOpportunitySubject(id="opp-1"),
+        CallTranscriptSubject(id="call-42"),
+    )
+    for s in subjects:
+        assert isinstance(s, ReasoningSubject)


### PR DESCRIPTION
## Summary

Demonstrates that the typed-envelope abstraction shipped in **M5-α** (#211) and validated by vendor-pressure in **M5-β** (#215) is genuinely domain-agnostic. `call_transcript` is a second concrete domain registered against the same `DomainReasoningResult` envelope and the same producer/consumer Protocols, **with zero changes to `extracted_reasoning_core` or `vendor_pressure.py`**.

This directly answers the original goal: *"I want to be able to use the reasoning systems for other use cases, like company data or whatever else a user may want to use it for. … I don't want to have to refactor again later when I want to reason over say call transcripts or internal company data."*

After this lands, adding a third domain (company_entity, support_ticket, etc.) is the same exact pattern — one new file, one new test file, no core changes.

## Pattern parity

| `vendor_pressure` | `call_transcript` |
|---|---|
| `VendorOpportunitySubject` | `CallTranscriptSubject` |
| `VendorPressurePayload` (`wedge`) | `CallTranscriptPayload` (`topics`, `sentiment`, `action_items`, `participants`) |
| `vendor_pressure_result_from_entry` | `call_transcript_result_from_entry` |
| `VendorPressureConsumer` (→ `archetype` / `reasoning_*` keys) | `CallTranscriptConsumer` (→ `transcript_*` keys) |
| `register_domain("vendor_pressure", ...)` | `register_domain("call_transcript", ...)` |

Both register through the same entry point. Both emit the same envelope type. **Only the domain-specific `domain_payload` shape and consumer field-name mapping differ.**

## Files

### `atlas_brain/reasoning/call_transcript.py` (new, 215 lines)

- **`CallTranscriptSubject`** — structurally satisfies `ReasoningSubject`. `domain` defaults to `"call_transcript"`.
- **`CallTranscriptPayload`** — `topics: tuple[str, ...]`, `sentiment: str | None`, `action_items: tuple[str, ...]`, `participants: tuple[str, ...]`. Universal fields (`confidence`, `executive_summary`, etc.) stay on the envelope.
- **`call_transcript_result_from_entry(entry, *, subject_id="")`** — pure dict-in / envelope-out builder. Sparse-entry guard for list fields (None → empty tuple), defensive coercion for non-string list items, lineage round-trips through `reference_ids` (`metric_ids`, `witness_ids`).
- **`CallTranscriptConsumer`** — implements `ReasoningConsumerPort[CallTranscriptPayload]`. Projects to `transcript_*`-prefixed overlay keys (no overlap with vendor-pressure's `archetype_*`/`reasoning_*` keys).
- Module-import side effect: `register_domain("call_transcript", ...)`.

### `tests/test_atlas_reasoning_call_transcript.py` (new, 16 tests)

- Subject / payload shape + Protocol satisfaction.
- Registration + **coexistence** with vendor_pressure in the registry.
- Builder: full + sparse + None-entry + null-list + non-string coercion + lineage round-trip.
- Consumer: full + sparse summary/detail projections.
- **Cross-domain isolation**: `VendorPressureConsumer` and `CallTranscriptConsumer` fed isomorphic envelopes produce overlay dicts with **disjoint keys**. This is the central value of the abstraction in one test.

### CI wiring

- `scripts/run_extracted_pipeline_checks.sh` — adds `tests/test_atlas_reasoning_call_transcript.py` to the pytest matrix.
- `.github/workflows/extracted_pipeline_checks.yml` — `paths:` filters extended to `atlas_brain/reasoning/call_transcript.py` and the new test file (both `pull_request` and `push`).

## Behavior-change statement

Zero. Pure additive new domain. Existing `vendor_pressure` paths and `signals.py` overlays are unchanged. Domain registry now contains both `vendor_pressure` and `call_transcript`; nothing else changes.

## Verification

```
$ python3 -m pytest tests/test_atlas_reasoning_call_transcript.py \
                    tests/test_atlas_reasoning_vendor_pressure.py \
                    tests/test_extracted_reasoning_core_domains.py -q
..................................................                       [100%]
50 passed in 0.35s
```

## Contract impact

Additive only. New module, new tests, no existing module/test changed.

## Rollback plan

Revert. Single new module + single new test file, both fully isolated.

## Plan reference

`docs/hybrid_extraction_plan_status_2026-05-05.md` — the "second-domain proof-of-life" follow-up listed in the M5-β PR. Validates the user-facing goal stated when M5 was reframed: domain-agnostic reasoning that won't need refactoring when new use cases land.

## Scope

This is a **proof-of-life** slice. It does **not** pull transcripts from any real source — there's no producer task that reads call data and calls `call_transcript_result_from_entry`. A future product PR can build that producer (the abstraction is now ready for it).

---
_Generated by [Claude Code](https://claude.ai/code/session_017k4xQ6eLxysGkgLnGv4noh)_