### PR TITLE
Clean up PR 230 extraction coordination

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -7,6 +7,5 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
-| #230 | Route battle-card runtime helpers through support port | `atlas_brain/services/b2b/battle_card_ports.py`; `extracted_competitive_intelligence/services/b2b/battle_card_ports.py`; `atlas_brain/autonomous/tasks/b2b_battle_cards.py`; `extracted_competitive_intelligence/autonomous/tasks/b2b_battle_cards.py`; `tests/test_extracted_competitive_battle_card_ports.py`; `extracted_competitive_intelligence/README.md`; `extracted_competitive_intelligence/STATUS.md` | codex-2026-05-05 | Competitive battle-card churn-scope/progress seams only; avoid synthesis reader, reasoning core, LLM gateway, content pipeline, and cross-product audit files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
## Summary
- remove PR #230 from the in-flight extraction coordination table after merge

## Validation
- `git diff --check`

Ready PR, not draft.