### PR TITLE
Clarify CampaignReasoningProviderPort role distinction; resolve M5-β followup #3

### DIFF
--- a/docs/hybrid_extraction_plan_status_2026-05-05.md
+++ b/docs/hybrid_extraction_plan_status_2026-05-05.md
@@ -117,20 +117,23 @@ Bare-minimum content for the compatibility matrix:
 
 PRs that close out the deferred items from M5-β / M5-γ:
 
-- **Wire b2b regression tests into CI** — *resolved* by adding the
-  two regression tests to `extracted_competitive_intelligence_checks.yml`
-  (the heavier CI tier that already does `pip install -r requirements.txt`).
-  PR for this followup is open (it sits on the same workflow that already
-  installs `apscheduler` / `asyncpg` / `mcp` / `torch`, so no install-line
+- **Wire b2b regression tests into CI** — *resolved in PR #229
+  (open, awaiting merge)*. Adds the two regression tests to
+  `.github/workflows/extracted_competitive_intelligence_checks.yml`
+  (the heavier CI tier that already does
+  `pip install -r requirements.txt` and so already carries
+  `apscheduler` / `asyncpg` / `mcp` / `torch` — no install-line
   expansion needed).
-- **Lineage / freshness in the typed envelope** — *resolved* by
-  threading `view.reference_ids` / `view.as_of_date_iso()` /
+- **Lineage / freshness in the typed envelope** — *resolved in PR
+  #232 (open, awaiting merge)*. Threads `view.reference_ids` /
+  `view.as_of_date_iso` (property) /
   `view.confidence("causal_narrative")` through the synthesis-view
   wrapper into `DomainReasoningResult.reference_ids` / `as_of` /
-  `confidence_label`. PR open. Wire shape preserved (consumer
-  projections still don't surface the new fields; that's a follow-up).
+  `confidence_label`. Wire shape preserved (consumer projections
+  still don't surface the new fields; that's a follow-up).
 - **Provider-port retyping (`CampaignReasoningProviderPort` →
-  `ReasoningProducerPort[...]`)** — *resolved as not-applicable*.
+  `ReasoningProducerPort[...]`)** — *resolved in this PR (open,
+  awaiting merge) as not-applicable*.
   On closer inspection, `CampaignReasoningProviderPort` is a
   **data-input provider** for the campaign generator, not a reasoning
   compute port. It returns a `CampaignReasoningContext` (anchor

--- a/docs/hybrid_extraction_plan_status_2026-05-05.md
+++ b/docs/hybrid_extraction_plan_status_2026-05-05.md
@@ -113,6 +113,46 @@ Bare-minimum content for the compatibility matrix:
 
 ---
 
+## Followup-resolution log
+
+PRs that close out the deferred items from M5-β / M5-γ:
+
+- **Wire b2b regression tests into CI** — *resolved* by adding the
+  two regression tests to `extracted_competitive_intelligence_checks.yml`
+  (the heavier CI tier that already does `pip install -r requirements.txt`).
+  PR for this followup is open (it sits on the same workflow that already
+  installs `apscheduler` / `asyncpg` / `mcp` / `torch`, so no install-line
+  expansion needed).
+- **Lineage / freshness in the typed envelope** — *resolved* by
+  threading `view.reference_ids` / `view.as_of_date_iso()` /
+  `view.confidence("causal_narrative")` through the synthesis-view
+  wrapper into `DomainReasoningResult.reference_ids` / `as_of` /
+  `confidence_label`. PR open. Wire shape preserved (consumer
+  projections still don't surface the new fields; that's a follow-up).
+- **Provider-port retyping (`CampaignReasoningProviderPort` →
+  `ReasoningProducerPort[...]`)** — *resolved as not-applicable*.
+  On closer inspection, `CampaignReasoningProviderPort` is a
+  **data-input provider** for the campaign generator, not a reasoning
+  compute port. It returns a `CampaignReasoningContext` (anchor
+  examples, witness highlights, top theses, account signals, proof
+  points -- a vendor-pressure-domain-shaped input bundle), whereas
+  `ReasoningProducerPort` returns a `DomainReasoningResult[PayloadT]`
+  (typed reasoning envelope). Different role, different return type.
+  Forcing one to be a Protocol-level specialization of the other would
+  break every implementer. Resolution: **document the role
+  distinction in `extracted_content_pipeline/services/reasoning_provider_port.py`**
+  so the next reader doesn't repeat the conflation. Future
+  enrichment can let `CampaignReasoningContext` carry a typed
+  envelope as it gains production-side use; that's enrichment-of-the-
+  bundle, not retyping-of-the-port.
+- **`VendorPressurePayload` enrichment** — deferred. Add
+  displacement narrative / account-signals / proof-points fields when
+  a producer-side caller needs them.
+- **Second-domain proof-of-life** — *resolved* by M5-γ
+  (`call_transcript`) — already merged.
+
+---
+
 ## Lessons from the codex-cloud loop
 
 This is for the record so we don't repeat the pattern:

--- a/extracted_content_pipeline/services/reasoning_provider_port.py
+++ b/extracted_content_pipeline/services/reasoning_provider_port.py
@@ -23,13 +23,13 @@ are **different architectural roles** that happen to share the word
 
 So a typical end-to-end flow looks like:
 
-    1. A reasoning producer (vendor-pressure, call-transcript, ...)
-       implements ``ReasoningProducerPort`` and emits a typed
+    1. A reasoning producer (``vendor_pressure``, ``call_transcript``,
+       ...) implements ``ReasoningProducerPort`` and emits a typed
        envelope per subject.
     2. A host pipeline persists / indexes that envelope.
     3. ``CampaignReasoningProviderPort`` (a *separate* component)
-       reads back the persisted vendor-pressure data shaped as a
-       ``CampaignReasoningContext`` so the campaign generator can
+       reads back the persisted ``vendor_pressure`` data shaped as
+       a ``CampaignReasoningContext`` so the campaign generator can
        consume it.
 
 A future enrichment can grow ``CampaignReasoningContext`` to carry a

--- a/extracted_content_pipeline/services/reasoning_provider_port.py
+++ b/extracted_content_pipeline/services/reasoning_provider_port.py
@@ -1,4 +1,45 @@
-"""Host-owned provider port for campaign reasoning context."""
+"""Host-owned provider port for campaign reasoning context.
+
+Role distinction (M5-alpha / M5-beta context):
+
+This port and ``extracted_reasoning_core.domains.ReasoningProducerPort``
+are **different architectural roles** that happen to share the word
+"reasoning":
+
+* ``CampaignReasoningProviderPort`` (this module) is a **data-input
+  provider**. It returns a ``CampaignReasoningContext`` -- a
+  vendor-pressure-domain-shaped bundle of pre-computed inputs
+  (``anchor_examples``, ``witness_highlights``, ``top_theses``,
+  ``account_signals``, ``proof_points``, ``timing_windows``, ...)
+  that the campaign generator feeds into its prompts. The host has
+  already done the upstream reasoning; this port just supplies the
+  per-target payload.
+
+* ``ReasoningProducerPort[SubjectT, PayloadT]`` (M5-alpha) is a
+  **reasoning compute port**. It takes a subject and produces a
+  typed ``DomainReasoningResult[PayloadT]`` envelope. The producer
+  is what *runs* the reasoning; consumers project the envelope into
+  overlay fields.
+
+So a typical end-to-end flow looks like:
+
+    1. A reasoning producer (vendor-pressure, call-transcript, ...)
+       implements ``ReasoningProducerPort`` and emits a typed
+       envelope per subject.
+    2. A host pipeline persists / indexes that envelope.
+    3. ``CampaignReasoningProviderPort`` (a *separate* component)
+       reads back the persisted vendor-pressure data shaped as a
+       ``CampaignReasoningContext`` so the campaign generator can
+       consume it.
+
+A future enrichment can grow ``CampaignReasoningContext`` to carry a
+``DomainReasoningResult[VendorPressurePayload]`` directly (or convert
+between the two shapes) once the producer-side typed envelope is in
+production use. That work is tracked in the plan-status doc as a
+follow-up; it is intentionally not done here because it would touch
+every campaign-generator caller and isn't required for the
+domain-agnostic reasoning abstraction itself to be useful.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +51,17 @@ from ..campaign_ports import CampaignReasoningContext, TenantScope
 
 @runtime_checkable
 class CampaignReasoningProviderPort(Protocol):
-    """Port for reading per-target reasoning context from a host provider."""
+    """Port for reading per-target reasoning context from a host provider.
+
+    Implementers fetch the prepared per-campaign-target reasoning bundle
+    keyed by ``scope`` (tenant) and ``target_id``. Returning ``None``
+    signals that no context is available for that target; the campaign
+    generator falls back to its zero-context defaults rather than
+    failing.
+
+    See module docstring for how this port relates to the M5-alpha
+    ``ReasoningProducerPort``.
+    """
 
     async def read_campaign_reasoning_context(
         self,


### PR DESCRIPTION
## Summary

Closes deferred follow-up **#3** from PR #215 (M5-β). The original followup said:

> `CampaignReasoningProviderPort` could be re-typed as a specialization of `ReasoningProducerPort[VendorOpportunitySubject, VendorPressurePayload]`.

On closer inspection that re-typing doesn't actually work — the right resolution is **documentation**, not code.

## Why re-typing doesn't apply

| | `CampaignReasoningProviderPort` | `ReasoningProducerPort` |
|---|---|---|
| Method | `read_campaign_reasoning_context(...)` | `produce(...)` |
| Returns | `CampaignReasoningContext` | `DomainReasoningResult[PayloadT]` |
| Role | **data-input provider** for the campaign generator | **reasoning compute port** |
| Caller has already done reasoning? | yes — this port just looks up per-target payload | no — this port *runs* the reasoning |

Forcing one to be a Protocol-level specialization of the other would require renaming the method, changing the return type to a typed envelope, and breaking every implementer (e.g. `FileCampaignReasoningContextProvider`). The two surfaces are genuinely different architectural roles that just happen to share the word "reasoning".

## Files

### `extracted_content_pipeline/services/reasoning_provider_port.py`

Adds a module-level docstring section explaining the role distinction with a concrete end-to-end-flow walkthrough so the next reader of this module doesn't repeat the conflation. Adds a class-level note clarifying when `None` is returned. **No protocol shape changes** — `FileCampaignReasoningContextProvider` and every other implementer is unaffected; `tests/test_extracted_campaign_reasoning_data.py` still passes 7/7.

### `docs/hybrid_extraction_plan_status_2026-05-05.md`

New "Followup-resolution log" section enumerating each deferred followup from M5-β / M5-γ with its resolution status:

| Followup | Status |
|---|---|
| Wire b2b regression tests into CI | resolved (#229 open) |
| Lineage / freshness in typed envelope | resolved (#232 open) |
| Provider-port retyping | **resolved as not-applicable** (this PR — documentation update with rationale) |
| `VendorPressurePayload` enrichment | deferred (no producer-side caller yet) |
| Second-domain proof-of-life | resolved (M5-γ #222 merged) |

After this lands, only **M6** (compatibility-matrix doc) remains to close the program.

## Behavior-change statement

Zero. Pure documentation.

## Contract impact

None. Protocol shape unchanged.

## Rollback plan

Revert. Two-file docs-only change.

## Verification

```
$ python3 -m pytest tests/test_extracted_campaign_reasoning_data.py -q
.......                                                                  [100%]
7 passed in 0.08s
```

## Plan reference

`docs/hybrid_extraction_plan_status_2026-05-05.md` — deferred follow-up #3 from PR #215. With this PR plus #229 and #232, all M5-β / M5-γ deferreds either resolve or have explicit "not-applicable / deferred-pending-caller" rationales documented.

---
_Generated by [Claude Code](https://claude.ai/code/session_017k4xQ6eLxysGkgLnGv4noh)_