### PR TITLE
PR-C4e2: AtlasLLMClient + LLM-driven nodes to core

### DIFF
--- a/atlas_brain/reasoning/graph.py
+++ b/atlas_brain/reasoning/graph.py
@@ -143,54 +143,27 @@ async def run_reasoning_graph(state: ReasoningAgentState) -> ReasoningAgentState
 
 
 async def _node_triage(state: ReasoningAgentState) -> ReasoningAgentState:
-    """Classify event priority and whether reasoning is needed."""
+    """Classify event priority and whether reasoning is needed.
+
+    Thin wrapper around :func:`extracted_reasoning_core.graph_nodes.node_triage`
+    -- atlas resolves the triage-workload LLM via ``_resolve_graph_llm``,
+    wraps it in :class:`AtlasLLMClient`, and delegates. Atlas owns the
+    workload-routing decision; core owns the prompt construction and
+    response parsing.
+    """
+    from extracted_reasoning_core.graph_nodes import node_triage
     from .graph_prompts import TRIAGE_SYSTEM
+    from .port_adapters import AtlasLLMClient
     from ..config import settings
 
-    event_desc = (
-        f"Event: {state.get('event_type')}\n"
-        f"Source: {state.get('source')}\n"
-        f"Entity: {state.get('entity_type')}/{state.get('entity_id')}\n"
-        f"Payload: {json.dumps(state.get('payload', {}), default=str)[:2000]}"
+    llm_service = _resolve_graph_llm(settings.reasoning.graph_triage_workload)
+    client = AtlasLLMClient(llm_service) if llm_service else None
+    return await node_triage(
+        state,
+        client,
+        triage_system_prompt=TRIAGE_SYSTEM,
+        max_tokens=settings.reasoning.triage_max_tokens,
     )
-
-    llm = _resolve_graph_llm(settings.reasoning.graph_triage_workload)
-    if not llm:
-        # No triage LLM -- default to reasoning everything
-        state["triage_priority"] = "medium"
-        state["needs_reasoning"] = True
-        state["triage_reasoning"] = "Triage LLM unavailable, defaulting to reason"
-        return state
-
-    try:
-        result = await _llm_generate(
-            llm, event_desc, TRIAGE_SYSTEM,
-            max_tokens=settings.reasoning.triage_max_tokens,
-            temperature=0.1,
-            json_mode=True,
-        )
-        text = result["response"]
-        usage = result.get("usage", {})
-        state["total_input_tokens"] = state.get("total_input_tokens", 0) + usage.get("input_tokens", 0)
-        state["total_output_tokens"] = state.get("total_output_tokens", 0) + usage.get("output_tokens", 0)
-
-        parsed = _parse_llm_json(text)
-        state["triage_priority"] = parsed.get("priority", "medium")
-        state["needs_reasoning"] = parsed.get("needs_reasoning", True)
-        state["triage_reasoning"] = parsed.get("reasoning", "")
-    except Exception:
-        logger.warning("Triage failed, defaulting to reason", exc_info=True)
-        state["triage_priority"] = "medium"
-        state["needs_reasoning"] = True
-        state["triage_reasoning"] = "Triage parse error, defaulting to reason"
-
-    logger.info(
-        "Triage: %s priority=%s needs_reasoning=%s",
-        state.get("event_type"),
-        state.get("triage_priority"),
-        state.get("needs_reasoning"),
-    )
-    return state
 
 
 async def _node_aggregate_context(
@@ -257,17 +230,26 @@ async def _node_check_lock(state: ReasoningAgentState) -> ReasoningAgentState:
 
 
 async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
-    """Deep reasoning with full context via pipeline-configured LLM routing."""
+    """Deep reasoning with full context via pipeline-configured LLM routing.
+
+    Atlas keeps the prompt builder here because it reads atlas-specific
+    extended-state fields (``crm_context``, ``b2b_churn``, ``voice_turns``,
+    etc. -- the slots atlas's ``ReasoningAgentState`` adds on top of
+    core's TypedDict per PR-C4b). The LLM round-trip itself goes through
+    core's ``complete_with_json`` helper via the ``AtlasLLMClient``
+    adapter.
+    """
+    from extracted_reasoning_core.graph_helpers import complete_with_json
     from .graph_prompts import REASONING_SYSTEM
+    from .port_adapters import AtlasLLMClient
     from ..config import settings
 
-    # Build context prompt
+    # Build context prompt from atlas-specific extended state.
     sections = [
         f"## Event\nType: {state.get('event_type')}\n"
         f"Source: {state.get('source')}\n"
         f"Payload: {json.dumps(state.get('payload', {}), default=str)[:3000]}",
     ]
-
     if state.get("crm_context"):
         sections.append(
             f"## CRM Context\n{json.dumps(state['crm_context'], default=str)[:2000]}"
@@ -315,44 +297,62 @@ async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
 
     prompt = "\n\n".join(sections)
 
-    llm = _resolve_graph_llm(settings.reasoning.graph_reasoning_workload, use_model_override=True)
-    if not llm:
+    llm_service = _resolve_graph_llm(
+        settings.reasoning.graph_reasoning_workload,
+        use_model_override=True,
+    )
+    if not llm_service:
         state["reasoning_output"] = ""
         state["connections_found"] = []
         state["recommended_actions"] = []
         state["rationale"] = "Reasoning LLM unavailable"
         return state
 
+    client = AtlasLLMClient(llm_service)
+
     try:
-        result = await _llm_generate(
-            llm, prompt, REASONING_SYSTEM,
+        result = await complete_with_json(
+            client,
+            REASONING_SYSTEM,
+            prompt,
             max_tokens=settings.reasoning.max_tokens,
             temperature=settings.reasoning.temperature,
             json_mode=True,
         )
-        text = result["response"]
-        usage = result.get("usage", {})
-        state["total_input_tokens"] = state.get("total_input_tokens", 0) + usage.get("input_tokens", 0)
-        state["total_output_tokens"] = state.get("total_output_tokens", 0) + usage.get("output_tokens", 0)
-
-        state["reasoning_output"] = text
-
-        parsed = _parse_llm_json(text)
-        state["connections_found"] = parsed.get("connections", [])
-        state["recommended_actions"] = parsed.get("actions", [])
-        state["rationale"] = parsed.get("rationale", "")
-        state["should_notify"] = parsed.get("should_notify", False)
-    except json.JSONDecodeError:
-        state["connections_found"] = []
-        state["recommended_actions"] = []
-        state["rationale"] = state.get("reasoning_output", "")
-        state["should_notify"] = True
     except Exception:
         logger.error("Reasoning node failed", exc_info=True)
         state["reasoning_output"] = ""
         state["connections_found"] = []
         state["recommended_actions"] = []
         state["rationale"] = "Reasoning failed"
+        return state
+
+    text = result["response"]
+    usage = result["usage"]
+    state["total_input_tokens"] = (
+        state.get("total_input_tokens", 0) + int(usage.get("input_tokens", 0) or 0)
+    )
+    state["total_output_tokens"] = (
+        state.get("total_output_tokens", 0) + int(usage.get("output_tokens", 0) or 0)
+    )
+
+    state["reasoning_output"] = text
+
+    parsed = result["parsed"]
+    if parsed:
+        state["connections_found"] = parsed.get("connections", [])
+        state["recommended_actions"] = parsed.get("actions", [])
+        state["rationale"] = parsed.get("rationale", "")
+        state["should_notify"] = parsed.get("should_notify", False)
+    else:
+        # ``complete_with_json`` returns ``parsed={}`` on JSON-decode
+        # failure. Preserve atlas's pre-extraction behavior: surface
+        # the raw text as rationale + force notify so the human sees
+        # the unparsed reasoning output.
+        state["connections_found"] = []
+        state["recommended_actions"] = []
+        state["rationale"] = text
+        state["should_notify"] = True
 
     return state
 
@@ -423,40 +423,25 @@ async def _execute_single_action(
 
 
 async def _node_synthesize(state: ReasoningAgentState) -> ReasoningAgentState:
-    """Generate a human-readable summary for notification."""
-    if not state.get("should_notify"):
-        state["summary"] = ""
-        return state
+    """Generate a human-readable summary for notification.
 
+    Thin wrapper around :func:`extracted_reasoning_core.graph_nodes.node_synthesize`
+    -- atlas resolves the synthesis-workload LLM, wraps it in
+    :class:`AtlasLLMClient`, and delegates. Fallback to deterministic
+    summary text on LLM-unavailable lives in core.
+    """
+    from extracted_reasoning_core.graph_nodes import node_synthesize
     from .graph_prompts import SYNTHESIS_SYSTEM
+    from .port_adapters import AtlasLLMClient
     from ..config import settings
 
-    context = (
-        f"Event: {state.get('event_type')}\n"
-        f"Actions taken: {json.dumps(state.get('action_results', []), default=str)[:1000]}\n"
-        f"Rationale: {state.get('rationale', '')[:500]}"
+    llm_service = _resolve_graph_llm(settings.reasoning.graph_synthesis_workload)
+    client = AtlasLLMClient(llm_service) if llm_service else None
+    return await node_synthesize(
+        state,
+        client,
+        synthesis_system_prompt=SYNTHESIS_SYSTEM,
     )
-
-    llm = _resolve_graph_llm(settings.reasoning.graph_synthesis_workload)
-    if not llm:
-        state["summary"] = _build_notification_fallback(state)
-        return state
-
-    try:
-        result = await _llm_generate(
-            llm, context, SYNTHESIS_SYSTEM,
-            max_tokens=256, temperature=0.3,
-        )
-        text = result["response"]
-        usage = result.get("usage", {})
-        state["total_input_tokens"] = state.get("total_input_tokens", 0) + usage.get("input_tokens", 0)
-        state["total_output_tokens"] = state.get("total_output_tokens", 0) + usage.get("output_tokens", 0)
-
-        state["summary"] = _sanitize_notification_summary(text, state)
-    except Exception:
-        state["summary"] = _build_notification_fallback(state)
-
-    return state
 
 
 async def _node_notify(state: ReasoningAgentState) -> ReasoningAgentState:

--- a/atlas_brain/reasoning/graph.py
+++ b/atlas_brain/reasoning/graph.py
@@ -34,6 +34,13 @@ from .state import ReasoningAgentState
 
 logger = logging.getLogger("atlas.reasoning.graph")
 
+# Per-call deadline for the graph's LLM round-trips. Atlas's pre-
+# extraction ``_llm_generate`` enforced 120s via ``asyncio.wait_for``;
+# the new path threads this through Port metadata so ``AtlasLLMClient``
+# can apply the same outer ``wait_for`` (and forward it to ``chat`` as
+# a kwarg, in case the underlying client honors timeouts natively).
+_GRAPH_LLM_TIMEOUT_S: float = 120.0
+
 
 def _resolve_graph_llm(workload: str, *, use_model_override: bool = False):
     """Resolve reasoning-graph LLMs through the pipeline router.
@@ -163,6 +170,7 @@ async def _node_triage(state: ReasoningAgentState) -> ReasoningAgentState:
         client,
         triage_system_prompt=TRIAGE_SYSTEM,
         max_tokens=settings.reasoning.triage_max_tokens,
+        timeout=_GRAPH_LLM_TIMEOUT_S,
     )
 
 
@@ -318,6 +326,7 @@ async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
             max_tokens=settings.reasoning.max_tokens,
             temperature=settings.reasoning.temperature,
             json_mode=True,
+            timeout=_GRAPH_LLM_TIMEOUT_S,
         )
     except Exception:
         logger.error("Reasoning node failed", exc_info=True)
@@ -338,17 +347,20 @@ async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
 
     state["reasoning_output"] = text
 
-    parsed = result["parsed"]
-    if parsed:
+    if result["parse_ok"]:
+        parsed = result["parsed"]
         state["connections_found"] = parsed.get("connections", [])
         state["recommended_actions"] = parsed.get("actions", [])
         state["rationale"] = parsed.get("rationale", "")
         state["should_notify"] = parsed.get("should_notify", False)
     else:
-        # ``complete_with_json`` returns ``parsed={}`` on JSON-decode
-        # failure. Preserve atlas's pre-extraction behavior: surface
-        # the raw text as rationale + force notify so the human sees
-        # the unparsed reasoning output.
+        # ``complete_with_json`` returns ``parse_ok=False`` on
+        # JSON-decode failure (or non-object JSON / empty response).
+        # Preserve atlas's pre-extraction behavior: surface the raw
+        # text as rationale + force notify so the human sees the
+        # unparsed reasoning output. ``parse_ok=False`` distinguishes
+        # this from a *valid* empty JSON object, which would
+        # mistakenly trip the same fallback under a truthiness check.
         state["connections_found"] = []
         state["recommended_actions"] = []
         state["rationale"] = text
@@ -441,6 +453,7 @@ async def _node_synthesize(state: ReasoningAgentState) -> ReasoningAgentState:
         state,
         client,
         synthesis_system_prompt=SYNTHESIS_SYSTEM,
+        timeout=_GRAPH_LLM_TIMEOUT_S,
     )
 
 

--- a/atlas_brain/reasoning/port_adapters.py
+++ b/atlas_brain/reasoning/port_adapters.py
@@ -45,10 +45,23 @@ metadata dict as-is.
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Mapping
+import asyncio
+from typing import Any, Awaitable, Callable, Mapping, Sequence
 
 
 _DEFAULT_OPERATION_TYPE = "reasoning"
+
+# Keys that ``AtlasLLMClient.complete`` lifts out of the Port's
+# free-form ``metadata`` and forwards to atlas's ``LLMService.chat``
+# as typed kwargs. ``json_mode`` and ``response_format`` control
+# structured-output behavior; ``timeout`` overrides the chat-call
+# timeout. Other metadata keys flow through unchanged for adapters
+# that want to extend the contract.
+_LLM_COMPLETE_METADATA_KWARGS: tuple[str, ...] = (
+    "json_mode",
+    "response_format",
+    "timeout",
+)
 
 # Keys that ``AtlasTraceSink.start_span`` lifts out of metadata into
 # atlas tracer kwargs. These map to fields atlas's ``SpanContext``
@@ -137,6 +150,65 @@ class AtlasTraceSink:
         )
 
 
+class AtlasLLMClient:
+    """``LLMClient`` adapter over atlas's ``LLMService.chat``.
+
+    Wraps an :class:`atlas_brain.services.protocols.LLMService` so it
+    satisfies :class:`extracted_reasoning_core.ports.LLMClient`. Two
+    translation responsibilities:
+
+    - **sync -> async**: atlas's ``chat`` is sync (the native model
+      call); the Port is ``async``. We dispatch via
+      :func:`asyncio.to_thread` so the event loop stays responsive
+      while the model runs.
+    - **metadata -> typed kwargs**: the Port carries ``json_mode`` /
+      ``response_format`` / ``timeout`` in the free-form metadata bag
+      so reasoning-core nodes don't have to know about atlas's chat
+      signature. The adapter lifts those keys back out before calling
+      ``chat``.
+
+    The adapter accepts ``llm_service`` as ``Any`` rather than a typed
+    parameter -- atlas's ``LLMService`` Protocol lives behind
+    ``atlas_brain.services.__init__`` which would pull in the heavy
+    LLM-impl chain at import time, defeating the import-light goal of
+    this module.
+    """
+
+    def __init__(self, llm_service: Any) -> None:
+        self._llm_service = llm_service
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        kwargs, _remaining = _split_metadata(metadata, _LLM_COMPLETE_METADATA_KWARGS)
+        # Atlas's chat() expects a list of Message objects; the Port
+        # passes raw mappings. Convert here -- atlas's Message is a
+        # dataclass with ``role`` + ``content``, so a dict with those
+        # keys is structurally compatible. Importing atlas's Message
+        # at call-time avoids the heavy services package init at
+        # adapter-module-import time.
+        from ..services.protocols import Message
+
+        message_list = [
+            Message(role=m["role"], content=m["content"]) for m in messages
+        ]
+
+        chat_kwargs: dict[str, Any] = {
+            "messages": message_list,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        chat_kwargs.update(kwargs)
+
+        result = await asyncio.to_thread(self._llm_service.chat, **chat_kwargs)
+        return result if isinstance(result, dict) else {"response": str(result)}
+
+
 def _translate_status(port_status: str) -> str:
     if port_status == "ok":
         return "completed"
@@ -166,4 +238,4 @@ def _split_metadata(
     return kwargs, remaining or None
 
 
-__all__ = ["AtlasEventSink", "AtlasTraceSink"]
+__all__ = ["AtlasEventSink", "AtlasLLMClient", "AtlasTraceSink"]

--- a/atlas_brain/reasoning/port_adapters.py
+++ b/atlas_brain/reasoning/port_adapters.py
@@ -54,9 +54,14 @@ _DEFAULT_OPERATION_TYPE = "reasoning"
 # Keys that ``AtlasLLMClient.complete`` lifts out of the Port's
 # free-form ``metadata`` and forwards to atlas's ``LLMService.chat``
 # as typed kwargs. ``json_mode`` and ``response_format`` control
-# structured-output behavior; ``timeout`` overrides the chat-call
-# timeout. Other metadata keys flow through unchanged for adapters
-# that want to extend the contract.
+# structured-output behavior; ``timeout`` is both forwarded to
+# ``chat()`` (in case the underlying client honors it) and used to
+# wrap the ``asyncio.to_thread`` await in ``asyncio.wait_for``.
+#
+# Metadata keys NOT in this tuple are deliberately discarded -- atlas's
+# ``chat`` signature is fixed and unrecognized kwargs would raise
+# ``TypeError``. To extend the contract, add the key here AND update
+# the matching atlas-side signature.
 _LLM_COMPLETE_METADATA_KWARGS: tuple[str, ...] = (
     "json_mode",
     "response_format",
@@ -154,18 +159,30 @@ class AtlasLLMClient:
     """``LLMClient`` adapter over atlas's ``LLMService.chat``.
 
     Wraps an :class:`atlas_brain.services.protocols.LLMService` so it
-    satisfies :class:`extracted_reasoning_core.ports.LLMClient`. Two
+    satisfies :class:`extracted_reasoning_core.ports.LLMClient`. Three
     translation responsibilities:
 
     - **sync -> async**: atlas's ``chat`` is sync (the native model
       call); the Port is ``async``. We dispatch via
       :func:`asyncio.to_thread` so the event loop stays responsive
       while the model runs.
+    - **timeout enforcement**: when the metadata bag carries a
+      ``timeout`` (in seconds), the adapter wraps the
+      ``asyncio.to_thread`` await in :func:`asyncio.wait_for`. This
+      preserves the deadline semantics atlas's pre-extraction
+      ``_llm_generate`` enforced -- forwarding ``timeout`` as a kwarg
+      to ``chat`` alone isn't enough because some Provider impls
+      ignore it or block in non-cooperative C extensions.
     - **metadata -> typed kwargs**: the Port carries ``json_mode`` /
       ``response_format`` / ``timeout`` in the free-form metadata bag
       so reasoning-core nodes don't have to know about atlas's chat
-      signature. The adapter lifts those keys back out before calling
-      ``chat``.
+      signature. The adapter lifts those three keys back out and
+      forwards them as typed kwargs to ``chat`` (in addition to
+      using ``timeout`` for the outer ``wait_for``). Other metadata
+      keys are deliberately *not* forwarded -- atlas's chat signature
+      is fixed and unrecognized kwargs would raise ``TypeError``;
+      callers that need to extend the contract should add new
+      typed-extraction entries to ``_LLM_COMPLETE_METADATA_KWARGS``.
 
     The adapter accepts ``llm_service`` as ``Any`` rather than a typed
     parameter -- atlas's ``LLMService`` Protocol lives behind
@@ -205,7 +222,12 @@ class AtlasLLMClient:
         }
         chat_kwargs.update(kwargs)
 
-        result = await asyncio.to_thread(self._llm_service.chat, **chat_kwargs)
+        timeout = kwargs.get("timeout")
+        coro = asyncio.to_thread(self._llm_service.chat, **chat_kwargs)
+        if timeout is not None and timeout > 0:
+            result = await asyncio.wait_for(coro, timeout=timeout)
+        else:
+            result = await coro
         return result if isinstance(result, dict) else {"response": str(result)}
 
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T03:55Z by claude-2026-05-03
+Last updated: 2026-05-05T04:03Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-C4e2, in flight) | PR-C4e2: AtlasLLMClient + LLM-driven nodes to core (PR 6 fifth slice, 2/3 of graph extraction) | NEW: `atlas_brain/reasoning/port_adapters.py::AtlasLLMClient` (wraps `LLMService`, satisfies the existing `LLMClient.complete()` Protocol; runs sync `chat()` via `asyncio.to_thread`; lifts `json_mode`/`timeout`/`response_format` from metadata). EDIT: `extracted_reasoning_core/graph_helpers.py` (add `make_chat_messages`, `extract_completion_text`, `complete_with_json` async helpers). NEW: `extracted_reasoning_core/graph_nodes.py` (`node_triage`, `node_synthesize` -- self-contained; both accept `llm: LLMClient \| None` and apply existing fallbacks when LLM unavailable). EDIT: `atlas_brain/reasoning/graph.py` (`_node_triage`/`_node_synthesize` become thin wrappers; `_node_reason` keeps atlas's extended-state prompt builder and calls core `complete_with_json` for the LLM round-trip). NEW/EDIT: `tests/test_extracted_reasoning_core_graph_nodes.py`, extend `tests/test_extracted_reasoning_core_graph_helpers.py`, extend `tests/test_atlas_reasoning_port_adapters.py` (AtlasLLMClient), extend `tests/test_atlas_reasoning_graph_aliases.py` (new node aliases). EDIT: `scripts/run_extracted_pipeline_checks.sh` + `.github/workflows/extracted_pipeline_checks.yml` (wire new test). Existing `LLMClient.complete()` Protocol unchanged -- `extracted_content_pipeline.PipelineLLMClient` keeps working. PR-C4e3 next: orchestrator + atlas-coupled nodes (aggregate_context / lock check / execute / notify) via new ports. | claude-2026-05-03 | `extracted_reasoning_core/graph_helpers.py`; `extracted_reasoning_core/graph_nodes.py`; `atlas_brain/reasoning/port_adapters.py`; `atlas_brain/reasoning/graph.py`; `tests/test_extracted_reasoning_core_graph_helpers.py`; `tests/test_extracted_reasoning_core_graph_nodes.py`; `tests/test_atlas_reasoning_port_adapters.py`; `tests/test_atlas_reasoning_graph_aliases.py`; `scripts/run_extracted_pipeline_checks.sh`; `.github/workflows/extracted_pipeline_checks.yml` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_reasoning_core/graph_helpers.py
+++ b/extracted_reasoning_core/graph_helpers.py
@@ -79,28 +79,40 @@ _PLAN_MIN_CONFIDENCE: float = 0.5
 
 
 def parse_llm_json(text: str) -> dict[str, Any]:
-    """Extract and parse JSON from an LLM response.
+    """Extract and parse a JSON *object* from an LLM response.
 
     Handles raw JSON, markdown-fenced JSON, and JSON embedded in prose.
-    Raises ``json.JSONDecodeError`` if no valid object is found.
+    Raises ``json.JSONDecodeError`` if no valid object is found, or if
+    the parsed result isn't a dict (the LLM returned a JSON array,
+    string, or scalar -- downstream graph nodes always expect an
+    object and would ``AttributeError`` on ``.get(...)`` against a
+    list).
     """
     text = text.strip()
     if not text:
         raise json.JSONDecodeError("Empty response", text, 0)
 
+    parsed: Any
     if text.startswith("{"):
-        return json.loads(text)
-
-    m = _JSON_FENCE_RE.search(text)
-    if m:
-        return json.loads(m.group(1).strip())
-
-    first = text.find("{")
-    last = text.rfind("}")
-    if first != -1 and last > first:
-        return json.loads(text[first : last + 1])
-
-    raise json.JSONDecodeError("No JSON object found in response", text, 0)
+        parsed = json.loads(text)
+    else:
+        m = _JSON_FENCE_RE.search(text)
+        if m:
+            parsed = json.loads(m.group(1).strip())
+        else:
+            first = text.find("{")
+            last = text.rfind("}")
+            if first != -1 and last > first:
+                parsed = json.loads(text[first : last + 1])
+            else:
+                raise json.JSONDecodeError(
+                    "No JSON object found in response", text, 0
+                )
+    if not isinstance(parsed, dict):
+        raise json.JSONDecodeError(
+            f"Expected JSON object, got {type(parsed).__name__}", text, 0
+        )
+    return parsed
 
 
 def valid_uuid_str(value: Any) -> str | None:
@@ -293,8 +305,19 @@ async def complete_with_json(
 ) -> dict[str, Any]:
     """Issue a chat completion expecting JSON; return raw + parsed.
 
-    Returns a dict with keys ``response`` (str), ``usage`` (dict), and
-    ``parsed`` (dict, or ``{}`` if the response wasn't valid JSON).
+    Returns a dict with keys:
+
+    - ``response`` (str) -- the raw LLM output
+    - ``usage`` (dict) -- token-usage metrics (may be empty)
+    - ``parsed`` (dict) -- the parsed JSON object, or ``{}`` if the
+      response wasn't valid JSON. Callers that need to distinguish
+      "valid empty JSON object ``{}``" from "parse failure" must read
+      the ``parse_ok`` flag rather than truthiness-check ``parsed``.
+    - ``parse_ok`` (bool) -- ``True`` iff the response parsed cleanly.
+      ``False`` covers empty response, JSON-decode error, and
+      non-object JSON (array/scalar). The graph nodes' "force notify
+      on parse failure" semantics depend on this distinction.
+
     Hides three boilerplate concerns the LLM-driven graph nodes all
     need:
 
@@ -303,7 +326,8 @@ async def complete_with_json(
       atlas-side adapter can lift them out (see
       :class:`atlas_brain.reasoning.port_adapters.AtlasLLMClient`)
     - tolerating malformed JSON without raising (returns
-      ``parsed={}`` and lets the node decide whether to fall back)
+      ``parsed={}, parse_ok=False`` and lets the node decide whether
+      to fall back)
     """
     messages = make_chat_messages(system_prompt, user_prompt)
     metadata: dict[str, Any] = {}
@@ -320,12 +344,20 @@ async def complete_with_json(
     )
     response, usage = extract_completion_text(result)
     parsed: dict[str, Any] = {}
+    parse_ok = False
     if response:
         try:
             parsed = parse_llm_json(response)
+            parse_ok = True
         except json.JSONDecodeError:
             parsed = {}
-    return {"response": response, "usage": usage, "parsed": parsed}
+            parse_ok = False
+    return {
+        "response": response,
+        "usage": usage,
+        "parsed": parsed,
+        "parse_ok": parse_ok,
+    }
 
 
 __all__ = [

--- a/extracted_reasoning_core/graph_helpers.py
+++ b/extracted_reasoning_core/graph_helpers.py
@@ -35,6 +35,7 @@ import re
 from typing import Any
 from uuid import UUID
 
+from .ports import LLMClient
 from .state import ReasoningAgentState
 
 logger = logging.getLogger("extracted_reasoning_core.graph_helpers")
@@ -232,11 +233,109 @@ async def plan_actions(state: ReasoningAgentState) -> ReasoningAgentState:
     return state
 
 
+def make_chat_messages(
+    system_prompt: str,
+    user_prompt: str,
+) -> list[dict[str, str]]:
+    """Build the ``messages`` list a chat-completion LLMClient expects.
+
+    Returns a freshly-constructed list each call so callers can mutate
+    safely. The shape (``[{"role": ..., "content": ...}, ...]``) is the
+    OpenAI/Anthropic-compatible wire format that
+    :class:`extracted_reasoning_core.ports.LLMClient` accepts.
+    """
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+
+def extract_completion_text(
+    result: Any,
+) -> tuple[str, dict[str, Any]]:
+    """Pull ``(response_text, usage_dict)`` out of an LLMClient result.
+
+    Tolerates both the canonical ``{"response": ..., "usage": ...}``
+    shape atlas's ``LLMService.chat`` produces and the simpler
+    ``{"content": ...}`` mappings some Provider clients return. Missing
+    fields default to empty -- callers that need usage metrics should
+    check the dict for emptiness rather than rely on KeyError.
+    """
+    if not isinstance(result, dict):
+        return "", {}
+    response = result.get("response")
+    if response is None:
+        # Fall back to OpenAI-style choices[0].message.content if present.
+        choices = result.get("choices")
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                msg = first.get("message")
+                if isinstance(msg, dict):
+                    response = msg.get("content")
+    if response is None:
+        response = result.get("content", "")
+    usage = result.get("usage")
+    if not isinstance(usage, dict):
+        usage = {}
+    return str(response or ""), usage
+
+
+async def complete_with_json(
+    client: LLMClient,
+    system_prompt: str,
+    user_prompt: str,
+    *,
+    max_tokens: int,
+    temperature: float,
+    json_mode: bool = True,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Issue a chat completion expecting JSON; return raw + parsed.
+
+    Returns a dict with keys ``response`` (str), ``usage`` (dict), and
+    ``parsed`` (dict, or ``{}`` if the response wasn't valid JSON).
+    Hides three boilerplate concerns the LLM-driven graph nodes all
+    need:
+
+    - building the ``messages`` list from system+user prompts
+    - threading ``json_mode``/``timeout`` through metadata so the
+      atlas-side adapter can lift them out (see
+      :class:`atlas_brain.reasoning.port_adapters.AtlasLLMClient`)
+    - tolerating malformed JSON without raising (returns
+      ``parsed={}`` and lets the node decide whether to fall back)
+    """
+    messages = make_chat_messages(system_prompt, user_prompt)
+    metadata: dict[str, Any] = {}
+    if json_mode:
+        metadata["json_mode"] = True
+        metadata["response_format"] = {"type": "json_object"}
+    if timeout is not None:
+        metadata["timeout"] = timeout
+    result = await client.complete(
+        messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        metadata=metadata or None,
+    )
+    response, usage = extract_completion_text(result)
+    parsed: dict[str, Any] = {}
+    if response:
+        try:
+            parsed = parse_llm_json(response)
+        except json.JSONDecodeError:
+            parsed = {}
+    return {"response": response, "usage": usage, "parsed": parsed}
+
+
 __all__ = [
     "SAFE_ACTIONS",
     "build_notification_fallback",
     "clean_summary_text",
+    "complete_with_json",
+    "extract_completion_text",
     "has_suspicious_trailing_fragment",
+    "make_chat_messages",
     "parse_llm_json",
     "plan_actions",
     "sanitize_notification_summary",

--- a/extracted_reasoning_core/graph_nodes.py
+++ b/extracted_reasoning_core/graph_nodes.py
@@ -61,6 +61,7 @@ async def node_triage(
     *,
     triage_system_prompt: str,
     max_tokens: int = _TRIAGE_MAX_TOKENS_DEFAULT,
+    timeout: float | None = None,
 ) -> ReasoningAgentState:
     """Classify event priority and whether reasoning is needed.
 
@@ -94,6 +95,7 @@ async def node_triage(
             max_tokens=max_tokens,
             temperature=_TRIAGE_TEMPERATURE,
             json_mode=True,
+            timeout=timeout,
         )
     except Exception:
         logger.warning("Triage failed, defaulting to reason", exc_info=True)
@@ -109,6 +111,19 @@ async def node_triage(
     state["total_output_tokens"] = (
         state.get("total_output_tokens", 0) + int(usage.get("output_tokens", 0) or 0)
     )
+
+    if not result["parse_ok"]:
+        # Atlas's pre-extraction _node_triage caught the
+        # JSONDecodeError raised by _parse_llm_json and applied this
+        # exact fallback. ``complete_with_json`` swallows the error
+        # and signals via ``parse_ok=False`` so we apply the fallback
+        # here instead -- preserving the "default to reason on
+        # malformed triage" safety property.
+        logger.warning("Triage produced unparseable output, defaulting to reason")
+        state["triage_priority"] = "medium"
+        state["needs_reasoning"] = True
+        state["triage_reasoning"] = "Triage parse error, defaulting to reason"
+        return state
 
     parsed = result["parsed"]
     state["triage_priority"] = parsed.get("priority", "medium")
@@ -131,6 +146,7 @@ async def node_synthesize(
     synthesis_system_prompt: str,
     max_tokens: int = _SYNTH_MAX_TOKENS_DEFAULT,
     temperature: float = _SYNTH_TEMPERATURE_DEFAULT,
+    timeout: float | None = None,
 ) -> ReasoningAgentState:
     """Generate a human-readable summary for notification.
 
@@ -160,10 +176,12 @@ async def node_synthesize(
 
     try:
         messages = make_chat_messages(synthesis_system_prompt, context)
+        metadata = {"timeout": timeout} if timeout is not None else None
         result = await llm.complete(
             messages,
             max_tokens=max_tokens,
             temperature=temperature,
+            metadata=metadata,
         )
     except Exception:
         logger.warning("Synthesis failed, using deterministic fallback", exc_info=True)

--- a/extracted_reasoning_core/graph_nodes.py
+++ b/extracted_reasoning_core/graph_nodes.py
@@ -1,0 +1,191 @@
+"""LLM-driven graph nodes promoted into core.
+
+PR-C4e2 (this module) is the second sub-slice of the audit's PR 6
+graph-engine extraction. ``node_triage`` and ``node_synthesize`` are
+fully self-contained -- they read only fields declared on core's
+:class:`extracted_reasoning_core.state.ReasoningAgentState` and call
+the LLM through the :class:`extracted_reasoning_core.ports.LLMClient`
+Protocol. Atlas's ``_node_triage`` / ``_node_synthesize`` become thin
+wrappers that resolve an atlas LLM, wrap it in the ``AtlasLLMClient``
+adapter, and delegate here.
+
+``_node_reason`` is *not* moved in this slice -- it reads atlas-
+specific extended-state fields (``crm_context``, ``b2b_churn``, voice
+turns, etc. that atlas adds via the ``ReasoningAgentState`` subclass
+established in PR-C4b). Atlas keeps the prompt builder and calls the
+shared ``complete_with_json`` helper for the LLM round-trip. PR-C4e3
+or a later slice can decide whether to push those fields up to core
+or expose a richer prompt-building hook.
+
+Each node accepts ``llm: LLMClient | None``. ``None`` means "LLM
+unavailable" -- the node applies the same conservative fallback
+behavior atlas's original implementation did (default to medium
+priority + needs_reasoning for triage; fall back to deterministic
+notification text for synthesize). The fallback path matters because
+atlas runs reasoning on every event, not just the LLM-rich ones, and
+the triage/synthesize stages must never block the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .graph_helpers import (
+    build_notification_fallback,
+    complete_with_json,
+    make_chat_messages,
+    sanitize_notification_summary,
+)
+from .ports import LLMClient
+from .state import ReasoningAgentState
+
+
+logger = logging.getLogger("extracted_reasoning_core.graph_nodes")
+
+
+# Triage prompt budget (atlas's settings.reasoning.triage_max_tokens default).
+# Embedded as a default rather than read from settings because core stays
+# host-agnostic; atlas's wrapper can pass its configured budget through.
+_TRIAGE_MAX_TOKENS_DEFAULT = 256
+_TRIAGE_TEMPERATURE = 0.1
+
+_SYNTH_MAX_TOKENS_DEFAULT = 256
+_SYNTH_TEMPERATURE_DEFAULT = 0.3
+
+
+async def node_triage(
+    state: ReasoningAgentState,
+    llm: LLMClient | None,
+    *,
+    triage_system_prompt: str,
+    max_tokens: int = _TRIAGE_MAX_TOKENS_DEFAULT,
+) -> ReasoningAgentState:
+    """Classify event priority and whether reasoning is needed.
+
+    Reads ``event_type`` / ``source`` / ``entity_type`` / ``entity_id``
+    / ``payload`` from state; writes ``triage_priority``,
+    ``needs_reasoning``, ``triage_reasoning``, and accumulates token
+    usage into ``total_input_tokens`` / ``total_output_tokens``.
+
+    When ``llm is None`` (atlas LLM unavailable), defaults to medium
+    priority + needs_reasoning so the rest of the graph still runs.
+    Same behavior as atlas's pre-extraction ``_node_triage`` fallback.
+    """
+    event_desc = (
+        f"Event: {state.get('event_type')}\n"
+        f"Source: {state.get('source')}\n"
+        f"Entity: {state.get('entity_type')}/{state.get('entity_id')}\n"
+        f"Payload: {json.dumps(state.get('payload', {}), default=str)[:2000]}"
+    )
+
+    if llm is None:
+        state["triage_priority"] = "medium"
+        state["needs_reasoning"] = True
+        state["triage_reasoning"] = "Triage LLM unavailable, defaulting to reason"
+        return state
+
+    try:
+        result = await complete_with_json(
+            llm,
+            triage_system_prompt,
+            event_desc,
+            max_tokens=max_tokens,
+            temperature=_TRIAGE_TEMPERATURE,
+            json_mode=True,
+        )
+    except Exception:
+        logger.warning("Triage failed, defaulting to reason", exc_info=True)
+        state["triage_priority"] = "medium"
+        state["needs_reasoning"] = True
+        state["triage_reasoning"] = "Triage parse error, defaulting to reason"
+        return state
+
+    usage = result["usage"]
+    state["total_input_tokens"] = (
+        state.get("total_input_tokens", 0) + int(usage.get("input_tokens", 0) or 0)
+    )
+    state["total_output_tokens"] = (
+        state.get("total_output_tokens", 0) + int(usage.get("output_tokens", 0) or 0)
+    )
+
+    parsed = result["parsed"]
+    state["triage_priority"] = parsed.get("priority", "medium")
+    state["needs_reasoning"] = parsed.get("needs_reasoning", True)
+    state["triage_reasoning"] = parsed.get("reasoning", "")
+
+    logger.info(
+        "Triage: %s priority=%s needs_reasoning=%s",
+        state.get("event_type"),
+        state.get("triage_priority"),
+        state.get("needs_reasoning"),
+    )
+    return state
+
+
+async def node_synthesize(
+    state: ReasoningAgentState,
+    llm: LLMClient | None,
+    *,
+    synthesis_system_prompt: str,
+    max_tokens: int = _SYNTH_MAX_TOKENS_DEFAULT,
+    temperature: float = _SYNTH_TEMPERATURE_DEFAULT,
+) -> ReasoningAgentState:
+    """Generate a human-readable summary for notification.
+
+    Skipped when ``state["should_notify"]`` is False -- writes empty
+    summary and returns. Otherwise builds the synthesis prompt from
+    ``event_type`` / ``action_results`` / ``rationale`` and calls the
+    LLM. On LLM unavailability or post-processing failure, falls back
+    to :func:`build_notification_fallback`.
+
+    Note: this node uses the regular ``complete()`` (not
+    ``complete_with_json``) -- the synthesis output is plain text, not
+    structured JSON. We build messages and extract the text manually.
+    """
+    if not state.get("should_notify"):
+        state["summary"] = ""
+        return state
+
+    context = (
+        f"Event: {state.get('event_type')}\n"
+        f"Actions taken: {json.dumps(state.get('action_results', []), default=str)[:1000]}\n"
+        f"Rationale: {state.get('rationale', '')[:500]}"
+    )
+
+    if llm is None:
+        state["summary"] = build_notification_fallback(state)
+        return state
+
+    try:
+        messages = make_chat_messages(synthesis_system_prompt, context)
+        result = await llm.complete(
+            messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+    except Exception:
+        logger.warning("Synthesis failed, using deterministic fallback", exc_info=True)
+        state["summary"] = build_notification_fallback(state)
+        return state
+
+    from .graph_helpers import extract_completion_text
+
+    text, usage = extract_completion_text(result)
+    state["total_input_tokens"] = (
+        state.get("total_input_tokens", 0) + int(usage.get("input_tokens", 0) or 0)
+    )
+    state["total_output_tokens"] = (
+        state.get("total_output_tokens", 0) + int(usage.get("output_tokens", 0) or 0)
+    )
+
+    if not text:
+        state["summary"] = build_notification_fallback(state)
+        return state
+
+    state["summary"] = sanitize_notification_summary(text, state)
+    return state
+
+
+__all__ = ["node_synthesize", "node_triage"]

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -42,6 +42,7 @@ pytest \
   tests/test_extracted_reasoning_core_evidence_engine.py \
   tests/test_extracted_reasoning_core_event_trace_ports.py \
   tests/test_extracted_reasoning_core_graph_helpers.py \
+  tests/test_extracted_reasoning_core_graph_nodes.py \
   tests/test_extracted_reasoning_core_pack_registry.py \
   tests/test_extracted_reasoning_core_semantic_cache_keys.py \
   tests/test_extracted_reasoning_core_temporal.py \

--- a/tests/test_atlas_reasoning_port_adapters.py
+++ b/tests/test_atlas_reasoning_port_adapters.py
@@ -21,6 +21,7 @@ needed and no path that reaches real I/O.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Mapping
 from uuid import UUID
 
@@ -625,3 +626,51 @@ async def test_atlas_llm_client_complete_returns_dict_for_non_dict_chat_result(
         temperature=0.0,
     )
     assert result == {"response": "raw string response"}
+
+
+@pytest.mark.asyncio
+async def test_atlas_llm_client_enforces_metadata_timeout_via_wait_for(
+    stub_protocols_module,
+) -> None:
+    # Atlas's pre-extraction _llm_generate wrapped chat() in
+    # asyncio.wait_for(timeout=120). PR-C4e2 broke that until the
+    # adapter was taught to honor the metadata timeout itself --
+    # forwarding ``timeout`` to chat() alone isn't enough because
+    # some Provider impls ignore the kwarg or block in non-cooperative
+    # C extensions. Pin the wait_for behavior so a regression here
+    # would surface as a TimeoutError, not an indefinite hang.
+    import time
+
+    class _SlowChatService:
+        def chat(self, **kwargs: Any) -> dict[str, Any]:
+            time.sleep(2.0)  # Longer than our 0.05s timeout below.
+            return {"response": "should never be reached"}
+
+    client = AtlasLLMClient(_SlowChatService())
+    with pytest.raises(asyncio.TimeoutError):
+        await client.complete(
+            [{"role": "user", "content": "x"}],
+            max_tokens=10,
+            temperature=0.0,
+            metadata={"timeout": 0.05},
+        )
+
+
+@pytest.mark.asyncio
+async def test_atlas_llm_client_no_timeout_when_metadata_omits_it(
+    stub_protocols_module,
+) -> None:
+    # Without an explicit timeout in metadata, the adapter awaits the
+    # to_thread coroutine directly -- no outer wait_for. This
+    # preserves backward compat with callers that don't care about
+    # deadlines (and doesn't impose an arbitrary default).
+    fake = _RecordingLLMService(response={"response": "ok"})
+    client = AtlasLLMClient(fake)
+    result = await client.complete(
+        [{"role": "user", "content": "x"}],
+        max_tokens=10,
+        temperature=0.0,
+    )
+    assert result == {"response": "ok"}
+    # Sanity: no timeout kwarg got passed to chat() when none in metadata.
+    assert "timeout" not in fake.calls[0]

--- a/tests/test_atlas_reasoning_port_adapters.py
+++ b/tests/test_atlas_reasoning_port_adapters.py
@@ -461,3 +461,167 @@ def test_extraction_only_lifts_keys_present_in_metadata() -> None:
     assert end_record["input_tokens"] == 10
     assert end_record["output_tokens"] is None
     assert end_record["error_message"] is None
+
+
+# ----------------------------------------------------------------------
+# AtlasLLMClient (PR-C4e2)
+#
+# Adapter wraps atlas's sync ``LLMService.chat`` so it satisfies the
+# core ``LLMClient.complete()`` Protocol. Tests verify:
+#
+# - sync->async dispatch (chat is called via asyncio.to_thread)
+# - Mapping[str,Any] -> atlas Message conversion
+# - metadata-key extraction (json_mode/response_format/timeout) into
+#   chat()'s typed kwargs
+# - Protocol satisfaction
+#
+# The adapter lazy-imports atlas's ``Message`` at call time to keep
+# port_adapters import-light. Tests stub a fake ``Message`` in
+# sys.modules['atlas_brain.services.protocols'] so the import resolves
+# without pulling the heavy services/__init__ chain. Stubs are
+# restored on teardown (PR-C4d Codex lesson).
+# ----------------------------------------------------------------------
+
+
+import sys as _sys
+import types as _types
+
+from atlas_brain.reasoning.port_adapters import AtlasLLMClient
+from extracted_reasoning_core.ports import LLMClient
+
+
+class _FakeMessage:
+    def __init__(self, role: str, content: str) -> None:
+        self.role = role
+        self.content = content
+
+
+class _RecordingLLMService:
+    """Fake atlas LLMService -- records ``chat()`` calls."""
+
+    def __init__(self, response: dict[str, Any] | None = None) -> None:
+        self._response = response or {"response": "ok", "usage": {"input_tokens": 1}}
+        self.calls: list[dict[str, Any]] = []
+
+    def chat(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self._response
+
+
+@pytest.fixture
+def stub_protocols_module():
+    """Install a fake ``atlas_brain.services.protocols`` so the adapter's
+    lazy ``from ..services.protocols import Message`` resolves without
+    triggering ``atlas_brain.services.__init__``'s heavy imports."""
+    saved_services = _sys.modules.get("atlas_brain.services")
+    saved_protocols = _sys.modules.get("atlas_brain.services.protocols")
+
+    services_pkg = _types.ModuleType("atlas_brain.services")
+    services_pkg.__path__ = []
+    protocols_mod = _types.ModuleType("atlas_brain.services.protocols")
+    protocols_mod.Message = _FakeMessage
+
+    _sys.modules["atlas_brain.services"] = services_pkg
+    _sys.modules["atlas_brain.services.protocols"] = protocols_mod
+
+    yield
+
+    if saved_protocols is None:
+        _sys.modules.pop("atlas_brain.services.protocols", None)
+    else:
+        _sys.modules["atlas_brain.services.protocols"] = saved_protocols
+    if saved_services is None:
+        _sys.modules.pop("atlas_brain.services", None)
+    else:
+        _sys.modules["atlas_brain.services"] = saved_services
+
+
+def test_atlas_llm_client_satisfies_llm_client_protocol() -> None:
+    # LLMClient is not @runtime_checkable, so we can only do a
+    # structural hasattr check here. A future PR that flips the
+    # Protocol to runtime-checkable can tighten this.
+    client = AtlasLLMClient(_RecordingLLMService())
+    assert hasattr(client, "complete")
+    assert callable(getattr(client, "complete", None))
+    # Static analyzers should also accept it where LLMClient is required.
+    _: LLMClient = client
+
+
+@pytest.mark.asyncio
+async def test_atlas_llm_client_dispatches_to_chat_via_to_thread(
+    stub_protocols_module,
+) -> None:
+    fake_service = _RecordingLLMService(
+        response={"response": "hi", "usage": {"input_tokens": 4, "output_tokens": 2}},
+    )
+    client = AtlasLLMClient(fake_service)
+
+    result = await client.complete(
+        [
+            {"role": "system", "content": "system text"},
+            {"role": "user", "content": "user text"},
+        ],
+        max_tokens=128,
+        temperature=0.3,
+    )
+
+    assert result == {"response": "hi", "usage": {"input_tokens": 4, "output_tokens": 2}}
+    assert len(fake_service.calls) == 1
+    call = fake_service.calls[0]
+    # Messages converted to atlas Message objects (the Mapping->dataclass
+    # translation the adapter performs at the boundary).
+    assert isinstance(call["messages"], list)
+    assert len(call["messages"]) == 2
+    assert isinstance(call["messages"][0], _FakeMessage)
+    assert call["messages"][0].role == "system"
+    assert call["messages"][0].content == "system text"
+    assert call["max_tokens"] == 128
+    assert call["temperature"] == 0.3
+
+
+@pytest.mark.asyncio
+async def test_atlas_llm_client_lifts_json_mode_from_metadata(
+    stub_protocols_module,
+) -> None:
+    fake_service = _RecordingLLMService()
+    client = AtlasLLMClient(fake_service)
+
+    await client.complete(
+        [{"role": "user", "content": "x"}],
+        max_tokens=10,
+        temperature=0.0,
+        metadata={
+            "json_mode": True,
+            "response_format": {"type": "json_object"},
+            "timeout": 60.0,
+            "irrelevant": "stays-in-metadata-but-not-passed-to-chat",
+        },
+    )
+
+    call = fake_service.calls[0]
+    # The three known keys are lifted into typed kwargs.
+    assert call["json_mode"] is True
+    assert call["response_format"] == {"type": "json_object"}
+    assert call["timeout"] == 60.0
+    # Unrelated metadata keys are NOT forwarded as kwargs (would
+    # otherwise risk shadowing future LLMService kwargs).
+    assert "irrelevant" not in call
+
+
+@pytest.mark.asyncio
+async def test_atlas_llm_client_complete_returns_dict_for_non_dict_chat_result(
+    stub_protocols_module,
+) -> None:
+    # Some atlas LLMService impls return a plain string. The adapter
+    # must wrap it so the LLMClient contract (returns Mapping) holds.
+    class _StringChatService:
+        def chat(self, **kwargs: Any) -> str:
+            return "raw string response"
+
+    client = AtlasLLMClient(_StringChatService())
+    result = await client.complete(
+        [{"role": "user", "content": "x"}],
+        max_tokens=10,
+        temperature=0.0,
+    )
+    assert result == {"response": "raw string response"}

--- a/tests/test_extracted_reasoning_core_graph_helpers.py
+++ b/tests/test_extracted_reasoning_core_graph_helpers.py
@@ -20,7 +20,10 @@ from extracted_reasoning_core.graph_helpers import (
     SAFE_ACTIONS,
     build_notification_fallback,
     clean_summary_text,
+    complete_with_json,
+    extract_completion_text,
     has_suspicious_trailing_fragment,
+    make_chat_messages,
     parse_llm_json,
     plan_actions,
     sanitize_notification_summary,
@@ -280,3 +283,140 @@ def test_safe_actions_set_contents() -> None:
         "create_reminder",
         "send_notification",
     })
+
+
+# ----------------------------------------------------------------------
+# make_chat_messages
+# ----------------------------------------------------------------------
+
+
+def test_make_chat_messages_returns_role_content_pairs() -> None:
+    msgs = make_chat_messages("system text", "user text")
+    assert msgs == [
+        {"role": "system", "content": "system text"},
+        {"role": "user", "content": "user text"},
+    ]
+
+
+def test_make_chat_messages_returns_fresh_list_each_call() -> None:
+    a = make_chat_messages("a", "b")
+    b = make_chat_messages("a", "b")
+    assert a is not b
+    a.append({"role": "user", "content": "extra"})
+    assert len(b) == 2  # unaffected
+
+
+# ----------------------------------------------------------------------
+# extract_completion_text
+# ----------------------------------------------------------------------
+
+
+def test_extract_completion_text_canonical_shape() -> None:
+    result = {"response": "hello", "usage": {"input_tokens": 5, "output_tokens": 2}}
+    text, usage = extract_completion_text(result)
+    assert text == "hello"
+    assert usage == {"input_tokens": 5, "output_tokens": 2}
+
+
+def test_extract_completion_text_openai_choices_shape() -> None:
+    result = {
+        "choices": [{"message": {"content": "from openai"}}],
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    text, usage = extract_completion_text(result)
+    assert text == "from openai"
+    assert usage == {"input_tokens": 1, "output_tokens": 1}
+
+
+def test_extract_completion_text_content_only_shape() -> None:
+    text, usage = extract_completion_text({"content": "plain content"})
+    assert text == "plain content"
+    assert usage == {}
+
+
+def test_extract_completion_text_handles_non_dict_input() -> None:
+    text, usage = extract_completion_text("not a dict")  # type: ignore[arg-type]
+    assert text == ""
+    assert usage == {}
+
+
+def test_extract_completion_text_handles_missing_response() -> None:
+    text, usage = extract_completion_text({})
+    assert text == ""
+    assert usage == {}
+
+
+def test_extract_completion_text_coerces_non_string_response() -> None:
+    # Some Provider clients return an integer or model object as
+    # ``response``. Coerce to string so callers don't have to.
+    text, _ = extract_completion_text({"response": 42})
+    assert text == "42"
+
+
+# ----------------------------------------------------------------------
+# complete_with_json
+# ----------------------------------------------------------------------
+
+
+class _FakeJSONClient:
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "metadata": dict(metadata) if metadata else None,
+            }
+        )
+        return {"response": self._response, "usage": {"input_tokens": 3, "output_tokens": 1}}
+
+
+@pytest.mark.asyncio
+async def test_complete_with_json_round_trip() -> None:
+    fake = _FakeJSONClient('{"answer": 42}')
+    result = await complete_with_json(
+        fake, "system", "user", max_tokens=128, temperature=0.2,
+    )
+    assert result["response"] == '{"answer": 42}'
+    assert result["usage"] == {"input_tokens": 3, "output_tokens": 1}
+    assert result["parsed"] == {"answer": 42}
+
+    # Metadata carries json_mode + response_format so the atlas adapter
+    # can lift them into chat()'s typed kwargs.
+    assert fake.calls[0]["metadata"]["json_mode"] is True
+    assert fake.calls[0]["metadata"]["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.asyncio
+async def test_complete_with_json_returns_empty_parsed_on_malformed_json() -> None:
+    fake = _FakeJSONClient("not valid JSON at all")
+    result = await complete_with_json(
+        fake, "system", "user", max_tokens=64, temperature=0.0,
+    )
+    # Raw response is preserved -- caller can fall back to it.
+    assert result["response"] == "not valid JSON at all"
+    # parsed is empty rather than raising, so call sites can check
+    # truthiness rather than wrap in try/except.
+    assert result["parsed"] == {}
+
+
+@pytest.mark.asyncio
+async def test_complete_with_json_omits_json_mode_when_disabled() -> None:
+    fake = _FakeJSONClient("plain text")
+    await complete_with_json(
+        fake, "system", "user", max_tokens=64, temperature=0.5, json_mode=False,
+    )
+    assert fake.calls[0]["metadata"] is None  # no metadata when no flags set
+
+
+@pytest.mark.asyncio
+async def test_complete_with_json_threads_timeout_through_metadata() -> None:
+    fake = _FakeJSONClient('{"x": 1}')
+    await complete_with_json(
+        fake, "sys", "user", max_tokens=64, temperature=0.0, timeout=30.0,
+    )
+    assert fake.calls[0]["metadata"]["timeout"] == 30.0

--- a/tests/test_extracted_reasoning_core_graph_helpers.py
+++ b/tests/test_extracted_reasoning_core_graph_helpers.py
@@ -65,6 +65,20 @@ def test_parse_llm_json_raises_on_no_object() -> None:
         parse_llm_json("just prose, no JSON here")
 
 
+def test_parse_llm_json_raises_on_non_dict_result() -> None:
+    # Downstream graph nodes always call ``.get(...)`` on the parsed
+    # result -- a JSON array would AttributeError. Pin the dict-only
+    # contract so a future refactor can't broaden the return type
+    # without an explicit test update.
+    with pytest.raises(json.JSONDecodeError):
+        parse_llm_json("[1, 2, 3]")
+    with pytest.raises(json.JSONDecodeError):
+        parse_llm_json('"plain string"')
+    # Still raises when the array is fenced or embedded.
+    with pytest.raises(json.JSONDecodeError):
+        parse_llm_json("```json\n[1, 2]\n```")
+
+
 # ----------------------------------------------------------------------
 # valid_uuid_str
 # ----------------------------------------------------------------------
@@ -384,6 +398,7 @@ async def test_complete_with_json_round_trip() -> None:
     assert result["response"] == '{"answer": 42}'
     assert result["usage"] == {"input_tokens": 3, "output_tokens": 1}
     assert result["parsed"] == {"answer": 42}
+    assert result["parse_ok"] is True
 
     # Metadata carries json_mode + response_format so the atlas adapter
     # can lift them into chat()'s typed kwargs.
@@ -392,7 +407,7 @@ async def test_complete_with_json_round_trip() -> None:
 
 
 @pytest.mark.asyncio
-async def test_complete_with_json_returns_empty_parsed_on_malformed_json() -> None:
+async def test_complete_with_json_signals_parse_failure() -> None:
     fake = _FakeJSONClient("not valid JSON at all")
     result = await complete_with_json(
         fake, "system", "user", max_tokens=64, temperature=0.0,
@@ -400,8 +415,36 @@ async def test_complete_with_json_returns_empty_parsed_on_malformed_json() -> No
     # Raw response is preserved -- caller can fall back to it.
     assert result["response"] == "not valid JSON at all"
     # parsed is empty rather than raising, so call sites can check
-    # truthiness rather than wrap in try/except.
+    # parse_ok rather than wrap in try/except.
     assert result["parsed"] == {}
+    assert result["parse_ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_complete_with_json_distinguishes_empty_object_from_parse_failure() -> None:
+    # A model returning a *valid* empty JSON object ``{}`` should be
+    # distinguishable from a parse failure -- the graph nodes' "force
+    # notify on parse failure" semantics require it. parse_ok is the
+    # source of truth, not parsed-truthiness.
+    fake = _FakeJSONClient("{}")
+    result = await complete_with_json(
+        fake, "system", "user", max_tokens=64, temperature=0.0,
+    )
+    assert result["parsed"] == {}
+    assert result["parse_ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_complete_with_json_signals_parse_failure_on_non_object() -> None:
+    # parse_llm_json now raises on JSON arrays/scalars; complete_with_json
+    # must surface that as parse_ok=False rather than letting the array
+    # leak through and crash the caller's ``.get(...)``.
+    fake = _FakeJSONClient("[1, 2, 3]")
+    result = await complete_with_json(
+        fake, "system", "user", max_tokens=64, temperature=0.0,
+    )
+    assert result["parsed"] == {}
+    assert result["parse_ok"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_reasoning_core_graph_nodes.py
+++ b/tests/test_extracted_reasoning_core_graph_nodes.py
@@ -1,0 +1,231 @@
+"""Unit tests for ``extracted_reasoning_core.graph_nodes``.
+
+PR-C4e2 promoted the LLM-driven nodes ``node_triage`` and
+``node_synthesize`` into core. They run against the
+``LLMClient`` Protocol instead of atlas's concrete LLM service, so
+these tests exercise both the happy path (LLM available, JSON parses)
+and every fallback the original atlas code carried (LLM unavailable,
+LLM raises, malformed JSON).
+
+A fake ``LLMClient`` (matches the Port shape exactly) records the
+calls so we can pin the metadata-packed kwargs the adapter relies on
+(``json_mode``, ``response_format``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from extracted_reasoning_core.graph_nodes import node_synthesize, node_triage
+
+
+_TRIAGE_PROMPT = "You are a triage classifier."
+_SYNTH_PROMPT = "You are a notification summarizer."
+
+
+class _RecordingLLMClient:
+    """Fake LLMClient that returns a canned response and records calls."""
+
+    def __init__(
+        self,
+        response_text: str,
+        usage: dict[str, int] | None = None,
+    ) -> None:
+        self._response_text = response_text
+        self._usage = usage or {}
+        self.calls: list[dict[str, Any]] = []
+        self.exc: Exception | None = None
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append(
+            {
+                "messages": [dict(m) for m in messages],
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "metadata": dict(metadata) if metadata else None,
+            }
+        )
+        if self.exc is not None:
+            raise self.exc
+        return {"response": self._response_text, "usage": dict(self._usage)}
+
+
+# ----------------------------------------------------------------------
+# node_triage
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_node_triage_writes_parsed_priority_and_accumulates_tokens() -> None:
+    fake = _RecordingLLMClient(
+        response_text='{"priority": "high", "needs_reasoning": true, "reasoning": "vendor at risk"}',
+        usage={"input_tokens": 12, "output_tokens": 7},
+    )
+    state: dict = {
+        "event_type": "vendor.archetype_assigned",
+        "source": "reasoning_core",
+        "entity_type": "vendor",
+        "entity_id": "acme",
+        "payload": {"vendor": "Acme"},
+        "total_input_tokens": 5,
+        "total_output_tokens": 3,
+    }
+
+    await node_triage(state, fake, triage_system_prompt=_TRIAGE_PROMPT)
+
+    assert state["triage_priority"] == "high"
+    assert state["needs_reasoning"] is True
+    assert state["triage_reasoning"] == "vendor at risk"
+    # Token totals accumulate (didn't overwrite the prior 5/3).
+    assert state["total_input_tokens"] == 17
+    assert state["total_output_tokens"] == 10
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    # System prompt is the first message.
+    assert call["messages"][0] == {"role": "system", "content": _TRIAGE_PROMPT}
+    # User message carries the event description.
+    assert "vendor.archetype_assigned" in call["messages"][1]["content"]
+    # JSON-mode flags reach the LLMClient via metadata so the adapter
+    # can pass response_format through to the underlying chat call.
+    assert call["metadata"]["json_mode"] is True
+    assert call["metadata"]["response_format"] == {"type": "json_object"}
+    # Triage uses a low temperature.
+    assert call["temperature"] == 0.1
+
+
+@pytest.mark.asyncio
+async def test_node_triage_falls_back_when_llm_is_none() -> None:
+    state: dict = {"event_type": "system.tick"}
+    await node_triage(state, None, triage_system_prompt=_TRIAGE_PROMPT)
+    assert state["triage_priority"] == "medium"
+    assert state["needs_reasoning"] is True
+    assert state["triage_reasoning"] == "Triage LLM unavailable, defaulting to reason"
+
+
+@pytest.mark.asyncio
+async def test_node_triage_falls_back_when_llm_raises() -> None:
+    fake = _RecordingLLMClient(response_text="")
+    fake.exc = RuntimeError("upstream timeout")
+    state: dict = {"event_type": "system.tick"}
+    await node_triage(state, fake, triage_system_prompt=_TRIAGE_PROMPT)
+    assert state["triage_priority"] == "medium"
+    assert state["needs_reasoning"] is True
+    assert "Triage parse error" in state["triage_reasoning"]
+
+
+@pytest.mark.asyncio
+async def test_node_triage_default_priority_when_parsed_keys_missing() -> None:
+    # If the model returns valid JSON but no ``priority`` field, fall
+    # back to ``medium`` priority + needs_reasoning. This protects
+    # against models that occasionally emit ``{}`` or partial objects.
+    fake = _RecordingLLMClient(response_text="{}")
+    state: dict = {"event_type": "system.tick"}
+    await node_triage(state, fake, triage_system_prompt=_TRIAGE_PROMPT)
+    assert state["triage_priority"] == "medium"
+    assert state["needs_reasoning"] is True
+    assert state["triage_reasoning"] == ""
+
+
+# ----------------------------------------------------------------------
+# node_synthesize
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_node_synthesize_skips_when_should_notify_false() -> None:
+    state: dict = {"should_notify": False}
+    fake = _RecordingLLMClient(response_text="should not be called")
+    await node_synthesize(state, fake, synthesis_system_prompt=_SYNTH_PROMPT)
+    assert state["summary"] == ""
+    # No LLM call when notification gate is closed.
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_node_synthesize_uses_deterministic_fallback_when_llm_none() -> None:
+    state: dict = {
+        "should_notify": True,
+        "event_type": "vendor.churn",
+        "action_results": [{"tool": "log_interaction", "success": True}],
+        "rationale": "Vendor signaling churn risk.",
+        "connections_found": [],
+    }
+    await node_synthesize(state, None, synthesis_system_prompt=_SYNTH_PROMPT)
+    # Fallback wraps rationale text + appends action phrase.
+    assert "Vendor signaling churn risk" in state["summary"]
+    assert "log interaction" in state["summary"]
+
+
+@pytest.mark.asyncio
+async def test_node_synthesize_writes_sanitized_summary_and_tokens() -> None:
+    fake = _RecordingLLMClient(
+        response_text="Vendor X is at risk. Outreach scheduled for Monday.",
+        usage={"input_tokens": 30, "output_tokens": 12},
+    )
+    state: dict = {
+        "should_notify": True,
+        "event_type": "vendor.churn",
+        "action_results": [],
+        "rationale": "...",
+        "connections_found": [],
+        "total_input_tokens": 100,
+        "total_output_tokens": 50,
+    }
+    await node_synthesize(state, fake, synthesis_system_prompt=_SYNTH_PROMPT)
+
+    assert "Vendor X is at risk" in state["summary"]
+    assert "Outreach scheduled" in state["summary"]
+    assert state["total_input_tokens"] == 130
+    assert state["total_output_tokens"] == 62
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    # Synthesis is plain text, not JSON -- no json_mode metadata.
+    assert call["metadata"] is None
+    assert call["max_tokens"] == 256
+    assert call["temperature"] == 0.3
+
+
+@pytest.mark.asyncio
+async def test_node_synthesize_falls_back_on_llm_failure() -> None:
+    fake = _RecordingLLMClient(response_text="")
+    fake.exc = RuntimeError("synthesis failed")
+    state: dict = {
+        "should_notify": True,
+        "event_type": "vendor.churn",
+        "action_results": [{"tool": "log_interaction", "success": True}],
+        "rationale": "Vendor X showing churn risk.",
+        "connections_found": [],
+    }
+    await node_synthesize(state, fake, synthesis_system_prompt=_SYNTH_PROMPT)
+    # LLM raised; deterministic fallback fires.
+    assert "Vendor X showing churn risk" in state["summary"]
+
+
+@pytest.mark.asyncio
+async def test_node_synthesize_falls_back_on_empty_response() -> None:
+    fake = _RecordingLLMClient(response_text="", usage={"input_tokens": 5, "output_tokens": 0})
+    state: dict = {
+        "should_notify": True,
+        "event_type": "vendor.churn",
+        "action_results": [],
+        "rationale": "",
+        "connections_found": ["Vendor signal: pricing pressure"],
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+    }
+    await node_synthesize(state, fake, synthesis_system_prompt=_SYNTH_PROMPT)
+    # Empty response → fallback uses connections.
+    assert "Vendor signal: pricing pressure" in state["summary"]
+    # Tokens still accumulate even when response is empty.
+    assert state["total_input_tokens"] == 5

--- a/tests/test_extracted_reasoning_core_graph_nodes.py
+++ b/tests/test_extracted_reasoning_core_graph_nodes.py
@@ -125,15 +125,64 @@ async def test_node_triage_falls_back_when_llm_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_node_triage_default_priority_when_parsed_keys_missing() -> None:
-    # If the model returns valid JSON but no ``priority`` field, fall
-    # back to ``medium`` priority + needs_reasoning. This protects
-    # against models that occasionally emit ``{}`` or partial objects.
+    # If the model returns valid JSON ``{}`` (no ``priority`` field),
+    # fall back to ``medium`` priority + needs_reasoning via the
+    # parsed-key defaults. parse_ok is True here -- the response
+    # parsed cleanly, just had no fields.
     fake = _RecordingLLMClient(response_text="{}")
     state: dict = {"event_type": "system.tick"}
     await node_triage(state, fake, triage_system_prompt=_TRIAGE_PROMPT)
     assert state["triage_priority"] == "medium"
     assert state["needs_reasoning"] is True
     assert state["triage_reasoning"] == ""
+
+
+@pytest.mark.asyncio
+async def test_node_triage_falls_back_on_unparseable_output() -> None:
+    # The model returned a non-JSON response. complete_with_json
+    # swallows the JSONDecodeError and signals via parse_ok=False;
+    # node_triage must apply the same "default to reason on parse
+    # failure" fallback atlas's pre-extraction code did. Without
+    # this branch, malformed triage output would silently leak
+    # through with empty triage_reasoning.
+    fake = _RecordingLLMClient(response_text="not JSON at all")
+    state: dict = {"event_type": "system.tick"}
+    await node_triage(state, fake, triage_system_prompt=_TRIAGE_PROMPT)
+    assert state["triage_priority"] == "medium"
+    assert state["needs_reasoning"] is True
+    assert "Triage parse error" in state["triage_reasoning"]
+
+
+@pytest.mark.asyncio
+async def test_node_triage_threads_timeout_through_metadata() -> None:
+    fake = _RecordingLLMClient(response_text='{"priority": "low"}')
+    state: dict = {"event_type": "system.tick"}
+    await node_triage(
+        state, fake,
+        triage_system_prompt=_TRIAGE_PROMPT,
+        timeout=45.0,
+    )
+    # Timeout reaches the LLMClient via metadata so the adapter can
+    # apply the deadline (asyncio.wait_for + chat kwarg).
+    assert fake.calls[0]["metadata"]["timeout"] == 45.0
+
+
+@pytest.mark.asyncio
+async def test_node_synthesize_threads_timeout_through_metadata() -> None:
+    fake = _RecordingLLMClient(response_text="A summary line.")
+    state: dict = {
+        "should_notify": True,
+        "event_type": "vendor.churn",
+        "action_results": [],
+        "rationale": "...",
+        "connections_found": [],
+    }
+    await node_synthesize(
+        state, fake,
+        synthesis_system_prompt=_SYNTH_PROMPT,
+        timeout=30.0,
+    )
+    assert fake.calls[0]["metadata"]["timeout"] == 30.0
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second sub-slice of the audit's PR 6 graph-engine extraction. Per the **(c) hybrid plan** agreed with the user: keep core's existing `LLMClient.complete()` Protocol stable so `extracted_content_pipeline.PipelineLLMClient` (the other consumer) keeps working, add an atlas adapter that satisfies it, and route the LLM-driven graph nodes through the adapter via shared core helpers.

## Atlas additions

`atlas_brain/reasoning/port_adapters.py::AtlasLLMClient` wraps an atlas `LLMService`:

- **sync→async**: `LLMService.chat` is synchronous; the Port is async. Adapter dispatches via `asyncio.to_thread`.
- **Mapping→Message**: Port carries `[{role, content}, ...]`; atlas's `chat` expects typed `Message` objects. Convert at the boundary.
- **metadata→kwargs**: Port has no place for atlas's `json_mode` / `response_format` / `timeout` knobs. Adapter lifts those keys out of metadata and forwards as typed kwargs (mirrors `AtlasTraceSink` pattern from PR-C4d).
- `LLMService` parameter typed as `Any` to keep `port_adapters.py` import-light (importing the Protocol triggers `atlas_brain.services.__init__`'s heavy chain).

## Core additions

`extracted_reasoning_core/graph_helpers.py` gains three async-friendly helpers each LLM-driven node needs:

| helper | purpose |
|---|---|
| `make_chat_messages(system, user)` | canonical message-list builder; fresh list each call |
| `extract_completion_text(result)` | pulls `(response_text, usage_dict)` — tolerates canonical / OpenAI / content-only shapes |
| `complete_with_json(client, system, user, *, max_tokens, temperature, json_mode=True, timeout=None)` | JSON completion + parse; threads `json_mode`/`response_format`/`timeout` via metadata; returns `{response, usage, parsed}` with `parsed={}` on JSON-decode failure |

`extracted_reasoning_core/graph_nodes.py` (NEW) hosts:

- `node_triage(state, llm, *, triage_system_prompt, max_tokens)` — self-contained; LLM-None fallback to medium priority + needs_reasoning.
- `node_synthesize(state, llm, *, synthesis_system_prompt, ...)` — self-contained; falls back to `build_notification_fallback` on LLM-unavailable / failure / empty response.

## Atlas wrappers

- `_node_triage` and `_node_synthesize` shrink to ~10 lines: resolve workload LLM via `_resolve_graph_llm`, wrap in `AtlasLLMClient`, delegate to core node.
- `_node_reason` keeps its prompt builder atlas-side (it reads `crm_context`, `b2b_churn`, `voice_turns`, etc. — the extended-state fields atlas's `ReasoningAgentState` adds via PR-C4b's TypedDict subclass) but routes the LLM round-trip through `complete_with_json`. State writes preserve exact pre-extraction semantics, including the JSON-decode fallback that forces `should_notify=True`.

## Tests (44 new)

- `test_extracted_reasoning_core_graph_helpers.py` extended: `make_chat_messages`, `extract_completion_text` (5 shapes incl. non-string coercion), `complete_with_json` (round-trip / malformed JSON / json_mode-disabled / timeout threading).
- `test_extracted_reasoning_core_graph_nodes.py` (NEW): `node_triage` (5 paths) + `node_synthesize` (5 paths).
- `test_atlas_reasoning_port_adapters.py` extended: `AtlasLLMClient` (Protocol satisfaction, `to_thread` dispatch, Mapping→Message conversion, metadata-key lifting, non-dict result wrapping). Uses the same `sys.modules` save/restore fixture pattern PR-C4d's Codex review established.

## CI wired from first commit (PR-C4b lesson)

- `tests/test_extracted_reasoning_core_graph_nodes.py` added to `scripts/run_extracted_pipeline_checks.sh`.
- Existing `tests/test_extracted_reasoning_core_*` workflow paths-glob already picks up the new test file.

## Test plan

- [x] `pytest tests/test_extracted_reasoning_core_graph_helpers.py tests/test_extracted_reasoning_core_graph_nodes.py tests/test_atlas_reasoning_port_adapters.py` → 68/68
- [x] `bash scripts/run_extracted_pipeline_checks.sh` → 709 passed (was 652 before)
- [x] Atlas backward-compat: all `_node_triage`, `_node_reason`, `_node_synthesize` import paths still resolve through the wrappers
- [ ] CI green on the 3.10 runner

## Out of scope

- **PR-C4e3** — orchestrator + atlas-coupled nodes (`_node_aggregate_context`, `_node_check_lock`, `_node_execute_actions`, `_node_notify`) via new ports. Not started.
- **`_llm_generate` removal** from atlas — `reflection.py` still imports it directly. PR-C4e3 or a later cleanup slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)