### PR TITLE
M6: hybrid reasoning compatibility matrix — closes M1-M6 program

### DIFF
--- a/docs/hybrid_extraction_plan_status_2026-05-05.md
+++ b/docs/hybrid_extraction_plan_status_2026-05-05.md
@@ -98,18 +98,15 @@ This is the same pattern PR-C4c (#192) is doing for `EventSink`/`TraceSink` in `
 
 ### M6 / PR-6 — Migration runbook + compatibility matrix
 
+**Status**: ✅ shipped via this PR — `docs/hybrid_reasoning_compatibility_matrix.md`.
+
 **Plan as written**: two new docs (`docs/hybrid_reasoning_migration_runbook.md`, `docs/hybrid_reasoning_compatibility_matrix.md`).
 
-**Reality check**: We already have `docs/reasoning_provider_port_migration.md` (#198) and `docs/hybrid_pr_body_template.md` (#198). Either rename the missing two to those, or fold them into a single runbook. PR-6's value is mostly checklist content — a 2-day doc PR.
+**What shipped instead**: a single consolidated `docs/hybrid_reasoning_compatibility_matrix.md` that contains the matrix, a 4-dimension decision rubric (ontology / evidence / output-contract / lineage), a 5-minute walk-through checklist, anti-patterns, and pointers to the two existing migration / scope-guard docs (`docs/reasoning_provider_port_migration.md` from #198 and `docs/hybrid_scope_guard.md` from #195) rather than duplicating them. The "migration runbook" the plan called for is already covered by those two docs; M6's actual value-add is the *decision* layer that sits above implementation.
 
-Bare-minimum content for the compatibility matrix:
+The matrix is filled out for the 8 known / likely domains: `vendor_pressure`, `call_transcript`, `competitive_intel`, `content_ops`, `company_entity`, `support_ticket`, `contract_clause`, plus a hypothetical graph-reasoning case as the canonical "rebuild" example. Six of the eight resolve to **reuse** with a ~200-line additive PR mirroring `call_transcript`; one is a separate role (`content_ops` data-input port — see PR #235); one is the rebuild escalation path.
 
-| Product | Reasoning ontology | Evidence semantics | Recommended path |
-|---|---|---|---|
-| Churn intelligence | vendor-pressure / displacement | `b2b_review_evidence_atoms` | reuse producer (`b2b_reasoning_synthesis`) |
-| Content ops | campaign-pain / wedge | host-provided via `CampaignReasoningProviderPort` | reuse consumer contract; producer host-owned |
-| Competitive intel | cross-vendor-edge | shared with churn | reuse producer; gate via `_b2b_cross_vendor_synthesis` |
-| New product domain X | (TBD) | (TBD) | rebuild producer if ontology diverges |
+This **closes the M1–M6 hybrid extraction program**. After M6 lands, the next reasoning use case — call transcripts, company entities, support tickets, anything else a user wants — is a small additive PR with no platform-coordination cost.
 
 ---
 
@@ -118,22 +115,22 @@ Bare-minimum content for the compatibility matrix:
 PRs that close out the deferred items from M5-β / M5-γ:
 
 - **Wire b2b regression tests into CI** — *resolved in PR #229
-  (open, awaiting merge)*. Adds the two regression tests to
+  (merged)*. Adds the two regression tests to
   `.github/workflows/extracted_competitive_intelligence_checks.yml`
   (the heavier CI tier that already does
   `pip install -r requirements.txt` and so already carries
   `apscheduler` / `asyncpg` / `mcp` / `torch` — no install-line
   expansion needed).
 - **Lineage / freshness in the typed envelope** — *resolved in PR
-  #232 (open, awaiting merge)*. Threads `view.reference_ids` /
+  #232 (merged)*. Threads `view.reference_ids` /
   `view.as_of_date_iso` (property) /
   `view.confidence("causal_narrative")` through the synthesis-view
   wrapper into `DomainReasoningResult.reference_ids` / `as_of` /
   `confidence_label`. Wire shape preserved (consumer projections
   still don't surface the new fields; that's a follow-up).
 - **Provider-port retyping (`CampaignReasoningProviderPort` →
-  `ReasoningProducerPort[...]`)** — *resolved in this PR (open,
-  awaiting merge) as not-applicable*.
+  `ReasoningProducerPort[...]`)** — *resolved in PR #235 (merged) as
+  not-applicable*.
   On closer inspection, `CampaignReasoningProviderPort` is a
   **data-input provider** for the campaign generator, not a reasoning
   compute port. It returns a `CampaignReasoningContext` (anchor

--- a/docs/hybrid_reasoning_compatibility_matrix.md
+++ b/docs/hybrid_reasoning_compatibility_matrix.md
@@ -35,14 +35,20 @@ The four dimensions that matter:
 
 These are genuinely different ontologies. A vendor-pressure producer cannot output "topics + sentiment" without violating its own contract. Conversely, a transcript producer cannot meaningfully output "wedge + displacement_narrative".
 
-**Compatible:** ontology overlaps ≥ ~70% with an existing domain payload.
-**Incompatible:** ontology centers on different concepts. Build a new producer + payload.
+**Two reuse modes** — distinguish them when reading the rest of this doc:
+
+* **Reuse an existing domain's producer + consumer** (e.g. you genuinely have *vendor pressure* — same wedge / displacement / proof-points ontology — and just want a new consumer surface). Requires ontology to **overlap** with an existing domain payload (≥ ~70% in practice).
+* **Reuse the M5-α envelope abstraction** (you have a *different* ontology — call transcripts, company entities, contracts — but want the typed `DomainReasoningResult[PayloadT]` envelope, registry, producer/consumer Protocols, lineage block). This is the path almost every new domain wants. Requires only that your conclusions can be expressed as a small fixed-shape dataclass — see dimensions 2–4.
+
+**Incompatible (with the M5-α envelope itself):** your reasoning genuinely doesn't produce "subject → typed conclusions + evidence lineage" shaped output. E.g. graph reasoning that emits edges-with-traces, not subject-scoped envelopes. That's the rare rebuild-the-core path; coordinate with platform.
+
+The original plan-status doc and PR #211 demonstrate that ontology divergence between `vendor_pressure` and `call_transcript` is **not** an envelope incompatibility — it's exactly what the typed `domain_payload` slot is for.
 
 ### 2. Evidence semantics
 
 **Question:** what counts as "evidence" in your domain, and where does it live?
 
-- **Vendor pressure** evidence: review atoms (`b2b_review_evidence_atoms`), pricing mentions, exec-change signals — discrete witnessed claims with metric IDs and witness IDs.
+- **Vendor pressure** evidence: persisted in `b2b_evidence_vault`, `b2b_vendor_witnesses`, and `b2b_vendor_reasoning_packets` (witness-backed evidence artifacts) — discrete witnessed claims with metric IDs and witness IDs.
 - **Call transcript** evidence: spans of text within the transcript itself, with timestamps + speaker IDs.
 - **Company entity** evidence: rows from CRM / contract / contacts tables, with source-system IDs.
 
@@ -77,9 +83,9 @@ The M5-α envelope carries `reference_ids: ReferenceIds(metric_ids, witness_ids)
 
 | Domain | Status | Ontology | Evidence | Consumer | Lineage | Recommended path |
 |---|---|---|---|---|---|---|
-| `vendor_pressure` | ✅ shipped (M5-β) | vendor-displacement / wedge | `b2b_review_evidence_atoms` (review atoms, metric ledger, witness pack) | `signals.py` MCP overlay (flat dict) | `metric_ids` / `witness_ids` from `SynthesisView.reference_ids` | **Reuse**. `vendor_pressure_result_from_synthesis_view` already wraps the producer. |
+| `vendor_pressure` | ✅ shipped (M5-β) | vendor-displacement / wedge | `b2b_evidence_vault` + `b2b_vendor_witnesses` + `b2b_vendor_reasoning_packets` (witness-backed evidence artifacts; metric ledger; witness pack) | `signals.py` MCP overlay (flat dict) | `metric_ids` / `witness_ids` from `SynthesisView.reference_ids` | **Reuse**. `vendor_pressure_result_from_synthesis_view` already wraps the producer. |
 | `call_transcript` | ✅ shipped (M5-γ) | topics / sentiment / action_items | per-transcript span (no formal evidence atoms yet) | transcript-detail overlay (flat dict) | optional; supported via nested `reference_ids` | **Reuse**. M5-γ ships the proof-of-life. A real producer reads the transcript and calls `call_transcript_result_from_entry`. |
-| `competitive_intel` (cross-vendor) | partial | cross-vendor-edge / displacement-direction | shared with `vendor_pressure` (review atoms) | battle-card / vendor-briefing renderers | shared with `vendor_pressure` | **Reuse**. Same producer (`b2b_reasoning_synthesis`); consumer-side decoupling is the M5 / phase-3 work that's on the competitive-intel STATUS roadmap. |
+| `competitive_intel` (cross-vendor) | partial | cross-vendor-edge / displacement-direction | shared with `vendor_pressure` (witness-backed evidence artifacts) | battle-card / vendor-briefing renderers | shared with `vendor_pressure` | **Reuse**. Same producer (`b2b_reasoning_synthesis`); consumer-side decoupling is the M5 / phase-3 work that's on the competitive-intel STATUS roadmap. |
 | `content_ops` (campaign generation) | shipped (#189) but **not** typed-envelope | campaign-pain / wedge / proof-points | host-provided (`CampaignReasoningProviderPort` data-input bundle) | campaign generator's prompt builder | implicit in the bundle | **Reuse the data-input port**, not the typed envelope. Different role — see PR #235 role-distinction doc. |
 | `company_entity` | not yet shipped | reconciled facts / coverage gaps / source authority | rows across CRM / contracts / contacts tables, with source-system IDs | company-detail UI overlay | per-fact `metric_ids` (the source-row IDs) and `witness_ids` (corroborating sources) | **Reuse** the typed envelope; build a domain payload that carries `reconciled_facts: tuple[FactDecision, ...]` / `coverage_gaps`. ~250-line additive PR mirroring `call_transcript`. |
 | `support_ticket` | not yet shipped | severity / escalation / related-tickets / root-cause-hypotheses | ticket history rows + linked customer-success records | ticket-detail UI overlay or alerting card | optional | **Reuse**. Same shape as `call_transcript` — a payload with `severity`, `escalation_path`, `related_ticket_ids`, `root_cause_hypotheses`. |
@@ -94,7 +100,7 @@ Use this checklist when scoping a new use case. Most rows answer "yes" → reuse
 
 ```
 [ ] Subject has a stable id and a domain identifier             (yes -> ReasoningSubject works)
-[ ] Conclusions fit a small fixed set of fields (≤ ~10)         (yes -> DomainPayload works)
+[ ] Conclusions fit a small fixed set of fields (≤ ~10)         (yes -> domain_payload PayloadT dataclass works)
 [ ] Evidence shape fits {source_type, source_id, text,          (yes -> existing EvidenceItem works)
     metrics, metadata}
 [ ] Consumer surface is flat dict or projects to one            (yes -> ReasoningConsumerPort works)

--- a/docs/hybrid_reasoning_compatibility_matrix.md
+++ b/docs/hybrid_reasoning_compatibility_matrix.md
@@ -1,0 +1,158 @@
+# Hybrid Reasoning Compatibility Matrix (M6)
+
+**Status:** PR-6 / M6 deliverable — closes the M1–M6 hybrid extraction program described in `docs/hybrid_extraction_plan_status_2026-05-05.md`.
+
+**Audience:** product leads + platform engineers deciding whether a new reasoning use case can **reuse** the existing producer / consumer / envelope, or whether it has to **rebuild** the producer side.
+
+**Scope:** the choice between reusing the M5-α typed-envelope abstraction (`extracted_reasoning_core.domains.DomainReasoningResult[PayloadT]`) for a new domain, and standing up a separate producer because the ontology diverges too far. This document is the rubric; the implementation steps for the chosen path live in `docs/reasoning_provider_port_migration.md`.
+
+---
+
+## When to consult this matrix
+
+You're starting a new product or feature that wants to "reason over X" — call transcripts, internal company data, contract clauses, support tickets, anything where the system needs to:
+
+1. Take a subject (a transcript, a company record, a ticket).
+2. Compute structured reasoning (confidence, supporting signals, falsification conditions, …) over evidence.
+3. Surface the reasoning in an MCP / API / UI overlay.
+
+Before writing code, walk through the four decision dimensions below to land on a path. Get the answer wrong and you either (a) rebuild things that already work, or (b) wedge a domain into a producer that doesn't fit and pay for it in maintenance forever.
+
+---
+
+## Decision dimensions
+
+The four dimensions that matter:
+
+### 1. Ontology
+
+**Question:** does your domain's "what we conclude" map onto an existing producer's conclusion shape?
+
+- **Vendor pressure** concludes: which vendor is at risk, what wedge is driving it, what the displacement narrative looks like, what proof points support it.
+- **Call transcript** concludes: what topics surfaced, sentiment, action items, who was on the call.
+- **Company entity** concludes: which facts are reconciled across sources, where coverage gaps are, what the canonical record should be.
+- **Support ticket** concludes: severity, escalation path, related tickets, root-cause hypotheses.
+
+These are genuinely different ontologies. A vendor-pressure producer cannot output "topics + sentiment" without violating its own contract. Conversely, a transcript producer cannot meaningfully output "wedge + displacement_narrative".
+
+**Compatible:** ontology overlaps ≥ ~70% with an existing domain payload.
+**Incompatible:** ontology centers on different concepts. Build a new producer + payload.
+
+### 2. Evidence semantics
+
+**Question:** what counts as "evidence" in your domain, and where does it live?
+
+- **Vendor pressure** evidence: review atoms (`b2b_review_evidence_atoms`), pricing mentions, exec-change signals — discrete witnessed claims with metric IDs and witness IDs.
+- **Call transcript** evidence: spans of text within the transcript itself, with timestamps + speaker IDs.
+- **Company entity** evidence: rows from CRM / contract / contacts tables, with source-system IDs.
+
+These are all "evidence with lineage", but the **shape** of the evidence atom differs. The existing `EvidenceItem` (`source_type`, `source_id`, `text`, `metrics`, `metadata`) in `extracted_reasoning_core.types` covers them all generically — that's a deliberate design choice from PR-1.
+
+**Compatible:** evidence fits the universal `EvidenceItem` shape, even if the `source_type` values are new.
+**Incompatible:** evidence requires a structurally different shape (e.g. graph edges instead of items). Build a new core, not just a new producer.
+
+### 3. Output contract (consumer side)
+
+**Question:** does the consumer want flat overlay fields (the M5-α `Consumer.to_summary_fields` / `to_detail_fields` pattern), or a different output shape?
+
+- MCP signal overlays, REST API responses, dashboard cards: flat overlay dict. ✓ Existing pattern works.
+- Custom UI rendering with nested objects, conditional sections: still works — the consumer projection is just a method, not a wire shape.
+- A producer that needs to feed *into another producer* (multi-stage reasoning): different role; that's the `CampaignReasoningContext` shape (data-input bundle), see PR #235's role-distinction doc.
+
+**Compatible:** consumer surface is a flat overlay or projects to one.
+**Incompatible:** consumer needs the producer's output as input to *another reasoning stage*. That's a producer-port composition, not a consumer-port projection.
+
+### 4. Lineage requirements
+
+**Question:** does your domain need `metric_ids` / `witness_ids` provenance threaded through to consumers?
+
+The M5-α envelope carries `reference_ids: ReferenceIds(metric_ids, witness_ids)` for any domain that wants it. Domains that don't (purely textual conclusions, no source-tracing requirement) leave them empty.
+
+**Compatible:** lineage either fits the two-bucket `metric_ids` / `witness_ids` model or is genuinely absent.
+**Incompatible:** lineage requires a different model (e.g. a chain-of-thought trace with intermediate provenance per step). That's an envelope extension, not a domain choice — coordinate with platform.
+
+---
+
+## Compatibility matrix (known / likely domains)
+
+| Domain | Status | Ontology | Evidence | Consumer | Lineage | Recommended path |
+|---|---|---|---|---|---|---|
+| `vendor_pressure` | ✅ shipped (M5-β) | vendor-displacement / wedge | `b2b_review_evidence_atoms` (review atoms, metric ledger, witness pack) | `signals.py` MCP overlay (flat dict) | `metric_ids` / `witness_ids` from `SynthesisView.reference_ids` | **Reuse**. `vendor_pressure_result_from_synthesis_view` already wraps the producer. |
+| `call_transcript` | ✅ shipped (M5-γ) | topics / sentiment / action_items | per-transcript span (no formal evidence atoms yet) | transcript-detail overlay (flat dict) | optional; supported via nested `reference_ids` | **Reuse**. M5-γ ships the proof-of-life. A real producer reads the transcript and calls `call_transcript_result_from_entry`. |
+| `competitive_intel` (cross-vendor) | partial | cross-vendor-edge / displacement-direction | shared with `vendor_pressure` (review atoms) | battle-card / vendor-briefing renderers | shared with `vendor_pressure` | **Reuse**. Same producer (`b2b_reasoning_synthesis`); consumer-side decoupling is the M5 / phase-3 work that's on the competitive-intel STATUS roadmap. |
+| `content_ops` (campaign generation) | shipped (#189) but **not** typed-envelope | campaign-pain / wedge / proof-points | host-provided (`CampaignReasoningProviderPort` data-input bundle) | campaign generator's prompt builder | implicit in the bundle | **Reuse the data-input port**, not the typed envelope. Different role — see PR #235 role-distinction doc. |
+| `company_entity` | not yet shipped | reconciled facts / coverage gaps / source authority | rows across CRM / contracts / contacts tables, with source-system IDs | company-detail UI overlay | per-fact `metric_ids` (the source-row IDs) and `witness_ids` (corroborating sources) | **Reuse** the typed envelope; build a domain payload that carries `reconciled_facts: tuple[FactDecision, ...]` / `coverage_gaps`. ~250-line additive PR mirroring `call_transcript`. |
+| `support_ticket` | not yet shipped | severity / escalation / related-tickets / root-cause-hypotheses | ticket history rows + linked customer-success records | ticket-detail UI overlay or alerting card | optional | **Reuse**. Same shape as `call_transcript` — a payload with `severity`, `escalation_path`, `related_ticket_ids`, `root_cause_hypotheses`. |
+| `contract_clause` | not yet shipped | risk_flags / counterparty_obligations / negotiated_deviations | contract paragraphs + clause references | redline / negotiation UI | per-clause `witness_ids` | **Reuse**. New payload with `clause_id`, `risk_flags`, `obligations`, `deviations_from_template`. |
+| (hypothetical) **graph reasoning** over knowledge-graph triples | — | structured edges with reasoning at each hop | graph triples (different shape from `EvidenceItem`) | graph-traversal UI | chain-of-thought across hops | **Rebuild core**. Doesn't fit `EvidenceItem` or `DomainReasoningResult` cleanly. Coordinate with platform on whether the reasoning core itself needs a new envelope variant. |
+
+---
+
+## Walk-through: deciding a new domain in 5 minutes
+
+Use this checklist when scoping a new use case. Most rows answer "yes" → reuse path, ~200-line additive PR mirroring `call_transcript`.
+
+```
+[ ] Subject has a stable id and a domain identifier             (yes -> ReasoningSubject works)
+[ ] Conclusions fit a small fixed set of fields (≤ ~10)         (yes -> DomainPayload works)
+[ ] Evidence shape fits {source_type, source_id, text,          (yes -> existing EvidenceItem works)
+    metrics, metadata}
+[ ] Consumer surface is flat dict or projects to one            (yes -> ReasoningConsumerPort works)
+[ ] Lineage fits metric_ids / witness_ids buckets               (yes -> ReferenceIds works)
+
+If 4-5 yes  -> Reuse. ~200-line additive PR, no core changes. Pattern: `call_transcript`.
+If 2-3 yes  -> Reuse with caveats. New domain payload, possibly new universal-field semantics
+                (talk to platform about whether to extend ReasoningResult vs adding to payload).
+If 0-1 yes  -> Rebuild. The domain wants a different reasoning shape; consult the M1
+                (`docs/reasoning_interface_contract.md`) to decide whether that warrants a new
+                envelope variant in extracted_reasoning_core or a separate package altogether.
+```
+
+---
+
+## Reuse path: what to ship
+
+For domains that pass the "reuse" checklist, the additive PR has five pieces (~200 lines total):
+
+1. `atlas_brain/reasoning/<domain>.py` (new) — `Subject` + `Payload` + `<domain>_result_from_entry` + `<DomainName>Consumer` + `register_domain(...)` at module import. Mirror `call_transcript.py` line-for-line.
+2. `tests/test_atlas_reasoning_<domain>.py` (new) — Subject/Payload protocol checks, registration, sparse + full builder, consumer projections, cross-domain isolation test.
+3. `scripts/run_extracted_pipeline_checks.sh` — add the test file to the pytest matrix.
+4. `.github/workflows/extracted_pipeline_checks.yml` — add `atlas_brain/reasoning/<domain>.py` and `tests/test_atlas_reasoning_<domain>.py` to `paths:` filters.
+5. (Optional) `atlas_brain/autonomous/tasks/<domain>_producer.py` — the actual producer that fetches subjects and calls `<domain>_result_from_entry`. This is the *use* of the abstraction, not the abstraction itself; ship it whenever the consuming product surface is ready.
+
+For implementation step-by-step, see `docs/reasoning_provider_port_migration.md`.
+
+---
+
+## Rebuild path: what to ship
+
+Rare. If you actually need to rebuild:
+
+1. Document why the existing envelope doesn't fit (which dimension fails — usually evidence shape or output-contract role).
+2. Coordinate with platform on whether the core needs a new envelope variant or a separate package. The M1 contract doc (`docs/reasoning_interface_contract.md`) is the authority.
+3. Ship the new core first (additive — keep the existing `DomainReasoningResult` working), then build your producer on top.
+
+Rebuild is an architectural escalation, not a product decision. If you find yourself reaching for it without one of the four dimensions clearly failing, walk back through the matrix.
+
+---
+
+## Anti-patterns
+
+These come up enough that they're worth naming:
+
+- **Wedging a transcript into vendor_pressure.** "It's all just text + signals". Wrong — the vendor-pressure producer is bound to vendor synthesis tables and its output keys (`wedge`, `displacement_narrative`) have hard semantics. Use a `call_transcript` producer.
+- **Calling a "data-input provider" a "reasoning producer".** `CampaignReasoningProviderPort` returns a `CampaignReasoningContext` (input bundle). `ReasoningProducerPort` returns a `DomainReasoningResult` (typed envelope). Different roles — see PR #235.
+- **Adding fields to `DomainReasoningResult` for a single domain.** Use `domain_payload`. The envelope's universal fields are universal precisely because every domain populates them.
+- **Skipping lineage because "we don't have IDs yet".** You will. Wire `reference_ids` through from day one even if the values are empty tuples; future you will thank past you when audit/compliance comes asking.
+
+---
+
+## Where this doc fits
+
+- **M1** — `docs/reasoning_interface_contract.md` — the canonical envelope contract.
+- **M5-α** — `extracted_reasoning_core.domains` — the typed-envelope abstraction.
+- **M5-β/γ** — `atlas_brain/reasoning/{vendor_pressure, call_transcript}.py` — two specializations.
+- **M6 (this doc)** — `docs/hybrid_reasoning_compatibility_matrix.md` — when to reuse vs rebuild.
+- **Implementation steps** — `docs/reasoning_provider_port_migration.md` (#198) — host migration to the provider port.
+- **PR scope guard** — `docs/hybrid_scope_guard.md` (#195) — whether your slice is in-program.
+- **PR body template** — `docs/hybrid_pr_body_template.md` (#198) — what to include.


### PR DESCRIPTION
## Summary

Final deliverable for the **hybrid-extraction reasoning program** (M1–M6) described in `docs/hybrid_extraction_plan_status_2026-05-05.md`. Ships `docs/hybrid_reasoning_compatibility_matrix.md` — the decision rubric for whether a new reasoning use case can **reuse** the M5-α typed envelope or has to **rebuild** a separate producer.

After this lands, the next reasoning use case (call transcripts in production, company entities, support tickets, anything else) is a small additive PR with zero platform-coordination cost.

## Doc structure

- **Decision dimensions** (4): ontology / evidence semantics / output contract / lineage requirements. Each dimension's compatibility threshold spelled out.
- **Compatibility matrix** filled out for 8 known / likely domains:

  | Domain | Status | Path |
  |---|---|---|
  | `vendor_pressure` | shipped (M5-β) | reuse |
  | `call_transcript` | shipped (M5-γ) | reuse |
  | `competitive_intel` | partial | reuse |
  | `content_ops` | shipped (#189) | reuse the data-input port (different role; PR #235) |
  | `company_entity` | not yet | reuse, ~200-line additive |
  | `support_ticket` | not yet | reuse, ~200-line additive |
  | `contract_clause` | not yet | reuse, ~200-line additive |
  | hypothetical graph reasoning | — | rebuild (canonical escalation example) |

- **5-minute walk-through checklist** with thresholds: 4–5 yes → reuse (~200 lines mirroring `call_transcript`); 2–3 yes → reuse with caveats; 0–1 yes → rebuild escalation.
- **Reuse path: what to ship** — the five-piece template (`Subject` + `Payload` + builder + `Consumer` + `register_domain` in one new module, plus tests + CI wiring).
- **Rebuild path: what to ship** — when and how to escalate.
- **Anti-patterns** section naming the four common conflations (wedging transcript into vendor_pressure, calling a data-input provider a reasoning producer, single-domain envelope-field drift, skipping lineage "because we don't have IDs yet").
- **Where this doc fits** — pointers to M1 contract, M5-α envelope module, M5-β/γ specializations, migration guide (#198), scope guard (#195), PR body template (#198).

## Why one doc instead of the two the original plan listed

The plan called for `docs/hybrid_reasoning_migration_runbook.md` + `docs/hybrid_reasoning_compatibility_matrix.md`. On review, the migration-runbook content is already covered by:
- `docs/reasoning_provider_port_migration.md` (PR #198) — host migration to the provider port.
- `docs/hybrid_scope_guard.md` (PR #195) — whether your slice is in-program.
- `docs/hybrid_pr_body_template.md` (PR #198) — what the PR body must contain.

M6's actual value-add is the **decision layer** that sits above implementation — when do you reuse vs rebuild? That's the matrix. Splitting it into two thin docs would just spread the same content across two files.

## Plan-status doc

Updated to reflect:
- M6 marked **✅ shipped via this PR** with the consolidation rationale.
- Followup-resolution log: #229, #232, #235 changed from "open, awaiting merge" to **merged**.

## Behavior-change statement

Zero. Pure docs.

## Contract impact

None.

## Rollback plan

Revert. Two-file docs-only PR.

## Plan reference

`docs/hybrid_extraction_plan_status_2026-05-05.md` § "M6 / PR-6 — Migration runbook + compatibility matrix".

## After this lands

The M1–M6 program is **structurally complete**:

| Slice | Status |
|---|---|
| M1 — interface contract | ✅ #178 |
| M2 — consumer adapter | ✅ #178/#187 |
| M3 — provider port | ✅ #189/#195/#198/#200 |
| M4 — forbid-imports guard | ✅ #207 |
| M5-α — generic protocols | ✅ #211 |
| M5-β — vendor-pressure specialization | ✅ #215 |
| M5-γ — second-domain proof-of-life | ✅ #222 |
| M5 followups (#229/#232/#235) | ✅ merged |
| **M6 — compatibility matrix** | 🟡 this PR |

After M6, additional domains (company_entity, support_ticket, …) ship as small additive PRs without re-opening the program.

---
_Generated by [Claude Code](https://claude.ai/code/session_017k4xQ6eLxysGkgLnGv4noh)_