### PR TITLE
Clean up PR-C4e3 (#245) extraction coordination

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T04:38Z by claude-2026-05-03
+Last updated: 2026-05-05T05:07Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-C4e3, in flight) | PR-C4e3: orchestrator to core via GraphNodes (PR 6 fifth slice, 3/3 of graph extraction) | NEW: `extracted_reasoning_core/graph.py` (`GraphNodes` frozen dataclass with eight callable fields + async `run_graph(state, nodes)` chaining triage -> aggregate_context -> check_lock -> reason -> plan_actions -> execute_actions -> synthesize -> notify with the existing early-exit branches: `needs_reasoning=False` after triage, `queued=True` after lock check). EDIT: `atlas_brain/reasoning/graph.py` (`run_reasoning_graph` becomes a wrapper that builds a `GraphNodes` bundle from atlas's existing `_node_*` callables and delegates to core's `run_graph`). NEW: `tests/test_extracted_reasoning_core_graph.py` (orchestrator chains nodes in order, respects both early-exit conditions, initializes token totals). NEW: `tests/test_atlas_reasoning_run_reasoning_graph_wiring.py` (atlas wrapper builds GraphNodes correctly + delegates). EDIT: `scripts/run_extracted_pipeline_checks.sh` + `.github/workflows/extracted_pipeline_checks.yml` (wire new tests). Atlas-coupled nodes (`_node_aggregate_context` / `_node_check_lock` / `_node_execute_actions` / `_node_notify`) stay atlas-side per the audit's "Atlas-specific tracing/settings/event bus stay in adapters" criterion -- they read DBs / atlas APIs / ntfy and are explicitly host-specific. Closes the orchestrator extraction; the audit's PR 6 acceptance ("LLM, cache, state store, event sink, trace sink are ports / atlas-specific stays in adapters") is now satisfied for the engine. | claude-2026-05-03 | `extracted_reasoning_core/graph.py`; `atlas_brain/reasoning/graph.py`; `tests/test_extracted_reasoning_core_graph.py`; `tests/test_atlas_reasoning_run_reasoning_graph_wiring.py`; `scripts/run_extracted_pipeline_checks.sh`; `.github/workflows/extracted_pipeline_checks.yml` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
PR #245 merged at `d45fce81` (2026-05-05T05:06:01Z). Drop the in-flight row + bump the per-file Last updated stamp.

Closes the audit's PR 6 graph-engine extraction. After the C4 sequence (PR-C4a → PR-C4e3, plus PR-C4d2 reflection-tracing gap fix), the audit's PR 6 acceptance is fully satisfied for the reasoning engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)