### PR TITLE
PR-D4c: Idempotency-Key + per-batch usage tracking for /llm/batch

### DIFF
--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -32,7 +32,7 @@ import time
 import uuid as _uuid
 from typing import Any, AsyncIterator, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -634,6 +634,17 @@ def _validate_batch_provider(provider: str) -> None:
 async def submit_batch(
     body: BatchSubmitRequest,
     user: AuthUser = Depends(require_llm_plan("llm_starter")),
+    idempotency_key: Optional[str] = Header(
+        default=None,
+        alias="Idempotency-Key",
+        max_length=128,
+        description=(
+            "Optional dedup token. If a prior submit used the same "
+            "key for this account, the original record is replayed "
+            "without a new Anthropic call -- prevents duplicate paid "
+            "batches on retry after timeout/network errors."
+        ),
+    ),
 ) -> BatchView:
     """Submit an Anthropic Message Batch.
 
@@ -649,7 +660,9 @@ async def submit_batch(
     PR -- a follow-up adds /batch/{id}/results to fetch the JSONL
     file Anthropic produces. For PR-D4b, customers can pull results
     via Anthropic's API directly using the ``provider_batch_id``
-    returned here.
+    returned here. Per-item usage IS persisted to ``llm_usage`` once
+    the batch reaches a terminal state (PR-D4c) so /api/v1/llm/usage
+    rollups include batch traffic.
 
     On submit failure (Anthropic rejects, validation error, etc.)
     the response body still carries the customer's ``id`` /
@@ -657,6 +670,11 @@ async def submit_batch(
     plus ``error_text`` so the caller can debug without losing the
     handle. Distinct from terminal ``status='ended'`` which means
     Anthropic finished processing successfully.
+
+    Idempotency: send an ``Idempotency-Key`` header (any 1-128 char
+    string; UUIDs recommended) to dedup retries. A prior submit
+    under the same key for the same account replays the original
+    record -- safe to retry without creating duplicate paid batches.
     """
     _validate_batch_provider(body.provider)
     _require_batch_enabled(user)
@@ -693,6 +711,7 @@ async def submit_batch(
             api_key=api_key,
             model=normalized_model,
             items=customer_items,
+            idempotency_key=idempotency_key,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -87,8 +87,8 @@ class CustomerBatchRecord:
     submitted_at: Optional[datetime]
     completed_at: Optional[datetime]
     # PR-D4c Codex P1: surfaced so the refresh path can detect a
-    # terminal row whose usage write never landed (atomic claim
-    # failed mid-iteration -> rolled back to FALSE) and retry.
+    # terminal row whose usage write never landed (results pre-fetch
+    # failed before the atomic claim could flip the flag) and retry.
     usage_tracked: bool = False
 
 
@@ -169,11 +169,11 @@ async def submit_customer_batch(
             normalized_key,
         )
         if existing:
-            settled = (
-                existing["provider_batch_id"]
-                or existing["status"] != "queued"
-            )
-            if settled:
+            # "Settled" = Anthropic accepted the submission. We have a
+            # provider_batch_id to point the customer at, regardless
+            # of whether the batch ended/canceled/expired. A retry
+            # with the same key gets the prior result back.
+            if existing["provider_batch_id"]:
                 logger.info(
                     "llm_gateway_batch.submit replay account=%s key=%s id=%s",
                     account_id,
@@ -182,28 +182,38 @@ async def submit_customer_batch(
                 )
                 return _row_to_record(existing)
 
-            # Codex P1 round 3 on PR-D4c: pre-submit row (queued
-            # with no provider_batch_id). Two cases:
-            #   a) An earlier attempt crashed between INSERT and
-            #      the Anthropic call -- naive replay would loop
-            #      forever returning the stale 'queued' row. Need
-            #      to genuinely re-submit.
-            #   b) A concurrent retry is in-flight to Anthropic
-            #      right now. Re-submitting would duplicate-pay.
-            # Distinguish via updated_at age, and do the
-            # decision atomically in SQL so two concurrent
-            # resumes can't both win. Threshold = 2x
-            # ANTHROPIC_SDK_TIMEOUT_SECONDS (30s) so an in-flight
-            # call has had time to either succeed or hit timeout.
+            # No provider_batch_id means the prior attempt never
+            # made it to Anthropic. Two cases:
+            #   a) status='queued', updated recently -- a concurrent
+            #      retry is in flight right now; re-submitting would
+            #      duplicate-pay. Replay so the customer polls.
+            #   b) status='queued' but stale (updated_at >
+            #      2x ANTHROPIC_SDK_TIMEOUT_SECONDS ago), OR
+            #      status='submit_failed' -- the prior attempt
+            #      crashed pre-submit (a) or Anthropic rejected /
+            #      timed out (b). Either way, the customer's batch
+            #      never landed; resume so the retry actually
+            #      submits. Codex P1 rounds 3+4 on PR-D4c.
+            #
+            # The decision is made atomically in SQL so two
+            # concurrent resumes can't both win. Threshold = 60s =
+            # 2x ANTHROPIC_SDK_TIMEOUT_SECONDS so an in-flight call
+            # has had time to either succeed or hit the SDK timeout
+            # (which would have updated the row to submit_failed).
             resumed = await pool.fetchrow(
                 """
                 UPDATE llm_gateway_batches
-                SET updated_at = NOW()
+                SET updated_at = NOW(),
+                    status = 'queued',
+                    error_text = NULL
                 WHERE id = $1
                   AND account_id = $2
-                  AND status = 'queued'
                   AND provider_batch_id IS NULL
-                  AND updated_at < NOW() - INTERVAL '60 seconds'
+                  AND (
+                    status = 'submit_failed'
+                    OR (status = 'queued'
+                        AND updated_at < NOW() - INTERVAL '60 seconds')
+                  )
                 RETURNING id, account_id, provider, provider_batch_id, model,
                           status, total_items, completed_items, failed_items,
                           error_text, created_at, updated_at, submitted_at,
@@ -213,23 +223,25 @@ async def submit_customer_batch(
                 account_id,
             )
             if resumed is None:
-                # Still in-flight (< 60s old) or another retry
-                # already claimed it. Replay -- the customer
-                # polls /batch/{id} either way.
+                # Recent queued (< 60s old) or another retry already
+                # claimed it. Replay -- the customer polls /batch/{id}
+                # either way.
                 logger.info(
                     "llm_gateway_batch.submit replay (in-flight) "
-                    "account=%s key=%s id=%s",
+                    "account=%s key=%s id=%s status=%s",
                     account_id,
                     normalized_key,
                     existing["id"],
+                    existing["status"],
                 )
                 return _row_to_record(existing)
             logger.info(
                 "llm_gateway_batch.submit resume pre-submit "
-                "account=%s key=%s id=%s",
+                "account=%s key=%s id=%s prior_status=%s",
                 account_id,
                 normalized_key,
                 existing["id"],
+                existing["status"],
             )
             row = resumed
 
@@ -423,13 +435,14 @@ async def refresh_customer_batch_status(
         return None
     if record.status in TERMINAL_STATUSES:
         # Codex P1 on PR-D4c: a terminal row whose usage write has
-        # not landed yet means the previous attempt failed mid-
-        # iteration and rolled ``usage_tracked`` back to FALSE. We
-        # must retry here -- the only other place that triggers a
-        # write is the non-terminal->terminal transition above, and
-        # that won't fire again. Without this branch, a single
-        # transient SDK error would silently lose the customer's
-        # usage data forever.
+        # not landed yet means the prior _persist_batch_usage call
+        # failed during the Anthropic results pre-fetch (so the
+        # atomic claim was never made and usage_tracked stayed
+        # FALSE). We must retry here -- the only other place that
+        # triggers a write is the non-terminal->terminal transition
+        # below, and that won't fire again. Without this branch, a
+        # single transient SDK error would silently lose the
+        # customer's usage data forever.
         if (
             not record.usage_tracked
             and record.status in ("ended", "canceled", "expired")

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -115,28 +115,66 @@ async def submit_customer_batch(
     api_key: str,
     model: str,
     items: Sequence[CustomerBatchItem],
+    idempotency_key: Optional[str] = None,
 ) -> CustomerBatchRecord:
     """Submit a batch to Anthropic with the customer's BYOK key.
 
     Inserts a tracking row first (status="queued"), calls Anthropic's
     batches.create, persists ``provider_batch_id`` + status="in_progress"
-    on success, persists ``error_text`` + status="ended" on failure.
-    Returns the persisted record.
+    on success, persists ``error_text`` + status="submit_failed" on
+    failure. Returns the persisted record.
+
+    When ``idempotency_key`` is provided, a prior submit with the same
+    key for the same account replays the original record -- no new
+    Anthropic call. Closes the accepted-upstream-but-timeout-locally
+    retry case where a customer would otherwise create duplicate paid
+    batches. PR-D4c.
     """
     if not items:
         raise ValueError("submit_customer_batch: items list is empty")
     if not api_key:
         raise ValueError("submit_customer_batch: api_key is required")
 
+    # Idempotency replay: if the customer already submitted under this
+    # key for this account, return the existing record without calling
+    # Anthropic again. Per-account UNIQUE constraint enforced at the
+    # DB level (migration 318). The empty-string key is treated as
+    # "no key supplied" so customers don't accidentally collide on it.
+    normalized_key = idempotency_key.strip() if idempotency_key else None
+    if not normalized_key:
+        normalized_key = None
+    if normalized_key:
+        existing = await pool.fetchrow(
+            """
+            SELECT id, account_id, provider, provider_batch_id, model,
+                   status, total_items, completed_items, failed_items,
+                   error_text, created_at, updated_at, submitted_at,
+                   completed_at
+            FROM llm_gateway_batches
+            WHERE account_id = $1 AND idempotency_key = $2
+            """,
+            account_id,
+            normalized_key,
+        )
+        if existing:
+            logger.info(
+                "llm_gateway_batch.submit replay account=%s key=%s id=%s",
+                account_id,
+                normalized_key,
+                existing["id"],
+            )
+            return _row_to_record(existing)
+
     # Insert pre-submit so a crash mid-call still leaves a queued row
-    # the customer can see.
+    # the customer can see. The idempotency_key column is NULL when
+    # no header was sent -- the partial UNIQUE index ignores NULL.
     async with pool.transaction() as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO llm_gateway_batches (
-                account_id, provider, model, status, total_items
+                account_id, provider, model, status, total_items, idempotency_key
             ) VALUES (
-                $1, 'anthropic', $2, 'queued', $3
+                $1, 'anthropic', $2, 'queued', $3, $4
             )
             RETURNING id, account_id, provider, provider_batch_id, model,
                       status, total_items, completed_items, failed_items,
@@ -146,6 +184,7 @@ async def submit_customer_batch(
             account_id,
             model,
             len(items),
+            normalized_key,
         )
 
     requests = []
@@ -340,4 +379,166 @@ async def refresh_customer_batch_status(
         completed,
         failed,
     )
-    return _row_to_record(updated)
+    refreshed = _row_to_record(updated)
+
+    # PR-D4c: when a batch transitions to a real Anthropic terminal
+    # state (ended/canceled/expired -- NOT submit_failed), fetch the
+    # per-item results from Anthropic and write llm_usage rows so the
+    # batch traffic shows up in /api/v1/llm/usage. Idempotent via the
+    # ``usage_tracked`` column -- repeat polls don't double-count.
+    if is_terminal and new_status in ("ended", "canceled", "expired"):
+        try:
+            await _persist_batch_usage(
+                pool,
+                account_id=account_id,
+                batch_id=batch_id,
+                provider_batch_id=record.provider_batch_id,
+                model=record.model,
+                api_key=api_key,
+            )
+        except Exception:
+            logger.exception(
+                "llm_gateway_batch.refresh: usage write failed account=%s batch=%s",
+                account_id,
+                batch_id,
+            )
+
+    return refreshed
+
+
+# ---- Batch usage persistence -------------------------------------------
+
+
+# Anthropic batch discount factor: tokens billed at 50% of the
+# synchronous rate. Mirrors the same factor in atlas's existing
+# ``services/b2b/anthropic_batch.py`` -- kept as a module-level
+# constant so any future Anthropic pricing change updates one place.
+_BATCH_DISCOUNT_FACTOR = 0.5
+
+
+async def _persist_batch_usage(
+    pool,
+    *,
+    account_id: _uuid.UUID,
+    batch_id: _uuid.UUID,
+    provider_batch_id: str,
+    model: str,
+    api_key: str,
+) -> None:
+    """Write per-item ``llm_usage`` rows for a completed batch.
+
+    Idempotent: runs at most once per batch via the
+    ``usage_tracked=FALSE`` precondition in the UPDATE that flips
+    the flag. A concurrent poller losing the race is a no-op
+    (conditional update returns 0 rows).
+
+    Per-item cost calculation applies the 50% Anthropic batch
+    discount. Customers see the discounted figure in their
+    ``/api/v1/llm/usage`` rollup -- which matches what Anthropic
+    actually charges them.
+    """
+    # Atomic claim: only proceed when usage_tracked transitions
+    # FALSE -> TRUE. A concurrent poller wins the race and the
+    # loser exits cleanly.
+    claim = await pool.fetchrow(
+        """
+        UPDATE llm_gateway_batches
+        SET usage_tracked = TRUE
+        WHERE id = $1 AND usage_tracked = FALSE
+        RETURNING id
+        """,
+        batch_id,
+    )
+    if claim is None:
+        return  # Already tracked by an earlier poll.
+
+    from anthropic import AsyncAnthropic
+
+    from ..pipelines.llm import trace_llm_call
+
+    try:
+        async with AsyncAnthropic(
+            api_key=api_key,
+            timeout=ANTHROPIC_SDK_TIMEOUT_SECONDS,
+        ) as client:
+            results_iter = await client.messages.batches.results(provider_batch_id)
+            async for entry in results_iter:
+                custom_id = getattr(entry, "custom_id", "") or ""
+                result = getattr(entry, "result", None)
+                rtype = getattr(result, "type", None) if result else None
+                if rtype != "succeeded":
+                    # Only successful items consumed tokens billed by
+                    # Anthropic. Errored / canceled / expired items
+                    # show in the failed_items counter but don't add
+                    # to llm_usage.
+                    continue
+                message = getattr(result, "message", None)
+                usage = getattr(message, "usage", None) if message else None
+                if usage is None:
+                    continue
+                input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+                output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+                cached_tokens = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+                cache_write_tokens = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+                provider_request_id = getattr(message, "id", None)
+                trace_llm_call(
+                    span_name="llm_gateway.batch_item",
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cached_tokens=cached_tokens,
+                    cache_write_tokens=cache_write_tokens,
+                    billable_input_tokens=input_tokens,
+                    model=model,
+                    provider="anthropic",
+                    provider_request_id=str(provider_request_id) if provider_request_id else None,
+                    cost_usd_override=_BATCH_DISCOUNT_FACTOR
+                    * _estimate_cost_usd(
+                        model=model,
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        cached_tokens=cached_tokens,
+                        cache_write_tokens=cache_write_tokens,
+                    ),
+                    metadata={
+                        "account_id": str(account_id),
+                        "batch_id": str(batch_id),
+                        "custom_id": custom_id,
+                        "endpoint": "llm_gateway.batch",
+                    },
+                )
+    except Exception:
+        # Roll the claim back so a future poll retries the usage
+        # write. Otherwise a transient SDK error during
+        # results-fetch would lose the usage permanently.
+        await pool.execute(
+            "UPDATE llm_gateway_batches SET usage_tracked = FALSE WHERE id = $1",
+            batch_id,
+        )
+        raise
+
+
+def _estimate_cost_usd(
+    *,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cached_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> float:
+    """Compute the synchronous-tier cost for a token mix using
+    atlas's existing pricing config. The caller multiplies by
+    ``_BATCH_DISCOUNT_FACTOR`` to get the actual batch cost.
+    """
+    from ..config import settings
+
+    return float(
+        settings.ftl_tracing.pricing.cost_usd(
+            "anthropic",
+            model,
+            input_tokens,
+            output_tokens,
+            cached_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+            billable_input_tokens=input_tokens,
+        )
+    )

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -509,94 +509,132 @@ async def _persist_batch_usage(
 ) -> None:
     """Write per-item ``llm_usage`` rows for a completed batch.
 
-    Idempotent: runs at most once per batch via the
-    ``usage_tracked=FALSE`` precondition in the UPDATE that flips
-    the flag. A concurrent poller losing the race is a no-op
-    (conditional update returns 0 rows).
+    Two-phase design (Codex P1 + Copilot on PR-D4c):
 
-    Per-item cost calculation applies the 50% Anthropic batch
-    discount. Customers see the discounted figure in their
-    ``/api/v1/llm/usage`` rollup -- which matches what Anthropic
-    actually charges them.
+    1. Pre-fetch all results from Anthropic into memory. No DB
+       writes happen yet -- if the SDK iteration fails mid-stream,
+       the usage_tracked flag stays FALSE and the next poll retries
+       cleanly.
+    2. Atomic claim flips usage_tracked FALSE->TRUE under
+       (id, account_id) so concurrent pollers and cross-account
+       batch_id misrouting both no-op.
+    3. Then persist. Trace_llm_call failures here are logged but
+       NOT rolled back, because the rollback + retry pattern would
+       re-emit the items that already landed and double-count
+       against the customer. Failure to write a single item is
+       recovered by ops (the partial-write is logged loudly).
+
+    Per-item cost applies the 50% Anthropic batch discount.
+    Customers see the discounted figure in
+    ``/api/v1/llm/usage`` -- matches what Anthropic actually
+    charges them.
     """
-    # Atomic claim: only proceed when usage_tracked transitions
-    # FALSE -> TRUE. A concurrent poller wins the race and the
-    # loser exits cleanly.
+    # Phase 1: Pre-fetch results from Anthropic. Materialize the
+    # async iterator into memory BEFORE we touch the DB. The SDK
+    # call is the most likely failure point (network, provider
+    # stall, rate limit), and surfacing the failure here means we
+    # never claim the batch -- next poll retries on a clean slate.
+    from anthropic import AsyncAnthropic
+
+    items_to_persist: list[dict[str, Any]] = []
+    async with AsyncAnthropic(
+        api_key=api_key,
+        timeout=ANTHROPIC_SDK_TIMEOUT_SECONDS,
+    ) as client:
+        results_iter = await client.messages.batches.results(provider_batch_id)
+        async for entry in results_iter:
+            custom_id = getattr(entry, "custom_id", "") or ""
+            result = getattr(entry, "result", None)
+            rtype = getattr(result, "type", None) if result else None
+            if rtype != "succeeded":
+                # Only successful items consumed tokens billed by
+                # Anthropic. Errored / canceled / expired items
+                # show in the failed_items counter but don't add
+                # to llm_usage.
+                continue
+            message = getattr(result, "message", None)
+            usage = getattr(message, "usage", None) if message else None
+            if usage is None:
+                continue
+            items_to_persist.append({
+                "custom_id": custom_id,
+                "input_tokens": int(getattr(usage, "input_tokens", 0) or 0),
+                "output_tokens": int(getattr(usage, "output_tokens", 0) or 0),
+                "cached_tokens": int(getattr(usage, "cache_read_input_tokens", 0) or 0),
+                "cache_write_tokens": int(getattr(usage, "cache_creation_input_tokens", 0) or 0),
+                "provider_request_id": getattr(message, "id", None),
+            })
+
+    # Phase 2: Atomic claim. Only proceed when usage_tracked
+    # transitions FALSE -> TRUE. The ``account_id`` predicate
+    # (Copilot on PR-D4c) defends against batch_id reuse or
+    # misrouting flipping the flag on a row outside the caller's
+    # account.
     claim = await pool.fetchrow(
         """
         UPDATE llm_gateway_batches
         SET usage_tracked = TRUE
-        WHERE id = $1 AND usage_tracked = FALSE
+        WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE
         RETURNING id
         """,
         batch_id,
+        account_id,
     )
     if claim is None:
-        return  # Already tracked by an earlier poll.
+        return  # Already tracked by an earlier poll, or wrong account.
 
-    from anthropic import AsyncAnthropic
-
+    # Phase 3: Persist. Trace_llm_call failures are logged but we
+    # do NOT roll back the claim -- the rollback-and-retry pattern
+    # would re-emit the items already written and double-count
+    # against the customer. The pending-usage index in migration
+    # 318 lets ops scan for any straggler rows that need a
+    # follow-up.
     from ..pipelines.llm import trace_llm_call
 
-    try:
-        async with AsyncAnthropic(
-            api_key=api_key,
-            timeout=ANTHROPIC_SDK_TIMEOUT_SECONDS,
-        ) as client:
-            results_iter = await client.messages.batches.results(provider_batch_id)
-            async for entry in results_iter:
-                custom_id = getattr(entry, "custom_id", "") or ""
-                result = getattr(entry, "result", None)
-                rtype = getattr(result, "type", None) if result else None
-                if rtype != "succeeded":
-                    # Only successful items consumed tokens billed by
-                    # Anthropic. Errored / canceled / expired items
-                    # show in the failed_items counter but don't add
-                    # to llm_usage.
-                    continue
-                message = getattr(result, "message", None)
-                usage = getattr(message, "usage", None) if message else None
-                if usage is None:
-                    continue
-                input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
-                output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
-                cached_tokens = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
-                cache_write_tokens = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
-                provider_request_id = getattr(message, "id", None)
-                trace_llm_call(
-                    span_name="llm_gateway.batch_item",
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    cached_tokens=cached_tokens,
-                    cache_write_tokens=cache_write_tokens,
-                    billable_input_tokens=input_tokens,
+    persisted = 0
+    for item in items_to_persist:
+        try:
+            trace_llm_call(
+                span_name="llm_gateway.batch_item",
+                input_tokens=item["input_tokens"],
+                output_tokens=item["output_tokens"],
+                cached_tokens=item["cached_tokens"],
+                cache_write_tokens=item["cache_write_tokens"],
+                billable_input_tokens=item["input_tokens"],
+                model=model,
+                provider="anthropic",
+                provider_request_id=(
+                    str(item["provider_request_id"])
+                    if item["provider_request_id"]
+                    else None
+                ),
+                cost_usd_override=_BATCH_DISCOUNT_FACTOR
+                * _estimate_cost_usd(
                     model=model,
-                    provider="anthropic",
-                    provider_request_id=str(provider_request_id) if provider_request_id else None,
-                    cost_usd_override=_BATCH_DISCOUNT_FACTOR
-                    * _estimate_cost_usd(
-                        model=model,
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        cached_tokens=cached_tokens,
-                        cache_write_tokens=cache_write_tokens,
-                    ),
-                    metadata={
-                        "account_id": str(account_id),
-                        "batch_id": str(batch_id),
-                        "custom_id": custom_id,
-                        "endpoint": "llm_gateway.batch",
-                    },
-                )
-    except Exception:
-        # Roll the claim back so a future poll retries the usage
-        # write. Otherwise a transient SDK error during
-        # results-fetch would lose the usage permanently.
-        await pool.execute(
-            "UPDATE llm_gateway_batches SET usage_tracked = FALSE WHERE id = $1",
-            batch_id,
-        )
-        raise
+                    input_tokens=item["input_tokens"],
+                    output_tokens=item["output_tokens"],
+                    cached_tokens=item["cached_tokens"],
+                    cache_write_tokens=item["cache_write_tokens"],
+                ),
+                metadata={
+                    "account_id": str(account_id),
+                    "batch_id": str(batch_id),
+                    "custom_id": item["custom_id"],
+                    "endpoint": "llm_gateway.batch",
+                },
+            )
+            persisted += 1
+        except Exception:
+            logger.exception(
+                "llm_gateway_batch.persist_usage: trace_llm_call failed "
+                "account=%s batch=%s custom_id=%s persisted=%d/%d",
+                account_id,
+                batch_id,
+                item["custom_id"],
+                persisted,
+                len(items_to_persist),
+            )
+            # Keep going. Partial loss > double-count.
 
 
 def _estimate_cost_usd(

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -35,6 +35,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional, Sequence
 
+import asyncpg
+
 from .llm.anthropic import convert_messages
 from .protocols import Message
 
@@ -84,6 +86,10 @@ class CustomerBatchRecord:
     updated_at: datetime
     submitted_at: Optional[datetime]
     completed_at: Optional[datetime]
+    # PR-D4c Codex P1: surfaced so the refresh path can detect a
+    # terminal row whose usage write never landed (atomic claim
+    # failed mid-iteration -> rolled back to FALSE) and retry.
+    usage_tracked: bool = False
 
 
 def _row_to_record(row: Any) -> CustomerBatchRecord:
@@ -102,6 +108,11 @@ def _row_to_record(row: Any) -> CustomerBatchRecord:
         updated_at=row["updated_at"],
         submitted_at=row["submitted_at"],
         completed_at=row["completed_at"],
+        # ``usage_tracked`` was added in migration 318. Use ``.get``
+        # via dict-like access so older callers / tests with shorter
+        # row mocks still work (the column defaults FALSE in the
+        # migration, so missing == not-yet-tracked).
+        usage_tracked=bool(row["usage_tracked"]) if "usage_tracked" in row.keys() else False,
     )
 
 
@@ -149,7 +160,7 @@ async def submit_customer_batch(
             SELECT id, account_id, provider, provider_batch_id, model,
                    status, total_items, completed_items, failed_items,
                    error_text, created_at, updated_at, submitted_at,
-                   completed_at
+                   completed_at, usage_tracked
             FROM llm_gateway_batches
             WHERE account_id = $1 AND idempotency_key = $2
             """,
@@ -168,24 +179,62 @@ async def submit_customer_batch(
     # Insert pre-submit so a crash mid-call still leaves a queued row
     # the customer can see. The idempotency_key column is NULL when
     # no header was sent -- the partial UNIQUE index ignores NULL.
-    async with pool.transaction() as conn:
-        row = await conn.fetchrow(
-            """
-            INSERT INTO llm_gateway_batches (
-                account_id, provider, model, status, total_items, idempotency_key
-            ) VALUES (
-                $1, 'anthropic', $2, 'queued', $3, $4
+    #
+    # Codex P1 on PR-D4c: the SELECT above is not atomic with this
+    # INSERT, so two concurrent retries with the same key can both
+    # miss the SELECT and race here. Catch the resulting unique
+    # violation and re-read so the loser of the race still gets the
+    # winner's record back (the contract callers expect from
+    # idempotency).
+    try:
+        async with pool.transaction() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO llm_gateway_batches (
+                    account_id, provider, model, status, total_items, idempotency_key
+                ) VALUES (
+                    $1, 'anthropic', $2, 'queued', $3, $4
+                )
+                RETURNING id, account_id, provider, provider_batch_id, model,
+                          status, total_items, completed_items, failed_items,
+                          error_text, created_at, updated_at, submitted_at,
+                          completed_at, usage_tracked
+                """,
+                account_id,
+                model,
+                len(items),
+                normalized_key,
             )
-            RETURNING id, account_id, provider, provider_batch_id, model,
-                      status, total_items, completed_items, failed_items,
-                      error_text, created_at, updated_at, submitted_at,
-                      completed_at
+    except asyncpg.exceptions.UniqueViolationError:
+        if not normalized_key:
+            # Should not happen -- the only unique constraint is the
+            # idempotency partial index, which excludes NULL keys.
+            raise
+        existing = await pool.fetchrow(
+            """
+            SELECT id, account_id, provider, provider_batch_id, model,
+                   status, total_items, completed_items, failed_items,
+                   error_text, created_at, updated_at, submitted_at,
+                   completed_at, usage_tracked
+            FROM llm_gateway_batches
+            WHERE account_id = $1 AND idempotency_key = $2
             """,
             account_id,
-            model,
-            len(items),
             normalized_key,
         )
+        if existing is None:
+            # Unique-violation but no matching row -- means the
+            # winner committed and rolled back, or some other
+            # column collided. Re-raise so the caller sees the real
+            # 500 instead of a confusing "missing record".
+            raise
+        logger.info(
+            "llm_gateway_batch.submit replay (race) account=%s key=%s id=%s",
+            account_id,
+            normalized_key,
+            existing["id"],
+        )
+        return _row_to_record(existing)
 
     requests = []
     for item in items:
@@ -239,7 +288,7 @@ async def submit_customer_batch(
             RETURNING id, account_id, provider, provider_batch_id, model,
                       status, total_items, completed_items, failed_items,
                       error_text, created_at, updated_at, submitted_at,
-                      completed_at
+                      completed_at, usage_tracked
             """,
             row["id"],
             f"Anthropic batch submit failed: {exc}",
@@ -260,7 +309,7 @@ async def submit_customer_batch(
         RETURNING id, account_id, provider, provider_batch_id, model,
                   status, total_items, completed_items, failed_items,
                   error_text, created_at, updated_at, submitted_at,
-                  completed_at
+                  completed_at, usage_tracked
         """,
         row["id"],
         str(provider_batch_id) if provider_batch_id else None,
@@ -287,7 +336,7 @@ async def get_customer_batch(
         SELECT id, account_id, provider, provider_batch_id, model,
                status, total_items, completed_items, failed_items,
                error_text, created_at, updated_at, submitted_at,
-               completed_at
+               completed_at, usage_tracked
         FROM llm_gateway_batches
         WHERE id = $1 AND account_id = $2
         """,
@@ -315,6 +364,39 @@ async def refresh_customer_batch_status(
     if record is None:
         return None
     if record.status in TERMINAL_STATUSES:
+        # Codex P1 on PR-D4c: a terminal row whose usage write has
+        # not landed yet means the previous attempt failed mid-
+        # iteration and rolled ``usage_tracked`` back to FALSE. We
+        # must retry here -- the only other place that triggers a
+        # write is the non-terminal->terminal transition above, and
+        # that won't fire again. Without this branch, a single
+        # transient SDK error would silently lose the customer's
+        # usage data forever.
+        if (
+            not record.usage_tracked
+            and record.status in ("ended", "canceled", "expired")
+            and record.provider_batch_id
+        ):
+            try:
+                await _persist_batch_usage(
+                    pool,
+                    account_id=account_id,
+                    batch_id=batch_id,
+                    provider_batch_id=record.provider_batch_id,
+                    model=record.model,
+                    api_key=api_key,
+                )
+            except Exception:
+                logger.exception(
+                    "llm_gateway_batch.refresh: usage retry failed "
+                    "account=%s batch=%s",
+                    account_id,
+                    batch_id,
+                )
+            # Re-read so usage_tracked / counts reflect the retry.
+            return await get_customer_batch(
+                pool, account_id=account_id, batch_id=batch_id
+            )
         return record
     if not record.provider_batch_id:
         # Submit failed before persisting provider_batch_id; nothing
@@ -372,7 +454,7 @@ async def refresh_customer_batch_status(
         RETURNING id, account_id, provider, provider_batch_id, model,
                   status, total_items, completed_items, failed_items,
                   error_text, created_at, updated_at, submitted_at,
-                  completed_at
+                  completed_at, usage_tracked
         """,
         batch_id,
         new_status,

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -154,6 +154,7 @@ async def submit_customer_batch(
     normalized_key = idempotency_key.strip() if idempotency_key else None
     if not normalized_key:
         normalized_key = None
+    row: Any = None
     if normalized_key:
         existing = await pool.fetchrow(
             """
@@ -168,13 +169,69 @@ async def submit_customer_batch(
             normalized_key,
         )
         if existing:
+            settled = (
+                existing["provider_batch_id"]
+                or existing["status"] != "queued"
+            )
+            if settled:
+                logger.info(
+                    "llm_gateway_batch.submit replay account=%s key=%s id=%s",
+                    account_id,
+                    normalized_key,
+                    existing["id"],
+                )
+                return _row_to_record(existing)
+
+            # Codex P1 round 3 on PR-D4c: pre-submit row (queued
+            # with no provider_batch_id). Two cases:
+            #   a) An earlier attempt crashed between INSERT and
+            #      the Anthropic call -- naive replay would loop
+            #      forever returning the stale 'queued' row. Need
+            #      to genuinely re-submit.
+            #   b) A concurrent retry is in-flight to Anthropic
+            #      right now. Re-submitting would duplicate-pay.
+            # Distinguish via updated_at age, and do the
+            # decision atomically in SQL so two concurrent
+            # resumes can't both win. Threshold = 2x
+            # ANTHROPIC_SDK_TIMEOUT_SECONDS (30s) so an in-flight
+            # call has had time to either succeed or hit timeout.
+            resumed = await pool.fetchrow(
+                """
+                UPDATE llm_gateway_batches
+                SET updated_at = NOW()
+                WHERE id = $1
+                  AND account_id = $2
+                  AND status = 'queued'
+                  AND provider_batch_id IS NULL
+                  AND updated_at < NOW() - INTERVAL '60 seconds'
+                RETURNING id, account_id, provider, provider_batch_id, model,
+                          status, total_items, completed_items, failed_items,
+                          error_text, created_at, updated_at, submitted_at,
+                          completed_at, usage_tracked
+                """,
+                existing["id"],
+                account_id,
+            )
+            if resumed is None:
+                # Still in-flight (< 60s old) or another retry
+                # already claimed it. Replay -- the customer
+                # polls /batch/{id} either way.
+                logger.info(
+                    "llm_gateway_batch.submit replay (in-flight) "
+                    "account=%s key=%s id=%s",
+                    account_id,
+                    normalized_key,
+                    existing["id"],
+                )
+                return _row_to_record(existing)
             logger.info(
-                "llm_gateway_batch.submit replay account=%s key=%s id=%s",
+                "llm_gateway_batch.submit resume pre-submit "
+                "account=%s key=%s id=%s",
                 account_id,
                 normalized_key,
                 existing["id"],
             )
-            return _row_to_record(existing)
+            row = resumed
 
     # Insert pre-submit so a crash mid-call still leaves a queued row
     # the customer can see. The idempotency_key column is NULL when
@@ -186,55 +243,56 @@ async def submit_customer_batch(
     # violation and re-read so the loser of the race still gets the
     # winner's record back (the contract callers expect from
     # idempotency).
-    try:
-        async with pool.transaction() as conn:
-            row = await conn.fetchrow(
-                """
-                INSERT INTO llm_gateway_batches (
-                    account_id, provider, model, status, total_items, idempotency_key
-                ) VALUES (
-                    $1, 'anthropic', $2, 'queued', $3, $4
+    if row is None:
+        try:
+            async with pool.transaction() as conn:
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO llm_gateway_batches (
+                        account_id, provider, model, status, total_items, idempotency_key
+                    ) VALUES (
+                        $1, 'anthropic', $2, 'queued', $3, $4
+                    )
+                    RETURNING id, account_id, provider, provider_batch_id, model,
+                              status, total_items, completed_items, failed_items,
+                              error_text, created_at, updated_at, submitted_at,
+                              completed_at, usage_tracked
+                    """,
+                    account_id,
+                    model,
+                    len(items),
+                    normalized_key,
                 )
-                RETURNING id, account_id, provider, provider_batch_id, model,
-                          status, total_items, completed_items, failed_items,
-                          error_text, created_at, updated_at, submitted_at,
-                          completed_at, usage_tracked
+        except asyncpg.exceptions.UniqueViolationError:
+            if not normalized_key:
+                # Should not happen -- the only unique constraint is the
+                # idempotency partial index, which excludes NULL keys.
+                raise
+            existing = await pool.fetchrow(
+                """
+                SELECT id, account_id, provider, provider_batch_id, model,
+                       status, total_items, completed_items, failed_items,
+                       error_text, created_at, updated_at, submitted_at,
+                       completed_at, usage_tracked
+                FROM llm_gateway_batches
+                WHERE account_id = $1 AND idempotency_key = $2
                 """,
                 account_id,
-                model,
-                len(items),
                 normalized_key,
             )
-    except asyncpg.exceptions.UniqueViolationError:
-        if not normalized_key:
-            # Should not happen -- the only unique constraint is the
-            # idempotency partial index, which excludes NULL keys.
-            raise
-        existing = await pool.fetchrow(
-            """
-            SELECT id, account_id, provider, provider_batch_id, model,
-                   status, total_items, completed_items, failed_items,
-                   error_text, created_at, updated_at, submitted_at,
-                   completed_at, usage_tracked
-            FROM llm_gateway_batches
-            WHERE account_id = $1 AND idempotency_key = $2
-            """,
-            account_id,
-            normalized_key,
-        )
-        if existing is None:
-            # Unique-violation but no matching row -- means the
-            # winner committed and rolled back, or some other
-            # column collided. Re-raise so the caller sees the real
-            # 500 instead of a confusing "missing record".
-            raise
-        logger.info(
-            "llm_gateway_batch.submit replay (race) account=%s key=%s id=%s",
-            account_id,
-            normalized_key,
-            existing["id"],
-        )
-        return _row_to_record(existing)
+            if existing is None:
+                # Unique-violation but no matching row -- means the
+                # winner committed and rolled back, or some other
+                # column collided. Re-raise so the caller sees the real
+                # 500 instead of a confusing "missing record".
+                raise
+            logger.info(
+                "llm_gateway_batch.submit replay (race) account=%s key=%s id=%s",
+                account_id,
+                normalized_key,
+                existing["id"],
+            )
+            return _row_to_record(existing)
 
     requests = []
     for item in items:

--- a/atlas_brain/storage/migrations/318_llm_gateway_batches_idempotency_and_usage.sql
+++ b/atlas_brain/storage/migrations/318_llm_gateway_batches_idempotency_and_usage.sql
@@ -1,0 +1,39 @@
+-- LLM Gateway batch idempotency + usage tracking (PR-D4c).
+--
+-- Adds two follow-up columns deferred from PR-D4b:
+--
+-- 1. idempotency_key: customer-supplied dedup token. POST /api/v1/llm/batch
+--    accepts an ``Idempotency-Key`` header; we store it on the row and
+--    refuse duplicate submits within the same account. Closes the
+--    accepted-upstream-but-timeout-locally retry case where a customer
+--    would otherwise create duplicate paid batches.
+--
+--    Format note: customers typically send a UUID here, but any 1-128
+--    char string is accepted. The constraint is per-account so two
+--    accounts can independently use the same value.
+--
+-- 2. usage_tracked: marks a batch whose per-item usage has been
+--    written to ``llm_usage`` already. Set true atomically with the
+--    transition to a terminal state (ended/canceled/expired) so
+--    repeat polls don't double-count tokens against the customer's
+--    /api/v1/llm/usage rollup.
+
+ALTER TABLE llm_gateway_batches
+    ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS usage_tracked   BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Per-account idempotency: account A and B can independently use the
+-- same idempotency_key without collision. NULL keys (the optional
+-- "no header sent" case) skip the constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_gateway_batches_idempotency
+    ON llm_gateway_batches (account_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+-- Used by the poll-completion path to find batches that are
+-- terminal but whose usage hasn't been written yet -- rare in
+-- practice (we write inline on the transition) but covers a
+-- case where atlas crashed mid-write.
+CREATE INDEX IF NOT EXISTS idx_llm_gateway_batches_usage_pending
+    ON llm_gateway_batches (status, updated_at DESC)
+    WHERE usage_tracked = FALSE
+      AND status IN ('ended', 'canceled', 'expired');

--- a/atlas_brain/storage/migrations/318_llm_gateway_batches_idempotency_and_usage.sql
+++ b/atlas_brain/storage/migrations/318_llm_gateway_batches_idempotency_and_usage.sql
@@ -29,10 +29,23 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_gateway_batches_idempotency
     ON llm_gateway_batches (account_id, idempotency_key)
     WHERE idempotency_key IS NOT NULL;
 
--- Used by the poll-completion path to find batches that are
--- terminal but whose usage hasn't been written yet -- rare in
--- practice (we write inline on the transition) but covers a
--- case where atlas crashed mid-write.
+-- Surfaces batches that ended/canceled/expired but whose
+-- ``usage_tracked`` flag is still FALSE. This catches the case
+-- where the Anthropic results pre-fetch failed (network /
+-- rate-limit / SDK timeout) so the atomic claim was never made.
+-- The refresh path retries on the next /batch/{id} poll, but a
+-- batch a customer never polls again could otherwise stay
+-- pending forever -- a future cron worker can scan this index
+-- and run _persist_batch_usage on stragglers.
+--
+-- NOTE: this index does NOT catch partial-write loss after the
+-- claim. trace_llm_call exceptions during the persist phase are
+-- logged but do not roll back the flag, because rolling back
+-- would let the next retry double-count the items that already
+-- landed. Per-item idempotency (unique key on llm_usage by
+-- account_id+batch_id+custom_id) is the proper fix and is
+-- planned as a follow-up; until then, partial-loss > double-
+-- count is the deliberate trade-off.
 CREATE INDEX IF NOT EXISTS idx_llm_gateway_batches_usage_pending
     ON llm_gateway_batches (status, updated_at DESC)
     WHERE usage_tracked = FALSE

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -95,6 +95,26 @@ def test_submit_customer_batch_inserts_idempotency_column():
     assert "idempotency_key" in src.split("INSERT INTO llm_gateway_batches")[1].split("RETURNING")[0]
 
 
+def test_submit_customer_batch_handles_unique_violation_race():
+    """Codex P1 fix: SELECT-then-INSERT is not atomic. Two concurrent
+    retries with the same key can both miss the SELECT and race on
+    the partial UNIQUE index. The loser must re-read and return the
+    winner's record -- otherwise the loser gets a 500 and the
+    idempotency contract is broken precisely in the case it exists
+    to handle."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Handler exists.
+    assert "asyncpg.exceptions.UniqueViolationError" in src
+    # Replay path re-reads by (account_id, idempotency_key).
+    assert (
+        "WHERE account_id = $1 AND idempotency_key = $2" in src
+    )
+    # Race-replay log line distinguishes from the normal-replay path.
+    assert 'logger.info(\n            "llm_gateway_batch.submit replay (race)' in src
+
+
 # ---- Router Idempotency-Key header --------------------------------------
 
 
@@ -226,6 +246,34 @@ def test_refresh_does_not_propagate_usage_write_failure():
     # try/except around _persist_batch_usage call.
     assert "try:\n            await _persist_batch_usage(" in src
     assert 'logger.exception(\n                "llm_gateway_batch.refresh: usage write failed' in src
+
+
+def test_refresh_retries_persist_usage_on_terminal_untracked():
+    """Codex P1 fix: a batch can be terminal but still have
+    ``usage_tracked = FALSE`` if a previous _persist_batch_usage
+    rolled back mid-iteration. The early-terminal short-circuit
+    must NOT skip retrying in that case -- otherwise a single
+    transient SDK error permanently loses the customer's usage."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.refresh_customer_batch_status)
+    # Retry condition explicit.
+    assert "not record.usage_tracked" in src
+    assert 'record.status in ("ended", "canceled", "expired")' in src
+    # Re-read after retry so the caller sees usage_tracked = TRUE.
+    assert "return await get_customer_batch(" in src
+
+
+def test_customer_batch_record_exposes_usage_tracked():
+    """The dataclass must surface ``usage_tracked`` so the refresh
+    path can decide whether to retry. Defaults FALSE so test mocks
+    that don't include the column still construct cleanly."""
+    from atlas_brain.services.llm_gateway_batch import CustomerBatchRecord
+
+    fields = {f.name for f in CustomerBatchRecord.__dataclass_fields__.values()}
+    assert "usage_tracked" in fields
+    field = CustomerBatchRecord.__dataclass_fields__["usage_tracked"]
+    assert field.default is False
 
 
 # ---- Cost helper -------------------------------------------------------

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -153,25 +153,56 @@ def test_persist_batch_usage_helper_exists():
 def test_persist_batch_usage_idempotent_via_atomic_claim():
     """The function must atomically transition usage_tracked
     FALSE->TRUE before doing the work. A concurrent poller losing
-    the race is a no-op (claim returns no rows)."""
+    the race is a no-op (claim returns no rows). Codex P1 + Copilot
+    on PR-D4c: claim is also account-scoped so a misrouted batch_id
+    can never flip the flag on a row outside the caller's account."""
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
-    assert "WHERE id = $1 AND usage_tracked = FALSE" in src
+    assert "WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE" in src
     assert "RETURNING id" in src
     # Loser path returns cleanly.
     assert "if claim is None:" in src
 
 
-def test_persist_batch_usage_rolls_back_on_error():
-    """If results-fetch raises (transient SDK error mid-iteration),
-    the usage_tracked flag must roll back so a future poll retries.
-    Otherwise the customer's usage would be lost permanently."""
+def test_persist_batch_usage_pre_fetches_before_claiming():
+    """Codex P1 + Copilot fix on PR-D4c: the SDK results fetch must
+    happen BEFORE the atomic claim, not after. Otherwise a transient
+    SDK error mid-iteration would happen with usage_tracked already
+    flipped to TRUE -- the rollback-then-retry pattern would re-emit
+    the items that already landed and double-count against the
+    customer. Pre-fetching means failures here leave usage_tracked
+    FALSE (no claim was made) so the next poll retries cleanly."""
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
-    # Rollback path on exception.
-    assert "SET usage_tracked = FALSE WHERE id = $1" in src
+    fetch_idx = src.find("client.messages.batches.results")
+    claim_idx = src.find("SET usage_tracked = TRUE")
+    assert fetch_idx > 0 and claim_idx > 0, "Both phases must be present"
+    assert fetch_idx < claim_idx, (
+        "Results fetch must precede the atomic claim so SDK failures "
+        "don't leave the row in an unrecoverable claimed state."
+    )
+
+
+def test_persist_batch_usage_does_not_roll_back_after_claim():
+    """Codex P1 + Copilot on PR-D4c: once the claim flips
+    usage_tracked to TRUE, we must NOT roll it back to FALSE on
+    subsequent failures. trace_llm_call failures during the persist
+    phase are logged loudly but the claim stays TRUE so retries
+    can't double-emit the items that already landed. A pending-
+    usage index in migration 318 lets ops scan for orphaned
+    partial-write batches."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    # No rollback statement.
+    assert "SET usage_tracked = FALSE" not in src
+    # But trace_llm_call failures still log so ops can see them.
+    assert (
+        'logger.exception(\n                '
+        '"llm_gateway_batch.persist_usage: trace_llm_call failed' in src
+    )
 
 
 def test_persist_batch_usage_only_counts_succeeded_items():

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -1,0 +1,241 @@
+"""Tests for batch idempotency + per-item usage tracking (PR-D4c).
+
+Pure structural + source-text tests (no live Anthropic calls).
+DB-bound integration tests live with other auth integration
+fixtures and are gated on a running Postgres.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+_MIG_DIR = Path(__file__).resolve().parent.parent / "atlas_brain" / "storage" / "migrations"
+
+
+def _read_migration(filename: str) -> str:
+    return (_MIG_DIR / filename).read_text(encoding="utf-8")
+
+
+# ---- Migration ----------------------------------------------------------
+
+
+def test_migration_318_adds_idempotency_and_usage_columns():
+    sql = _read_migration("318_llm_gateway_batches_idempotency_and_usage.sql")
+    assert "ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(128)" in sql
+    assert "ADD COLUMN IF NOT EXISTS usage_tracked   BOOLEAN NOT NULL DEFAULT FALSE" in sql
+
+
+def test_migration_318_partial_unique_per_account():
+    """Each account has its own idempotency namespace -- two
+    accounts can independently use the same key without colliding.
+    NULL keys (the optional case) skip the constraint."""
+    sql = _read_migration("318_llm_gateway_batches_idempotency_and_usage.sql")
+    assert "uq_llm_gateway_batches_idempotency" in sql
+    assert "(account_id, idempotency_key)" in sql
+    assert "WHERE idempotency_key IS NOT NULL" in sql
+
+
+def test_migration_318_index_for_pending_usage_writes():
+    """Catches batches that ended but didn't get usage written
+    (atlas crashed mid-write, etc.). A future cron worker can
+    scan this index to retry."""
+    sql = _read_migration("318_llm_gateway_batches_idempotency_and_usage.sql")
+    assert "idx_llm_gateway_batches_usage_pending" in sql
+    assert "WHERE usage_tracked = FALSE" in sql
+    assert "AND status IN ('ended', 'canceled', 'expired')" in sql
+
+
+# ---- submit_customer_batch idempotency ----------------------------------
+
+
+def test_submit_customer_batch_signature_accepts_idempotency_key():
+    from atlas_brain.services.llm_gateway_batch import submit_customer_batch
+
+    sig = inspect.signature(submit_customer_batch)
+    assert "idempotency_key" in sig.parameters
+    assert sig.parameters["idempotency_key"].default is None
+
+
+def test_submit_customer_batch_replay_check_in_source():
+    """Source-text pin: the replay path queries the existing row by
+    (account_id, idempotency_key) BEFORE inserting a new one. Without
+    this, the partial UNIQUE index would 500 on conflict instead of
+    returning the prior record."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    assert "WHERE account_id = $1 AND idempotency_key = $2" in src
+    # Replay is a no-op aside from logging + return.
+    assert 'logger.info(\n                "llm_gateway_batch.submit replay' in src
+
+
+def test_submit_customer_batch_normalizes_empty_idempotency():
+    """Empty-string and whitespace-only idempotency keys are
+    treated as 'not supplied' so customers don't accidentally
+    collide on them."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # The function strips and normalizes empty -> None.
+    assert "normalized_key = idempotency_key.strip() if idempotency_key else None" in src
+    assert "if not normalized_key:" in src
+
+
+def test_submit_customer_batch_inserts_idempotency_column():
+    """The INSERT statement must include the idempotency_key column
+    so the unique-per-account constraint can deduplicate retries."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Column listed explicitly in INSERT.
+    assert "idempotency_key" in src.split("INSERT INTO llm_gateway_batches")[1].split("RETURNING")[0]
+
+
+# ---- Router Idempotency-Key header --------------------------------------
+
+
+def test_submit_batch_route_accepts_idempotency_header():
+    """The router must declare ``Idempotency-Key`` as a Header
+    parameter so FastAPI parses it (otherwise the value never
+    reaches the service-level dedup logic)."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.submit_batch)
+    assert 'alias="Idempotency-Key"' in src
+    assert "Header(" in src
+    # And the value is threaded into the service call.
+    assert "idempotency_key=idempotency_key" in src
+
+
+def test_submit_batch_idempotency_key_caps_at_128():
+    """Bound the header length so a malicious caller can't ship
+    arbitrarily large headers."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.submit_batch)
+    assert "max_length=128" in src
+
+
+# ---- Batch usage persistence -------------------------------------------
+
+
+def test_persist_batch_usage_helper_exists():
+    from atlas_brain.services import llm_gateway_batch
+
+    assert hasattr(llm_gateway_batch, "_persist_batch_usage")
+    assert inspect.iscoroutinefunction(llm_gateway_batch._persist_batch_usage)
+
+
+def test_persist_batch_usage_idempotent_via_atomic_claim():
+    """The function must atomically transition usage_tracked
+    FALSE->TRUE before doing the work. A concurrent poller losing
+    the race is a no-op (claim returns no rows)."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    assert "WHERE id = $1 AND usage_tracked = FALSE" in src
+    assert "RETURNING id" in src
+    # Loser path returns cleanly.
+    assert "if claim is None:" in src
+
+
+def test_persist_batch_usage_rolls_back_on_error():
+    """If results-fetch raises (transient SDK error mid-iteration),
+    the usage_tracked flag must roll back so a future poll retries.
+    Otherwise the customer's usage would be lost permanently."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    # Rollback path on exception.
+    assert "SET usage_tracked = FALSE WHERE id = $1" in src
+
+
+def test_persist_batch_usage_only_counts_succeeded_items():
+    """Errored / canceled / expired items don't consume billable
+    tokens at Anthropic, so they shouldn't generate llm_usage rows.
+    Only succeeded items get tracked."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    assert 'rtype != "succeeded"' in src
+    assert "continue" in src
+
+
+def test_persist_batch_usage_applies_50_percent_discount():
+    """Anthropic charges 50% of synchronous rate for batch.
+    /api/v1/llm/usage must show the discounted figure -- matches
+    what the customer pays."""
+    from atlas_brain.services import llm_gateway_batch
+
+    assert llm_gateway_batch._BATCH_DISCOUNT_FACTOR == 0.5
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    assert "_BATCH_DISCOUNT_FACTOR" in src
+
+
+def test_persist_batch_usage_threads_account_id_into_metadata():
+    """Same metadata pattern as /chat -- per-account scoping in
+    llm_usage requires account_id in the trace metadata so PR-D3's
+    INSERT picks it up."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    assert '"account_id": str(account_id)' in src
+    assert '"batch_id": str(batch_id)' in src
+    assert '"custom_id": custom_id' in src
+
+
+def test_persist_batch_usage_uses_async_with():
+    """Same async-with posture as the rest of the module -- close
+    the httpx connection pool after the results-fetch."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    assert "async with AsyncAnthropic(" in src
+    assert "timeout=ANTHROPIC_SDK_TIMEOUT_SECONDS" in src
+
+
+# ---- Refresh -> usage persistence wiring -------------------------------
+
+
+def test_refresh_calls_persist_usage_on_terminal_transition():
+    """Polling /batch/{id} must trigger the usage write when the
+    batch transitions to a real Anthropic terminal state. Excludes
+    submit_failed which is an atlas-internal terminal state with
+    no Anthropic-side results to fetch."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.refresh_customer_batch_status)
+    assert "_persist_batch_usage" in src
+    # submit_failed must NOT trigger the results-fetch (no batch on
+    # Anthropic's side).
+    assert 'new_status in ("ended", "canceled", "expired")' in src
+
+
+def test_refresh_does_not_propagate_usage_write_failure():
+    """A usage-write failure (transient SDK error fetching results)
+    must NOT block /batch/{id} from returning the new status.
+    Customer keeps polling; the usage_tracked rollback ensures the
+    next poll retries."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.refresh_customer_batch_status)
+    # try/except around _persist_batch_usage call.
+    assert "try:\n            await _persist_batch_usage(" in src
+    assert 'logger.exception(\n                "llm_gateway_batch.refresh: usage write failed' in src
+
+
+# ---- Cost helper -------------------------------------------------------
+
+
+def test_estimate_cost_uses_atlas_pricing_config():
+    """The cost helper reuses ``settings.ftl_tracing.pricing`` so
+    pricing changes update one place (not duplicated here)."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._estimate_cost_usd)
+    assert "settings.ftl_tracing.pricing.cost_usd" in src
+    assert '"anthropic"' in src

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import inspect
 from pathlib import Path
 
-import pytest
-
 
 _MIG_DIR = Path(__file__).resolve().parent.parent / "atlas_brain" / "storage" / "migrations"
 
@@ -116,28 +114,49 @@ def test_submit_customer_batch_handles_unique_violation_race():
 
 
 def test_submit_customer_batch_resumes_stale_pre_submit_atomically():
-    """Codex P1 round 3 on PR-D4c: a row stuck in pre-submit state
-    ('queued', no provider_batch_id) means a previous attempt
-    crashed between INSERT and the Anthropic call. Naive replay
-    would loop forever returning the stale row -- the customer's
-    batch never actually submits. Resume via an atomic SQL claim
-    that flips updated_at; concurrent in-flight calls are
-    distinguished from stuck rows via updated_at age (60s = 2x
-    SDK timeout). Two concurrent resumes can't both win because
+    """Codex P1 rounds 3+4 on PR-D4c: a row without provider_batch_id
+    means the prior attempt never landed on Anthropic. Either it
+    crashed pre-submit (status='queued', stale) or Anthropic
+    rejected/timed out (status='submit_failed'). Both are resumable
+    -- naive replay would loop forever returning the dead row, so
+    the customer's batch never actually submits. Resume via an
+    atomic SQL claim; concurrent in-flight queued calls are
+    distinguished from stuck queued rows via updated_at age (60s =
+    2x SDK timeout). Two concurrent resumes can't both win because
     the UPDATE is atomic."""
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
-    # Atomic SQL claim with the staleness predicate.
-    assert "AND status = 'queued'" in src
+    # Atomic SQL claim covers BOTH submit_failed and stale-queued.
     assert "AND provider_batch_id IS NULL" in src
+    assert "status = 'submit_failed'" in src
+    assert "OR (status = 'queued'" in src
     assert "AND updated_at < NOW() - INTERVAL '60 seconds'" in src
     # account_id is in the WHERE (defense-in-depth, same pattern
     # as _persist_batch_usage's atomic claim).
     assert "WHERE id = $1\n                  AND account_id = $2" in src
+    # Resume clears stale error_text (submit_failed sets it) and
+    # bumps status back to queued so the row looks freshly-INSERTed.
+    assert "SET updated_at = NOW(),\n                    status = 'queued',\n                    error_text = NULL" in src
     # Distinct log lines for each branch so ops can spot leaks.
     assert "submit replay (in-flight)" in src
     assert "submit resume pre-submit" in src
+
+
+def test_submit_customer_batch_replay_only_when_provider_batch_id_set():
+    """The fast-path replay must check provider_batch_id, not just
+    status. A retry with the same key against a settled row
+    (Anthropic accepted the submission) returns immediately;
+    everything else falls through to the resume claim. Codex P1
+    round 4 on PR-D4c -- the prior `status != 'queued'` check
+    incorrectly treated submit_failed as settled."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Replay guard keys on provider_batch_id only.
+    assert 'if existing["provider_batch_id"]:' in src
+    # No spurious status check before the replay return.
+    assert 'or existing["status"] != "queued"' not in src
 
 
 # ---- Router Idempotency-Key header --------------------------------------

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -112,7 +112,32 @@ def test_submit_customer_batch_handles_unique_violation_race():
         "WHERE account_id = $1 AND idempotency_key = $2" in src
     )
     # Race-replay log line distinguishes from the normal-replay path.
-    assert 'logger.info(\n            "llm_gateway_batch.submit replay (race)' in src
+    assert 'logger.info(\n                "llm_gateway_batch.submit replay (race)' in src
+
+
+def test_submit_customer_batch_resumes_stale_pre_submit_atomically():
+    """Codex P1 round 3 on PR-D4c: a row stuck in pre-submit state
+    ('queued', no provider_batch_id) means a previous attempt
+    crashed between INSERT and the Anthropic call. Naive replay
+    would loop forever returning the stale row -- the customer's
+    batch never actually submits. Resume via an atomic SQL claim
+    that flips updated_at; concurrent in-flight calls are
+    distinguished from stuck rows via updated_at age (60s = 2x
+    SDK timeout). Two concurrent resumes can't both win because
+    the UPDATE is atomic."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Atomic SQL claim with the staleness predicate.
+    assert "AND status = 'queued'" in src
+    assert "AND provider_batch_id IS NULL" in src
+    assert "AND updated_at < NOW() - INTERVAL '60 seconds'" in src
+    # account_id is in the WHERE (defense-in-depth, same pattern
+    # as _persist_batch_usage's atomic claim).
+    assert "WHERE id = $1\n                  AND account_id = $2" in src
+    # Distinct log lines for each branch so ops can spot leaks.
+    assert "submit replay (in-flight)" in src
+    assert "submit resume pre-submit" in src
 
 
 # ---- Router Idempotency-Key header --------------------------------------


### PR DESCRIPTION
## Summary

Closes the two items deferred from PR-D4b (#239):

- **Idempotency-Key header** on `POST /api/v1/llm/batch` — customer-supplied dedup token (<=128 chars). Duplicate submits within the same account return the prior batch record without a second Anthropic call. Per-account namespace via partial UNIQUE index — two accounts can use the same key independently; NULL opts out.
- **Per-batch `llm_usage` rows** — new `_persist_batch_usage` helper walks the Anthropic results stream and writes one `trace_llm_call` per `succeeded` item with the 50% batch discount applied (`_BATCH_DISCOUNT_FACTOR = 0.5`). Atomic FALSE->TRUE claim on `usage_tracked` prevents double-counting under concurrent polls; rolls back on mid-iteration failure so the next poll retries.

## Wedge feature: customer-visible cost discount

The 50% Anthropic batch discount is the marketing wedge — `/api/v1/llm/usage` now reflects what the customer actually pays for batch traffic instead of synchronous-rate dollars (which would overstate the bill).

## Design notes

- **Empty / whitespace keys** normalize to `None` so customers don't collide accidentally on falsy values.
- **`refresh_customer_batch_status`** triggers usage write only on real Anthropic terminal states (`ended`/`canceled`/`expired`) — `submit_failed` is excluded since there's no batch on Anthropic's side to fetch results for.
- **Usage-write failures don't block status** — `/batch/{id}` still returns the new status if the results-fetch transient-fails; rollback to `usage_tracked = FALSE` lets the next terminal poll retry.
- **Migration 318** adds `idx_llm_gateway_batches_usage_pending` covering the case where atlas crashed mid-write — a future cron worker can sweep stragglers.
- **Cost helper reuses `settings.ftl_tracing.pricing.cost_usd`** — pricing changes in one place.

## Test plan

- [x] 19 new tests (`tests/test_llm_gateway_idempotency_usage.py`) — migration content, idempotency replay, header parsing, atomic claim, rollback on error, succeeded-only filter, 50% discount, account_id metadata threading, async-with posture, refresh wiring, refresh failure isolation, cost helper config reuse
- [x] Full LLM-gateway suite passes: 184 passed (no regressions)
- [ ] Codex/Copilot review
- [ ] Migration applied in staging before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
