### PR TITLE
PR-D7b1: tiers.py atlas wrapper

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -11,6 +11,7 @@ on:
       - "atlas_brain/reasoning/call_transcript.py"
       - "atlas_brain/reasoning/agent.py"
       - "atlas_brain/reasoning/reflection.py"
+      - "atlas_brain/reasoning/tiers.py"
       - "atlas_brain/reasoning/graph.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
       - "atlas_brain/mcp/b2b/signals.py"
@@ -33,6 +34,7 @@ on:
       - "tests/test_atlas_reasoning_reflection_tracing.py"
       - "tests/test_atlas_reasoning_graph_aliases.py"
       - "tests/test_atlas_reasoning_run_reasoning_graph_wiring.py"
+      - "tests/test_atlas_reasoning_tiers_aliases.py"
       - "tests/test_forbid_atlas_reasoning_imports.py"
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
   push:
@@ -45,6 +47,7 @@ on:
       - "atlas_brain/reasoning/call_transcript.py"
       - "atlas_brain/reasoning/agent.py"
       - "atlas_brain/reasoning/reflection.py"
+      - "atlas_brain/reasoning/tiers.py"
       - "atlas_brain/reasoning/graph.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
       - "atlas_brain/mcp/b2b/signals.py"
@@ -67,6 +70,7 @@ on:
       - "tests/test_atlas_reasoning_reflection_tracing.py"
       - "tests/test_atlas_reasoning_graph_aliases.py"
       - "tests/test_atlas_reasoning_run_reasoning_graph_wiring.py"
+      - "tests/test_atlas_reasoning_tiers_aliases.py"
       - "tests/test_forbid_atlas_reasoning_imports.py"
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
 

--- a/atlas_brain/reasoning/tiers.py
+++ b/atlas_brain/reasoning/tiers.py
@@ -10,181 +10,38 @@ Defines the 4-tier reasoning hierarchy and inheritance rules:
 Lower tiers inherit higher-tier conclusions as priors (context tags) and
 never re-derive them. When T2 analyzes "Vendor X (CRM)", it receives T4's
 "ai_disruption_pressure: high" tag as input context.
+
+PR-D7b1 promoted this module's body into
+:mod:`extracted_reasoning_core.tiers`. Atlas keeps the import surface
+``atlas_brain.reasoning.tiers`` as a thin re-export so internal
+callers (tests, autonomous tasks) don't need to change import sites --
+the audit's "atlas adapts to shared core without behavior drift"
+criterion is satisfied. Two minor namespace changes flow from the
+move: the debug logger name migrates from ``atlas.reasoning.tiers``
+to ``extracted_reasoning_core.tiers`` (correct -- the code is core's),
+and ``TierConfig`` is now ``frozen=True`` with ``inherits_from`` as
+a ``tuple`` instead of a ``list`` (stricter; no atlas caller mutated
+either, verified pre-conversion).
 """
 
 from __future__ import annotations
 
-import logging
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
-from enum import IntEnum
-from typing import Any
+from extracted_reasoning_core.tiers import (
+    TIER_CONFIGS,
+    Tier,
+    TierConfig,
+    build_tiered_pattern_sig,
+    gather_tier_context,
+    get_tier_config,
+    needs_refresh,
+)
 
-logger = logging.getLogger("atlas.reasoning.tiers")
-
-
-class Tier(IntEnum):
-    """Reasoning abstraction tiers (higher = broader scope)."""
-    VENDOR_STATE = 1        # daily, no LLM
-    VENDOR_ARCHETYPE = 2    # weekly
-    CATEGORY_PATTERN = 3    # monthly
-    MARKET_DYNAMICS = 4     # quarterly
-
-
-@dataclass
-class TierConfig:
-    """Configuration for a single tier."""
-    tier: Tier
-    name: str
-    refresh_interval: timedelta
-    pattern_sig_prefix: str
-    description: str
-    inherits_from: list[Tier] = field(default_factory=list)
-
-
-# Default tier configurations
-TIER_CONFIGS: dict[Tier, TierConfig] = {
-    Tier.VENDOR_STATE: TierConfig(
-        tier=Tier.VENDOR_STATE,
-        name="Vendor State",
-        refresh_interval=timedelta(days=1),
-        pattern_sig_prefix="t1",
-        description="Deterministic metrics: churn density, urgency, review counts. No LLM.",
-        inherits_from=[Tier.VENDOR_ARCHETYPE, Tier.CATEGORY_PATTERN, Tier.MARKET_DYNAMICS],
-    ),
-    Tier.VENDOR_ARCHETYPE: TierConfig(
-        tier=Tier.VENDOR_ARCHETYPE,
-        name="Vendor Archetype",
-        refresh_interval=timedelta(weeks=1),
-        pattern_sig_prefix="t2",
-        description="Vendor-level archetype classification with evidence graph.",
-        inherits_from=[Tier.CATEGORY_PATTERN, Tier.MARKET_DYNAMICS],
-    ),
-    Tier.CATEGORY_PATTERN: TierConfig(
-        tier=Tier.CATEGORY_PATTERN,
-        name="Category Pattern",
-        refresh_interval=timedelta(days=30),
-        pattern_sig_prefix="t3",
-        description="Category-level baselines and archetype distributions.",
-        inherits_from=[Tier.MARKET_DYNAMICS],
-    ),
-    Tier.MARKET_DYNAMICS: TierConfig(
-        tier=Tier.MARKET_DYNAMICS,
-        name="Market Dynamics",
-        refresh_interval=timedelta(days=90),
-        pattern_sig_prefix="t4",
-        description="Market-level displacement patterns and structural shifts.",
-        inherits_from=[],
-    ),
-}
-
-
-def get_tier_config(tier: Tier) -> TierConfig:
-    """Get configuration for a tier."""
-    return TIER_CONFIGS[tier]
-
-
-def build_tiered_pattern_sig(tier: Tier, entity_name: str, evidence_hash: str) -> str:
-    """Build a pattern_sig scoped to a tier.
-
-    Examples:
-        t1:vendor:slack:abc123
-        t2:vendor:slack:def456
-        t3:category:crm:ghi789
-        t4:market:saas:jkl012
-    """
-    config = TIER_CONFIGS[tier]
-    safe = entity_name.lower().replace(" ", "_").replace(".", "")
-    if tier == Tier.MARKET_DYNAMICS:
-        return f"{config.pattern_sig_prefix}:market:{safe}:{evidence_hash}"
-    elif tier == Tier.CATEGORY_PATTERN:
-        return f"{config.pattern_sig_prefix}:category:{safe}:{evidence_hash}"
-    else:
-        return f"{config.pattern_sig_prefix}:vendor:{safe}:{evidence_hash}"
-
-
-def needs_refresh(tier: Tier, last_validated_at: datetime | None) -> bool:
-    """Check if a cached entry for this tier needs re-reasoning based on age."""
-    if last_validated_at is None:
-        return True
-    config = TIER_CONFIGS[tier]
-    now = datetime.now(timezone.utc)
-    if last_validated_at.tzinfo is None:
-        last_validated_at = last_validated_at.replace(tzinfo=timezone.utc)
-    age = now - last_validated_at
-    return age > config.refresh_interval
-
-
-async def gather_tier_context(
-    cache: Any,
-    tier: Tier,
-    vendor_name: str = "",
-    product_category: str = "",
-) -> dict[str, Any]:
-    """Gather inherited context from higher tiers.
-
-    For T2 (Vendor Archetype), this loads T3 category patterns and T4 market
-    dynamics as prior context tags. The caller passes these as additional
-    context to the LLM, so it doesn't re-derive broad conclusions.
-    """
-    config = TIER_CONFIGS[tier]
-    context: dict[str, Any] = {
-        "tier": tier.value,
-        "tier_name": config.name,
-    }
-
-    if not config.inherits_from:
-        return context
-
-    inherited_priors: list[dict[str, Any]] = []
-
-    for parent_tier in config.inherits_from:
-        parent_config = TIER_CONFIGS[parent_tier]
-
-        # Look up cached conclusions from the parent tier.
-        # T4: conclusion_type='market_dynamics' (market structure, HHI)
-        # T3: conclusion_type='category_pattern' (archetype dist, pains)
-        # T2: vendor archetype entries (conclusion_type = archetype name)
-        entries = []
-        if parent_tier == Tier.MARKET_DYNAMICS and product_category:
-            entries = await cache.lookup_for_tier(
-                "market_dynamics", product_category=product_category, limit=3,
-            )
-        elif parent_tier == Tier.CATEGORY_PATTERN and product_category:
-            entries = await cache.lookup_for_tier(
-                "category_pattern", product_category=product_category, limit=3,
-            )
-        elif parent_tier == Tier.VENDOR_ARCHETYPE and vendor_name:
-            # T2: find prior archetype conclusions for this vendor
-            # (exclude ecosystem entries which have vendor_name='__ecosystem__')
-            entries = await cache.lookup_for_tier(
-                "", vendor_name=vendor_name, limit=1,
-            )
-            entries = [e for e in entries if e.vendor_name != "__ecosystem__"]
-
-        for entry in entries:
-            prior = {
-                "tier": parent_tier.value,
-                "tier_name": parent_config.name,
-                "pattern": entry.pattern_sig,
-                "conclusion_type": entry.conclusion_type,
-                "confidence": entry.effective_confidence or entry.confidence,
-            }
-            # Extract key tags from the conclusion
-            conclusion = entry.conclusion
-            if isinstance(conclusion, dict):
-                for tag_key in ("market_pressure", "category_trend", "archetype",
-                                "risk_level", "displacement_direction"):
-                    if tag_key in conclusion:
-                        prior[tag_key] = conclusion[tag_key]
-            inherited_priors.append(prior)
-
-    if inherited_priors:
-        context["inherited_priors"] = inherited_priors
-        logger.debug(
-            "Tier %s gathered %d priors from %s",
-            config.name, len(inherited_priors),
-            [TIER_CONFIGS[t].name for t in config.inherits_from],
-        )
-
-    return context
+__all__ = [
+    "TIER_CONFIGS",
+    "Tier",
+    "TierConfig",
+    "build_tiered_pattern_sig",
+    "gather_tier_context",
+    "get_tier_config",
+    "needs_refresh",
+]

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T05:45Z by claude-2026-05-03
+Last updated: 2026-05-05T05:56Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-D7b1, in flight) | PR-D7b1: tiers.py atlas wrapper (PR 7 second slice, 1/5 of fork migration) | EDIT: `atlas_brain/reasoning/tiers.py` (190-LOC fork becomes a ~25-LOC re-export from `extracted_reasoning_core.tiers`; preserves the six public symbols Tier / TierConfig / TIER_CONFIGS / get_tier_config / build_tiered_pattern_sig / needs_refresh / gather_tier_context). NEW: `tests/test_atlas_reasoning_tiers_aliases.py` (alias-identity pin similar to test_atlas_reasoning_graph_aliases.py). EDIT: `scripts/run_extracted_pipeline_checks.sh` + `.github/workflows/extracted_pipeline_checks.yml` (wire new test + atlas tiers.py path). Behavior preserved per drift analysis: core's TierConfig(frozen=True) and inherits_from=tuple are stricter than atlas's; no atlas caller mutates either; debug-log loses one detail string acceptable; logger namespace migrates to extracted_reasoning_core.tiers (correct — code is core's). PR-D7b2-b5 follow with wedge_registry / evidence_engine / temporal / archetypes wrappers. | claude-2026-05-03 | `atlas_brain/reasoning/tiers.py`; `tests/test_atlas_reasoning_tiers_aliases.py`; `scripts/run_extracted_pipeline_checks.sh`; `.github/workflows/extracted_pipeline_checks.yml` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -59,6 +59,7 @@ pytest \
   tests/test_atlas_reasoning_reflection_tracing.py \
   tests/test_atlas_reasoning_graph_aliases.py \
   tests/test_atlas_reasoning_run_reasoning_graph_wiring.py \
+  tests/test_atlas_reasoning_tiers_aliases.py \
   tests/test_forbid_atlas_reasoning_imports.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \

--- a/tests/test_atlas_reasoning_tiers_aliases.py
+++ b/tests/test_atlas_reasoning_tiers_aliases.py
@@ -1,0 +1,88 @@
+"""Pin atlas's re-exports from ``atlas_brain.reasoning.tiers``.
+
+PR-D7b1 promoted the tiers module into
+``extracted_reasoning_core.tiers`` and replaced atlas's 190-line fork
+with a thin re-export wrapper. Internal callers (autonomous tasks +
+tests/test_reasoning_live.py) keep their existing import sites
+``from atlas_brain.reasoning.tiers import Tier, gather_tier_context``
+working through the wrapper.
+
+These tests use ``is`` identity checks rather than just ``hasattr``:
+each alias must point to the exact same object as the core export, so
+a future refactor that accidentally redefines a symbol inside
+``atlas_brain.reasoning.tiers`` (instead of importing) would surface
+here. Mirrors the alias-identity pattern PR-C4e1 established for
+``atlas_brain.reasoning.graph``.
+"""
+
+from __future__ import annotations
+
+from atlas_brain.reasoning import tiers as atlas_tiers
+from extracted_reasoning_core import tiers as core_tiers
+
+
+def test_tier_alias_identity() -> None:
+    assert atlas_tiers.Tier is core_tiers.Tier
+
+
+def test_tier_config_alias_identity() -> None:
+    assert atlas_tiers.TierConfig is core_tiers.TierConfig
+
+
+def test_tier_configs_alias_identity() -> None:
+    # The TIER_CONFIGS dict itself must be the same object so a caller
+    # that holds a reference doesn't end up reading from a stale copy.
+    assert atlas_tiers.TIER_CONFIGS is core_tiers.TIER_CONFIGS
+
+
+def test_get_tier_config_alias_identity() -> None:
+    assert atlas_tiers.get_tier_config is core_tiers.get_tier_config
+
+
+def test_build_tiered_pattern_sig_alias_identity() -> None:
+    assert atlas_tiers.build_tiered_pattern_sig is core_tiers.build_tiered_pattern_sig
+
+
+def test_needs_refresh_alias_identity() -> None:
+    assert atlas_tiers.needs_refresh is core_tiers.needs_refresh
+
+
+def test_gather_tier_context_alias_identity() -> None:
+    assert atlas_tiers.gather_tier_context is core_tiers.gather_tier_context
+
+
+def test_atlas_tiers_all_matches_re_export_set() -> None:
+    # __all__ is the public-surface contract; pin it so a regression
+    # that drops a symbol from the wrapper surfaces a test failure
+    # rather than a silent ImportError on an existing caller.
+    assert set(atlas_tiers.__all__) == {
+        "TIER_CONFIGS",
+        "Tier",
+        "TierConfig",
+        "build_tiered_pattern_sig",
+        "gather_tier_context",
+        "get_tier_config",
+        "needs_refresh",
+    }
+
+
+def test_atlas_tiers_does_not_redefine_symbols() -> None:
+    # Defensive: the wrapper module body should not contain any
+    # ``def`` / ``class`` re-implementations -- only the re-export
+    # imports + __all__ literal. Catches a refactor that accidentally
+    # forks the implementation back into atlas-side.
+    import ast
+    import inspect
+
+    source = inspect.getsource(atlas_tiers)
+    tree = ast.parse(source)
+
+    redefinitions: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            redefinitions.append(node.name)
+
+    assert redefinitions == [], (
+        f"atlas_brain.reasoning.tiers should be a pure re-export wrapper, "
+        f"but it defines: {redefinitions}"
+    )


### PR DESCRIPTION
## Summary

First sub-slice of the audit's PR 7 atlas-side fork migration. Atlas's 190-line `tiers.py` becomes a thin re-export from `extracted_reasoning_core.tiers`, mirroring the wrapper pattern PR-C4e1 established for `graph.py`.

## Drift analysis (verified pre-conversion)

Six public symbols match between atlas and core. Three minor differences — all in core's favor — are absorbed by the wrapper:

| change | direction | impact |
|---|---|---|
| `TierConfig` is `frozen=True` | core stricter | safe — no atlas caller mutates `TierConfig` instances |
| `inherits_from` is `tuple[Tier, ...]` | core stricter | safe — no caller calls `.append`; iteration identical |
| debug log line drops one detail string | minor obs loss | debug-level only; production runs at INFO+ |

Logger namespace migrates `atlas.reasoning.tiers` → `extracted_reasoning_core.tiers` (correct — the code is core's). No callers configure handlers on the old name.

## Files

- **`atlas_brain/reasoning/tiers.py`**: 190-line fork → ~25-line re-export. Module docstring preserved + extended with the conversion rationale.
- **`tests/test_atlas_reasoning_tiers_aliases.py`** (NEW, 9 tests): `is` identity check per public symbol + `__all__` contract pin + AST-level "no redefinition" guard ensuring the wrapper body contains only re-export imports.
- `scripts/run_extracted_pipeline_checks.sh` + workflow `paths:` filter: wire new test + atlas tiers.py path.

## Production caller verified

`tests/test_reasoning_live.py` (the only atlas-side importer) does `from atlas_brain.reasoning.tiers import Tier, gather_tier_context` — both still resolve through the wrapper.

## Test plan

- [x] `pytest tests/test_atlas_reasoning_tiers_aliases.py` → 9/9
- [x] `bash scripts/run_extracted_pipeline_checks.sh` → 778 passed (was 769 before)
- [x] `from atlas_brain.reasoning.tiers import Tier, gather_tier_context` resolves end-to-end
- [ ] CI green on the 3.10 runner

## Forward look (out of scope)

- **PR-D7b2** — `wedge_registry.py` wrapper (159 LOC, 3 atlas callers + 1 test).
- **PR-D7b3** — `evidence_engine.py` wrapper (548 LOC, 3 atlas callers + 3 tests; possible drift-forward into core).
- **PR-D7b4** — `temporal.py` wrapper (490 LOC, 2 atlas callers; core is bigger from PR-C1b consolidation).
- **PR-D7b5** — `archetypes.py` wrapper (592 LOC, 1 atlas caller; core is bigger from PR-C1a consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)