### PR TITLE
PR-D7b2: wedge_registry.py atlas wrapper

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -12,6 +12,7 @@ on:
       - "atlas_brain/reasoning/agent.py"
       - "atlas_brain/reasoning/reflection.py"
       - "atlas_brain/reasoning/tiers.py"
+      - "atlas_brain/reasoning/wedge_registry.py"
       - "atlas_brain/reasoning/graph.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
       - "atlas_brain/mcp/b2b/signals.py"
@@ -35,6 +36,7 @@ on:
       - "tests/test_atlas_reasoning_graph_aliases.py"
       - "tests/test_atlas_reasoning_run_reasoning_graph_wiring.py"
       - "tests/test_atlas_reasoning_tiers_aliases.py"
+      - "tests/test_atlas_reasoning_wedge_registry_aliases.py"
       - "tests/test_forbid_atlas_reasoning_imports.py"
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
   push:
@@ -48,6 +50,7 @@ on:
       - "atlas_brain/reasoning/agent.py"
       - "atlas_brain/reasoning/reflection.py"
       - "atlas_brain/reasoning/tiers.py"
+      - "atlas_brain/reasoning/wedge_registry.py"
       - "atlas_brain/reasoning/graph.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
       - "atlas_brain/mcp/b2b/signals.py"
@@ -71,6 +74,7 @@ on:
       - "tests/test_atlas_reasoning_graph_aliases.py"
       - "tests/test_atlas_reasoning_run_reasoning_graph_wiring.py"
       - "tests/test_atlas_reasoning_tiers_aliases.py"
+      - "tests/test_atlas_reasoning_wedge_registry_aliases.py"
       - "tests/test_forbid_atlas_reasoning_imports.py"
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
 

--- a/atlas_brain/reasoning/wedge_registry.py
+++ b/atlas_brain/reasoning/wedge_registry.py
@@ -10,150 +10,41 @@ The wedge registry is the single source of truth for:
 - Archetype-to-wedge mapping
 - Sales motion guidance per wedge
 - Required pool layers per wedge
+
+PR-D7b2 promoted this module's body into
+:mod:`extracted_reasoning_core.wedge_registry`. Atlas keeps the import
+surface ``atlas_brain.reasoning.wedge_registry`` as a thin re-export
+so internal callers (B2B synthesis tasks, blog post generation, the
+synthesis_v2 test suite) don't need to change import sites -- the
+audit's "atlas adapts to shared core without behavior drift"
+criterion is satisfied. Drift was cosmetic only: core gained an
+``__all__`` declaration and trimmed two inline comments + one
+docstring sentence; the eight public symbols (Wedge, WedgeMeta,
+WEDGE_ENUM_VALUES, wedge_from_archetype, validate_wedge,
+get_wedge_meta, get_sales_motion, get_required_pools) are
+implementation-identical.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Sequence
-
-
-class Wedge(str, Enum):
-    """Sales-oriented wedge types."""
-
-    PRICE_SQUEEZE = "price_squeeze"
-    FEATURE_PARITY = "feature_parity"
-    SUPPORT_EROSION = "support_erosion"
-    INTEGRATION_LOCK = "integration_lock"
-    CATEGORY_SHIFT = "category_shift"
-    ACQUISITION_HANGOVER = "acquisition_hangover"
-    COMPLIANCE_EXPOSURE = "compliance_exposure"
-    UX_REGRESSION = "ux_regression"
-    SEGMENT_MISMATCH = "segment_mismatch"
-    STABLE = "stable"
-
-
-WEDGE_ENUM_VALUES: frozenset[str] = frozenset(w.value for w in Wedge)
-
-
-@dataclass(frozen=True, slots=True)
-class WedgeMeta:
-    """Metadata for a wedge type."""
-
-    wedge: Wedge
-    label: str
-    archetype_map: tuple[str, ...]
-    sales_motion: str
-    required_pools: tuple[str, ...] = field(default=("evidence_vault",))
-
-
-_WEDGE_CATALOG: tuple[WedgeMeta, ...] = (
-    WedgeMeta(
-        wedge=Wedge.PRICE_SQUEEZE,
-        label="Price Squeeze",
-        archetype_map=("pricing_shock",),
-        sales_motion="Lead with TCO comparison and hidden-cost analysis",
-        required_pools=("evidence_vault", "segment", "accounts"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.FEATURE_PARITY,
-        label="Feature Parity",
-        archetype_map=("feature_gap",),
-        sales_motion="Demo the missing capability live; anchor on workflow impact",
-        required_pools=("evidence_vault", "displacement", "segment"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.SUPPORT_EROSION,
-        label="Support Erosion",
-        archetype_map=("support_collapse",),
-        sales_motion="Offer white-glove onboarding and named CSM commitment",
-        required_pools=("evidence_vault", "temporal", "accounts"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.INTEGRATION_LOCK,
-        label="Integration Lock-in",
-        archetype_map=("integration_break",),
-        sales_motion="Show migration playbook with timeline and risk mitigation",
-        required_pools=("evidence_vault", "displacement"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.CATEGORY_SHIFT,
-        label="Category Shift",
-        archetype_map=("category_disruption",),
-        sales_motion="Position as the category leader; frame incumbent as legacy",
-        required_pools=("evidence_vault", "category", "displacement"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.ACQUISITION_HANGOVER,
-        label="Acquisition Hangover",
-        archetype_map=("acquisition_decay", "leadership_redesign"),
-        sales_motion="Exploit post-acquisition confusion and roadmap uncertainty",
-        required_pools=("evidence_vault", "temporal", "accounts"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.COMPLIANCE_EXPOSURE,
-        label="Compliance Exposure",
-        archetype_map=("compliance_gap",),
-        sales_motion="Lead with compliance matrix; urgency from regulatory deadline",
-        required_pools=("evidence_vault", "temporal"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.UX_REGRESSION,
-        label="UX Regression",
-        archetype_map=("feature_gap",),
-        sales_motion="Side-by-side UX walkthrough showing workflow friction",
-        required_pools=("evidence_vault", "segment"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.SEGMENT_MISMATCH,
-        label="Segment Mismatch",
-        archetype_map=("mixed",),
-        sales_motion="Target the underserved segment with tailored positioning",
-        required_pools=("evidence_vault", "segment", "accounts"),
-    ),
-    WedgeMeta(
-        wedge=Wedge.STABLE,
-        label="Stable",
-        archetype_map=("stable",),
-        sales_motion="Long-game nurture; monitor for trigger events",
-        required_pools=("evidence_vault",),
-    ),
+from extracted_reasoning_core.wedge_registry import (
+    WEDGE_ENUM_VALUES,
+    Wedge,
+    WedgeMeta,
+    get_required_pools,
+    get_sales_motion,
+    get_wedge_meta,
+    validate_wedge,
+    wedge_from_archetype,
 )
 
-# Archetype -> Wedge lookup (first match wins)
-_ARCHETYPE_TO_WEDGE: dict[str, Wedge] = {}
-for _meta in _WEDGE_CATALOG:
-    for _arch in _meta.archetype_map:
-        _ARCHETYPE_TO_WEDGE.setdefault(_arch, _meta.wedge)
-
-# Wedge -> WedgeMeta lookup
-_WEDGE_TO_META: dict[Wedge, WedgeMeta] = {m.wedge: m for m in _WEDGE_CATALOG}
-
-
-def wedge_from_archetype(archetype: str) -> Wedge:
-    """Map a churn archetype to its sales wedge. Defaults to SEGMENT_MISMATCH."""
-    return _ARCHETYPE_TO_WEDGE.get(archetype, Wedge.SEGMENT_MISMATCH)
-
-
-def validate_wedge(value: str) -> Wedge | None:
-    """Return the Wedge enum member if *value* is valid, else None."""
-    try:
-        return Wedge(value)
-    except ValueError:
-        return None
-
-
-def get_wedge_meta(wedge: Wedge) -> WedgeMeta:
-    """Return metadata for a wedge type."""
-    return _WEDGE_TO_META[wedge]
-
-
-def get_sales_motion(wedge: Wedge) -> str:
-    """Return the recommended sales motion for a wedge."""
-    return _WEDGE_TO_META[wedge].sales_motion
-
-
-def get_required_pools(wedge: Wedge) -> Sequence[str]:
-    """Return the pool layers required for a wedge."""
-    return _WEDGE_TO_META[wedge].required_pools
+__all__ = [
+    "WEDGE_ENUM_VALUES",
+    "Wedge",
+    "WedgeMeta",
+    "get_required_pools",
+    "get_sales_motion",
+    "get_wedge_meta",
+    "validate_wedge",
+    "wedge_from_archetype",
+]

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T13:19Z by claude-2026-05-03
+Last updated: 2026-05-05T13:25Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-D7b2, in flight) | PR-D7b2: wedge_registry.py atlas wrapper (PR 7 third slice, 2/5 of fork migration) | EDIT: `atlas_brain/reasoning/wedge_registry.py` (159-LOC fork becomes a ~30-LOC re-export from `extracted_reasoning_core.wedge_registry`; preserves the eight public symbols Wedge / WedgeMeta / WEDGE_ENUM_VALUES / wedge_from_archetype / validate_wedge / get_wedge_meta / get_sales_motion / get_required_pools). NEW: `tests/test_atlas_reasoning_wedge_registry_aliases.py` (alias-identity pin mirroring PR-D7b1's tiers test). EDIT: `scripts/run_extracted_pipeline_checks.sh` + `.github/workflows/extracted_pipeline_checks.yml` (wire new test + atlas wedge_registry.py path). Drift analysis: cosmetic only -- atlas's richer module docstring preserved in wrapper, core gained `__all__` (more disciplined), no behavioral diffs across the 8 symbols. Production callers verified: `_b2b_synthesis_validation.py`, `_b2b_reasoning_contracts.py`, `_b2b_synthesis_reader.py`, `b2b_blog_post_generation.py` + `tests/test_reasoning_synthesis_v2.py`. PR-D7b3-b5 follow with evidence_engine / temporal / archetypes wrappers. | claude-2026-05-03 | `atlas_brain/reasoning/wedge_registry.py`; `tests/test_atlas_reasoning_wedge_registry_aliases.py`; `scripts/run_extracted_pipeline_checks.sh`; `.github/workflows/extracted_pipeline_checks.yml` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -60,6 +60,7 @@ pytest \
   tests/test_atlas_reasoning_graph_aliases.py \
   tests/test_atlas_reasoning_run_reasoning_graph_wiring.py \
   tests/test_atlas_reasoning_tiers_aliases.py \
+  tests/test_atlas_reasoning_wedge_registry_aliases.py \
   tests/test_forbid_atlas_reasoning_imports.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \

--- a/tests/test_atlas_reasoning_wedge_registry_aliases.py
+++ b/tests/test_atlas_reasoning_wedge_registry_aliases.py
@@ -1,0 +1,101 @@
+"""Pin atlas's re-exports from ``atlas_brain.reasoning.wedge_registry``.
+
+PR-D7b2 promoted the wedge registry module into
+``extracted_reasoning_core.wedge_registry`` and replaced atlas's
+159-line fork with a thin re-export wrapper. Internal callers
+(B2B synthesis validation/contracts/reader, blog post generation,
+``tests/test_reasoning_synthesis_v2.py``) keep their existing import
+sites working through the wrapper.
+
+Mirrors ``test_atlas_reasoning_tiers_aliases.py`` (PR-D7b1) and
+``test_atlas_reasoning_graph_aliases.py`` (PR-C4e1): each alias must
+point to the exact same object as the core export, plus an AST-level
+guard that the wrapper body contains no def/class redefinitions.
+"""
+
+from __future__ import annotations
+
+from atlas_brain.reasoning import wedge_registry as atlas_wedge_registry
+from extracted_reasoning_core import wedge_registry as core_wedge_registry
+
+
+def test_wedge_alias_identity() -> None:
+    assert atlas_wedge_registry.Wedge is core_wedge_registry.Wedge
+
+
+def test_wedge_meta_alias_identity() -> None:
+    assert atlas_wedge_registry.WedgeMeta is core_wedge_registry.WedgeMeta
+
+
+def test_wedge_enum_values_alias_identity() -> None:
+    # The frozenset itself must be the same object so a caller that
+    # holds a reference compares ``is`` against any other reader.
+    assert (
+        atlas_wedge_registry.WEDGE_ENUM_VALUES
+        is core_wedge_registry.WEDGE_ENUM_VALUES
+    )
+
+
+def test_wedge_from_archetype_alias_identity() -> None:
+    assert (
+        atlas_wedge_registry.wedge_from_archetype
+        is core_wedge_registry.wedge_from_archetype
+    )
+
+
+def test_validate_wedge_alias_identity() -> None:
+    assert atlas_wedge_registry.validate_wedge is core_wedge_registry.validate_wedge
+
+
+def test_get_wedge_meta_alias_identity() -> None:
+    assert atlas_wedge_registry.get_wedge_meta is core_wedge_registry.get_wedge_meta
+
+
+def test_get_sales_motion_alias_identity() -> None:
+    assert (
+        atlas_wedge_registry.get_sales_motion
+        is core_wedge_registry.get_sales_motion
+    )
+
+
+def test_get_required_pools_alias_identity() -> None:
+    assert (
+        atlas_wedge_registry.get_required_pools
+        is core_wedge_registry.get_required_pools
+    )
+
+
+def test_atlas_wedge_registry_all_matches_re_export_set() -> None:
+    # __all__ pins the public-surface contract.
+    assert set(atlas_wedge_registry.__all__) == {
+        "WEDGE_ENUM_VALUES",
+        "Wedge",
+        "WedgeMeta",
+        "get_required_pools",
+        "get_sales_motion",
+        "get_wedge_meta",
+        "validate_wedge",
+        "wedge_from_archetype",
+    }
+
+
+def test_atlas_wedge_registry_does_not_redefine_symbols() -> None:
+    # Defensive: the wrapper module body should not contain any
+    # ``def``/``class`` re-implementations -- only the re-export
+    # imports + ``__all__`` literal. Catches a refactor that
+    # accidentally forks the implementation back into atlas-side.
+    import ast
+    import inspect
+
+    source = inspect.getsource(atlas_wedge_registry)
+    tree = ast.parse(source)
+
+    redefinitions: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            redefinitions.append(node.name)
+
+    assert redefinitions == [], (
+        f"atlas_brain.reasoning.wedge_registry should be a pure re-export "
+        f"wrapper, but it defines: {redefinitions}"
+    )


### PR DESCRIPTION
## Summary

Second sub-slice of the audit's PR 7 atlas-side fork migration. Atlas's 159-line `wedge_registry.py` becomes a thin re-export from `extracted_reasoning_core.wedge_registry`, mirroring PR-D7b1's pattern.

## Drift analysis (verified pre-conversion)

Cosmetic only. All 8 public symbols are implementation-identical:

| symbol | atlas | core |
|---|---|---|
| `Wedge` | ✓ | ✓ |
| `WedgeMeta` | ✓ | ✓ |
| `WEDGE_ENUM_VALUES` | ✓ | ✓ |
| `wedge_from_archetype` | ✓ | ✓ |
| `validate_wedge` | ✓ | ✓ |
| `get_wedge_meta` | ✓ | ✓ |
| `get_sales_motion` | ✓ | ✓ |
| `get_required_pools` | ✓ | ✓ |

- Atlas had a richer module docstring — preserved on the wrapper.
- Core gained `__all__` (more disciplined surface declaration).
- Two inline comments + one docstring sentence trimmed in core (cosmetic).

## Production callers verified

All 4 atlas-side import sites + the test suite resolve through the wrapper:

- `atlas_brain/autonomous/tasks/_b2b_synthesis_validation.py` — `WEDGE_ENUM_VALUES`, `validate_wedge`
- `atlas_brain/autonomous/tasks/_b2b_reasoning_contracts.py` — `validate_wedge`
- `atlas_brain/autonomous/tasks/_b2b_synthesis_reader.py` — `Wedge`, `validate_wedge`
- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` — `Wedge`, `get_wedge_meta`
- `tests/test_reasoning_synthesis_v2.py` — multiple

## Files

- `atlas_brain/reasoning/wedge_registry.py`: 159-line fork → ~30-line re-export.
- `tests/test_atlas_reasoning_wedge_registry_aliases.py` (NEW, 10 tests): `is` identity per symbol + `__all__` contract pin + AST-level "no redefinition" guard.
- `scripts/run_extracted_pipeline_checks.sh` + workflow `paths:` filter: wire new test + atlas wedge_registry.py path.

## Test plan

- [x] `pytest tests/test_atlas_reasoning_wedge_registry_aliases.py` → 10/10
- [x] `bash scripts/run_extracted_pipeline_checks.sh` → 819 passed (was 809 before)
- [x] Each caller's exact import shape verified end-to-end
- [ ] CI green on the 3.10 runner

## Forward look (out of scope)

- **PR-D7b3** — `evidence_engine.py` wrapper (548 LOC, 3 atlas callers + 3 tests; possible drift-forward into core).
- **PR-D7b4** — `temporal.py` wrapper (490 LOC, 2 atlas callers; core is bigger from PR-C1b consolidation).
- **PR-D7b5** — `archetypes.py` wrapper (592 LOC, 1 atlas caller; core is bigger from PR-C1a consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)