### PR TITLE
Add hosted campaign operations API triggers

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T14:00Z by codex-d9-campaign-operations
+Last updated: 2026-05-05T14:05Z by codex-2026-05-05-d9
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
-| TBD | D9 hosted campaign operations API triggers | `extracted_content_pipeline/api/campaign_operations.py`, `tests/test_extracted_campaign_api_operations.py`, `extracted_content_pipeline/manifest.json`, `scripts/run_extracted_pipeline_checks.sh`, content pipeline docs/status | codex-d9-campaign-operations | Avoid adding campaign send/progression/analytics API triggers or editing the same extracted pipeline runner entry until this PR lands |
+| TBD | D9 hosted campaign operations API triggers | `extracted_content_pipeline/api/campaign_operations.py`, `tests/test_extracted_campaign_api_operations.py`, `extracted_content_pipeline/manifest.json`, `scripts/run_extracted_pipeline_checks.sh`, content pipeline docs/status | codex-2026-05-05-d9 | Avoid adding campaign send/progression/analytics API triggers or editing the same extracted pipeline runner entry until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T13:19Z by claude-2026-05-03
+Last updated: 2026-05-05T14:00Z by codex-d9-campaign-operations
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| TBD | D9 hosted campaign operations API triggers | `extracted_content_pipeline/api/campaign_operations.py`, `tests/test_extracted_campaign_api_operations.py`, `extracted_content_pipeline/manifest.json`, `scripts/run_extracted_pipeline_checks.sh`, content pipeline docs/status | codex-d9-campaign-operations | Avoid adding campaign send/progression/analytics API triggers or editing the same extracted pipeline runner entry until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -373,6 +373,41 @@ python scripts/progress_extracted_campaign_sequences.py \
   --json
 ```
 
+Hosts with FastAPI apps can mount the same send, sequence progression, and
+analytics worker triggers through a hosted operations router. The host injects
+its database pool, sender, optional LLM/skill providers, and auth dependencies;
+request payloads only control batch limits.
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.campaign_operations import (
+    CampaignOperationsApiConfig,
+    create_campaign_operations_router,
+)
+
+
+app.include_router(
+    create_campaign_operations_router(
+        pool_provider=get_pool,
+        sender_provider=get_campaign_sender,
+        llm_provider=get_campaign_llm,
+        skills_provider=get_campaign_skills,
+        config=CampaignOperationsApiConfig(
+            send_default_from_email="audit@customer.com",
+            sequence_from_email="audit@customer.com",
+        ),
+        dependencies=[Depends(require_content_ops_admin)],
+    )
+)
+```
+
+This adds `POST /campaigns/operations/send/queued`,
+`POST /campaigns/operations/sequences/progress`, and
+`POST /campaigns/operations/analytics/refresh` without exposing provider
+credentials, sender identity, unsubscribe policy, or LLM configuration through
+HTTP payloads.
+
 ## Import smoke test
 
 ```bash
@@ -472,6 +507,8 @@ Several small utility shims provide product-owned local behavior by default so t
   host worker CLIs
 - `api/campaign_webhooks.py`: optional FastAPI router factory for host-mounted
   campaign webhook and unsubscribe routes
+- `api/campaign_operations.py`: optional FastAPI router factory for
+  host-mounted send, sequence progression, and analytics operation triggers
 - `api/b2b_campaigns.py`: optional FastAPI router factory for host-mounted
   B2B draft list/export/review routes
 - `api/seller_campaigns.py`: optional FastAPI router factory for host-mounted

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -70,6 +70,10 @@
   DB-backed webhook seam. Hosts inject pool/signing-secret providers, an
   unsubscribe-token verifier, and any auth dependencies instead of importing
   Atlas API globals.
+- `api.campaign_operations` provides a FastAPI router factory around hosted
+  send, sequence progression, and analytics refresh triggers. Hosts inject the
+  database, sender, optional LLM/skill providers, and auth dependencies; HTTP
+  payloads only control batch sizing.
 - `campaign_postgres_sequence_progression` provides a DB-backed follow-up
   generation worker seam. Hosts reuse due `campaign_sequences` rows, packaged
   or custom sequence prompts, and the product LLM port to queue the next

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -197,7 +197,7 @@ def _sequence_config(
 def _public_analytics_result(result: Any) -> dict[str, Any]:
     data = result.as_dict()
     if data.get("error"):
-        logger.warning("Campaign analytics refresh failed: %s", data.get("error"))
+        logger.warning("Campaign analytics refresh failed")
         data["error"] = _ANALYTICS_ERROR_SUMMARY
     return data
 

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -1,0 +1,292 @@
+"""FastAPI router factory for hosted campaign operations."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Body, HTTPException
+except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
+    APIRouter = None
+    Body = None
+    HTTPException = None
+    _FASTAPI_IMPORT_ERROR: ImportError | None = exc
+else:
+    _FASTAPI_IMPORT_ERROR = None
+
+from ..campaign_ports import CampaignSender, LLMClient, SkillStore
+from ..campaign_postgres_analytics import refresh_campaign_analytics_from_postgres
+from ..campaign_postgres_send import send_due_campaigns_from_postgres
+from ..campaign_postgres_sequence_progression import (
+    progress_campaign_sequences_from_postgres,
+)
+from ..campaign_send import CampaignSendConfig
+from ..campaign_sequence_progression import CampaignSequenceProgressionConfig
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+SenderProvider = Callable[[], CampaignSender | Awaitable[CampaignSender]]
+LLMProvider = Callable[[], LLMClient | Awaitable[LLMClient]]
+SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
+
+logger = logging.getLogger(__name__)
+_ANALYTICS_ERROR_SUMMARY = "Campaign analytics refresh failed."
+
+
+@dataclass(frozen=True)
+class CampaignOperationsApiConfig:
+    """Host-owned API defaults for campaign operation routes."""
+
+    prefix: str = "/campaigns/operations"
+    tags: tuple[str, ...] = ("campaign-operations",)
+    default_send_limit: int = 20
+    max_send_limit: int = 200
+    send_default_from_email: str = ""
+    send_default_reply_to: str | None = None
+    send_unsubscribe_base_url: str = ""
+    send_unsubscribe_token_secret: str = ""
+    send_company_address: str = ""
+    default_sequence_limit: int = 20
+    max_sequence_limit: int = 200
+    default_sequence_max_steps: int = 5
+    max_sequence_steps: int = 20
+    sequence_from_email: str = ""
+    sequence_onboarding_product_name: str = ""
+    sequence_temperature: float = 0.7
+
+    def __post_init__(self) -> None:
+        _validate_default_limit(
+            self.default_send_limit,
+            self.max_send_limit,
+            default_name="default_send_limit",
+            max_name="max_send_limit",
+        )
+        _validate_default_limit(
+            self.default_sequence_limit,
+            self.max_sequence_limit,
+            default_name="default_sequence_limit",
+            max_name="max_sequence_limit",
+        )
+        _validate_default_limit(
+            self.default_sequence_max_steps,
+            self.max_sequence_steps,
+            default_name="default_sequence_max_steps",
+            max_name="max_sequence_steps",
+        )
+
+
+def _require_fastapi() -> None:
+    if _FASTAPI_IMPORT_ERROR is None:
+        return
+    raise RuntimeError(
+        "FastAPI is required to create campaign operation API routes. "
+        "Install fastapi in the host application environment."
+    ) from _FASTAPI_IMPORT_ERROR
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+async def _resolve_pool(pool_provider: PoolProvider) -> Any:
+    pool = await _maybe_await(pool_provider())
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    if getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    return pool
+
+
+async def _resolve_sender(
+    sender_provider: SenderProvider | None,
+) -> CampaignSender:
+    if sender_provider is None:
+        raise HTTPException(status_code=503, detail="Campaign sender unavailable")
+    sender = await _maybe_await(sender_provider())
+    if sender is None:
+        raise HTTPException(status_code=503, detail="Campaign sender unavailable")
+    return sender
+
+
+async def _resolve_optional(provider: Callable[[], Any | Awaitable[Any]] | None) -> Any:
+    if provider is None:
+        return None
+    return await _maybe_await(provider())
+
+
+def _validate_default_limit(
+    default: int,
+    max_value: int,
+    *,
+    default_name: str,
+    max_name: str,
+) -> None:
+    if default <= 0:
+        raise ValueError(f"{default_name} must be positive")
+    if max_value <= 0:
+        raise ValueError(f"{max_name} must be positive")
+    if default > max_value:
+        raise ValueError(f"{default_name} must be less than or equal to {max_name}")
+
+
+def _payload_limit(
+    payload: Mapping[str, Any],
+    key: str,
+    default: int,
+    *,
+    max_value: int,
+) -> int:
+    raw_value = payload.get(key)
+    if isinstance(raw_value, bool) or isinstance(raw_value, float):
+        raise HTTPException(status_code=400, detail=f"{key} must be an integer")
+    try:
+        value = default if raw_value is None else int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"{key} must be an integer") from exc
+    if value <= 0:
+        raise HTTPException(status_code=400, detail=f"{key} must be greater than 0")
+    if value > max_value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{key} must be less than or equal to {max_value}",
+        )
+    return value
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _send_config(config: CampaignOperationsApiConfig, *, limit: int) -> CampaignSendConfig:
+    return CampaignSendConfig(
+        default_from_email=config.send_default_from_email,
+        default_reply_to=config.send_default_reply_to,
+        unsubscribe_base_url=config.send_unsubscribe_base_url,
+        unsubscribe_token_secret=config.send_unsubscribe_token_secret,
+        company_address=config.send_company_address,
+        limit=limit,
+    )
+
+
+def _sequence_config(
+    config: CampaignOperationsApiConfig,
+    *,
+    limit: int,
+    max_steps: int,
+) -> CampaignSequenceProgressionConfig:
+    from_email = _clean(config.sequence_from_email)
+    if not from_email:
+        raise HTTPException(
+            status_code=503,
+            detail="Campaign sequence from_email is not configured",
+        )
+    return CampaignSequenceProgressionConfig(
+        batch_limit=limit,
+        max_steps=max_steps,
+        from_email=from_email,
+        onboarding_product_name=config.sequence_onboarding_product_name,
+        temperature=float(config.sequence_temperature),
+    )
+
+
+def _public_analytics_result(result: Any) -> dict[str, Any]:
+    data = result.as_dict()
+    if data.get("error"):
+        logger.warning("Campaign analytics refresh failed: %s", data.get("error"))
+        data["error"] = _ANALYTICS_ERROR_SUMMARY
+    return data
+
+
+def create_campaign_operations_router(
+    *,
+    pool_provider: PoolProvider,
+    sender_provider: SenderProvider | None = None,
+    llm_provider: LLMProvider | None = None,
+    skills_provider: SkillsProvider | None = None,
+    config: CampaignOperationsApiConfig | None = None,
+    dependencies: Sequence[Any] | None = None,
+) -> APIRouter:
+    """Create host-mounted campaign operation routes."""
+    _require_fastapi()
+    resolved_config = config or CampaignOperationsApiConfig()
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+        dependencies=list(dependencies or ()),
+    )
+
+    @router.post("/send/queued")
+    async def send_queued(
+        payload: dict[str, Any] | None = Body(None),
+    ) -> dict[str, Any]:
+        resolved_payload = payload or {}
+        limit = _payload_limit(
+            resolved_payload,
+            "limit",
+            resolved_config.default_send_limit,
+            max_value=resolved_config.max_send_limit,
+        )
+        pool = await _resolve_pool(pool_provider)
+        sender = await _resolve_sender(sender_provider)
+        result = await send_due_campaigns_from_postgres(
+            pool,
+            sender=sender,
+            config=_send_config(resolved_config, limit=limit),
+            limit=limit,
+        )
+        return result.as_dict()
+
+    @router.post("/sequences/progress")
+    async def progress_sequences(
+        payload: dict[str, Any] | None = Body(None),
+    ) -> dict[str, Any]:
+        resolved_payload = payload or {}
+        limit = _payload_limit(
+            resolved_payload,
+            "limit",
+            resolved_config.default_sequence_limit,
+            max_value=resolved_config.max_sequence_limit,
+        )
+        max_steps = _payload_limit(
+            resolved_payload,
+            "max_steps",
+            resolved_config.default_sequence_max_steps,
+            max_value=resolved_config.max_sequence_steps,
+        )
+        sequence_config = _sequence_config(
+            resolved_config,
+            limit=limit,
+            max_steps=max_steps,
+        )
+        pool = await _resolve_pool(pool_provider)
+        llm = await _resolve_optional(llm_provider)
+        skills = await _resolve_optional(skills_provider)
+        result = await progress_campaign_sequences_from_postgres(
+            pool,
+            llm=llm,
+            skills=skills,
+            config=sequence_config,
+        )
+        return result.as_dict()
+
+    @router.post("/analytics/refresh")
+    async def refresh_analytics(
+        payload: dict[str, Any] | None = Body(None),
+    ) -> dict[str, Any]:
+        _ = payload
+        pool = await _resolve_pool(pool_provider)
+        result = await refresh_campaign_analytics_from_postgres(pool)
+        return _public_analytics_result(result)
+
+    return router
+
+
+__all__ = [
+    "CampaignOperationsApiConfig",
+    "create_campaign_operations_router",
+]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -421,6 +421,44 @@ python scripts/progress_extracted_campaign_sequences.py \
   --limit 10
 ```
 
+Or mount the hosted operations router in a FastAPI app for admin-triggered
+send, sequence progression, and analytics refresh actions:
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.campaign_operations import (
+    CampaignOperationsApiConfig,
+    create_campaign_operations_router,
+)
+
+
+app.include_router(
+    create_campaign_operations_router(
+        pool_provider=get_pool,
+        sender_provider=get_campaign_sender,
+        llm_provider=get_campaign_llm,
+        skills_provider=get_campaign_skills,
+        config=CampaignOperationsApiConfig(
+            send_default_from_email="audit@customer.com",
+            sequence_from_email="audit@customer.com",
+        ),
+        dependencies=[Depends(require_content_ops_admin)],
+    )
+)
+```
+
+The hosted operations payloads are intentionally narrow. Callers may set
+`limit` and, for sequence progression, `max_steps`; provider credentials,
+sender identity, unsubscribe policy, LLM client, and skill roots stay
+host-configured.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/campaigns/operations/send/queued` | Send queued campaign rows through the injected sender. |
+| `POST` | `/campaigns/operations/sequences/progress` | Generate and queue due follow-up sequence steps. |
+| `POST` | `/campaigns/operations/analytics/refresh` | Refresh packaged campaign analytics aggregates. |
+
 Reject a draft without deleting it:
 
 ```bash

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -203,6 +203,13 @@ list/export/review locked to `target_mode="amazon_seller"` and still defers
 LLM draft generation to worker/CLI paths so hosts can control provider runtime
 policy separately.
 
+`extracted_content_pipeline/api/campaign_operations.py` owns the host-mounted
+FastAPI surface for operational campaign workers. It exposes send queued,
+sequence progression, and analytics refresh triggers while requiring the host
+to inject database, sender, auth, and optional LLM/skill providers. Request
+payloads are limited to batch sizing so provider credentials, sender identity,
+unsubscribe policy, and LLM routing remain host-owned.
+
 `extracted_content_pipeline/campaign_postgres_send.py` owns the DB-backed send
 worker seam. It composes `PostgresCampaignRepository`,
 `PostgresSuppressionRepository`, `PostgresCampaignAuditSink`, and

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -241,6 +241,9 @@
       "target": "extracted_content_pipeline/api/campaign_webhooks.py"
     },
     {
+      "target": "extracted_content_pipeline/api/campaign_operations.py"
+    },
+    {
       "target": "extracted_content_pipeline/api/b2b_campaigns.py"
     },
     {

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -29,6 +29,7 @@ pytest \
   tests/test_extracted_campaign_postgres_analytics.py \
   tests/test_extracted_campaign_postgres_webhooks.py \
   tests/test_extracted_campaign_api_webhooks.py \
+  tests/test_extracted_campaign_api_operations.py \
   tests/test_extracted_campaign_api_b2b_campaigns.py \
   tests/test_extracted_campaign_api_seller_campaigns.py \
   tests/test_extracted_campaign_postgres_sequence_progression.py \

--- a/scripts/smoke_extracted_pipeline_imports.py
+++ b/scripts/smoke_extracted_pipeline_imports.py
@@ -30,6 +30,7 @@ MODULES = [
     "extracted_content_pipeline.podcast_example",
     "extracted_content_pipeline.services.podcast_quality",
     "extracted_content_pipeline.api.campaign_webhooks",
+    "extracted_content_pipeline.api.campaign_operations",
     "extracted_content_pipeline.api.b2b_campaigns",
     "extracted_content_pipeline.api.seller_campaigns",
     "extracted_content_pipeline.campaign_postgres_seller_opportunities",

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import extracted_content_pipeline.api.campaign_operations as operations_api
+from extracted_content_pipeline.api.campaign_operations import (
+    CampaignOperationsApiConfig,
+    create_campaign_operations_router,
+)
+
+
+class _Pool:
+    def __init__(self, *, initialized: bool = True) -> None:
+        self.is_initialized = initialized
+
+
+class _Result:
+    def __init__(self, **values: Any) -> None:
+        self.values = values
+
+    def as_dict(self) -> dict[str, Any]:
+        return dict(self.values)
+
+
+class _Sender:
+    pass
+
+
+class _LLM:
+    pass
+
+
+class _Skills:
+    pass
+
+
+def _client(
+    pool: Any,
+    *,
+    sender: Any = None,
+    llm: Any = None,
+    skills: Any = None,
+    config: CampaignOperationsApiConfig | None = None,
+    dependencies: list[Any] | None = None,
+    counters: dict[str, int] | None = None,
+) -> TestClient:
+    app = FastAPI()
+    counts = counters if counters is not None else {}
+
+    async def pool_provider():
+        counts["pool"] = counts.get("pool", 0) + 1
+        return pool
+
+    async def sender_provider():
+        counts["sender"] = counts.get("sender", 0) + 1
+        return sender
+
+    async def llm_provider():
+        counts["llm"] = counts.get("llm", 0) + 1
+        return llm
+
+    async def skills_provider():
+        counts["skills"] = counts.get("skills", 0) + 1
+        return skills
+
+    app.include_router(
+        create_campaign_operations_router(
+            pool_provider=pool_provider,
+            sender_provider=sender_provider if sender is not None else None,
+            llm_provider=llm_provider if llm is not None else None,
+            skills_provider=skills_provider if skills is not None else None,
+            config=config,
+            dependencies=dependencies,
+        )
+    )
+    return TestClient(app)
+
+
+def test_campaign_operations_router_sends_queued_campaigns(monkeypatch) -> None:
+    pool = _Pool()
+    sender = _Sender()
+    calls: list[tuple[Any, dict[str, Any]]] = []
+    counters: dict[str, int] = {}
+
+    async def _send(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(sent=2, failed=0, suppressed=1, skipped=0)
+
+    monkeypatch.setattr(operations_api, "send_due_campaigns_from_postgres", _send)
+
+    response = _client(
+        pool,
+        sender=sender,
+        counters=counters,
+        config=CampaignOperationsApiConfig(
+            max_send_limit=60,
+            send_default_from_email="audit@example.com",
+            send_default_reply_to="reply@example.com",
+            send_unsubscribe_base_url="https://example.com/unsubscribe",
+            send_unsubscribe_token_secret="secret",
+            send_company_address="123 Main St",
+        ),
+    ).post("/campaigns/operations/send/queued", json={"limit": 7})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "sent": 2,
+        "failed": 0,
+        "suppressed": 1,
+        "skipped": 0,
+    }
+    assert counters == {"pool": 1, "sender": 1}
+    assert calls[0][0] is pool
+    assert calls[0][1]["sender"] is sender
+    assert calls[0][1]["limit"] == 7
+    send_config = calls[0][1]["config"]
+    assert send_config.default_from_email == "audit@example.com"
+    assert send_config.default_reply_to == "reply@example.com"
+    assert send_config.unsubscribe_base_url == "https://example.com/unsubscribe"
+    assert send_config.unsubscribe_token_secret == "secret"
+    assert send_config.company_address == "123 Main St"
+    assert send_config.limit == 7
+
+
+@pytest.mark.parametrize(
+    ("payload", "detail"),
+    (
+        ({"limit": True}, "limit must be an integer"),
+        ({"limit": 3.5}, "limit must be an integer"),
+        ({"limit": 0}, "limit must be greater than 0"),
+        ({"limit": 61}, "limit must be less than or equal to 60"),
+    ),
+)
+def test_campaign_operations_router_rejects_invalid_send_limits(
+    monkeypatch,
+    payload,
+    detail,
+) -> None:
+    calls = []
+
+    async def _send(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(sent=1)
+
+    monkeypatch.setattr(operations_api, "send_due_campaigns_from_postgres", _send)
+
+    response = _client(
+        _Pool(),
+        sender=_Sender(),
+        config=CampaignOperationsApiConfig(max_send_limit=60),
+    ).post("/campaigns/operations/send/queued", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+    assert calls == []
+
+
+def test_campaign_operations_router_requires_sender_before_send(monkeypatch) -> None:
+    calls = []
+
+    async def _send(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(sent=1)
+
+    monkeypatch.setattr(operations_api, "send_due_campaigns_from_postgres", _send)
+
+    response = _client(_Pool()).post("/campaigns/operations/send/queued")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Campaign sender unavailable"
+    assert calls == []
+
+
+def test_campaign_operations_router_progresses_sequences(monkeypatch) -> None:
+    pool = _Pool()
+    llm = _LLM()
+    skills = _Skills()
+    calls: list[tuple[Any, dict[str, Any]]] = []
+    counters: dict[str, int] = {}
+
+    async def _progress(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(due_sequences=3, progressed=2, skipped=1, disabled=False)
+
+    monkeypatch.setattr(
+        operations_api,
+        "progress_campaign_sequences_from_postgres",
+        _progress,
+    )
+
+    response = _client(
+        pool,
+        llm=llm,
+        skills=skills,
+        counters=counters,
+        config=CampaignOperationsApiConfig(
+            max_sequence_limit=40,
+            max_sequence_steps=9,
+            sequence_from_email="audit@example.com",
+            sequence_onboarding_product_name="Content Ops",
+            sequence_temperature=0.4,
+        ),
+    ).post(
+        "/campaigns/operations/sequences/progress",
+        json={"limit": 8, "max_steps": 4},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "due_sequences": 3,
+        "progressed": 2,
+        "skipped": 1,
+        "disabled": False,
+    }
+    assert counters == {"pool": 1, "llm": 1, "skills": 1}
+    assert calls[0][0] is pool
+    assert calls[0][1]["llm"] is llm
+    assert calls[0][1]["skills"] is skills
+    sequence_config = calls[0][1]["config"]
+    assert sequence_config.batch_limit == 8
+    assert sequence_config.max_steps == 4
+    assert sequence_config.from_email == "audit@example.com"
+    assert sequence_config.onboarding_product_name == "Content Ops"
+    assert sequence_config.temperature == 0.4
+
+
+def test_campaign_operations_router_rejects_invalid_sequence_limits(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    async def _progress(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(progressed=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "progress_campaign_sequences_from_postgres",
+        _progress,
+    )
+
+    response = _client(
+        _Pool(),
+        config=CampaignOperationsApiConfig(
+            default_sequence_limit=10,
+            max_sequence_limit=10,
+            max_sequence_steps=5,
+            sequence_from_email="audit@example.com",
+        ),
+    ).post(
+        "/campaigns/operations/sequences/progress",
+        json={"limit": 11, "max_steps": 2},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "limit must be less than or equal to 10"
+    assert calls == []
+
+    response = _client(
+        _Pool(),
+        config=CampaignOperationsApiConfig(
+            default_sequence_limit=10,
+            max_sequence_limit=10,
+            max_sequence_steps=5,
+            sequence_from_email="audit@example.com",
+        ),
+    ).post(
+        "/campaigns/operations/sequences/progress",
+        json={"limit": 3, "max_steps": 6},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "max_steps must be less than or equal to 5"
+    assert calls == []
+
+
+def test_campaign_operations_router_requires_sequence_from_email(monkeypatch) -> None:
+    counters: dict[str, int] = {}
+    calls = []
+
+    async def _progress(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(progressed=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "progress_campaign_sequences_from_postgres",
+        _progress,
+    )
+
+    response = _client(
+        _Pool(),
+        counters=counters,
+    ).post("/campaigns/operations/sequences/progress", json={"limit": 3})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Campaign sequence from_email is not configured"
+    assert counters == {}
+    assert calls == []
+
+
+def test_campaign_operations_router_refreshes_analytics(monkeypatch) -> None:
+    pool = _Pool()
+    calls = []
+
+    async def _refresh(received_pool):
+        calls.append(received_pool)
+        return _Result(refreshed=True, error=None)
+
+    monkeypatch.setattr(
+        operations_api,
+        "refresh_campaign_analytics_from_postgres",
+        _refresh,
+    )
+
+    response = _client(pool).post("/campaigns/operations/analytics/refresh")
+
+    assert response.status_code == 200
+    assert response.json() == {"refreshed": True, "error": None}
+    assert calls == [pool]
+
+
+def test_campaign_operations_router_sanitizes_analytics_errors(monkeypatch) -> None:
+    async def _refresh(_pool):
+        return _Result(refreshed=False, error="SELECT * FROM private_table failed")
+
+    monkeypatch.setattr(
+        operations_api,
+        "refresh_campaign_analytics_from_postgres",
+        _refresh,
+    )
+
+    response = _client(_Pool()).post("/campaigns/operations/analytics/refresh")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "refreshed": False,
+        "error": operations_api._ANALYTICS_ERROR_SUMMARY,
+    }
+
+
+def test_campaign_operations_router_requires_database() -> None:
+    response = _client(_Pool(initialized=False), sender=_Sender()).post(
+        "/campaigns/operations/send/queued"
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database unavailable"
+
+
+def test_campaign_operations_router_honors_host_dependencies() -> None:
+    def require_auth():
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    response = _client(
+        _Pool(),
+        sender=_Sender(),
+        dependencies=[Depends(require_auth)],
+    ).post("/campaigns/operations/send/queued")
+
+    assert response.status_code == 403
+
+
+def test_campaign_operations_api_config_rejects_invalid_limits() -> None:
+    with pytest.raises(ValueError, match="default_send_limit must be positive"):
+        CampaignOperationsApiConfig(default_send_limit=0)
+
+    with pytest.raises(ValueError, match="max_send_limit must be positive"):
+        CampaignOperationsApiConfig(max_send_limit=0)
+
+    with pytest.raises(ValueError, match="default_sequence_limit must be less"):
+        CampaignOperationsApiConfig(default_sequence_limit=5, max_sequence_limit=4)
+
+
+def test_campaign_operations_router_requires_fastapi(monkeypatch) -> None:
+    monkeypatch.setattr(
+        operations_api,
+        "_FASTAPI_IMPORT_ERROR",
+        ImportError("missing"),
+    )
+
+    with pytest.raises(RuntimeError, match="FastAPI is required"):
+        create_campaign_operations_router(pool_provider=lambda: None)


### PR DESCRIPTION
## Summary
- Add `api.campaign_operations` FastAPI router for hosted send, sequence progression, and analytics refresh triggers.
- Keep runtime-sensitive configuration host-owned: payloads only control batch limits and max sequence steps.
- Wire the new API into manifest ownership, smoke imports, extracted pipeline checks, README, runbook, status, productization docs, and coordination tracking.

## Validation
- `pytest tests/test_extracted_campaign_api_operations.py` (15/15)
- Adjacent API/worker sweep: 113/113
- `bash scripts/run_extracted_pipeline_checks.sh` (824/824, existing torch/pynvml warning)

## Coordination
- Claimed D9 in `docs/extraction/coordination/inflight.md` so parallel sessions avoid campaign operations API/router work until this lands.