### PR TITLE
PR-D4d: Direct llm_usage writes + per-item idempotency (closes audit SEVERE)

### DIFF
--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -664,6 +664,23 @@ async def _persist_batch_usage(
     ``/api/v1/llm/usage`` -- matches what Anthropic actually
     charges them.
     """
+    # Short-circuit: if a concurrent poller already persisted
+    # usage for this batch, skip the (potentially expensive)
+    # Anthropic results fetch. The flag flip in phase 3 is
+    # account-scoped + idempotent, so this is purely a
+    # cost-saving check -- correctness is preserved either way.
+    # Copilot on PR-D4d.
+    already_tracked = await pool.fetchval(
+        """
+        SELECT usage_tracked FROM llm_gateway_batches
+        WHERE id = $1 AND account_id = $2
+        """,
+        batch_id,
+        account_id,
+    )
+    if already_tracked is True:
+        return
+
     # Phase 1: Pre-fetch results from Anthropic. Materialize the
     # async iterator into memory BEFORE we touch the DB. The SDK
     # call is the most likely failure point (network, provider
@@ -699,6 +716,29 @@ async def _persist_batch_usage(
                 "cache_write_tokens": int(getattr(usage, "cache_creation_input_tokens", 0) or 0),
                 "provider_request_id": getattr(message, "id", None),
             })
+
+    # Validate custom_ids before any DB write. A blank or
+    # duplicate custom_id would be silently absorbed by ON
+    # CONFLICT DO NOTHING (NULLs are distinct in UNIQUE indexes;
+    # duplicates collapse), but we'd still flip usage_tracked to
+    # TRUE and undercount the customer. Raise instead so
+    # usage_tracked stays FALSE and the next poll retries (or
+    # ops investigates the malformed payload). Copilot on PR-D4d.
+    seen_custom_ids: set[str] = set()
+    for item in items_to_persist:
+        cid = item["custom_id"]
+        if not cid:
+            raise ValueError(
+                f"_persist_batch_usage: blank custom_id from "
+                f"provider for batch={batch_id}; refusing to write"
+            )
+        if cid in seen_custom_ids:
+            raise ValueError(
+                f"_persist_batch_usage: duplicate custom_id "
+                f"{cid!r} from provider for batch={batch_id}; "
+                "refusing to write"
+            )
+        seen_custom_ids.add(cid)
 
     # Phase 2: Direct INSERT each per-item row. Conflicts (a prior
     # retry that wrote the same (account_id, batch_id, custom_id))

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -29,6 +29,7 @@ Atlas-internal lifecycle states (NOT Anthropic):
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid as _uuid
 from dataclasses import dataclass
@@ -54,6 +55,17 @@ TERMINAL_STATUSES = ("ended", "canceled", "expired", "submit_failed")
 
 # Provider statuses we treat as in-flight on the read path.
 ACTIVE_STATUSES = ("queued", "in_progress", "canceling")
+
+# Span name written into the ``span_name`` column of ``llm_usage``
+# for batch-item rows. Stable identifier so /api/v1/llm/usage
+# rollups can split batch traffic vs synchronous /chat traffic
+# without joining ``llm_gateway_batches``.
+_BATCH_ITEM_SPAN_NAME = "llm_gateway.batch_item"
+
+# Endpoint marker for batch-item rows. Mirrors the ``endpoint``
+# label written for sync /chat traffic so the same rollup queries
+# can group both lanes.
+_BATCH_ITEM_ENDPOINT = "llm_gateway.batch"
 
 
 @dataclass(frozen=True)
@@ -226,15 +238,35 @@ async def submit_customer_batch(
                 # Recent queued (< 60s old) or another retry already
                 # claimed it. Replay -- the customer polls /batch/{id}
                 # either way.
+                #
+                # PR-D4d post-audit: re-read the row before returning.
+                # The ``existing`` snapshot was taken before the resume
+                # claim attempt; if a concurrent retry just succeeded
+                # (set provider_batch_id, transitioned to in_progress),
+                # ``existing`` is stale. Fetching fresh state means the
+                # caller sees the current row instead of the snapshot.
+                latest = await pool.fetchrow(
+                    """
+                    SELECT id, account_id, provider, provider_batch_id, model,
+                           status, total_items, completed_items, failed_items,
+                           error_text, created_at, updated_at, submitted_at,
+                           completed_at, usage_tracked
+                    FROM llm_gateway_batches
+                    WHERE id = $1 AND account_id = $2
+                    """,
+                    existing["id"],
+                    account_id,
+                )
+                replay_row = latest if latest is not None else existing
                 logger.info(
                     "llm_gateway_batch.submit replay (in-flight) "
                     "account=%s key=%s id=%s status=%s",
                     account_id,
                     normalized_key,
-                    existing["id"],
-                    existing["status"],
+                    replay_row["id"],
+                    replay_row["status"],
                 )
-                return _row_to_record(existing)
+                return _row_to_record(replay_row)
             logger.info(
                 "llm_gateway_batch.submit resume pre-submit "
                 "account=%s key=%s id=%s prior_status=%s",
@@ -569,6 +601,28 @@ async def refresh_customer_batch_status(
 _BATCH_DISCOUNT_FACTOR = 0.5
 
 
+_BATCH_USAGE_INSERT_SQL = """
+INSERT INTO llm_usage (
+    span_name, operation_type, model_name, model_provider,
+    input_tokens, output_tokens, total_tokens,
+    billable_input_tokens, cached_tokens, cache_write_tokens,
+    cost_usd, status, metadata,
+    api_endpoint, provider_request_id, account_id,
+    batch_id, custom_id
+) VALUES (
+    $1, 'llm_call', $2, 'anthropic',
+    $3, $4, $5,
+    $6, $7, $8,
+    $9, 'completed', $10::jsonb,
+    $11, $12, $13,
+    $14, $15
+)
+ON CONFLICT (account_id, batch_id, custom_id)
+WHERE batch_id IS NOT NULL
+DO NOTHING
+"""
+
+
 async def _persist_batch_usage(
     pool,
     *,
@@ -580,20 +634,30 @@ async def _persist_batch_usage(
 ) -> None:
     """Write per-item ``llm_usage`` rows for a completed batch.
 
-    Two-phase design (Codex P1 + Copilot on PR-D4c):
+    Three-phase design (PR-D4d, post-audit):
 
     1. Pre-fetch all results from Anthropic into memory. No DB
        writes happen yet -- if the SDK iteration fails mid-stream,
-       the usage_tracked flag stays FALSE and the next poll retries
-       cleanly.
-    2. Atomic claim flips usage_tracked FALSE->TRUE under
-       (id, account_id) so concurrent pollers and cross-account
-       batch_id misrouting both no-op.
-    3. Then persist. Trace_llm_call failures here are logged but
-       NOT rolled back, because the rollback + retry pattern would
-       re-emit the items that already landed and double-count
-       against the customer. Failure to write a single item is
-       recovered by ops (the partial-write is logged loudly).
+       ``usage_tracked`` stays FALSE and the next poll retries
+       from a clean slate.
+    2. Direct INSERT each per-item row via ``pool.executemany``
+       under a transaction. Each row uses ``ON CONFLICT
+       (account_id, batch_id, custom_id) DO NOTHING`` (migration
+       319) so retries are safe -- if a partial set of rows
+       already landed, conflicts no-op silently.
+    3. Flip ``usage_tracked = TRUE`` only AFTER the inserts
+       commit. A concurrent poller racing on the same batch hits
+       the same ON CONFLICT predicate (no double-write), and the
+       UPDATE-at-end is account-scoped so cross-account batch_id
+       reuse can never flip a foreign row.
+
+    PR-D4c routed per-item writes through ``trace_llm_call``,
+    which calls ``tracer.end_span`` -> ``loop.create_task`` --
+    fire-and-forget. That meant the persist phase could not catch
+    DB failures and ``usage_tracked = TRUE`` was set BEFORE writes
+    actually landed. PR-D4d issues writes directly so failures
+    surface synchronously and the flag flip honestly reflects
+    "all rows landed."
 
     Per-item cost applies the 50% Anthropic batch discount.
     Customers see the discounted figure in
@@ -604,7 +668,7 @@ async def _persist_batch_usage(
     # async iterator into memory BEFORE we touch the DB. The SDK
     # call is the most likely failure point (network, provider
     # stall, rate limit), and surfacing the failure here means we
-    # never claim the batch -- next poll retries on a clean slate.
+    # never write a partial set -- next poll retries cleanly.
     from anthropic import AsyncAnthropic
 
     items_to_persist: list[dict[str, Any]] = []
@@ -636,76 +700,63 @@ async def _persist_batch_usage(
                 "provider_request_id": getattr(message, "id", None),
             })
 
-    # Phase 2: Atomic claim. Only proceed when usage_tracked
-    # transitions FALSE -> TRUE. The ``account_id`` predicate
-    # (Copilot on PR-D4c) defends against batch_id reuse or
-    # misrouting flipping the flag on a row outside the caller's
-    # account.
-    claim = await pool.fetchrow(
-        """
-        UPDATE llm_gateway_batches
-        SET usage_tracked = TRUE
-        WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE
-        RETURNING id
-        """,
-        batch_id,
-        account_id,
-    )
-    if claim is None:
-        return  # Already tracked by an earlier poll, or wrong account.
-
-    # Phase 3: Persist. Trace_llm_call failures are logged but we
-    # do NOT roll back the claim -- the rollback-and-retry pattern
-    # would re-emit the items already written and double-count
-    # against the customer. The pending-usage index in migration
-    # 318 lets ops scan for any straggler rows that need a
-    # follow-up.
-    from ..pipelines.llm import trace_llm_call
-
-    persisted = 0
-    for item in items_to_persist:
-        try:
-            trace_llm_call(
-                span_name="llm_gateway.batch_item",
+    # Phase 2: Direct INSERT each per-item row. Conflicts (a prior
+    # retry that wrote the same (account_id, batch_id, custom_id))
+    # no-op silently so we never double-count. The whole batch is
+    # one transaction so a mid-iteration DB failure leaves no
+    # partial state visible to other pollers.
+    if items_to_persist:
+        rows_args = []
+        for item in items_to_persist:
+            cost_usd = _BATCH_DISCOUNT_FACTOR * _estimate_cost_usd(
+                model=model,
                 input_tokens=item["input_tokens"],
                 output_tokens=item["output_tokens"],
                 cached_tokens=item["cached_tokens"],
                 cache_write_tokens=item["cache_write_tokens"],
-                billable_input_tokens=item["input_tokens"],
-                model=model,
-                provider="anthropic",
-                provider_request_id=(
-                    str(item["provider_request_id"])
-                    if item["provider_request_id"]
-                    else None
-                ),
-                cost_usd_override=_BATCH_DISCOUNT_FACTOR
-                * _estimate_cost_usd(
-                    model=model,
-                    input_tokens=item["input_tokens"],
-                    output_tokens=item["output_tokens"],
-                    cached_tokens=item["cached_tokens"],
-                    cache_write_tokens=item["cache_write_tokens"],
-                ),
-                metadata={
-                    "account_id": str(account_id),
-                    "batch_id": str(batch_id),
-                    "custom_id": item["custom_id"],
-                    "endpoint": "llm_gateway.batch",
-                },
             )
-            persisted += 1
-        except Exception:
-            logger.exception(
-                "llm_gateway_batch.persist_usage: trace_llm_call failed "
-                "account=%s batch=%s custom_id=%s persisted=%d/%d",
-                account_id,
+            metadata = json.dumps({
+                "account_id": str(account_id),
+                "batch_id": str(batch_id),
+                "custom_id": item["custom_id"],
+                "endpoint": _BATCH_ITEM_ENDPOINT,
+            })
+            total_tokens = item["input_tokens"] + item["output_tokens"]
+            rows_args.append((
+                _BATCH_ITEM_SPAN_NAME,
+                model,
+                item["input_tokens"],
+                item["output_tokens"],
+                total_tokens,
+                item["input_tokens"],  # billable_input_tokens
+                item["cached_tokens"],
+                item["cache_write_tokens"],
+                cost_usd,
+                metadata,
+                _BATCH_ITEM_ENDPOINT,
+                str(item["provider_request_id"]) if item["provider_request_id"] else None,
+                str(account_id),
                 batch_id,
                 item["custom_id"],
-                persisted,
-                len(items_to_persist),
-            )
-            # Keep going. Partial loss > double-count.
+            ))
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.executemany(_BATCH_USAGE_INSERT_SQL, rows_args)
+
+    # Phase 3: Flip the flag. Account-scoped so cross-account
+    # batch_id reuse cannot accidentally mark a foreign row.
+    # ``usage_tracked = FALSE`` precondition makes the UPDATE
+    # idempotent under concurrent pollers (loser sees no rows
+    # to update; the inserts already succeeded via ON CONFLICT).
+    await pool.execute(
+        """
+        UPDATE llm_gateway_batches
+        SET usage_tracked = TRUE
+        WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE
+        """,
+        batch_id,
+        account_id,
+    )
 
 
 def _estimate_cost_usd(

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -705,6 +705,13 @@ async def _persist_batch_usage(
     # no-op silently so we never double-count. The whole batch is
     # one transaction so a mid-iteration DB failure leaves no
     # partial state visible to other pollers.
+    #
+    # ``pool.transaction()`` is the right primitive here. atlas's
+    # ``DatabasePool.acquire`` is a plain async-def returning a
+    # connection, NOT an async-context-manager protocol, so async-
+    # with on it would raise at runtime. ``pool.transaction()``
+    # (storage/database.py:144) handles the acquire + release +
+    # BEGIN/COMMIT in one block. Codex P1 fix on PR-D4d.
     if items_to_persist:
         rows_args = []
         for item in items_to_persist:
@@ -739,9 +746,8 @@ async def _persist_batch_usage(
                 batch_id,
                 item["custom_id"],
             ))
-        async with pool.acquire() as conn:
-            async with conn.transaction():
-                await conn.executemany(_BATCH_USAGE_INSERT_SQL, rows_args)
+        async with pool.transaction() as conn:
+            await conn.executemany(_BATCH_USAGE_INSERT_SQL, rows_args)
 
     # Phase 3: Flip the flag. Account-scoped so cross-account
     # batch_id reuse cannot accidentally mark a foreign row.

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -618,7 +618,7 @@ INSERT INTO llm_usage (
     $14, $15
 )
 ON CONFLICT (account_id, batch_id, custom_id)
-WHERE batch_id IS NOT NULL
+WHERE batch_id IS NOT NULL AND custom_id IS NOT NULL
 DO NOTHING
 """
 
@@ -704,6 +704,21 @@ async def _persist_batch_usage(
                 # show in the failed_items counter but don't add
                 # to llm_usage.
                 continue
+            # Fail loud on a malformed succeeded item rather than
+            # falling back to provider message id or silently
+            # absorbing the row via ON CONFLICT later. Anthropic
+            # echoes the customer-supplied custom_id verbatim, so
+            # an empty value here means either Anthropic violated
+            # contract or the customer submitted blanks (which we
+            # should also refuse). usage_tracked stays FALSE so
+            # the next poll retries (or ops investigates).
+            # Copilot on PR-D4d.
+            if not custom_id:
+                raise ValueError(
+                    f"_persist_batch_usage: succeeded item with "
+                    f"blank custom_id from provider for batch="
+                    f"{batch_id}; refusing to write"
+                )
             message = getattr(result, "message", None)
             usage = getattr(message, "usage", None) if message else None
             if usage is None:

--- a/atlas_brain/storage/migrations/319_llm_usage_batch_uniqueness.sql
+++ b/atlas_brain/storage/migrations/319_llm_usage_batch_uniqueness.sql
@@ -50,13 +50,9 @@ BEGIN
     END IF;
 END $$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_usage_batch_item
-    ON llm_usage (account_id, batch_id, custom_id)
-    WHERE batch_id IS NOT NULL;
-
--- Lookup-by-batch helper (used by /api/v1/llm/usage rollups that
--- want to break out batch traffic by submission). Cheap to add and
--- gives the planner an option for the partial-aggregate query.
-CREATE INDEX IF NOT EXISTS idx_llm_usage_batch_id
-    ON llm_usage (batch_id, created_at DESC)
-    WHERE batch_id IS NOT NULL;
+-- Indexes are created in companion migrations 320 and 321 with
+-- ``CREATE INDEX CONCURRENTLY`` so the build doesn't take an
+-- ACCESS EXCLUSIVE lock on llm_usage and block live inserts.
+-- ``CREATE INDEX CONCURRENTLY`` cannot run inside a transaction
+-- block, so each one needs its own migration file (same pattern
+-- as migration 090). Copilot on PR-D4d.

--- a/atlas_brain/storage/migrations/319_llm_usage_batch_uniqueness.sql
+++ b/atlas_brain/storage/migrations/319_llm_usage_batch_uniqueness.sql
@@ -1,0 +1,39 @@
+-- LLM Gateway batch per-item idempotency (PR-D4d).
+--
+-- Closes the partial-write loss gap PR-D4c documented as deferred:
+-- _persist_batch_usage previously routed per-item writes through
+-- the fire-and-forget tracer dispatch, so a process crash between
+-- "usage_tracked = TRUE" and the queued INSERTs landing would lose
+-- billing data permanently. PR-D4d switches to a direct INSERT
+-- with ``ON CONFLICT DO NOTHING`` keyed on (account_id, batch_id,
+-- custom_id) so a retry can safely re-emit any subset of rows
+-- without double-counting.
+--
+-- Two columns added to ``llm_usage``:
+--   batch_id   -- references llm_gateway_batches(id) for batch
+--                 traffic; NULL for sync /chat traffic. Lets the
+--                 unique index scope only batch rows.
+--   custom_id  -- echoes the customer-supplied per-item id from
+--                 the original Anthropic batch request. NULL for
+--                 sync traffic. Combined with batch_id this is
+--                 the natural key for batch items.
+--
+-- Partial UNIQUE index: only batch rows (batch_id IS NOT NULL)
+-- participate. Non-batch /chat traffic (batch_id NULL) is unaffected,
+-- which preserves the high-volume insert path's perf and avoids
+-- requiring a value to satisfy the index.
+
+ALTER TABLE llm_usage
+    ADD COLUMN IF NOT EXISTS batch_id  UUID,
+    ADD COLUMN IF NOT EXISTS custom_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_usage_batch_item
+    ON llm_usage (account_id, batch_id, custom_id)
+    WHERE batch_id IS NOT NULL;
+
+-- Lookup-by-batch helper (used by /api/v1/llm/usage rollups that
+-- want to break out batch traffic by submission). Cheap to add and
+-- gives the planner an option for the partial-aggregate query.
+CREATE INDEX IF NOT EXISTS idx_llm_usage_batch_id
+    ON llm_usage (batch_id, created_at DESC)
+    WHERE batch_id IS NOT NULL;

--- a/atlas_brain/storage/migrations/319_llm_usage_batch_uniqueness.sql
+++ b/atlas_brain/storage/migrations/319_llm_usage_batch_uniqueness.sql
@@ -27,6 +27,29 @@ ALTER TABLE llm_usage
     ADD COLUMN IF NOT EXISTS batch_id  UUID,
     ADD COLUMN IF NOT EXISTS custom_id TEXT;
 
+-- Copilot on PR-D4d: a NULL custom_id is treated as distinct in
+-- the UNIQUE index, so without this CHECK two retries with NULL
+-- custom_id under the same batch_id could both insert -- exactly
+-- the double-write the index is meant to prevent. Empty string
+-- gets the same treatment because Anthropic shouldn't return one
+-- and we'd rather fail loud than silently group all blanks
+-- together as one item. Postgres rejects empty CHECK names so
+-- we use a DO-block guard for re-run safety.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'llm_usage_batch_requires_custom_id'
+    ) THEN
+        ALTER TABLE llm_usage
+        ADD CONSTRAINT llm_usage_batch_requires_custom_id
+        CHECK (
+            batch_id IS NULL
+            OR (custom_id IS NOT NULL AND custom_id <> '')
+        );
+    END IF;
+END $$;
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_usage_batch_item
     ON llm_usage (account_id, batch_id, custom_id)
     WHERE batch_id IS NOT NULL;

--- a/atlas_brain/storage/migrations/320_llm_usage_batch_unique_index.sql
+++ b/atlas_brain/storage/migrations/320_llm_usage_batch_unique_index.sql
@@ -1,0 +1,35 @@
+-- LLM Gateway batch per-item idempotency: UNIQUE index (PR-D4d).
+--
+-- Companion to 319 (column adds + CHECK constraint). Split out
+-- because ``CREATE INDEX CONCURRENTLY`` can't run inside a
+-- transaction block -- atlas's migration runner sends each .sql
+-- file as its own statement, so a single-statement file is the
+-- guaranteed-safe pattern (mirrors migration 090).
+--
+-- Why CONCURRENTLY: regular CREATE UNIQUE INDEX takes
+-- ACCESS EXCLUSIVE on llm_usage during the build, which blocks
+-- live inserts for the duration. atlas's pipeline writes 100k+
+-- rows/month into llm_usage; a multi-second lock during a
+-- production deploy would stall request handling. CONCURRENTLY
+-- builds in the background with only a SHARE UPDATE EXCLUSIVE
+-- lock, which is compatible with concurrent INSERTs.
+--
+-- Why ``custom_id IS NOT NULL`` in the predicate (Copilot on
+-- PR-D4d): the partial UNIQUE alone wouldn't dedup rows with
+-- NULL custom_id (NULLs are distinct in PG UNIQUE indexes).
+-- The CHECK in 319 already forbids that combination, but
+-- including the predicate here is defense-in-depth -- if the
+-- CHECK is ever disabled or NOT VALID, the index still won't
+-- index NULL rows, so the failure mode is "insert succeeds,
+-- doesn't dedup" rather than "insert succeeds, falsely passes
+-- as unique."
+--
+-- Per-item idempotency end-to-end:
+-- _persist_batch_usage emits INSERT ... ON CONFLICT
+-- (account_id, batch_id, custom_id) DO NOTHING. A retry that
+-- re-emits already-written rows no-ops at the DB level instead
+-- of double-counting against the customer's billing rollup.
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_llm_usage_batch_item
+    ON llm_usage (account_id, batch_id, custom_id)
+    WHERE batch_id IS NOT NULL AND custom_id IS NOT NULL;

--- a/atlas_brain/storage/migrations/321_llm_usage_batch_lookup_index.sql
+++ b/atlas_brain/storage/migrations/321_llm_usage_batch_lookup_index.sql
@@ -1,0 +1,18 @@
+-- LLM Gateway batch lookup helper index (PR-D4d).
+--
+-- Companion to 319 + 320. Separate file because
+-- ``CREATE INDEX CONCURRENTLY`` cannot share a transaction
+-- with anything else -- one CONCURRENTLY per migration file is
+-- the guaranteed-safe pattern (see migration 090).
+--
+-- Use case: /api/v1/llm/usage rollups that want to break out
+-- batch traffic by submission (e.g., "what did I spend on
+-- batch_id X?"). The composite (batch_id, created_at DESC)
+-- ordering matches the typical "show me this batch's items
+-- newest-first" query shape. Predicate-only (batch_id IS NOT
+-- NULL) so the index doesn't bloat with the high-volume sync
+-- /chat traffic.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_llm_usage_batch_id
+    ON llm_usage (batch_id, created_at DESC)
+    WHERE batch_id IS NOT NULL;

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -47,6 +47,25 @@ def test_migration_318_index_for_pending_usage_writes():
     assert "AND status IN ('ended', 'canceled', 'expired')" in sql
 
 
+# ---- Migration 319: per-item llm_usage uniqueness ----------------------
+
+
+def test_migration_319_adds_batch_columns_and_unique_index():
+    """PR-D4d post-audit: per-item idempotency at the DB level.
+    batch_id + custom_id columns + partial UNIQUE index on
+    (account_id, batch_id, custom_id) WHERE batch_id IS NOT NULL
+    so retries of _persist_batch_usage can ON CONFLICT DO NOTHING
+    on rows that already landed."""
+    sql = _read_migration("319_llm_usage_batch_uniqueness.sql")
+    # New columns nullable so existing /chat traffic still inserts cleanly.
+    assert "ADD COLUMN IF NOT EXISTS batch_id  UUID" in sql
+    assert "ADD COLUMN IF NOT EXISTS custom_id TEXT" in sql
+    # Partial UNIQUE index scoped to batch rows only.
+    assert "uq_llm_usage_batch_item" in sql
+    assert "(account_id, batch_id, custom_id)" in sql
+    assert "WHERE batch_id IS NOT NULL" in sql
+
+
 # ---- submit_customer_batch idempotency ----------------------------------
 
 
@@ -159,6 +178,30 @@ def test_submit_customer_batch_replay_only_when_provider_batch_id_set():
     assert 'or existing["status"] != "queued"' not in src
 
 
+def test_in_flight_replay_re_reads_row_before_returning():
+    """PR-D4d post-audit: when the resume claim returns None
+    (recent in-flight call or another retry already claimed it),
+    we must re-read the row before returning. The original
+    ``existing`` snapshot was taken before the claim attempt,
+    so a concurrent retry that just succeeded (set
+    provider_batch_id, transitioned to in_progress) would be
+    invisible to the snapshot. Customer would see stale data."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    in_flight_idx = src.find("if resumed is None:")
+    re_read_idx = src.find("latest = await pool.fetchrow(")
+    log_idx = src.find('"llm_gateway_batch.submit replay (in-flight) "')
+    return_idx = src.rfind("return _row_to_record(replay_row)")
+    assert in_flight_idx > 0 and re_read_idx > 0
+    assert in_flight_idx < re_read_idx < log_idx
+    assert log_idx < return_idx
+    # The returned record uses the freshly-read row (or the
+    # snapshot as a defensive fallback if the row vanished --
+    # which shouldn't happen under normal flow).
+    assert "replay_row = latest if latest is not None else existing" in src
+
+
 # ---- Router Idempotency-Key header --------------------------------------
 
 
@@ -194,58 +237,81 @@ def test_persist_batch_usage_helper_exists():
     assert inspect.iscoroutinefunction(llm_gateway_batch._persist_batch_usage)
 
 
-def test_persist_batch_usage_idempotent_via_atomic_claim():
-    """The function must atomically transition usage_tracked
-    FALSE->TRUE before doing the work. A concurrent poller losing
-    the race is a no-op (claim returns no rows). Codex P1 + Copilot
-    on PR-D4c: claim is also account-scoped so a misrouted batch_id
-    can never flip the flag on a row outside the caller's account."""
+def test_persist_batch_usage_idempotent_via_on_conflict():
+    """PR-D4d post-audit: per-item idempotency comes from the
+    UNIQUE (account_id, batch_id, custom_id) partial index in
+    migration 319 + ``ON CONFLICT DO NOTHING`` on the INSERT.
+    A retry that hits an already-written row no-ops at the DB
+    level instead of double-writing. The ``usage_tracked`` flag
+    flip at the end is account-scoped so cross-account batch_id
+    reuse can never flip a foreign row."""
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    # Per-item dedup at DB level.
+    assert "ON CONFLICT (account_id, batch_id, custom_id)" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
+    assert "WHERE batch_id IS NOT NULL" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
+    assert "DO NOTHING" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
+    # Account-scoped flag flip.
     assert "WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE" in src
-    assert "RETURNING id" in src
-    # Loser path returns cleanly.
-    assert "if claim is None:" in src
 
 
-def test_persist_batch_usage_pre_fetches_before_claiming():
-    """Codex P1 + Copilot fix on PR-D4c: the SDK results fetch must
-    happen BEFORE the atomic claim, not after. Otherwise a transient
-    SDK error mid-iteration would happen with usage_tracked already
-    flipped to TRUE -- the rollback-then-retry pattern would re-emit
-    the items that already landed and double-count against the
-    customer. Pre-fetching means failures here leave usage_tracked
-    FALSE (no claim was made) so the next poll retries cleanly."""
+def test_persist_batch_usage_pre_fetches_before_writing():
+    """PR-D4d: the Anthropic results fetch must happen BEFORE any
+    DB writes. SDK failures during the fetch leave usage_tracked
+    FALSE so the next poll retries cleanly with no partial DB
+    state visible."""
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
     fetch_idx = src.find("client.messages.batches.results")
-    claim_idx = src.find("SET usage_tracked = TRUE")
-    assert fetch_idx > 0 and claim_idx > 0, "Both phases must be present"
-    assert fetch_idx < claim_idx, (
-        "Results fetch must precede the atomic claim so SDK failures "
-        "don't leave the row in an unrecoverable claimed state."
+    insert_idx = src.find("conn.executemany(")
+    flag_idx = src.find("SET usage_tracked = TRUE")
+    assert fetch_idx > 0 and insert_idx > 0 and flag_idx > 0
+    assert fetch_idx < insert_idx < flag_idx, (
+        "Order must be: fetch results -> insert rows -> flip flag. "
+        "Any other ordering re-introduces the partial-write loss the "
+        "PR-D4d audit found."
     )
 
 
-def test_persist_batch_usage_does_not_roll_back_after_claim():
-    """Codex P1 + Copilot on PR-D4c: once the claim flips
-    usage_tracked to TRUE, we must NOT roll it back to FALSE on
-    subsequent failures. trace_llm_call failures during the persist
-    phase are logged loudly but the claim stays TRUE so retries
-    can't double-emit the items that already landed. A pending-
-    usage index in migration 318 lets ops scan for orphaned
-    partial-write batches."""
+def test_persist_batch_usage_writes_directly_via_pool():
+    """PR-D4d post-audit fix: PR-D4c routed per-item writes through
+    ``trace_llm_call`` -> tracer.end_span -> loop.create_task --
+    fire-and-forget, so DB failures could not be caught and the
+    flag was flipped before writes actually landed. PR-D4d issues
+    the INSERT directly via pool.executemany under a transaction
+    so failures surface synchronously."""
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
-    # No rollback statement.
-    assert "SET usage_tracked = FALSE" not in src
-    # But trace_llm_call failures still log so ops can see them.
-    assert (
-        'logger.exception(\n                '
-        '"llm_gateway_batch.persist_usage: trace_llm_call failed' in src
+    # Direct executemany under explicit transaction.
+    assert "async with pool.acquire() as conn:" in src
+    assert "async with conn.transaction():" in src
+    assert "await conn.executemany(_BATCH_USAGE_INSERT_SQL" in src
+    # No more fire-and-forget tracer for batch items.
+    # (docstring may reference the old approach by name; what we
+    # care about is the absence of an actual call site or import).
+    assert "trace_llm_call(" not in src
+    assert "from ..pipelines.llm import trace_llm_call" not in src
+
+
+def test_persist_batch_usage_flips_flag_only_after_inserts():
+    """PR-D4d: the usage_tracked flip happens AFTER conn.executemany
+    returns successfully. If the inserts raise (transient asyncpg
+    error, schema drift), the flag stays FALSE so a retry can
+    re-attempt. Conflicts on already-written items are absorbed
+    by ON CONFLICT DO NOTHING, not by skipping the flip."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    insert_idx = src.find("conn.executemany(_BATCH_USAGE_INSERT_SQL")
+    flag_update_idx = src.find("SET usage_tracked = TRUE")
+    assert insert_idx > 0 and flag_update_idx > 0
+    assert insert_idx < flag_update_idx, (
+        "The flag must flip only after inserts commit. Otherwise the "
+        "round-trip through the fire-and-forget tracer reintroduces "
+        "the partial-write loss the audit caught."
     )
 
 
@@ -271,16 +337,29 @@ def test_persist_batch_usage_applies_50_percent_discount():
     assert "_BATCH_DISCOUNT_FACTOR" in src
 
 
-def test_persist_batch_usage_threads_account_id_into_metadata():
-    """Same metadata pattern as /chat -- per-account scoping in
-    llm_usage requires account_id in the trace metadata so PR-D3's
-    INSERT picks it up."""
+def test_persist_batch_usage_threads_account_id_into_row():
+    """PR-D3 per-account scoping requires account_id on each
+    llm_usage row. PR-D4d writes the column directly (rather than
+    through tracer metadata) and also records batch_id + custom_id
+    natively so the partial UNIQUE index can dedup retries."""
     from atlas_brain.services import llm_gateway_batch
 
+    sql = llm_gateway_batch._BATCH_USAGE_INSERT_SQL
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
+    # account_id, batch_id, custom_id are explicit columns now.
+    assert "account_id" in sql
+    assert "batch_id" in sql
+    assert "custom_id" in sql
+    # Args tuple threads them into the INSERT.
+    assert "str(account_id)" in src
+    assert "batch_id" in src
+    assert 'item["custom_id"]' in src
+    # Metadata payload still carries the same triplet so /api/v1/llm/usage
+    # consumers that read metadata.endpoint / metadata.batch_id keep
+    # working (non-breaking change for any downstream rollups).
     assert '"account_id": str(account_id)' in src
     assert '"batch_id": str(batch_id)' in src
-    assert '"custom_id": custom_id' in src
+    assert '"custom_id": item["custom_id"]' in src
 
 
 def test_persist_batch_usage_uses_async_with():

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -71,6 +71,22 @@ def test_migration_319_adds_batch_columns_and_unique_index():
     assert "WHERE batch_id IS NOT NULL" in sql
 
 
+def test_migration_319_check_constraint_blocks_null_or_blank_custom_id():
+    """Copilot on PR-D4d: a NULL custom_id is treated as distinct
+    in UNIQUE indexes, so the partial UNIQUE alone doesn't prevent
+    double-write. CHECK constraint enforces the invariant at the
+    DB level: any row with batch_id set MUST have a non-empty
+    custom_id."""
+    sql = _read_migration("319_llm_usage_batch_uniqueness.sql")
+    assert "llm_usage_batch_requires_custom_id" in sql
+    assert (
+        "CHECK (\n"
+        "            batch_id IS NULL\n"
+        "            OR (custom_id IS NOT NULL AND custom_id <> '')\n"
+        "        )"
+    ) in sql
+
+
 # ---- submit_customer_batch idempotency ----------------------------------
 
 
@@ -474,12 +490,16 @@ class _FakePool:
       - ``transaction()`` -- async context manager yielding a conn
         (matches storage/database.py:144).
       - ``execute()`` -- awaitable for the post-insert flag flip.
+      - ``fetchval()`` -- awaitable for the short-circuit check
+        on ``usage_tracked`` (PR-D4d Copilot).
       - DOES NOT implement ``acquire()``, so any code that tries
         the wrong primitive blows up immediately."""
 
-    def __init__(self) -> None:
+    def __init__(self, usage_tracked: bool = False) -> None:
         self.conn = _FakePoolConn()
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.fetchval_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self._usage_tracked = usage_tracked
 
     @asynccontextmanager
     async def transaction(self):
@@ -487,6 +507,14 @@ class _FakePool:
 
     async def execute(self, query: str, *args: Any) -> None:
         self.execute_calls.append((query, args))
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append((query, args))
+        # Mirror real DB behaviour: SELECT usage_tracked returns the
+        # column's bool value (or None if no matching row).
+        if "SELECT usage_tracked" in query:
+            return self._usage_tracked
+        return None
 
 
 class _FakeAnthropicResultEntry:
@@ -611,6 +639,112 @@ def test_persist_batch_usage_runtime_smoke():
     assert "SET usage_tracked = TRUE" in flag_sql
     assert "WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE" in flag_sql
     assert flag_args == (batch_id, account_id)
+
+
+def test_persist_batch_usage_short_circuits_when_already_tracked():
+    """Copilot on PR-D4d: when a concurrent poller already
+    persisted usage and flipped the flag, _persist_batch_usage
+    should skip the (potentially expensive) Anthropic results
+    fetch and exit immediately. Saves provider calls under
+    polling races; correctness is preserved either way (the flag
+    flip is idempotent + account-scoped)."""
+    from atlas_brain.services import llm_gateway_batch
+
+    pool = _FakePool(usage_tracked=True)
+
+    # Anthropic factory shouldn't be touched because the short-
+    # circuit fires first. Wire one that asserts if called.
+    sentinel: dict[str, bool] = {"sdk_called": False}
+
+    def _exploding_anthropic_factory(*args, **kwargs):
+        sentinel["sdk_called"] = True
+        return _FakeAsyncAnthropic(entries=[])
+
+    with patch("anthropic.AsyncAnthropic", _exploding_anthropic_factory):
+        asyncio.run(llm_gateway_batch._persist_batch_usage(
+            pool,
+            account_id=_uuid.uuid4(),
+            batch_id=_uuid.uuid4(),
+            provider_batch_id="msgbatch_already_tracked",
+            model="claude-haiku-4-5-20251001",
+            api_key="test-key",
+        ))
+
+    # Pre-check ran.
+    assert len(pool.fetchval_calls) == 1
+    assert "SELECT usage_tracked" in pool.fetchval_calls[0][0]
+    # SDK was NOT called.
+    assert sentinel["sdk_called"] is False
+    # No inserts, no flag flip.
+    assert pool.conn.executemany_calls == []
+    assert pool.execute_calls == []
+
+
+def test_persist_batch_usage_rejects_blank_custom_id():
+    """Copilot on PR-D4d: a blank custom_id from the provider
+    would be silently absorbed by ON CONFLICT (NULL/'' treated as
+    distinct in the UNIQUE index), but we'd still flip
+    usage_tracked TRUE and undercount. Raise instead so the flag
+    stays FALSE for retry / ops triage."""
+    from atlas_brain.services import llm_gateway_batch
+
+    pool = _FakePool()
+    entries = [_FakeAnthropicResultEntry("", 100, 50)]
+
+    def _fake_anthropic_factory(*args, **kwargs):
+        return _FakeAsyncAnthropic(entries=entries)
+
+    with patch("anthropic.AsyncAnthropic", _fake_anthropic_factory):
+        try:
+            asyncio.run(llm_gateway_batch._persist_batch_usage(
+                pool,
+                account_id=_uuid.uuid4(),
+                batch_id=_uuid.uuid4(),
+                provider_batch_id="msgbatch_blank",
+                model="claude-haiku-4-5-20251001",
+                api_key="test-key",
+            ))
+            raise AssertionError("expected ValueError")
+        except ValueError as exc:
+            assert "blank custom_id" in str(exc)
+
+    # No inserts, no flag flip -- usage_tracked stays FALSE so retry works.
+    assert pool.conn.executemany_calls == []
+    assert pool.execute_calls == []
+
+
+def test_persist_batch_usage_rejects_duplicate_custom_id():
+    """Copilot on PR-D4d: duplicate custom_id within a single
+    batch result set would have the second row absorbed by
+    ON CONFLICT, again undercounting silently. Detect at the
+    Python layer before any DB write."""
+    from atlas_brain.services import llm_gateway_batch
+
+    pool = _FakePool()
+    entries = [
+        _FakeAnthropicResultEntry("dup", 100, 50),
+        _FakeAnthropicResultEntry("dup", 200, 75),
+    ]
+
+    def _fake_anthropic_factory(*args, **kwargs):
+        return _FakeAsyncAnthropic(entries=entries)
+
+    with patch("anthropic.AsyncAnthropic", _fake_anthropic_factory):
+        try:
+            asyncio.run(llm_gateway_batch._persist_batch_usage(
+                pool,
+                account_id=_uuid.uuid4(),
+                batch_id=_uuid.uuid4(),
+                provider_batch_id="msgbatch_dup",
+                model="claude-haiku-4-5-20251001",
+                api_key="test-key",
+            ))
+            raise AssertionError("expected ValueError")
+        except ValueError as exc:
+            assert "duplicate custom_id" in str(exc)
+
+    assert pool.conn.executemany_calls == []
+    assert pool.execute_calls == []
 
 
 def test_persist_batch_usage_skips_db_when_no_succeeded_items():

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -55,20 +55,18 @@ def test_migration_318_index_for_pending_usage_writes():
 # ---- Migration 319: per-item llm_usage uniqueness ----------------------
 
 
-def test_migration_319_adds_batch_columns_and_unique_index():
-    """PR-D4d post-audit: per-item idempotency at the DB level.
-    batch_id + custom_id columns + partial UNIQUE index on
-    (account_id, batch_id, custom_id) WHERE batch_id IS NOT NULL
-    so retries of _persist_batch_usage can ON CONFLICT DO NOTHING
-    on rows that already landed."""
+def test_migration_319_adds_batch_columns():
+    """PR-D4d post-audit: batch_id + custom_id columns on llm_usage
+    so per-item batch rows have a natural key. Index creates moved
+    to migrations 320/321 (CONCURRENTLY can't share a transaction
+    with other DDL)."""
     sql = _read_migration("319_llm_usage_batch_uniqueness.sql")
     # New columns nullable so existing /chat traffic still inserts cleanly.
     assert "ADD COLUMN IF NOT EXISTS batch_id  UUID" in sql
     assert "ADD COLUMN IF NOT EXISTS custom_id TEXT" in sql
-    # Partial UNIQUE index scoped to batch rows only.
-    assert "uq_llm_usage_batch_item" in sql
-    assert "(account_id, batch_id, custom_id)" in sql
-    assert "WHERE batch_id IS NOT NULL" in sql
+    # Indexes deliberately NOT in this migration (see 320, 321).
+    assert "uq_llm_usage_batch_item" not in sql
+    assert "idx_llm_usage_batch_id" not in sql
 
 
 def test_migration_319_check_constraint_blocks_null_or_blank_custom_id():
@@ -85,6 +83,32 @@ def test_migration_319_check_constraint_blocks_null_or_blank_custom_id():
         "            OR (custom_id IS NOT NULL AND custom_id <> '')\n"
         "        )"
     ) in sql
+
+
+def test_migration_320_creates_unique_index_concurrently():
+    """Copilot on PR-D4d: CREATE UNIQUE INDEX without CONCURRENTLY
+    takes ACCESS EXCLUSIVE on llm_usage and blocks live inserts.
+    Migration 320 isolates the index build so it uses
+    CONCURRENTLY (which can't share a transaction with other DDL).
+    Predicate also filters custom_id IS NOT NULL as defense-in-
+    depth -- the CHECK in 319 enforces it but the index predicate
+    keeps the safety even if the constraint is ever NOT VALID."""
+    sql = _read_migration("320_llm_usage_batch_unique_index.sql")
+    assert "CREATE UNIQUE INDEX CONCURRENTLY" in sql
+    assert "uq_llm_usage_batch_item" in sql
+    assert "(account_id, batch_id, custom_id)" in sql
+    assert "WHERE batch_id IS NOT NULL AND custom_id IS NOT NULL" in sql
+
+
+def test_migration_321_creates_lookup_index_concurrently():
+    """Companion lookup index for /api/v1/llm/usage rollups that
+    break out batch traffic by submission. CONCURRENTLY for the
+    same production-safety reason as 320."""
+    sql = _read_migration("321_llm_usage_batch_lookup_index.sql")
+    assert "CREATE INDEX CONCURRENTLY" in sql
+    assert "idx_llm_usage_batch_id" in sql
+    assert "(batch_id, created_at DESC)" in sql
+    assert "WHERE batch_id IS NOT NULL" in sql
 
 
 # ---- submit_customer_batch idempotency ----------------------------------
@@ -269,9 +293,11 @@ def test_persist_batch_usage_idempotent_via_on_conflict():
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
-    # Per-item dedup at DB level.
+    # Per-item dedup at DB level. ON CONFLICT predicate must match
+    # migration 320's index predicate exactly or Postgres can't
+    # use the index for conflict resolution.
     assert "ON CONFLICT (account_id, batch_id, custom_id)" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
-    assert "WHERE batch_id IS NOT NULL" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
+    assert "WHERE batch_id IS NOT NULL AND custom_id IS NOT NULL" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
     assert "DO NOTHING" in llm_gateway_batch._BATCH_USAGE_INSERT_SQL
     # Account-scoped flag flip.
     assert "WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE" in src

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -7,8 +7,13 @@ fixtures and are gated on a running Postgres.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import uuid as _uuid
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 
 _MIG_DIR = Path(__file__).resolve().parent.parent / "atlas_brain" / "storage" / "migrations"
@@ -285,10 +290,15 @@ def test_persist_batch_usage_writes_directly_via_pool():
     from atlas_brain.services import llm_gateway_batch
 
     src = inspect.getsource(llm_gateway_batch._persist_batch_usage)
-    # Direct executemany under explicit transaction.
-    assert "async with pool.acquire() as conn:" in src
-    assert "async with conn.transaction():" in src
+    # Direct executemany under pool.transaction() -- atlas's
+    # DatabasePool.acquire is async-def-returning-connection, NOT
+    # an async context manager, so async-with-acquire would raise
+    # at runtime. pool.transaction() handles the acquire + tx scope
+    # in one block. Codex P1 fix on PR-D4d.
+    assert "async with pool.transaction() as conn:" in src
     assert "await conn.executemany(_BATCH_USAGE_INSERT_SQL" in src
+    # The buggy acquire() pattern must not return.
+    assert "async with pool.acquire()" not in src
     # No more fire-and-forget tracer for batch items.
     # (docstring may reference the old approach by name; what we
     # care about is the absence of an actual call site or import).
@@ -441,3 +451,192 @@ def test_estimate_cost_uses_atlas_pricing_config():
     src = inspect.getsource(llm_gateway_batch._estimate_cost_usd)
     assert "settings.ftl_tracing.pricing.cost_usd" in src
     assert '"anthropic"' in src
+
+
+# ---- Runtime smoke (catches "wrong primitive" class of bugs) -----------
+
+
+class _FakePoolConn:
+    """Records executemany calls so the smoke test can assert the
+    INSERT was issued with the expected args. Mirrors asyncpg's
+    Connection.executemany signature (just enough for our path)."""
+
+    def __init__(self) -> None:
+        self.executemany_calls: list[tuple[str, list[tuple[Any, ...]]]] = []
+
+    async def executemany(self, query: str, args: list[tuple[Any, ...]]) -> None:
+        self.executemany_calls.append((query, args))
+
+
+class _FakePool:
+    """Minimal stand-in for atlas's DatabasePool used to runtime-
+    exercise _persist_batch_usage. Implements:
+      - ``transaction()`` -- async context manager yielding a conn
+        (matches storage/database.py:144).
+      - ``execute()`` -- awaitable for the post-insert flag flip.
+      - DOES NOT implement ``acquire()``, so any code that tries
+        the wrong primitive blows up immediately."""
+
+    def __init__(self) -> None:
+        self.conn = _FakePoolConn()
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self.conn
+
+    async def execute(self, query: str, *args: Any) -> None:
+        self.execute_calls.append((query, args))
+
+
+class _FakeAnthropicResultEntry:
+    def __init__(self, custom_id: str, input_tokens: int, output_tokens: int):
+        self.custom_id = custom_id
+
+        class _Usage:
+            pass
+        u = _Usage()
+        u.input_tokens = input_tokens
+        u.output_tokens = output_tokens
+        u.cache_read_input_tokens = 0
+        u.cache_creation_input_tokens = 0
+
+        class _Message:
+            pass
+        m = _Message()
+        m.usage = u
+        m.id = f"msg_{custom_id}"
+
+        class _Result:
+            pass
+        r = _Result()
+        r.type = "succeeded"
+        r.message = m
+
+        self.result = r
+
+
+class _FakeAsyncIter:
+    def __init__(self, entries):
+        self._entries = list(entries)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._entries:
+            raise StopAsyncIteration
+        return self._entries.pop(0)
+
+
+class _FakeBatchesResource:
+    def __init__(self, entries):
+        self._entries = entries
+
+    async def results(self, provider_batch_id: str):
+        return _FakeAsyncIter(self._entries)
+
+
+class _FakeMessagesResource:
+    def __init__(self, entries):
+        self.batches = _FakeBatchesResource(entries)
+
+
+class _FakeAsyncAnthropic:
+    """Stands in for AsyncAnthropic. Supports async-with for the
+    connection-pool teardown the real client does."""
+
+    def __init__(self, *args, entries=None, **kwargs):
+        self.messages = _FakeMessagesResource(entries or [])
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def test_persist_batch_usage_runtime_smoke():
+    """Catches the "wrong primitive" class of bug: source-text
+    pins passed for `async with pool.acquire()` but it would have
+    raised at runtime because atlas's DatabasePool.acquire is a
+    plain async-def. This smoke test exercises the full path with
+    a fake pool that only implements the correct interface, so
+    any future regression is caught at test time."""
+    from atlas_brain.services import llm_gateway_batch
+
+    pool = _FakePool()
+    account_id = _uuid.uuid4()
+    batch_id = _uuid.uuid4()
+    entries = [
+        _FakeAnthropicResultEntry("item-1", 100, 50),
+        _FakeAnthropicResultEntry("item-2", 200, 75),
+    ]
+
+    def _fake_anthropic_factory(*args, **kwargs):
+        return _FakeAsyncAnthropic(entries=entries)
+
+    with patch("anthropic.AsyncAnthropic", _fake_anthropic_factory):
+        asyncio.run(llm_gateway_batch._persist_batch_usage(
+            pool,
+            account_id=account_id,
+            batch_id=batch_id,
+            provider_batch_id="msgbatch_test",
+            model="claude-haiku-4-5-20251001",
+            api_key="test-key",
+        ))
+
+    # executemany was called once with both rows.
+    assert len(pool.conn.executemany_calls) == 1
+    sql, args = pool.conn.executemany_calls[0]
+    assert "INSERT INTO llm_usage" in sql
+    assert "ON CONFLICT (account_id, batch_id, custom_id)" in sql
+    assert len(args) == 2
+    # args tuple positions: span_name, model, input_tok, output_tok, total,
+    # billable_in, cached, cache_write, cost, metadata, endpoint,
+    # provider_request_id, account_id, batch_id, custom_id
+    assert args[0][0] == "llm_gateway.batch_item"  # span_name
+    assert args[0][1] == "claude-haiku-4-5-20251001"  # model
+    assert args[0][2] == 100  # input_tokens
+    assert args[0][3] == 50   # output_tokens
+    assert args[0][4] == 150  # total_tokens
+    assert args[0][13] == batch_id  # batch_id
+    assert args[0][14] == "item-1"  # custom_id
+    assert args[1][14] == "item-2"  # custom_id of second item
+
+    # Flag flip ran AFTER the insert -- check both ordering and the
+    # account-scoped predicate.
+    assert len(pool.execute_calls) == 1
+    flag_sql, flag_args = pool.execute_calls[0]
+    assert "SET usage_tracked = TRUE" in flag_sql
+    assert "WHERE id = $1 AND account_id = $2 AND usage_tracked = FALSE" in flag_sql
+    assert flag_args == (batch_id, account_id)
+
+
+def test_persist_batch_usage_skips_db_when_no_succeeded_items():
+    """If the batch had only errored / canceled items, items_to_persist
+    is empty -- we should NOT issue an executemany (asyncpg raises on
+    empty rows-args) but we SHOULD still flip the flag so the
+    refresh path doesn't keep retrying."""
+    from atlas_brain.services import llm_gateway_batch
+
+    pool = _FakePool()
+    # Empty entries iterator -> nothing to persist.
+    def _fake_anthropic_factory(*args, **kwargs):
+        return _FakeAsyncAnthropic(entries=[])
+
+    with patch("anthropic.AsyncAnthropic", _fake_anthropic_factory):
+        asyncio.run(llm_gateway_batch._persist_batch_usage(
+            pool,
+            account_id=_uuid.uuid4(),
+            batch_id=_uuid.uuid4(),
+            provider_batch_id="msgbatch_empty",
+            model="claude-haiku-4-5-20251001",
+            api_key="test-key",
+        ))
+
+    # No executemany call (no rows to write).
+    assert pool.conn.executemany_calls == []
+    # But flag flip still ran -- otherwise refresh keeps retrying.
+    assert len(pool.execute_calls) == 1
+    assert "SET usage_tracked = TRUE" in pool.execute_calls[0][0]


### PR DESCRIPTION
## Summary

Closes the SEVERE finding from the PR-D4c post-merge audit: per-item batch usage writes were going through the fire-and-forget tracer (`trace_llm_call` → `tracer.end_span` → `loop.create_task`), so:

- The `try/except` around the call only caught synchronous span construction errors. Actual `INSERT INTO llm_usage` failures in the spawned task were silenced (asyncio task exceptions don't propagate; they're logged on GC).
- `usage_tracked = TRUE` flipped BEFORE writes landed. A process crash between `_persist_batch_usage` returning and the queued tasks completing would lose customer billing data permanently. The pending-usage index from migration 318 could not surface the row because the flag was already TRUE.

## Three coordinated changes

**1. Migration 319** — add `batch_id` (UUID) + `custom_id` (TEXT) columns to `llm_usage` plus a partial `UNIQUE (account_id, batch_id, custom_id) WHERE batch_id IS NOT NULL`. Existing /chat inserts (where `batch_id` is NULL) are unaffected; the partial index excludes them entirely.

**2. `_persist_batch_usage` rewritten as three explicit phases**:
   - **Phase 1**: Pre-fetch results from Anthropic into memory.
   - **Phase 2**: INSERT all rows directly via `pool.executemany` under a transaction, with `ON CONFLICT DO NOTHING` so retries can safely re-emit any subset of rows.
   - **Phase 3**: Flip `usage_tracked = TRUE` only after the inserts commit.

   Failures at each phase surface synchronously to the caller, so `refresh_customer_batch_status`'s `try/except` now actually means something.

**3. Submit in-flight replay** re-reads the row before returning instead of using the snapshot taken before the resume claim. A concurrent retry that succeeded between SELECT and claim would otherwise leave the customer seeing stale data.

## Why ON CONFLICT DO NOTHING is the right call here

The advisor flagged this exact pattern when the alternative ("flip flag last; if anything fails, retry from scratch") was on the table. Direct retry-from-scratch double-counts because `INSERT INTO llm_usage` has no natural primary key for batch items. With the `(account_id, batch_id, custom_id)` UNIQUE index, retries become safely idempotent at the DB level — partial-write loss is impossible because we never claim the flag until ALL inserts have committed, and a retry that hits already-written rows no-ops via the conflict clause.

## Audit findings deliberately left for follow-up PRs

- Resume-after-60s can duplicate-pay if local UPDATE failed after Anthropic accepted (medium #2 in audit) — needs Anthropic-side idempotency on `batches.create`.
- Retry-on-terminal lacks rate limiting (medium #4) — storms are operationally bounded but worth a backoff.
- Minor display inconsistencies (completed_at on resume, total_items / model on retry-with-different-args).

## Test plan

- [x] 28 tests in `test_llm_gateway_idempotency_usage.py` (was 25; +3 new pinning the new contract, 4 rewritten to match post-PR-D4c semantics)
- [x] Full LLM-gateway + auth + plan-tier + scoping suite: 218 passed
- [x] ASCII compliance verified
- [x] No inline hard-coded values (all literals → module constants)
- [x] No breaking changes to dependent code (`_persist_batch_usage` signature unchanged; only same-file callers)
- [ ] Codex / Copilot review
- [ ] Migration 319 applied in staging before merge

## Phase ordering safety check

The new code is also robust under concurrent pollers:

```
Poller A: pre-fetch → executemany (writes rows 1..N) → flag flip succeeds
Poller B: pre-fetch → executemany (all rows hit ON CONFLICT, no-op) → flag flip's WHERE usage_tracked=FALSE matches no rows → no-op
```

Either ordering is safe; no double-counting, no race window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
