### PR TITLE
Add hosted campaign draft generation trigger

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T14:10Z by codex-2026-05-05-d9
+Last updated: 2026-05-05T14:15Z by codex-2026-05-05-d10
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| TBD | D10 hosted campaign draft generation API trigger | `extracted_content_pipeline/api/campaign_operations.py`, `tests/test_extracted_campaign_api_operations.py`, content pipeline docs/status | codex-2026-05-05-d10 | Avoid adding campaign generation HTTP triggers or editing the same operations router until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -373,10 +373,11 @@ python scripts/progress_extracted_campaign_sequences.py \
   --json
 ```
 
-Hosts with FastAPI apps can mount the same send, sequence progression, and
-analytics worker triggers through a hosted operations router. The host injects
-its database pool, sender, optional LLM/skill providers, and auth dependencies;
-request payloads only control batch limits.
+Hosts with FastAPI apps can mount draft generation, send, sequence progression,
+and analytics worker triggers through a hosted operations router. The host
+injects its database pool, sender, optional LLM/skill/reasoning providers, and
+auth dependencies; request payloads only control tenant scope, target/channel,
+filters, and batch sizing.
 
 ```python
 from fastapi import Depends
@@ -393,6 +394,7 @@ app.include_router(
         sender_provider=get_campaign_sender,
         llm_provider=get_campaign_llm,
         skills_provider=get_campaign_skills,
+        reasoning_context_provider=get_campaign_reasoning_context,
         config=CampaignOperationsApiConfig(
             send_default_from_email="audit@customer.com",
             sequence_from_email="audit@customer.com",
@@ -402,7 +404,8 @@ app.include_router(
 )
 ```
 
-This adds `POST /campaigns/operations/send/queued`,
+This adds `POST /campaigns/operations/drafts/generate`,
+`POST /campaigns/operations/send/queued`,
 `POST /campaigns/operations/sequences/progress`, and
 `POST /campaigns/operations/analytics/refresh` without exposing provider
 credentials, sender identity, unsubscribe policy, or LLM configuration through
@@ -508,7 +511,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `api/campaign_webhooks.py`: optional FastAPI router factory for host-mounted
   campaign webhook and unsubscribe routes
 - `api/campaign_operations.py`: optional FastAPI router factory for
-  host-mounted send, sequence progression, and analytics operation triggers
+  host-mounted draft generation, send, sequence progression, and analytics
+  operation triggers
 - `api/b2b_campaigns.py`: optional FastAPI router factory for host-mounted
   B2B draft list/export/review routes
 - `api/seller_campaigns.py`: optional FastAPI router factory for host-mounted

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -71,9 +71,10 @@
   unsubscribe-token verifier, and any auth dependencies instead of importing
   Atlas API globals.
 - `api.campaign_operations` provides a FastAPI router factory around hosted
-  send, sequence progression, and analytics refresh triggers. Hosts inject the
-  database, sender, optional LLM/skill providers, and auth dependencies; HTTP
-  payloads only control batch sizing.
+  draft generation, send, sequence progression, and analytics refresh triggers.
+  Hosts inject the database, sender, optional LLM/skill/reasoning providers,
+  and auth dependencies; HTTP payloads only control tenant scope,
+  target/channel, filters, and batch sizing.
 - `campaign_postgres_sequence_progression` provides a DB-backed follow-up
   generation worker seam. Hosts reuse due `campaign_sequences` rows, packaged
   or custom sequence prompts, and the product LLM port to queue the next

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -17,7 +17,9 @@ except ImportError as exc:  # pragma: no cover - exercised in dependency-light C
 else:
     _FASTAPI_IMPORT_ERROR = None
 
-from ..campaign_ports import CampaignSender, LLMClient, SkillStore
+from ..campaign_generation import CampaignGenerationConfig
+from ..campaign_ports import CampaignSender, LLMClient, SkillStore, TenantScope
+from ..campaign_postgres_generation import generate_campaign_drafts_from_postgres
 from ..campaign_postgres_analytics import refresh_campaign_analytics_from_postgres
 from ..campaign_postgres_send import send_due_campaigns_from_postgres
 from ..campaign_postgres_sequence_progression import (
@@ -31,6 +33,8 @@ PoolProvider = Callable[[], Any | Awaitable[Any]]
 SenderProvider = Callable[[], CampaignSender | Awaitable[CampaignSender]]
 LLMProvider = Callable[[], LLMClient | Awaitable[LLMClient]]
 SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
+ReasoningProvider = Callable[[], Any | Awaitable[Any]]
+ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
 
 logger = logging.getLogger(__name__)
 _ANALYTICS_ERROR_SUMMARY = "Campaign analytics refresh failed."
@@ -56,6 +60,17 @@ class CampaignOperationsApiConfig:
     sequence_from_email: str = ""
     sequence_onboarding_product_name: str = ""
     sequence_temperature: float = 0.7
+    default_generation_limit: int = 20
+    max_generation_limit: int = 200
+    generation_target_mode: str = "vendor_retention"
+    generation_channel: str = "email"
+    generation_channels: tuple[str, ...] = ()
+    generation_skill_name: str = "digest/b2b_campaign_generation"
+    generation_max_tokens: int = 1200
+    generation_temperature: float = 0.4
+    generation_include_source_opportunity: bool = True
+    generation_opportunity_table: str = "campaign_opportunities"
+    generation_vendor_targets_table: str = "vendor_targets"
 
     def __post_init__(self) -> None:
         _validate_default_limit(
@@ -76,6 +91,20 @@ class CampaignOperationsApiConfig:
             default_name="default_sequence_max_steps",
             max_name="max_sequence_steps",
         )
+        _validate_default_limit(
+            self.default_generation_limit,
+            self.max_generation_limit,
+            default_name="default_generation_limit",
+            max_name="max_generation_limit",
+        )
+        if not _clean(self.generation_target_mode):
+            raise ValueError("generation_target_mode is required")
+        if not _clean(self.generation_channel):
+            raise ValueError("generation_channel is required")
+        if not _clean(self.generation_skill_name):
+            raise ValueError("generation_skill_name is required")
+        if self.generation_max_tokens <= 0:
+            raise ValueError("generation_max_tokens must be positive")
 
 
 def _require_fastapi() -> None:
@@ -117,6 +146,17 @@ async def _resolve_optional(provider: Callable[[], Any | Awaitable[Any]] | None)
     if provider is None:
         return None
     return await _maybe_await(provider())
+
+
+async def _resolve_scope(
+    scope_provider: ScopeProvider | None,
+) -> TenantScope | Mapping[str, Any] | None:
+    if scope_provider is None:
+        return None
+    scope = await _maybe_await(scope_provider())
+    if scope is None or isinstance(scope, (TenantScope, Mapping)):
+        return scope
+    raise HTTPException(status_code=500, detail="Invalid tenant scope")
 
 
 def _validate_default_limit(
@@ -162,6 +202,61 @@ def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _scope_account_id(scope: TenantScope | Mapping[str, Any] | None) -> str | None:
+    if isinstance(scope, TenantScope):
+        return scope.account_id
+    if isinstance(scope, Mapping):
+        return _clean(scope.get("account_id")) or None
+    return None
+
+
+def _generation_scope(
+    scope: TenantScope | Mapping[str, Any] | None,
+    payload: Mapping[str, Any],
+) -> TenantScope | Mapping[str, Any] | None:
+    scoped_account_id = _scope_account_id(scope)
+    payload_account_id = _clean(payload.get("account_id")) or None
+    if scoped_account_id and payload_account_id and payload_account_id != scoped_account_id:
+        raise HTTPException(status_code=403, detail="account_id does not match scope")
+    if scope is not None:
+        return scope
+    user_id = _clean(payload.get("user_id")) or None
+    if payload_account_id or user_id:
+        return {"account_id": payload_account_id, "user_id": user_id}
+    return None
+
+
+def _payload_mapping(
+    payload: Mapping[str, Any],
+    key: str,
+) -> Mapping[str, Any] | None:
+    raw_value = payload.get(key)
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, Mapping):
+        return raw_value
+    raise HTTPException(status_code=400, detail=f"{key} must be an object")
+
+
+def _payload_channels(
+    payload: Mapping[str, Any],
+    default: Sequence[str],
+) -> tuple[str, ...]:
+    raw_value = payload.get("channels")
+    if raw_value is None:
+        return tuple(default)
+    if isinstance(raw_value, str):
+        candidates: Sequence[Any] = raw_value.split(",")
+    elif isinstance(raw_value, Sequence) and not isinstance(
+        raw_value,
+        (bytes, bytearray),
+    ):
+        candidates = raw_value
+    else:
+        raise HTTPException(status_code=400, detail="channels must be a list or string")
+    return tuple(item for item in (_clean(value) for value in candidates) if item)
+
+
 def _send_config(config: CampaignOperationsApiConfig, *, limit: int) -> CampaignSendConfig:
     return CampaignSendConfig(
         default_from_email=config.send_default_from_email,
@@ -194,6 +289,24 @@ def _sequence_config(
     )
 
 
+def _generation_config(
+    config: CampaignOperationsApiConfig,
+    *,
+    channel: str,
+    channels: tuple[str, ...],
+    limit: int,
+) -> CampaignGenerationConfig:
+    return CampaignGenerationConfig(
+        skill_name=config.generation_skill_name,
+        channel=channel,
+        channels=channels,
+        limit=limit,
+        max_tokens=config.generation_max_tokens,
+        temperature=float(config.generation_temperature),
+        include_source_opportunity=config.generation_include_source_opportunity,
+    )
+
+
 def _public_analytics_result(result: Any) -> dict[str, Any]:
     data = result.as_dict()
     if data.get("error"):
@@ -206,8 +319,10 @@ def create_campaign_operations_router(
     *,
     pool_provider: PoolProvider,
     sender_provider: SenderProvider | None = None,
+    scope_provider: ScopeProvider | None = None,
     llm_provider: LLMProvider | None = None,
     skills_provider: SkillsProvider | None = None,
+    reasoning_context_provider: ReasoningProvider | None = None,
     config: CampaignOperationsApiConfig | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
@@ -219,6 +334,60 @@ def create_campaign_operations_router(
         tags=list(resolved_config.tags),
         dependencies=list(dependencies or ()),
     )
+
+    @router.post("/drafts/generate")
+    async def generate_drafts(
+        payload: dict[str, Any] | None = Body(None),
+    ) -> dict[str, Any]:
+        resolved_payload = payload or {}
+        limit = _payload_limit(
+            resolved_payload,
+            "limit",
+            resolved_config.default_generation_limit,
+            max_value=resolved_config.max_generation_limit,
+        )
+        target_mode = (
+            _clean(resolved_payload.get("target_mode"))
+            or resolved_config.generation_target_mode
+        )
+        channel = _clean(resolved_payload.get("channel")) or resolved_config.generation_channel
+        filters = _payload_mapping(resolved_payload, "filters")
+        channels = _payload_channels(
+            resolved_payload,
+            resolved_config.generation_channels,
+        )
+        scope = _generation_scope(
+            await _resolve_scope(scope_provider),
+            resolved_payload,
+        )
+        pool = await _resolve_pool(pool_provider)
+        llm = await _resolve_optional(llm_provider)
+        skills = await _resolve_optional(skills_provider)
+        reasoning_context = await _resolve_optional(reasoning_context_provider)
+        try:
+            result = await generate_campaign_drafts_from_postgres(
+                pool,
+                scope=scope,
+                target_mode=target_mode,
+                channel=channel,
+                channels=channels,
+                limit=limit,
+                filters=filters,
+                llm=llm,
+                skills=skills,
+                reasoning_context=reasoning_context,
+                config=_generation_config(
+                    resolved_config,
+                    channel=channel,
+                    channels=channels,
+                    limit=limit,
+                ),
+                opportunity_table=resolved_config.generation_opportunity_table,
+                vendor_targets_table=resolved_config.generation_vendor_targets_table,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return result.as_dict()
 
     @router.post("/send/queued")
     async def send_queued(

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -422,7 +422,7 @@ python scripts/progress_extracted_campaign_sequences.py \
 ```
 
 Or mount the hosted operations router in a FastAPI app for admin-triggered
-send, sequence progression, and analytics refresh actions:
+draft generation, send, sequence progression, and analytics refresh actions:
 
 ```python
 from fastapi import Depends
@@ -439,6 +439,7 @@ app.include_router(
         sender_provider=get_campaign_sender,
         llm_provider=get_campaign_llm,
         skills_provider=get_campaign_skills,
+        reasoning_context_provider=get_campaign_reasoning_context,
         config=CampaignOperationsApiConfig(
             send_default_from_email="audit@customer.com",
             sequence_from_email="audit@customer.com",
@@ -449,12 +450,13 @@ app.include_router(
 ```
 
 The hosted operations payloads are intentionally narrow. Callers may set
-`limit` and, for sequence progression, `max_steps`; provider credentials,
-sender identity, unsubscribe policy, LLM client, and skill roots stay
-host-configured.
+tenant scope, target/channel, filters, `limit`, and, for sequence progression,
+`max_steps`; provider credentials, sender identity, unsubscribe policy, LLM
+client, skill roots, and reasoning providers stay host-configured.
 
 | Method | Path | Purpose |
 |---|---|---|
+| `POST` | `/campaigns/operations/drafts/generate` | Generate and persist campaign drafts from `campaign_opportunities`. |
 | `POST` | `/campaigns/operations/send/queued` | Send queued campaign rows through the injected sender. |
 | `POST` | `/campaigns/operations/sequences/progress` | Generate and queue due follow-up sequence steps. |
 | `POST` | `/campaigns/operations/analytics/refresh` | Refresh packaged campaign analytics aggregates. |

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -204,11 +204,12 @@ LLM draft generation to worker/CLI paths so hosts can control provider runtime
 policy separately.
 
 `extracted_content_pipeline/api/campaign_operations.py` owns the host-mounted
-FastAPI surface for operational campaign workers. It exposes send queued,
-sequence progression, and analytics refresh triggers while requiring the host
-to inject database, sender, auth, and optional LLM/skill providers. Request
-payloads are limited to batch sizing so provider credentials, sender identity,
-unsubscribe policy, and LLM routing remain host-owned.
+FastAPI surface for operational campaign workers. It exposes draft generation,
+send queued, sequence progression, and analytics refresh triggers while
+requiring the host to inject database, sender, auth, and optional
+LLM/skill/reasoning providers. Request payloads are limited to tenant scope,
+target/channel, filters, and batch sizing so provider credentials, sender
+identity, unsubscribe policy, and LLM routing remain host-owned.
 
 `extracted_content_pipeline/campaign_postgres_send.py` owns the DB-backed send
 worker seam. It composes `PostgresCampaignRepository`,

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -14,6 +14,7 @@ from extracted_content_pipeline.api.campaign_operations import (
     CampaignOperationsApiConfig,
     create_campaign_operations_router,
 )
+from extracted_content_pipeline.campaign_ports import TenantScope
 
 
 class _Pool:
@@ -41,12 +42,18 @@ class _Skills:
     pass
 
 
+class _Reasoning:
+    pass
+
+
 def _client(
     pool: Any,
     *,
     sender: Any = None,
+    scope: Any = None,
     llm: Any = None,
     skills: Any = None,
+    reasoning: Any = None,
     config: CampaignOperationsApiConfig | None = None,
     dependencies: list[Any] | None = None,
     counters: dict[str, int] | None = None,
@@ -62,6 +69,10 @@ def _client(
         counts["sender"] = counts.get("sender", 0) + 1
         return sender
 
+    async def scope_provider():
+        counts["scope"] = counts.get("scope", 0) + 1
+        return scope
+
     async def llm_provider():
         counts["llm"] = counts.get("llm", 0) + 1
         return llm
@@ -70,17 +81,200 @@ def _client(
         counts["skills"] = counts.get("skills", 0) + 1
         return skills
 
+    async def reasoning_context_provider():
+        counts["reasoning"] = counts.get("reasoning", 0) + 1
+        return reasoning
+
     app.include_router(
         create_campaign_operations_router(
             pool_provider=pool_provider,
             sender_provider=sender_provider if sender is not None else None,
+            scope_provider=scope_provider if scope is not None else None,
             llm_provider=llm_provider if llm is not None else None,
             skills_provider=skills_provider if skills is not None else None,
+            reasoning_context_provider=(
+                reasoning_context_provider if reasoning is not None else None
+            ),
             config=config,
             dependencies=dependencies,
         )
     )
     return TestClient(app)
+
+
+def test_campaign_operations_router_generates_campaign_drafts(monkeypatch) -> None:
+    pool = _Pool()
+    llm = _LLM()
+    skills = _Skills()
+    reasoning = _Reasoning()
+    calls: list[tuple[Any, dict[str, Any]]] = []
+    counters: dict[str, int] = {}
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(
+            requested=2,
+            generated=2,
+            skipped=0,
+            saved_ids=["campaign-1", "campaign-2"],
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1", user_id="user_1"),
+        llm=llm,
+        skills=skills,
+        reasoning=reasoning,
+        counters=counters,
+        config=CampaignOperationsApiConfig(
+            max_generation_limit=50,
+            generation_opportunity_table="opps",
+            generation_vendor_targets_table="targets",
+            generation_skill_name="digest/custom_campaign_generation",
+            generation_max_tokens=900,
+            generation_temperature=0.3,
+        ),
+    ).post(
+        "/campaigns/operations/drafts/generate",
+        json={
+            "account_id": "acct_1",
+            "target_mode": "vendor_retention",
+            "channel": "email",
+            "channels": ["email_cold", "email_followup"],
+            "filters": {"vendor_name": "HubSpot"},
+            "limit": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "requested": 2,
+        "generated": 2,
+        "skipped": 0,
+        "saved_ids": ["campaign-1", "campaign-2"],
+        "errors": [],
+    }
+    assert counters == {
+        "scope": 1,
+        "pool": 1,
+        "llm": 1,
+        "skills": 1,
+        "reasoning": 1,
+    }
+    assert calls[0][0] is pool
+    kwargs = calls[0][1]
+    assert kwargs["scope"] == TenantScope(account_id="acct_1", user_id="user_1")
+    assert kwargs["target_mode"] == "vendor_retention"
+    assert kwargs["channel"] == "email"
+    assert kwargs["channels"] == ("email_cold", "email_followup")
+    assert kwargs["limit"] == 2
+    assert kwargs["filters"] == {"vendor_name": "HubSpot"}
+    assert kwargs["llm"] is llm
+    assert kwargs["skills"] is skills
+    assert kwargs["reasoning_context"] is reasoning
+    assert kwargs["opportunity_table"] == "opps"
+    assert kwargs["vendor_targets_table"] == "targets"
+    config = kwargs["config"]
+    assert config.skill_name == "digest/custom_campaign_generation"
+    assert config.max_tokens == 900
+    assert config.temperature == 0.3
+
+
+def test_campaign_operations_router_generates_with_payload_scope(monkeypatch) -> None:
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(requested=1, generated=1, skipped=0, saved_ids=[], errors=[])
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(_Pool()).post(
+        "/campaigns/operations/drafts/generate",
+        json={"account_id": "acct_1", "user_id": "user_1"},
+    )
+
+    assert response.status_code == 200
+    assert calls[0][1]["scope"] == {"account_id": "acct_1", "user_id": "user_1"}
+
+
+def test_campaign_operations_router_rejects_generation_scope_mismatch(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(generated=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        _Pool(),
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/campaigns/operations/drafts/generate",
+        json={"account_id": "acct_2"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "account_id does not match scope"
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("payload", "detail"),
+    (
+        ({"limit": True}, "limit must be an integer"),
+        ({"limit": 0}, "limit must be greater than 0"),
+        ({"limit": 51}, "limit must be less than or equal to 50"),
+        ({"filters": ["vendor_name", "HubSpot"]}, "filters must be an object"),
+        ({"channels": {"name": "email"}}, "channels must be a list or string"),
+    ),
+)
+def test_campaign_operations_router_rejects_invalid_generation_payload(
+    monkeypatch,
+    payload,
+    detail,
+) -> None:
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(generated=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        _Pool(),
+        config=CampaignOperationsApiConfig(
+            default_generation_limit=50,
+            max_generation_limit=50,
+        ),
+    ).post("/campaigns/operations/drafts/generate", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+    assert calls == []
 
 
 def test_campaign_operations_router_sends_queued_campaigns(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Extend `api.campaign_operations` with `POST /campaigns/operations/drafts/generate` for hosted draft generation from `campaign_opportunities`.
- Keep LLM, skills, reasoning context, database, and auth host-injected; payloads only control tenant scope, target/channel, filters, and batch sizing.
- Update docs/status and claim the D10 slice in coordination tracking.

## Validation
- `pytest tests/test_extracted_campaign_api_operations.py tests/test_extracted_campaign_manifest.py` (30/30)
- `bash scripts/run_extracted_pipeline_checks.sh` (842/842, existing torch/pynvml warning)