### PR TITLE
PR-D4e: Resume safety + retry cooldown + display fixes (closes audit mediums #1, #2, minors)

### DIFF
--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -584,38 +584,33 @@ async def refresh_customer_batch_status(
             and record.status in ("ended", "canceled", "expired")
             and record.provider_batch_id
         ):
-            # PR-D4e cooldown: if the prior retry attempt is more
-            # recent than the cooldown window, skip this attempt
-            # to avoid hammering Anthropic's results endpoint
-            # under a transient-failure poll storm. Returns the
-            # current record so the customer keeps polling --
-            # the next poll outside the cooldown will retry.
-            cooldown_active = await pool.fetchval(
+            # PR-D4e cooldown (Codex P2): atomic claim collapses
+            # the cooldown check + stamp into a single conditional
+            # UPDATE so two concurrent pollers can't both observe
+            # cooldown_active=false and race into _persist_batch_usage.
+            # Returns a row if the claim won (this poller proceeds);
+            # returns None if the cooldown is active OR another
+            # concurrent poller already claimed the slot (this poller
+            # returns the current record so the customer keeps
+            # polling -- the next attempt outside the window retries).
+            claim = await pool.fetchrow(
                 """
-                SELECT (last_usage_retry_at IS NOT NULL
-                        AND last_usage_retry_at >
-                            NOW() - make_interval(secs => $3))
-                FROM llm_gateway_batches
+                UPDATE llm_gateway_batches
+                SET last_usage_retry_at = NOW()
                 WHERE id = $1 AND account_id = $2
+                  AND (
+                    last_usage_retry_at IS NULL
+                    OR last_usage_retry_at <=
+                        NOW() - make_interval(secs => $3)
+                  )
+                RETURNING id
                 """,
                 batch_id,
                 account_id,
                 _USAGE_RETRY_COOLDOWN_SECONDS,
             )
-            if cooldown_active:
+            if claim is None:
                 return record
-            # Stamp the retry-attempt timestamp BEFORE calling
-            # _persist_batch_usage so a concurrent poller in the
-            # same window sees the cooldown and skips.
-            await pool.execute(
-                """
-                UPDATE llm_gateway_batches
-                SET last_usage_retry_at = NOW()
-                WHERE id = $1 AND account_id = $2
-                """,
-                batch_id,
-                account_id,
-            )
             try:
                 await _persist_batch_usage(
                     pool,

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -48,6 +48,16 @@ logger = logging.getLogger("atlas.services.llm_gateway_batch")
 # is bounded so a single slow upstream cannot stack blocked workers.
 ANTHROPIC_SDK_TIMEOUT_SECONDS = 30.0
 
+# Cooldown between automatic retries of _persist_batch_usage on
+# a terminal row whose usage_tracked flag is still FALSE. Without
+# it, a 1Hz /batch/{id} poll loop fires _persist_batch_usage
+# every poll under transient SDK failures, hammering Anthropic's
+# results endpoint. 30s is shorter than the 60s resume threshold
+# (so customers still see retry happen on a typical poll cadence)
+# but long enough that a sustained transient failure doesn't
+# storm the upstream. PR-D4e.
+_USAGE_RETRY_COOLDOWN_SECONDS = 30
+
 # Terminal statuses (no more polling needed). ``submit_failed`` is
 # also terminal -- the row never made it to Anthropic, so polling
 # would do nothing useful.
@@ -102,6 +112,15 @@ class CustomerBatchRecord:
     # terminal row whose usage write never landed (results pre-fetch
     # failed before the atomic claim could flip the flag) and retry.
     usage_tracked: bool = False
+    # PR-D4e: set BEFORE the AsyncAnthropic.batches.create call.
+    # NULL means we never started the Anthropic side -- the resume
+    # claim relies on this to distinguish "safe to re-submit" from
+    # "may have created a duplicate paid batch already".
+    anthropic_call_initiated_at: Optional[datetime] = None
+    # PR-D4e: timestamp of the most recent _persist_batch_usage
+    # retry attempt. The refresh path skips retry when this is
+    # within the cooldown window, preventing poll-storms.
+    last_usage_retry_at: Optional[datetime] = None
 
 
 def _row_to_record(row: Any) -> CustomerBatchRecord:
@@ -125,6 +144,18 @@ def _row_to_record(row: Any) -> CustomerBatchRecord:
         # row mocks still work (the column defaults FALSE in the
         # migration, so missing == not-yet-tracked).
         usage_tracked=bool(row["usage_tracked"]) if "usage_tracked" in row.keys() else False,
+        # PR-D4e migration 322 added these. Same defensive pattern
+        # for mocks that don't include the columns.
+        anthropic_call_initiated_at=(
+            row["anthropic_call_initiated_at"]
+            if "anthropic_call_initiated_at" in row.keys()
+            else None
+        ),
+        last_usage_retry_at=(
+            row["last_usage_retry_at"]
+            if "last_usage_retry_at" in row.keys()
+            else None
+        ),
     )
 
 
@@ -173,7 +204,8 @@ async def submit_customer_batch(
             SELECT id, account_id, provider, provider_batch_id, model,
                    status, total_items, completed_items, failed_items,
                    error_text, created_at, updated_at, submitted_at,
-                   completed_at, usage_tracked
+                   completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
             FROM llm_gateway_batches
             WHERE account_id = $1 AND idempotency_key = $2
             """,
@@ -195,32 +227,48 @@ async def submit_customer_batch(
                 return _row_to_record(existing)
 
             # No provider_batch_id means the prior attempt never
-            # made it to Anthropic. Two cases:
-            #   a) status='queued', updated recently -- a concurrent
-            #      retry is in flight right now; re-submitting would
-            #      duplicate-pay. Replay so the customer polls.
-            #   b) status='queued' but stale (updated_at >
-            #      2x ANTHROPIC_SDK_TIMEOUT_SECONDS ago), OR
-            #      status='submit_failed' -- the prior attempt
-            #      crashed pre-submit (a) or Anthropic rejected /
-            #      timed out (b). Either way, the customer's batch
-            #      never landed; resume so the retry actually
-            #      submits. Codex P1 rounds 3+4 on PR-D4c.
+            # made it to Anthropic. Three sub-cases distinguished
+            # by ``anthropic_call_initiated_at`` (PR-D4e migration
+            # 322 -- set just before AsyncAnthropic.batches.create
+            # below):
+            #   a) initiated_at IS NULL, status='queued', recent --
+            #      another retry is in flight right now; replay.
+            #   b) initiated_at IS NULL, status='queued' or
+            #      'submit_failed' AND stale -- the prior attempt
+            #      crashed before reaching Anthropic. SAFE to
+            #      resume because the batch never existed on
+            #      Anthropic's side.
+            #   c) initiated_at IS NOT NULL -- AMBIGUOUS. Anthropic
+            #      may have accepted the create call before the
+            #      crash; auto-resubmitting would duplicate-pay.
+            #      Resume claim falls through to the in-flight
+            #      replay path; ops gets a WARN log for manual
+            #      recovery.
             #
             # The decision is made atomically in SQL so two
             # concurrent resumes can't both win. Threshold = 60s =
             # 2x ANTHROPIC_SDK_TIMEOUT_SECONDS so an in-flight call
             # has had time to either succeed or hit the SDK timeout
             # (which would have updated the row to submit_failed).
+            #
+            # ``total_items`` and ``model`` are bumped to the
+            # current call's values on resume so the row reflects
+            # what's actually being submitted (the original values
+            # would normally match per the idempotency contract,
+            # but enforcing here keeps the row truthful even if a
+            # customer reuses a key with different inputs).
             resumed = await pool.fetchrow(
                 """
                 UPDATE llm_gateway_batches
                 SET updated_at = NOW(),
                     status = 'queued',
-                    error_text = NULL
+                    error_text = NULL,
+                    total_items = $3,
+                    model = $4
                 WHERE id = $1
                   AND account_id = $2
                   AND provider_batch_id IS NULL
+                  AND anthropic_call_initiated_at IS NULL
                   AND (
                     status = 'submit_failed'
                     OR (status = 'queued'
@@ -229,10 +277,13 @@ async def submit_customer_batch(
                 RETURNING id, account_id, provider, provider_batch_id, model,
                           status, total_items, completed_items, failed_items,
                           error_text, created_at, updated_at, submitted_at,
-                          completed_at, usage_tracked
+                          completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
                 """,
                 existing["id"],
                 account_id,
+                len(items),
+                model,
             )
             if resumed is None:
                 # Recent queued (< 60s old) or another retry already
@@ -250,7 +301,8 @@ async def submit_customer_batch(
                     SELECT id, account_id, provider, provider_batch_id, model,
                            status, total_items, completed_items, failed_items,
                            error_text, created_at, updated_at, submitted_at,
-                           completed_at, usage_tracked
+                           completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
                     FROM llm_gateway_batches
                     WHERE id = $1 AND account_id = $2
                     """,
@@ -258,14 +310,38 @@ async def submit_customer_batch(
                     account_id,
                 )
                 replay_row = latest if latest is not None else existing
-                logger.info(
-                    "llm_gateway_batch.submit replay (in-flight) "
-                    "account=%s key=%s id=%s status=%s",
-                    account_id,
-                    normalized_key,
-                    replay_row["id"],
-                    replay_row["status"],
-                )
+                # PR-D4e: distinguish in-flight replay (recent
+                # concurrent retry, replay is correct) from
+                # ambiguous-orphan (anthropic_call_initiated_at
+                # set but no provider_batch_id -- we can't tell
+                # if Anthropic accepted; auto-resume is unsafe).
+                # The latter requires manual recovery; WARN so
+                # ops can find these rows.
+                if (
+                    replay_row["provider_batch_id"] is None
+                    and replay_row["anthropic_call_initiated_at"] is not None
+                ):
+                    logger.warning(
+                        "llm_gateway_batch.submit ambiguous-orphan "
+                        "account=%s key=%s id=%s status=%s "
+                        "anthropic_call_initiated_at=%s -- Anthropic "
+                        "may have accepted the prior submit; manual "
+                        "recovery required (do not auto-resume)",
+                        account_id,
+                        normalized_key,
+                        replay_row["id"],
+                        replay_row["status"],
+                        replay_row["anthropic_call_initiated_at"],
+                    )
+                else:
+                    logger.info(
+                        "llm_gateway_batch.submit replay (in-flight) "
+                        "account=%s key=%s id=%s status=%s",
+                        account_id,
+                        normalized_key,
+                        replay_row["id"],
+                        replay_row["status"],
+                    )
                 return _row_to_record(replay_row)
             logger.info(
                 "llm_gateway_batch.submit resume pre-submit "
@@ -300,7 +376,8 @@ async def submit_customer_batch(
                     RETURNING id, account_id, provider, provider_batch_id, model,
                               status, total_items, completed_items, failed_items,
                               error_text, created_at, updated_at, submitted_at,
-                              completed_at, usage_tracked
+                              completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
                     """,
                     account_id,
                     model,
@@ -317,7 +394,8 @@ async def submit_customer_batch(
                 SELECT id, account_id, provider, provider_batch_id, model,
                        status, total_items, completed_items, failed_items,
                        error_text, created_at, updated_at, submitted_at,
-                       completed_at, usage_tracked
+                       completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
                 FROM llm_gateway_batches
                 WHERE account_id = $1 AND idempotency_key = $2
                 """,
@@ -350,6 +428,23 @@ async def submit_customer_batch(
         if system_prompt:
             params["system"] = system_prompt
         requests.append({"custom_id": item.custom_id, "params": params})
+
+    # PR-D4e: stamp ``anthropic_call_initiated_at`` BEFORE the
+    # AsyncAnthropic call. The resume claim treats a row with
+    # this stamp set + no provider_batch_id as an ambiguous
+    # orphan (Anthropic may have accepted but our local UPDATE
+    # never landed) -- without this, a stale ``queued`` row
+    # would auto-resume and risk a duplicate paid batch.
+    await pool.execute(
+        """
+        UPDATE llm_gateway_batches
+        SET anthropic_call_initiated_at = NOW(),
+            updated_at = NOW()
+        WHERE id = $1 AND account_id = $2
+        """,
+        row["id"],
+        account_id,
+    )
 
     # Call Anthropic. Imported lazily so unit tests can stub the
     # client without dragging the SDK into module load.
@@ -390,7 +485,8 @@ async def submit_customer_batch(
             RETURNING id, account_id, provider, provider_batch_id, model,
                       status, total_items, completed_items, failed_items,
                       error_text, created_at, updated_at, submitted_at,
-                      completed_at, usage_tracked
+                      completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
             """,
             row["id"],
             f"Anthropic batch submit failed: {exc}",
@@ -400,18 +496,25 @@ async def submit_customer_batch(
     provider_batch_id = getattr(provider_batch, "id", None)
     initial_status = getattr(provider_batch, "processing_status", None) or "in_progress"
 
+    # Success UPDATE. PR-D4e: clear ``completed_at`` (a prior
+    # submit_failed attempt sets it to NOW() at line ~488; a
+    # successful resume retry must clear it so the row's display
+    # state matches its actual lifecycle -- in_progress rows
+    # shouldn't carry a completed_at from a stale failure).
     updated_row = await pool.fetchrow(
         """
         UPDATE llm_gateway_batches
         SET provider_batch_id = $2,
             status = $3,
             submitted_at = NOW(),
-            updated_at = NOW()
+            updated_at = NOW(),
+            completed_at = NULL
         WHERE id = $1
         RETURNING id, account_id, provider, provider_batch_id, model,
                   status, total_items, completed_items, failed_items,
                   error_text, created_at, updated_at, submitted_at,
-                  completed_at, usage_tracked
+                  completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
         """,
         row["id"],
         str(provider_batch_id) if provider_batch_id else None,
@@ -438,7 +541,8 @@ async def get_customer_batch(
         SELECT id, account_id, provider, provider_batch_id, model,
                status, total_items, completed_items, failed_items,
                error_text, created_at, updated_at, submitted_at,
-               completed_at, usage_tracked
+               completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
         FROM llm_gateway_batches
         WHERE id = $1 AND account_id = $2
         """,
@@ -480,6 +584,38 @@ async def refresh_customer_batch_status(
             and record.status in ("ended", "canceled", "expired")
             and record.provider_batch_id
         ):
+            # PR-D4e cooldown: if the prior retry attempt is more
+            # recent than the cooldown window, skip this attempt
+            # to avoid hammering Anthropic's results endpoint
+            # under a transient-failure poll storm. Returns the
+            # current record so the customer keeps polling --
+            # the next poll outside the cooldown will retry.
+            cooldown_active = await pool.fetchval(
+                """
+                SELECT (last_usage_retry_at IS NOT NULL
+                        AND last_usage_retry_at >
+                            NOW() - make_interval(secs => $3))
+                FROM llm_gateway_batches
+                WHERE id = $1 AND account_id = $2
+                """,
+                batch_id,
+                account_id,
+                _USAGE_RETRY_COOLDOWN_SECONDS,
+            )
+            if cooldown_active:
+                return record
+            # Stamp the retry-attempt timestamp BEFORE calling
+            # _persist_batch_usage so a concurrent poller in the
+            # same window sees the cooldown and skips.
+            await pool.execute(
+                """
+                UPDATE llm_gateway_batches
+                SET last_usage_retry_at = NOW()
+                WHERE id = $1 AND account_id = $2
+                """,
+                batch_id,
+                account_id,
+            )
             try:
                 await _persist_batch_usage(
                     pool,
@@ -557,7 +693,8 @@ async def refresh_customer_batch_status(
         RETURNING id, account_id, provider, provider_batch_id, model,
                   status, total_items, completed_items, failed_items,
                   error_text, created_at, updated_at, submitted_at,
-                  completed_at, usage_tracked
+                  completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at
         """,
         batch_id,
         new_status,

--- a/atlas_brain/storage/migrations/322_llm_gateway_batches_resume_safety.sql
+++ b/atlas_brain/storage/migrations/322_llm_gateway_batches_resume_safety.sql
@@ -1,0 +1,36 @@
+-- LLM Gateway resume + retry safety (PR-D4e).
+--
+-- Closes two PR-D4c audit items:
+--
+-- 1. Duplicate-pay window: previously the resume claim treated
+--    any stale ``queued`` row (no provider_batch_id, >60s old) as
+--    "crashed pre-submit, safe to resubmit". That conflated two
+--    failure modes:
+--      a) atlas crashed before reaching the Anthropic call (safe
+--         to re-submit -- batch never existed).
+--      b) Anthropic accepted the create call BUT the local
+--         UPDATE writing provider_batch_id failed (asyncpg
+--         transient, container restart, network partition).
+--         Re-submitting in this case creates a duplicate paid
+--         batch on the customer's account.
+--
+--    ``anthropic_call_initiated_at`` is set BEFORE the
+--    AsyncAnthropic.batches.create call. The resume claim
+--    narrows to ``WHERE anthropic_call_initiated_at IS NULL``
+--    so we only auto-resume rows that demonstrably never
+--    reached Anthropic. Ambiguous rows (initiated_at set, no
+--    provider_batch_id) require manual recovery and are logged
+--    loudly so ops can find them.
+--
+-- 2. Retry-on-terminal storm: refresh_customer_batch_status
+--    fires _persist_batch_usage on every poll when a terminal
+--    row has usage_tracked=FALSE. Under transient SDK failures
+--    a 1Hz poll loop hammers Anthropic's results endpoint.
+--    ``last_usage_retry_at`` records the timestamp of each
+--    retry attempt so the refresh path can enforce a cooldown
+--    (currently 30s -- shorter than the 60s resume threshold so
+--    customers still see retry happen on a typical poll cadence).
+
+ALTER TABLE llm_gateway_batches
+    ADD COLUMN IF NOT EXISTS anthropic_call_initiated_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_usage_retry_at TIMESTAMPTZ;

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -111,6 +111,23 @@ def test_migration_321_creates_lookup_index_concurrently():
     assert "WHERE batch_id IS NOT NULL" in sql
 
 
+def test_migration_322_adds_resume_safety_columns():
+    """PR-D4e migration 322:
+      - anthropic_call_initiated_at: stamped before
+        AsyncAnthropic.batches.create so the resume claim can
+        distinguish 'never reached Anthropic' (safe to resubmit)
+        from 'Anthropic may have accepted, our local UPDATE
+        crashed' (ambiguous orphan, do not auto-resubmit -- this
+        was the duplicate-pay window the audit flagged).
+      - last_usage_retry_at: timestamp of the most recent
+        _persist_batch_usage retry from refresh_customer_batch_status
+        so the cooldown predicate can skip retries inside the
+        window."""
+    sql = _read_migration("322_llm_gateway_batches_resume_safety.sql")
+    assert "ADD COLUMN IF NOT EXISTS anthropic_call_initiated_at TIMESTAMPTZ" in sql
+    assert "ADD COLUMN IF NOT EXISTS last_usage_retry_at TIMESTAMPTZ" in sql
+
+
 # ---- submit_customer_batch idempotency ----------------------------------
 
 
@@ -205,6 +222,139 @@ def test_submit_customer_batch_resumes_stale_pre_submit_atomically():
     # Distinct log lines for each branch so ops can spot leaks.
     assert "submit replay (in-flight)" in src
     assert "submit resume pre-submit" in src
+
+
+def test_resume_claim_requires_anthropic_call_never_initiated():
+    """PR-D4e: the audit flagged a duplicate-pay window where
+    Anthropic accepted batches.create but our local UPDATE writing
+    provider_batch_id failed (asyncpg transient, container
+    restart). After 60s, the resume claim would treat the row as
+    'crashed pre-submit' and resubmit -- billing the customer
+    twice for the same logical batch. Fix: narrow the resume
+    predicate to ``anthropic_call_initiated_at IS NULL`` so we
+    only auto-resume rows that demonstrably never reached
+    Anthropic."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # New predicate -- only rows where Anthropic was never contacted.
+    assert "AND anthropic_call_initiated_at IS NULL" in src
+
+
+def test_resume_claim_updates_total_items_and_model():
+    """PR-D4e: resume reuses the existing row id but the customer's
+    retry has the current call's items/model. Update those fields
+    on the row so the persisted state matches what's actually
+    submitted (idempotency contract says retries match, but the
+    row should be authoritative either way)."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Resume UPDATE bumps total_items and model.
+    assert "total_items = $3" in src
+    assert "model = $4" in src
+
+
+def test_anthropic_call_stamped_before_create():
+    """PR-D4e: the audit fix relies on
+    ``anthropic_call_initiated_at`` being set BEFORE the
+    AsyncAnthropic.batches.create call -- otherwise a crash
+    between the stamp and the call could still result in an
+    ambiguous orphan being mis-classified as 'never initiated'.
+    Source-text pin verifies the ordering."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    stamp_idx = src.find("SET anthropic_call_initiated_at = NOW()")
+    create_idx = src.find("client.messages.batches.create(")
+    assert stamp_idx > 0 and create_idx > 0
+    assert stamp_idx < create_idx, (
+        "anthropic_call_initiated_at must be stamped BEFORE "
+        "batches.create() or the resume safety predicate is "
+        "useless under crash-between-stamp-and-call."
+    )
+
+
+def test_success_update_clears_completed_at():
+    """PR-D4e minor fix: a submit_failed row carries
+    completed_at = NOW() from the failure UPDATE. A successful
+    resume retry transitions to in_progress; completed_at must
+    be cleared so the row's display state matches its lifecycle
+    (in_progress rows shouldn't show a completed_at)."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Success UPDATE clears completed_at alongside the other fields.
+    success_block = src.split("provider_batch_id = $2,")[1].split('"""', 2)[0]
+    assert "completed_at = NULL" in success_block, (
+        "Success UPDATE must clear completed_at so a resumed-from-"
+        "submit_failed row doesn't display stale completion time."
+    )
+
+
+def test_ambiguous_orphan_logs_warning_for_ops():
+    """PR-D4e: when the resume claim returns None and the row's
+    ``anthropic_call_initiated_at`` is set with no
+    provider_batch_id, the row is in an ambiguous state --
+    Anthropic may have accepted but our UPDATE crashed. Customer
+    can't recover automatically; ops needs to find the row.
+    Distinct WARN log line for that case."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.submit_customer_batch)
+    # Distinct log line for the ambiguous case.
+    assert "ambiguous-orphan" in src
+    # WARN level (not info) so it surfaces in ops alerts.
+    assert "logger.warning" in src
+    # Detection condition explicit.
+    assert 'replay_row["provider_batch_id"] is None' in src
+    assert 'replay_row["anthropic_call_initiated_at"] is not None' in src
+
+
+def test_refresh_retry_on_terminal_uses_cooldown():
+    """PR-D4e: a 1Hz /batch/{id} poll loop under transient
+    SDK failures would fire _persist_batch_usage every poll
+    without a cooldown. last_usage_retry_at + 30s window
+    bounds the storm. Cooldown query uses make_interval so the
+    threshold parameterizes via _USAGE_RETRY_COOLDOWN_SECONDS."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.refresh_customer_batch_status)
+    # Cooldown predicate present.
+    assert "last_usage_retry_at" in src
+    assert "make_interval(secs => $3)" in src
+    assert "_USAGE_RETRY_COOLDOWN_SECONDS" in src
+    # Constant value reasonable.
+    assert llm_gateway_batch._USAGE_RETRY_COOLDOWN_SECONDS == 30
+
+
+def test_refresh_stamps_retry_timestamp_before_persist():
+    """PR-D4e: the timestamp must be stamped BEFORE _persist_batch_usage
+    runs so a concurrent poller in the same window sees the cooldown
+    is active and skips. Stamping after would race."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.refresh_customer_batch_status)
+    stamp_idx = src.find("SET last_usage_retry_at = NOW()")
+    persist_idx = src.find("await _persist_batch_usage(")
+    assert stamp_idx > 0 and persist_idx > 0
+    assert stamp_idx < persist_idx, (
+        "Cooldown stamp must precede _persist_batch_usage call so "
+        "concurrent pollers see it within the window."
+    )
+
+
+def test_customer_batch_record_exposes_resume_safety_fields():
+    """PR-D4e adds two fields to the dataclass for the refresh +
+    submit paths to read. Defaults None so test mocks that don't
+    include the columns still construct cleanly."""
+    from atlas_brain.services.llm_gateway_batch import CustomerBatchRecord
+
+    fields = CustomerBatchRecord.__dataclass_fields__
+    assert "anthropic_call_initiated_at" in fields
+    assert "last_usage_retry_at" in fields
+    assert fields["anthropic_call_initiated_at"].default is None
+    assert fields["last_usage_retry_at"].default is None
 
 
 def test_submit_customer_batch_replay_only_when_provider_batch_id_set():

--- a/tests/test_llm_gateway_idempotency_usage.py
+++ b/tests/test_llm_gateway_idempotency_usage.py
@@ -344,6 +344,28 @@ def test_refresh_stamps_retry_timestamp_before_persist():
     )
 
 
+def test_refresh_cooldown_uses_atomic_claim_not_select_then_update():
+    """Codex P2 on PR-D4e: SELECT-then-UPDATE is racy -- two
+    concurrent pollers can both observe cooldown_active=false
+    before either writes. The cooldown gate must be a single
+    conditional UPDATE...RETURNING so only one poller can claim
+    the retry slot per cooldown window. Same atomic-claim pattern
+    PR-D4d uses for the usage_tracked flag flip."""
+    from atlas_brain.services import llm_gateway_batch
+
+    src = inspect.getsource(llm_gateway_batch.refresh_customer_batch_status)
+    # Single atomic claim with RETURNING.
+    assert "claim = await pool.fetchrow(" in src
+    assert "RETURNING id" in src
+    assert "if claim is None:" in src
+    # Predicate covers both NULL and outside-the-window cases.
+    assert "last_usage_retry_at IS NULL" in src
+    assert "OR last_usage_retry_at <=" in src
+    # The racy SELECT-then-UPDATE pattern must not return.
+    assert "cooldown_active = await pool.fetchval" not in src
+    assert "if cooldown_active:" not in src
+
+
 def test_customer_batch_record_exposes_resume_safety_fields():
     """PR-D4e adds two fields to the dataclass for the refresh +
     submit paths to read. Defaults None so test mocks that don't


### PR DESCRIPTION
## Summary

Closes the three remaining audit findings from the PR-D4c post-merge audit:

| # | Severity | Item | Fix |
|---|---|---|---|
| 1 | 🟠 Medium | Duplicate-pay window (Anthropic accepted, local UPDATE failed → 60s later, resume duplicate-pays) | New `anthropic_call_initiated_at` column stamped before `batches.create`; resume claim narrows to `IS NULL` |
| 2 | 🟠 Medium | Retry-on-terminal poll storm (1Hz poll loop hammers Anthropic results endpoint under transient SDK failures) | New `last_usage_retry_at` column + 30s cooldown predicate |
| 3 | 🟡 Minor | Resume display inconsistencies (`completed_at` stale, `total_items`/`model` not refreshed) | Success UPDATE clears `completed_at`; resume UPDATE bumps `total_items` + `model` |

## Migration 322

Two columns added to `llm_gateway_batches`:
- `anthropic_call_initiated_at TIMESTAMPTZ` — stamped BEFORE `AsyncAnthropic.batches.create` so the resume claim can distinguish "never reached Anthropic" (safe to resubmit) from "Anthropic may have accepted, our local UPDATE crashed" (ambiguous orphan, do not auto-resubmit)
- `last_usage_retry_at TIMESTAMPTZ` — timestamp of the most recent `_persist_batch_usage` retry from `refresh_customer_batch_status` so the cooldown predicate can skip retries inside the window

## Why no Anthropic-side idempotency header

Considered passing an `Anthropic-Idempotency-Key` header on `batches.create` as belt-and-suspenders against the duplicate-pay window. The Anthropic SDK exposes `_idempotency_header = None` for this provider — a strong signal Anthropic doesn't support a standard idempotency header on batches. Without verified behavior against the live API, shipping the header would mean cargo-cult code with confident comments. The `anthropic_call_initiated_at` schema change is the real fix; if Anthropic later publishes an idempotency mechanism, that's a follow-up PR with verified behavior.

## Ambiguous-orphan UX

When the resume claim returns None because the row's `anthropic_call_initiated_at` is set with no `provider_batch_id` (the dangerous case), the customer sees the row in its prior state (queued or submit_failed) and can't auto-recover. The flow now emits a distinct `WARN` log line:

```
llm_gateway_batch.submit ambiguous-orphan account=... key=... id=... 
status=... anthropic_call_initiated_at=... -- Anthropic may have 
accepted the prior submit; manual recovery required (do not auto-resume)
```

Ops can grep for `ambiguous-orphan` to find these rows. A future PR could add a customer-visible `submit_uncertain` status + a force-reset path; explicitly out of scope here.

## Test plan

- [x] 45 idempotency tests (was 36; +9 new):
  - `test_migration_322_adds_resume_safety_columns`
  - `test_resume_claim_requires_anthropic_call_never_initiated`
  - `test_resume_claim_updates_total_items_and_model`
  - `test_anthropic_call_stamped_before_create`
  - `test_success_update_clears_completed_at`
  - `test_ambiguous_orphan_logs_warning_for_ops`
  - `test_refresh_retry_on_terminal_uses_cooldown`
  - `test_refresh_stamps_retry_timestamp_before_persist`
  - `test_customer_batch_record_exposes_resume_safety_fields`
- [x] Full LLM-gateway + auth + plan-tier + scoping suite: 235 passed
- [x] ASCII compliance verified
- [x] No inline hard-coded values (all literals → module constants or migration)
- [x] No breaking changes (CustomerBatchRecord new fields default to None for back-compat with row mocks)
- [ ] Codex / Copilot review
- [ ] Migration 322 applied in staging before merge

## Concurrency posture (for the cooldown)

Two concurrent pollers race for the retry slot. The cooldown UPDATE-stamps `last_usage_retry_at = NOW()` BEFORE calling `_persist_batch_usage`, so:

```
Poller A: cooldown_active = false (NULL or stale) → stamp NOW() → persist
Poller B (within 30s window): cooldown_active = true → return record (skip)
```

`_persist_batch_usage`'s own atomic claim (added in PR-D4d) provides additional protection against double-writes if the cooldown stamp UPDATE somehow loses to a race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
