### PR TITLE
PR-D7b5: archetypes.py atlas wrapper

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -14,6 +14,7 @@ on:
       - "atlas_brain/reasoning/tiers.py"
       - "atlas_brain/reasoning/wedge_registry.py"
       - "atlas_brain/reasoning/temporal.py"
+      - "atlas_brain/reasoning/archetypes.py"
       - "atlas_brain/reasoning/graph.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
       - "atlas_brain/mcp/b2b/signals.py"
@@ -39,6 +40,7 @@ on:
       - "tests/test_atlas_reasoning_tiers_aliases.py"
       - "tests/test_atlas_reasoning_wedge_registry_aliases.py"
       - "tests/test_atlas_reasoning_temporal_aliases.py"
+      - "tests/test_atlas_reasoning_archetypes_aliases.py"
       - "tests/test_forbid_atlas_reasoning_imports.py"
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
   push:
@@ -54,6 +56,7 @@ on:
       - "atlas_brain/reasoning/tiers.py"
       - "atlas_brain/reasoning/wedge_registry.py"
       - "atlas_brain/reasoning/temporal.py"
+      - "atlas_brain/reasoning/archetypes.py"
       - "atlas_brain/reasoning/graph.py"
       - "atlas_brain/autonomous/tasks/_b2b_reasoning_consumer_adapter.py"
       - "atlas_brain/mcp/b2b/signals.py"
@@ -79,6 +82,7 @@ on:
       - "tests/test_atlas_reasoning_tiers_aliases.py"
       - "tests/test_atlas_reasoning_wedge_registry_aliases.py"
       - "tests/test_atlas_reasoning_temporal_aliases.py"
+      - "tests/test_atlas_reasoning_archetypes_aliases.py"
       - "tests/test_forbid_atlas_reasoning_imports.py"
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
 

--- a/atlas_brain/reasoning/archetypes.py
+++ b/atlas_brain/reasoning/archetypes.py
@@ -1,592 +1,68 @@
 """Churn Archetype Definitions and Signal Matching (WS2).
 
-Defines 8 canonical churn archetypes with signal signatures. The scorer
-evaluates vendor evidence (including temporal data from WS1) against each
-archetype's expected signal profile and returns ranked matches.
+Defines the canonical churn archetypes with signal signatures. The
+scorer evaluates vendor evidence (including temporal data from WS1)
+against each archetype's expected signal profile and returns ranked
+matches. Pure data, no LLM.
 
-This is a pure-data pre-filter -- it does NOT call the LLM. The ranked
-scores feed into synthesis-first vendor reasoning as context, and enable
-vendor-state updates without LLM calls.
+PR-D7b5 promoted this module's body into
+:mod:`extracted_reasoning_core.archetypes` (per the PR-C1a
+consolidation). Atlas keeps the import surface
+``atlas_brain.reasoning.archetypes`` as a thin re-export wrapper so
+internal callers (``b2b_churn_intelligence``, ``_b2b_shared``,
+``test_reasoning_live``, ``test_archetype_propagation``) keep their
+existing import sites working.
 
-Archetypes:
-    pricing_shock       -- Sudden price increase -> complaint spike -> competitor mentions
-    feature_gap         -- Competitor launches key feature -> "missing X" reviews surge
-    acquisition_decay   -- Post-acquisition quality decline -> support complaints -> churn
-    leadership_redesign -- New VP Product -> UI overhaul -> "new interface" complaints
-    integration_break   -- API change breaks workflows -> "integration" pain spike
-    support_collapse    -- Support quality drop -> response time complaints -> trust erosion
-    category_disruption -- New entrant class (AI-native) -> incumbents lose narrative
-    compliance_gap      -- Regulatory requirement unmet -> enterprise segments leave
+Drift handling: core deliberately split ``ArchetypeMatch`` into two
+shapes per PR-C1a's design.
+
+- ``_ArchetypeMatchInternal`` (in ``core.archetypes``) -- the rich
+  internal result with atlas's original field names (``archetype`` /
+  ``score`` / ``matched_signals`` / ``missing_signals`` /
+  ``risk_level``). Core's ``score_evidence`` / ``best_match`` /
+  ``top_matches`` / ``enrich_evidence_with_archetypes`` all return
+  this type. Atlas-side callers continue to consume it directly.
+
+- ``ArchetypeMatch`` (in ``core.types``) -- the canonical public
+  contract with renamed fields (``archetype_id`` / ``label`` /
+  ``evidence_hits`` / ``missing_evidence`` / ``risk_label``). Only
+  reachable through ``core.api.score_archetypes`` for external
+  products that need the stable surface.
+
+This wrapper aliases atlas's ``ArchetypeMatch`` to the rich internal
+type so existing atlas code reading ``.archetype`` / ``.matched_signals``
+/ ``.risk_level`` keeps working without translation. The canonical
+``core.types.ArchetypeMatch`` is intentionally NOT exposed here -- if
+an atlas caller ever needs the public shape, it should reach through
+``core.api`` like any other product.
 """
 
 from __future__ import annotations
 
-import logging
-import re
-from dataclasses import dataclass, field
-from typing import Any
-
-logger = logging.getLogger("atlas.reasoning.archetypes")
-
-# Minimum score to consider an archetype a plausible match
-MATCH_THRESHOLD = 0.25
-
-
-@dataclass
-class SignalRule:
-    """A single signal check within an archetype signature."""
-
-    metric: str        # evidence key to check
-    direction: str     # "high", "low", "increasing", "decreasing", "present"
-    weight: float = 1.0
-    threshold: float | None = None  # numeric threshold (meaning depends on direction)
-    pain_keywords: list[str] = field(default_factory=list)  # keywords to match in text fields
-
-
-@dataclass
-class ArchetypeProfile:
-    """Definition of a churn archetype with its expected signal signature."""
-
-    name: str
-    description: str
-    signals: list[SignalRule]
-    typical_risk: str  # "low", "medium", "high", "critical"
-    velocity_hints: dict[str, str] = field(default_factory=dict)
-    falsification_templates: list[str] = field(default_factory=list)
-
-
-@dataclass
-class ArchetypeMatch:
-    """Result of scoring a vendor's evidence against an archetype."""
-
-    archetype: str
-    score: float  # 0.0-1.0 weighted match score
-    matched_signals: list[str]
-    missing_signals: list[str]
-    risk_level: str
-
-
-# ------------------------------------------------------------------
-# The 8 canonical archetypes
-# ------------------------------------------------------------------
-
-ARCHETYPES: dict[str, ArchetypeProfile] = {
-    "pricing_shock": ArchetypeProfile(
-        name="pricing_shock",
-        description="Sudden price increase -> complaint spike -> competitor mentions",
-        typical_risk="high",
-        signals=[
-            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.0),
-            SignalRule("top_pain", "present", weight=2.0,
-                       pain_keywords=["price", "pricing", "cost", "expensive", "renewal", "invoice"]),
-            SignalRule("competitor_count", "high", weight=1.0, threshold=3),
-            SignalRule("recommend_ratio", "low", weight=1.0, threshold=0.4),
-            SignalRule("displacement_edge_count", "high", weight=1.2, threshold=2),
-            SignalRule("positive_review_pct", "low", weight=0.8, threshold=40.0),
-        ],
-        velocity_hints={
-            "avg_urgency": "increasing",
-            "competitor_count": "increasing",
-            "recommend_ratio": "decreasing",
-        },
-        falsification_templates=[
-            "Vendor reverts to previous pricing or introduces budget tier",
-            "Positive review trend reversal (3+ consecutive weeks improving)",
-            "Competitor count stabilizes or decreases",
-        ],
-    ),
-    "feature_gap": ArchetypeProfile(
-        name="feature_gap",
-        description="Competitor launches key feature -> 'missing X' reviews surge",
-        typical_risk="medium",
-        signals=[
-            SignalRule("top_pain", "present", weight=2.0,
-                       pain_keywords=["missing", "lack", "need", "feature", "no support for",
-                                      "doesn't have", "wish", "roadmap"]),
-            SignalRule("competitor_count", "high", weight=1.5, threshold=2),
-            SignalRule("displacement_edge_count", "high", weight=1.5, threshold=2),
-            SignalRule("pain_count", "high", weight=1.0, threshold=4),
-            SignalRule("recommend_ratio", "low", weight=0.8, threshold=0.5),
-        ],
-        velocity_hints={
-            "competitor_count": "increasing",
-            "displacement_edge_count": "increasing",
-            "pain_count": "increasing",
-        },
-        falsification_templates=[
-            "Vendor releases the missing feature",
-            "Competitor mentions decrease by 50%+",
-            "Pain count drops below 2",
-        ],
-    ),
-    "acquisition_decay": ArchetypeProfile(
-        name="acquisition_decay",
-        description="Post-acquisition quality decline -> support complaints -> churn",
-        typical_risk="high",
-        signals=[
-            SignalRule("positive_review_pct", "low", weight=1.5, threshold=35.0),
-            SignalRule("avg_urgency", "high", weight=1.2, threshold=5.5),
-            SignalRule("top_pain", "present", weight=2.0,
-                       pain_keywords=["acquired", "acquisition", "buyout", "merged",
-                                      "new ownership", "quality decline", "worse since"]),
-            SignalRule("recommend_ratio", "low", weight=1.0, threshold=0.35),
-            SignalRule("churn_density", "high", weight=1.0, threshold=0.6),
-        ],
-        velocity_hints={
-            "positive_review_pct": "decreasing",
-            "avg_urgency": "increasing",
-            "churn_density": "increasing",
-        },
-        falsification_templates=[
-            "Positive review percentage improves above 50%",
-            "Support response time improves to < 4h average",
-            "New leadership announces quality investment plan",
-        ],
-    ),
-    "leadership_redesign": ArchetypeProfile(
-        name="leadership_redesign",
-        description="New VP Product -> UI overhaul -> 'new interface' complaints",
-        typical_risk="medium",
-        signals=[
-            SignalRule("top_pain", "present", weight=2.5,
-                       pain_keywords=["redesign", "new ui", "new interface", "update",
-                                      "changed layout", "new version", "ui overhaul",
-                                      "workflow changed", "moved features"]),
-            SignalRule("avg_urgency", "high", weight=1.0, threshold=5.0),
-            SignalRule("pain_count", "high", weight=0.8, threshold=3),
-            SignalRule("positive_review_pct", "low", weight=1.0, threshold=45.0),
-        ],
-        velocity_hints={
-            "avg_urgency": "increasing",
-            "positive_review_pct": "decreasing",
-            "pain_count": "increasing",
-        },
-        falsification_templates=[
-            "Vendor reverts UI changes or provides classic mode",
-            "Positive review pct recovers above 55%",
-            "Pain count related to UI drops below 2",
-        ],
-    ),
-    "integration_break": ArchetypeProfile(
-        name="integration_break",
-        description="API change breaks workflows -> 'integration' pain spike",
-        typical_risk="high",
-        signals=[
-            SignalRule("top_pain", "present", weight=2.5,
-                       pain_keywords=["api", "integration", "webhook", "connector",
-                                      "broke", "breaking change", "deprecated",
-                                      "incompatible", "migration", "sdk"]),
-            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.5),
-            SignalRule("high_intent_company_count", "high", weight=1.2, threshold=3),
-            SignalRule("churn_density", "high", weight=1.0, threshold=0.5),
-        ],
-        velocity_hints={
-            "avg_urgency": "increasing",
-            "churn_density": "increasing",
-            "high_intent_company_count": "increasing",
-        },
-        falsification_templates=[
-            "Vendor provides backward-compatible API or migration tooling",
-            "Urgency drops below 4.0",
-            "Integration-related pain mentions drop by 60%+",
-        ],
-    ),
-    "support_collapse": ArchetypeProfile(
-        name="support_collapse",
-        description="Support quality drop -> response time complaints -> trust erosion",
-        typical_risk="critical",
-        signals=[
-            SignalRule("top_pain", "present", weight=2.0,
-                       pain_keywords=["support", "response time", "ticket", "help desk",
-                                      "no response", "slow support", "waiting",
-                                      "customer service", "escalation"]),
-            SignalRule("avg_urgency", "high", weight=1.5, threshold=6.0),
-            SignalRule("positive_review_pct", "low", weight=1.5, threshold=30.0),
-            SignalRule("recommend_ratio", "low", weight=1.2, threshold=0.3),
-            SignalRule("churn_density", "high", weight=1.0, threshold=0.7),
-        ],
-        velocity_hints={
-            "positive_review_pct": "decreasing",
-            "avg_urgency": "increasing",
-            "churn_density": "increasing",
-            "recommend_ratio": "decreasing",
-        },
-        falsification_templates=[
-            "Support response time improves to < 4h average",
-            "Positive review pct recovers above 45%",
-            "Support-related complaints drop by 50%+",
-        ],
-    ),
-    "category_disruption": ArchetypeProfile(
-        name="category_disruption",
-        description="New entrant class (e.g., AI-native) -> incumbents lose narrative",
-        typical_risk="high",
-        signals=[
-            SignalRule("competitor_count", "high", weight=2.0, threshold=5),
-            SignalRule("displacement_edge_count", "high", weight=2.0, threshold=4),
-            SignalRule("top_pain", "present", weight=1.0,
-                       pain_keywords=["alternative", "switch to", "moved to", "replaced by",
-                                      "ai-native", "modern", "next-gen", "outdated"]),
-            SignalRule("high_intent_company_count", "high", weight=1.5, threshold=5),
-            SignalRule("recommend_ratio", "low", weight=0.8, threshold=0.4),
-        ],
-        velocity_hints={
-            "competitor_count": "increasing",
-            "displacement_edge_count": "increasing",
-            "high_intent_company_count": "increasing",
-        },
-        falsification_templates=[
-            "Vendor launches competitive AI/modern features",
-            "Competitor count drops or stabilizes for 4+ weeks",
-            "Displacement edge count decreases by 40%+",
-        ],
-    ),
-    "compliance_gap": ArchetypeProfile(
-        name="compliance_gap",
-        description="Regulatory requirement unmet -> enterprise segments leave",
-        typical_risk="critical",
-        signals=[
-            SignalRule("top_pain", "present", weight=3.0,
-                       pain_keywords=["compliance", "gdpr", "hipaa", "soc2", "soc 2",
-                                      "iso 27001", "fedramp", "pci", "audit",
-                                      "regulation", "security", "data residency",
-                                      "encryption", "certification"]),
-            SignalRule("high_intent_company_count", "high", weight=1.5, threshold=3),
-            SignalRule("avg_urgency", "high", weight=1.0, threshold=5.5),
-            SignalRule("churn_density", "high", weight=1.0, threshold=0.5),
-        ],
-        velocity_hints={
-            "high_intent_company_count": "increasing",
-            "churn_density": "increasing",
-        },
-        falsification_templates=[
-            "Vendor achieves the missing certification/compliance requirement",
-            "Compliance-related complaints drop to zero",
-            "Enterprise churn intent stabilizes",
-        ],
-    ),
-    "scale_up_stumble": ArchetypeProfile(
-        name="scale_up_stumble",
-        description="High growth (hiring/reviews) -> support quality/culture degrades",
-        typical_risk="medium",
-        signals=[
-            SignalRule("employee_growth_rate", "high", weight=2.0, threshold=0.20),  # >20% growth
-            SignalRule("support_sentiment", "decreasing_30d", weight=1.5),
-            SignalRule("recommend_ratio", "decreasing_30d", weight=1.0),
-            SignalRule("pain_count", "high", weight=1.0, threshold=3),
-            SignalRule("top_pain", "present", weight=1.0,
-                        pain_keywords=["growing pains", "used to be better", "new reps", 
-                                       "training", "knowledge gap", "slow response"]),
-        ],
-        velocity_hints={
-            "pain_count": "increasing",
-            "recommend_ratio": "decreasing",
-        },
-        falsification_templates=[
-            "Support sentiment stabilizes for 30+ days",
-            "Hiring pace normalizes (<5% quarterly)",
-            "Training investment announced",
-        ],
-    ),
-    "pivot_abandonment": ArchetypeProfile(
-        name="pivot_abandonment",
-        description="Focus shifts to new segment/product -> legacy customer neglect",
-        typical_risk="high",
-        signals=[
-            SignalRule("new_feature_velocity", "high", weight=1.5, threshold=0.5),
-            SignalRule("legacy_support_score", "low", weight=1.5, threshold=0.4),
-            SignalRule("churn_density", "increasing_30d", weight=2.0),
-            SignalRule("top_pain", "present", weight=1.5,
-                        pain_keywords=["legacy", "ignored", "forgotten", "deprecated", 
-                                       "forced migration", "sunset", "old version"]),
-        ],
-        velocity_hints={
-            "churn_density": "increasing",
-        },
-        falsification_templates=[
-            "Vendor recommits to legacy product roadmap",
-            "Migration tools provided free of charge",
-            "Churn density stabilizes",
-        ],
-    ),
-}
-
-
-# ------------------------------------------------------------------
-# Scoring engine
-# ------------------------------------------------------------------
-
-
-def score_evidence(
-    evidence: dict[str, Any],
-    temporal: dict[str, Any] | None = None,
-) -> list[ArchetypeMatch]:
-    """Score vendor evidence against all archetypes.
-
-    *evidence*: flat dict from b2b_vendor_snapshots (and enriched fields).
-    *temporal*: output of TemporalEngine.to_evidence_dict() -- velocity/accel/anomaly data.
-
-    Returns list of ArchetypeMatch sorted by score descending.
-    """
-    merged = {**evidence}
-    if temporal:
-        merged.update(temporal)
-
-    results = []
-    for name, profile in ARCHETYPES.items():
-        match = _score_archetype(profile, merged)
-        results.append(match)
-
-    results.sort(key=lambda m: m.score, reverse=True)
-    return results
-
-
-def best_match(
-    evidence: dict[str, Any],
-    temporal: dict[str, Any] | None = None,
-) -> ArchetypeMatch | None:
-    """Return the highest-scoring archetype above threshold, or None."""
-    matches = score_evidence(evidence, temporal)
-    if matches and matches[0].score >= MATCH_THRESHOLD:
-        return matches[0]
-    return None
-
-
-def top_matches(
-    evidence: dict[str, Any],
-    temporal: dict[str, Any] | None = None,
-    *,
-    limit: int = 3,
-) -> list[ArchetypeMatch]:
-    """Return the top N archetype matches above threshold."""
-    matches = score_evidence(evidence, temporal)
-    return [m for m in matches[:limit] if m.score >= MATCH_THRESHOLD]
-
-
-def get_archetype(name: str) -> ArchetypeProfile | None:
-    """Lookup an archetype by name."""
-    return ARCHETYPES.get(name)
-
-
-def get_falsification_conditions(archetype_name: str) -> list[str]:
-    """Get falsification condition templates for a given archetype."""
-    profile = ARCHETYPES.get(archetype_name)
-    return list(profile.falsification_templates) if profile else []
-
-
-# ------------------------------------------------------------------
-# Internal scoring
-# ------------------------------------------------------------------
-
-
-def _score_archetype(profile: ArchetypeProfile, evidence: dict[str, Any]) -> ArchetypeMatch:
-    """Score evidence against a single archetype profile."""
-    total_weight = sum(s.weight for s in profile.signals)
-    if total_weight == 0:
-        return ArchetypeMatch(
-            archetype=profile.name,
-            score=0.0,
-            matched_signals=[],
-            missing_signals=[],
-            risk_level=profile.typical_risk,
-        )
-
-    weighted_score = 0.0
-    matched = []
-    missing = []
-
-    for rule in profile.signals:
-        hit = _evaluate_rule(rule, evidence)
-        if hit:
-            weighted_score += rule.weight
-            matched.append(rule.metric)
-        else:
-            missing.append(rule.metric)
-
-    # Velocity bonus: if temporal data shows expected direction, boost score
-    velocity_bonus = _velocity_bonus(profile, evidence)
-    weighted_score += velocity_bonus
-
-    # Anomaly bonus: if z-score anomalies overlap with archetype signals
-    anomaly_bonus = _anomaly_bonus(profile, evidence)
-    weighted_score += anomaly_bonus
-
-    # Normalize to 0.0-1.0
-    max_possible = total_weight + len(profile.velocity_hints) * 0.3 + 0.5
-    score = min(weighted_score / max_possible, 1.0)
-
-    # Determine risk level from score
-    risk = _risk_from_score(score, profile.typical_risk)
-
-    return ArchetypeMatch(
-        archetype=profile.name,
-        score=round(score, 3),
-        matched_signals=matched,
-        missing_signals=missing,
-        risk_level=risk,
-    )
-
-
-def _evaluate_rule(rule: SignalRule, evidence: dict[str, Any]) -> bool:
-    """Check if a single signal rule matches the evidence."""
-    # Text-based keyword matching (for top_pain and similar text fields)
-    if rule.pain_keywords:
-        text_fields = ["top_pain", "top_competitor", "pain_summary"]
-        combined = ""
-        for f in text_fields:
-            val = evidence.get(f)
-            if val is not None:
-                combined += " " + str(val).lower()
-        # Also check list fields (pain_categories, etc.)
-        for key in evidence:
-            if "pain" in key or "complaint" in key:
-                val = evidence[key]
-                if isinstance(val, list):
-                    combined += " " + " ".join(str(v).lower() for v in val)
-        if combined.strip():
-            if any(kw in combined for kw in rule.pain_keywords):
-                return True
-        return False
-
-    if rule.direction == "present":
-        return rule.metric in evidence
-
-    # Value-based checks require the metric to be present and numeric
-    if rule.direction in ("high", "low"):
-        val = evidence.get(rule.metric)
-        if val is None:
-            return False
-        try:
-            val_f = float(val)
-        except (ValueError, TypeError):
-            return False
-
-        if rule.direction == "high":
-            return val_f >= (rule.threshold if rule.threshold is not None else 0)
-        elif rule.direction == "low":
-            return val_f <= (rule.threshold if rule.threshold is not None else float("inf"))
-
-    # Velocity/Trend checks look for derived fields
-    elif rule.direction == "increasing":
-        vel = evidence.get(f"velocity_{rule.metric}")
-        if vel is not None:
-            return float(vel) > 0
-        return False
-    elif rule.direction == "decreasing":
-        vel = evidence.get(f"velocity_{rule.metric}")
-        if vel is not None:
-            return float(vel) < 0
-        return False
-    elif rule.direction == "increasing_30d":
-        slope = evidence.get(f"trend_30d_{rule.metric}")
-        if slope is not None:
-            return float(slope) > 0
-        return False
-    elif rule.direction == "decreasing_30d":
-        slope = evidence.get(f"trend_30d_{rule.metric}")
-        if slope is not None:
-            return float(slope) < 0
-        return False
-
-    return False
-
-
-def _velocity_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float:
-    """Bonus score for velocity signals matching expected directions."""
-    bonus = 0.0
-    for metric, expected_dir in profile.velocity_hints.items():
-        vel_key = f"velocity_{metric}"
-        vel = evidence.get(vel_key)
-        if vel is None:
-            continue
-        try:
-            vel_f = float(vel)
-        except (ValueError, TypeError):
-            continue
-
-        if expected_dir == "increasing" and vel_f > 0:
-            bonus += 0.3
-        elif expected_dir == "decreasing" and vel_f < 0:
-            bonus += 0.3
-
-        # Extra bonus for acceleration in the expected direction
-        accel_key = f"accel_{metric}"
-        accel = evidence.get(accel_key)
-        if accel is not None:
-            try:
-                accel_f = float(accel)
-                if expected_dir == "increasing" and accel_f > 0:
-                    bonus += 0.15
-                elif expected_dir == "decreasing" and accel_f < 0:
-                    bonus += 0.15
-            except (ValueError, TypeError):
-                pass
-
-    return bonus
-
-
-def _anomaly_bonus(profile: ArchetypeProfile, evidence: dict[str, Any]) -> float:
-    """Bonus if z-score anomalies align with the archetype's signal metrics."""
-    anomalies = evidence.get("anomalies")
-    if not anomalies or not isinstance(anomalies, list):
-        return 0.0
-
-    archetype_metrics = {s.metric for s in profile.signals if not s.pain_keywords}
-    bonus = 0.0
-    for anom in anomalies:
-        if not isinstance(anom, dict):
-            continue
-        metric = anom.get("metric", "")
-        if metric in archetype_metrics:
-            z = abs(anom.get("z_score", 0))
-            if z > 2.0:
-                bonus += 0.25
-            elif z > 1.5:
-                bonus += 0.1
-
-    return min(bonus, 0.5)  # cap anomaly bonus
-
-
-def _risk_from_score(score: float, base_risk: str) -> str:
-    """Derive risk level from match score and archetype's typical risk."""
-    if score < 0.25:
-        return "low"
-    if score < 0.45:
-        return "medium" if base_risk in ("high", "critical") else "low"
-    if score < 0.65:
-        return "medium" if base_risk != "critical" else "high"
-    if score < 0.80:
-        return "high"
-    return base_risk if base_risk == "critical" else "high"
-
-
-# ------------------------------------------------------------------
-# Utilities for integration
-# ------------------------------------------------------------------
-
-
-def enrich_evidence_with_archetypes(
-    evidence: dict[str, Any],
-    temporal: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Enrich evidence dict with archetype scores for LLM context.
-
-    Adds 'archetype_scores' key with top 3 matches, making the LLM's
-    classification job easier and more consistent.
-    """
-    matches = top_matches(evidence, temporal, limit=3)
-    if not matches:
-        return evidence
-
-    enriched = dict(evidence)
-    enriched["archetype_scores"] = [
-        {
-            "archetype": m.archetype,
-            "signal_score": m.score,
-            "matched_signals": m.matched_signals,
-            "missing_signals": m.missing_signals,
-            "risk_level": m.risk_level,
-        }
-        for m in matches
-    ]
-    return enriched
+from extracted_reasoning_core.archetypes import (
+    ARCHETYPES,
+    MATCH_THRESHOLD,
+    ArchetypeProfile,
+    SignalRule,
+    _ArchetypeMatchInternal as ArchetypeMatch,
+    best_match,
+    enrich_evidence_with_archetypes,
+    get_archetype,
+    get_falsification_conditions,
+    score_evidence,
+    top_matches,
+)
+
+__all__ = [
+    "ARCHETYPES",
+    "ArchetypeMatch",
+    "ArchetypeProfile",
+    "MATCH_THRESHOLD",
+    "SignalRule",
+    "best_match",
+    "enrich_evidence_with_archetypes",
+    "get_archetype",
+    "get_falsification_conditions",
+    "score_evidence",
+    "top_matches",
+]

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T14:55Z by codex-2026-05-05-d11
+Last updated: 2026-05-05T14:56Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-D7b5, in flight) | PR-D7b5: archetypes.py atlas wrapper (PR 7 fifth slice, 4/5 of fork migration -- evidence_engine still deferred) | EDIT: `atlas_brain/reasoning/archetypes.py` (592-LOC fork becomes a ~50-LOC re-export from `extracted_reasoning_core.archetypes`; preserves ARCHETYPES + ArchetypeProfile + SignalRule + MATCH_THRESHOLD + score_evidence + best_match + top_matches + get_archetype + get_falsification_conditions + enrich_evidence_with_archetypes). Atlas's `ArchetypeMatch` aliases core's `_ArchetypeMatchInternal` -- core deliberately preserved atlas's field names (archetype / score / matched_signals / missing_signals / risk_level) on the rich internal type per PR-C1a's design ("Atlas-side callers continue to consume this richer shape directly"). The canonical public `ArchetypeMatch` in `core.types` (with archetype_id / label / evidence_hits / etc.) stays separate -- only external products through `core.api.score_archetypes` see that shape. NEW: `tests/test_atlas_reasoning_archetypes_aliases.py` (alias-identity pin mirroring PR-D7b1/b2/b4). EDIT: `scripts/run_extracted_pipeline_checks.sh` + `.github/workflows/extracted_pipeline_checks.yml`. No test or caller updates required: atlas's existing field reads (m.archetype, m.matched_signals, m.risk_level in test_reasoning_live.py) keep working because core's _ArchetypeMatchInternal has the same field names. PR-D7 closes after this with 4/5 forks wrapped; b3/evidence_engine remains deferred behind PR-C1e. | claude-2026-05-03 | `atlas_brain/reasoning/archetypes.py`; `tests/test_atlas_reasoning_archetypes_aliases.py`; `scripts/run_extracted_pipeline_checks.sh`; `.github/workflows/extracted_pipeline_checks.yml` |
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -64,6 +64,7 @@ pytest \
   tests/test_atlas_reasoning_tiers_aliases.py \
   tests/test_atlas_reasoning_wedge_registry_aliases.py \
   tests/test_atlas_reasoning_temporal_aliases.py \
+  tests/test_atlas_reasoning_archetypes_aliases.py \
   tests/test_forbid_atlas_reasoning_imports.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \

--- a/tests/test_atlas_reasoning_archetypes_aliases.py
+++ b/tests/test_atlas_reasoning_archetypes_aliases.py
@@ -1,0 +1,174 @@
+"""Pin atlas's re-exports from ``atlas_brain.reasoning.archetypes``.
+
+PR-D7b5 promoted the archetypes module into
+``extracted_reasoning_core.archetypes`` (PR-C1a's 10-archetype
+consolidation). Atlas keeps the import surface
+``atlas_brain.reasoning.archetypes`` as a thin re-export wrapper.
+
+Notable design decision (mirrors core's docstring): atlas's
+``ArchetypeMatch`` aliases core's ``_ArchetypeMatchInternal`` -- the
+rich internal type that preserves atlas's original field names
+(``archetype`` / ``score`` / ``matched_signals`` / ``missing_signals``
+/ ``risk_level``). Core's canonical public ``ArchetypeMatch`` (in
+``core.types``, with renamed fields like ``archetype_id`` / ``label`` /
+``evidence_hits``) is only reachable via ``core.api.score_archetypes``
+for external products. The wrapper keeps atlas's existing
+``score_evidence`` / ``best_match`` / ``top_matches`` /
+``enrich_evidence_with_archetypes`` callers working without field
+renames -- ``test_reasoning_live.py`` reads ``m.archetype`` /
+``m.matched_signals`` / ``m.risk_level`` and those still resolve.
+"""
+
+from __future__ import annotations
+
+from atlas_brain.reasoning import archetypes as atlas_archetypes
+from extracted_reasoning_core import archetypes as core_archetypes
+
+
+def test_archetype_match_aliases_internal_not_public() -> None:
+    # atlas's ArchetypeMatch is the rich internal type from core,
+    # NOT the canonical public ArchetypeMatch in core.types. Pin
+    # this so a future refactor that "fixes" the import to point at
+    # core.types.ArchetypeMatch doesn't silently break atlas callers
+    # reading m.archetype / m.matched_signals / m.risk_level.
+    assert atlas_archetypes.ArchetypeMatch is core_archetypes._ArchetypeMatchInternal
+
+
+def test_archetype_match_preserves_atlas_field_names() -> None:
+    # atlas-style field names must be present on the aliased type so
+    # test_reasoning_live's m.archetype / m.matched_signals reads
+    # keep working through the wrapper.
+    fields = {
+        f.name for f in atlas_archetypes.ArchetypeMatch.__dataclass_fields__.values()
+    }
+    assert fields == {
+        "archetype",
+        "score",
+        "matched_signals",
+        "missing_signals",
+        "risk_level",
+    }
+
+
+def test_archetype_profile_alias_identity() -> None:
+    assert atlas_archetypes.ArchetypeProfile is core_archetypes.ArchetypeProfile
+
+
+def test_signal_rule_alias_identity() -> None:
+    assert atlas_archetypes.SignalRule is core_archetypes.SignalRule
+
+
+def test_archetypes_dict_alias_identity() -> None:
+    # The ARCHETYPES dict itself must be the same object so a caller
+    # that holds a reference always reads the canonical 10-entry set.
+    assert atlas_archetypes.ARCHETYPES is core_archetypes.ARCHETYPES
+
+
+def test_archetypes_dict_has_ten_canonical_entries() -> None:
+    # Pin the count + names so a future revert that drops one of the
+    # PR-C1a archetypes surfaces here.
+    assert set(atlas_archetypes.ARCHETYPES.keys()) == {
+        "pricing_shock",
+        "feature_gap",
+        "acquisition_decay",
+        "leadership_redesign",
+        "integration_break",
+        "support_collapse",
+        "category_disruption",
+        "compliance_gap",
+        "scale_up_stumble",
+        "pivot_abandonment",
+    }
+
+
+def test_match_threshold_alias_identity() -> None:
+    assert atlas_archetypes.MATCH_THRESHOLD == core_archetypes.MATCH_THRESHOLD == 0.25
+
+
+def test_score_evidence_alias_identity() -> None:
+    assert atlas_archetypes.score_evidence is core_archetypes.score_evidence
+
+
+def test_best_match_alias_identity() -> None:
+    assert atlas_archetypes.best_match is core_archetypes.best_match
+
+
+def test_top_matches_alias_identity() -> None:
+    assert atlas_archetypes.top_matches is core_archetypes.top_matches
+
+
+def test_get_archetype_alias_identity() -> None:
+    assert atlas_archetypes.get_archetype is core_archetypes.get_archetype
+
+
+def test_get_falsification_conditions_alias_identity() -> None:
+    assert (
+        atlas_archetypes.get_falsification_conditions
+        is core_archetypes.get_falsification_conditions
+    )
+
+
+def test_enrich_evidence_with_archetypes_alias_identity() -> None:
+    assert (
+        atlas_archetypes.enrich_evidence_with_archetypes
+        is core_archetypes.enrich_evidence_with_archetypes
+    )
+
+
+def test_atlas_archetypes_all_matches_re_export_set() -> None:
+    assert set(atlas_archetypes.__all__) == {
+        "ARCHETYPES",
+        "ArchetypeMatch",
+        "ArchetypeProfile",
+        "MATCH_THRESHOLD",
+        "SignalRule",
+        "best_match",
+        "enrich_evidence_with_archetypes",
+        "get_archetype",
+        "get_falsification_conditions",
+        "score_evidence",
+        "top_matches",
+    }
+
+
+def test_atlas_archetypes_does_not_redefine_symbols() -> None:
+    # AST-level guard: the wrapper body should contain only re-export
+    # imports + ``__all__`` literal -- no def/class statements.
+    import ast
+    import inspect
+
+    source = inspect.getsource(atlas_archetypes)
+    tree = ast.parse(source)
+
+    redefinitions: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            redefinitions.append(node.name)
+
+    assert redefinitions == [], (
+        f"atlas_brain.reasoning.archetypes should be a pure re-export "
+        f"wrapper, but it defines: {redefinitions}"
+    )
+
+
+def test_score_evidence_returns_atlas_style_match() -> None:
+    # End-to-end smoke: scoring real evidence yields matches whose
+    # field reads work via atlas's ArchetypeMatch alias. Catches a
+    # regression where score_evidence's return type drifts off the
+    # internal type.
+    evidence = {
+        "vendor_name": "TestCo",
+        "avg_urgency": 7.0,
+        "top_pain": "pricing surprise",
+        "competitor_count": 4,
+    }
+    matches = atlas_archetypes.score_evidence(evidence)
+    assert len(matches) > 0
+    top = matches[0]
+    # Atlas-style field reads -- these would fail if ArchetypeMatch
+    # were rebound to the canonical core.types shape.
+    assert isinstance(top.archetype, str)
+    assert isinstance(top.score, float)
+    assert isinstance(top.matched_signals, list)
+    assert isinstance(top.missing_signals, list)
+    assert isinstance(top.risk_level, str)


### PR DESCRIPTION
## Summary

PR-D7 fifth slice (4/5 of fork migration -- evidence_engine still deferred behind PR-C1e).

Promotes the 592-LOC `atlas_brain/reasoning/archetypes.py` fork to a ~50-LOC re-export wrapper around `extracted_reasoning_core.archetypes`. Atlas-side callers (b2b_churn_intelligence, _b2b_shared, test_reasoning_live, test_archetype_propagation) keep their existing import sites without changes.

### Why two `ArchetypeMatch` shapes (intentional)

Per PR-C1a's consolidation design, core deliberately split `ArchetypeMatch` into two shapes:

- `_ArchetypeMatchInternal` (in `core.archetypes`) -- the rich internal result with **atlas's original field names**: `archetype` / `score` / `matched_signals` / `missing_signals` / `risk_level`. Core's `score_evidence` / `best_match` / `top_matches` / `enrich_evidence_with_archetypes` all return this type. Atlas-side callers consume it directly.
- `ArchetypeMatch` (in `core.types`) -- the canonical public contract with renamed fields (`archetype_id` / `label` / `evidence_hits` / `missing_evidence` / `risk_label`). Only reachable through `core.api.score_archetypes` for external products that need the stable surface.

This wrapper aliases atlas's `ArchetypeMatch` to the **internal** type. That is why no test or caller updates were required -- atlas's existing field reads (e.g., `m.archetype`, `m.matched_signals`, `m.risk_level` in `test_reasoning_live.py`) keep working through the wrapper. The canonical public `core.types.ArchetypeMatch` is intentionally NOT exposed in the wrapper.

### Re-exports preserved

`ARCHETYPES`, `ArchetypeProfile`, `SignalRule`, `MATCH_THRESHOLD`, `score_evidence`, `best_match`, `top_matches`, `get_archetype`, `get_falsification_conditions`, `enrich_evidence_with_archetypes`.

### Test pin (mirrors PR-D7b1/b2/b4)

`tests/test_atlas_reasoning_archetypes_aliases.py` pins:
- `ArchetypeMatch is _ArchetypeMatchInternal` (NOT the public `core.types.ArchetypeMatch`) so a future "fix" doesn't silently break atlas callers.
- All five atlas-style field names survive on the aliased dataclass.
- `ARCHETYPES` has exactly the canonical 10 entries (PR-C1a consolidation).
- Every public symbol is identity-equal to core's.
- `__all__` contract is the full re-export set.
- AST-level guard: no `def` or `class` statements in the wrapper body.
- End-to-end smoke that `score_evidence`'s return type still exposes atlas-style field reads.

### CI wiring

- `scripts/run_extracted_pipeline_checks.sh`: adds the new alias test.
- `.github/workflows/extracted_pipeline_checks.yml`: adds `atlas_brain/reasoning/archetypes.py` and the new test to the paths-filter (both `pull_request` and `push` blocks).

### Local standalone CI

`EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` -> **870 passed** (including the 16 new archetype-alias tests + 100 dependent atlas tests that read `m.archetype` etc.).

### Closes audit slice

PR-D7 closes after this with 4/5 forks wrapped (tiers, wedge_registry, temporal, archetypes). The remaining b3/evidence_engine slice stays deferred behind PR-C1e per-review enrichment carve-out.

## Test plan

- [x] `pytest tests/test_atlas_reasoning_archetypes_aliases.py -v` -- 16/16
- [x] `pytest tests/test_archetype_propagation.py tests/test_forbid_atlas_reasoning_imports.py -v` -- 100/100
- [x] `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` -- 870 passed
- [ ] Extracted Pipeline Checks workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)