### PR TITLE
Add single-pass campaign reasoning provider

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T14:55Z by codex-2026-05-05-d11
+Last updated: 2026-05-05T15:05Z by codex-2026-05-05-d12
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| TBD | D12 single-pass campaign reasoning provider | `extracted_content_pipeline/services/single_pass_reasoning_provider.py`, `extracted_content_pipeline/skills/digest/b2b_campaign_reasoning_context.md`, `tests/test_extracted_campaign_single_pass_reasoning.py`, `scripts/run_extracted_pipeline_checks.sh`, content pipeline reasoning docs/status | codex-2026-05-05-d12 | Avoid adding campaign reasoning provider implementations or editing the reasoning handoff docs until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -155,6 +155,13 @@ rows by target id, company, email, or vendor and feeds the normalized
 `CampaignReasoningContextProvider` port documented in
 `docs/reasoning_handoff_contract.md`.
 
+For lightweight installs that do not already have reasoning JSON, use
+`services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`.
+It calls the configured `LLMClient` once per opportunity with the packaged
+`digest/b2b_campaign_reasoning_context` prompt and returns the same normalized
+context shape. This is not a multi-hop graph reasoner; it is the small packaged
+Tier 1 path for "source row in, reasoned draft out."
+
 Use host-provided prompt contracts by pointing at a markdown skill directory:
 
 ```bash

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -138,6 +138,11 @@
   reference file-backed adapter for that boundary. It lets examples and hosts
   provide precomputed reasoning JSON keyed by target id, company, email, or
   vendor without importing a reasoning producer.
+- `services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`
+  is the packaged Tier 1 reasoning producer. It uses the existing LLM and skill
+  ports to build one normalized `CampaignReasoningContext` per opportunity with
+  the `digest/b2b_campaign_reasoning_context` prompt, without importing Atlas
+  reasoning producers or graph state.
 - Both the offline and Postgres campaign generation runners can consume that
   JSON through `--reasoning-context`, so file-backed host reasoning is available
   on demo and DB-backed generation paths.
@@ -150,11 +155,11 @@
 - `reasoning.evidence_engine` is product-owned and evaluates deterministic
   conclusion gates, section suppression gates, and confidence labels from
   built-in rules or an optional host-provided evidence map.
-- Reasoning generation is explicitly host-owned. AI Content Ops consumes
-  compressed reasoning through `CampaignReasoningContextProvider` and the
-  contract documented in `docs/reasoning_handoff_contract.md`; it does not
-  import Atlas synthesis, pool compression, or extracted reasoning-core
-  internals.
+- Long-running reasoning generation is explicitly host-owned. AI Content Ops
+  consumes compressed reasoning through `CampaignReasoningContextProvider` and
+  includes a lightweight single-pass provider for opportunity-level context; it
+  does not import Atlas synthesis, pool compression, graph state, or extracted
+  reasoning-core internals.
 - `docs/host_install_runbook.md` documents the end-to-end host path for
   database-backed installs: migrations, opportunity import, optional reasoning
   JSON, optional skill roots, generation, and output verification.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -181,6 +181,14 @@ The file-backed reasoning adapter matches rows by target id, company, email, or
 vendor. The generator still works without this file, but output quality is lower
 because prompts only see the opportunity row.
 
+If a host does not already have reasoning JSON, it can configure
+`SinglePassCampaignReasoningProvider` from
+`extracted_content_pipeline.services.single_pass_reasoning_provider`. The
+provider uses the same LLM and skill ports as campaign generation, calls the
+packaged `digest/b2b_campaign_reasoning_context` prompt once per opportunity,
+and returns the same normalized context shape. This improves specificity
+without importing Atlas reasoning producers or long-running graph state.
+
 See `reasoning_handoff_contract.md` for the accepted shape and the no-direct-
 import rule. AI Content Ops consumes compressed reasoning; it does not import a
 reasoning engine.
@@ -508,5 +516,6 @@ DELETE FROM campaign_opportunities WHERE account_id = 'acct_123';
   path yet. Host apps inject auth dependencies into the packaged routers.
 - The runbook covers campaign opportunity generation, not blog generation or
   vendor briefing delivery.
-- Reasoning production remains host-owned. This product accepts reasoning
-  context; it does not compute long-running graph state.
+- Long-running reasoning production remains host-owned. The product includes a
+  single-pass opportunity-level provider for lightweight installs, but it does
+  not compute graph state or multi-hop synthesis.

--- a/extracted_content_pipeline/docs/reasoning_handoff_contract.md
+++ b/extracted_content_pipeline/docs/reasoning_handoff_contract.md
@@ -10,9 +10,10 @@ decides multi-hop strategy.
 
 ## Decision
 
-Reasoning generation is host-owned and reaches the product through the
-`CampaignReasoningContextProvider` port in
-`extracted_content_pipeline/campaign_ports.py`.
+Long-running reasoning generation is host-owned and reaches the product through
+the `CampaignReasoningContextProvider` port in
+`extracted_content_pipeline/campaign_ports.py`. Lightweight installs can use
+the packaged single-pass provider described below.
 
 That keeps the package composable:
 
@@ -121,11 +122,27 @@ python scripts/run_extracted_campaign_generation_example.py \
   --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
 ```
 
+## Packaged Single-Pass Provider
+
+`services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`
+is the lightweight packaged producer for hosts that do not already have
+reasoning JSON. It implements the same `CampaignReasoningContextProvider`
+Protocol, calls the configured `LLMClient` once per opportunity, uses the
+packaged `digest/b2b_campaign_reasoning_context` prompt, and normalizes the
+JSON response into `CampaignReasoningContext`.
+
+This provider is intentionally narrow. It improves opportunity-level
+specificity, but it does not perform multi-hop graph traversal, falsification,
+semantic caching, entity locking, or long-running synthesis. Hosts that need
+those behaviors should provide their own reasoning adapter or use a separate
+reasoning product.
+
 ## Integration Modes
 
 | Mode | Who produces reasoning? | Content package behavior |
 |---|---|---|
 | Atlas-hosted | Atlas synthesis/compression adapters. | Adapter returns the contract shape above. No direct Atlas imports in product code. |
+| Packaged single-pass | AI Content Ops `SinglePassCampaignReasoningProvider`. | One LLM call per opportunity returns the normalized context shape. No graph state or multi-hop synthesis. |
 | Extracted reasoning product | `extracted_reasoning_core` or a future reasoning-producer package. | Adapter converts reasoning output to `CampaignReasoningContext`. |
 | Buyer-owned reasoning | Customer engine, warehouse job, agent workflow, or CRM scoring layer. | Customer adapter implements the provider port. |
 | No reasoning | No provider configured. | Generator uses embedded opportunity fields only; quality is lower but standalone operation remains valid. |

--- a/extracted_content_pipeline/docs/reasoning_state_audit.md
+++ b/extracted_content_pipeline/docs/reasoning_state_audit.md
@@ -13,17 +13,17 @@ with its own data flow.
 
 ## TL;DR
 
-- The product is **shippable today** for buyers who either bring their
-  own reasoning input as JSON or accept a known quality penalty
-  (~60-70% specificity reduction, qualitative estimate).
+- The product is **shippable today** for buyers who bring their own reasoning
+  input as JSON, configure the packaged single-pass reasoning provider, or
+  accept a known quality penalty from running without reasoning.
 - The standalone debt audit reports **0 atlas_brain runtime imports**.
 - The reasoning *consumer* surface is complete and clean.
-- The reasoning *producer* surface does not exist in the extracted
-  package. `extracted_reasoning_core` exposes evaluator helpers
-  (`score_archetypes`, `evaluate_evidence`, `build_temporal_evidence`)
-  but its four producer-shaped functions (`run_reasoning`,
-  `continue_reasoning`, `check_falsification`, `build_narrative_plan`)
-  all raise `NotImplementedError`.
+- The extracted package now includes a Tier 1 opportunity-level reasoning
+  producer: `SinglePassCampaignReasoningProvider`. It does not replace the
+  heavier reasoning-core producer stubs; `extracted_reasoning_core` still has
+  four producer-shaped functions (`run_reasoning`, `continue_reasoning`,
+  `check_falsification`, `build_narrative_plan`) that raise
+  `NotImplementedError`.
 - No branch in flight wires `extracted_reasoning_core` into the
   content-pipeline generator.
 
@@ -122,6 +122,7 @@ normalize into this shape. Reference example payload:
 |---|---|---|
 | `reasoning_context = None` (default) | Generator falls back to `normalize_campaign_reasoning_context` over the opportunity row itself; only fields embedded in the source data flow into the prompt | Lowest. Drafts are generic. |
 | `FileCampaignReasoningContextProvider` (file-backed) | Loads pre-baked reasoning JSON keyed by target_id / company / email / vendor; normalized and threaded into the prompt | High when the source file is well-built. Quality scales with effort the host put into producing the JSON. |
+| `SinglePassCampaignReasoningProvider` | Calls the configured LLM once per opportunity with the packaged reasoning prompt; normalized and threaded into the campaign prompt | Medium. Better than no reasoning, but no multi-hop planning, cache, or falsification. |
 | Custom `CampaignReasoningContextProvider` (e.g. real producer) | Provider is called once per opportunity; output normalized and threaded in | High. This is the architecturally intended path. |
 
 ## What "add a source and reason over it" costs, by tier
@@ -131,8 +132,7 @@ Each lands the buyer at "source in, drafts out":
 
 ### Tier 1: Single-pass prompt reasoning
 
-- ~1 day of work, ~300 LOC
-- New `extracted_content_pipeline/services/single_pass_reasoning_provider.py`
+- Implemented in `extracted_content_pipeline/services/single_pass_reasoning_provider.py`
 - One LLM call per opportunity that takes the source row + context and
   produces the `CampaignReasoningContext` shape directly via a
   structured-output prompt
@@ -176,24 +176,20 @@ Not recommended. Captured here for completeness; the cost-benefit on
 Tier 3 only makes sense if the goal is to fold the reasoning engine
 into the content product as a single SKU.
 
-## Decision points open before sizing the next sprint
+## Decision points after Tier 1
 
-These need answering before the work can be scoped concretely:
+Tier 1 is now implemented for B2B campaign opportunities. Remaining choices are
+about deeper reasoning, not basic "source row in, reasoned draft out":
 
-1. **Which tier?** Tier 1 (1 day) or Tier 2 (2-3 weeks). Tier 3 is
-   already documented as not the chosen path.
-2. **What is "the extracted reasoning system"?** Confirmed to be
-   `extracted_reasoning_core` (the only candidate package). Whether it
-   means "fill the four NotImplementedError stubs" (Tier 2) or "use
-   the existing evaluators with a thin orchestrator" (a smaller Tier
-   1.5) is the choice that decides effort.
-3. **What source format?** CRM dump, review/complaint data, episode
-   transcripts, sales call transcripts — each needs a different
-   schema-aware extraction step in the reasoning provider's input.
-4. **Multi-step required?** If single-pass meets the product promise
-   on the landing page, Tier 1 is sufficient. If the page promises
-   "reasons over your data with multi-pass refinement," Tier 2 is
-   the floor.
+1. **Tier 2 scope.** Decide whether to fill the four
+   `extracted_reasoning_core` producer stubs for multi-pass planning,
+   falsification, and cache-aware reasoning.
+2. **Additional source formats.** CRM rows are covered through
+   `campaign_opportunities`; review/complaint data, episode transcripts, and
+   sales call transcripts need their own schema-aware adapters.
+3. **Product promise.** If single-pass meets the sold promise, AI Content Ops is
+   operational. If the promise is "multi-pass refinement over your data," Tier
+   2 is the floor.
 
 ## Status verdict
 
@@ -206,12 +202,12 @@ These need answering before the work can be scoped concretely:
 | Buyer can review and export drafts | Yes |
 | Buyer can supply pre-baked reasoning as JSON | Yes |
 | Buyer can supply a custom Python reasoning provider | Yes (port is defined) |
-| The product itself produces reasoning from a source | No |
+| The product itself produces reasoning from a source | Yes, single-pass opportunity-level reasoning only |
 | `extracted_reasoning_core` produces reasoning from a source | No (4 stubs raise NotImplementedError) |
 
-The structural gap is **one decision and one build away** from
-"buyer plugs in a source and gets reasoned drafts": pick Tier 1 or
-Tier 2, build it, ship.
+The remaining structural gap is multi-step reasoning. Tier 1 now lands the
+buyer at "source in, reasoned drafts out"; Tier 2 is still required for
+multi-pass planning, falsification, cache, and deeper reasoning state.
 
 ## References
 

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -217,6 +217,9 @@
       "target": "extracted_content_pipeline/campaign_reasoning_data.py"
     },
     {
+      "target": "extracted_content_pipeline/services/single_pass_reasoning_provider.py"
+    },
+    {
       "target": "extracted_content_pipeline/storage/migration_runner.py"
     },
     {
@@ -230,6 +233,9 @@
     },
     {
       "target": "extracted_content_pipeline/skills/registry.py"
+    },
+    {
+      "target": "extracted_content_pipeline/skills/digest/b2b_campaign_reasoning_context.md"
     },
     {
       "target": "extracted_content_pipeline/settings.py"

--- a/extracted_content_pipeline/services/single_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/single_pass_reasoning_provider.py
@@ -129,12 +129,27 @@ def _json_candidates(text: str) -> list[Any]:
 
     depth = 0
     start = -1
+    in_string = False
+    escaped = False
     for index, char in enumerate(cleaned):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            continue
         if char == "{":
             if depth == 0:
                 start = index
             depth += 1
         elif char == "}":
+            if depth <= 0:
+                continue
             depth -= 1
             if depth == 0 and start >= 0:
                 try:

--- a/extracted_content_pipeline/services/single_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/single_pass_reasoning_provider.py
@@ -1,0 +1,166 @@
+"""Single-pass LLM reasoning provider for campaign generation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+import re
+from typing import Any
+
+from ..campaign_ports import (
+    CampaignReasoningContext,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
+from .campaign_reasoning_context import normalize_campaign_reasoning_context
+
+
+DEFAULT_REASONING_SKILL_NAME = "digest/b2b_campaign_reasoning_context"
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+@dataclass(frozen=True)
+class SinglePassReasoningConfig:
+    """Host-owned defaults for single-pass campaign reasoning."""
+
+    skill_name: str = DEFAULT_REASONING_SKILL_NAME
+    max_tokens: int = 900
+    temperature: float = 0.2
+    include_source_opportunity: bool = True
+
+    def __post_init__(self) -> None:
+        if not _clean(self.skill_name):
+            raise ValueError("skill_name is required")
+        if self.max_tokens <= 0:
+            raise ValueError("max_tokens must be positive")
+
+
+@dataclass(frozen=True)
+class SinglePassCampaignReasoningProvider:
+    """Generate compact campaign reasoning context with one LLM call."""
+
+    llm: LLMClient
+    skills: SkillStore
+    config: SinglePassReasoningConfig = SinglePassReasoningConfig()
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> CampaignReasoningContext | None:
+        prompt_template = self.skills.get_prompt(self.config.skill_name)
+        if not prompt_template:
+            raise ValueError(f"Campaign reasoning skill not found: {self.config.skill_name}")
+
+        scope_payload = _scope_payload(scope)
+        opportunity_payload = dict(opportunity) if self.config.include_source_opportunity else {}
+        opportunity_json = json.dumps(opportunity_payload, separators=(",", ":"), default=str)
+        scope_json = json.dumps(scope_payload, separators=(",", ":"), default=str)
+        prompt = (
+            prompt_template
+            .replace("{target_mode}", _clean(target_mode))
+            .replace("{target_id}", _clean(target_id))
+            .replace("{scope}", scope_json)
+            .replace("{opportunity}", opportunity_json)
+            .replace("{opportunity_json}", opportunity_json)
+        )
+        response = await self.llm.complete(
+            [
+                LLMMessage(role="system", content=prompt),
+                LLMMessage(
+                    role="user",
+                    content=(
+                        "Return one compact campaign reasoning context as JSON.\n"
+                        f"target_mode={_clean(target_mode)}\n"
+                        f"target_id={_clean(target_id)}\n"
+                        f"scope={scope_json}\n"
+                        f"opportunity={opportunity_json}"
+                    ),
+                ),
+            ],
+            max_tokens=self.config.max_tokens,
+            temperature=float(self.config.temperature),
+            metadata={
+                "target_mode": _clean(target_mode),
+                "target_id": _clean(target_id),
+                "skill_name": self.config.skill_name,
+                "reasoning_provider": "single_pass",
+            },
+        )
+        return parse_reasoning_context_response(response.content)
+
+
+def parse_reasoning_context_response(text: str) -> CampaignReasoningContext | None:
+    """Parse an LLM JSON response into normalized campaign reasoning context."""
+
+    for candidate in _json_candidates(text):
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, Mapping):
+            continue
+        context = normalize_campaign_reasoning_context(candidate)
+        if context.has_content():
+            return context
+    return None
+
+
+def _json_candidates(text: str) -> list[Any]:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return []
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    candidates: list[Any] = []
+    try:
+        candidates.append(json.loads(cleaned))
+    except json.JSONDecodeError:
+        pass
+
+    depth = 0
+    start = -1
+    for index, char in enumerate(cleaned):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    candidates.append(json.loads(cleaned[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+    return candidates
+
+
+def _scope_payload(scope: TenantScope) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+            "allowed_vendors": list(scope.allowed_vendors),
+            "roles": list(scope.roles),
+        }.items()
+        if value not in (None, "", [], {})
+    }
+
+
+__all__ = [
+    "DEFAULT_REASONING_SKILL_NAME",
+    "SinglePassCampaignReasoningProvider",
+    "SinglePassReasoningConfig",
+    "parse_reasoning_context_response",
+]

--- a/extracted_content_pipeline/skills/digest/b2b_campaign_reasoning_context.md
+++ b/extracted_content_pipeline/skills/digest/b2b_campaign_reasoning_context.md
@@ -1,0 +1,95 @@
+---
+name: digest/b2b_campaign_reasoning_context
+description: Build compact campaign reasoning context from one normalized B2B opportunity
+tags: [b2b, campaign, reasoning, context]
+version: 1
+---
+
+# B2B Campaign Reasoning Context Builder
+
+You create compact reasoning context for downstream campaign copy generation.
+You are not writing the campaign email. You are selecting the strategic angle,
+proof points, timing cues, and confidence limits that a separate generator can
+use.
+
+## Input
+
+You receive:
+
+- `target_mode`: campaign target mode, such as `vendor_retention`.
+- `target_id`: stable opportunity id.
+- `scope`: host tenant/account context.
+- `opportunity`: normalized campaign opportunity JSON.
+
+## Output
+
+Return one JSON object only. Do not include markdown or commentary.
+
+Use this shape:
+
+```json
+{
+  "reasoning_context": {
+    "wedge": "price_squeeze",
+    "confidence": "medium",
+    "summary": "One-sentence causal read of why this account is reachable now.",
+    "why_now": "One-sentence timing reason.",
+    "recommended_action": "Recommended outbound angle.",
+    "key_signals": ["pricing_mentions", "renewal_window"]
+  },
+  "campaign_reasoning_context": {
+    "top_theses": [
+      {
+        "wedge": "price_squeeze",
+        "summary": "Short thesis.",
+        "why_now": "Timing or trigger.",
+        "confidence": "medium"
+      }
+    ],
+    "timing_windows": [
+      {
+        "window_type": "renewal",
+        "anchor": "Q3",
+        "urgency": "medium",
+        "recommended_action": "Lead with renewal risk."
+      }
+    ],
+    "proof_points": [
+      {
+        "label": "pricing_mentions",
+        "value": 12,
+        "interpretation": "Pricing is a repeated complaint."
+      }
+    ],
+    "account_signals": [
+      {
+        "company": "Acme",
+        "buying_stage": "evaluation",
+        "competitor_context": "Considering alternatives",
+        "primary_pain": "pricing"
+      }
+    ],
+    "coverage_limits": ["thin_account_signals"]
+  },
+  "reasoning_scope_summary": {
+    "selection_strategy": "single_pass_opportunity",
+    "reviews_considered_total": 0,
+    "reviews_in_scope": 0,
+    "witnesses_in_scope": 0
+  }
+}
+```
+
+## Rules
+
+1. Return valid JSON only.
+2. Use only facts present in the opportunity input.
+3. Do not invent quotes, customer names, review counts, dates, or competitors.
+4. Use `coverage_limits` when evidence is thin or ambiguous.
+5. Keep arrays short: at most two theses, two timing windows, two proof points,
+   two account signals, and three coverage limits.
+6. Prefer these wedge values when they fit: `price_squeeze`, `feature_parity`,
+   `support_erosion`, `integration_lock`, `category_shift`,
+   `acquisition_hangover`, `compliance_exposure`, `ux_regression`,
+   `segment_mismatch`, `stable`.
+7. Use `confidence` values `high`, `medium`, `low`, or `insufficient`.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -35,6 +35,7 @@ pytest \
   tests/test_extracted_campaign_api_seller_campaigns.py \
   tests/test_extracted_campaign_postgres_sequence_progression.py \
   tests/test_extracted_campaign_postgres_import.py \
+  tests/test_extracted_campaign_single_pass_reasoning.py \
   tests/test_extracted_content_pipeline_migration_runner.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_content_pipeline_reasoning_archetypes.py \

--- a/tests/test_extracted_campaign_single_pass_reasoning.py
+++ b/tests/test_extracted_campaign_single_pass_reasoning.py
@@ -151,6 +151,16 @@ def test_parse_reasoning_context_response_accepts_embedded_json() -> None:
     assert context.as_dict()["confidence"] == "low"
 
 
+def test_parse_reasoning_context_response_ignores_braces_inside_strings() -> None:
+    context = parse_reasoning_context_response(
+        "Here is the answer: "
+        "{\"reasoning_context\":{\"summary\":\"Renewal window starts {Q3\"}}"
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "Renewal window starts {Q3"
+
+
 def test_parse_reasoning_context_response_returns_none_for_empty_context() -> None:
     assert parse_reasoning_context_response("{}") is None
     assert parse_reasoning_context_response("not json") is None

--- a/tests/test_extracted_campaign_single_pass_reasoning.py
+++ b/tests/test_extracted_campaign_single_pass_reasoning.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    LLMMessage,
+    LLMResponse,
+    TenantScope,
+)
+from extracted_content_pipeline.services.single_pass_reasoning_provider import (
+    DEFAULT_REASONING_SKILL_NAME,
+    SinglePassCampaignReasoningProvider,
+    SinglePassReasoningConfig,
+    parse_reasoning_context_response,
+)
+from extracted_content_pipeline.skills.registry import get_skill_registry
+
+
+class _LLM:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages,
+        *,
+        max_tokens,
+        temperature,
+        metadata=None,
+    ):
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": metadata,
+        })
+        return LLMResponse(content=self.content, model="test-model")
+
+
+class _Skills:
+    def __init__(self, prompts: dict[str, str]) -> None:
+        self.prompts = prompts
+
+    def get_prompt(self, name: str) -> str | None:
+        return self.prompts.get(name)
+
+
+def _response_payload() -> str:
+    return json.dumps({
+        "reasoning_context": {
+            "wedge": "price_squeeze",
+            "confidence": "medium",
+            "summary": "Acme is feeling renewal pressure.",
+            "why_now": "The contract window is close.",
+            "recommended_action": "Lead with cost control.",
+            "key_signals": ["pricing_mentions"],
+        },
+        "campaign_reasoning_context": {
+            "proof_points": [
+                {
+                    "label": "pricing_mentions",
+                    "value": 12,
+                    "interpretation": "Pricing repeats in the source data.",
+                }
+            ],
+            "timing_windows": [
+                {
+                    "window_type": "renewal",
+                    "anchor": "Q3",
+                    "urgency": "medium",
+                }
+            ],
+            "coverage_limits": ["thin_account_signals"],
+        },
+        "reasoning_scope_summary": {
+            "selection_strategy": "single_pass_opportunity",
+            "reviews_considered_total": 12,
+            "reviews_in_scope": 4,
+        },
+    })
+
+
+@pytest.mark.asyncio
+async def test_single_pass_reasoning_provider_builds_normalized_context() -> None:
+    llm = _LLM(_response_payload())
+    skills = _Skills({
+        DEFAULT_REASONING_SKILL_NAME: (
+            "target={target_id};mode={target_mode};scope={scope};"
+            "opportunity={opportunity_json}"
+        )
+    })
+    provider = SinglePassCampaignReasoningProvider(
+        llm=llm,
+        skills=skills,
+        config=SinglePassReasoningConfig(max_tokens=500, temperature=0.1),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(
+            account_id="acct_1",
+            user_id="user_1",
+            allowed_vendors=("LegacyCRM",),
+        ),
+        target_id="opp_1",
+        target_mode="vendor_retention",
+        opportunity={"company_name": "Acme", "vendor_name": "LegacyCRM"},
+    )
+
+    assert context is not None
+    assert context.as_dict()["wedge"] == "price_squeeze"
+    assert context.proof_points[0]["label"] == "pricing_mentions"
+    assert context.timing_windows[0]["anchor"] == "Q3"
+    assert context.coverage_limits == ("thin_account_signals",)
+    assert context.scope_summary["reviews_in_scope"] == 4
+
+    call = llm.calls[0]
+    assert call["max_tokens"] == 500
+    assert call["temperature"] == 0.1
+    assert call["metadata"] == {
+        "target_mode": "vendor_retention",
+        "target_id": "opp_1",
+        "skill_name": DEFAULT_REASONING_SKILL_NAME,
+        "reasoning_provider": "single_pass",
+    }
+    messages = call["messages"]
+    assert all(isinstance(message, LLMMessage) for message in messages)
+    assert "{target_id}" not in messages[0].content
+    assert "LegacyCRM" in messages[0].content
+    assert "acct_1" in messages[1].content
+
+
+def test_parse_reasoning_context_response_accepts_fenced_json() -> None:
+    context = parse_reasoning_context_response(
+        "```json\n{\"reasoning_context\":{\"summary\":\"ready\"}}\n```"
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "ready"
+
+
+def test_parse_reasoning_context_response_accepts_embedded_json() -> None:
+    context = parse_reasoning_context_response(
+        "Here is the answer: {\"reasoning_context\":{\"confidence\":\"low\"}}"
+    )
+
+    assert context is not None
+    assert context.as_dict()["confidence"] == "low"
+
+
+def test_parse_reasoning_context_response_returns_none_for_empty_context() -> None:
+    assert parse_reasoning_context_response("{}") is None
+    assert parse_reasoning_context_response("not json") is None
+
+
+@pytest.mark.asyncio
+async def test_single_pass_reasoning_provider_requires_skill() -> None:
+    provider = SinglePassCampaignReasoningProvider(
+        llm=_LLM(_response_payload()),
+        skills=_Skills({}),
+    )
+
+    with pytest.raises(ValueError, match="Campaign reasoning skill not found"):
+        await provider.read_campaign_reasoning_context(
+            scope=TenantScope(),
+            target_id="opp_1",
+            target_mode="vendor_retention",
+            opportunity={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_single_pass_reasoning_provider_can_omit_source_opportunity() -> None:
+    llm = _LLM(_response_payload())
+    provider = SinglePassCampaignReasoningProvider(
+        llm=llm,
+        skills=_Skills({DEFAULT_REASONING_SKILL_NAME: "opportunity={opportunity}"}),
+        config=SinglePassReasoningConfig(include_source_opportunity=False),
+    )
+
+    await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp_1",
+        target_mode="vendor_retention",
+        opportunity={"company_name": "Acme"},
+    )
+
+    assert "opportunity={}" in llm.calls[0]["messages"][0].content
+
+
+def test_single_pass_reasoning_config_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError, match="skill_name is required"):
+        SinglePassReasoningConfig(skill_name="")
+
+    with pytest.raises(ValueError, match="max_tokens must be positive"):
+        SinglePassReasoningConfig(max_tokens=0)
+
+
+def test_packaged_single_pass_reasoning_skill_is_loadable() -> None:
+    prompt = get_skill_registry().get_prompt(DEFAULT_REASONING_SKILL_NAME)
+
+    assert prompt is not None
+    assert "Return one JSON object only" in prompt


### PR DESCRIPTION
## Summary
- Add `SinglePassCampaignReasoningProvider`, a product-owned Tier 1 `CampaignReasoningContextProvider` that uses the existing LLM and skill ports to produce one normalized reasoning context per campaign opportunity.
- Add the packaged `digest/b2b_campaign_reasoning_context` prompt and manifest ownership entries.
- Add parser/provider tests and wire them into `run_extracted_pipeline_checks.sh`.
- Update reasoning docs/status to distinguish lightweight opportunity-level reasoning from host-owned multi-hop/graph reasoning.
- Address Codex parser feedback with string-aware embedded JSON brace scanning.
- Claim the D12 coordination slice.

## Validation
- `python -m py_compile extracted_content_pipeline/services/single_pass_reasoning_provider.py tests/test_extracted_campaign_single_pass_reasoning.py`
- `pytest tests/test_extracted_campaign_single_pass_reasoning.py tests/test_extracted_campaign_manifest.py` (16/16 after parser regression)
- `python -m json.tool extracted_content_pipeline/manifest.json`
- `bash scripts/run_extracted_pipeline_checks.sh` (863/863, existing torch/pynvml warning)
- `git diff --check`
- ASCII scan on D12 Python files