### PR TITLE
Wire single-pass reasoning into campaign CLIs

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T15:10Z by codex-2026-05-05-d12-cleanup
+Last updated: 2026-05-05T15:11Z by codex-2026-05-05-d13
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| TBD | D13 single-pass reasoning CLI wiring | `scripts/run_extracted_campaign_generation_example.py`, `scripts/run_extracted_campaign_generation_postgres.py`, campaign generation CLI tests, content pipeline README/runbook/status | codex-2026-05-05-d13 | Avoid adding host-facing campaign reasoning CLI flags until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -162,6 +162,15 @@ It calls the configured `LLMClient` once per opportunity with the packaged
 context shape. This is not a multi-hop graph reasoner; it is the small packaged
 Tier 1 path for "source row in, reasoned draft out."
 
+The example CLI can wire that provider directly when the product LLM adapter is
+configured:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  --llm pipeline \
+  --single-pass-reasoning
+```
+
 Use host-provided prompt contracts by pointing at a markdown skill directory:
 
 ```bash
@@ -227,6 +236,14 @@ It also accepts the same host-provided reasoning JSON as the offline example:
 python scripts/run_extracted_campaign_generation_postgres.py \
   --account-id acct_123 \
   --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
+```
+
+Or generate lightweight reasoning context during the DB-backed run:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --single-pass-reasoning
 ```
 
 Use `--skills-root customer_skills` on the Postgres runner for the same

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -143,9 +143,10 @@
   ports to build one normalized `CampaignReasoningContext` per opportunity with
   the `digest/b2b_campaign_reasoning_context` prompt, without importing Atlas
   reasoning producers or graph state.
-- Both the offline and Postgres campaign generation runners can consume that
-  JSON through `--reasoning-context`, so file-backed host reasoning is available
-  on demo and DB-backed generation paths.
+- Both the offline and Postgres campaign generation runners can consume
+  file-backed reasoning through `--reasoning-context`; they can also opt into
+  the packaged single-pass provider with `--single-pass-reasoning` when the
+  product LLM adapter is configured.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -189,6 +189,19 @@ packaged `digest/b2b_campaign_reasoning_context` prompt once per opportunity,
 and returns the same normalized context shape. This improves specificity
 without importing Atlas reasoning producers or long-running graph state.
 
+The Postgres generation runner wires that provider directly when the product
+LLM adapter is configured:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --single-pass-reasoning
+```
+
+Use `--reasoning-skill-name`, `--reasoning-max-tokens`, and
+`--reasoning-temperature` to tune the provider, or `--skills-root` to override
+the packaged reasoning prompt.
+
 See `reasoning_handoff_contract.md` for the accepted shape and the no-direct-
 import rule. AI Content Ops consumes compressed reasoning; it does not import a
 reasoning engine.

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -24,11 +24,16 @@ from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
 )
+from extracted_content_pipeline.services.single_pass_reasoning_provider import (  # noqa: E402
+    SinglePassCampaignReasoningProvider,
+    SinglePassReasoningConfig,
+)
 
 
 DEFAULT_PAYLOAD = (
     ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.json"
 )
+DEFAULT_REASONING_CONFIG = SinglePassReasoningConfig()
 
 
 def _load_payload(path: Path, *, file_format: str = "auto") -> dict[str, Any]:
@@ -93,6 +98,38 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--single-pass-reasoning",
+        action="store_true",
+        help=(
+            "Generate campaign reasoning context with the packaged single-pass "
+            "reasoning prompt. Requires --llm pipeline."
+        ),
+    )
+    parser.add_argument(
+        "--reasoning-skill-name",
+        default=DEFAULT_REASONING_CONFIG.skill_name,
+        help="Skill name for --single-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--reasoning-max-tokens",
+        type=int,
+        default=DEFAULT_REASONING_CONFIG.max_tokens,
+        help="Maximum LLM output tokens for --single-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--reasoning-temperature",
+        type=float,
+        default=DEFAULT_REASONING_CONFIG.temperature,
+        help="LLM temperature for --single-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--no-reasoning-source-opportunity",
+        dest="reasoning_include_source_opportunity",
+        action="store_false",
+        default=DEFAULT_REASONING_CONFIG.include_source_opportunity,
+        help="Do not include the full source opportunity in the reasoning prompt.",
+    )
+    parser.add_argument(
         "--skills-root",
         type=Path,
         help=(
@@ -112,16 +149,37 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _validate_reasoning_args(args: argparse.Namespace) -> None:
+    if args.reasoning_context and args.single_pass_reasoning:
+        raise SystemExit(
+            "--reasoning-context and --single-pass-reasoning cannot be combined"
+        )
+    if args.single_pass_reasoning and args.llm != "pipeline":
+        raise SystemExit("--single-pass-reasoning requires --llm pipeline")
+
+
+def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoningConfig:
+    return SinglePassReasoningConfig(
+        skill_name=str(args.reasoning_skill_name or ""),
+        max_tokens=int(args.reasoning_max_tokens),
+        temperature=float(args.reasoning_temperature),
+        include_source_opportunity=bool(args.reasoning_include_source_opportunity),
+    )
+
+
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    _validate_reasoning_args(args)
     overrides: dict[str, Any] = {}
     if args.reasoning_context:
         overrides["reasoning_context"] = load_reasoning_provider_port(
             args.reasoning_context
         )
+    skills = None
     if args.skills_root:
         from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: PLC0415
 
-        overrides["skills"] = get_skill_registry(root=args.skills_root)
+        skills = get_skill_registry(root=args.skills_root)
+        overrides["skills"] = skills
     if args.llm == "offline":
         return overrides
 
@@ -130,13 +188,22 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
     )
     from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: PLC0415
 
-    overrides["llm"] = create_pipeline_llm_client()
-    overrides.setdefault("skills", get_skill_registry())
+    llm = create_pipeline_llm_client()
+    skills = skills or get_skill_registry()
+    overrides["llm"] = llm
+    overrides.setdefault("skills", skills)
+    if args.single_pass_reasoning:
+        overrides["reasoning_context"] = SinglePassCampaignReasoningProvider(
+            llm=llm,
+            skills=skills,
+            config=_single_pass_config_from_args(args),
+        )
     return overrides
 
 
 async def _main() -> int:
     args = _parse_args()
+    _validate_reasoning_args(args)
     payload = _load_payload(args.payload, file_format=args.format)
     if args.target_mode:
         payload["target_mode"] = args.target_mode

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -26,7 +26,17 @@ from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
 )
+from extracted_content_pipeline.campaign_llm_client import (  # noqa: E402
+    create_pipeline_llm_client,
+)
+from extracted_content_pipeline.services.single_pass_reasoning_provider import (  # noqa: E402
+    SinglePassCampaignReasoningProvider,
+    SinglePassReasoningConfig,
+)
 from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
+
+
+DEFAULT_REASONING_CONFIG = SinglePassReasoningConfig()
 
 
 def _json_object(value: str | None) -> dict[str, Any]:
@@ -75,6 +85,38 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--single-pass-reasoning",
+        action="store_true",
+        help=(
+            "Generate campaign reasoning context with the packaged single-pass "
+            "reasoning prompt. Requires --llm pipeline."
+        ),
+    )
+    parser.add_argument(
+        "--reasoning-skill-name",
+        default=DEFAULT_REASONING_CONFIG.skill_name,
+        help="Skill name for --single-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--reasoning-max-tokens",
+        type=int,
+        default=DEFAULT_REASONING_CONFIG.max_tokens,
+        help="Maximum LLM output tokens for --single-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--reasoning-temperature",
+        type=float,
+        default=DEFAULT_REASONING_CONFIG.temperature,
+        help="LLM temperature for --single-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--no-reasoning-source-opportunity",
+        dest="reasoning_include_source_opportunity",
+        action="store_false",
+        default=DEFAULT_REASONING_CONFIG.include_source_opportunity,
+        help="Do not include the full source opportunity in the reasoning prompt.",
+    )
+    parser.add_argument(
         "--skills-root",
         type=Path,
         help=(
@@ -96,6 +138,24 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _validate_reasoning_args(args: argparse.Namespace) -> None:
+    if args.reasoning_context and args.single_pass_reasoning:
+        raise SystemExit(
+            "--reasoning-context and --single-pass-reasoning cannot be combined"
+        )
+    if args.single_pass_reasoning and args.llm != "pipeline":
+        raise SystemExit("--single-pass-reasoning requires --llm pipeline")
+
+
+def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoningConfig:
+    return SinglePassReasoningConfig(
+        skill_name=str(args.reasoning_skill_name or ""),
+        max_tokens=int(args.reasoning_max_tokens),
+        temperature=float(args.reasoning_temperature),
+        include_source_opportunity=bool(args.reasoning_include_source_opportunity),
+    )
+
+
 async def _create_pool(database_url: str):
     try:
         import asyncpg  # type: ignore[import-not-found]
@@ -107,13 +167,26 @@ async def _create_pool(database_url: str):
 
 
 def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    _validate_reasoning_args(args)
     overrides: dict[str, Any] = {}
     if args.reasoning_context:
         overrides["reasoning_context"] = load_reasoning_provider_port(
             args.reasoning_context
         )
+    skills = None
     if args.skills_root:
-        overrides["skills"] = get_skill_registry(root=args.skills_root)
+        skills = get_skill_registry(root=args.skills_root)
+        overrides["skills"] = skills
+    if args.single_pass_reasoning:
+        llm = create_pipeline_llm_client()
+        skills = skills or get_skill_registry()
+        overrides["llm"] = llm
+        overrides.setdefault("skills", skills)
+        overrides["reasoning_context"] = SinglePassCampaignReasoningProvider(
+            llm=llm,
+            skills=skills,
+            config=_single_pass_config_from_args(args),
+        )
     if args.llm == "pipeline":
         return overrides
     overrides.update({
@@ -125,6 +198,7 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
 
 async def _main() -> int:
     args = _parse_args()
+    _validate_reasoning_args(args)
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
     pool = await _create_pool(args.database_url)

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -16,6 +16,9 @@ from extracted_content_pipeline.campaign_reasoning_data import (
     FileCampaignReasoningContextProvider,
     load_reasoning_provider_port,
 )
+from extracted_content_pipeline.services.single_pass_reasoning_provider import (
+    SinglePassCampaignReasoningProvider,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -285,6 +288,88 @@ def test_campaign_generation_example_cli_accepts_skills_root(tmp_path) -> None:
     assert overrides["skills"].get_prompt("digest/b2b_campaign_generation") == (
         "Custom host prompt {opportunity_json}"
     )
+
+
+def test_campaign_generation_example_cli_wires_single_pass_reasoning(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    example_cli = _load_example_cli_module()
+    llm = _InjectedLLM()
+    skills = _InjectedSkills()
+    skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("Custom host prompt {opportunity_json}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "extracted_content_pipeline.campaign_llm_client.create_pipeline_llm_client",
+        lambda: llm,
+    )
+    monkeypatch.setattr(
+        "extracted_content_pipeline.skills.registry.get_skill_registry",
+        lambda root=None: skills,
+    )
+
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--llm",
+        "pipeline",
+        "--skills-root",
+        str(tmp_path),
+        "--single-pass-reasoning",
+        "--reasoning-skill-name",
+        "digest/custom_reasoning",
+        "--reasoning-max-tokens",
+        "321",
+        "--reasoning-temperature",
+        "0.3",
+        "--no-reasoning-source-opportunity",
+    ])
+    overrides = example_cli._dependency_overrides(args)
+
+    provider = overrides["reasoning_context"]
+    assert isinstance(provider, SinglePassCampaignReasoningProvider)
+    assert provider.llm is llm
+    assert provider.skills is skills
+    assert provider.config.skill_name == "digest/custom_reasoning"
+    assert provider.config.max_tokens == 321
+    assert provider.config.temperature == 0.3
+    assert provider.config.include_source_opportunity is False
+    assert overrides["llm"] is llm
+    assert overrides["skills"] is skills
+
+
+def test_campaign_generation_example_cli_rejects_conflicting_reasoning_modes(
+    tmp_path,
+) -> None:
+    example_cli = _load_example_cli_module()
+    reasoning_path = tmp_path / "reasoning.json"
+    reasoning_path.write_text("[]", encoding="utf-8")
+
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--llm",
+        "pipeline",
+        "--reasoning-context",
+        str(reasoning_path),
+        "--single-pass-reasoning",
+    ])
+
+    with pytest.raises(SystemExit, match="cannot be combined"):
+        example_cli._dependency_overrides(args)
+
+
+def test_campaign_generation_example_cli_rejects_offline_single_pass_reasoning() -> None:
+    example_cli = _load_example_cli_module()
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--llm",
+        "offline",
+        "--single-pass-reasoning",
+    ])
+
+    with pytest.raises(SystemExit, match="requires --llm pipeline"):
+        example_cli._dependency_overrides(args)
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -11,6 +11,9 @@ from extracted_content_pipeline.campaign_postgres_generation import (
     generate_campaign_drafts_from_postgres,
     tenant_scope_from_mapping,
 )
+from extracted_content_pipeline.services.single_pass_reasoning_provider import (
+    SinglePassCampaignReasoningProvider,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -320,3 +323,73 @@ def test_postgres_runner_cli_uses_provider_port_loader(tmp_path) -> None:
 
     assert calls == [reasoning_path]
     assert overrides["reasoning_context"] == "provider-port"
+
+
+def test_postgres_runner_cli_wires_single_pass_reasoning(monkeypatch, tmp_path) -> None:
+    postgres_cli = _load_postgres_cli_module()
+    llm = _LLM()
+    skills = _Skills()
+    skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("Custom DB prompt {opportunity_json}", encoding="utf-8")
+
+    monkeypatch.setattr(postgres_cli, "create_pipeline_llm_client", lambda: llm)
+    monkeypatch.setattr(postgres_cli, "get_skill_registry", lambda root=None: skills)
+
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--skills-root",
+        str(tmp_path),
+        "--single-pass-reasoning",
+        "--reasoning-skill-name",
+        "digest/custom_reasoning",
+        "--reasoning-max-tokens",
+        "321",
+        "--reasoning-temperature",
+        "0.3",
+        "--no-reasoning-source-opportunity",
+    ])
+    overrides = postgres_cli._dependency_overrides(args)
+
+    provider = overrides["reasoning_context"]
+    assert isinstance(provider, SinglePassCampaignReasoningProvider)
+    assert provider.llm is llm
+    assert provider.skills is skills
+    assert provider.config.skill_name == "digest/custom_reasoning"
+    assert provider.config.max_tokens == 321
+    assert provider.config.temperature == 0.3
+    assert provider.config.include_source_opportunity is False
+    assert overrides["llm"] is llm
+    assert overrides["skills"] is skills
+
+
+def test_postgres_runner_cli_rejects_conflicting_reasoning_modes(tmp_path) -> None:
+    postgres_cli = _load_postgres_cli_module()
+    reasoning_path = tmp_path / "reasoning.json"
+    reasoning_path.write_text("[]", encoding="utf-8")
+
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--reasoning-context",
+        str(reasoning_path),
+        "--single-pass-reasoning",
+    ])
+
+    with pytest.raises(SystemExit, match="cannot be combined"):
+        postgres_cli._dependency_overrides(args)
+
+
+def test_postgres_runner_cli_rejects_offline_single_pass_reasoning() -> None:
+    postgres_cli = _load_postgres_cli_module()
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--llm",
+        "offline",
+        "--single-pass-reasoning",
+    ])
+
+    with pytest.raises(SystemExit, match="requires --llm pipeline"):
+        postgres_cli._dependency_overrides(args)


### PR DESCRIPTION
## Summary
- Add opt-in `--single-pass-reasoning` support to the offline and Postgres campaign generation CLIs.
- Reuse the existing `SinglePassCampaignReasoningProvider` through the existing `reasoning_context` port, with configurable skill name, max tokens, temperature, and source-opportunity inclusion.
- Preserve existing `--reasoning-context` file behavior and reject conflicting reasoning modes; require `--llm pipeline` for generated single-pass context.
- Update README/runbook/status docs and claim the D13 coordination slice.

## Validation
- `python -m py_compile scripts/run_extracted_campaign_generation_example.py scripts/run_extracted_campaign_generation_postgres.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py`
- `pytest tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_single_pass_reasoning.py` (32/32)
- `rg -n "[^\\x00-\\x7F]" scripts/run_extracted_campaign_generation_example.py scripts/run_extracted_campaign_generation_postgres.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py` (no matches)
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` (870/870, existing torch/pynvml warning)