### PR TITLE
Add single-pass reasoning option to campaign operations API

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T15:23Z by codex-2026-05-05-d13-cleanup
+Last updated: 2026-05-05T15:28Z by codex-2026-05-05-d14
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| TBD | D14 hosted campaign API single-pass reasoning | `extracted_content_pipeline/api/campaign_operations.py`, API operation tests, content pipeline README/runbook/status | codex-2026-05-05-d14 | Avoid editing hosted campaign operations reasoning wiring until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -428,6 +428,14 @@ app.include_router(
 )
 ```
 
+If the host does not have a separate reasoning provider but does provide LLM and
+skill providers, it can omit `reasoning_context_provider` and enable the
+packaged single-pass provider:
+
+```python
+config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True)
+```
+
 This adds `POST /campaigns/operations/drafts/generate`,
 `POST /campaigns/operations/send/queued`,
 `POST /campaigns/operations/sequences/progress`, and

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -74,7 +74,9 @@
   draft generation, send, sequence progression, and analytics refresh triggers.
   Hosts inject the database, sender, optional LLM/skill/reasoning providers,
   and auth dependencies; HTTP payloads only control tenant scope,
-  target/channel, filters, and batch sizing.
+  target/channel, filters, and batch sizing. Hosted installs can opt into the
+  packaged single-pass reasoning provider through config when LLM and skill
+  providers are injected.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -411,13 +411,14 @@ def create_campaign_operations_router(
         pool = await _resolve_pool(pool_provider)
         llm = await _resolve_optional(llm_provider)
         skills = await _resolve_optional(skills_provider)
-        reasoning_context = _generation_reasoning_context(
-            resolved_config,
-            explicit_reasoning_context=await _resolve_optional(reasoning_context_provider),
-            llm=llm,
-            skills=skills,
-        )
+        explicit_reasoning_context = await _resolve_optional(reasoning_context_provider)
         try:
+            reasoning_context = _generation_reasoning_context(
+                resolved_config,
+                explicit_reasoning_context=explicit_reasoning_context,
+                llm=llm,
+                skills=skills,
+            )
             result = await generate_campaign_drafts_from_postgres(
                 pool,
                 scope=scope,

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -27,6 +27,11 @@ from ..campaign_postgres_sequence_progression import (
 )
 from ..campaign_send import CampaignSendConfig
 from ..campaign_sequence_progression import CampaignSequenceProgressionConfig
+from ..services.single_pass_reasoning_provider import (
+    DEFAULT_REASONING_SKILL_NAME,
+    SinglePassCampaignReasoningProvider,
+    SinglePassReasoningConfig,
+)
 
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
@@ -71,6 +76,11 @@ class CampaignOperationsApiConfig:
     generation_include_source_opportunity: bool = True
     generation_opportunity_table: str = "campaign_opportunities"
     generation_vendor_targets_table: str = "vendor_targets"
+    generation_single_pass_reasoning: bool = False
+    generation_reasoning_skill_name: str = DEFAULT_REASONING_SKILL_NAME
+    generation_reasoning_max_tokens: int = 900
+    generation_reasoning_temperature: float = 0.2
+    generation_reasoning_include_source_opportunity: bool = True
 
     def __post_init__(self) -> None:
         _validate_default_limit(
@@ -105,6 +115,11 @@ class CampaignOperationsApiConfig:
             raise ValueError("generation_skill_name is required")
         if self.generation_max_tokens <= 0:
             raise ValueError("generation_max_tokens must be positive")
+        if self.generation_single_pass_reasoning:
+            if not _clean(self.generation_reasoning_skill_name):
+                raise ValueError("generation_reasoning_skill_name is required")
+            if self.generation_reasoning_max_tokens <= 0:
+                raise ValueError("generation_reasoning_max_tokens must be positive")
 
 
 def _require_fastapi() -> None:
@@ -307,6 +322,39 @@ def _generation_config(
     )
 
 
+def _generation_reasoning_config(
+    config: CampaignOperationsApiConfig,
+) -> SinglePassReasoningConfig:
+    return SinglePassReasoningConfig(
+        skill_name=config.generation_reasoning_skill_name,
+        max_tokens=config.generation_reasoning_max_tokens,
+        temperature=float(config.generation_reasoning_temperature),
+        include_source_opportunity=config.generation_reasoning_include_source_opportunity,
+    )
+
+
+def _generation_reasoning_context(
+    config: CampaignOperationsApiConfig,
+    *,
+    explicit_reasoning_context: Any,
+    llm: LLMClient | None,
+    skills: SkillStore | None,
+) -> Any:
+    if explicit_reasoning_context is not None:
+        return explicit_reasoning_context
+    if not config.generation_single_pass_reasoning:
+        return None
+    if llm is None:
+        raise HTTPException(status_code=503, detail="Campaign reasoning LLM unavailable")
+    if skills is None:
+        raise HTTPException(status_code=503, detail="Campaign reasoning skills unavailable")
+    return SinglePassCampaignReasoningProvider(
+        llm=llm,
+        skills=skills,
+        config=_generation_reasoning_config(config),
+    )
+
+
 def _public_analytics_result(result: Any) -> dict[str, Any]:
     data = result.as_dict()
     if data.get("error"):
@@ -363,7 +411,12 @@ def create_campaign_operations_router(
         pool = await _resolve_pool(pool_provider)
         llm = await _resolve_optional(llm_provider)
         skills = await _resolve_optional(skills_provider)
-        reasoning_context = await _resolve_optional(reasoning_context_provider)
+        reasoning_context = _generation_reasoning_context(
+            resolved_config,
+            explicit_reasoning_context=await _resolve_optional(reasoning_context_provider),
+            llm=llm,
+            skills=skills,
+        )
         try:
             result = await generate_campaign_drafts_from_postgres(
                 pool,

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -475,6 +475,12 @@ tenant scope, target/channel, filters, `limit`, and, for sequence progression,
 `max_steps`; provider credentials, sender identity, unsubscribe policy, LLM
 client, skill roots, and reasoning providers stay host-configured.
 
+For lightweight hosted installs without a separate reasoning provider, set
+`generation_single_pass_reasoning=True` on `CampaignOperationsApiConfig`. The
+draft generation route then builds `SinglePassCampaignReasoningProvider` from
+the injected LLM and skill providers before calling the Postgres generation
+runner. Explicit `reasoning_context_provider` injection still takes precedence.
+
 | Method | Path | Purpose |
 |---|---|---|
 | `POST` | `/campaigns/operations/drafts/generate` | Generate and persist campaign drafts from `campaign_opportunities`. |

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -330,6 +330,36 @@ def test_campaign_operations_router_rejects_single_pass_without_skills(
     assert calls == []
 
 
+def test_campaign_operations_router_maps_single_pass_config_errors(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(generated=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        _Pool(),
+        llm=_LLM(),
+        skills=_Skills(),
+        config=CampaignOperationsApiConfig(
+            generation_single_pass_reasoning=True,
+            generation_reasoning_temperature="not-a-number",  # type: ignore[arg-type]
+        ),
+    ).post("/campaigns/operations/drafts/generate", json={"limit": 1})
+
+    assert response.status_code == 400
+    assert "not-a-number" in response.json()["detail"]
+    assert calls == []
+
+
 def test_campaign_operations_router_rejects_generation_scope_mismatch(
     monkeypatch,
 ) -> None:

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -15,6 +15,9 @@ from extracted_content_pipeline.api.campaign_operations import (
     create_campaign_operations_router,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.services.single_pass_reasoning_provider import (
+    SinglePassCampaignReasoningProvider,
+)
 
 
 class _Pool:
@@ -207,6 +210,124 @@ def test_campaign_operations_router_generates_with_payload_scope(monkeypatch) ->
 
     assert response.status_code == 200
     assert calls[0][1]["scope"] == {"account_id": "acct_1", "user_id": "user_1"}
+
+
+def test_campaign_operations_router_builds_single_pass_reasoning(monkeypatch) -> None:
+    pool = _Pool()
+    llm = _LLM()
+    skills = _Skills()
+    calls: list[tuple[Any, dict[str, Any]]] = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(requested=1, generated=1, skipped=0, saved_ids=[], errors=[])
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        pool,
+        llm=llm,
+        skills=skills,
+        config=CampaignOperationsApiConfig(
+            generation_single_pass_reasoning=True,
+            generation_reasoning_skill_name="digest/custom_reasoning",
+            generation_reasoning_max_tokens=321,
+            generation_reasoning_temperature=0.3,
+            generation_reasoning_include_source_opportunity=False,
+        ),
+    ).post("/campaigns/operations/drafts/generate", json={"limit": 1})
+
+    assert response.status_code == 200
+    provider = calls[0][1]["reasoning_context"]
+    assert isinstance(provider, SinglePassCampaignReasoningProvider)
+    assert provider.llm is llm
+    assert provider.skills is skills
+    assert provider.config.skill_name == "digest/custom_reasoning"
+    assert provider.config.max_tokens == 321
+    assert provider.config.temperature == 0.3
+    assert provider.config.include_source_opportunity is False
+
+
+def test_campaign_operations_router_prefers_explicit_reasoning_provider(
+    monkeypatch,
+) -> None:
+    reasoning = _Reasoning()
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(requested=1, generated=1, skipped=0, saved_ids=[], errors=[])
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        _Pool(),
+        reasoning=reasoning,
+        config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True),
+    ).post("/campaigns/operations/drafts/generate", json={"limit": 1})
+
+    assert response.status_code == 200
+    assert calls[0][1]["reasoning_context"] is reasoning
+
+
+def test_campaign_operations_router_rejects_single_pass_without_llm(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(generated=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        _Pool(),
+        skills=_Skills(),
+        config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True),
+    ).post("/campaigns/operations/drafts/generate", json={"limit": 1})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Campaign reasoning LLM unavailable"
+    assert calls == []
+
+
+def test_campaign_operations_router_rejects_single_pass_without_skills(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    async def _generate(received_pool, **kwargs):
+        calls.append((received_pool, kwargs))
+        return _Result(generated=1)
+
+    monkeypatch.setattr(
+        operations_api,
+        "generate_campaign_drafts_from_postgres",
+        _generate,
+    )
+
+    response = _client(
+        _Pool(),
+        llm=_LLM(),
+        config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True),
+    ).post("/campaigns/operations/drafts/generate", json={"limit": 1})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Campaign reasoning skills unavailable"
+    assert calls == []
 
 
 def test_campaign_operations_router_rejects_generation_scope_mismatch(


### PR DESCRIPTION
## Summary
- Add config-gated single-pass reasoning support to the hosted campaign operations draft-generation route.
- Preserve default behavior: no reasoning provider is built unless `generation_single_pass_reasoning=True`.
- Preserve explicit provider precedence: injected `reasoning_context_provider` still wins over the packaged provider.
- Return 503 when single-pass reasoning is enabled without injected LLM or skill providers, avoiding silent unreasoned drafts.
- Address Codex review: single-pass reasoning config conversion now happens inside the existing `ValueError` guard so config errors return 400.
- Update README/runbook/status docs and claim the D14 coordination slice.

## Validation
- `python -m py_compile extracted_content_pipeline/api/campaign_operations.py tests/test_extracted_campaign_api_operations.py`
- `pytest tests/test_extracted_campaign_api_operations.py tests/test_extracted_campaign_api_hosted_workflow.py` (30/30 after review fix)
- `rg -n "[^\\x00-\\x7F]" extracted_content_pipeline/api/campaign_operations.py tests/test_extracted_campaign_api_operations.py` (no matches)
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` (875/875, existing torch/pynvml warning)