### PR TITLE
Add campaign operations status endpoint

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T15:45Z by codex-2026-05-05-d14-cleanup
+Last updated: 2026-05-05T16:00Z by codex-2026-05-05-d15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| TBD | D15 campaign operations status endpoint | `extracted_content_pipeline/api/campaign_operations.py`, API operation/workflow tests, content pipeline README/runbook/status | codex-2026-05-05-d15 | Avoid editing hosted campaign operations status/readiness wiring until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -443,18 +443,25 @@ This adds `POST /campaigns/operations/drafts/generate`,
 credentials, sender identity, unsubscribe policy, or LLM configuration through
 HTTP payloads.
 
+It also adds `GET /campaigns/operations/status` for admin dashboards. The
+status route reports database availability, injected provider presence, feature
+readiness, and configured limits without resolving sender/LLM/skill providers
+or exposing secrets.
+
 Mount this router beside `create_b2b_campaign_router` to run the hosted B2B
 flow without SQL in the admin UI:
 
-1. `POST /campaigns/operations/drafts/generate` creates scoped draft rows from
+1. `GET /campaigns/operations/status` lets the admin UI enable only ready
+   operations.
+2. `POST /campaigns/operations/drafts/generate` creates scoped draft rows from
    active `campaign_opportunities`.
-2. `GET /b2b/campaigns/drafts` or `/drafts/export` lets operators inspect the
+3. `GET /b2b/campaigns/drafts` or `/drafts/export` lets operators inspect the
    generated drafts.
-3. `POST /b2b/campaigns/drafts/review` moves selected drafts to `queued` after
+4. `POST /b2b/campaigns/drafts/review` moves selected drafts to `queued` after
    approval.
-4. `POST /campaigns/operations/send/queued` sends approved queued drafts
+5. `POST /campaigns/operations/send/queued` sends approved queued drafts
    through the injected sender.
-5. `POST /campaigns/operations/analytics/refresh` refreshes packaged funnel
+6. `POST /campaigns/operations/analytics/refresh` refreshes packaged funnel
    reporting after send/webhook activity.
 
 ## Import smoke test

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -76,7 +76,10 @@
   and auth dependencies; HTTP payloads only control tenant scope,
   target/channel, filters, and batch sizing. Hosted installs can opt into the
   packaged single-pass reasoning provider through config when LLM and skill
-  providers are injected.
+  providers are injected. The router also exposes `GET
+  /campaigns/operations/status` for admin dashboards to inspect database
+  availability, provider presence, feature readiness, and configured limits
+  without exposing credentials.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -398,7 +398,9 @@ def _operation_readiness(
         and skills_configured
     )
     generation_ready = database_available and (
-        not config.generation_single_pass_reasoning or single_pass_ready
+        explicit_reasoning
+        or not config.generation_single_pass_reasoning
+        or single_pass_ready
     )
     sequence_ready = database_available and bool(_clean(config.sequence_from_email))
     return {

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -146,6 +146,31 @@ async def _resolve_pool(pool_provider: PoolProvider) -> Any:
     return pool
 
 
+async def _pool_status(pool_provider: PoolProvider) -> dict[str, Any]:
+    try:
+        pool = await _maybe_await(pool_provider())
+    except Exception:  # pragma: no cover - exact host provider failures vary.
+        logger.warning("Campaign operations database status check failed", exc_info=True)
+        return {
+            "configured": True,
+            "available": False,
+            "reason": "provider_error",
+        }
+    if pool is None:
+        return {
+            "configured": True,
+            "available": False,
+            "reason": "missing_pool",
+        }
+    if getattr(pool, "is_initialized", True) is False:
+        return {
+            "configured": True,
+            "available": False,
+            "reason": "pool_uninitialized",
+        }
+    return {"configured": True, "available": True}
+
+
 async def _resolve_sender(
     sender_provider: SenderProvider | None,
 ) -> CampaignSender:
@@ -355,6 +380,75 @@ def _generation_reasoning_context(
     )
 
 
+def _operation_readiness(
+    config: CampaignOperationsApiConfig,
+    *,
+    database_available: bool,
+    sender_provider: SenderProvider | None,
+    llm_provider: LLMProvider | None,
+    skills_provider: SkillsProvider | None,
+    reasoning_context_provider: ReasoningProvider | None,
+) -> dict[str, Any]:
+    llm_configured = llm_provider is not None
+    skills_configured = skills_provider is not None
+    explicit_reasoning = reasoning_context_provider is not None
+    single_pass_ready = (
+        bool(config.generation_single_pass_reasoning)
+        and llm_configured
+        and skills_configured
+    )
+    generation_ready = database_available and (
+        not config.generation_single_pass_reasoning or single_pass_ready
+    )
+    sequence_ready = database_available and bool(_clean(config.sequence_from_email))
+    return {
+        "providers": {
+            "database": database_available,
+            "sender": sender_provider is not None,
+            "llm": llm_configured,
+            "skills": skills_configured,
+            "reasoning": explicit_reasoning,
+        },
+        "reasoning": {
+            "mode": (
+                "explicit_provider"
+                if explicit_reasoning
+                else ("single_pass" if config.generation_single_pass_reasoning else "none")
+            ),
+            "single_pass_configured": bool(config.generation_single_pass_reasoning),
+            "single_pass_ready": single_pass_ready,
+        },
+        "features": {
+            "draft_generation": generation_ready,
+            "send_queued": database_available and sender_provider is not None,
+            "sequence_progression": sequence_ready,
+            "analytics_refresh": database_available,
+        },
+    }
+
+
+def _operation_limits(config: CampaignOperationsApiConfig) -> dict[str, Any]:
+    return {
+        "generation": {
+            "default_limit": config.default_generation_limit,
+            "max_limit": config.max_generation_limit,
+            "target_mode": config.generation_target_mode,
+            "channel": config.generation_channel,
+            "channels": list(config.generation_channels),
+        },
+        "send": {
+            "default_limit": config.default_send_limit,
+            "max_limit": config.max_send_limit,
+        },
+        "sequence": {
+            "default_limit": config.default_sequence_limit,
+            "max_limit": config.max_sequence_limit,
+            "default_max_steps": config.default_sequence_max_steps,
+            "max_steps": config.max_sequence_steps,
+        },
+    }
+
+
 def _public_analytics_result(result: Any) -> dict[str, Any]:
     data = result.as_dict()
     if data.get("error"):
@@ -382,6 +476,24 @@ def create_campaign_operations_router(
         tags=list(resolved_config.tags),
         dependencies=list(dependencies or ()),
     )
+
+    @router.get("/status")
+    async def operations_status() -> dict[str, Any]:
+        database = await _pool_status(pool_provider)
+        database_available = bool(database.get("available"))
+        return {
+            "status": "ready" if database_available else "degraded",
+            "database": database,
+            **_operation_readiness(
+                resolved_config,
+                database_available=database_available,
+                sender_provider=sender_provider,
+                llm_provider=llm_provider,
+                skills_provider=skills_provider,
+                reasoning_context_provider=reasoning_context_provider,
+            ),
+            "limits": _operation_limits(resolved_config),
+        }
 
     @router.post("/drafts/generate")
     async def generate_drafts(

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -483,6 +483,7 @@ runner. Explicit `reasoning_context_provider` injection still takes precedence.
 
 | Method | Path | Purpose |
 |---|---|---|
+| `GET` | `/campaigns/operations/status` | Report database availability, provider presence, feature readiness, and configured limits for admin dashboards. |
 | `POST` | `/campaigns/operations/drafts/generate` | Generate and persist campaign drafts from `campaign_opportunities`. |
 | `POST` | `/campaigns/operations/send/queued` | Send queued campaign rows through the injected sender. |
 | `POST` | `/campaigns/operations/sequences/progress` | Generate and queue due follow-up sequence steps. |
@@ -491,13 +492,15 @@ runner. Explicit `reasoning_context_provider` injection still takes precedence.
 For B2B installs, mount this router beside `create_b2b_campaign_router` and run
 the hosted admin sequence in order:
 
-1. Generate drafts from active opportunities with
+1. Check `/campaigns/operations/status` so the admin UI only enables ready
+   actions.
+2. Generate drafts from active opportunities with
    `/campaigns/operations/drafts/generate`.
-2. Inspect generated rows with `/b2b/campaigns/drafts` or
+3. Inspect generated rows with `/b2b/campaigns/drafts` or
    `/b2b/campaigns/drafts/export`.
-3. Approve and queue selected rows with `/b2b/campaigns/drafts/review`.
-4. Send queued rows with `/campaigns/operations/send/queued`.
-5. Refresh reporting with `/campaigns/operations/analytics/refresh`.
+4. Approve and queue selected rows with `/b2b/campaigns/drafts/review`.
+5. Send queued rows with `/campaigns/operations/send/queued`.
+6. Refresh reporting with `/campaigns/operations/analytics/refresh`.
 
 Reject a draft without deleting it:
 

--- a/tests/test_extracted_campaign_api_hosted_workflow.py
+++ b/tests/test_extracted_campaign_api_hosted_workflow.py
@@ -191,6 +191,7 @@ def test_hosted_campaign_api_workflow_uses_shared_scope_and_provider_ports(
         counters=counters,
     )
 
+    status_response = client.get("/campaigns/operations/status")
     generate_response = client.post(
         "/campaigns/operations/drafts/generate",
         json={
@@ -216,11 +217,18 @@ def test_hosted_campaign_api_workflow_uses_shared_scope_and_provider_ports(
     send_response = client.post("/campaigns/operations/send/queued", json={"limit": 1})
     analytics_response = client.post("/campaigns/operations/analytics/refresh")
 
+    assert status_response.status_code == 200
     assert generate_response.status_code == 200
     assert list_response.status_code == 200
     assert review_response.status_code == 200
     assert send_response.status_code == 200
     assert analytics_response.status_code == 200
+    assert status_response.json()["features"] == {
+        "draft_generation": True,
+        "send_queued": True,
+        "sequence_progression": True,
+        "analytics_refresh": True,
+    }
     assert [name for name, _ in calls] == [
         "generate",
         "list",
@@ -244,9 +252,9 @@ def test_hosted_campaign_api_workflow_uses_shared_scope_and_provider_ports(
     assert calls[2][1]["scope"] == scope
     assert calls[3][1]["sender"] is sender
     assert counters == {
-        "auth": 5,
+        "auth": 6,
         "scope": 3,
-        "pool": 5,
+        "pool": 6,
         "llm": 1,
         "skills": 1,
         "reasoning": 1,

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -190,6 +190,127 @@ def test_campaign_operations_router_generates_campaign_drafts(monkeypatch) -> No
     assert config.temperature == 0.3
 
 
+def test_campaign_operations_router_reports_status() -> None:
+    counters: dict[str, int] = {}
+    response = _client(
+        _Pool(),
+        sender=_Sender(),
+        llm=_LLM(),
+        skills=_Skills(),
+        reasoning=_Reasoning(),
+        counters=counters,
+        config=CampaignOperationsApiConfig(
+            default_generation_limit=7,
+            max_generation_limit=70,
+            generation_target_mode="vendor_retention",
+            generation_channel="email",
+            generation_channels=("email_cold", "email_followup"),
+            default_send_limit=8,
+            max_send_limit=80,
+            default_sequence_limit=9,
+            max_sequence_limit=90,
+            default_sequence_max_steps=4,
+            max_sequence_steps=12,
+            sequence_from_email="audit@example.com",
+        ),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "database": {"configured": True, "available": True},
+        "providers": {
+            "database": True,
+            "sender": True,
+            "llm": True,
+            "skills": True,
+            "reasoning": True,
+        },
+        "reasoning": {
+            "mode": "explicit_provider",
+            "single_pass_configured": False,
+            "single_pass_ready": False,
+        },
+        "features": {
+            "draft_generation": True,
+            "send_queued": True,
+            "sequence_progression": True,
+            "analytics_refresh": True,
+        },
+        "limits": {
+            "generation": {
+                "default_limit": 7,
+                "max_limit": 70,
+                "target_mode": "vendor_retention",
+                "channel": "email",
+                "channels": ["email_cold", "email_followup"],
+            },
+            "send": {"default_limit": 8, "max_limit": 80},
+            "sequence": {
+                "default_limit": 9,
+                "max_limit": 90,
+                "default_max_steps": 4,
+                "max_steps": 12,
+            },
+        },
+    }
+    assert counters == {"pool": 1}
+
+
+def test_campaign_operations_router_status_reports_degraded_database() -> None:
+    response = _client(_Pool(initialized=False)).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "degraded"
+    assert payload["database"] == {
+        "configured": True,
+        "available": False,
+        "reason": "pool_uninitialized",
+    }
+    assert payload["features"] == {
+        "draft_generation": False,
+        "send_queued": False,
+        "sequence_progression": False,
+        "analytics_refresh": False,
+    }
+
+
+def test_campaign_operations_router_status_reports_single_pass_readiness() -> None:
+    response = _client(
+        _Pool(),
+        config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ready"
+    assert payload["reasoning"] == {
+        "mode": "single_pass",
+        "single_pass_configured": True,
+        "single_pass_ready": False,
+    }
+    assert payload["features"]["draft_generation"] is False
+
+
+def test_campaign_operations_router_status_marks_single_pass_ready() -> None:
+    response = _client(
+        _Pool(),
+        llm=_LLM(),
+        skills=_Skills(),
+        config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reasoning"] == {
+        "mode": "single_pass",
+        "single_pass_configured": True,
+        "single_pass_ready": True,
+    }
+    assert payload["features"]["draft_generation"] is True
+
+
 def test_campaign_operations_router_generates_with_payload_scope(monkeypatch) -> None:
     calls = []
 

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -311,6 +311,23 @@ def test_campaign_operations_router_status_marks_single_pass_ready() -> None:
     assert payload["features"]["draft_generation"] is True
 
 
+def test_campaign_operations_router_status_treats_explicit_reasoning_as_ready() -> None:
+    response = _client(
+        _Pool(),
+        reasoning=_Reasoning(),
+        config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reasoning"] == {
+        "mode": "explicit_provider",
+        "single_pass_configured": True,
+        "single_pass_ready": False,
+    }
+    assert payload["features"]["draft_generation"] is True
+
+
 def test_campaign_operations_router_generates_with_payload_scope(monkeypatch) -> None:
     calls = []
 


### PR DESCRIPTION
## Summary
- Add `GET /campaigns/operations/status` to the hosted campaign operations router for admin dashboard readiness checks.
- Report database availability, injected provider presence, reasoning mode/readiness, feature readiness, and configured operation limits without resolving sender/LLM/skill providers or exposing credentials.
- Keep action routes unchanged; status is read-only and uses the existing router dependencies/auth.
- Update hosted workflow coverage, README/runbook/status docs, and claim the D15 coordination slice.
- Treat an explicit `reasoning_context_provider` as draft-generation ready even when single-pass reasoning is enabled.

## Validation
- `python -m py_compile extracted_content_pipeline/api/campaign_operations.py tests/test_extracted_campaign_api_operations.py tests/test_extracted_campaign_api_hosted_workflow.py`
- `pytest tests/test_extracted_campaign_api_operations.py tests/test_extracted_campaign_api_hosted_workflow.py` (35/35)
- `rg -n "[^\\x00-\\x7F]" extracted_content_pipeline/api/campaign_operations.py tests/test_extracted_campaign_api_operations.py tests/test_extracted_campaign_api_hosted_workflow.py` (no matches)
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` (880/880, existing torch/pynvml warning)