### PR TITLE
PR-D6b: Wire exact cache through /api/v1/llm/chat (5-layer bundle: cache layer 1)

### DIFF
--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -39,6 +39,12 @@ from pydantic import BaseModel, Field
 from ..api.billing import LLM_PLAN_LIMITS
 from ..auth.dependencies import AuthUser, require_llm_plan
 from ..pipelines.llm import trace_llm_call
+from ..services.b2b.llm_exact_cache import (
+    build_request_envelope,
+    is_llm_gateway_exact_cache_enabled,
+    lookup_cached_text,
+    store_cached_text,
+)
 from ..services.byok_keys import lookup_provider_key_async
 from ..services.llm.anthropic import convert_messages
 from ..services.llm_gateway_batch import (
@@ -59,6 +65,13 @@ router = APIRouter(prefix="/llm", tags=["llm-gateway"])
 # Groq) layer in subsequent PRs once their LLMService implementations
 # are exercised through the gateway path.
 _PROVIDERS_THIS_PR = ("anthropic",)
+
+
+# Exact-cache namespace for /chat (PR-D6b). The
+# ``llm_gateway.`` prefix routes the cache module's enablement
+# check to the gateway's own feature flag rather than the B2B
+# pipeline flag, so the two products stay decoupled.
+_LLM_CHAT_CACHE_NAMESPACE = "llm_gateway.chat"
 
 
 # ---- Request / response schemas -----------------------------------------
@@ -210,6 +223,73 @@ async def chat(
     if system_prompt:
         create_kwargs["system"] = system_prompt
 
+    # PR-D6b: exact-match cache lookup. The envelope hashes
+    # provider/model/messages/max_tokens/temperature plus the system
+    # prompt under ``extra`` so any difference produces a different
+    # cache key. Account-scoped via the (cache_key, account_id)
+    # composite PK from PR-D3 -- cross-tenant hits are impossible.
+    # Cache failures must NOT fail the chat request: any exception
+    # falls through to a normal Anthropic call.
+    request_envelope = build_request_envelope(
+        provider=body.provider,
+        model=llm.model,
+        messages=api_messages,
+        max_tokens=body.max_tokens,
+        temperature=body.temperature,
+        extra={"system": system_prompt} if system_prompt else None,
+    )
+    cache_hit = None
+    if is_llm_gateway_exact_cache_enabled():
+        try:
+            cache_hit = await lookup_cached_text(
+                _LLM_CHAT_CACHE_NAMESPACE,
+                request_envelope,
+                pool=pool,
+                account_id=user.account_id,
+            )
+        except Exception:
+            logger.exception(
+                "llm_gateway.chat cache lookup failed account=%s",
+                user.account_id,
+            )
+
+    if cache_hit is not None:
+        # Cache hit: skip Anthropic, return cached text with zero
+        # token counts (the customer didn't consume tokens this
+        # call). Write a zero-token llm_usage row tagged
+        # ``cache_hit: true`` so dashboard analytics can compute
+        # cache savings ("you would have paid X, you paid 0").
+        response_id = f"llm_{_uuid.uuid4().hex[:24]}"
+        try:
+            trace_llm_call(
+                span_name="llm_gateway.chat",
+                input_tokens=0,
+                output_tokens=0,
+                billable_input_tokens=0,
+                model=body.model,
+                provider=body.provider,
+                duration_ms=0,
+                metadata={
+                    "account_id": user.account_id,
+                    "request_id": response_id,
+                    "endpoint": "llm_gateway.chat",
+                    "cache_hit": True,
+                },
+            )
+        except Exception:
+            logger.exception("llm_gateway.chat cache-hit usage tracking failed")
+        return ChatResponse(
+            id=response_id,
+            provider=body.provider,
+            model=body.model,
+            response=cache_hit["response_text"],
+            usage=ChatUsage(
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
+            ),
+        )
+
     # Capture full response (text + usage) via direct SDK call.
     # PR-D4 review fix already addressed the "chat_async returned
     # only text -> zero token usage" bug; PR-D4b also closes the
@@ -267,6 +347,35 @@ async def chat(
         )
     except Exception:
         logger.exception("llm_gateway.chat usage tracking failed")
+
+    # PR-D6b: store the response in the exact cache so an identical
+    # subsequent call from this account hits. Skipped on empty
+    # response (lookup_cached_text would treat it as a non-hit anyway)
+    # and on flag off. Cache write failures must not fail the chat
+    # response -- log and proceed.
+    if text and is_llm_gateway_exact_cache_enabled():
+        try:
+            await store_cached_text(
+                _LLM_CHAT_CACHE_NAMESPACE,
+                request_envelope,
+                provider=body.provider,
+                model=body.model,
+                response_text=text,
+                usage={
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cached_tokens": cached_tokens,
+                    "cache_write_tokens": cache_write_tokens,
+                },
+                metadata={"endpoint": "llm_gateway.chat"},
+                pool=pool,
+                account_id=user.account_id,
+            )
+        except Exception:
+            logger.exception(
+                "llm_gateway.chat cache store failed account=%s",
+                user.account_id,
+            )
 
     return ChatResponse(
         id=response_id,

--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -74,6 +74,30 @@ _PROVIDERS_THIS_PR = ("anthropic",)
 _LLM_CHAT_CACHE_NAMESPACE = "llm_gateway.chat"
 
 
+# Cache-hit rows have legitimately-zero token counts (the customer
+# didn't consume any provider tokens), but the tracer's _store_local
+# short-circuits when every token field is falsy -- so routing
+# through trace_llm_call would silently drop the row and the future
+# cache-savings dashboard would never see it. Direct INSERT instead
+# (same pattern _persist_batch_usage uses for batch items in
+# llm_gateway_batch.py). Codex P1 fix on PR-D6b.
+_CACHE_HIT_USAGE_INSERT_SQL = """
+INSERT INTO llm_usage (
+    span_name, operation_type, model_name, model_provider,
+    input_tokens, output_tokens, total_tokens,
+    billable_input_tokens, cached_tokens, cache_write_tokens,
+    cost_usd, duration_ms, status, metadata,
+    api_endpoint, account_id
+) VALUES (
+    'llm_gateway.chat', 'llm_call', $1, $2,
+    0, 0, 0,
+    0, 0, 0,
+    0, 0, 'completed', $3::jsonb,
+    'llm_gateway.chat', $4
+)
+"""
+
+
 # ---- Request / response schemas -----------------------------------------
 
 
@@ -259,22 +283,25 @@ async def chat(
         # call). Write a zero-token llm_usage row tagged
         # ``cache_hit: true`` so dashboard analytics can compute
         # cache savings ("you would have paid X, you paid 0").
+        # Codex P1 on PR-D6b: route the INSERT directly to the
+        # pool. trace_llm_call -> _store_local short-circuits when
+        # every token field is falsy, which would drop this row
+        # silently. Direct write keeps the legitimate-zero row
+        # visible to /api/v1/llm/usage rollups.
         response_id = f"llm_{_uuid.uuid4().hex[:24]}"
         try:
-            trace_llm_call(
-                span_name="llm_gateway.chat",
-                input_tokens=0,
-                output_tokens=0,
-                billable_input_tokens=0,
-                model=body.model,
-                provider=body.provider,
-                duration_ms=0,
-                metadata={
-                    "account_id": user.account_id,
-                    "request_id": response_id,
-                    "endpoint": "llm_gateway.chat",
-                    "cache_hit": True,
-                },
+            cache_hit_metadata = json.dumps({
+                "account_id": user.account_id,
+                "request_id": response_id,
+                "endpoint": "llm_gateway.chat",
+                "cache_hit": True,
+            })
+            await pool.execute(
+                _CACHE_HIT_USAGE_INSERT_SQL,
+                body.model,
+                body.provider,
+                cache_hit_metadata,
+                user.account_id,
             )
         except Exception:
             logger.exception("llm_gateway.chat cache-hit usage tracking failed")

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -14,6 +14,31 @@ ENV_FILES = (".env", ".env.local")
 DEFAULT_OPENROUTER_CLAUDE_SONNET_MODEL = "anthropic/claude-sonnet-4-5"
 
 
+class LLMGatewayConfig(BaseSettings):
+    """LLM Gateway product-level configuration (PR-D6b+).
+
+    Settings that scope to the customer-facing /api/v1/llm/* surface.
+    Distinct from ``b2b_churn`` (atlas's internal pipeline) so flags
+    like the exact cache can be toggled per product without coupling.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="ATLAS_LLM_GATEWAY_",
+        env_file=ENV_FILES,
+        extra="ignore",
+    )
+
+    exact_cache_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable exact-match Postgres caching for customer-facing "
+            "/api/v1/llm/chat calls. Reuses the b2b_llm_exact_cache "
+            "table with namespace='llm_gateway.chat' and per-account "
+            "scoping (PR-D3 migration 314)."
+        ),
+    )
+
+
 class SaaSAuthConfig(BaseSettings):
     """SaaS authentication and billing configuration."""
 
@@ -5476,6 +5501,7 @@ class Settings(BaseSettings):
     news_intel: NewsIntelligenceConfig = Field(default_factory=NewsIntelligenceConfig)
     provider_cost: ProviderCostConfig = Field(default_factory=ProviderCostConfig)
     saas_auth: SaaSAuthConfig = Field(default_factory=SaaSAuthConfig)
+    llm_gateway: LLMGatewayConfig = Field(default_factory=LLMGatewayConfig)
 
     # Reasoning agent (cross-domain event-driven intelligence)
     @staticmethod

--- a/atlas_brain/services/b2b/llm_exact_cache.py
+++ b/atlas_brain/services/b2b/llm_exact_cache.py
@@ -30,6 +30,35 @@ def is_b2b_llm_exact_cache_enabled() -> bool:
     return bool(getattr(settings.b2b_churn, "llm_exact_cache_enabled", False))
 
 
+# Namespace prefix that routes to the customer-facing LLM Gateway
+# product (PR-D6b). Cache rows written with ``namespace`` starting
+# with this prefix are gated by ``settings.llm_gateway.exact_cache_enabled``
+# rather than the B2B flag, so atlas's internal pipeline and the
+# Gateway can be toggled independently.
+LLM_GATEWAY_NAMESPACE_PREFIX = "llm_gateway."
+
+
+def is_llm_gateway_exact_cache_enabled() -> bool:
+    """Return whether the LLM Gateway product's exact cache is enabled."""
+    from ...config import settings
+
+    return bool(
+        getattr(
+            getattr(settings, "llm_gateway", None),
+            "exact_cache_enabled",
+            False,
+        )
+    )
+
+
+def _is_cache_enabled_for_namespace(namespace: str) -> bool:
+    """Dispatch the enablement check on the namespace prefix so the
+    B2B and LLM Gateway products own their own feature flags."""
+    if namespace.startswith(LLM_GATEWAY_NAMESPACE_PREFIX):
+        return is_llm_gateway_exact_cache_enabled()
+    return is_b2b_llm_exact_cache_enabled()
+
+
 def _normalize_maybe_json_string(value: str) -> Any:
     stripped = value.strip()
     if stripped and stripped[0] in "{[":
@@ -247,7 +276,7 @@ async def lookup_cached_text(
     so cross-tenant hits are impossible -- the (cache_key, account_id)
     composite PK guarantees isolation at the storage layer.
     """
-    if not namespace or not is_b2b_llm_exact_cache_enabled():
+    if not namespace or not _is_cache_enabled_for_namespace(namespace):
         return None
 
     db_pool = _resolve_pool(pool)
@@ -311,7 +340,7 @@ async def store_cached_text(
         not namespace
         or not response_text
         or not str(response_text).strip()
-        or not is_b2b_llm_exact_cache_enabled()
+        or not _is_cache_enabled_for_namespace(namespace)
     ):
         return False
 

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -422,3 +422,229 @@ def test_resolve_byok_helper_calls_db_aware_resolver():
     src = inspect.getsource(llm_gateway._resolve_byok_or_503)
     assert "lookup_provider_key_async" in src
     assert "lookup_provider_key(" not in src.replace("lookup_provider_key_async", "")
+
+
+# ---- Exact cache wiring (PR-D6b) ----------------------------------------
+
+
+def test_llm_gateway_config_has_exact_cache_flag():
+    """PR-D6b: the customer-facing /chat surface gets its own
+    feature flag, decoupled from b2b_churn.llm_exact_cache_enabled
+    so the two products toggle independently."""
+    from atlas_brain.config import settings
+
+    assert hasattr(settings, "llm_gateway")
+    assert hasattr(settings.llm_gateway, "exact_cache_enabled")
+    # Default OFF -- caching is opt-in.
+    assert settings.llm_gateway.exact_cache_enabled is False
+
+
+def test_chat_namespace_constant_routes_to_gateway_flag():
+    """The cache namespace must start with the prefix the cache
+    module's _is_cache_enabled_for_namespace() dispatcher checks.
+    Otherwise enablement falls through to the B2B flag and the
+    products couple."""
+    from atlas_brain.api import llm_gateway
+    from atlas_brain.services.b2b.llm_exact_cache import (
+        LLM_GATEWAY_NAMESPACE_PREFIX,
+    )
+
+    assert llm_gateway._LLM_CHAT_CACHE_NAMESPACE.startswith(
+        LLM_GATEWAY_NAMESPACE_PREFIX
+    )
+
+
+def test_chat_route_imports_cache_helpers():
+    """Source-text pin: the chat route must import the cache
+    primitives. Without the imports the wiring below silently
+    falls back to the un-cached path."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway)
+    assert "from ..services.b2b.llm_exact_cache import" in src
+    assert "build_request_envelope" in src
+    assert "is_llm_gateway_exact_cache_enabled" in src
+    assert "lookup_cached_text" in src
+    assert "store_cached_text" in src
+
+
+def test_chat_lookup_runs_before_anthropic_call():
+    """Cache lookup must happen BEFORE the Anthropic call --
+    otherwise we pay for a request whose answer is already cached.
+    Pin the source ordering."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    lookup_idx = src.find("await lookup_cached_text(")
+    create_idx = src.find("await client.messages.create(")
+    assert lookup_idx > 0 and create_idx > 0
+    assert lookup_idx < create_idx
+
+
+def test_chat_lookup_is_account_scoped():
+    """Cross-account leak guard: the lookup must thread the
+    customer's account_id (not the sentinel) so PR-D3's
+    composite (cache_key, account_id) PK isolates tenants."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    # Find the lookup block specifically (not the store block).
+    lookup_block = src.split("await lookup_cached_text(")[1].split(")", 1)[0]
+    assert "account_id=user.account_id" in lookup_block
+
+
+def test_chat_lookup_gated_by_feature_flag():
+    """Lookup only runs when settings.llm_gateway.exact_cache_enabled
+    is True. With the flag off (the default), the cache module
+    isn't even called -- no DB round-trip."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    flag_idx = src.find("if is_llm_gateway_exact_cache_enabled():")
+    lookup_idx = src.find("await lookup_cached_text(")
+    assert flag_idx > 0 and lookup_idx > 0
+    # Flag check is the immediate guard for the lookup.
+    assert flag_idx < lookup_idx
+
+
+def test_chat_cache_lookup_failures_do_not_fail_request():
+    """If the cache lookup raises (DB transient, schema drift),
+    the chat request must NOT 500 -- fall through to a normal
+    Anthropic call. Pin the try/except wrap and the empty
+    fall-through."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    # try/except around the lookup call.
+    assert "try:\n            cache_hit = await lookup_cached_text(" in src
+    assert "llm_gateway.chat cache lookup failed" in src
+
+
+def test_chat_cache_hit_returns_zero_token_usage():
+    """On cache hit: ChatResponse.usage = 0/0/0 (no tokens consumed
+    this call). Customer can infer cache via the zero usage; a
+    follow-up PR adds a `cached: bool` field for explicit signaling."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    # The cache-hit ChatResponse path uses ChatUsage zeros.
+    assert "if cache_hit is not None:" in src
+    hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
+    assert "input_tokens=0" in hit_block
+    assert "output_tokens=0" in hit_block
+    assert "total_tokens=0" in hit_block
+    # And the response_text comes from the cache hit.
+    assert 'response=cache_hit["response_text"]' in hit_block
+
+
+def test_chat_cache_hit_writes_zero_token_usage_row_with_cache_hit_metadata():
+    """Cache savings analytics depend on a zero-token llm_usage
+    row tagged ``cache_hit: true`` -- without it, dashboard can't
+    distinguish "didn't call provider" from "didn't track"."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
+    # trace_llm_call still fires on hit.
+    assert "trace_llm_call(" in hit_block
+    # With zero tokens.
+    assert "input_tokens=0" in hit_block
+    # And the cache_hit metadata flag.
+    assert '"cache_hit": True' in hit_block
+
+
+def test_chat_cache_hit_skips_anthropic_call():
+    """The cache-hit branch must return BEFORE the Anthropic
+    create call -- otherwise the customer pays for a request
+    whose answer was just served from cache."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
+    # The hit branch must return.
+    assert "return ChatResponse(" in hit_block
+
+
+def test_chat_store_runs_after_successful_anthropic_call():
+    """Cache store must happen AFTER the Anthropic call so we
+    only persist responses that actually came back -- and after
+    the trace_llm_call usage row is written so the success
+    accounting precedes the cache write."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    create_idx = src.find("await client.messages.create(")
+    store_idx = src.find("await store_cached_text(")
+    assert create_idx > 0 and store_idx > 0
+    assert create_idx < store_idx
+
+
+def test_chat_store_is_account_scoped():
+    """Same isolation guard as lookup -- store must thread the
+    customer's account_id so the row lands in the right tenant
+    namespace."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    store_block = src.split("await store_cached_text(")[1].split(")", 1)[0]
+    assert "account_id=user.account_id" in store_block
+
+
+def test_chat_cache_store_failures_do_not_fail_request():
+    """Same posture as lookup: cache store errors get logged but
+    do not raise -- the chat response was already produced."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    assert "try:\n            await store_cached_text(" in src
+    assert "llm_gateway.chat cache store failed" in src
+
+
+def test_chat_envelope_includes_system_prompt_in_extra():
+    """The system prompt is part of the request's identity and
+    must be in the cache key envelope -- otherwise two calls with
+    the same messages but different system prompts collide."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    assert 'extra={"system": system_prompt}' in src
+
+
+# ---- Cache module: namespace dispatch (PR-D6b) -------------------------
+
+
+def test_cache_module_dispatches_enablement_by_namespace():
+    """The B2B and LLM Gateway products own separate feature flags;
+    the cache module dispatches based on namespace prefix so
+    callers don't accidentally couple."""
+    from atlas_brain.services.b2b import llm_exact_cache
+
+    assert hasattr(llm_exact_cache, "is_llm_gateway_exact_cache_enabled")
+    assert hasattr(llm_exact_cache, "_is_cache_enabled_for_namespace")
+    assert llm_exact_cache.LLM_GATEWAY_NAMESPACE_PREFIX == "llm_gateway."
+
+    # Dispatcher branches.
+    src = inspect.getsource(llm_exact_cache._is_cache_enabled_for_namespace)
+    assert "LLM_GATEWAY_NAMESPACE_PREFIX" in src
+    assert "is_llm_gateway_exact_cache_enabled" in src
+    assert "is_b2b_llm_exact_cache_enabled" in src
+
+
+def test_lookup_cached_text_uses_namespace_dispatch_not_b2b_flag():
+    """The lookup must check the namespace-aware dispatcher, not
+    the bare B2B flag -- otherwise gateway-namespaced calls fail
+    when the B2B flag is off."""
+    from atlas_brain.services.b2b import llm_exact_cache
+
+    src = inspect.getsource(llm_exact_cache.lookup_cached_text)
+    assert "_is_cache_enabled_for_namespace(namespace)" in src
+    # The bare B2B flag check shouldn't appear in this function.
+    assert "is_b2b_llm_exact_cache_enabled()" not in src
+
+
+def test_store_cached_text_uses_namespace_dispatch_not_b2b_flag():
+    from atlas_brain.services.b2b import llm_exact_cache
+
+    src = inspect.getsource(llm_exact_cache.store_cached_text)
+    assert "_is_cache_enabled_for_namespace(namespace)" in src
+    assert "is_b2b_llm_exact_cache_enabled()" not in src

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -540,17 +540,54 @@ def test_chat_cache_hit_returns_zero_token_usage():
 def test_chat_cache_hit_writes_zero_token_usage_row_with_cache_hit_metadata():
     """Cache savings analytics depend on a zero-token llm_usage
     row tagged ``cache_hit: true`` -- without it, dashboard can't
-    distinguish "didn't call provider" from "didn't track"."""
+    distinguish "didn't call provider" from "didn't track".
+
+    Codex P1 on PR-D6b: trace_llm_call -> _store_local
+    short-circuits when every token field is falsy, so routing
+    through it would drop the row silently. Direct INSERT to
+    pool.execute(_CACHE_HIT_USAGE_INSERT_SQL, ...) instead --
+    same pattern _persist_batch_usage uses for batch items."""
     from atlas_brain.api import llm_gateway
 
     src = inspect.getsource(llm_gateway.chat)
     hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
-    # trace_llm_call still fires on hit.
-    assert "trace_llm_call(" in hit_block
-    # With zero tokens.
-    assert "input_tokens=0" in hit_block
-    # And the cache_hit metadata flag.
+    # Direct INSERT, NOT trace_llm_call (which would silently drop).
+    assert "await pool.execute(\n                _CACHE_HIT_USAGE_INSERT_SQL," in hit_block
+    assert "trace_llm_call(" not in hit_block
+    # cache_hit metadata flag is in the JSON payload.
     assert '"cache_hit": True' in hit_block
+
+    # The constant SQL is shaped correctly: zero token counts
+    # baked in (legitimate -- they didn't consume tokens) and
+    # the cache_hit row is identifiable by api_endpoint
+    # 'llm_gateway.chat' + metadata.cache_hit=True.
+    sql = llm_gateway._CACHE_HIT_USAGE_INSERT_SQL
+    assert "INSERT INTO llm_usage" in sql
+    assert "input_tokens, output_tokens, total_tokens" in sql
+    assert "0, 0, 0" in sql  # token zeros baked in
+
+
+def test_cache_hit_insert_sql_does_not_route_through_tracer_drop_filter():
+    """Pin the design rationale: the tracer's _store_local returns
+    early when every token field is falsy. A cache-hit row has
+    legitimately-zero tokens and would be dropped if we routed
+    through trace_llm_call. Direct INSERT bypasses the filter."""
+    from atlas_brain.api import llm_gateway
+    from atlas_brain.services import tracing
+
+    # Confirm the tracer DOES drop zero-token payloads (the bug
+    # this test guards against).
+    store_local_src = inspect.getsource(tracing.FTLTracingClient._store_local)
+    assert "if not any(" in store_local_src
+    assert '"input_tokens"' in store_local_src
+    assert '"output_tokens"' in store_local_src
+
+    # The cache-hit constant is the bypass.
+    assert hasattr(llm_gateway, "_CACHE_HIT_USAGE_INSERT_SQL")
+    # And the chat handler uses it in the hit branch.
+    src = inspect.getsource(llm_gateway.chat)
+    hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
+    assert "_CACHE_HIT_USAGE_INSERT_SQL" in hit_block
 
 
 def test_chat_cache_hit_skips_anthropic_call():


### PR DESCRIPTION
## Summary

First step of the LLM Gateway product's **5-layer cost-control bundle** (cache + batch + reconciliation + budget + multi-provider). Wires the existing exact-match Postgres cache (PR-D3 migration 314, already account-scoped) through the customer-facing `/api/v1/llm/chat` route.

## What ships

### Three coordinated changes

**1. New `LLMGatewayConfig` SubConfig** — single field `exact_cache_enabled: bool = False`, env_prefix `ATLAS_LLM_GATEWAY_`. Decoupled from `b2b_churn.llm_exact_cache_enabled` so atlas's internal pipeline cache and the customer-facing gateway cache toggle independently.

**2. Namespace-aware enablement dispatcher in the cache module:**
- `LLM_GATEWAY_NAMESPACE_PREFIX = "llm_gateway."`
- `is_llm_gateway_exact_cache_enabled()` reads the new flag
- `_is_cache_enabled_for_namespace(namespace)` dispatches by prefix so callers don't accidentally couple flags
- `lookup_cached_text` + `store_cached_text` use the dispatcher instead of the bare B2B flag check

**3. `/chat` route wiring with namespace `llm_gateway.chat`:**
- Build envelope (provider, model, messages, max_tokens, temperature, plus system prompt under `extra`) before the Anthropic call
- Lookup cache; on hit return `ChatResponse` with `usage = 0/0/0` and write a zero-token `llm_usage` row tagged `cache_hit: true` so the future cache-savings dashboard can compute "you would have paid X, you paid 0"
- On miss, normal Anthropic call + store on success
- Cache lookup/store failures must NOT fail the request (try/except + logger.exception, fall through to no-cache behavior)

## Account isolation

The cache is account-scoped via PR-D3's composite `(cache_key, account_id)` PK on `b2b_llm_exact_cache` — cross-tenant cache hits are impossible at the storage layer regardless of caller hygiene. The `/chat` route threads `user.account_id` (real customer UUID) into both `lookup_cached_text` and `store_cached_text`.

## On a cache hit

```python
# ChatResponse.usage = 0/0/0 (no tokens consumed this call)
# llm_usage row written with input_tokens=0, output_tokens=0,
#   metadata = {"cache_hit": True, "endpoint": "llm_gateway.chat", ...}
# Anthropic NOT called
# b2b_llm_exact_cache row's hit_count incremented (handled by lookup_cached_text)
```

The customer can infer cache via `usage.total_tokens == 0`. A follow-up PR will add a `cached: bool` field on `ChatResponse` for explicit signaling — deferred to keep this PR's API surface minimum.

## Deferred to follow-up PRs

Logged in memory (`memory/project_llm_gateway_post_d6b_followups.md`):
1. `cached: bool` field on `ChatResponse`
2. `/api/v1/llm/usage` cache-savings rollup endpoint
3. `/chat/stream` cache support
4. `Cache-Control: no-store` opt-out header
5. Semantic cache layer (`reasoning_semantic_cache` wiring)
6. `/batch` cache

## Pre-existing test failure flagged (out of scope)

`tests/test_b2b_cache_strategy.py::test_exact_cache_strategies_reference_cache_namespace_and_helpers` fails on baseline `origin/main` before any of my changes. The strategy expects `stage_id='b2b_enrichment.tier1'` to appear in `atlas_brain/autonomous/tasks/b2b_enrichment.py` but only the `tier1` substring is there. Per the project's surgical-changes rule, flagging here for separate cleanup rather than fixing in this PR.

## Test plan

- [x] 17 new tests in `test_llm_gateway_router.py` covering:
  - Config flag exists with correct default
  - Namespace prefix routes to gateway flag (not B2B)
  - Cache helpers imported by chat route
  - Lookup runs BEFORE Anthropic call
  - Lookup is account-scoped
  - Lookup gated by feature flag
  - Lookup failure isolation
  - Hit-path returns zero usage
  - Hit-path writes zero-token usage row with `cache_hit: true`
  - Hit-path skips Anthropic call (returns first)
  - Store runs AFTER successful Anthropic call
  - Store is account-scoped
  - Store failure isolation
  - Envelope includes system prompt under `extra`
  - Cache module exports namespace dispatcher
  - lookup_cached_text uses dispatcher (not bare flag)
  - store_cached_text uses dispatcher (not bare flag)
- [x] Full LLM-gateway + auth + cache regression: 256 passed
- [x] ASCII compliance verified
- [x] No inline hard-coded values (`"llm_gateway.chat"` namespace and `"llm_gateway."` prefix as module constants)
- [ ] Codex / Copilot review
- [ ] `ATLAS_LLM_GATEWAY_EXACT_CACHE_ENABLED=true` set in staging before customer rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
