### PR TITLE
email_graph_sync: route Stage 1 LLM through llm_router (not direct Ollama)

### DIFF
--- a/atlas_brain/jobs/email_graph_sync.py
+++ b/atlas_brain/jobs/email_graph_sync.py
@@ -46,15 +46,27 @@ class EmailGraphSync:
         return self._rag_client
 
     def _get_llm(self):
-        """Get or create a dedicated OllamaLLM instance for qwen3:32b."""
-        if self._llm is None:
-            from ..services.llm.ollama import OllamaLLM
+        """Get the Stage 1 extraction LLM via the LLM router.
 
-            model = self._settings.memory.email_graph_model
-            base_url = self._settings.llm.ollama_url
-            self._llm = OllamaLLM(model=model, base_url=base_url)
-            self._llm.load()
-            logger.info("Loaded extraction LLM: %s at %s", model, base_url)
+        Routes through the email_triage workflow so this stage uses whatever
+        provider main.py initialized (typically OpenRouter -> Anthropic Haiku
+        in production; falls back to the local registry if not initialized).
+        Lifecycle is router-managed -- callers must not call .unload().
+        """
+        if self._llm is None:
+            from ..services.llm_router import get_llm
+
+            self._llm = get_llm("email_triage")
+            if self._llm is None:
+                raise RuntimeError(
+                    "No LLM available for email_graph_sync stage 1. "
+                    "Initialize the triage LLM in main.py (init_triage_llm) "
+                    "or activate a local LLM in llm_registry."
+                )
+            logger.info(
+                "email_graph_sync stage 1 using LLM: %s",
+                getattr(self._llm, "model_name", type(self._llm).__name__),
+            )
         return self._llm
 
     async def _get_gmail_client(self):
@@ -300,15 +312,12 @@ class EmailGraphSync:
             })
             graphiti_ids.append(msg_id)
 
-        # Unload Stage 1 model before Graphiti calls Ollama -- frees the runner
-        # so Graphiti (via Docker) doesn't hit a stale/busy model instance.
-        if self._llm is not None:
-            try:
-                self._llm.unload()
-                self._llm = None
-                logger.info("Unloaded extraction LLM before Graphiti send")
-            except Exception:
-                pass
+        # Stage 1 LLM lifecycle is router-managed (singleton in llm_router);
+        # nothing to unload here. The original code freed local Ollama VRAM
+        # before Graphiti ran qwen3:32b on the same GPU -- with router-backed
+        # LLMs (OpenRouter, Anthropic, etc.) the call is remote and there is
+        # no shared resource to free. Just clear the local cache reference.
+        self._llm = None
 
         # Stage 2: Send batch to Graphiti for entity/relationship extraction.
         # Brief pause lets Ollama's model runner fully settle after Stage 1.

--- a/tests/test_email_graph_sync_routing.py
+++ b/tests/test_email_graph_sync_routing.py
@@ -1,0 +1,52 @@
+"""Verify email_graph_sync stage 1 routes through llm_router (not direct Ollama).
+
+This guards against regressions where the email-to-graph pipeline gets
+hardcoded to a specific local LLM, which silently breaks when the
+production setup uses cloud LLMs (OpenRouter, Anthropic, etc.).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_get_llm_uses_router_email_triage_workflow():
+    """EmailGraphSync._get_llm must call llm_router.get_llm('email_triage')."""
+    from atlas_brain.jobs.email_graph_sync import EmailGraphSync
+
+    fake_llm = MagicMock(name="triage_llm")
+    fake_llm.model_name = "anthropic/claude-haiku-4-5"
+
+    with patch("atlas_brain.services.llm_router.get_llm", return_value=fake_llm) as mock_router:
+        job = EmailGraphSync()
+        result = job._get_llm()
+
+    assert result is fake_llm
+    mock_router.assert_called_once_with("email_triage")
+
+
+def test_get_llm_raises_when_router_returns_none():
+    """If the router has no LLM configured for email_triage and no local
+    fallback, raise a clear error instead of silently returning None.
+    """
+    from atlas_brain.jobs.email_graph_sync import EmailGraphSync
+
+    with patch("atlas_brain.services.llm_router.get_llm", return_value=None):
+        job = EmailGraphSync()
+        with pytest.raises(RuntimeError, match="No LLM available"):
+            job._get_llm()
+
+
+def test_get_llm_caches_for_subsequent_calls():
+    """The router lookup is cached on the instance for the run."""
+    from atlas_brain.jobs.email_graph_sync import EmailGraphSync
+
+    fake_llm = MagicMock(name="triage_llm")
+
+    with patch("atlas_brain.services.llm_router.get_llm", return_value=fake_llm) as mock_router:
+        job = EmailGraphSync()
+        job._get_llm()
+        job._get_llm()
+        job._get_llm()
+
+    assert mock_router.call_count == 1


### PR DESCRIPTION
## Summary

Stage 1 of the email-to-graph pipeline was hardcoded to instantiate `OllamaLLM` directly, making it hard-dependent on a local Ollama running with `qwen3:14b` loaded. With Atlas's production direction shifting toward cloud LLMs (OpenRouter -> Anthropic Haiku in the wrapper), this hardcode blocked re-enabling the task. This PR routes Stage 1 through `llm_router.get_llm('email_triage')` so it picks up whatever the production triage LLM is.

## Context

This is unblocking work for re-enabling `email_graph_sync` (currently `enabled=False` in `scheduled_tasks`). The task has been off for the entire history of `processed_emails` -- 0 of 1,743 emails synced to the graph, 160 currently pending with `priority=action_required`.

The wrapper (Stage 2) was migrated to OpenRouter in #285. Stage 1 was the remaining Ollama dependency in this pipeline.

## Changes

`atlas_brain/jobs/email_graph_sync.py`:
- `_get_llm()` now calls `llm_router.get_llm('email_triage')` instead of constructing `OllamaLLM` directly.
- Removed the Ollama-specific `.load()` / `.unload()` lifecycle. The router owns LLM lifecycle, and remote LLMs have no VRAM to manage. The original unload was a VRAM dance to free the GPU before Stage 2 ran `qwen3:32b` on the same hardware -- irrelevant when both stages are remote.
- Raises a clear `RuntimeError` when the router has no LLM configured, instead of returning `None` and crashing later in `chat_async`.

## Tests

`tests/test_email_graph_sync_routing.py` (new, 3 cases):
- `_get_llm` calls the router with workflow `'email_triage'`
- Raises `RuntimeError` with a clear message when the router returns `None`
- Caches the LLM reference so the router is only consulted once per run

All 3 pass locally. ASCII-clean.

## Out of scope

- This PR does NOT re-enable the scheduled task. That stays a manual `UPDATE scheduled_tasks SET enabled=true WHERE name='email_graph_sync'` after the user confirms ready.
- The `email_graph_model` config field (currently defaults to `qwen3:14b`) is now unused but retained for backward compat. Can be deleted in a follow-up cleanup.