### PR TITLE
docs: document graphiti-wrapper LLM provider switch in .env.example

### DIFF
--- a/graphiti-wrapper/.env.example
+++ b/graphiti-wrapper/.env.example
@@ -1,9 +1,35 @@
 # Graphiti Wrapper Configuration
 # Copy this to .env.local and fill in your values
 
+# ============================================
 # LLM for entity extraction
-OPENAI_API_KEY=your-openai-api-key-here
-MODEL_NAME=gpt-4o-mini
+# ============================================
+# The wrapper uses an OpenAI-compatible client. Switch providers by changing
+# the three values below. Pick ONE block and uncomment it.
+#
+# --- OpenRouter -> Anthropic Haiku (current Atlas default) ---
+# Routes through OpenRouter for unified billing and easy model swaps.
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+OPENAI_API_KEY=sk-or-v1-your-openrouter-key-here
+MODEL_NAME=anthropic/claude-haiku-4-5
+#
+# --- Direct Anthropic (production option, not yet implemented) ---
+# Requires adding an anthropic-native client to the wrapper. See main.py
+# is_ollama branching for where the provider switch happens.
+# OPENAI_BASE_URL=
+# OPENAI_API_KEY=sk-ant-your-anthropic-key-here
+# MODEL_NAME=claude-haiku-4-5
+#
+# --- OpenAI direct ---
+# OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_API_KEY=sk-your-openai-key-here
+# MODEL_NAME=gpt-4o-mini
+#
+# --- Local Ollama (offline / dev fallback) ---
+# Requires `ollama serve` running on the host with MODEL_NAME pulled.
+# OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+# OPENAI_API_KEY=ollama
+# MODEL_NAME=qwen3:32b
 
 # Neo4j Configuration
 # Local Neo4j


### PR DESCRIPTION
## Summary

Document the four LLM provider variants in `graphiti-wrapper/.env.example` so the switch is discoverable without reading `docker-compose.graphiti.yml` and `main.py`.

## Why now

PR #285 made `OPENAI_BASE_URL` overridable from `graphiti-wrapper/.env` (it was previously hard-coded to Ollama in compose). The `.env.example` didn't show `OPENAI_BASE_URL` at all -- a fresh contributor would not know the switch existed.

## Variants documented

- **OpenRouter -> Anthropic Haiku** (current Atlas default; uncommented)
- **Direct Anthropic** (commented; queued for a future PR adding `anthropic_llm_client.py` to the wrapper)
- **OpenAI direct** (commented)
- **Local Ollama** (commented; for offline / dev work)

Each block has the full triplet (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, `MODEL_NAME`) so swapping providers is a copy-paste-edit, not a synthesis exercise.

## Out of scope

- The "Direct Anthropic" block is documented as not-yet-implemented because the wrapper currently routes everything through an OpenAI-compat client. Implementing direct Anthropic requires adding a native client to the wrapper. Tracked separately.
- No code changes; pure docs.