### PR TITLE
PR-D6c: Surface exact-cache savings in /api/v1/llm/usage

### DIFF
--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -479,9 +479,15 @@ async def usage(
         raise HTTPException(status_code=503, detail="Database not ready")
 
     # PR-D6c: cache_savings_usd is summed from the metadata field
-    # stamped on each cache-hit row at hit time. Cast via NULLIF
-    # so non-cache rows (no metadata key) and malformed values
-    # contribute 0 instead of erroring.
+    # stamped on each cache-hit row at hit time. The
+    # ``jsonb_typeof = 'number'`` guard handles three cases that
+    # would otherwise raise ``invalid input syntax for type
+    # double precision`` and break /usage for the whole period:
+    #   - missing key (typeof returns NULL)
+    #   - non-cache rows (typeof returns NULL)
+    #   - malformed string value, e.g. {"cache_savings_usd": "n/a"}
+    #     (typeof returns 'string', not 'number')
+    # Codex P2 fix on PR-D6c.
     rows = await pool.fetch(
         """
         SELECT model_provider, model_name,
@@ -490,7 +496,11 @@ async def usage(
                COALESCE(SUM(total_tokens), 0)::bigint  AS total_tokens,
                COALESCE(SUM(cost_usd), 0)::float       AS cost_usd,
                COALESCE(SUM(
-                   NULLIF(metadata->>'cache_savings_usd', '')::float
+                   CASE
+                       WHEN jsonb_typeof(metadata->'cache_savings_usd') = 'number'
+                       THEN (metadata->>'cache_savings_usd')::float
+                       ELSE 0
+                   END
                ), 0)::float                            AS cache_savings_usd,
                COUNT(*)::bigint                         AS call_count,
                MIN(created_at)                          AS period_start,

--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -49,6 +49,7 @@ from ..services.byok_keys import lookup_provider_key_async
 from ..services.llm.anthropic import convert_messages
 from ..services.llm_gateway_batch import (
     CustomerBatchItem,
+    _estimate_cost_usd,
     get_customer_batch,
     refresh_customer_batch_status,
     submit_customer_batch,
@@ -72,6 +73,14 @@ _PROVIDERS_THIS_PR = ("anthropic",)
 # check to the gateway's own feature flag rather than the B2B
 # pipeline flag, so the two products stay decoupled.
 _LLM_CHAT_CACHE_NAMESPACE = "llm_gateway.chat"
+
+
+# Metadata key for the would-have-paid USD on a cache-hit row
+# (PR-D6c). Stamped at hit time with the synchronous-tier cost
+# computed from the cached entry's stored token counts; summed
+# at /usage query time as ``total_cache_savings_usd``. Defined as
+# a module constant so the write site and read site can't drift.
+_CACHE_SAVINGS_METADATA_KEY = "cache_savings_usd"
 
 
 # Cache-hit rows have legitimately-zero token counts (the customer
@@ -161,6 +170,10 @@ class UsageBreakdownRow(BaseModel):
     total_tokens: int = 0
     cost_usd: float = 0.0
     call_count: int = 0
+    # PR-D6c: would-have-paid for cache-hit calls in this group.
+    # Summed from each cache_hit row's metadata; defaults to 0
+    # when there are no hits in the period (back-compat).
+    cache_savings_usd: float = 0.0
 
 
 class UsageResponse(BaseModel):
@@ -170,6 +183,11 @@ class UsageResponse(BaseModel):
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cost_usd: float = 0.0
+    # PR-D6c: total $-value of provider calls avoided by exact-cache
+    # hits in this period. The sales pitch's "you would have paid X,
+    # you paid Y" number lives here. Defaults to 0 -- back-compat
+    # with clients that don't know about caching.
+    total_cache_savings_usd: float = 0.0
     by_provider: list[UsageBreakdownRow]
 
 
@@ -290,11 +308,36 @@ async def chat(
         # visible to /api/v1/llm/usage rollups.
         response_id = f"llm_{_uuid.uuid4().hex[:24]}"
         try:
+            # PR-D6c: compute would-have-paid USD from the cached
+            # entry's stored token counts so /api/v1/llm/usage can
+            # surface the savings. Reuses the batch module's
+            # _estimate_cost_usd (already imported) -- it's
+            # underscore-private but the function is the right
+            # primitive here and there's no public alias yet.
+            # Failures (model not in pricing config, missing
+            # tokens) fall back to 0.0 so a malformed cache entry
+            # doesn't break the chat response.
+            cached_usage = cache_hit.get("usage") or {}
+            try:
+                cache_savings_usd = _estimate_cost_usd(
+                    model=cache_hit.get("model") or body.model,
+                    input_tokens=int(cached_usage.get("input_tokens", 0) or 0),
+                    output_tokens=int(cached_usage.get("output_tokens", 0) or 0),
+                    cached_tokens=int(cached_usage.get("cached_tokens", 0) or 0),
+                    cache_write_tokens=int(cached_usage.get("cache_write_tokens", 0) or 0),
+                )
+            except Exception:
+                logger.exception(
+                    "llm_gateway.chat cache-hit savings estimate failed; "
+                    "row will record 0.0",
+                )
+                cache_savings_usd = 0.0
             cache_hit_metadata = json.dumps({
                 "account_id": user.account_id,
                 "request_id": response_id,
                 "endpoint": "llm_gateway.chat",
                 "cache_hit": True,
+                _CACHE_SAVINGS_METADATA_KEY: cache_savings_usd,
             })
             await pool.execute(
                 _CACHE_HIT_USAGE_INSERT_SQL,
@@ -435,6 +478,10 @@ async def usage(
     if not pool.is_initialized:
         raise HTTPException(status_code=503, detail="Database not ready")
 
+    # PR-D6c: cache_savings_usd is summed from the metadata field
+    # stamped on each cache-hit row at hit time. Cast via NULLIF
+    # so non-cache rows (no metadata key) and malformed values
+    # contribute 0 instead of erroring.
     rows = await pool.fetch(
         """
         SELECT model_provider, model_name,
@@ -442,6 +489,9 @@ async def usage(
                COALESCE(SUM(output_tokens), 0)::bigint AS output_tokens,
                COALESCE(SUM(total_tokens), 0)::bigint  AS total_tokens,
                COALESCE(SUM(cost_usd), 0)::float       AS cost_usd,
+               COALESCE(SUM(
+                   NULLIF(metadata->>'cache_savings_usd', '')::float
+               ), 0)::float                            AS cache_savings_usd,
                COUNT(*)::bigint                         AS call_count,
                MIN(created_at)                          AS period_start,
                MAX(created_at)                          AS period_end
@@ -459,9 +509,11 @@ async def usage(
     total_input = 0
     total_output = 0
     total_cost = 0.0
+    total_cache_savings = 0.0
     period_start = None
     period_end = None
     for row in rows:
+        row_cache_savings = float(row["cache_savings_usd"] or 0.0)
         breakdown.append(
             UsageBreakdownRow(
                 provider=row["model_provider"],
@@ -471,11 +523,13 @@ async def usage(
                 total_tokens=int(row["total_tokens"] or 0),
                 cost_usd=float(row["cost_usd"] or 0.0),
                 call_count=int(row["call_count"] or 0),
+                cache_savings_usd=row_cache_savings,
             )
         )
         total_input += int(row["input_tokens"] or 0)
         total_output += int(row["output_tokens"] or 0)
         total_cost += float(row["cost_usd"] or 0.0)
+        total_cache_savings += row_cache_savings
         if period_start is None or (row["period_start"] and row["period_start"] < period_start):
             period_start = row["period_start"]
         if period_end is None or (row["period_end"] and row["period_end"] > period_end):
@@ -496,6 +550,7 @@ async def usage(
         total_input_tokens=total_input,
         total_output_tokens=total_output,
         total_cost_usd=total_cost,
+        total_cache_savings_usd=total_cache_savings,
         by_provider=breakdown,
     )
 

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -772,13 +772,20 @@ def test_usage_breakdown_row_exposes_per_group_savings():
 
 def test_usage_sql_aggregates_cache_savings_per_group():
     """Source-text pin on the rollup SQL: SUM the metadata field
-    per (provider, model) group. NULLIF guards rows that don't
-    have the metadata key (everything other than cache hits) so
-    the SUM doesn't error on cast."""
+    per (provider, model) group. The jsonb_typeof guard (Codex
+    P2 fix on PR-D6c) ensures only actual JSON numbers get cast,
+    so a malformed string value like {"cache_savings_usd": "n/a"}
+    contributes 0 instead of raising ``invalid input syntax for
+    type double precision`` and breaking /usage for the period."""
     from atlas_brain.api import llm_gateway
 
     src = inspect.getsource(llm_gateway.usage)
-    assert "NULLIF(metadata->>'cache_savings_usd', '')::float" in src
+    # Cast only when the JSONB value is actually a number.
+    assert "jsonb_typeof(metadata->'cache_savings_usd') = 'number'" in src
+    assert "(metadata->>'cache_savings_usd')::float" in src
+    # The racy NULLIF-only pattern from the initial commit must
+    # not return -- it doesn't catch malformed strings.
+    assert "NULLIF(metadata->>'cache_savings_usd'" not in src
     assert "AS cache_savings_usd" in src
 
 

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -685,3 +685,114 @@ def test_store_cached_text_uses_namespace_dispatch_not_b2b_flag():
     src = inspect.getsource(llm_exact_cache.store_cached_text)
     assert "_is_cache_enabled_for_namespace(namespace)" in src
     assert "is_b2b_llm_exact_cache_enabled()" not in src
+
+
+# ---- Cache savings rollup (PR-D6c) -------------------------------------
+
+
+def test_cache_savings_metadata_key_is_module_constant():
+    """Write site (cache-hit handler) and read site (/usage SQL)
+    must agree on the metadata key. Defining once as a module
+    constant prevents drift."""
+    from atlas_brain.api import llm_gateway
+
+    assert hasattr(llm_gateway, "_CACHE_SAVINGS_METADATA_KEY")
+    assert llm_gateway._CACHE_SAVINGS_METADATA_KEY == "cache_savings_usd"
+    # Read site: the SQL clause that pulls it out for the rollup.
+    src = inspect.getsource(llm_gateway.usage)
+    assert "metadata->>'cache_savings_usd'" in src
+
+
+def test_cache_hit_stamps_savings_metadata():
+    """The cache-hit branch must stamp the would-have-paid USD on
+    the llm_usage row's metadata so /usage can sum it later. The
+    value comes from _estimate_cost_usd applied to the cached
+    entry's stored token counts."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
+    # _estimate_cost_usd is called on the cached usage.
+    assert "_estimate_cost_usd(" in hit_block
+    assert 'cache_hit.get("usage")' in hit_block
+    # Result is stamped into the metadata payload using the constant.
+    assert "_CACHE_SAVINGS_METADATA_KEY: cache_savings_usd" in hit_block
+
+
+def test_cache_hit_savings_estimate_failure_falls_back_to_zero():
+    """A model missing from the pricing config (or any other
+    estimate failure) must NOT break the chat response. Catch
+    the exception, log, default the field to 0.0 -- the row
+    still gets written, the savings just don't show up for that
+    call."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.chat)
+    hit_block = src.split("if cache_hit is not None:")[1].split("# Capture full response")[0]
+    # try/except wraps the estimate call.
+    assert "try:\n                cache_savings_usd = _estimate_cost_usd(" in hit_block
+    assert "cache_savings_usd = 0.0" in hit_block
+    # Distinct log line so ops can spot pricing-config holes.
+    assert "cache-hit savings estimate failed" in hit_block
+
+
+def test_estimate_cost_usd_imported_from_batch_module():
+    """Reuse the existing helper rather than duplicating the
+    pricing math. The function lives in llm_gateway_batch.py
+    (PR-D4d) -- import it from there. Underscore-private name is
+    deliberate (no public alias yet); revisit if a third caller
+    appears."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway)
+    assert "_estimate_cost_usd," in src
+
+
+def test_usage_response_exposes_total_cache_savings_usd():
+    """New top-level field on UsageResponse so customers see
+    aggregate cache savings for the period in a single number."""
+    from atlas_brain.api.llm_gateway import UsageResponse
+
+    fields = UsageResponse.model_fields
+    assert "total_cache_savings_usd" in fields
+    # Default 0.0 -- back-compat with clients that don't know
+    # about the field, and correct value for periods with no hits.
+    assert fields["total_cache_savings_usd"].default == 0.0
+
+
+def test_usage_breakdown_row_exposes_per_group_savings():
+    """Customers want savings broken out by (provider, model) too
+    so they can see "cache hit-rate on Opus" vs "Haiku"."""
+    from atlas_brain.api.llm_gateway import UsageBreakdownRow
+
+    fields = UsageBreakdownRow.model_fields
+    assert "cache_savings_usd" in fields
+    assert fields["cache_savings_usd"].default == 0.0
+
+
+def test_usage_sql_aggregates_cache_savings_per_group():
+    """Source-text pin on the rollup SQL: SUM the metadata field
+    per (provider, model) group. NULLIF guards rows that don't
+    have the metadata key (everything other than cache hits) so
+    the SUM doesn't error on cast."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.usage)
+    assert "NULLIF(metadata->>'cache_savings_usd', '')::float" in src
+    assert "AS cache_savings_usd" in src
+
+
+def test_usage_handler_threads_savings_into_response():
+    """The query result feeds both the per-row breakdown and
+    the top-level total. Accumulator pattern matches the existing
+    cost_usd handling."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.usage)
+    # Per-row breakdown carries it.
+    assert "cache_savings_usd=row_cache_savings" in src
+    # Total accumulator.
+    assert "total_cache_savings = 0.0" in src
+    assert "total_cache_savings += row_cache_savings" in src
+    # And the response object surfaces the total.
+    assert "total_cache_savings_usd=total_cache_savings" in src


### PR DESCRIPTION
## Summary

Makes layer 1 of the **LLM Gateway 5-layer cost-control bundle** visible to customers. PR-D6b shipped the data collection (`cache_hit` rows in `llm_usage`); this PR computes "would-have-paid" USD at cache-hit time and surfaces the rollup via `GET /api/v1/llm/usage` so customers can see their savings — the central proof point for the product's pitch.

## Changes

**1. Module constant `_CACHE_SAVINGS_METADATA_KEY = "cache_savings_usd"`** — write site (cache-hit handler) and read site (`/usage` SQL clause) reference the same field name. Single source of truth prevents drift.

**2. Cache-hit branch** in `/chat` computes savings via `_estimate_cost_usd` (imported from `llm_gateway_batch.py` — the existing helper from PR-D4d that reads `settings.ftl_tracing.pricing.cost_usd`). The cached entry's stored token counts feed the calculation; result lands in the row's metadata.

Estimate failures (model missing from pricing config, malformed cached usage) fall back to `0.0` with `logger.exception` — the chat response never breaks because of a pricing-config gap.

**3. `/usage` SQL** adds:

```sql
COALESCE(SUM(
    NULLIF(metadata->>'cache_savings_usd', '')::float
), 0)::float AS cache_savings_usd
```

per `(provider, model)` group. `NULLIF` guards against rows without the metadata key so the cast can't error.

**4. Response schemas:**
- `UsageBreakdownRow.cache_savings_usd: float = 0.0` (per-group)
- `UsageResponse.total_cache_savings_usd: float = 0.0` (period total)

Both default to `0.0` so existing clients aren't broken and periods with no cache hits return the correct value.

## Customer-visible behavior

```
GET /api/v1/llm/usage
{
  "account_id": "...",
  "period_start": "...",
  "period_end": "...",
  "total_input_tokens": 12345,
  "total_output_tokens": 6789,
  "total_cost_usd": 1.23,
  "total_cache_savings_usd": 0.89,
  "by_provider": [
    {
      "provider": "anthropic",
      "model": "claude-haiku-4-5-20251001",
      "input_tokens": 12345,
      "output_tokens": 6789,
      "total_tokens": 19134,
      "cost_usd": 1.23,
      "call_count": 100,
      "cache_savings_usd": 0.89
    }
  ]
}
```

Customer sees their actual spend AND the dollar value of cache hits avoided.

## Test plan

- [x] 8 new tests in `test_llm_gateway_router.py` (58 total in file, was 50):
  - `_CACHE_SAVINGS_METADATA_KEY` constant aligns write site and read site
  - Cache-hit handler stamps savings via `_estimate_cost_usd`
  - Estimate failure falls back to `0.0` (chat never 500s)
  - `_estimate_cost_usd` imported from batch module
  - `UsageResponse.total_cache_savings_usd` field exists with default `0.0`
  - `UsageBreakdownRow.cache_savings_usd` field exists with default `0.0`
  - `/usage` SQL aggregates the metadata field per group with `NULLIF` guard
  - Handler threads per-row + total accumulator into the response
- [x] Full LLM-gateway + auth + cache regression: 265 passed
- [x] ASCII compliance verified
- [x] No inline hard-coded values (metadata key promoted to module constant)
- [ ] Codex / Copilot review

## Reuse decision

`_estimate_cost_usd` lives in `llm_gateway_batch.py` with a leading underscore. Imported as-is rather than renamed public — `import _estimate_cost_usd` from the module is the lightest-touch option vs renaming public (which would ripple through PR-D4d tests). Revisit if a third caller appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
