### PR TITLE
Centralize competitive vendor briefing state

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_vendor_briefing.py
+++ b/atlas_brain/autonomous/tasks/b2b_vendor_briefing.py
@@ -36,6 +36,17 @@ from ...services.b2b.vendor_briefing_delivery import (
     require_vendor_briefing_delivery_configured,
     send_vendor_briefing_delivery,
 )
+from ...services.b2b.vendor_briefing_repository import (
+    fetch_pending_approval_briefing,
+    has_prior_deliverable_briefing,
+    has_recent_deliverable_briefing,
+    insert_delivery_briefing_record,
+    insert_pending_approval_briefing_record,
+    insert_suppressed_briefing_record,
+    mark_pending_briefing_failed,
+    mark_pending_briefing_sent,
+    reject_pending_briefing,
+)
 from ...services.b2b.vendor_briefing_ports import (
     align_vendor_intelligence_record_to_scorecard as _align_vendor_intelligence_record_to_scorecard,
     build_llm_messages,
@@ -428,15 +439,7 @@ def build_gate_url(vendor_name: str) -> str:
 
 async def _is_first_briefing(pool: Any, vendor_name: str) -> bool:
     """Return True if no successful briefing has ever been sent for this vendor."""
-    count = await pool.fetchval(
-        """
-        SELECT COUNT(*) FROM b2b_vendor_briefings
-        WHERE LOWER(vendor_name) = LOWER($1)
-          AND status NOT IN ('failed', 'suppressed', 'rejected')
-        """,
-        vendor_name,
-    )
-    return (count or 0) == 0
+    return not await has_prior_deliverable_briefing(pool, vendor_name)
 
 
 # ---------------------------------------------------------------------------
@@ -2713,16 +2716,12 @@ async def send_vendor_briefing(
                 {"challenger_mode": challenger_mode},
             )
             try:
-                await pool.execute(
-                    """
-                    INSERT INTO b2b_vendor_briefings
-                        (vendor_name, recipient_email, subject, briefing_data, status)
-                    VALUES ($1, $2, $3, $4::jsonb, 'suppressed')
-                    """,
-                    vendor_name,
-                    to_email,
-                    suppressed_subject,
-                    json.dumps(briefing_data, default=str),
+                await insert_suppressed_briefing_record(
+                    pool,
+                    vendor_name=vendor_name,
+                    recipient_email=to_email,
+                    subject=suppressed_subject,
+                    briefing_data=briefing_data,
                 )
             except Exception as exc:
                 logger.warning("Failed to persist suppressed record: %s", exc)
@@ -2748,18 +2747,14 @@ async def send_vendor_briefing(
     # Persist delivery record
     if pool.is_initialized:
         try:
-            await pool.execute(
-                """
-                INSERT INTO b2b_vendor_briefings
-                    (vendor_name, recipient_email, subject, briefing_data, resend_id, status)
-                VALUES ($1, $2, $3, $4::jsonb, $5, $6)
-                """,
-                vendor_name,
-                to_email,
-                subject,
-                json.dumps(briefing_data, default=str),
-                resend_id,
-                status,
+            await insert_delivery_briefing_record(
+                pool,
+                vendor_name=vendor_name,
+                recipient_email=to_email,
+                subject=subject,
+                briefing_data=briefing_data,
+                resend_id=resend_id,
+                status=status,
             )
         except Exception as exc:
             logger.warning("Failed to persist briefing record: %s", exc)
@@ -2780,24 +2775,14 @@ async def send_approved_briefing(briefing_id: str) -> dict[str, Any]:
     if not pool.is_initialized:
         return {"error": "Database not ready"}
 
-    row = await pool.fetchrow(
-        """
-        SELECT id, vendor_name, recipient_email, subject,
-               briefing_data, briefing_html
-        FROM b2b_vendor_briefings
-        WHERE id = $1 AND status = 'pending_approval'
-        """,
-        briefing_id,
-    )
-    if not row:
+    pending = await fetch_pending_approval_briefing(pool, briefing_id)
+    if pending is None:
         return {"error": "Briefing not found or not pending approval"}
 
-    vendor_name = row["vendor_name"]
-    to_email = row["recipient_email"]
-    subject = row["subject"]
-    html = row["briefing_html"]
-    bd = row["briefing_data"]
-    briefing_data = json.loads(bd) if isinstance(bd, str) else (bd or {})
+    vendor_name = pending.vendor_name
+    to_email = pending.recipient_email
+    subject = pending.subject
+    html = pending.briefing_html
 
     if not html:
         return {"error": "No rendered HTML stored for this briefing"}
@@ -2824,26 +2809,13 @@ async def send_approved_briefing(briefing_id: str) -> dict[str, Any]:
         status = "failed"
 
     if status == "sent":
-        await pool.execute(
-            """
-            UPDATE b2b_vendor_briefings
-            SET status = $1, resend_id = $2, approved_at = NOW()
-            WHERE id = $3
-            """,
-            status,
-            resend_id,
-            briefing_id,
+        await mark_pending_briefing_sent(
+            pool,
+            briefing_id=briefing_id,
+            resend_id=resend_id,
         )
     else:
-        await pool.execute(
-            """
-            UPDATE b2b_vendor_briefings
-            SET status = $1
-            WHERE id = $2
-            """,
-            status,
-            briefing_id,
-        )
+        await mark_pending_briefing_failed(pool, briefing_id)
 
     return {
         "id": str(briefing_id),
@@ -2860,16 +2832,12 @@ async def reject_briefing(briefing_id: str, reason: str | None = None) -> dict[s
     if not pool.is_initialized:
         return {"error": "Database not ready"}
 
-    result = await pool.execute(
-        """
-        UPDATE b2b_vendor_briefings
-        SET status = 'rejected', rejected_at = NOW(), reject_reason = $1
-        WHERE id = $2 AND status = 'pending_approval'
-        """,
-        reason,
-        briefing_id,
+    rejected = await reject_pending_briefing(
+        pool,
+        briefing_id=briefing_id,
+        reason=reason,
     )
-    if result == "UPDATE 0":
+    if not rejected:
         return {"error": "Briefing not found or not pending approval"}
 
     return {"id": str(briefing_id), "status": "rejected"}
@@ -2958,19 +2926,7 @@ async def _check_cooldown(
     pool: Any, vendor_name: str, cooldown_days: int
 ) -> bool:
     """Return True if a recent briefing exists (should skip)."""
-    row = await pool.fetchval(
-        """
-        SELECT EXISTS(
-            SELECT 1 FROM b2b_vendor_briefings
-            WHERE LOWER(vendor_name) = LOWER($1)
-              AND status NOT IN ('failed', 'suppressed', 'rejected')
-              AND created_at > NOW() - make_interval(days => $2)
-        )
-        """,
-        vendor_name,
-        cooldown_days,
-    )
-    return bool(row)
+    return await has_recent_deliverable_briefing(pool, vendor_name, cooldown_days)
 
 
 # ---------------------------------------------------------------------------
@@ -3110,34 +3066,17 @@ async def send_batch_briefings() -> dict[str, Any]:
         # Render HTML and store as pending_approval (HITL gate)
         briefing_html = render_vendor_briefing_html(briefing_data)
 
-        challenger_mode = briefing_data.get("challenger_mode", False)
-        if briefing_data.get("prospect_mode"):
-            subject = (
-                f"{vendor_name} -- Accounts In Motion"
-                if challenger_mode
-                else f"{vendor_name} -- Churn Signals Detected"
-            )
-        else:
-            subject = (
-                f"Sales Intelligence Briefing: {vendor_name}"
-                if challenger_mode
-                else f"Churn Intelligence Briefing: {vendor_name}"
-            )
+        subject = build_vendor_briefing_subject(vendor_name, briefing_data)
 
         try:
-            await pool.execute(
-                """
-                INSERT INTO b2b_vendor_briefings
-                    (vendor_name, recipient_email, subject, briefing_data,
-                     briefing_html, status, target_mode)
-                VALUES ($1, $2, $3, $4::jsonb, $5, 'pending_approval', $6)
-                """,
-                vendor_name,
-                to_email,
-                subject,
-                json.dumps(briefing_data, default=str),
-                briefing_html,
-                target_mode,
+            await insert_pending_approval_briefing_record(
+                pool,
+                vendor_name=vendor_name,
+                recipient_email=to_email,
+                subject=subject,
+                briefing_data=briefing_data,
+                briefing_html=briefing_html,
+                target_mode=target_mode,
             )
             queued += 1
             details.append({

--- a/atlas_brain/services/b2b/vendor_briefing_repository.py
+++ b/atlas_brain/services/b2b/vendor_briefing_repository.py
@@ -1,0 +1,204 @@
+"""Repository helpers for Competitive Intelligence vendor briefing state."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PendingVendorBriefing:
+    vendor_name: str
+    recipient_email: str
+    subject: str
+    briefing_data: dict[str, Any]
+    briefing_html: str
+
+
+def _json_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+async def has_prior_deliverable_briefing(pool: Any, vendor_name: str) -> bool:
+    count = await pool.fetchval(
+        """
+        SELECT COUNT(*) FROM b2b_vendor_briefings
+        WHERE LOWER(vendor_name) = LOWER($1)
+          AND status NOT IN ('failed', 'suppressed', 'rejected')
+        """,
+        vendor_name,
+    )
+    return int(count or 0) > 0
+
+
+async def has_recent_deliverable_briefing(
+    pool: Any,
+    vendor_name: str,
+    cooldown_days: int,
+) -> bool:
+    row = await pool.fetchval(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM b2b_vendor_briefings
+            WHERE LOWER(vendor_name) = LOWER($1)
+              AND status NOT IN ('failed', 'suppressed', 'rejected')
+              AND created_at > NOW() - make_interval(days => $2)
+        )
+        """,
+        vendor_name,
+        cooldown_days,
+    )
+    return bool(row)
+
+
+async def insert_suppressed_briefing_record(
+    pool: Any,
+    *,
+    vendor_name: str,
+    recipient_email: str,
+    subject: str,
+    briefing_data: dict[str, Any],
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO b2b_vendor_briefings
+            (vendor_name, recipient_email, subject, briefing_data, status)
+        VALUES ($1, $2, $3, $4::jsonb, 'suppressed')
+        """,
+        vendor_name,
+        recipient_email,
+        subject,
+        json.dumps(briefing_data, default=str),
+    )
+
+
+async def insert_delivery_briefing_record(
+    pool: Any,
+    *,
+    vendor_name: str,
+    recipient_email: str,
+    subject: str,
+    briefing_data: dict[str, Any],
+    resend_id: str | None,
+    status: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO b2b_vendor_briefings
+            (vendor_name, recipient_email, subject, briefing_data, resend_id, status)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+        """,
+        vendor_name,
+        recipient_email,
+        subject,
+        json.dumps(briefing_data, default=str),
+        resend_id,
+        status,
+    )
+
+
+async def insert_pending_approval_briefing_record(
+    pool: Any,
+    *,
+    vendor_name: str,
+    recipient_email: str,
+    subject: str,
+    briefing_data: dict[str, Any],
+    briefing_html: str,
+    target_mode: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO b2b_vendor_briefings
+            (vendor_name, recipient_email, subject, briefing_data,
+             briefing_html, status, target_mode)
+        VALUES ($1, $2, $3, $4::jsonb, $5, 'pending_approval', $6)
+        """,
+        vendor_name,
+        recipient_email,
+        subject,
+        json.dumps(briefing_data, default=str),
+        briefing_html,
+        target_mode,
+    )
+
+
+async def fetch_pending_approval_briefing(
+    pool: Any,
+    briefing_id: str,
+) -> PendingVendorBriefing | None:
+    row = await pool.fetchrow(
+        """
+        SELECT id, vendor_name, recipient_email, subject,
+               briefing_data, briefing_html
+        FROM b2b_vendor_briefings
+        WHERE id = $1 AND status = 'pending_approval'
+        """,
+        briefing_id,
+    )
+    if not row:
+        return None
+    return PendingVendorBriefing(
+        vendor_name=row["vendor_name"],
+        recipient_email=row["recipient_email"],
+        subject=row["subject"],
+        briefing_data=_json_dict(row["briefing_data"]),
+        briefing_html=row["briefing_html"] or "",
+    )
+
+
+async def mark_pending_briefing_sent(
+    pool: Any,
+    *,
+    briefing_id: str,
+    resend_id: str | None,
+) -> None:
+    await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = $1, resend_id = $2, approved_at = NOW()
+        WHERE id = $3
+        """,
+        "sent",
+        resend_id,
+        briefing_id,
+    )
+
+
+async def mark_pending_briefing_failed(pool: Any, briefing_id: str) -> None:
+    await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = $1
+        WHERE id = $2
+        """,
+        "failed",
+        briefing_id,
+    )
+
+
+async def reject_pending_briefing(
+    pool: Any,
+    *,
+    briefing_id: str,
+    reason: str | None = None,
+) -> bool:
+    result = await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = 'rejected', rejected_at = NOW(), reject_reason = $1
+        WHERE id = $2 AND status = 'pending_approval'
+        """,
+        reason,
+        briefing_id,
+    )
+    return result != "UPDATE 0"

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T18:34Z by codex-2026-05-05
+Last updated: 2026-05-05T18:39Z by codex-2026-05-05
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
-| pending | Centralize Competitive Intelligence vendor briefing state | `atlas_brain/autonomous/tasks/b2b_vendor_briefing.py`, `atlas_brain/services/b2b/vendor_briefing_repository.py`, `extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py`, `extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py`, `extracted_competitive_intelligence/manifest.json`, `extracted_competitive_intelligence/STATUS.md`, competitive repository tests | codex-2026-05-05 | Avoid vendor briefing delivery/HITL persistence and scheduled pending-approval state edits until this lands |
+| #292 | Centralize Competitive Intelligence vendor briefing state | `atlas_brain/autonomous/tasks/b2b_vendor_briefing.py`, `atlas_brain/services/b2b/vendor_briefing_repository.py`, `extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py`, `extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py`, `extracted_competitive_intelligence/manifest.json`, `extracted_competitive_intelligence/STATUS.md`, competitive repository tests | codex-2026-05-05 | Avoid vendor briefing delivery/HITL persistence and scheduled pending-approval state edits until this lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T17:02Z by codex-2026-05-05
+Last updated: 2026-05-05T18:34Z by codex-2026-05-05
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | #164 | docs: log cross-product standalone % audit | `docs/extraction/cross_product_audit_2026-05-04.md` | canfieldjuan | Avoid editing the cross-product audit doc until PR #164 lands |
+| pending | Centralize Competitive Intelligence vendor briefing state | `atlas_brain/autonomous/tasks/b2b_vendor_briefing.py`, `atlas_brain/services/b2b/vendor_briefing_repository.py`, `extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py`, `extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py`, `extracted_competitive_intelligence/manifest.json`, `extracted_competitive_intelligence/STATUS.md`, competitive repository tests | codex-2026-05-05 | Avoid vendor briefing delivery/HITL persistence and scheduled pending-approval state edits until this lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_competitive_intelligence/README.md
+++ b/extracted_competitive_intelligence/README.md
@@ -28,6 +28,7 @@ Differentiator: every output is grounded in real switching signals and uses the 
 | `services/b2b/source_impact.py` | Source impact ledger (which sources feed which products) |
 | `services/b2b/battle_card_ports.py` | Host port for battle-card shared helper, data-read, synthesis-reader, and webhook support |
 | `services/b2b/vendor_briefing_delivery.py` | Shared delivery helper for config-backed vendor briefing subject/sender/tags |
+| `services/b2b/vendor_briefing_repository.py` | Shared repository helper for vendor briefing delivery and HITL state |
 | `services/b2b/vendor_briefing_ports.py` | Host port for vendor briefing evidence, scorecard, synthesis-reader, and LLM/cache support |
 | `services/b2b/vendor_briefing_api_ports.py` | Host/runtime port for checkout, session lookup, and gated report email delivery |
 | `services/b2b/product_claim.py` | Compatibility surface for `extracted_quality_gate.product_claim` |
@@ -79,6 +80,7 @@ Set `EXTRACTED_COMP_INTEL_STANDALONE=1` to route core substrate imports away fro
 - `services/b2b/anthropic_batch.py` uses `extracted_llm_infrastructure` for standalone battle-card batch overlays
 - `services/b2b/battle_card_ports.py` exposes fail-closed host ports for battle-card shared helper, data-read, churn-scope, execution-progress, synthesis-reader, and webhook support
 - `services/b2b/vendor_briefing_delivery.py` centralizes config-backed CampaignSender delivery metadata for scheduled and approved vendor briefings
+- `services/b2b/vendor_briefing_repository.py` centralizes `b2b_vendor_briefings` delivery and HITL state writes
 - `services/b2b/vendor_briefing_ports.py` exposes fail-closed host ports for vendor briefing evidence, scorecard, and synthesis-reader support, plus standalone-safe LLM/cache runtime bridges
 - `services/b2b/vendor_briefing_api_ports.py` centralizes checkout, Stripe session lookup, and gated report email delivery runtime edges
 - `services/protocols.py`, `services/llm_router.py`, and `pipelines/llm.py` use `extracted_llm_infrastructure`
@@ -162,6 +164,11 @@ bridges. The mapped vendor briefing task no longer imports `_b2b_shared.py`,
 `services/b2b/vendor_briefing_delivery.py` is a shared delivery helper for
 vendor briefing emails. Scheduled sends and approval sends share the same
 config-backed subject, from-address, tag, and CampaignSender invocation logic.
+
+`services/b2b/vendor_briefing_repository.py` is a shared repository helper for
+vendor briefing state. Direct sends, approval sends, rejections, cooldown
+checks, and scheduled pending-approval writes share the same
+`b2b_vendor_briefings` persistence contract.
 
 `services/b2b/vendor_briefing_api_ports.py` is a product-owned runtime port for
 the customer-facing briefing API. It owns Stripe checkout/session lookup and

--- a/extracted_competitive_intelligence/STATUS.md
+++ b/extracted_competitive_intelligence/STATUS.md
@@ -36,6 +36,7 @@ Full task/runtime decoupling remains Phase 3.
 | Battle-card support port | ✅ `services.b2b.battle_card_ports` replaces direct `_b2b_shared.py`, churn-scope, execution-progress, synthesis-reader, and webhook imports for battle-card support |
 | Vendor briefing intelligence port | ✅ `services.b2b.vendor_briefing_ports` replaces direct `_b2b_shared.py`, `_b2b_synthesis_reader.py`, LLM pipeline, LLM router, protocol, and cache-runner imports for vendor briefing support |
 | Vendor briefing delivery helper | ✅ `services.b2b.vendor_briefing_delivery` centralizes config-backed subject/from/tags and CampaignSender invocation for scheduled and approved briefing sends |
+| Vendor briefing repository helper | ✅ `services.b2b.vendor_briefing_repository` centralizes delivery records, HITL approval/rejection updates, cooldown checks, and pending-approval writes |
 | Vendor briefing API runtime port | ✅ `services.b2b.vendor_briefing_api_ports` owns checkout, session lookup, PDF attachment delivery, and gated-report email runtime edges |
 | ProductClaim compatibility | ✅ `services.b2b.product_claim` re-exports `extracted_quality_gate.product_claim` instead of bridging to Atlas |
 | Suppression-callback Protocol | ✅ `autonomous.tasks.campaign_suppression` routes to injectable standalone suppression policy |
@@ -59,9 +60,9 @@ Full task/runtime decoupling remains Phase 3.
 
 | Metric | Count |
 |---|---:|
-| Extracted files | 94 |
-| Manifest mappings | 12 |
-| Manifest Python snapshots | 3 |
+| Extracted files | 95 |
+| Manifest mappings | 13 |
+| Manifest Python snapshots | 4 |
 | Manifest SQL snapshots | 9 |
 | Product-owned modules | 26 |
 
@@ -126,7 +127,7 @@ Product-owned modules:
 | `reasoning/ecosystem.py` | n/a | ✅ | ✅ |
 | `autonomous/tasks/_b2b_batch_utils.py` | n/a | ✅ | ✅ |
 | `autonomous/tasks/b2b_battle_cards.py` | ✅ | 🔲 (shared-helper, churn-scope, progress, synthesis-reader, and webhook imports routed through `battle_card_ports.py`; remaining runtime seams need follow-up ports) | 🔲 |
-| `autonomous/tasks/b2b_vendor_briefing.py` | ✅ | 🔲 (evidence, scorecard, synthesis-reader, LLM/cache, protocol, and tracing imports routed through `vendor_briefing_ports.py`; remaining runtime seams need follow-up ports) | 🔲 |
+| `autonomous/tasks/b2b_vendor_briefing.py` | ✅ | 🔲 (evidence, scorecard, synthesis-reader, LLM/cache, protocol, tracing, delivery, and briefing-state persistence routed through support modules; remaining runtime seams need follow-up ports) | 🔲 |
 | `autonomous/tasks/_b2b_cross_vendor_synthesis.py` | ✅ | ✅ | ✅ |
 | `services/b2b_competitive_sets.py` | ✅ | ✅ | ✅ |
 | `reasoning/cross_vendor_selection.py` | ✅ | ✅ | ✅ |

--- a/extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py
+++ b/extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py
@@ -36,6 +36,17 @@ from ...services.b2b.vendor_briefing_delivery import (
     require_vendor_briefing_delivery_configured,
     send_vendor_briefing_delivery,
 )
+from ...services.b2b.vendor_briefing_repository import (
+    fetch_pending_approval_briefing,
+    has_prior_deliverable_briefing,
+    has_recent_deliverable_briefing,
+    insert_delivery_briefing_record,
+    insert_pending_approval_briefing_record,
+    insert_suppressed_briefing_record,
+    mark_pending_briefing_failed,
+    mark_pending_briefing_sent,
+    reject_pending_briefing,
+)
 from ...services.b2b.vendor_briefing_ports import (
     align_vendor_intelligence_record_to_scorecard as _align_vendor_intelligence_record_to_scorecard,
     build_llm_messages,
@@ -428,15 +439,7 @@ def build_gate_url(vendor_name: str) -> str:
 
 async def _is_first_briefing(pool: Any, vendor_name: str) -> bool:
     """Return True if no successful briefing has ever been sent for this vendor."""
-    count = await pool.fetchval(
-        """
-        SELECT COUNT(*) FROM b2b_vendor_briefings
-        WHERE LOWER(vendor_name) = LOWER($1)
-          AND status NOT IN ('failed', 'suppressed', 'rejected')
-        """,
-        vendor_name,
-    )
-    return (count or 0) == 0
+    return not await has_prior_deliverable_briefing(pool, vendor_name)
 
 
 # ---------------------------------------------------------------------------
@@ -2713,16 +2716,12 @@ async def send_vendor_briefing(
                 {"challenger_mode": challenger_mode},
             )
             try:
-                await pool.execute(
-                    """
-                    INSERT INTO b2b_vendor_briefings
-                        (vendor_name, recipient_email, subject, briefing_data, status)
-                    VALUES ($1, $2, $3, $4::jsonb, 'suppressed')
-                    """,
-                    vendor_name,
-                    to_email,
-                    suppressed_subject,
-                    json.dumps(briefing_data, default=str),
+                await insert_suppressed_briefing_record(
+                    pool,
+                    vendor_name=vendor_name,
+                    recipient_email=to_email,
+                    subject=suppressed_subject,
+                    briefing_data=briefing_data,
                 )
             except Exception as exc:
                 logger.warning("Failed to persist suppressed record: %s", exc)
@@ -2748,18 +2747,14 @@ async def send_vendor_briefing(
     # Persist delivery record
     if pool.is_initialized:
         try:
-            await pool.execute(
-                """
-                INSERT INTO b2b_vendor_briefings
-                    (vendor_name, recipient_email, subject, briefing_data, resend_id, status)
-                VALUES ($1, $2, $3, $4::jsonb, $5, $6)
-                """,
-                vendor_name,
-                to_email,
-                subject,
-                json.dumps(briefing_data, default=str),
-                resend_id,
-                status,
+            await insert_delivery_briefing_record(
+                pool,
+                vendor_name=vendor_name,
+                recipient_email=to_email,
+                subject=subject,
+                briefing_data=briefing_data,
+                resend_id=resend_id,
+                status=status,
             )
         except Exception as exc:
             logger.warning("Failed to persist briefing record: %s", exc)
@@ -2780,24 +2775,14 @@ async def send_approved_briefing(briefing_id: str) -> dict[str, Any]:
     if not pool.is_initialized:
         return {"error": "Database not ready"}
 
-    row = await pool.fetchrow(
-        """
-        SELECT id, vendor_name, recipient_email, subject,
-               briefing_data, briefing_html
-        FROM b2b_vendor_briefings
-        WHERE id = $1 AND status = 'pending_approval'
-        """,
-        briefing_id,
-    )
-    if not row:
+    pending = await fetch_pending_approval_briefing(pool, briefing_id)
+    if pending is None:
         return {"error": "Briefing not found or not pending approval"}
 
-    vendor_name = row["vendor_name"]
-    to_email = row["recipient_email"]
-    subject = row["subject"]
-    html = row["briefing_html"]
-    bd = row["briefing_data"]
-    briefing_data = json.loads(bd) if isinstance(bd, str) else (bd or {})
+    vendor_name = pending.vendor_name
+    to_email = pending.recipient_email
+    subject = pending.subject
+    html = pending.briefing_html
 
     if not html:
         return {"error": "No rendered HTML stored for this briefing"}
@@ -2824,26 +2809,13 @@ async def send_approved_briefing(briefing_id: str) -> dict[str, Any]:
         status = "failed"
 
     if status == "sent":
-        await pool.execute(
-            """
-            UPDATE b2b_vendor_briefings
-            SET status = $1, resend_id = $2, approved_at = NOW()
-            WHERE id = $3
-            """,
-            status,
-            resend_id,
-            briefing_id,
+        await mark_pending_briefing_sent(
+            pool,
+            briefing_id=briefing_id,
+            resend_id=resend_id,
         )
     else:
-        await pool.execute(
-            """
-            UPDATE b2b_vendor_briefings
-            SET status = $1
-            WHERE id = $2
-            """,
-            status,
-            briefing_id,
-        )
+        await mark_pending_briefing_failed(pool, briefing_id)
 
     return {
         "id": str(briefing_id),
@@ -2860,16 +2832,12 @@ async def reject_briefing(briefing_id: str, reason: str | None = None) -> dict[s
     if not pool.is_initialized:
         return {"error": "Database not ready"}
 
-    result = await pool.execute(
-        """
-        UPDATE b2b_vendor_briefings
-        SET status = 'rejected', rejected_at = NOW(), reject_reason = $1
-        WHERE id = $2 AND status = 'pending_approval'
-        """,
-        reason,
-        briefing_id,
+    rejected = await reject_pending_briefing(
+        pool,
+        briefing_id=briefing_id,
+        reason=reason,
     )
-    if result == "UPDATE 0":
+    if not rejected:
         return {"error": "Briefing not found or not pending approval"}
 
     return {"id": str(briefing_id), "status": "rejected"}
@@ -2958,19 +2926,7 @@ async def _check_cooldown(
     pool: Any, vendor_name: str, cooldown_days: int
 ) -> bool:
     """Return True if a recent briefing exists (should skip)."""
-    row = await pool.fetchval(
-        """
-        SELECT EXISTS(
-            SELECT 1 FROM b2b_vendor_briefings
-            WHERE LOWER(vendor_name) = LOWER($1)
-              AND status NOT IN ('failed', 'suppressed', 'rejected')
-              AND created_at > NOW() - make_interval(days => $2)
-        )
-        """,
-        vendor_name,
-        cooldown_days,
-    )
-    return bool(row)
+    return await has_recent_deliverable_briefing(pool, vendor_name, cooldown_days)
 
 
 # ---------------------------------------------------------------------------
@@ -3110,34 +3066,17 @@ async def send_batch_briefings() -> dict[str, Any]:
         # Render HTML and store as pending_approval (HITL gate)
         briefing_html = render_vendor_briefing_html(briefing_data)
 
-        challenger_mode = briefing_data.get("challenger_mode", False)
-        if briefing_data.get("prospect_mode"):
-            subject = (
-                f"{vendor_name} -- Accounts In Motion"
-                if challenger_mode
-                else f"{vendor_name} -- Churn Signals Detected"
-            )
-        else:
-            subject = (
-                f"Sales Intelligence Briefing: {vendor_name}"
-                if challenger_mode
-                else f"Churn Intelligence Briefing: {vendor_name}"
-            )
+        subject = build_vendor_briefing_subject(vendor_name, briefing_data)
 
         try:
-            await pool.execute(
-                """
-                INSERT INTO b2b_vendor_briefings
-                    (vendor_name, recipient_email, subject, briefing_data,
-                     briefing_html, status, target_mode)
-                VALUES ($1, $2, $3, $4::jsonb, $5, 'pending_approval', $6)
-                """,
-                vendor_name,
-                to_email,
-                subject,
-                json.dumps(briefing_data, default=str),
-                briefing_html,
-                target_mode,
+            await insert_pending_approval_briefing_record(
+                pool,
+                vendor_name=vendor_name,
+                recipient_email=to_email,
+                subject=subject,
+                briefing_data=briefing_data,
+                briefing_html=briefing_html,
+                target_mode=target_mode,
             )
             queued += 1
             details.append({

--- a/extracted_competitive_intelligence/manifest.json
+++ b/extracted_competitive_intelligence/manifest.json
@@ -3,6 +3,7 @@
     {"source": "atlas_brain/autonomous/tasks/b2b_battle_cards.py", "target": "extracted_competitive_intelligence/autonomous/tasks/b2b_battle_cards.py"},
     {"source": "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py", "target": "extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py"},
     {"source": "atlas_brain/services/b2b/vendor_briefing_delivery.py", "target": "extracted_competitive_intelligence/services/b2b/vendor_briefing_delivery.py"},
+    {"source": "atlas_brain/services/b2b/vendor_briefing_repository.py", "target": "extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py"},
     {"source": "atlas_brain/storage/migrations/095_b2b_vendor_registry.sql", "target": "extracted_competitive_intelligence/storage/migrations/095_b2b_vendor_registry.sql"},
     {"source": "atlas_brain/storage/migrations/099_displacement_edges_and_company_signals.sql", "target": "extracted_competitive_intelligence/storage/migrations/099_displacement_edges_and_company_signals.sql"},
     {"source": "atlas_brain/storage/migrations/101_vendor_buyer_profiles.sql", "target": "extracted_competitive_intelligence/storage/migrations/101_vendor_buyer_profiles.sql"},

--- a/extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py
+++ b/extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py
@@ -1,0 +1,204 @@
+"""Repository helpers for Competitive Intelligence vendor briefing state."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PendingVendorBriefing:
+    vendor_name: str
+    recipient_email: str
+    subject: str
+    briefing_data: dict[str, Any]
+    briefing_html: str
+
+
+def _json_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+async def has_prior_deliverable_briefing(pool: Any, vendor_name: str) -> bool:
+    count = await pool.fetchval(
+        """
+        SELECT COUNT(*) FROM b2b_vendor_briefings
+        WHERE LOWER(vendor_name) = LOWER($1)
+          AND status NOT IN ('failed', 'suppressed', 'rejected')
+        """,
+        vendor_name,
+    )
+    return int(count or 0) > 0
+
+
+async def has_recent_deliverable_briefing(
+    pool: Any,
+    vendor_name: str,
+    cooldown_days: int,
+) -> bool:
+    row = await pool.fetchval(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM b2b_vendor_briefings
+            WHERE LOWER(vendor_name) = LOWER($1)
+              AND status NOT IN ('failed', 'suppressed', 'rejected')
+              AND created_at > NOW() - make_interval(days => $2)
+        )
+        """,
+        vendor_name,
+        cooldown_days,
+    )
+    return bool(row)
+
+
+async def insert_suppressed_briefing_record(
+    pool: Any,
+    *,
+    vendor_name: str,
+    recipient_email: str,
+    subject: str,
+    briefing_data: dict[str, Any],
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO b2b_vendor_briefings
+            (vendor_name, recipient_email, subject, briefing_data, status)
+        VALUES ($1, $2, $3, $4::jsonb, 'suppressed')
+        """,
+        vendor_name,
+        recipient_email,
+        subject,
+        json.dumps(briefing_data, default=str),
+    )
+
+
+async def insert_delivery_briefing_record(
+    pool: Any,
+    *,
+    vendor_name: str,
+    recipient_email: str,
+    subject: str,
+    briefing_data: dict[str, Any],
+    resend_id: str | None,
+    status: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO b2b_vendor_briefings
+            (vendor_name, recipient_email, subject, briefing_data, resend_id, status)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+        """,
+        vendor_name,
+        recipient_email,
+        subject,
+        json.dumps(briefing_data, default=str),
+        resend_id,
+        status,
+    )
+
+
+async def insert_pending_approval_briefing_record(
+    pool: Any,
+    *,
+    vendor_name: str,
+    recipient_email: str,
+    subject: str,
+    briefing_data: dict[str, Any],
+    briefing_html: str,
+    target_mode: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO b2b_vendor_briefings
+            (vendor_name, recipient_email, subject, briefing_data,
+             briefing_html, status, target_mode)
+        VALUES ($1, $2, $3, $4::jsonb, $5, 'pending_approval', $6)
+        """,
+        vendor_name,
+        recipient_email,
+        subject,
+        json.dumps(briefing_data, default=str),
+        briefing_html,
+        target_mode,
+    )
+
+
+async def fetch_pending_approval_briefing(
+    pool: Any,
+    briefing_id: str,
+) -> PendingVendorBriefing | None:
+    row = await pool.fetchrow(
+        """
+        SELECT id, vendor_name, recipient_email, subject,
+               briefing_data, briefing_html
+        FROM b2b_vendor_briefings
+        WHERE id = $1 AND status = 'pending_approval'
+        """,
+        briefing_id,
+    )
+    if not row:
+        return None
+    return PendingVendorBriefing(
+        vendor_name=row["vendor_name"],
+        recipient_email=row["recipient_email"],
+        subject=row["subject"],
+        briefing_data=_json_dict(row["briefing_data"]),
+        briefing_html=row["briefing_html"] or "",
+    )
+
+
+async def mark_pending_briefing_sent(
+    pool: Any,
+    *,
+    briefing_id: str,
+    resend_id: str | None,
+) -> None:
+    await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = $1, resend_id = $2, approved_at = NOW()
+        WHERE id = $3
+        """,
+        "sent",
+        resend_id,
+        briefing_id,
+    )
+
+
+async def mark_pending_briefing_failed(pool: Any, briefing_id: str) -> None:
+    await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = $1
+        WHERE id = $2
+        """,
+        "failed",
+        briefing_id,
+    )
+
+
+async def reject_pending_briefing(
+    pool: Any,
+    *,
+    briefing_id: str,
+    reason: str | None = None,
+) -> bool:
+    result = await pool.execute(
+        """
+        UPDATE b2b_vendor_briefings
+        SET status = 'rejected', rejected_at = NOW(), reject_reason = $1
+        WHERE id = $2 AND status = 'pending_approval'
+        """,
+        reason,
+        briefing_id,
+    )
+    return result != "UPDATE 0"

--- a/scripts/run_extracted_competitive_intelligence_checks.sh
+++ b/scripts/run_extracted_competitive_intelligence_checks.sh
@@ -28,6 +28,7 @@ python -m pytest -q \
   tests/test_extracted_competitive_llm_router_bridge.py \
   tests/test_extracted_competitive_battle_card_ports.py \
   tests/test_extracted_competitive_vendor_briefing_delivery.py \
+  tests/test_extracted_competitive_vendor_briefing_repository.py \
   tests/test_extracted_competitive_vendor_briefing_ports.py \
   tests/test_extracted_competitive_sets.py \
   tests/test_extracted_competitive_synthesis_packets.py \

--- a/scripts/smoke_extracted_competitive_intelligence_imports.py
+++ b/scripts/smoke_extracted_competitive_intelligence_imports.py
@@ -40,6 +40,7 @@ MODULES = [
     "extracted_competitive_intelligence.autonomous.tasks.b2b_vendor_briefing",
     "extracted_competitive_intelligence.autonomous.tasks._b2b_cross_vendor_synthesis",
     "extracted_competitive_intelligence.services.b2b.vendor_briefing_delivery",
+    "extracted_competitive_intelligence.services.b2b.vendor_briefing_repository",
     "extracted_competitive_intelligence.services.b2b.vendor_briefing_api_ports",
     "extracted_competitive_intelligence.services.b2b_competitive_sets",
     "extracted_competitive_intelligence.reasoning.ecosystem",

--- a/scripts/smoke_extracted_competitive_intelligence_standalone.py
+++ b/scripts/smoke_extracted_competitive_intelligence_standalone.py
@@ -41,6 +41,7 @@ MODULES = [
     "extracted_competitive_intelligence.services.b2b.competitive_set_ports",
     "extracted_competitive_intelligence.services.b2b.battle_card_ports",
     "extracted_competitive_intelligence.services.b2b.vendor_briefing_delivery",
+    "extracted_competitive_intelligence.services.b2b.vendor_briefing_repository",
     "extracted_competitive_intelligence.services.b2b.vendor_briefing_ports",
     "extracted_competitive_intelligence.services.b2b.vendor_briefing_api_ports",
     "extracted_competitive_intelligence.services.b2b.llm_exact_cache",

--- a/tests/test_extracted_competitive_vendor_briefing_repository.py
+++ b/tests/test_extracted_competitive_vendor_briefing_repository.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from extracted_competitive_intelligence.services.b2b import (
+    vendor_briefing_repository as repository,
+)
+
+
+class RecordingPool:
+    def __init__(
+        self,
+        *,
+        fetchval_result: Any = None,
+        fetchrow_result: dict[str, Any] | None = None,
+        execute_result: str = "UPDATE 1",
+    ) -> None:
+        self.fetchval_result = fetchval_result
+        self.fetchrow_result = fetchrow_result
+        self.execute_result = execute_result
+        self.fetchval_calls: list[tuple[Any, ...]] = []
+        self.fetchrow_calls: list[tuple[Any, ...]] = []
+        self.execute_calls: list[tuple[Any, ...]] = []
+
+    async def fetchval(self, *args: Any) -> Any:
+        self.fetchval_calls.append(args)
+        return self.fetchval_result
+
+    async def fetchrow(self, *args: Any) -> dict[str, Any] | None:
+        self.fetchrow_calls.append(args)
+        return self.fetchrow_result
+
+    async def execute(self, *args: Any) -> str:
+        self.execute_calls.append(args)
+        return self.execute_result
+
+
+@pytest.mark.asyncio
+async def test_prior_and_recent_briefing_checks_share_deliverable_status_filter() -> None:
+    prior_pool = RecordingPool(fetchval_result=1)
+    recent_pool = RecordingPool(fetchval_result=True)
+
+    assert await repository.has_prior_deliverable_briefing(prior_pool, "Acme")
+    assert await repository.has_recent_deliverable_briefing(recent_pool, "Acme", 7)
+
+    prior_query = prior_pool.fetchval_calls[0][0]
+    recent_query = recent_pool.fetchval_calls[0][0]
+    assert "status NOT IN ('failed', 'suppressed', 'rejected')" in prior_query
+    assert "status NOT IN ('failed', 'suppressed', 'rejected')" in recent_query
+
+
+@pytest.mark.asyncio
+async def test_delivery_record_helpers_write_expected_status_rows() -> None:
+    pool = RecordingPool()
+
+    await repository.insert_suppressed_briefing_record(
+        pool,
+        vendor_name="Acme",
+        recipient_email="buyer@example.com",
+        subject="Suppressed",
+        briefing_data={"vendor": "Acme"},
+    )
+    await repository.insert_delivery_briefing_record(
+        pool,
+        vendor_name="Acme",
+        recipient_email="buyer@example.com",
+        subject="Sent",
+        briefing_data={"vendor": "Acme"},
+        resend_id="resend-1",
+        status="sent",
+    )
+    await repository.insert_pending_approval_briefing_record(
+        pool,
+        vendor_name="Acme",
+        recipient_email="buyer@example.com",
+        subject="Pending",
+        briefing_data={"vendor": "Acme"},
+        briefing_html="<p>briefing</p>",
+        target_mode="vendor_retention",
+    )
+
+    queries = [call[0] for call in pool.execute_calls]
+    assert "'suppressed'" in queries[0]
+    assert "resend_id, status" in queries[1]
+    assert "'pending_approval'" in queries[2]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_approval_briefing_parses_json_payload() -> None:
+    pool = RecordingPool(
+        fetchrow_result={
+            "vendor_name": "Acme",
+            "recipient_email": "buyer@example.com",
+            "subject": "Stored Subject",
+            "briefing_data": "{\"vendor\": \"Acme\"}",
+            "briefing_html": "<p>briefing</p>",
+        }
+    )
+
+    pending = await repository.fetch_pending_approval_briefing(pool, "briefing-1")
+
+    assert pending == repository.PendingVendorBriefing(
+        vendor_name="Acme",
+        recipient_email="buyer@example.com",
+        subject="Stored Subject",
+        briefing_data={"vendor": "Acme"},
+        briefing_html="<p>briefing</p>",
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_and_rejection_updates_preserve_existing_status_contract() -> None:
+    pool = RecordingPool()
+    missing_pool = RecordingPool(execute_result="UPDATE 0")
+
+    await repository.mark_pending_briefing_sent(
+        pool,
+        briefing_id="briefing-1",
+        resend_id="resend-1",
+    )
+    await repository.mark_pending_briefing_failed(pool, "briefing-2")
+    rejected = await repository.reject_pending_briefing(
+        pool,
+        briefing_id="briefing-3",
+        reason="bad fit",
+    )
+    missing = await repository.reject_pending_briefing(
+        missing_pool,
+        briefing_id="briefing-4",
+    )
+
+    assert rejected is True
+    assert missing is False
+    assert "approved_at = NOW()" in pool.execute_calls[0][0]
+    assert "SET status = $1" in pool.execute_calls[1][0]
+    assert "rejected_at = NOW()" in pool.execute_calls[2][0]


### PR DESCRIPTION
## Summary
- Add a mapped `vendor_briefing_repository.py` helper for `b2b_vendor_briefings` delivery records, cooldown checks, pending approval rows, and HITL approve/reject updates.
- Route direct sends, approved sends, rejection, cooldown, first-briefing, and scheduled pending-approval writes through the helper while preserving public task APIs.
- Reuse the centralized subject builder for scheduled pending-approval briefings so direct and batch paths share the same config-backed subject logic.

## Validation
- `python -m py_compile atlas_brain/services/b2b/vendor_briefing_repository.py atlas_brain/autonomous/tasks/b2b_vendor_briefing.py extracted_competitive_intelligence/services/b2b/vendor_briefing_repository.py extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py tests/test_extracted_competitive_vendor_briefing_repository.py`
- `bash scripts/validate_extracted_competitive_intelligence.sh`
- `bash scripts/check_ascii_python_competitive_intelligence.sh`
- `python scripts/check_extracted_competitive_intelligence_imports.py`
- `python scripts/smoke_extracted_competitive_intelligence_imports.py`
- `python scripts/smoke_extracted_competitive_intelligence_standalone.py`
- `pytest -q tests/test_extracted_competitive_vendor_briefing_repository.py tests/test_extracted_competitive_vendor_briefing_delivery.py tests/test_extracted_competitive_manifest.py` (18 passed)
- Competitive pytest set minus local optional-MCP contract test: 84 passed