### PR TITLE
Sync vendor_briefing_delivery into extracted_content_pipeline manifest

### DIFF
--- a/extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py
@@ -31,7 +31,11 @@ import httpx
 import jwt as pyjwt
 
 from ...config import settings
-from ...services.campaign_sender import get_campaign_sender
+from ...services.b2b.vendor_briefing_delivery import (
+    build_vendor_briefing_subject,
+    require_vendor_briefing_delivery_configured,
+    send_vendor_briefing_delivery,
+)
 from ...services.b2b.vendor_briefing_ports import (
     align_vendor_intelligence_record_to_scorecard as _align_vendor_intelligence_record_to_scorecard,
     build_llm_messages,
@@ -2686,8 +2690,9 @@ async def send_vendor_briefing(
     briefing_data: dict,
 ) -> dict | None:
     """Send a vendor briefing email via CampaignSender and persist to DB."""
-    cfg = settings.campaign_sequence
-    if not cfg.resend_api_key or not cfg.resend_from_email:
+    try:
+        require_vendor_briefing_delivery_configured()
+    except Exception:
         logger.warning("Resend not configured -- cannot send briefing")
         return None
 
@@ -2703,10 +2708,9 @@ async def send_vendor_briefing(
         suppressed = await is_suppressed(pool, email=to_email)
         if suppressed:
             logger.info("Suppressed briefing to %s (vendor=%s)", to_email, vendor_name)
-            suppressed_subject = (
-                f"Sales Intelligence Briefing: {vendor_name}"
-                if challenger_mode
-                else f"Churn Intelligence Briefing: {vendor_name}"
+            suppressed_subject = build_vendor_briefing_subject(
+                vendor_name,
+                {"challenger_mode": challenger_mode},
             )
             try:
                 await pool.execute(
@@ -2724,41 +2728,19 @@ async def send_vendor_briefing(
                 logger.warning("Failed to persist suppressed record: %s", exc)
             return None
 
-    sender_name = settings.b2b_churn.vendor_briefing_sender_name
-    from_addr = f"{sender_name} <{cfg.resend_from_email}>"
-
-    if briefing_data.get("prospect_mode"):
-        if challenger_mode:
-            subject = f"{vendor_name} -- Accounts In Motion"
-        else:
-            subject = f"{vendor_name} -- Churn Signals Detected"
-    elif briefing_data.get("is_gated_delivery"):
-        if challenger_mode:
-            subject = f"Your {vendor_name} Sales Intelligence Report"
-        else:
-            subject = f"Your {vendor_name} Churn Intelligence Report"
-    else:
-        if challenger_mode:
-            subject = f"Sales Intelligence Briefing: {vendor_name}"
-        else:
-            subject = f"Churn Intelligence Briefing: {vendor_name}"
+    subject = build_vendor_briefing_subject(vendor_name, briefing_data)
 
     resend_id: str | None = None
     status = "sent"
 
     try:
-        sender = get_campaign_sender()
-        result = await sender.send(
-            to=to_email,
-            from_email=from_addr,
+        result = await send_vendor_briefing_delivery(
+            to_email=to_email,
+            vendor_name=vendor_name,
             subject=subject,
-            body=briefing_html,
-            tags=[
-                {"name": "type", "value": "vendor_briefing"},
-                {"name": "vendor", "value": vendor_name},
-            ],
+            briefing_html=briefing_html,
         )
-        resend_id = result.get("id")
+        resend_id = result.provider_message_id
     except Exception as exc:
         logger.warning("Failed to send briefing to %s: %s", to_email, exc)
         status = "failed"
@@ -2821,29 +2803,22 @@ async def send_approved_briefing(briefing_id: str) -> dict[str, Any]:
         return {"error": "No rendered HTML stored for this briefing"}
 
     # Send via CampaignSender
-    cfg = settings.campaign_sequence
-    if not cfg.resend_api_key or not cfg.resend_from_email:
+    try:
+        require_vendor_briefing_delivery_configured()
+    except Exception:
         return {"error": "Resend not configured"}
-
-    sender_name = settings.b2b_churn.vendor_briefing_sender_name
-    from_addr = f"{sender_name} <{cfg.resend_from_email}>"
 
     resend_id: str | None = None
     status = "sent"
 
     try:
-        sender = get_campaign_sender()
-        result = await sender.send(
-            to=to_email,
-            from_email=from_addr,
+        result = await send_vendor_briefing_delivery(
+            to_email=to_email,
+            vendor_name=vendor_name,
             subject=subject,
-            body=html,
-            tags=[
-                {"name": "type", "value": "vendor_briefing"},
-                {"name": "vendor", "value": vendor_name},
-            ],
+            briefing_html=html,
         )
-        resend_id = result.get("id")
+        resend_id = result.provider_message_id
     except Exception as exc:
         logger.warning("Failed to send approved briefing %s: %s", briefing_id, exc)
         status = "failed"

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -159,6 +159,10 @@
     {
       "source": "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py",
       "target": "extracted_content_pipeline/autonomous/tasks/b2b_vendor_briefing.py"
+    },
+    {
+      "source": "atlas_brain/services/b2b/vendor_briefing_delivery.py",
+      "target": "extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py"
     }
   ],
   "owned": [

--- a/extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py
+++ b/extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py
@@ -1,0 +1,98 @@
+"""Shared delivery helpers for Competitive Intelligence vendor briefings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ...config import settings
+from ...services.campaign_sender import get_campaign_sender
+
+
+class VendorBriefingDeliveryNotConfigured(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class VendorBriefingDeliveryResult:
+    provider_message_id: str | None
+
+
+def vendor_briefing_delivery_configured() -> bool:
+    cfg = settings.campaign_sequence
+    return bool(cfg.resend_api_key and cfg.resend_from_email)
+
+
+def require_vendor_briefing_delivery_configured() -> None:
+    if not vendor_briefing_delivery_configured():
+        raise VendorBriefingDeliveryNotConfigured("Resend not configured")
+
+
+def _format_subject_template(template: str, vendor_name: str) -> str:
+    return template.format(vendor_name=vendor_name)
+
+
+def build_vendor_briefing_subject(
+    vendor_name: str,
+    briefing_data: dict[str, Any],
+) -> str:
+    cfg = settings.b2b_churn
+    challenger_mode = bool(briefing_data.get("challenger_mode"))
+    if briefing_data.get("prospect_mode"):
+        template = (
+            cfg.vendor_briefing_prospect_sales_subject_template
+            if challenger_mode
+            else cfg.vendor_briefing_prospect_churn_subject_template
+        )
+        return _format_subject_template(template, vendor_name)
+    if briefing_data.get("is_gated_delivery"):
+        template = (
+            cfg.vendor_briefing_gated_sales_subject_template
+            if challenger_mode
+            else cfg.vendor_briefing_gated_churn_subject_template
+        )
+        return _format_subject_template(template, vendor_name)
+    template = (
+        cfg.vendor_briefing_standard_sales_subject_template
+        if challenger_mode
+        else cfg.vendor_briefing_standard_churn_subject_template
+    )
+    return _format_subject_template(template, vendor_name)
+
+
+def build_vendor_briefing_from_address() -> str:
+    require_vendor_briefing_delivery_configured()
+    sender_name = settings.b2b_churn.vendor_briefing_sender_name
+    from_email = settings.campaign_sequence.resend_from_email
+    return f"{sender_name} <{from_email}>"
+
+
+def build_vendor_briefing_tags(vendor_name: str) -> list[dict[str, str]]:
+    cfg = settings.b2b_churn
+    return [
+        {
+            "name": cfg.vendor_briefing_tag_type_name,
+            "value": cfg.vendor_briefing_tag_type_value,
+        },
+        {"name": cfg.vendor_briefing_tag_vendor_name, "value": vendor_name},
+    ]
+
+
+async def send_vendor_briefing_delivery(
+    *,
+    to_email: str,
+    vendor_name: str,
+    subject: str,
+    briefing_html: str,
+) -> VendorBriefingDeliveryResult:
+    sender = get_campaign_sender()
+    result = await sender.send(
+        to=to_email,
+        from_email=build_vendor_briefing_from_address(),
+        subject=subject,
+        body=briefing_html,
+        tags=build_vendor_briefing_tags(vendor_name),
+    )
+    return VendorBriefingDeliveryResult(
+        provider_message_id=result.get("id") if isinstance(result, dict) else None
+    )


### PR DESCRIPTION
## Summary

PR #286 added `atlas_brain/services/b2b/vendor_briefing_delivery.py` and mirrored it into `extracted_competitive_intelligence/manifest.json`, but the `extracted_content_pipeline/manifest.json` was missed. The standalone import smoke fails because `b2b_vendor_briefing.py` and `b2b_campaign_generation.py` both import from `extracted_content_pipeline.services.b2b.vendor_briefing_delivery`.

This PR:
- Adds the source/target mapping to `extracted_content_pipeline/manifest.json`
- Runs `sync_extracted.sh` to copy the file
- Picks up the matching `b2b_vendor_briefing.py` refresh that PR #286 should have triggered

This unblocks PR-D7b3 (and any other PR touching the standalone CI) which currently fails the smoke check on `vendor_briefing_delivery`.

## Test plan

- [x] `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` → 896 passed
- [ ] Extracted Pipeline Checks workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)