### PR TITLE
Add content visibility sink adapters

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T19:15Z by codex-2026-05-05-d16
+Last updated: 2026-05-05T19:20Z by codex-2026-05-05-d17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBA | D17 content visibility sink adapters | `extracted_content_pipeline/campaign_visibility.py`, campaign visibility tests, content pipeline README/runbook/status | codex-2026-05-05-d17 | Avoid editing AI Content Ops visibility sink adapter surfaces until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -455,6 +455,22 @@ the `VisibilitySink` port so dashboards can show worker activity without the
 content product owning a dashboard store. Sink failures are logged and do not
 change operation responses.
 
+For local dashboards or host audit logs, wire a product-owned visibility sink:
+
+```python
+from extracted_content_pipeline.campaign_visibility import JsonlVisibilitySink
+
+visibility = JsonlVisibilitySink("/var/log/content-ops/campaign-events.jsonl")
+
+app.include_router(
+    create_campaign_operations_router(
+        pool_provider=get_pool,
+        sender_provider=get_campaign_sender,
+        visibility_provider=lambda: visibility,
+    )
+)
+```
+
 Mount this router beside `create_b2b_campaign_router` to run the hosted B2B
 flow without SQL in the admin UI:
 
@@ -545,6 +561,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `campaign_llm_client.py`: `PipelineLLMClient` adapter from the campaign
   `LLMClient` port to extracted LLM infrastructure services, with product-owned
   provider routing config
+- `campaign_visibility.py`: reference in-memory and JSONL `VisibilitySink`
+  adapters for hosted operations telemetry
 - `storage/database.py` and `storage/models.py`: minimal `get_db_pool` and `ScheduledTask` fallbacks
 - `campaign_postgres.py`: async Postgres adapters for intelligence,
   campaign, sequence, suppression, and audit ports, including the product-owned

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -116,6 +116,9 @@
 - `pipelines.notify` is product-owned and dispatches through the
   `VisibilitySink` port when configured, while staying a no-op when no host
   visibility adapter is installed.
+- `campaign_visibility` provides reference `VisibilitySink` adapters for
+  hosts: an in-memory sink for local dashboards/tests and a JSONL sink for
+  append-only operation audit trails.
 - Small task utility helpers are product-owned rather than Atlas-synced:
   `_execution_progress`, `_google_news`, `_blog_ts`, `_blog_deploy`, and
   `_b2b_batch_utils`, and `_blog_matching`.

--- a/extracted_content_pipeline/campaign_visibility.py
+++ b/extracted_content_pipeline/campaign_visibility.py
@@ -1,0 +1,130 @@
+"""Reference visibility sinks for host-mounted campaign operations."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+Clock = Callable[[], datetime]
+
+
+@dataclass(frozen=True)
+class VisibilityEvent:
+    """A host-visible campaign operation or pipeline event."""
+
+    event_type: str
+    payload: Mapping[str, Any]
+    emitted_at: datetime
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "event_type": self.event_type,
+            "payload": dict(self.payload),
+            "emitted_at": self.emitted_at.isoformat(),
+        }
+
+
+class InMemoryVisibilitySink:
+    """Visibility sink for tests, local demos, and lightweight hosts."""
+
+    def __init__(
+        self,
+        *,
+        max_events: int | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._max_events = max_events
+        self._clock = clock or _utcnow
+        self._events: list[VisibilityEvent] = []
+
+    @property
+    def events(self) -> tuple[VisibilityEvent, ...]:
+        return tuple(self._events)
+
+    def as_dicts(self) -> list[dict[str, Any]]:
+        return [event.as_dict() for event in self._events]
+
+    async def emit(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        self._events.append(
+            VisibilityEvent(
+                event_type=str(event_type),
+                payload=dict(payload),
+                emitted_at=self._clock(),
+            )
+        )
+        if self._max_events is not None:
+            self._events = self._events[-max(0, int(self._max_events)) :]
+
+
+class JsonlVisibilitySink:
+    """Append visibility events to a host-owned JSONL file."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        clock: Clock | None = None,
+        ensure_parent: bool = True,
+        encoding: str = "utf-8",
+    ) -> None:
+        self.path = Path(path)
+        self._clock = clock or _utcnow
+        self._ensure_parent = ensure_parent
+        self._encoding = encoding
+
+    async def emit(self, event_type: str, payload: Mapping[str, Any]) -> None:
+        event = VisibilityEvent(
+            event_type=str(event_type),
+            payload=dict(payload),
+            emitted_at=self._clock(),
+        )
+        if self._ensure_parent:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event.as_dict(), default=_json_default, sort_keys=True)
+        with self.path.open("a", encoding=self._encoding) as handle:
+            handle.write(line + "\n")
+
+
+def read_jsonl_visibility_events(
+    path: str | Path,
+    *,
+    limit: int | None = None,
+    encoding: str = "utf-8",
+) -> list[dict[str, Any]]:
+    """Read visibility events written by ``JsonlVisibilitySink``."""
+
+    rows: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding=encoding) as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            rows.append(json.loads(text))
+    if limit is None:
+        return rows
+    return rows[-max(0, int(limit)) :]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    return str(value)
+
+
+__all__ = [
+    "InMemoryVisibilitySink",
+    "JsonlVisibilitySink",
+    "VisibilityEvent",
+    "read_jsonl_visibility_events",
+]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -481,6 +481,22 @@ POST operation routes emit best-effort `campaign_operation_started`,
 the `VisibilitySink` port. Sink failures are logged and do not change operation
 responses.
 
+For a file-backed audit trail without writing a custom sink first:
+
+```python
+from extracted_content_pipeline.campaign_visibility import JsonlVisibilitySink
+
+visibility = JsonlVisibilitySink("/var/log/content-ops/campaign-events.jsonl")
+
+app.include_router(
+    create_campaign_operations_router(
+        pool_provider=get_pool,
+        sender_provider=get_campaign_sender,
+        visibility_provider=lambda: visibility,
+    )
+)
+```
+
 For lightweight hosted installs without a separate reasoning provider, set
 `generation_single_pass_reasoning=True` on `CampaignOperationsApiConfig`. The
 draft generation route then builds `SinglePassCampaignReasoningProvider` from

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -173,6 +173,9 @@
       "target": "extracted_content_pipeline/campaign_ports.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_visibility.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_generation.py"
     },
     {

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -12,6 +12,7 @@ python scripts/smoke_extracted_pipeline_imports.py
 python scripts/audit_extracted_standalone.py --fail-on-debt
 pytest \
   tests/test_extracted_campaign_analytics.py \
+  tests/test_extracted_campaign_visibility.py \
   tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation_seams.py \
   tests/test_extracted_campaign_generation.py \

--- a/scripts/smoke_extracted_pipeline_imports.py
+++ b/scripts/smoke_extracted_pipeline_imports.py
@@ -33,6 +33,7 @@ MODULES = [
     "extracted_content_pipeline.api.campaign_operations",
     "extracted_content_pipeline.api.b2b_campaigns",
     "extracted_content_pipeline.api.seller_campaigns",
+    "extracted_content_pipeline.campaign_visibility",
     "extracted_content_pipeline.campaign_postgres_seller_opportunities",
     "extracted_content_pipeline.campaign_postgres_seller_category_intelligence",
 ]

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -118,6 +118,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/pipelines/notify.py" in owned
     assert "extracted_content_pipeline/campaign_llm_client.py" in owned
     assert "extracted_content_pipeline/campaign_ports.py" in owned
+    assert "extracted_content_pipeline/campaign_visibility.py" in owned
     assert "extracted_content_pipeline/campaign_generation.py" in owned
     assert "extracted_content_pipeline/campaign_analytics.py" in owned
     assert "extracted_content_pipeline/campaign_webhooks.py" in owned
@@ -169,6 +170,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     mapped = _mapped_targets()
 
     assert "extracted_content_pipeline/campaign_ports.py" not in mapped
+    assert "extracted_content_pipeline/campaign_visibility.py" not in mapped
     assert "extracted_content_pipeline/campaign_generation.py" not in mapped
     assert "extracted_content_pipeline/campaign_analytics.py" not in mapped
     assert "extracted_content_pipeline/campaign_webhooks.py" not in mapped

--- a/tests/test_extracted_campaign_visibility.py
+++ b/tests/test_extracted_campaign_visibility.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_visibility import (
+    InMemoryVisibilitySink,
+    JsonlVisibilitySink,
+    read_jsonl_visibility_events,
+)
+
+
+def _clock() -> datetime:
+    return datetime(2026, 5, 5, 19, 20, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_in_memory_visibility_sink_records_events() -> None:
+    sink = InMemoryVisibilitySink(clock=_clock)
+
+    await sink.emit("campaign_operation_started", {"operation": "send_queued"})
+
+    assert len(sink.events) == 1
+    assert sink.events[0].event_type == "campaign_operation_started"
+    assert sink.events[0].payload == {"operation": "send_queued"}
+    assert sink.as_dicts() == [
+        {
+            "event_type": "campaign_operation_started",
+            "payload": {"operation": "send_queued"},
+            "emitted_at": "2026-05-05T19:20:00+00:00",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_visibility_sink_respects_max_events() -> None:
+    sink = InMemoryVisibilitySink(max_events=2, clock=_clock)
+
+    await sink.emit("one", {"index": 1})
+    await sink.emit("two", {"index": 2})
+    await sink.emit("three", {"index": 3})
+
+    assert [event.event_type for event in sink.events] == ["two", "three"]
+
+
+@pytest.mark.asyncio
+async def test_jsonl_visibility_sink_appends_events(tmp_path: Path) -> None:
+    path = tmp_path / "visibility" / "events.jsonl"
+    sink = JsonlVisibilitySink(path, clock=_clock)
+
+    await sink.emit(
+        "campaign_operation_failed",
+        {
+            "operation": "draft_generation",
+            "error_type": "reported_failures",
+            "result": {"error_count": 1},
+        },
+    )
+
+    assert read_jsonl_visibility_events(path) == [
+        {
+            "emitted_at": "2026-05-05T19:20:00+00:00",
+            "event_type": "campaign_operation_failed",
+            "payload": {
+                "error_type": "reported_failures",
+                "operation": "draft_generation",
+                "result": {"error_count": 1},
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_jsonl_visibility_sink_serializes_non_json_values(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    sink = JsonlVisibilitySink(path, clock=_clock)
+
+    await sink.emit("pipeline_notification", {"path": Path("artifact.json")})
+
+    rows = read_jsonl_visibility_events(path)
+
+    assert rows[0]["payload"] == {"path": "artifact.json"}
+
+
+@pytest.mark.asyncio
+async def test_read_jsonl_visibility_events_respects_limit(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    sink = JsonlVisibilitySink(path, clock=_clock)
+
+    await sink.emit("one", {"index": 1})
+    await sink.emit("two", {"index": 2})
+    await sink.emit("three", {"index": 3})
+
+    assert [
+        row["event_type"]
+        for row in read_jsonl_visibility_events(path, limit=2)
+    ] == ["two", "three"]


### PR DESCRIPTION
## Summary
- Add product-owned `campaign_visibility.py` with `InMemoryVisibilitySink`, `JsonlVisibilitySink`, `VisibilityEvent`, and a JSONL read helper.
- Mark the adapter as content-pipeline-owned, add smoke/full-check coverage, and document how hosts wire the sink into the hosted campaign operations router.
- Claim the D17 coordination slice so parallel sessions avoid visibility sink adapter work.

## Validation
- `python -m py_compile extracted_content_pipeline/campaign_visibility.py tests/test_extracted_campaign_visibility.py scripts/smoke_extracted_pipeline_imports.py`
- `pytest tests/test_extracted_campaign_visibility.py tests/test_extracted_campaign_manifest.py` (12/12)
- `python scripts/smoke_extracted_pipeline_imports.py`
- `rg -n "[^\\x00-\\x7F]" extracted_content_pipeline/campaign_visibility.py tests/test_extracted_campaign_visibility.py` (no matches)
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` (914/914, existing torch/pynvml warning)