### PR TITLE
Add JSONL visibility to campaign worker CLIs

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T19:36Z by codex-2026-05-05-d17
+Last updated: 2026-05-05T19:42Z by codex-2026-05-05-d18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBA | D18 campaign worker CLI JSONL visibility | campaign worker scripts, campaign visibility tests/docs/status | codex-2026-05-05-d18 | Avoid editing host-facing AI Content Ops worker CLI visibility wiring until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -397,6 +397,20 @@ python scripts/progress_extracted_campaign_sequences.py \
   --json
 ```
 
+For non-FastAPI worker installs, the four operational CLIs can append the same
+start/completed/failed telemetry to a JSONL audit trail:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --visibility-jsonl /var/log/content-ops/campaign-events.jsonl
+
+python scripts/send_extracted_campaigns.py \
+  --provider resend \
+  --default-from-email audit@customer.com \
+  --visibility-jsonl /var/log/content-ops/campaign-events.jsonl
+```
+
 Hosts with FastAPI apps can mount draft generation, send, sequence progression,
 and analytics worker triggers through a hosted operations router. The host
 injects its database pool, sender, optional LLM/skill/reasoning providers, and

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -117,8 +117,9 @@
   `VisibilitySink` port when configured, while staying a no-op when no host
   visibility adapter is installed.
 - `campaign_visibility` provides reference `VisibilitySink` adapters for
-  hosts: an in-memory sink for local dashboards/tests and a JSONL sink for
-  append-only operation audit trails.
+  hosts: an in-memory sink for local dashboards/tests, a JSONL sink for
+  append-only operation audit trails, and shared event helpers used by hosted
+  operation routes and worker CLIs.
 - Small task utility helpers are product-owned rather than Atlas-synced:
   `_execution_progress`, `_google_news`, `_blog_ts`, `_blog_deploy`, and
   `_b2b_batch_utils`, and `_blog_matching`.

--- a/extracted_content_pipeline/campaign_visibility.py
+++ b/extracted_content_pipeline/campaign_visibility.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .campaign_ports import VisibilitySink
+
 
 Clock = Callable[[], datetime]
+OPERATION_STARTED_EVENT = "campaign_operation_started"
+OPERATION_COMPLETED_EVENT = "campaign_operation_completed"
+OPERATION_FAILED_EVENT = "campaign_operation_failed"
+REPORTED_ERROR_TYPE = "reported_error"
+REPORTED_FAILURES_ERROR_TYPE = "reported_failures"
 
 
 @dataclass(frozen=True)
@@ -110,6 +117,42 @@ def read_jsonl_visibility_events(
     return rows[-max(0, int(limit)) :]
 
 
+def visibility_result_summary(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a compact visibility-safe summary for operation result payloads."""
+
+    summary: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, (bool, int, float)) or value is None:
+            summary[key] = value
+        elif isinstance(value, Sequence) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        ):
+            if key == "errors":
+                summary["error_count"] = len(value)
+            elif key.endswith("_ids"):
+                summary[f"{key}_count"] = len(value)
+    return summary
+
+
+async def emit_operation_event(
+    visibility: VisibilitySink | None,
+    event_type: str,
+    operation: str,
+    payload: Mapping[str, Any] | None = None,
+) -> None:
+    """Best effort operation event emission for host-facing runners."""
+
+    if visibility is None:
+        return
+    event_payload = {"operation": str(operation)}
+    event_payload.update(dict(payload or {}))
+    try:
+        await visibility.emit(event_type, event_payload)
+    except Exception:
+        return
+
+
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -123,8 +166,15 @@ def _json_default(value: Any) -> str:
 
 
 __all__ = [
+    "OPERATION_COMPLETED_EVENT",
+    "OPERATION_FAILED_EVENT",
+    "OPERATION_STARTED_EVENT",
+    "REPORTED_ERROR_TYPE",
+    "REPORTED_FAILURES_ERROR_TYPE",
     "InMemoryVisibilitySink",
     "JsonlVisibilitySink",
     "VisibilityEvent",
+    "emit_operation_event",
     "read_jsonl_visibility_events",
+    "visibility_result_summary",
 ]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -442,6 +442,11 @@ python scripts/progress_extracted_campaign_sequences.py \
   --limit 10
 ```
 
+Add `--visibility-jsonl /var/log/content-ops/campaign-events.jsonl` to the
+generation, send, sequence progression, or analytics CLIs when the host wants a
+file-backed operation audit trail without mounting the FastAPI operations
+router.
+
 Or mount the hosted operations router in a FastAPI app for admin-triggered
 draft generation, send, sequence progression, and analytics refresh actions:
 

--- a/scripts/progress_extracted_campaign_sequences.py
+++ b/scripts/progress_extracted_campaign_sequences.py
@@ -27,6 +27,14 @@ from extracted_content_pipeline.campaign_postgres_sequence_progression import ( 
 from extracted_content_pipeline.campaign_sequence_progression import (  # noqa: E402
     CampaignSequenceProgressionConfig,
 )
+from extracted_content_pipeline.campaign_visibility import (  # noqa: E402
+    JsonlVisibilitySink,
+    OPERATION_COMPLETED_EVENT,
+    OPERATION_FAILED_EVENT,
+    OPERATION_STARTED_EVENT,
+    emit_operation_event,
+    visibility_result_summary,
+)
 from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
 
 
@@ -154,6 +162,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Emit JSON summary instead of a concise text summary.",
     )
+    parser.add_argument(
+        "--visibility-jsonl",
+        type=Path,
+        help="Append campaign operation visibility events to this JSONL file.",
+    )
     return parser.parse_args(argv)
 
 
@@ -200,22 +213,44 @@ async def _main() -> int:
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
     _validate_args(args)
-    pool = await _create_pool(args.database_url)
+    visibility = JsonlVisibilitySink(args.visibility_jsonl) if args.visibility_jsonl else None
+    operation_payload = {"limit": args.limit, "max_steps": args.max_steps}
+    await emit_operation_event(
+        visibility,
+        OPERATION_STARTED_EVENT,
+        "sequence_progression",
+        operation_payload,
+    )
+    pool = None
     try:
+        pool = await _create_pool(args.database_url)
         result = await progress_campaign_sequences_from_postgres(
             pool,
             llm=_llm_from_args(args),
             skills=get_skill_registry(root=args.skills_root),
             config=_config_from_args(args),
         )
+    except Exception as exc:
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "sequence_progression",
+            {**operation_payload, "error_type": type(exc).__name__},
+        )
+        raise
     finally:
-        close = getattr(pool, "close", None)
-        if close is not None:
+        if pool is not None and (close := getattr(pool, "close", None)) is not None:
             maybe_awaitable = close()
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
 
     summary = result.as_dict()
+    await emit_operation_event(
+        visibility,
+        OPERATION_COMPLETED_EVENT,
+        "sequence_progression",
+        {**operation_payload, "result": visibility_result_summary(summary)},
+    )
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:

--- a/scripts/refresh_extracted_campaign_analytics.py
+++ b/scripts/refresh_extracted_campaign_analytics.py
@@ -18,6 +18,15 @@ if str(ROOT) not in sys.path:
 from extracted_content_pipeline.campaign_postgres_analytics import (  # noqa: E402
     refresh_campaign_analytics_from_postgres,
 )
+from extracted_content_pipeline.campaign_visibility import (  # noqa: E402
+    JsonlVisibilitySink,
+    OPERATION_COMPLETED_EVENT,
+    OPERATION_FAILED_EVENT,
+    OPERATION_STARTED_EVENT,
+    REPORTED_ERROR_TYPE,
+    emit_operation_event,
+    visibility_result_summary,
+)
 
 
 DATABASE_URL_ENV = ("EXTRACTED_DATABASE_URL", "DATABASE_URL")
@@ -45,6 +54,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Emit JSON summary instead of a concise text summary.",
     )
+    parser.add_argument(
+        "--visibility-jsonl",
+        type=Path,
+        help="Append campaign operation visibility events to this JSONL file.",
+    )
     return parser.parse_args(argv)
 
 
@@ -63,17 +77,49 @@ async def _main() -> int:
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
 
-    pool = await _create_pool(args.database_url)
+    visibility = JsonlVisibilitySink(args.visibility_jsonl) if args.visibility_jsonl else None
+    await emit_operation_event(
+        visibility,
+        OPERATION_STARTED_EVENT,
+        "analytics_refresh",
+        {},
+    )
+    pool = None
     try:
+        pool = await _create_pool(args.database_url)
         result = await refresh_campaign_analytics_from_postgres(pool)
+    except Exception as exc:
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "analytics_refresh",
+            {"error_type": type(exc).__name__},
+        )
+        raise
     finally:
-        close = getattr(pool, "close", None)
-        if close is not None:
+        if pool is not None and (close := getattr(pool, "close", None)) is not None:
             maybe_awaitable = close()
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
 
     summary = result.as_dict()
+    if not result.refreshed:
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "analytics_refresh",
+            {
+                "error_type": REPORTED_ERROR_TYPE,
+                "result": visibility_result_summary(summary),
+            },
+        )
+    else:
+        await emit_operation_event(
+            visibility,
+            OPERATION_COMPLETED_EVENT,
+            "analytics_refresh",
+            {"result": visibility_result_summary(summary)},
+        )
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -23,6 +23,15 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
 from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
     generate_campaign_drafts_from_postgres,
 )
+from extracted_content_pipeline.campaign_visibility import (  # noqa: E402
+    JsonlVisibilitySink,
+    OPERATION_COMPLETED_EVENT,
+    OPERATION_FAILED_EVENT,
+    OPERATION_STARTED_EVENT,
+    REPORTED_FAILURES_ERROR_TYPE,
+    emit_operation_event,
+    visibility_result_summary,
+)
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
 )
@@ -135,6 +144,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help="Write result JSON to this path instead of stdout.",
     )
+    parser.add_argument(
+        "--visibility-jsonl",
+        type=Path,
+        help="Append campaign operation visibility events to this JSONL file.",
+    )
     return parser.parse_args(argv)
 
 
@@ -201,29 +215,70 @@ async def _main() -> int:
     _validate_reasoning_args(args)
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
-    pool = await _create_pool(args.database_url)
+    visibility = JsonlVisibilitySink(args.visibility_jsonl) if args.visibility_jsonl else None
+    operation_payload = {
+        "limit": args.limit,
+        "target_mode": args.target_mode,
+        "channel": args.channel,
+        "channels": [
+            item.strip()
+            for item in str(args.channels or "").split(",")
+            if item.strip()
+        ],
+        "account_id": args.account_id,
+    }
+    await emit_operation_event(
+        visibility,
+        OPERATION_STARTED_EVENT,
+        "draft_generation",
+        operation_payload,
+    )
+    pool = None
     try:
+        pool = await _create_pool(args.database_url)
         result = await generate_campaign_drafts_from_postgres(
             pool,
             scope={"account_id": args.account_id, "user_id": args.user_id},
             target_mode=args.target_mode,
             channel=args.channel,
-            channels=tuple(
-                item.strip()
-                for item in str(args.channels or "").split(",")
-                if item.strip()
-            ),
+            channels=tuple(operation_payload["channels"]),
             limit=args.limit,
             filters=_json_object(args.filters_json),
             **_dependency_overrides(args),
         )
+    except Exception as exc:
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "draft_generation",
+            {**operation_payload, "error_type": type(exc).__name__},
+        )
+        raise
     finally:
-        close = getattr(pool, "close", None)
-        if close is not None:
+        if pool is not None and (close := getattr(pool, "close", None)) is not None:
             maybe_awaitable = close()
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
-    output = json.dumps(result.as_dict(), indent=2, sort_keys=True)
+    data = result.as_dict()
+    if data.get("errors") or data.get("skipped"):
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "draft_generation",
+            {
+                **operation_payload,
+                "error_type": REPORTED_FAILURES_ERROR_TYPE,
+                "result": visibility_result_summary(data),
+            },
+        )
+    else:
+        await emit_operation_event(
+            visibility,
+            OPERATION_COMPLETED_EVENT,
+            "draft_generation",
+            {**operation_payload, "result": visibility_result_summary(data)},
+        )
+    output = json.dumps(data, indent=2, sort_keys=True)
     if args.output:
         args.output.write_text(f"{output}\n", encoding="utf-8")
     else:

--- a/scripts/send_extracted_campaigns.py
+++ b/scripts/send_extracted_campaigns.py
@@ -302,10 +302,10 @@ async def _main() -> int:
     args = _parse_args()
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    visibility = JsonlVisibilitySink(args.visibility_jsonl) if args.visibility_jsonl else None
     provider, provider_config = _sender_config(args)
     _validate_sender_config(provider, provider_config)
     _validate_send_args(args)
-    sender = create_campaign_sender(provider, provider_config)
     config = CampaignSendConfig(
         default_from_email=args.default_from_email or args.ses_from_email or "",
         default_reply_to=args.reply_to,
@@ -314,7 +314,6 @@ async def _main() -> int:
         company_address=args.company_address,
         limit=args.limit,
     )
-    visibility = JsonlVisibilitySink(args.visibility_jsonl) if args.visibility_jsonl else None
     operation_payload = {"limit": args.limit, "provider": provider}
     await emit_operation_event(
         visibility,
@@ -324,6 +323,7 @@ async def _main() -> int:
     )
     pool = None
     try:
+        sender = create_campaign_sender(provider, provider_config)
         pool = await _create_pool(args.database_url)
         summary = await send_due_campaigns_from_postgres(
             pool,

--- a/scripts/send_extracted_campaigns.py
+++ b/scripts/send_extracted_campaigns.py
@@ -26,6 +26,15 @@ from extracted_content_pipeline.campaign_sender import (  # noqa: E402
     RESEND_API_URL,
     create_campaign_sender,
 )
+from extracted_content_pipeline.campaign_visibility import (  # noqa: E402
+    JsonlVisibilitySink,
+    OPERATION_COMPLETED_EVENT,
+    OPERATION_FAILED_EVENT,
+    OPERATION_STARTED_EVENT,
+    REPORTED_FAILURES_ERROR_TYPE,
+    emit_operation_event,
+    visibility_result_summary,
+)
 
 
 DEFAULT_CAMPAIGN_SENDER_PROVIDER = "resend"
@@ -215,6 +224,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Emit JSON summary instead of a concise text summary.",
     )
+    parser.add_argument(
+        "--visibility-jsonl",
+        type=Path,
+        help="Append campaign operation visibility events to this JSONL file.",
+    )
     return parser.parse_args(argv)
 
 
@@ -300,27 +314,63 @@ async def _main() -> int:
         company_address=args.company_address,
         limit=args.limit,
     )
-    pool = await _create_pool(args.database_url)
+    visibility = JsonlVisibilitySink(args.visibility_jsonl) if args.visibility_jsonl else None
+    operation_payload = {"limit": args.limit, "provider": provider}
+    await emit_operation_event(
+        visibility,
+        OPERATION_STARTED_EVENT,
+        "send_queued",
+        operation_payload,
+    )
+    pool = None
     try:
+        pool = await _create_pool(args.database_url)
         summary = await send_due_campaigns_from_postgres(
             pool,
             sender=sender,
             config=config,
             limit=args.limit,
         )
+    except Exception as exc:
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "send_queued",
+            {**operation_payload, "error_type": type(exc).__name__},
+        )
+        raise
     finally:
-        close = getattr(pool, "close", None)
-        if close is not None:
+        if pool is not None and (close := getattr(pool, "close", None)) is not None:
             maybe_awaitable = close()
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
 
+    data = summary.as_dict()
+    if data.get("failed"):
+        await emit_operation_event(
+            visibility,
+            OPERATION_FAILED_EVENT,
+            "send_queued",
+            {
+                **operation_payload,
+                "error_type": REPORTED_FAILURES_ERROR_TYPE,
+                "result": visibility_result_summary(data),
+            },
+        )
+    else:
+        await emit_operation_event(
+            visibility,
+            OPERATION_COMPLETED_EVENT,
+            "send_queued",
+            {**operation_payload, "result": visibility_result_summary(data)},
+        )
+
     if args.json:
-        print(json.dumps(summary.as_dict(), indent=2, sort_keys=True))
+        print(json.dumps(data, indent=2, sort_keys=True))
     else:
         print(
             "sent={sent} failed={failed} suppressed={suppressed} skipped={skipped}".format(
-                **summary.as_dict()
+                **data
             )
         )
     return 0

--- a/tests/test_extracted_campaign_postgres_analytics.py
+++ b/tests/test_extracted_campaign_postgres_analytics.py
@@ -9,6 +9,7 @@ from extracted_content_pipeline.campaign_analytics import CampaignAnalyticsRefre
 from extracted_content_pipeline.campaign_postgres_analytics import (
     refresh_campaign_analytics_from_postgres,
 )
+from extracted_content_pipeline.campaign_visibility import read_jsonl_visibility_events
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -123,9 +124,14 @@ async def test_analytics_cli_closes_pool_and_prints_json(monkeypatch, capsys) ->
 
 
 @pytest.mark.asyncio
-async def test_analytics_cli_returns_nonzero_on_refresh_error(monkeypatch, capsys) -> None:
+async def test_analytics_cli_returns_nonzero_on_refresh_error(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
     cli = _load_cli_module()
     pool = _Pool()
+    visibility_path = tmp_path / "visibility.jsonl"
 
     async def fake_create_pool(database_url):
         return pool
@@ -137,6 +143,8 @@ async def test_analytics_cli_returns_nonzero_on_refresh_error(monkeypatch, capsy
     monkeypatch.setattr(cli, "_parse_args", lambda: parse_args([
         "--database-url",
         "postgres://example",
+        "--visibility-jsonl",
+        str(visibility_path),
     ]))
     monkeypatch.setattr(cli, "_create_pool", fake_create_pool)
     monkeypatch.setattr(cli, "refresh_campaign_analytics_from_postgres", fake_refresh)
@@ -146,3 +154,14 @@ async def test_analytics_cli_returns_nonzero_on_refresh_error(monkeypatch, capsy
     assert exit_code == 1
     assert pool.closed is True
     assert "refreshed=False error=view locked" in capsys.readouterr().out
+    events = read_jsonl_visibility_events(visibility_path)
+    assert [row["event_type"] for row in events] == [
+        "campaign_operation_started",
+        "campaign_operation_failed",
+    ]
+    assert events[0]["payload"] == {"operation": "analytics_refresh"}
+    assert events[1]["payload"] == {
+        "error_type": "reported_error",
+        "operation": "analytics_refresh",
+        "result": {"refreshed": False},
+    }

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline.campaign_postgres_generation import (
     generate_campaign_drafts_from_postgres,
     tenant_scope_from_mapping,
 )
+from extracted_content_pipeline.campaign_visibility import read_jsonl_visibility_events
 from extracted_content_pipeline.services.single_pass_reasoning_provider import (
     SinglePassCampaignReasoningProvider,
 )
@@ -246,6 +247,7 @@ async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
         }),
         encoding="utf-8",
     )
+    visibility_path = tmp_path / "visibility.jsonl"
     created_urls = []
 
     async def create_pool(database_url):
@@ -270,6 +272,8 @@ async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
             "offline",
             "--reasoning-context",
             str(reasoning_path),
+            "--visibility-jsonl",
+            str(visibility_path),
         ],
     )
 
@@ -287,6 +291,20 @@ async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
         "wedge": "renewal pressure",
     }
     assert pool.closed is True
+    events = read_jsonl_visibility_events(visibility_path)
+    assert [row["event_type"] for row in events] == [
+        "campaign_operation_started",
+        "campaign_operation_completed",
+    ]
+    assert events[0]["payload"]["operation"] == "draft_generation"
+    assert events[0]["payload"]["account_id"] == "acct-1"
+    assert events[1]["payload"]["result"] == {
+        "error_count": 0,
+        "generated": 1,
+        "requested": 1,
+        "saved_ids_count": 1,
+        "skipped": 0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_campaign_postgres_send.py
+++ b/tests/test_extracted_campaign_postgres_send.py
@@ -436,3 +436,55 @@ async def test_send_cli_requires_ses_from_email_before_sender_creation(monkeypat
 
     with pytest.raises(SystemExit, match="Missing --ses-from-email"):
         await cli._main()
+
+
+@pytest.mark.asyncio
+async def test_send_cli_reports_sender_initialization_failure_to_visibility(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    visibility_path = tmp_path / "visibility.jsonl"
+    pool_called = False
+
+    async def create_pool(database_url):
+        nonlocal pool_called
+        pool_called = True
+        return _Pool()
+
+    def create_sender(provider, config):
+        raise RuntimeError("boto3 unavailable")
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(cli, "create_campaign_sender", create_sender)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "send",
+            "--database-url",
+            "postgres://example",
+            "--provider",
+            "ses",
+            "--default-from-email",
+            "sales@example.com",
+            "--visibility-jsonl",
+            str(visibility_path),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="boto3 unavailable"):
+        await cli._main()
+
+    assert pool_called is False
+    events = read_jsonl_visibility_events(visibility_path)
+    assert [row["event_type"] for row in events] == [
+        "campaign_operation_started",
+        "campaign_operation_failed",
+    ]
+    assert events[1]["payload"] == {
+        "error_type": "RuntimeError",
+        "limit": 20,
+        "operation": "send_queued",
+        "provider": "ses",
+    }

--- a/tests/test_extracted_campaign_postgres_send.py
+++ b/tests/test_extracted_campaign_postgres_send.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline.campaign_postgres_send import (
     send_due_campaigns_from_postgres,
 )
 from extracted_content_pipeline.campaign_send import CampaignSendConfig, CampaignSendSummary
+from extracted_content_pipeline.campaign_visibility import read_jsonl_visibility_events
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -234,10 +235,15 @@ def test_send_cli_reports_invalid_float_env(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_cli_outputs_json_summary_and_closes_pool(monkeypatch, capsys) -> None:
+async def test_send_cli_outputs_json_summary_and_closes_pool(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
     cli = _load_cli_module()
     pool = _Pool()
     calls: dict[str, object] = {}
+    visibility_path = tmp_path / "visibility.jsonl"
 
     async def create_pool(database_url):
         calls["database_url"] = database_url
@@ -276,6 +282,8 @@ async def test_send_cli_outputs_json_summary_and_closes_pool(monkeypatch, capsys
             "--limit",
             "4",
             "--json",
+            "--visibility-jsonl",
+            str(visibility_path),
         ],
     )
 
@@ -302,6 +310,23 @@ async def test_send_cli_outputs_json_summary_and_closes_pool(monkeypatch, capsys
         company_address="",
         limit=4,
     )
+    events = read_jsonl_visibility_events(visibility_path)
+    assert [row["event_type"] for row in events] == [
+        "campaign_operation_started",
+        "campaign_operation_failed",
+    ]
+    assert events[0]["payload"] == {
+        "limit": 4,
+        "operation": "send_queued",
+        "provider": "resend",
+    }
+    assert events[1]["payload"]["error_type"] == "reported_failures"
+    assert events[1]["payload"]["result"] == {
+        "failed": 1,
+        "sent": 2,
+        "skipped": 1,
+        "suppressed": 0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_campaign_postgres_sequence_progression.py
+++ b/tests/test_extracted_campaign_postgres_sequence_progression.py
@@ -13,7 +13,9 @@ from extracted_content_pipeline.campaign_postgres_sequence_progression import (
 )
 from extracted_content_pipeline.campaign_sequence_progression import (
     CampaignSequenceProgressionConfig,
+    CampaignSequenceProgressionResult,
 )
+from extracted_content_pipeline.campaign_visibility import read_jsonl_visibility_events
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -313,3 +315,79 @@ def test_sequence_cli_builds_config_and_offline_llm() -> None:
     assert config.onboarding_product_name == "Atlas Ops"
     assert config.temperature == 0.1
     assert cli._llm_from_args(args).__class__.__name__ == "DeterministicCampaignLLM"
+
+
+@pytest.mark.asyncio
+async def test_sequence_cli_writes_visibility_events(monkeypatch, capsys, tmp_path) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+    visibility_path = tmp_path / "visibility.jsonl"
+    calls: dict[str, object] = {}
+
+    async def create_pool(database_url):
+        calls["database_url"] = database_url
+        return pool
+
+    async def progress_from_postgres(pool_arg, *, llm, skills, config):
+        calls["pool"] = pool_arg
+        calls["llm"] = llm
+        calls["skills"] = skills
+        calls["config"] = config
+        return CampaignSequenceProgressionResult(
+            due_sequences=2,
+            progressed=1,
+            skipped=1,
+            disabled=False,
+        )
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli,
+        "progress_campaign_sequences_from_postgres",
+        progress_from_postgres,
+    )
+    monkeypatch.setattr(cli, "get_skill_registry", lambda root=None: _Skills())
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "progress",
+            "--database-url",
+            "postgres://example",
+            "--limit",
+            "4",
+            "--max-steps",
+            "3",
+            "--from-email",
+            "sales@example.com",
+            "--llm",
+            "offline",
+            "--json",
+            "--visibility-jsonl",
+            str(visibility_path),
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["progressed"] == 1
+    assert calls["database_url"] == "postgres://example"
+    assert calls["pool"] is pool
+    assert pool.closed is True
+    events = read_jsonl_visibility_events(visibility_path)
+    assert [row["event_type"] for row in events] == [
+        "campaign_operation_started",
+        "campaign_operation_completed",
+    ]
+    assert events[0]["payload"] == {
+        "limit": 4,
+        "max_steps": 3,
+        "operation": "sequence_progression",
+    }
+    assert events[1]["payload"]["result"] == {
+        "disabled": False,
+        "due_sequences": 2,
+        "progressed": 1,
+        "skipped": 1,
+    }

--- a/tests/test_extracted_campaign_visibility.py
+++ b/tests/test_extracted_campaign_visibility.py
@@ -8,12 +8,21 @@ import pytest
 from extracted_content_pipeline.campaign_visibility import (
     InMemoryVisibilitySink,
     JsonlVisibilitySink,
+    OPERATION_STARTED_EVENT,
+    emit_operation_event,
     read_jsonl_visibility_events,
+    visibility_result_summary,
 )
 
 
 def _clock() -> datetime:
     return datetime(2026, 5, 5, 19, 20, tzinfo=timezone.utc)
+
+
+class _FailingSink:
+    async def emit(self, event_type: str, payload: dict[str, object]) -> None:
+        _ = event_type, payload
+        raise RuntimeError("visibility path unavailable")
 
 
 @pytest.mark.asyncio
@@ -97,3 +106,28 @@ async def test_read_jsonl_visibility_events_respects_limit(tmp_path: Path) -> No
         row["event_type"]
         for row in read_jsonl_visibility_events(path, limit=2)
     ] == ["two", "three"]
+
+
+def test_visibility_result_summary_compacts_sequence_fields() -> None:
+    assert visibility_result_summary({
+        "generated": 3,
+        "saved_ids": ["one", "two"],
+        "errors": ["bad"],
+        "raw_rows": [{"large": True}],
+        "refreshed": True,
+    }) == {
+        "generated": 3,
+        "saved_ids_count": 2,
+        "error_count": 1,
+        "refreshed": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_emit_operation_event_is_best_effort() -> None:
+    await emit_operation_event(
+        _FailingSink(),
+        OPERATION_STARTED_EVENT,
+        "draft_generation",
+        {"limit": 3},
+    )


### PR DESCRIPTION
## Summary
- add shared campaign visibility event constants, result summarization, and best-effort emit helper
- wire `--visibility-jsonl` into draft generation, queued send, sequence progression, and analytics refresh CLIs
- document the non-FastAPI JSONL operation audit path and record the D18 coordination claim

## Validation
- `python -m py_compile extracted_content_pipeline/campaign_visibility.py scripts/run_extracted_campaign_generation_postgres.py scripts/send_extracted_campaigns.py scripts/progress_extracted_campaign_sequences.py scripts/refresh_extracted_campaign_analytics.py tests/test_extracted_campaign_visibility.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_postgres_send.py tests/test_extracted_campaign_postgres_sequence_progression.py tests/test_extracted_campaign_postgres_analytics.py`
- `pytest tests/test_extracted_campaign_visibility.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_postgres_send.py tests/test_extracted_campaign_postgres_sequence_progression.py tests/test_extracted_campaign_postgres_analytics.py`
- `bash scripts/run_extracted_pipeline_checks.sh`