### PR TITLE
Clean up D18 coordination row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-05T19:42Z by codex-2026-05-05-d18
+Last updated: 2026-05-06T01:40Z by codex-2026-05-05-d18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBA | D18 campaign worker CLI JSONL visibility | campaign worker scripts, campaign visibility tests/docs/status | codex-2026-05-05-d18 | Avoid editing host-facing AI Content Ops worker CLI visibility wiring until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
## Summary
- remove the merged D18 campaign worker CLI visibility row from the in-flight coordination table
- refresh the coordination timestamp

## Validation
- `git diff --check`