### PR TITLE
Add campaign visibility reader CLI

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T01:40Z by codex-2026-05-05-d18
+Last updated: 2026-05-06T01:45Z by codex-2026-05-05-d19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBA | D19 campaign visibility reader CLI | campaign visibility scripts/tests/docs/status | codex-2026-05-05-d19 | Avoid editing AI Content Ops JSONL visibility reader wiring until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -409,6 +409,11 @@ python scripts/send_extracted_campaigns.py \
   --provider resend \
   --default-from-email audit@customer.com \
   --visibility-jsonl /var/log/content-ops/campaign-events.jsonl
+
+python scripts/read_extracted_campaign_visibility.py \
+  /var/log/content-ops/campaign-events.jsonl \
+  --operation send_queued \
+  --limit 10
 ```
 
 Hosts with FastAPI apps can mount draft generation, send, sequence progression,

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -120,6 +120,9 @@
   hosts: an in-memory sink for local dashboards/tests, a JSONL sink for
   append-only operation audit trails, and shared event helpers used by hosted
   operation routes and worker CLIs.
+- `scripts/read_extracted_campaign_visibility.py` gives lightweight worker
+  installs a read-only way to filter and inspect JSONL operation audit trails
+  without mounting the hosted operations router.
 - Small task utility helpers are product-owned rather than Atlas-synced:
   `_execution_progress`, `_google_news`, `_blog_ts`, `_blog_deploy`, and
   `_b2b_batch_utils`, and `_blog_matching`.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -445,7 +445,14 @@ python scripts/progress_extracted_campaign_sequences.py \
 Add `--visibility-jsonl /var/log/content-ops/campaign-events.jsonl` to the
 generation, send, sequence progression, or analytics CLIs when the host wants a
 file-backed operation audit trail without mounting the FastAPI operations
-router.
+router. Inspect the same file with:
+
+```bash
+python scripts/read_extracted_campaign_visibility.py \
+  /var/log/content-ops/campaign-events.jsonl \
+  --json \
+  --limit 20
+```
 
 Or mount the hosted operations router in a FastAPI app for admin-triggered
 draft generation, send, sequence progression, and analytics refresh actions:

--- a/scripts/read_extracted_campaign_visibility.py
+++ b/scripts/read_extracted_campaign_visibility.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Read campaign operation visibility events from a JSONL audit trail."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_visibility import (  # noqa: E402
+    read_jsonl_visibility_events,
+)
+
+
+DEFAULT_LIMIT = 20
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read campaign operation visibility events from a JSONL file."
+    )
+    parser.add_argument("path", type=Path, help="Visibility JSONL file to read.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="Maximum matching events to return.",
+    )
+    parser.add_argument("--operation", help="Filter by payload.operation.")
+    parser.add_argument("--event-type", help="Filter by event_type.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of concise text lines.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional output path.")
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.limit) <= 0:
+        raise SystemExit("Invalid --limit: must be greater than 0")
+
+
+def _event_payload(row: dict[str, Any]) -> dict[str, Any]:
+    payload = row.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _matches_event(
+    row: dict[str, Any],
+    *,
+    operation: str | None,
+    event_type: str | None,
+) -> bool:
+    if event_type and row.get("event_type") != event_type:
+        return False
+    payload = _event_payload(row)
+    if operation and payload.get("operation") != operation:
+        return False
+    return True
+
+
+def _filtered_events(args: argparse.Namespace) -> list[dict[str, Any]]:
+    rows = read_jsonl_visibility_events(args.path)
+    matched = [
+        row
+        for row in rows
+        if _matches_event(
+            row,
+            operation=args.operation,
+            event_type=args.event_type,
+        )
+    ]
+    return matched[-int(args.limit) :]
+
+
+def _format_event(row: dict[str, Any]) -> str:
+    payload = _event_payload(row)
+    parts = [
+        str(row.get("emitted_at") or ""),
+        str(row.get("event_type") or ""),
+        f"operation={payload.get('operation') or '-'}",
+    ]
+    if payload.get("error_type"):
+        parts.append(f"error_type={payload['error_type']}")
+    result = payload.get("result")
+    if isinstance(result, dict):
+        parts.append(f"result={json.dumps(result, sort_keys=True)}")
+    return " ".join(part for part in parts if part)
+
+
+def _render_output(rows: list[dict[str, Any]], *, as_json: bool) -> str:
+    if as_json:
+        return json.dumps(
+            {"count": len(rows), "events": rows},
+            indent=2,
+            sort_keys=True,
+        )
+    return "\n".join(_format_event(row) for row in rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    rows = _filtered_events(args)
+    output = _render_output(rows, as_json=bool(args.json))
+    if args.output:
+        args.output.write_text(f"{output}\n", encoding="utf-8")
+    elif output:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -13,6 +13,7 @@ python scripts/audit_extracted_standalone.py --fail-on-debt
 pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_visibility.py \
+  tests/test_extracted_campaign_visibility_reader_cli.py \
   tests/test_extracted_campaign_manifest.py \
   tests/test_extracted_campaign_generation_seams.py \
   tests/test_extracted_campaign_generation.py \

--- a/tests/test_extracted_campaign_visibility_reader_cli.py
+++ b/tests/test_extracted_campaign_visibility_reader_cli.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_visibility import JsonlVisibilitySink
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/read_extracted_campaign_visibility.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "read_extracted_campaign_visibility",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _clock() -> datetime:
+    return datetime(2026, 5, 5, 20, 0, tzinfo=timezone.utc)
+
+
+async def _write_events(path: Path) -> None:
+    sink = JsonlVisibilitySink(path, clock=_clock)
+    await sink.emit(
+        "campaign_operation_started",
+        {"operation": "draft_generation", "limit": 2},
+    )
+    await sink.emit(
+        "campaign_operation_failed",
+        {
+            "operation": "send_queued",
+            "error_type": "reported_failures",
+            "result": {"failed": 1, "sent": 0},
+        },
+    )
+    await sink.emit(
+        "campaign_operation_completed",
+        {
+            "operation": "send_queued",
+            "result": {"failed": 0, "sent": 2},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_visibility_reader_cli_filters_operation_and_emits_json(
+    tmp_path,
+    capsys,
+) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "events.jsonl"
+    await _write_events(path)
+
+    exit_code = cli.main([
+        str(path),
+        "--operation",
+        "send_queued",
+        "--json",
+    ])
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["count"] == 2
+    assert [row["event_type"] for row in output["events"]] == [
+        "campaign_operation_failed",
+        "campaign_operation_completed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_visibility_reader_cli_filters_event_type_and_limit(
+    tmp_path,
+    capsys,
+) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "events.jsonl"
+    await _write_events(path)
+
+    exit_code = cli.main([
+        str(path),
+        "--event-type",
+        "campaign_operation_completed",
+        "--limit",
+        "1",
+    ])
+
+    output = capsys.readouterr().out.strip()
+    assert exit_code == 0
+    assert "campaign_operation_completed" in output
+    assert "operation=send_queued" in output
+    assert 'result={"failed": 0, "sent": 2}' in output
+
+
+@pytest.mark.asyncio
+async def test_visibility_reader_cli_writes_output_file(tmp_path, capsys) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "events.jsonl"
+    output_path = tmp_path / "events-summary.json"
+    await _write_events(path)
+
+    exit_code = cli.main([
+        str(path),
+        "--event-type",
+        "campaign_operation_failed",
+        "--json",
+        "--output",
+        str(output_path),
+    ])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output["count"] == 1
+    assert output["events"][0]["payload"]["error_type"] == "reported_failures"
+
+
+def test_visibility_reader_cli_rejects_non_positive_limit(tmp_path) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "events.jsonl"
+    path.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="Invalid --limit"):
+        cli.main([str(path), "--limit", "0"])


### PR DESCRIPTION
## Summary
- add a read-only `read_extracted_campaign_visibility.py` CLI for JSONL campaign operation audit trails
- support filtering by operation/event type, limiting, JSON output, and output files
- document the reader in the README/runbook/status and include its tests in the extracted pipeline check runner

## Validation
- `python -m py_compile scripts/read_extracted_campaign_visibility.py tests/test_extracted_campaign_visibility_reader_cli.py`
- `pytest tests/test_extracted_campaign_visibility.py tests/test_extracted_campaign_visibility_reader_cli.py`
- `bash scripts/run_extracted_pipeline_checks.sh`