### PR TITLE
Clean up D19 coordination row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T01:45Z by codex-2026-05-05-d19
+Last updated: 2026-05-06T01:56Z by codex-2026-05-05-d19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBA | D19 campaign visibility reader CLI | campaign visibility scripts/tests/docs/status | codex-2026-05-05-d19 | Avoid editing AI Content Ops JSONL visibility reader wiring until this PR lands |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
## Summary
- remove the merged D19 visibility reader row from the in-flight coordination table
- refresh the coordination timestamp

## Validation
- `git diff --check`