### PR TITLE
PR-D20a: Implement run_reasoning() (single-pass lift from b2b_reasoning_synthesis)

### DIFF
--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import re
+from dataclasses import asdict, is_dataclass
 from typing import Any, Mapping, Sequence
 
 from .types import (
@@ -31,6 +34,12 @@ from .tiers import (
     get_tier_config,
     needs_refresh,
 )
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when reasoning core is missing a required host port."""
+
+
 from .wedge_registry import (
     WEDGE_ENUM_VALUES,
     Wedge,
@@ -234,12 +243,411 @@ async def run_reasoning(
     pack: ReasoningPack | None = None,
     ports: ReasoningPorts | None = None,
 ) -> ReasoningResult:
-    """Run the shared reasoning engine."""
-    del reasoning_input
-    del depth
-    del pack
-    del ports
-    raise NotImplementedError("run_reasoning lands with graph/state consolidation")
+    """Run the single-pass reasoning synthesis flow.
+
+    This is the extracted, product-neutral lift of the production
+    per-vendor synthesis loop: build one prompt from already-prepared
+    evidence/witness context, call the shared LLM port, validate the JSON
+    response, and retry with compact validation feedback when validation
+    fails. Host-owned witness compression stays outside this package and
+    is supplied either through ``ReasoningPorts.witness_context`` or the
+    input context.
+    """
+
+    port_bundle = ports or ReasoningPorts()
+    if port_bundle.llm is None:
+        raise ConfigurationError(
+            "run_reasoning requires ReasoningPorts.llm; provide an "
+            "extracted_llm_infrastructure-backed LLM port."
+        )
+
+    effective_pack = pack or ReasoningPack(
+        name=reasoning_input.pack_name or "reasoning_synthesis",
+        prompts={},
+        policies={},
+    )
+    policies = dict(effective_pack.policies or {})
+    max_attempts = max(1, int(policies.get("max_attempts", 2)))
+    feedback_limit = max(1, int(policies.get("feedback_limit", 5)))
+    max_tokens = max(1, int(policies.get("max_tokens", 16384)))
+    temperature = float(policies.get("temperature", 0.3))
+
+    witness_context = await _resolve_witness_context(
+        reasoning_input,
+        depth=depth,
+        pack=effective_pack,
+        ports=port_bundle,
+    )
+    system_prompt = _resolve_reasoning_prompt(effective_pack)
+    payload = _build_reasoning_payload(
+        reasoning_input,
+        depth=depth,
+        pack=effective_pack,
+        witness_context=witness_context,
+    )
+    payload_text = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+    trace_sink = port_bundle.trace_sink
+    span = None
+    if trace_sink is not None:
+        span = trace_sink.start_span(
+            "extracted_reasoning_core.run_reasoning",
+            metadata={
+                "entity_id": reasoning_input.entity_id,
+                "entity_type": reasoning_input.entity_type,
+                "depth": depth,
+                "pack": effective_pack.name,
+            },
+        )
+
+    attempts: list[dict[str, Any]] = []
+    failure_reasons: list[str] = []
+    last_text = ""
+    last_candidate: dict[str, Any] | None = None
+    total_tokens = 0
+
+    try:
+        for attempt_index in range(max_attempts):
+            attempt_no = attempt_index + 1
+            messages: list[Mapping[str, Any]] = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": payload_text},
+            ]
+            if attempt_index > 0 and last_text:
+                messages.append({"role": "assistant", "content": last_text})
+            if attempt_index > 0 and failure_reasons:
+                feedback = "\n".join(
+                    f"- {reason}" for reason in failure_reasons[:feedback_limit]
+                )
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        "Your previous response was rejected. Return a complete "
+                        "corrected JSON object only.\nFix these issues:\n"
+                        f"{feedback}"
+                    ),
+                })
+
+            response = await port_bundle.llm.complete(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                metadata={
+                    "entity_id": reasoning_input.entity_id,
+                    "entity_type": reasoning_input.entity_type,
+                    "goal": reasoning_input.goal,
+                    "depth": depth,
+                    "pack": effective_pack.name,
+                    "attempt_no": attempt_no,
+                    "reasoning_mode": "single_pass_synthesis",
+                },
+            )
+            text = _response_text(response)
+            last_text = _clean_reasoning_text(text)
+            usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
+            attempt_tokens = _usage_tokens(usage)
+            total_tokens += attempt_tokens
+
+            parsed = _parse_llm_json(last_text)
+            validation = _validate_reasoning_candidate(parsed)
+            attempts.append({
+                "attempt_no": attempt_no,
+                "valid": validation["valid"],
+                "errors": tuple(validation["errors"]),
+                "warnings": tuple(validation["warnings"]),
+                "tokens_used": attempt_tokens,
+            })
+
+            if validation["valid"]:
+                assert isinstance(parsed, dict)
+                last_candidate = parsed
+                result = _candidate_to_reasoning_result(
+                    parsed,
+                    reasoning_input=reasoning_input,
+                    depth=depth,
+                    pack=effective_pack,
+                    witness_context=witness_context,
+                    attempts=attempts,
+                    tokens_used=total_tokens,
+                )
+                if port_bundle.event_sink is not None:
+                    await port_bundle.event_sink.emit(
+                        "reasoning.synthesis.completed",
+                        "extracted_reasoning_core.run_reasoning",
+                        {"attempts_used": attempt_no, "tokens_used": total_tokens},
+                        entity_type=reasoning_input.entity_type,
+                        entity_id=reasoning_input.entity_id,
+                    )
+                if trace_sink is not None and span is not None:
+                    trace_sink.end_span(
+                        span,
+                        status="ok",
+                        metadata={"attempts_used": attempt_no, "tokens_used": total_tokens},
+                    )
+                return result
+
+            failure_reasons = list(validation["errors"])
+
+        error_text = "; ".join(failure_reasons[:2])[:200] or "validation failed"
+        if port_bundle.event_sink is not None:
+            await port_bundle.event_sink.emit(
+                "reasoning.synthesis.validation_failed",
+                "extracted_reasoning_core.run_reasoning",
+                {
+                    "attempts_used": max_attempts,
+                    "tokens_used": total_tokens,
+                    "errors": tuple(failure_reasons[:feedback_limit]),
+                },
+                entity_type=reasoning_input.entity_type,
+                entity_id=reasoning_input.entity_id,
+            )
+        if trace_sink is not None and span is not None:
+            trace_sink.end_span(
+                span,
+                status="error",
+                metadata={"attempts_used": max_attempts, "error_text": error_text},
+            )
+        return ReasoningResult(
+            summary="Reasoning synthesis failed validation",
+            claims=(),
+            confidence=0.0,
+            tier=depth,
+            state={
+                "status": "failed",
+                "succeeded": False,
+                "stage": "validation",
+                "error_text": error_text,
+                "reasons": tuple(failure_reasons[:feedback_limit]),
+                "attempts_used": max_attempts,
+                "tokens_used": total_tokens,
+            },
+            trace={
+                "attempts": tuple(attempts),
+                "last_response": last_text,
+                "last_candidate": last_candidate or {},
+                "witness_context_present": bool(witness_context),
+            },
+        )
+    except Exception:
+        if trace_sink is not None and span is not None:
+            trace_sink.end_span(span, status="error", metadata={"stage": "exception"})
+        raise
+
+
+async def _resolve_witness_context(
+    reasoning_input: ReasoningInput,
+    *,
+    depth: ReasoningDepth,
+    pack: ReasoningPack,
+    ports: ReasoningPorts,
+) -> Mapping[str, Any]:
+    if ports.witness_context is not None:
+        return dict(await ports.witness_context.get_witness_context(
+            reasoning_input,
+            depth=depth,
+            pack=pack,
+        ))
+    context = dict(reasoning_input.context or {})
+    for key in ("witness_context", "compressed_witness_context", "witness_pack"):
+        value = context.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return {}
+
+
+def _resolve_reasoning_prompt(pack: ReasoningPack) -> str:
+    for key in ("reasoning_synthesis", "system", "prompt"):
+        prompt = str((pack.prompts or {}).get(key) or "").strip()
+        if prompt:
+            return prompt
+    from .skills.registry import get_skill_registry
+
+    registry = get_skill_registry()
+    return registry.get_prompt("digest/reasoning_synthesis") or (
+        "Return a valid JSON reasoning synthesis with summary, claims, and confidence."
+    )
+
+
+def _build_reasoning_payload(
+    reasoning_input: ReasoningInput,
+    *,
+    depth: ReasoningDepth,
+    pack: ReasoningPack,
+    witness_context: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return {
+        "entity_id": reasoning_input.entity_id,
+        "entity_type": reasoning_input.entity_type,
+        "goal": reasoning_input.goal,
+        "depth": depth,
+        "pack": {"name": pack.name, "version": pack.version},
+        "evidence": tuple(_evidence_to_mapping(item) for item in reasoning_input.evidence),
+        "context": dict(reasoning_input.context or {}),
+        "witness_context": dict(witness_context or {}),
+    }
+
+
+def _evidence_to_mapping(item: EvidenceItem) -> Mapping[str, Any]:
+    if is_dataclass(item):
+        return asdict(item)
+    return dict(item)  # type: ignore[arg-type]
+
+
+def _response_text(response: Mapping[str, Any]) -> str:
+    for key in ("response", "content", "text"):
+        value = response.get(key)
+        if value is not None:
+            return str(value)
+    message = response.get("message")
+    if isinstance(message, Mapping) and message.get("content") is not None:
+        return str(message.get("content"))
+    return json.dumps(response, default=str)
+
+
+def _clean_reasoning_text(text: str) -> str:
+    cleaned = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
+    if "<scratchpad>" in cleaned:
+        cleaned = cleaned.split("</scratchpad>")[-1].strip()
+    return cleaned
+
+
+def _parse_llm_json(text: str) -> Any:
+    try:
+        from extracted_llm_infrastructure.pipelines.llm import parse_json_response
+    except ImportError:
+        parse_json_response = None
+    if parse_json_response is not None:
+        return parse_json_response(text, recover_truncated=True)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _validate_reasoning_candidate(candidate: Any) -> Mapping[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not isinstance(candidate, dict):
+        return {"valid": False, "errors": ("LLM did not return a JSON object",), "warnings": ()}
+    if candidate.get("_parse_fallback"):
+        return {"valid": False, "errors": ("LLM did not return valid JSON",), "warnings": ()}
+    summary = _extract_summary(candidate)
+    claims = _extract_claims(candidate)
+    if not summary:
+        errors.append("missing_summary")
+    if not claims:
+        errors.append("missing_claims")
+    confidence = _extract_confidence(candidate, claims)
+    if confidence <= 0.0:
+        warnings.append("zero_or_missing_confidence")
+    return {"valid": not errors, "errors": tuple(errors), "warnings": tuple(warnings)}
+
+
+def _extract_summary(candidate: Mapping[str, Any]) -> str:
+    for key in ("summary", "executive_summary", "causal_narrative"):
+        value = candidate.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, Mapping):
+            nested = _extract_summary(value)
+            if nested:
+                return nested
+    contracts = candidate.get("reasoning_contracts")
+    if isinstance(contracts, Mapping):
+        for value in contracts.values():
+            if isinstance(value, Mapping):
+                nested = _extract_summary(value)
+                if nested:
+                    return nested
+    return ""
+
+
+def _extract_claims(candidate: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    raw = candidate.get("claims")
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        claims = tuple(dict(item) if isinstance(item, Mapping) else {"claim": str(item)} for item in raw)
+        if claims:
+            return claims
+    contracts = candidate.get("reasoning_contracts")
+    found: list[Mapping[str, Any]] = []
+    if isinstance(contracts, Mapping):
+        _collect_contract_claims(contracts, found)
+    return tuple(found)
+
+
+def _collect_contract_claims(value: Mapping[str, Any], found: list[Mapping[str, Any]]) -> None:
+    for key, item in value.items():
+        if not isinstance(item, Mapping):
+            continue
+        claim_text = item.get("claim") or item.get("summary") or item.get("narrative")
+        if claim_text:
+            found.append({"claim": str(claim_text), "section": str(key), **dict(item)})
+        nested = item.get("claims") or item.get("sections")
+        if isinstance(nested, Mapping):
+            _collect_contract_claims(nested, found)
+
+
+def _extract_confidence(candidate: Mapping[str, Any], claims: Sequence[Mapping[str, Any]]) -> float:
+    rank = {"high": 0.9, "medium": 0.6, "low": 0.3, "insufficient": 0.0}
+    raw = candidate.get("confidence")
+    if raw is not None:
+        try:
+            return max(0.0, min(1.0, float(raw)))
+        except (TypeError, ValueError):
+            return rank.get(str(raw).strip().lower(), 0.0)
+    values: list[float] = []
+    for claim in claims:
+        value = claim.get("confidence")
+        try:
+            values.append(float(value))
+        except (TypeError, ValueError):
+            values.append(rank.get(str(value or "").strip().lower(), 0.0))
+    return max(values) if values else 0.0
+
+
+def _candidate_to_reasoning_result(
+    candidate: Mapping[str, Any],
+    *,
+    reasoning_input: ReasoningInput,
+    depth: ReasoningDepth,
+    pack: ReasoningPack,
+    witness_context: Mapping[str, Any],
+    attempts: Sequence[Mapping[str, Any]],
+    tokens_used: int,
+) -> ReasoningResult:
+    claims = _extract_claims(candidate)
+    confidence = _extract_confidence(candidate, claims)
+    return ReasoningResult(
+        summary=_extract_summary(candidate),
+        claims=claims,
+        confidence=confidence,
+        tier=depth,
+        state={
+            "status": "completed",
+            "succeeded": True,
+            "entity_id": reasoning_input.entity_id,
+            "entity_type": reasoning_input.entity_type,
+            "goal": reasoning_input.goal,
+            "pack": pack.name,
+            "pack_version": pack.version,
+            "attempts_used": len(attempts),
+            "tokens_used": tokens_used,
+            "raw_synthesis": dict(candidate),
+        },
+        trace={
+            "attempts": tuple(attempts),
+            "witness_context_present": bool(witness_context),
+            "validation_warnings": tuple(
+                warning
+                for attempt in attempts
+                for warning in attempt.get("warnings", ())
+            ),
+        },
+    )
+
+
+def _usage_tokens(usage: Mapping[str, Any]) -> int:
+    return int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0)
 
 
 async def continue_reasoning(
@@ -317,6 +725,7 @@ __all__ = [
     "NarrativePlan",
     "OutputPolicy",
     "ReasoningDepth",
+    "ConfigurationError",
     "ReasoningAgentState",
     "ReasoningInput",
     "ReasoningPack",

--- a/extracted_reasoning_core/ports.py
+++ b/extracted_reasoning_core/ports.py
@@ -36,6 +36,23 @@ class SemanticCacheStore(Protocol):
         """Invalidate a cached entry."""
 
 
+class WitnessContextPort(Protocol):
+    """Port for host-prepared compressed witness context.
+
+    Pool compression and witness grounding stay host-side; reasoning core only
+    consumes an already-normalized context mapping through this port.
+    """
+
+    async def get_witness_context(
+        self,
+        reasoning_input: Any,
+        *,
+        depth: str,
+        pack: Any | None = None,
+    ) -> Mapping[str, Any]:
+        """Return compressed witness context for a reasoning input."""
+
+
 class ReasoningStateStore(Protocol):
     """Port for long-running reasoning state and continuation checkpoints."""
 
@@ -124,4 +141,5 @@ __all__ = [
     "ReasoningStateStore",
     "SemanticCacheStore",
     "TraceSink",
+    "WitnessContextPort",
 ]

--- a/extracted_reasoning_core/skills/__init__.py
+++ b/extracted_reasoning_core/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Markdown-backed prompts for extracted reasoning core."""

--- a/extracted_reasoning_core/skills/digest/reasoning_synthesis.md
+++ b/extracted_reasoning_core/skills/digest/reasoning_synthesis.md
@@ -1,0 +1,12 @@
+You are the shared Atlas reasoning synthesis engine.
+
+Return one complete JSON object only. Do not include markdown fences.
+
+Required fields:
+- summary: concise synthesis of the strongest supported reasoning.
+- claims: a non-empty array of claim objects. Each claim should include a claim
+  or text field, confidence, and citations/source_ids where available.
+- confidence: numeric confidence from 0.0 to 1.0 or one of high/medium/low/insufficient.
+
+Use only the supplied evidence and witness context. If support is insufficient,
+state that explicitly in the summary and lower the confidence.

--- a/extracted_reasoning_core/skills/registry.py
+++ b/extracted_reasoning_core/skills/registry.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_PACKAGE_SKILL_ROOT = Path(__file__).resolve().parent
+
+
+@dataclass
+class LocalSkill:
+    name: str
+    content: str
+    path: Path | None = None
+
+
+class LocalSkillRegistry:
+    """Markdown-backed skill registry for reasoning-core prompts."""
+
+    def __init__(self, roots: Path | str | Sequence[Path | str]) -> None:
+        self.roots = _normalize_roots(roots)
+
+    def get(self, name: str):
+        rel = _skill_relative_path(name)
+        if rel is None:
+            return None
+        for root in self.roots:
+            path = root / rel
+            if path.exists() and path.is_file():
+                return LocalSkill(
+                    name=_skill_name_from_path(rel),
+                    content=path.read_text(encoding="utf-8"),
+                    path=path,
+                )
+        return None
+
+    def get_prompt(self, name: str) -> str | None:
+        skill = self.get(name)
+        return skill.content if skill else None
+
+
+def get_skill_registry(
+    root: Path | str | None = None,
+    *,
+    roots: Sequence[Path | str] = (),
+    include_package: bool = True,
+):
+    """Return a markdown skill registry.
+
+    Host roots are searched before packaged skills, matching the extracted
+    content pipeline skill registry pattern so hosts can override prompts.
+    """
+
+    search_roots: list[Path | str] = []
+    if root is not None:
+        search_roots.append(root)
+    search_roots.extend(roots)
+    if include_package:
+        search_roots.append(_PACKAGE_SKILL_ROOT)
+    return LocalSkillRegistry(search_roots)
+
+
+def _normalize_roots(roots: Path | str | Sequence[Path | str]) -> tuple[Path, ...]:
+    if isinstance(roots, (str, Path)):
+        values: Sequence[Path | str] = (roots,)
+    else:
+        values = roots
+    normalized: list[Path] = []
+    for value in values:
+        path = Path(value).expanduser()
+        if path not in normalized:
+            normalized.append(path)
+    return tuple(normalized)
+
+
+def _skill_relative_path(name: Any) -> Path | None:
+    raw = str(name or "").replace("\\", "/").strip().strip("/")
+    if not raw:
+        return None
+    if raw.endswith(".md"):
+        raw = raw[:-3]
+    parts = [part for part in raw.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        return None
+    path = Path(*parts)
+    if path.is_absolute():
+        return None
+    return path.with_suffix(".md")
+
+
+def _skill_name_from_path(path: Path) -> str:
+    return path.with_suffix("").as_posix()
+
+
+__all__ = ["LocalSkill", "LocalSkillRegistry", "get_skill_registry"]

--- a/extracted_reasoning_core/types.py
+++ b/extracted_reasoning_core/types.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping, Sequence
 
-from .ports import Clock, EventSink, LLMClient, ReasoningStateStore, SemanticCacheStore, TraceSink
+from .ports import (
+    Clock,
+    EventSink,
+    LLMClient,
+    ReasoningStateStore,
+    SemanticCacheStore,
+    TraceSink,
+    WitnessContextPort,
+)
 from .wedge_registry import Wedge, WedgeMeta
 
 
@@ -49,6 +57,7 @@ class ReasoningPorts:
     clock: Clock | None = None
     event_sink: EventSink | None = None
     trace_sink: TraceSink | None = None
+    witness_context: WitnessContextPort | None = None
 
 
 @dataclass(frozen=True)

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -44,6 +44,7 @@ pytest \
   tests/test_extracted_content_pipeline_reasoning_temporal.py \
   tests/test_extracted_content_pipeline_reasoning_evidence_engine.py \
   tests/test_extracted_reasoning_core_api.py \
+  tests/test_extracted_reasoning_core_run_reasoning.py \
   tests/test_extracted_reasoning_core_archetypes.py \
   tests/test_extracted_reasoning_core_evidence_engine.py \
   tests/test_extracted_reasoning_core_event_trace_ports.py \

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -233,7 +233,7 @@ async def test_stubbed_async_entry_points_fail_closed_until_consolidated() -> No
         evidence=(evidence,),
     )
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(api.ConfigurationError):
         await api.run_reasoning(reasoning_input)
 
     with pytest.raises(NotImplementedError):

--- a/tests/test_extracted_reasoning_core_run_reasoning.py
+++ b/tests/test_extracted_reasoning_core_run_reasoning.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from extracted_reasoning_core.api import ConfigurationError, run_reasoning
+from extracted_reasoning_core.types import (
+    EvidenceItem,
+    ReasoningInput,
+    ReasoningPack,
+    ReasoningPorts,
+    ReasoningResult,
+)
+
+
+class FakeLLMPort:
+    def __init__(self, responses: Sequence[Mapping[str, Any]]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        return self.responses.pop(0)
+
+
+class FakeWitnessContextPort:
+    def __init__(self, context: Mapping[str, Any]) -> None:
+        self.context = dict(context)
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_witness_context(
+        self,
+        reasoning_input: Any,
+        *,
+        depth: str,
+        pack: Any | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "entity_id": reasoning_input.entity_id,
+            "depth": depth,
+            "pack": getattr(pack, "name", None),
+        })
+        return self.context
+
+
+def _input() -> ReasoningInput:
+    return ReasoningInput(
+        entity_id="acme",
+        entity_type="vendor",
+        goal="synthesize vendor pressure",
+        evidence=(
+            EvidenceItem(
+                source_type="review",
+                source_id="r1",
+                text="Buyers mention renewal pricing pressure.",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_happy_path_populates_result_with_ports() -> None:
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "summary": "Pricing pressure is the strongest supported wedge.",
+                "claims": [
+                    {
+                        "claim": "Renewal pricing is creating displacement pressure.",
+                        "confidence": "high",
+                        "source_ids": ["r1"],
+                    }
+                ],
+                "confidence": 0.84,
+            }),
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+    ])
+    witness = FakeWitnessContextPort({"witness_pack": [{"id": "w1"}]})
+
+    result = await run_reasoning(
+        _input(),
+        depth="L2",
+        pack=ReasoningPack(
+            name="reasoning_synthesis",
+            prompts={"reasoning_synthesis": "Return JSON."},
+            policies={"max_attempts": 2, "max_tokens": 1000, "temperature": 0.1},
+        ),
+        ports=ReasoningPorts(llm=llm, witness_context=witness),
+    )
+
+    assert isinstance(result, ReasoningResult)
+    assert result.summary == "Pricing pressure is the strongest supported wedge."
+    assert result.claims[0]["claim"] == "Renewal pricing is creating displacement pressure."
+    assert result.confidence == pytest.approx(0.84)
+    assert result.tier == "L2"
+    assert result.state["status"] == "completed"
+    assert result.state["attempts_used"] == 1
+    assert result.state["tokens_used"] == 15
+    assert result.trace["witness_context_present"] is True
+    assert witness.calls == [{"entity_id": "acme", "depth": "L2", "pack": "reasoning_synthesis"}]
+    assert llm.calls[0]["metadata"]["reasoning_mode"] == "single_pass_synthesis"
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_retries_validation_failure_and_returns_final_failure_shape() -> None:
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({"summary": "Missing claims."}),
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        },
+        {
+            "response": json.dumps({"summary": "Still missing claims."}),
+            "usage": {"input_tokens": 4, "output_tokens": 2},
+        },
+    ])
+
+    result = await run_reasoning(
+        _input(),
+        pack=ReasoningPack(
+            name="reasoning_synthesis",
+            prompts={"reasoning_synthesis": "Return JSON."},
+            policies={"max_attempts": 2},
+        ),
+        ports=ReasoningPorts(
+            llm=llm,
+            witness_context=FakeWitnessContextPort({"witness_pack": []}),
+        ),
+    )
+
+    assert len(llm.calls) == 2
+    assert "previous response was rejected" in llm.calls[1]["messages"][-1]["content"]
+    assert "missing_claims" in llm.calls[1]["messages"][-1]["content"]
+    assert result.summary == "Reasoning synthesis failed validation"
+    assert result.claims == ()
+    assert result.confidence == 0.0
+    assert result.state == {
+        "status": "failed",
+        "succeeded": False,
+        "stage": "validation",
+        "error_text": "missing_claims",
+        "reasons": ("missing_claims",),
+        "attempts_used": 2,
+        "tokens_used": 11,
+    }
+    assert tuple(a["valid"] for a in result.trace["attempts"]) == (False, False)
+    assert tuple(a["errors"] for a in result.trace["attempts"]) == (("missing_claims",), ("missing_claims",))
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_missing_llm_port_raises_configuration_error() -> None:
+    with pytest.raises(ConfigurationError, match="ReasoningPorts.llm"):
+        await run_reasoning(
+            _input(),
+            ports=ReasoningPorts(witness_context=FakeWitnessContextPort({})),
+        )


### PR DESCRIPTION
### Motivation
- Provide a real single-pass reasoning runner by lifting the per-vendor synthesis flow (one LLM call per vendor + retry-on-validation-fail) into the extracted core so hosts can call a stable, decoupled surface.
- Keep host-specific responsibilities (pool compression, witness grounding, DB persistence, batching, visibility) out of core and accept already-prepared witness context via a port.

### Description
- Implemented `extracted_reasoning_core.api.run_reasoning()` to: resolve witness context, build a prompt payload, call `ReasoningPorts.llm.complete()`, parse JSON (via `extracted_llm_infrastructure` when available), validate summary/claims/confidence, retry with validation feedback, and return a populated `ReasoningResult` on success or a terminal validation-failure shape on final failure.
- Added `ConfigurationError` to fail clearly when `ReasoningPorts.llm` is missing, and added a `WitnessContextPort` in `ports.py` + `ReasoningPorts.witness_context` to accept host-prepared compressed witness context (keeps pool/witness code host-side).
- Introduced a small markdown-backed skill registry under `extracted_reasoning_core/skills` and a default `digest/reasoning_synthesis.md` prompt so core can load a packaged system prompt if no pack is provided.
- Implemented payload / parsing / validation / result-mapping helpers (`_build_reasoning_payload`, `_parse_llm_json`, `_validate_reasoning_candidate`, `_candidate_to_reasoning_result`, etc.) and preserved the single-pass retry-on-validation semantics from the source task.
- Tests: added `tests/test_extracted_reasoning_core_run_reasoning.py` with a happy-path (fake LLM + fake witness context), a validation-failure retry case asserting retry content and final-failure shape, and a missing-LLM `ConfigurationError` case; updated one existing test to expect `ConfigurationError` for missing LLM.
- Integration decision: Option B — left `atlas_brain/autonomous/tasks/b2b_reasoning_synthesis.py` untouched to avoid the high-risk changes required to convert that 3,903-line production task into a thin wrapper in this scoped PR.

### Testing
- `python -c "import extracted_reasoning_core"` succeeded, verifying no atlas_brain imports at module-load time.
- `python -m py_compile` on modified modules and new tests passed, confirming syntactic validity.
- Direct async smoke exercise of `run_reasoning()` (in-process) passed for both success and missing-LLM `ConfigurationError` cases.
- Added unit tests (`tests/test_extracted_reasoning_core_run_reasoning.py`) covering the happy path, validation-retry behavior, and missing-LLM configuration; tests are included in the branch but running `pytest` in this environment was blocked because `pytest-asyncio` is not installed and network access for pip is blocked by a proxy (attempt to `pip install pytest-asyncio` failed with 403).
- `bash scripts/run_extracted_pipeline_checks.sh` ran and completed the pre-pytest checks; the pytest phase could not execute here due to the `pytest-asyncio` environment limitation.

Notes: diff size is under the 1,500-line guidance (~724 insertions). Option B chosen to minimize risk and scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad23cfab8832eaf736e259f5ae0d0)