### PR TITLE
PR-D20b: Implement continue_reasoning() (multi-pass refinement on prior reasoning state)

### DIFF
--- a/extracted_reasoning_core/_synthesis.py
+++ b/extracted_reasoning_core/_synthesis.py
@@ -1,0 +1,289 @@
+"""Shared synthesis primitives for the reasoning core.
+
+Private module. Provides the LLM-call-with-retry-on-validation-failure loop
+and the parsing/validation/extraction helpers used by both
+``run_reasoning`` and ``continue_reasoning``. Tracing and event-sink
+emission are NOT performed here; public functions own that wrapping so
+they can attach their own span names and event names.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class SynthesisLoopConfig:
+    """Pack-derived policies for the synthesis loop."""
+
+    max_attempts: int = 2
+    feedback_limit: int = 5
+    max_tokens: int = 16384
+    temperature: float = 0.3
+
+
+@dataclass
+class SynthesisLoopResult:
+    """Outcome of one full synthesis loop, success or terminal failure."""
+
+    valid_candidate: dict[str, Any] | None = None
+    attempts: tuple[Mapping[str, Any], ...] = ()
+    total_tokens: int = 0
+    failure_reasons: tuple[str, ...] = ()
+    last_text: str = ""
+    last_candidate: dict[str, Any] | None = None
+    error_text: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.valid_candidate is not None
+
+
+def synthesis_config_from_pack(pack: Any) -> SynthesisLoopConfig:
+    """Read max_attempts / feedback_limit / max_tokens / temperature from a pack."""
+
+    policies = dict(getattr(pack, "policies", None) or {})
+    return SynthesisLoopConfig(
+        max_attempts=max(1, int(policies.get("max_attempts", 2))),
+        feedback_limit=max(1, int(policies.get("feedback_limit", 5))),
+        max_tokens=max(1, int(policies.get("max_tokens", 16384))),
+        temperature=float(policies.get("temperature", 0.3)),
+    )
+
+
+async def invoke_synthesis_loop(
+    *,
+    system_prompt: str,
+    payload_text: str,
+    llm_metadata: Mapping[str, Any],
+    config: SynthesisLoopConfig,
+    llm_port: Any,
+) -> SynthesisLoopResult:
+    """Run system+user prompt through the LLM with validation-feedback retry.
+
+    Pure: no tracing, no event emission. The caller wraps this with whatever
+    span/event semantics they need. ``llm_metadata`` is forwarded into each
+    LLM call so attempt-level metadata (entity_id, reasoning_mode, etc.) is
+    attached at the provider boundary.
+    """
+
+    attempts: list[dict[str, Any]] = []
+    failure_reasons: list[str] = []
+    last_text = ""
+    last_candidate: dict[str, Any] | None = None
+    total_tokens = 0
+
+    for attempt_index in range(config.max_attempts):
+        attempt_no = attempt_index + 1
+        messages: list[Mapping[str, Any]] = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": payload_text},
+        ]
+        if attempt_index > 0 and last_text:
+            messages.append({"role": "assistant", "content": last_text})
+        if attempt_index > 0 and failure_reasons:
+            feedback = "\n".join(
+                f"- {reason}" for reason in failure_reasons[: config.feedback_limit]
+            )
+            messages.append({
+                "role": "user",
+                "content": (
+                    "Your previous response was rejected. Return a complete "
+                    "corrected JSON object only.\nFix these issues:\n"
+                    f"{feedback}"
+                ),
+            })
+
+        response = await llm_port.complete(
+            messages,
+            max_tokens=config.max_tokens,
+            temperature=config.temperature,
+            metadata={**dict(llm_metadata), "attempt_no": attempt_no},
+        )
+        text = _response_text(response)
+        cleaned = _clean_reasoning_text(text)
+        last_text = cleaned
+        usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
+        attempt_tokens = _usage_tokens(usage)
+        total_tokens += attempt_tokens
+
+        parsed = _parse_llm_json(cleaned)
+        validation = _validate_reasoning_candidate(parsed)
+        attempts.append({
+            "attempt_no": attempt_no,
+            "valid": validation["valid"],
+            "errors": tuple(validation["errors"]),
+            "warnings": tuple(validation["warnings"]),
+            "tokens_used": attempt_tokens,
+        })
+
+        if validation["valid"]:
+            assert isinstance(parsed, dict)
+            return SynthesisLoopResult(
+                valid_candidate=parsed,
+                attempts=tuple(attempts),
+                total_tokens=total_tokens,
+                failure_reasons=(),
+                last_text=cleaned,
+                last_candidate=parsed,
+            )
+
+        if isinstance(parsed, dict):
+            last_candidate = parsed
+        failure_reasons = list(validation["errors"])
+
+    error_text = "; ".join(failure_reasons[:2])[:200] or "validation failed"
+    return SynthesisLoopResult(
+        valid_candidate=None,
+        attempts=tuple(attempts),
+        total_tokens=total_tokens,
+        failure_reasons=tuple(failure_reasons[: config.feedback_limit]),
+        last_text=last_text,
+        last_candidate=last_candidate,
+        error_text=error_text,
+    )
+
+
+def evidence_to_mapping(item: Any) -> Mapping[str, Any]:
+    if is_dataclass(item):
+        return asdict(item)
+    if isinstance(item, Mapping):
+        return dict(item)
+    return {"text": str(item)}
+
+
+def _response_text(response: Mapping[str, Any]) -> str:
+    for key in ("response", "content", "text"):
+        value = response.get(key)
+        if value is not None:
+            return str(value)
+    message = response.get("message")
+    if isinstance(message, Mapping) and message.get("content") is not None:
+        return str(message.get("content"))
+    return json.dumps(response, default=str)
+
+
+def _clean_reasoning_text(text: str) -> str:
+    cleaned = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
+    if "<scratchpad>" in cleaned:
+        cleaned = cleaned.split("</scratchpad>")[-1].strip()
+    return cleaned
+
+
+def _parse_llm_json(text: str) -> Any:
+    try:
+        from extracted_llm_infrastructure.pipelines.llm import parse_json_response
+    except ImportError:
+        parse_json_response = None
+    if parse_json_response is not None:
+        return parse_json_response(text, recover_truncated=True)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _validate_reasoning_candidate(candidate: Any) -> Mapping[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not isinstance(candidate, dict):
+        return {"valid": False, "errors": ("LLM did not return a JSON object",), "warnings": ()}
+    if candidate.get("_parse_fallback"):
+        return {"valid": False, "errors": ("LLM did not return valid JSON",), "warnings": ()}
+    summary = extract_summary(candidate)
+    claims = extract_claims(candidate)
+    if not summary:
+        errors.append("missing_summary")
+    if not claims:
+        errors.append("missing_claims")
+    confidence = extract_confidence(candidate, claims)
+    if confidence <= 0.0:
+        warnings.append("zero_or_missing_confidence")
+    return {"valid": not errors, "errors": tuple(errors), "warnings": tuple(warnings)}
+
+
+def extract_summary(candidate: Mapping[str, Any]) -> str:
+    for key in ("summary", "executive_summary", "causal_narrative"):
+        value = candidate.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, Mapping):
+            nested = extract_summary(value)
+            if nested:
+                return nested
+    contracts = candidate.get("reasoning_contracts")
+    if isinstance(contracts, Mapping):
+        for value in contracts.values():
+            if isinstance(value, Mapping):
+                nested = extract_summary(value)
+                if nested:
+                    return nested
+    return ""
+
+
+def extract_claims(candidate: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    raw = candidate.get("claims")
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        claims = tuple(
+            dict(item) if isinstance(item, Mapping) else {"claim": str(item)}
+            for item in raw
+        )
+        if claims:
+            return claims
+    contracts = candidate.get("reasoning_contracts")
+    found: list[Mapping[str, Any]] = []
+    if isinstance(contracts, Mapping):
+        _collect_contract_claims(contracts, found)
+    return tuple(found)
+
+
+def _collect_contract_claims(value: Mapping[str, Any], found: list[Mapping[str, Any]]) -> None:
+    for key, item in value.items():
+        if not isinstance(item, Mapping):
+            continue
+        claim_text = item.get("claim") or item.get("summary") or item.get("narrative")
+        if claim_text:
+            found.append({"claim": str(claim_text), "section": str(key), **dict(item)})
+        nested = item.get("claims") or item.get("sections")
+        if isinstance(nested, Mapping):
+            _collect_contract_claims(nested, found)
+
+
+def extract_confidence(
+    candidate: Mapping[str, Any],
+    claims: Sequence[Mapping[str, Any]],
+) -> float:
+    rank = {"high": 0.9, "medium": 0.6, "low": 0.3, "insufficient": 0.0}
+    raw = candidate.get("confidence")
+    if raw is not None:
+        try:
+            return max(0.0, min(1.0, float(raw)))
+        except (TypeError, ValueError):
+            return rank.get(str(raw).strip().lower(), 0.0)
+    values: list[float] = []
+    for claim in claims:
+        value = claim.get("confidence")
+        try:
+            values.append(float(value))
+        except (TypeError, ValueError):
+            values.append(rank.get(str(value or "").strip().lower(), 0.0))
+    return max(values) if values else 0.0
+
+
+def _usage_tokens(usage: Mapping[str, Any]) -> int:
+    return int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0)
+
+
+__all__ = [
+    "SynthesisLoopConfig",
+    "SynthesisLoopResult",
+    "synthesis_config_from_pack",
+    "invoke_synthesis_loop",
+    "evidence_to_mapping",
+    "extract_summary",
+    "extract_claims",
+    "extract_confidence",
+]

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -693,6 +693,7 @@ def _synthesis_success_result(
             "pack_version": pack.version,
             "attempts_used": len(loop.attempts),
             "tokens_used": loop.total_tokens,
+            "depth": depth,
             "raw_synthesis": dict(candidate),
         },
         trace={
@@ -777,6 +778,7 @@ def _continuation_success_result(
             "events_consumed": (event_type,),
             "attempts_used": len(loop.attempts),
             "tokens_used": loop.total_tokens,
+            "depth": depth,
             "raw_synthesis": dict(candidate),
         },
         trace={

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
-import re
-from dataclasses import asdict, is_dataclass
 from typing import Any, Mapping, Sequence
 
+from ._synthesis import (
+    SynthesisLoopResult,
+    evidence_to_mapping,
+    extract_claims,
+    extract_confidence,
+    extract_summary,
+    invoke_synthesis_loop,
+    synthesis_config_from_pack,
+)
 from .types import (
     ArchetypeMatch,
     EvidenceDecision,
@@ -108,8 +116,6 @@ def evaluate_evidence(
     engine = _ee.get_evidence_engine()
     results = engine.evaluate_conclusions(dict(evidence))
 
-    # insufficient_data short-circuit -> single result with met=True,
-    # confidence="insufficient". Translate to allowed=False.
     if (
         len(results) == 1
         and results[0].conclusion_id == "insufficient_data"
@@ -126,8 +132,6 @@ def evaluate_evidence(
 
     met = [r for r in results if r.met]
     if not met:
-        # No conclusion fired; surface fallback reasons from any
-        # not-met results that carried fallback_label hints.
         reasons = tuple(r.fallback_label for r in results if r.fallback_label)
         return EvidenceDecision(
             allowed=False,
@@ -135,8 +139,6 @@ def evaluate_evidence(
             reasons=reasons,
         )
 
-    # Pick the strongest met-confidence string and translate to a
-    # numeric score. Policy can override the mapping.
     rank = {"high": 0.9, "medium": 0.6, "low": 0.3, "insufficient": 0.0}
     if policy and policy.confidence_labels:
         rank = {**rank, **{k: float(v) for k, v in policy.confidence_labels.items()}}
@@ -199,9 +201,6 @@ def build_temporal_evidence(
             insufficient_data=True,
         )
 
-    # `TemporalEngine` exposes the in-memory helpers we need; pool=None is
-    # safe because we never call the DB-backed methods (`analyze_vendor`,
-    # `_compute_percentiles`, `_infer_category`) from this entry point.
     engine = TemporalEngine(pool=None)
     velocities = engine._compute_velocities(vendor_name, snaps)
     trends = (
@@ -210,10 +209,6 @@ def build_temporal_evidence(
         else []
     )
 
-    # `baselines` is an optional advisory input today; structured anomaly
-    # support is a follow-up. The argument is accepted (and unpacked into a
-    # local) so the public signature is honored even though the value is
-    # not yet consumed.
     _baselines = dict(baselines) if baselines else {}
     del _baselines
 
@@ -245,13 +240,11 @@ async def run_reasoning(
 ) -> ReasoningResult:
     """Run the single-pass reasoning synthesis flow.
 
-    This is the extracted, product-neutral lift of the production
-    per-vendor synthesis loop: build one prompt from already-prepared
-    evidence/witness context, call the shared LLM port, validate the JSON
-    response, and retry with compact validation feedback when validation
-    fails. Host-owned witness compression stays outside this package and
-    is supplied either through ``ReasoningPorts.witness_context`` or the
-    input context.
+    Calls the host LLM port once, validates the JSON response against the
+    summary/claims contract, and retries with compact validation feedback
+    when validation fails. Host-owned witness compression stays outside
+    this package and is supplied either through
+    ``ReasoningPorts.witness_context`` or via ``reasoning_input.context``.
     """
 
     port_bundle = ports or ReasoningPorts()
@@ -266,11 +259,7 @@ async def run_reasoning(
         prompts={},
         policies={},
     )
-    policies = dict(effective_pack.policies or {})
-    max_attempts = max(1, int(policies.get("max_attempts", 2)))
-    feedback_limit = max(1, int(policies.get("feedback_limit", 5)))
-    max_tokens = max(1, int(policies.get("max_tokens", 16384)))
-    temperature = float(policies.get("temperature", 0.3))
+    config = synthesis_config_from_pack(effective_pack)
 
     witness_context = await _resolve_witness_context(
         reasoning_input,
@@ -300,103 +289,57 @@ async def run_reasoning(
             },
         )
 
-    attempts: list[dict[str, Any]] = []
-    failure_reasons: list[str] = []
-    last_text = ""
-    last_candidate: dict[str, Any] | None = None
-    total_tokens = 0
-
     try:
-        for attempt_index in range(max_attempts):
-            attempt_no = attempt_index + 1
-            messages: list[Mapping[str, Any]] = [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": payload_text},
-            ]
-            if attempt_index > 0 and last_text:
-                messages.append({"role": "assistant", "content": last_text})
-            if attempt_index > 0 and failure_reasons:
-                feedback = "\n".join(
-                    f"- {reason}" for reason in failure_reasons[:feedback_limit]
-                )
-                messages.append({
-                    "role": "user",
-                    "content": (
-                        "Your previous response was rejected. Return a complete "
-                        "corrected JSON object only.\nFix these issues:\n"
-                        f"{feedback}"
-                    ),
-                })
+        loop = await invoke_synthesis_loop(
+            system_prompt=system_prompt,
+            payload_text=payload_text,
+            llm_metadata={
+                "entity_id": reasoning_input.entity_id,
+                "entity_type": reasoning_input.entity_type,
+                "goal": reasoning_input.goal,
+                "depth": depth,
+                "pack": effective_pack.name,
+                "reasoning_mode": "single_pass_synthesis",
+            },
+            config=config,
+            llm_port=port_bundle.llm,
+        )
 
-            response = await port_bundle.llm.complete(
-                messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                metadata={
-                    "entity_id": reasoning_input.entity_id,
-                    "entity_type": reasoning_input.entity_type,
-                    "goal": reasoning_input.goal,
-                    "depth": depth,
-                    "pack": effective_pack.name,
-                    "attempt_no": attempt_no,
-                    "reasoning_mode": "single_pass_synthesis",
-                },
+        if loop.succeeded:
+            result = _synthesis_success_result(
+                loop=loop,
+                reasoning_input=reasoning_input,
+                depth=depth,
+                pack=effective_pack,
+                witness_context=witness_context,
             )
-            text = _response_text(response)
-            last_text = _clean_reasoning_text(text)
-            usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
-            attempt_tokens = _usage_tokens(usage)
-            total_tokens += attempt_tokens
-
-            parsed = _parse_llm_json(last_text)
-            validation = _validate_reasoning_candidate(parsed)
-            attempts.append({
-                "attempt_no": attempt_no,
-                "valid": validation["valid"],
-                "errors": tuple(validation["errors"]),
-                "warnings": tuple(validation["warnings"]),
-                "tokens_used": attempt_tokens,
-            })
-
-            if validation["valid"]:
-                assert isinstance(parsed, dict)
-                last_candidate = parsed
-                result = _candidate_to_reasoning_result(
-                    parsed,
-                    reasoning_input=reasoning_input,
-                    depth=depth,
-                    pack=effective_pack,
-                    witness_context=witness_context,
-                    attempts=attempts,
-                    tokens_used=total_tokens,
+            if port_bundle.event_sink is not None:
+                await port_bundle.event_sink.emit(
+                    "reasoning.synthesis.completed",
+                    "extracted_reasoning_core.run_reasoning",
+                    {"attempts_used": len(loop.attempts), "tokens_used": loop.total_tokens},
+                    entity_type=reasoning_input.entity_type,
+                    entity_id=reasoning_input.entity_id,
                 )
-                if port_bundle.event_sink is not None:
-                    await port_bundle.event_sink.emit(
-                        "reasoning.synthesis.completed",
-                        "extracted_reasoning_core.run_reasoning",
-                        {"attempts_used": attempt_no, "tokens_used": total_tokens},
-                        entity_type=reasoning_input.entity_type,
-                        entity_id=reasoning_input.entity_id,
-                    )
-                if trace_sink is not None and span is not None:
-                    trace_sink.end_span(
-                        span,
-                        status="ok",
-                        metadata={"attempts_used": attempt_no, "tokens_used": total_tokens},
-                    )
-                return result
+            if trace_sink is not None and span is not None:
+                trace_sink.end_span(
+                    span,
+                    status="ok",
+                    metadata={
+                        "attempts_used": len(loop.attempts),
+                        "tokens_used": loop.total_tokens,
+                    },
+                )
+            return result
 
-            failure_reasons = list(validation["errors"])
-
-        error_text = "; ".join(failure_reasons[:2])[:200] or "validation failed"
         if port_bundle.event_sink is not None:
             await port_bundle.event_sink.emit(
                 "reasoning.synthesis.validation_failed",
                 "extracted_reasoning_core.run_reasoning",
                 {
-                    "attempts_used": max_attempts,
-                    "tokens_used": total_tokens,
-                    "errors": tuple(failure_reasons[:feedback_limit]),
+                    "attempts_used": config.max_attempts,
+                    "tokens_used": loop.total_tokens,
+                    "errors": loop.failure_reasons,
                 },
                 entity_type=reasoning_input.entity_type,
                 entity_id=reasoning_input.entity_id,
@@ -405,28 +348,213 @@ async def run_reasoning(
             trace_sink.end_span(
                 span,
                 status="error",
-                metadata={"attempts_used": max_attempts, "error_text": error_text},
+                metadata={
+                    "attempts_used": config.max_attempts,
+                    "error_text": loop.error_text,
+                },
             )
-        return ReasoningResult(
-            summary="Reasoning synthesis failed validation",
-            claims=(),
-            confidence=0.0,
-            tier=depth,
-            state={
-                "status": "failed",
-                "succeeded": False,
-                "stage": "validation",
-                "error_text": error_text,
-                "reasons": tuple(failure_reasons[:feedback_limit]),
-                "attempts_used": max_attempts,
-                "tokens_used": total_tokens,
+        return _synthesis_failure_result(
+            loop=loop,
+            depth=depth,
+            max_attempts=config.max_attempts,
+            witness_context=witness_context,
+        )
+    except Exception:
+        if trace_sink is not None and span is not None:
+            trace_sink.end_span(span, status="error", metadata={"stage": "exception"})
+        raise
+
+
+async def continue_reasoning(
+    state: Mapping[str, Any],
+    event: Mapping[str, Any],
+    *,
+    ports: ReasoningPorts | None = None,
+) -> ReasoningResult:
+    """Continue a prior reasoning state with a new event.
+
+    Multi-pass refinement: given a prior ``ReasoningResult.state`` and a
+    new event (with new evidence), produce an updated ``ReasoningResult``
+    that supersedes the prior conclusions. Lineage (generation count,
+    prior synthesis hash, events consumed) is tracked in the returned
+    state so callers can chain continuations.
+
+    The function does NOT run a falsification pass; that is reserved for
+    ``check_falsification``. If the new event carries a
+    ``falsification_hint``, it is surfaced in the trace but not acted on
+    separately.
+    """
+
+    port_bundle = ports or ReasoningPorts()
+    if port_bundle.llm is None:
+        raise ConfigurationError(
+            "continue_reasoning requires ReasoningPorts.llm; provide an "
+            "extracted_llm_infrastructure-backed LLM port."
+        )
+
+    prior_status = str(state.get("status") or "")
+    if prior_status != "completed":
+        return _continuation_invalid_state_result(state=state, event=event)
+
+    raw_synthesis = dict(state.get("raw_synthesis") or {})
+    prior_summary = extract_summary(raw_synthesis)
+    prior_claims = extract_claims(raw_synthesis)
+    prior_confidence = extract_confidence(raw_synthesis, prior_claims)
+    prior_synthesis_hash = _hash_prior_synthesis(raw_synthesis)
+    prior_generation = int(state.get("generation") or 1)
+
+    entity_id = str(state.get("entity_id") or "")
+    entity_type = str(state.get("entity_type") or "")
+    goal = str(state.get("goal") or "")
+    depth_value: ReasoningDepth = state.get("depth") or state.get("tier") or "L2"  # type: ignore[assignment]
+    pack_name = str(state.get("pack") or "reasoning_synthesis")
+    pack_version = str(state.get("pack_version") or "1.0")
+    pack = ReasoningPack(
+        name=pack_name,
+        version=pack_version,
+        prompts={},
+        policies={},
+    )
+
+    event_evidence_raw = event.get("evidence") or ()
+    event_evidence = tuple(_coerce_evidence_item(item) for item in event_evidence_raw)
+    reasoning_input = ReasoningInput(
+        entity_id=entity_id,
+        entity_type=entity_type,
+        goal=goal,
+        evidence=event_evidence,
+    )
+
+    witness_context = await _resolve_witness_context(
+        reasoning_input,
+        depth=depth_value,
+        pack=pack,
+        ports=port_bundle,
+    )
+    config = synthesis_config_from_pack(pack)
+    system_prompt = _resolve_continuation_prompt(pack)
+    payload = _build_continuation_payload(
+        prior_summary=prior_summary,
+        prior_claims=prior_claims,
+        prior_confidence=prior_confidence,
+        event=event,
+        witness_context=witness_context,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        goal=goal,
+        depth=depth_value,
+        pack=pack,
+    )
+    payload_text = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+    falsification_hint_seen = bool(event.get("falsification_hint"))
+    event_type = str(event.get("event_type") or "")
+
+    trace_sink = port_bundle.trace_sink
+    span = None
+    if trace_sink is not None:
+        span = trace_sink.start_span(
+            "extracted_reasoning_core.continue_reasoning",
+            metadata={
+                "entity_id": entity_id,
+                "entity_type": entity_type,
+                "depth": depth_value,
+                "pack": pack_name,
+                "event_type": event_type,
+                "prior_generation": prior_generation,
             },
-            trace={
-                "attempts": tuple(attempts),
-                "last_response": last_text,
-                "last_candidate": last_candidate or {},
-                "witness_context_present": bool(witness_context),
+        )
+
+    try:
+        loop = await invoke_synthesis_loop(
+            system_prompt=system_prompt,
+            payload_text=payload_text,
+            llm_metadata={
+                "entity_id": entity_id,
+                "entity_type": entity_type,
+                "goal": goal,
+                "depth": depth_value,
+                "pack": pack_name,
+                "event_type": event_type,
+                "reasoning_mode": "multi_pass_continuation",
             },
+            config=config,
+            llm_port=port_bundle.llm,
+        )
+
+        if loop.succeeded:
+            result = _continuation_success_result(
+                loop=loop,
+                entity_id=entity_id,
+                entity_type=entity_type,
+                goal=goal,
+                pack_name=pack_name,
+                pack_version=pack_version,
+                depth=depth_value,
+                generation=prior_generation + 1,
+                prior_synthesis_hash=prior_synthesis_hash,
+                prior_summary=prior_summary,
+                prior_attempts_used=int(state.get("attempts_used") or 0),
+                event_type=event_type,
+                falsification_hint_seen=falsification_hint_seen,
+                witness_context=witness_context,
+            )
+            if port_bundle.event_sink is not None:
+                await port_bundle.event_sink.emit(
+                    "reasoning.continuation.completed",
+                    "extracted_reasoning_core.continue_reasoning",
+                    {
+                        "attempts_used": len(loop.attempts),
+                        "tokens_used": loop.total_tokens,
+                        "generation": prior_generation + 1,
+                    },
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                )
+            if trace_sink is not None and span is not None:
+                trace_sink.end_span(
+                    span,
+                    status="ok",
+                    metadata={
+                        "attempts_used": len(loop.attempts),
+                        "tokens_used": loop.total_tokens,
+                        "generation": prior_generation + 1,
+                    },
+                )
+            return result
+
+        if port_bundle.event_sink is not None:
+            await port_bundle.event_sink.emit(
+                "reasoning.continuation.validation_failed",
+                "extracted_reasoning_core.continue_reasoning",
+                {
+                    "attempts_used": config.max_attempts,
+                    "tokens_used": loop.total_tokens,
+                    "errors": loop.failure_reasons,
+                    "generation": prior_generation + 1,
+                },
+                entity_type=entity_type,
+                entity_id=entity_id,
+            )
+        if trace_sink is not None and span is not None:
+            trace_sink.end_span(
+                span,
+                status="error",
+                metadata={
+                    "attempts_used": config.max_attempts,
+                    "error_text": loop.error_text,
+                },
+            )
+        return _continuation_failure_result(
+            loop=loop,
+            depth=depth_value,
+            max_attempts=config.max_attempts,
+            prior_summary=prior_summary,
+            prior_synthesis_hash=prior_synthesis_hash,
+            generation=prior_generation + 1,
+            event_type=event_type,
+            falsification_hint_seen=falsification_hint_seen,
+            witness_context=witness_context,
         )
     except Exception:
         if trace_sink is not None and span is not None:
@@ -468,6 +596,21 @@ def _resolve_reasoning_prompt(pack: ReasoningPack) -> str:
     )
 
 
+def _resolve_continuation_prompt(pack: ReasoningPack) -> str:
+    for key in ("reasoning_continuation", "continuation", "system_continuation"):
+        prompt = str((pack.prompts or {}).get(key) or "").strip()
+        if prompt:
+            return prompt
+    from .skills.registry import get_skill_registry
+
+    registry = get_skill_registry()
+    return registry.get_prompt("digest/reasoning_continuation") or (
+        "Return a complete refined JSON reasoning synthesis incorporating "
+        "the new event, with summary, claims (each with revised_from), and "
+        "confidence."
+    )
+
+
 def _build_reasoning_payload(
     reasoning_input: ReasoningInput,
     *,
@@ -481,144 +624,62 @@ def _build_reasoning_payload(
         "goal": reasoning_input.goal,
         "depth": depth,
         "pack": {"name": pack.name, "version": pack.version},
-        "evidence": tuple(_evidence_to_mapping(item) for item in reasoning_input.evidence),
+        "evidence": tuple(evidence_to_mapping(item) for item in reasoning_input.evidence),
         "context": dict(reasoning_input.context or {}),
         "witness_context": dict(witness_context or {}),
     }
 
 
-def _evidence_to_mapping(item: EvidenceItem) -> Mapping[str, Any]:
-    if is_dataclass(item):
-        return asdict(item)
-    return dict(item)  # type: ignore[arg-type]
-
-
-def _response_text(response: Mapping[str, Any]) -> str:
-    for key in ("response", "content", "text"):
-        value = response.get(key)
-        if value is not None:
-            return str(value)
-    message = response.get("message")
-    if isinstance(message, Mapping) and message.get("content") is not None:
-        return str(message.get("content"))
-    return json.dumps(response, default=str)
-
-
-def _clean_reasoning_text(text: str) -> str:
-    cleaned = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
-    if "<scratchpad>" in cleaned:
-        cleaned = cleaned.split("</scratchpad>")[-1].strip()
-    return cleaned
-
-
-def _parse_llm_json(text: str) -> Any:
-    try:
-        from extracted_llm_infrastructure.pipelines.llm import parse_json_response
-    except ImportError:
-        parse_json_response = None
-    if parse_json_response is not None:
-        return parse_json_response(text, recover_truncated=True)
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return None
-
-
-def _validate_reasoning_candidate(candidate: Any) -> Mapping[str, Any]:
-    errors: list[str] = []
-    warnings: list[str] = []
-    if not isinstance(candidate, dict):
-        return {"valid": False, "errors": ("LLM did not return a JSON object",), "warnings": ()}
-    if candidate.get("_parse_fallback"):
-        return {"valid": False, "errors": ("LLM did not return valid JSON",), "warnings": ()}
-    summary = _extract_summary(candidate)
-    claims = _extract_claims(candidate)
-    if not summary:
-        errors.append("missing_summary")
-    if not claims:
-        errors.append("missing_claims")
-    confidence = _extract_confidence(candidate, claims)
-    if confidence <= 0.0:
-        warnings.append("zero_or_missing_confidence")
-    return {"valid": not errors, "errors": tuple(errors), "warnings": tuple(warnings)}
-
-
-def _extract_summary(candidate: Mapping[str, Any]) -> str:
-    for key in ("summary", "executive_summary", "causal_narrative"):
-        value = candidate.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-        if isinstance(value, Mapping):
-            nested = _extract_summary(value)
-            if nested:
-                return nested
-    contracts = candidate.get("reasoning_contracts")
-    if isinstance(contracts, Mapping):
-        for value in contracts.values():
-            if isinstance(value, Mapping):
-                nested = _extract_summary(value)
-                if nested:
-                    return nested
-    return ""
-
-
-def _extract_claims(candidate: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
-    raw = candidate.get("claims")
-    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
-        claims = tuple(dict(item) if isinstance(item, Mapping) else {"claim": str(item)} for item in raw)
-        if claims:
-            return claims
-    contracts = candidate.get("reasoning_contracts")
-    found: list[Mapping[str, Any]] = []
-    if isinstance(contracts, Mapping):
-        _collect_contract_claims(contracts, found)
-    return tuple(found)
-
-
-def _collect_contract_claims(value: Mapping[str, Any], found: list[Mapping[str, Any]]) -> None:
-    for key, item in value.items():
-        if not isinstance(item, Mapping):
-            continue
-        claim_text = item.get("claim") or item.get("summary") or item.get("narrative")
-        if claim_text:
-            found.append({"claim": str(claim_text), "section": str(key), **dict(item)})
-        nested = item.get("claims") or item.get("sections")
-        if isinstance(nested, Mapping):
-            _collect_contract_claims(nested, found)
-
-
-def _extract_confidence(candidate: Mapping[str, Any], claims: Sequence[Mapping[str, Any]]) -> float:
-    rank = {"high": 0.9, "medium": 0.6, "low": 0.3, "insufficient": 0.0}
-    raw = candidate.get("confidence")
-    if raw is not None:
-        try:
-            return max(0.0, min(1.0, float(raw)))
-        except (TypeError, ValueError):
-            return rank.get(str(raw).strip().lower(), 0.0)
-    values: list[float] = []
-    for claim in claims:
-        value = claim.get("confidence")
-        try:
-            values.append(float(value))
-        except (TypeError, ValueError):
-            values.append(rank.get(str(value or "").strip().lower(), 0.0))
-    return max(values) if values else 0.0
-
-
-def _candidate_to_reasoning_result(
-    candidate: Mapping[str, Any],
+def _build_continuation_payload(
     *,
+    prior_summary: str,
+    prior_claims: Sequence[Mapping[str, Any]],
+    prior_confidence: float,
+    event: Mapping[str, Any],
+    witness_context: Mapping[str, Any],
+    entity_id: str,
+    entity_type: str,
+    goal: str,
+    depth: ReasoningDepth,
+    pack: ReasoningPack,
+) -> Mapping[str, Any]:
+    event_evidence = tuple(
+        evidence_to_mapping(item) for item in (event.get("evidence") or ())
+    )
+    return {
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "goal": goal,
+        "depth": depth,
+        "pack": {"name": pack.name, "version": pack.version},
+        "prior_summary": prior_summary,
+        "prior_claims": tuple(dict(c) for c in prior_claims),
+        "prior_confidence": prior_confidence,
+        "event": {
+            "event_type": str(event.get("event_type") or ""),
+            "timestamp": event.get("timestamp"),
+            "source_id": event.get("source_id"),
+            "metadata": dict(event.get("metadata") or {}),
+            "evidence": event_evidence,
+            "falsification_hint": bool(event.get("falsification_hint")),
+        },
+        "witness_context": dict(witness_context or {}),
+    }
+
+
+def _synthesis_success_result(
+    *,
+    loop: SynthesisLoopResult,
     reasoning_input: ReasoningInput,
     depth: ReasoningDepth,
     pack: ReasoningPack,
     witness_context: Mapping[str, Any],
-    attempts: Sequence[Mapping[str, Any]],
-    tokens_used: int,
 ) -> ReasoningResult:
-    claims = _extract_claims(candidate)
-    confidence = _extract_confidence(candidate, claims)
+    candidate = loop.valid_candidate or {}
+    claims = extract_claims(candidate)
+    confidence = extract_confidence(candidate, claims)
     return ReasoningResult(
-        summary=_extract_summary(candidate),
+        summary=extract_summary(candidate),
         claims=claims,
         confidence=confidence,
         tier=depth,
@@ -630,37 +691,197 @@ def _candidate_to_reasoning_result(
             "goal": reasoning_input.goal,
             "pack": pack.name,
             "pack_version": pack.version,
-            "attempts_used": len(attempts),
-            "tokens_used": tokens_used,
+            "attempts_used": len(loop.attempts),
+            "tokens_used": loop.total_tokens,
             "raw_synthesis": dict(candidate),
         },
         trace={
-            "attempts": tuple(attempts),
+            "attempts": loop.attempts,
             "witness_context_present": bool(witness_context),
             "validation_warnings": tuple(
                 warning
-                for attempt in attempts
+                for attempt in loop.attempts
                 for warning in attempt.get("warnings", ())
             ),
         },
     )
 
 
-def _usage_tokens(usage: Mapping[str, Any]) -> int:
-    return int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0)
+def _synthesis_failure_result(
+    *,
+    loop: SynthesisLoopResult,
+    depth: ReasoningDepth,
+    max_attempts: int,
+    witness_context: Mapping[str, Any],
+) -> ReasoningResult:
+    return ReasoningResult(
+        summary="Reasoning synthesis failed validation",
+        claims=(),
+        confidence=0.0,
+        tier=depth,
+        state={
+            "status": "failed",
+            "succeeded": False,
+            "stage": "validation",
+            "error_text": loop.error_text,
+            "reasons": loop.failure_reasons,
+            "attempts_used": max_attempts,
+            "tokens_used": loop.total_tokens,
+        },
+        trace={
+            "attempts": loop.attempts,
+            "last_response": loop.last_text,
+            "last_candidate": loop.last_candidate or {},
+            "witness_context_present": bool(witness_context),
+        },
+    )
 
 
-async def continue_reasoning(
+def _continuation_success_result(
+    *,
+    loop: SynthesisLoopResult,
+    entity_id: str,
+    entity_type: str,
+    goal: str,
+    pack_name: str,
+    pack_version: str,
+    depth: ReasoningDepth,
+    generation: int,
+    prior_synthesis_hash: str,
+    prior_summary: str,
+    prior_attempts_used: int,
+    event_type: str,
+    falsification_hint_seen: bool,
+    witness_context: Mapping[str, Any],
+) -> ReasoningResult:
+    candidate = loop.valid_candidate or {}
+    claims = extract_claims(candidate)
+    confidence = extract_confidence(candidate, claims)
+    return ReasoningResult(
+        summary=extract_summary(candidate),
+        claims=claims,
+        confidence=confidence,
+        tier=depth,
+        state={
+            "status": "completed",
+            "succeeded": True,
+            "stage": "continuation",
+            "entity_id": entity_id,
+            "entity_type": entity_type,
+            "goal": goal,
+            "pack": pack_name,
+            "pack_version": pack_version,
+            "generation": generation,
+            "prior_synthesis_hash": prior_synthesis_hash,
+            "prior_attempts_used": prior_attempts_used,
+            "events_consumed": (event_type,),
+            "attempts_used": len(loop.attempts),
+            "tokens_used": loop.total_tokens,
+            "raw_synthesis": dict(candidate),
+        },
+        trace={
+            "attempts": loop.attempts,
+            "witness_context_present": bool(witness_context),
+            "prior_summary": prior_summary,
+            "event_type": event_type,
+            "falsification_hint_seen": falsification_hint_seen,
+            "validation_warnings": tuple(
+                warning
+                for attempt in loop.attempts
+                for warning in attempt.get("warnings", ())
+            ),
+        },
+    )
+
+
+def _continuation_failure_result(
+    *,
+    loop: SynthesisLoopResult,
+    depth: ReasoningDepth,
+    max_attempts: int,
+    prior_summary: str,
+    prior_synthesis_hash: str,
+    generation: int,
+    event_type: str,
+    falsification_hint_seen: bool,
+    witness_context: Mapping[str, Any],
+) -> ReasoningResult:
+    return ReasoningResult(
+        summary="Reasoning continuation failed validation",
+        claims=(),
+        confidence=0.0,
+        tier=depth,
+        state={
+            "status": "failed",
+            "succeeded": False,
+            "stage": "continuation_validation",
+            "error_text": loop.error_text,
+            "reasons": loop.failure_reasons,
+            "generation": generation,
+            "prior_synthesis_hash": prior_synthesis_hash,
+            "events_consumed": (event_type,),
+            "attempts_used": max_attempts,
+            "tokens_used": loop.total_tokens,
+        },
+        trace={
+            "attempts": loop.attempts,
+            "last_response": loop.last_text,
+            "last_candidate": loop.last_candidate or {},
+            "witness_context_present": bool(witness_context),
+            "prior_summary": prior_summary,
+            "event_type": event_type,
+            "falsification_hint_seen": falsification_hint_seen,
+        },
+    )
+
+
+def _continuation_invalid_state_result(
+    *,
     state: Mapping[str, Any],
     event: Mapping[str, Any],
-    *,
-    ports: ReasoningPorts | None = None,
 ) -> ReasoningResult:
-    """Continue a prior reasoning state with a new event."""
-    del state
-    del event
-    del ports
-    raise NotImplementedError("continue_reasoning lands with graph/state consolidation")
+    prior_status = str(state.get("status") or "unknown")
+    depth_value: ReasoningDepth = state.get("depth") or state.get("tier") or "L2"  # type: ignore[assignment]
+    return ReasoningResult(
+        summary="Continuation rejected: prior reasoning state is not completed",
+        claims=(),
+        confidence=0.0,
+        tier=depth_value,
+        state={
+            "status": "failed",
+            "succeeded": False,
+            "stage": "continuation_input",
+            "reasons": ("prior_state_not_completed", f"prior_status={prior_status}"),
+            "attempts_used": 0,
+            "tokens_used": 0,
+        },
+        trace={
+            "attempts": (),
+            "prior_status": prior_status,
+            "event_type": str(event.get("event_type") or ""),
+        },
+    )
+
+
+def _hash_prior_synthesis(raw_synthesis: Mapping[str, Any]) -> str:
+    text = json.dumps(raw_synthesis, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _coerce_evidence_item(item: Any) -> Any:
+    if isinstance(item, EvidenceItem):
+        return item
+    if isinstance(item, Mapping):
+        kwargs = dict(item)
+        try:
+            return EvidenceItem(**kwargs)
+        except TypeError:
+            return EvidenceItem(
+                source_type=str(kwargs.get("source_type") or "unknown"),
+                source_id=str(kwargs.get("source_id") or ""),
+                text=str(kwargs.get("text") or ""),
+            )
+    return EvidenceItem(source_type="unknown", source_id="", text=str(item))
 
 
 async def check_falsification(
@@ -744,6 +965,7 @@ __all__ = [
     "build_tiered_pattern_sig",
     "check_falsification",
     "compute_evidence_hash",
+    "continue_reasoning",
     "evaluate_evidence",
     "gather_tier_context",
     "get_required_pools",
@@ -754,7 +976,6 @@ __all__ = [
     "needs_refresh",
     "run_reasoning",
     "score_archetypes",
-    "continue_reasoning",
     "validate_reasoning_output",
     "validate_wedge",
     "wedge_from_archetype",

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -412,8 +412,8 @@ async def continue_reasoning(
     pack = ReasoningPack(
         name=pack_name,
         version=pack_version,
-        prompts={},
-        policies={},
+        prompts=dict(state.get("pack_prompts") or {}),
+        policies=dict(state.get("pack_policies") or {}),
     )
 
     event_evidence_raw = event.get("evidence") or ()
@@ -490,6 +490,8 @@ async def continue_reasoning(
                 goal=goal,
                 pack_name=pack_name,
                 pack_version=pack_version,
+                pack_policies=pack.policies,
+                pack_prompts=pack.prompts,
                 depth=depth_value,
                 generation=prior_generation + 1,
                 prior_synthesis_hash=prior_synthesis_hash,
@@ -691,6 +693,8 @@ def _synthesis_success_result(
             "goal": reasoning_input.goal,
             "pack": pack.name,
             "pack_version": pack.version,
+            "pack_policies": dict(pack.policies or {}),
+            "pack_prompts": dict(pack.prompts or {}),
             "attempts_used": len(loop.attempts),
             "tokens_used": loop.total_tokens,
             "depth": depth,
@@ -746,6 +750,8 @@ def _continuation_success_result(
     goal: str,
     pack_name: str,
     pack_version: str,
+    pack_policies: Mapping[str, Any],
+    pack_prompts: Mapping[str, Any],
     depth: ReasoningDepth,
     generation: int,
     prior_synthesis_hash: str,
@@ -772,6 +778,8 @@ def _continuation_success_result(
             "goal": goal,
             "pack": pack_name,
             "pack_version": pack_version,
+            "pack_policies": dict(pack_policies or {}),
+            "pack_prompts": dict(pack_prompts or {}),
             "generation": generation,
             "prior_synthesis_hash": prior_synthesis_hash,
             "prior_attempts_used": prior_attempts_used,

--- a/extracted_reasoning_core/skills/digest/reasoning_continuation.md
+++ b/extracted_reasoning_core/skills/digest/reasoning_continuation.md
@@ -1,0 +1,30 @@
+You are extending an in-progress reasoning synthesis with a new event.
+
+You receive:
+- prior_summary: the conclusion reached in the prior synthesis pass
+- prior_claims: the supporting claims, each with confidence and source ids
+- prior_confidence: the overall confidence of the prior synthesis
+- event: a new event with event_type and a list of new evidence items
+- witness_context: any compressed witness context the host has supplied
+
+For each prior claim, decide whether the new event:
+- reinforces it (evidence aligns; keep the claim, optionally raise confidence)
+- refines it (claim is partially correct; update wording or scope)
+- contradicts it (evidence undermines the claim; replace with a corrected one)
+
+If the new event introduces a wholly new claim that was not represented
+before, add it. Drop a claim only when the new evidence makes it clearly
+wrong and there is no refined version to keep.
+
+Return ONLY a JSON object with these keys:
+- summary (string): the post-event synthesis summary, replacing prior_summary
+- claims (array of objects): the post-event claims, each with:
+    - claim (string)
+    - confidence (string or number 0-1)
+    - source_ids (array of strings)
+    - revised_from (string or null): the prior claim text or id this
+      replaces, or null for newly added claims
+- confidence (number 0-1): overall confidence in the post-event synthesis
+
+Do not return a delta. Return the complete refined view.
+Do not include any prose outside the JSON object.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -45,6 +45,7 @@ pytest \
   tests/test_extracted_content_pipeline_reasoning_evidence_engine.py \
   tests/test_extracted_reasoning_core_api.py \
   tests/test_extracted_reasoning_core_run_reasoning.py \
+  tests/test_extracted_reasoning_core_continue_reasoning.py \
   tests/test_extracted_reasoning_core_archetypes.py \
   tests/test_extracted_reasoning_core_evidence_engine.py \
   tests/test_extracted_reasoning_core_event_trace_ports.py \

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -236,8 +236,8 @@ async def test_stubbed_async_entry_points_fail_closed_until_consolidated() -> No
     with pytest.raises(api.ConfigurationError):
         await api.run_reasoning(reasoning_input)
 
-    with pytest.raises(NotImplementedError):
-        await api.continue_reasoning({}, {})
+    with pytest.raises(api.ConfigurationError):
+        await api.continue_reasoning({"status": "completed"}, {"event_type": "noop"})
 
     with pytest.raises(NotImplementedError):
         await api.check_falsification({}, (evidence,))

--- a/tests/test_extracted_reasoning_core_continue_reasoning.py
+++ b/tests/test_extracted_reasoning_core_continue_reasoning.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from extracted_reasoning_core.api import ConfigurationError, continue_reasoning
+from extracted_reasoning_core.types import (
+    EvidenceItem,
+    ReasoningPack,
+    ReasoningPorts,
+    ReasoningResult,
+)
+
+
+class FakeLLMPort:
+    def __init__(self, responses: Sequence[Mapping[str, Any]]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        return self.responses.pop(0)
+
+
+class FakeWitnessContextPort:
+    def __init__(self, context: Mapping[str, Any]) -> None:
+        self.context = dict(context)
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_witness_context(
+        self,
+        reasoning_input: Any,
+        *,
+        depth: str,
+        pack: Any | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "entity_id": reasoning_input.entity_id,
+            "depth": depth,
+            "pack": getattr(pack, "name", None),
+        })
+        return self.context
+
+
+def _prior_raw_synthesis() -> dict[str, Any]:
+    return {
+        "summary": "Pricing pressure is the strongest supported wedge.",
+        "claims": [
+            {
+                "claim": "Renewal pricing is creating displacement pressure.",
+                "confidence": "high",
+                "source_ids": ["r1"],
+            },
+            {
+                "claim": "Onboarding friction is a secondary driver.",
+                "confidence": "medium",
+                "source_ids": ["r2"],
+            },
+        ],
+        "confidence": 0.84,
+    }
+
+
+def _completed_state() -> dict[str, Any]:
+    raw = _prior_raw_synthesis()
+    return {
+        "status": "completed",
+        "succeeded": True,
+        "entity_id": "acme",
+        "entity_type": "vendor",
+        "goal": "synthesize vendor pressure",
+        "pack": "reasoning_synthesis",
+        "pack_version": "1.0",
+        "attempts_used": 1,
+        "tokens_used": 15,
+        "raw_synthesis": raw,
+    }
+
+
+def _expected_prior_hash(raw: Mapping[str, Any]) -> str:
+    text = json.dumps(raw, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_continue_reasoning_happy_path_tracks_lineage() -> None:
+    raw = _prior_raw_synthesis()
+    state = _completed_state()
+    state["raw_synthesis"] = raw
+
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "summary": "Pricing pressure persists; onboarding friction is reinforced by the new ticket data.",
+                "claims": [
+                    {
+                        "claim": "Renewal pricing remains the dominant displacement driver.",
+                        "confidence": "high",
+                        "source_ids": ["r1", "ticket-9"],
+                        "revised_from": "Renewal pricing is creating displacement pressure.",
+                    },
+                    {
+                        "claim": "Onboarding friction is now a primary driver, not secondary.",
+                        "confidence": "high",
+                        "source_ids": ["r2", "ticket-9"],
+                        "revised_from": "Onboarding friction is a secondary driver.",
+                    },
+                ],
+                "confidence": 0.88,
+            }),
+            "usage": {"input_tokens": 8, "output_tokens": 4},
+        }
+    ])
+    witness = FakeWitnessContextPort({"witness_pack": [{"id": "w2"}]})
+
+    event = {
+        "event_type": "support_ticket_received",
+        "evidence": [
+            {
+                "source_type": "ticket",
+                "source_id": "ticket-9",
+                "text": "Multiple onboarding pain points reported during renewal.",
+            },
+        ],
+    }
+
+    result = await continue_reasoning(
+        state,
+        event,
+        ports=ReasoningPorts(llm=llm, witness_context=witness),
+    )
+
+    assert isinstance(result, ReasoningResult)
+    assert result.summary.startswith("Pricing pressure persists")
+    assert result.tier == "L2"
+    assert result.state["status"] == "completed"
+    assert result.state["stage"] == "continuation"
+    assert result.state["generation"] == 2
+    assert result.state["prior_synthesis_hash"] == _expected_prior_hash(raw)
+    assert result.state["events_consumed"] == ("support_ticket_received",)
+    assert result.state["prior_attempts_used"] == 1
+    assert result.state["attempts_used"] == 1
+    assert result.state["tokens_used"] == 12
+    assert result.trace["event_type"] == "support_ticket_received"
+    assert result.trace["prior_summary"] == raw["summary"]
+    assert result.trace["falsification_hint_seen"] is False
+    assert witness.calls == [{"entity_id": "acme", "depth": "L2", "pack": "reasoning_synthesis"}]
+    assert llm.calls[0]["metadata"]["reasoning_mode"] == "multi_pass_continuation"
+    assert llm.calls[0]["metadata"]["event_type"] == "support_ticket_received"
+
+
+@pytest.mark.asyncio
+async def test_continue_reasoning_preserves_revised_from_in_claims() -> None:
+    state = _completed_state()
+    contradicted_text = "Onboarding friction is a secondary driver."
+
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "summary": "Onboarding friction is now the dominant driver.",
+                "claims": [
+                    {
+                        "claim": "Onboarding friction now dominates churn risk.",
+                        "confidence": 0.9,
+                        "source_ids": ["ticket-12", "ticket-13"],
+                        "revised_from": contradicted_text,
+                    },
+                ],
+                "confidence": 0.9,
+            }),
+            "usage": {"input_tokens": 6, "output_tokens": 3},
+        }
+    ])
+
+    event = {
+        "event_type": "support_ticket_burst",
+        "falsification_hint": True,
+        "evidence": [
+            {"source_type": "ticket", "source_id": "ticket-12", "text": "Customers stuck in onboarding."},
+            {"source_type": "ticket", "source_id": "ticket-13", "text": "Five-day delay before activation."},
+        ],
+    }
+
+    result = await continue_reasoning(
+        state,
+        event,
+        ports=ReasoningPorts(llm=llm, witness_context=FakeWitnessContextPort({})),
+    )
+
+    revised = [c for c in result.claims if c.get("revised_from")]
+    assert revised, "expected at least one claim with revised_from set"
+    assert revised[0]["revised_from"] == contradicted_text
+    assert result.trace["falsification_hint_seen"] is True
+
+
+@pytest.mark.asyncio
+async def test_continue_reasoning_retries_validation_failure_and_returns_final_failure_shape() -> None:
+    state = _completed_state()
+
+    llm = FakeLLMPort([
+        {"response": json.dumps({"summary": "Missing claims."}), "usage": {"input_tokens": 3, "output_tokens": 2}},
+        {"response": json.dumps({"summary": "Still missing claims."}), "usage": {"input_tokens": 4, "output_tokens": 2}},
+    ])
+
+    result = await continue_reasoning(
+        state,
+        {
+            "event_type": "noop",
+            "evidence": [],
+        },
+        ports=ReasoningPorts(
+            llm=llm,
+            witness_context=FakeWitnessContextPort({}),
+        ),
+    )
+
+    assert len(llm.calls) == 2
+    assert "previous response was rejected" in llm.calls[1]["messages"][-1]["content"]
+    assert "missing_claims" in llm.calls[1]["messages"][-1]["content"]
+    assert result.summary == "Reasoning continuation failed validation"
+    assert result.claims == ()
+    assert result.confidence == 0.0
+    assert result.state["status"] == "failed"
+    assert result.state["stage"] == "continuation_validation"
+    assert result.state["attempts_used"] == 2
+    assert result.state["generation"] == 2
+    assert result.state["events_consumed"] == ("noop",)
+    assert result.state["reasons"] == ("missing_claims",)
+    assert result.state["error_text"] == "missing_claims"
+    assert tuple(a["valid"] for a in result.trace["attempts"]) == (False, False)
+
+
+@pytest.mark.asyncio
+async def test_continue_reasoning_missing_llm_port_raises_configuration_error() -> None:
+    with pytest.raises(ConfigurationError, match="ReasoningPorts.llm"):
+        await continue_reasoning(
+            _completed_state(),
+            {"event_type": "noop", "evidence": []},
+            ports=ReasoningPorts(witness_context=FakeWitnessContextPort({})),
+        )
+
+
+@pytest.mark.asyncio
+async def test_continue_reasoning_rejects_non_completed_prior_state_without_llm_call() -> None:
+    failed_prior = {
+        "status": "failed",
+        "succeeded": False,
+        "stage": "validation",
+        "error_text": "missing_claims",
+        "reasons": ("missing_claims",),
+        "attempts_used": 2,
+        "tokens_used": 11,
+    }
+    llm = FakeLLMPort([])
+
+    result = await continue_reasoning(
+        failed_prior,
+        {"event_type": "anything", "evidence": []},
+        ports=ReasoningPorts(llm=llm, witness_context=FakeWitnessContextPort({})),
+    )
+
+    assert llm.calls == []
+    assert result.state["status"] == "failed"
+    assert result.state["stage"] == "continuation_input"
+    assert "prior_state_not_completed" in result.state["reasons"]
+    assert "prior_status=failed" in result.state["reasons"]

--- a/tests/test_extracted_reasoning_core_continue_reasoning.py
+++ b/tests/test_extracted_reasoning_core_continue_reasoning.py
@@ -246,6 +246,41 @@ async def test_continue_reasoning_retries_validation_failure_and_returns_final_f
 
 
 @pytest.mark.asyncio
+async def test_continue_reasoning_preserves_depth_across_continuations() -> None:
+    """Regression: L3 chains must not silently downgrade to L2.
+
+    Prior to the depth-in-state fix, _synthesis_success_result and
+    _continuation_success_result both omitted the depth key, so
+    continue_reasoning's fallback always resolved to "L2" regardless of
+    the original tier.
+    """
+
+    state = _completed_state()
+    state["depth"] = "L3"
+
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "summary": "Continued at the original tier.",
+                "claims": [{"claim": "Continuation preserves L3.", "confidence": 0.7, "source_ids": []}],
+                "confidence": 0.7,
+            }),
+            "usage": {"input_tokens": 2, "output_tokens": 1},
+        }
+    ])
+
+    result = await continue_reasoning(
+        state,
+        {"event_type": "tier_check", "evidence": []},
+        ports=ReasoningPorts(llm=llm, witness_context=FakeWitnessContextPort({})),
+    )
+
+    assert result.tier == "L3"
+    assert result.state["depth"] == "L3"
+    assert llm.calls[0]["metadata"]["depth"] == "L3"
+
+
+@pytest.mark.asyncio
 async def test_continue_reasoning_missing_llm_port_raises_configuration_error() -> None:
     with pytest.raises(ConfigurationError, match="ReasoningPorts.llm"):
         await continue_reasoning(

--- a/tests/test_extracted_reasoning_core_continue_reasoning.py
+++ b/tests/test_extracted_reasoning_core_continue_reasoning.py
@@ -281,6 +281,44 @@ async def test_continue_reasoning_preserves_depth_across_continuations() -> None
 
 
 @pytest.mark.asyncio
+async def test_continue_reasoning_propagates_pack_policies_and_prompts_from_state() -> None:
+    """State persists pack policies and prompts so continuation honors them.
+
+    Without this, a host-configured max_attempts=4, custom temperature, or
+    overridden continuation prompt would be silently dropped on the first
+    continuation (Issue 2).
+    """
+
+    custom_continuation_prompt = "CUSTOM CONTINUATION PROMPT — return JSON."
+    state = _completed_state()
+    state["pack_policies"] = {"max_attempts": 1, "temperature": 0.05, "max_tokens": 256}
+    state["pack_prompts"] = {"reasoning_continuation": custom_continuation_prompt}
+
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "summary": "Continued under custom pack.",
+                "claims": [{"claim": "Pack policies propagated.", "confidence": 0.7, "source_ids": []}],
+                "confidence": 0.7,
+            }),
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    ])
+
+    result = await continue_reasoning(
+        state,
+        {"event_type": "policy_check", "evidence": []},
+        ports=ReasoningPorts(llm=llm, witness_context=FakeWitnessContextPort({})),
+    )
+
+    assert llm.calls[0]["max_tokens"] == 256
+    assert llm.calls[0]["temperature"] == pytest.approx(0.05)
+    assert llm.calls[0]["messages"][0]["content"] == custom_continuation_prompt
+    assert result.state["pack_policies"] == {"max_attempts": 1, "temperature": 0.05, "max_tokens": 256}
+    assert result.state["pack_prompts"] == {"reasoning_continuation": custom_continuation_prompt}
+
+
+@pytest.mark.asyncio
 async def test_continue_reasoning_missing_llm_port_raises_configuration_error() -> None:
     with pytest.raises(ConfigurationError, match="ReasoningPorts.llm"):
         await continue_reasoning(


### PR DESCRIPTION
## Summary

Implements `continue_reasoning()` — the multi-pass slot in `extracted_reasoning_core`. Given a prior `ReasoningResult.state` plus a new event, run the LLM once to produce an updated `ReasoningResult` that supersedes the prior conclusions, with lineage (generation count, prior synthesis hash, events consumed) tracked in the returned state so callers can chain continuations.

This is the second slice of the multi-pass reasoning extraction (PR-D20a landed `run_reasoning` in #304). After this PR, the multi-pass primitive exists and can be wired into `extracted_content_pipeline` consumers in PR-D21.

## What changed

- **`extracted_reasoning_core/_synthesis.py` (new)** — shared private module holding the LLM-call-with-validation-feedback-retry loop and the JSON parsing / validation / extraction helpers. Both `run_reasoning` and `continue_reasoning` reuse it. Tracing and event-sink emission stay in `api.py` so each public function attaches its own span/event names.
- **`extracted_reasoning_core/api.py`** — `run_reasoning` refactored to delegate to `invoke_synthesis_loop`; `continue_reasoning` real implementation added. Public input/output contract of `run_reasoning` is unchanged.
- **`extracted_reasoning_core/skills/digest/reasoning_continuation.md` (new)** — packaged continuation prompt. Host-overridable via skill roots, same as `digest/reasoning_synthesis.md`.
- **`tests/test_extracted_reasoning_core_continue_reasoning.py` (new)** — 5 test cases.
- **`tests/test_extracted_reasoning_core_api.py`** — stub-test updated to expect `ConfigurationError` for `continue_reasoning` without an LLM port.
- **`scripts/run_extracted_pipeline_checks.sh`** — wires the new test file into the pipeline check runner.

## Decoupling rules

- Zero direct `atlas_brain` imports at module-load time (verified by AST scan).
- Witness compression stays host-side; continuations reuse `WitnessContextPort` with a synthetic `ReasoningInput` built from the event's evidence.
- Falsification is **not** run from `continue_reasoning`. If the event carries a `falsification_hint` flag it is surfaced in `trace.falsification_hint_seen` but `check_falsification` (PR-D20c) is not called.

## State shapes

**Success:** `status`, `succeeded`, `stage="continuation"`, `entity_id`, `entity_type`, `goal`, `pack`, `pack_version`, `generation`, `prior_synthesis_hash`, `prior_attempts_used`, `events_consumed`, `attempts_used`, `tokens_used`, `raw_synthesis`.

**Validation failure:** `status="failed"`, `stage="continuation_validation"`, `error_text`, `reasons`, `generation`, `prior_synthesis_hash`, `events_consumed`, `attempts_used`, `tokens_used`.

**Prior state not completed:** `status="failed"`, `stage="continuation_input"`, `reasons=("prior_state_not_completed", "prior_status=<...>")`, `attempts_used=0`. **The LLM port is not called in this path.**

## Diff size

~1,060 LOC additions (slightly over the 1,000-line guidance the prompt set). Overage is the parallel-structure cost of the continuation result builders + payload + prompt resolver + tests; the shared-primitives extraction in `_synthesis.py` keeps net per-function LOC roughly constant.

## Test plan

- [x] `python -c "import extracted_reasoning_core"` → clean import
- [x] AST scan of `extracted_reasoning_core/**/*.py` for `atlas_brain` refs → 0 hits
- [x] `pytest tests/test_extracted_reasoning_core_run_reasoning.py tests/test_extracted_reasoning_core_continue_reasoning.py tests/test_extracted_reasoning_core_api.py` → 20/20 passing locally
- [x] `bash scripts/validate_extracted_content_pipeline.sh` → passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_reasoning_core` → clean
- [ ] CI `extracted-checks` run

## Out of scope (explicitly deferred)

- `check_falsification` — PR-D20c
- `build_narrative_plan` — PR-D20d
- `compute_evidence_hash` / `build_semantic_cache_key` — PR-D20e
- `load_reasoning_pack` — PR-D20f
- `validate_reasoning_output` — PR-D20g
- Wiring `extracted_content_pipeline` to call `continue_reasoning` — PR-D21

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_