### PR TITLE
PR-D20c: Implement check_falsification() (per-claim refute/confirm pass)

### DIFF
--- a/extracted_reasoning_core/_synthesis.py
+++ b/extracted_reasoning_core/_synthesis.py
@@ -103,14 +103,14 @@ async def invoke_synthesis_loop(
             temperature=config.temperature,
             metadata={**dict(llm_metadata), "attempt_no": attempt_no},
         )
-        text = _response_text(response)
-        cleaned = _clean_reasoning_text(text)
+        text = response_text(response)
+        cleaned = clean_reasoning_text(text)
         last_text = cleaned
         usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
         attempt_tokens = _usage_tokens(usage)
         total_tokens += attempt_tokens
 
-        parsed = _parse_llm_json(cleaned)
+        parsed = parse_llm_json(cleaned)
         validation = _validate_reasoning_candidate(parsed)
         attempts.append({
             "attempt_no": attempt_no,
@@ -155,7 +155,7 @@ def evidence_to_mapping(item: Any) -> Mapping[str, Any]:
     return {"text": str(item)}
 
 
-def _response_text(response: Mapping[str, Any]) -> str:
+def response_text(response: Mapping[str, Any]) -> str:
     for key in ("response", "content", "text"):
         value = response.get(key)
         if value is not None:
@@ -166,14 +166,14 @@ def _response_text(response: Mapping[str, Any]) -> str:
     return json.dumps(response, default=str)
 
 
-def _clean_reasoning_text(text: str) -> str:
+def clean_reasoning_text(text: str) -> str:
     cleaned = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
     if "<scratchpad>" in cleaned:
         cleaned = cleaned.split("</scratchpad>")[-1].strip()
     return cleaned
 
 
-def _parse_llm_json(text: str) -> Any:
+def parse_llm_json(text: str) -> Any:
     try:
         from extracted_llm_infrastructure.pipelines.llm import parse_json_response
     except ImportError:
@@ -286,4 +286,7 @@ __all__ = [
     "extract_summary",
     "extract_claims",
     "extract_confidence",
+    "response_text",
+    "clean_reasoning_text",
+    "parse_llm_json",
 ]

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -927,11 +927,19 @@ async def check_falsification(
     effective_policy = policy or FalsificationPolicy()
     # Synthesize stable ids for any rule missing id/name/condition_id so the
     # LLM, the policy surface, and the result all reference the same handle.
+    # Collision-safe: skip past any rule_<i> a host already assigned explicitly.
+    explicit_ids = {_rule_id(r) for r in effective_policy.rules if _rule_id(r)}
     normalized_rules: list[dict[str, Any]] = []
     rule_ids_list: list[str] = []
-    for index, rule in enumerate(effective_policy.rules):
+    synth_counter = 0
+    for rule in effective_policy.rules:
         rule_dict = dict(rule)
-        rid = _rule_id(rule_dict) or f"rule_{index}"
+        rid = _rule_id(rule_dict)
+        if not rid:
+            while f"rule_{synth_counter}" in explicit_ids:
+                synth_counter += 1
+            rid = f"rule_{synth_counter}"
+            synth_counter += 1
         rule_dict["id"] = rid
         normalized_rules.append(rule_dict)
         rule_ids_list.append(rid)
@@ -965,8 +973,8 @@ async def check_falsification(
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": payload_text},
             ],
-            max_tokens=4096,
-            temperature=0.1,
+            max_tokens=effective_policy.max_tokens,
+            temperature=effective_policy.temperature,
             metadata={
                 "reasoning_mode": "falsification_check",
                 "claim_id": claim_id,

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -8,11 +8,14 @@ from typing import Any, Mapping, Sequence
 
 from ._synthesis import (
     SynthesisLoopResult,
+    clean_reasoning_text,
     evidence_to_mapping,
     extract_claims,
     extract_confidence,
     extract_summary,
     invoke_synthesis_loop,
+    parse_llm_json,
+    response_text,
     synthesis_config_from_pack,
 )
 from .types import (
@@ -901,12 +904,121 @@ async def check_falsification(
     policy: FalsificationPolicy | None = None,
     ports: ReasoningPorts | None = None,
 ) -> FalsificationResult:
-    """Check whether fresh evidence falsifies a prior claim."""
-    del claim
-    del fresh_evidence
-    del policy
-    del ports
-    raise NotImplementedError("check_falsification lands with falsification consolidation")
+    """Check whether fresh evidence falsifies a prior claim.
+
+    Sends the claim, the fresh evidence, and the policy's rules to the
+    host LLM port and asks which conditions are triggered. Returns a
+    structured ``FalsificationResult`` with triggered/non-triggered
+    condition lists and a single ``should_invalidate`` verdict.
+
+    Conservative semantics (``policy.conservative=True``, the default):
+    if the LLM returns malformed JSON or refuses to commit, no
+    conditions are reported triggered and ``should_invalidate`` is
+    ``False`` -- the prior claim survives ambiguity.
+    """
+
+    port_bundle = ports or ReasoningPorts()
+    if port_bundle.llm is None:
+        raise ConfigurationError(
+            "check_falsification requires ReasoningPorts.llm; provide an "
+            "extracted_llm_infrastructure-backed LLM port."
+        )
+
+    effective_policy = policy or FalsificationPolicy()
+    rule_ids = tuple(_rule_id(r) for r in effective_policy.rules if _rule_id(r))
+    payload = {
+        "claim": dict(claim or {}),
+        "fresh_evidence": tuple(evidence_to_mapping(item) for item in fresh_evidence),
+        "rules": tuple(dict(r) for r in effective_policy.rules),
+        "conservative": bool(effective_policy.conservative),
+    }
+    payload_text = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    system_prompt = _resolve_falsification_prompt()
+
+    response = await port_bundle.llm.complete(
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": payload_text},
+        ],
+        max_tokens=4096,
+        temperature=0.1,
+        metadata={
+            "reasoning_mode": "falsification_check",
+            "claim_id": str((claim or {}).get("claim_id") or (claim or {}).get("id") or ""),
+            "rule_count": len(rule_ids),
+        },
+    )
+
+    raw_text = clean_reasoning_text(response_text(response))
+    parsed = parse_llm_json(raw_text)
+
+    triggered: tuple[str, ...] = ()
+    non_triggered: tuple[str, ...] = ()
+    should_invalidate = False
+    parse_failed = False
+    raw_triggered: list[Any] = []
+    raw_non_triggered: list[Any] = []
+
+    if isinstance(parsed, Mapping) and not parsed.get("_parse_fallback"):
+        raw_triggered = list(parsed.get("triggered_conditions") or [])
+        raw_non_triggered = list(parsed.get("non_triggered_conditions") or [])
+        triggered = tuple(_normalize_condition(c) for c in raw_triggered if _normalize_condition(c))
+        non_triggered = tuple(_normalize_condition(c) for c in raw_non_triggered if _normalize_condition(c))
+        verdict = parsed.get("should_invalidate")
+        if verdict is None:
+            # Conservative: never auto-invalidate. Aggressive: any trigger invalidates.
+            should_invalidate = bool(triggered) and not effective_policy.conservative
+        else:
+            should_invalidate = bool(verdict)
+        if effective_policy.conservative and not triggered:
+            # Override LLM verdict: no triggered conditions means no invalidation.
+            should_invalidate = False
+    else:
+        parse_failed = True
+        # Conservative fallback: surface no triggers, do not invalidate.
+
+    if rule_ids:
+        seen = set(triggered) | set(non_triggered)
+        unseen = tuple(rid for rid in rule_ids if rid not in seen)
+        non_triggered = non_triggered + unseen
+
+    usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
+    return FalsificationResult(
+        triggered_conditions=triggered,
+        non_triggered_conditions=non_triggered,
+        should_invalidate=should_invalidate,
+        trace={
+            "conservative": effective_policy.conservative,
+            "rule_ids": rule_ids,
+            "parse_failed": parse_failed,
+            "raw_triggered": tuple(str(c) for c in raw_triggered),
+            "raw_non_triggered": tuple(str(c) for c in raw_non_triggered),
+            "tokens_used": int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0),
+            "claim_id": str((claim or {}).get("claim_id") or (claim or {}).get("id") or ""),
+        },
+    )
+
+
+def _resolve_falsification_prompt() -> str:
+    from .skills.registry import get_skill_registry
+
+    registry = get_skill_registry()
+    return registry.get_prompt("digest/reasoning_falsification") or (
+        "Given a claim, fresh evidence, and a list of falsification rules, "
+        "return a JSON object with triggered_conditions (array of rule ids), "
+        "non_triggered_conditions (array of rule ids), and should_invalidate "
+        "(boolean). Be conservative when conservative=true."
+    )
+
+
+def _rule_id(rule: Mapping[str, Any]) -> str:
+    return str(rule.get("id") or rule.get("name") or rule.get("condition_id") or "").strip()
+
+
+def _normalize_condition(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return _rule_id(value)
+    return str(value or "").strip()
 
 
 def compute_evidence_hash(evidence: Mapping[str, Any]) -> str:

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -925,78 +925,139 @@ async def check_falsification(
         )
 
     effective_policy = policy or FalsificationPolicy()
-    rule_ids = tuple(_rule_id(r) for r in effective_policy.rules if _rule_id(r))
+    # Synthesize stable ids for any rule missing id/name/condition_id so the
+    # LLM, the policy surface, and the result all reference the same handle.
+    normalized_rules: list[dict[str, Any]] = []
+    rule_ids_list: list[str] = []
+    for index, rule in enumerate(effective_policy.rules):
+        rule_dict = dict(rule)
+        rid = _rule_id(rule_dict) or f"rule_{index}"
+        rule_dict["id"] = rid
+        normalized_rules.append(rule_dict)
+        rule_ids_list.append(rid)
+    rule_ids = tuple(rule_ids_list)
+
+    claim_id = str((claim or {}).get("claim_id") or (claim or {}).get("id") or "")
     payload = {
         "claim": dict(claim or {}),
         "fresh_evidence": tuple(evidence_to_mapping(item) for item in fresh_evidence),
-        "rules": tuple(dict(r) for r in effective_policy.rules),
+        "rules": tuple(normalized_rules),
         "conservative": bool(effective_policy.conservative),
     }
     payload_text = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     system_prompt = _resolve_falsification_prompt()
 
-    response = await port_bundle.llm.complete(
-        [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": payload_text},
-        ],
-        max_tokens=4096,
-        temperature=0.1,
-        metadata={
-            "reasoning_mode": "falsification_check",
-            "claim_id": str((claim or {}).get("claim_id") or (claim or {}).get("id") or ""),
-            "rule_count": len(rule_ids),
-        },
-    )
+    trace_sink = port_bundle.trace_sink
+    span = None
+    if trace_sink is not None:
+        span = trace_sink.start_span(
+            "extracted_reasoning_core.check_falsification",
+            metadata={
+                "claim_id": claim_id,
+                "rule_count": len(rule_ids),
+                "conservative": effective_policy.conservative,
+            },
+        )
 
-    raw_text = clean_reasoning_text(response_text(response))
-    parsed = parse_llm_json(raw_text)
+    try:
+        response = await port_bundle.llm.complete(
+            [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": payload_text},
+            ],
+            max_tokens=4096,
+            temperature=0.1,
+            metadata={
+                "reasoning_mode": "falsification_check",
+                "claim_id": claim_id,
+                "rule_count": len(rule_ids),
+            },
+        )
 
-    triggered: tuple[str, ...] = ()
-    non_triggered: tuple[str, ...] = ()
-    should_invalidate = False
-    parse_failed = False
-    raw_triggered: list[Any] = []
-    raw_non_triggered: list[Any] = []
+        raw_text = clean_reasoning_text(response_text(response))
+        parsed = parse_llm_json(raw_text)
 
-    if isinstance(parsed, Mapping) and not parsed.get("_parse_fallback"):
-        raw_triggered = list(parsed.get("triggered_conditions") or [])
-        raw_non_triggered = list(parsed.get("non_triggered_conditions") or [])
-        triggered = tuple(_normalize_condition(c) for c in raw_triggered if _normalize_condition(c))
-        non_triggered = tuple(_normalize_condition(c) for c in raw_non_triggered if _normalize_condition(c))
-        verdict = parsed.get("should_invalidate")
-        if verdict is None:
-            # Conservative: never auto-invalidate. Aggressive: any trigger invalidates.
-            should_invalidate = bool(triggered) and not effective_policy.conservative
+        triggered: tuple[str, ...] = ()
+        non_triggered: tuple[str, ...] = ()
+        should_invalidate = False
+        parse_failed = False
+        raw_triggered: list[Any] = []
+        raw_non_triggered: list[Any] = []
+
+        if isinstance(parsed, Mapping) and not parsed.get("_parse_fallback"):
+            raw_triggered = list(parsed.get("triggered_conditions") or [])
+            raw_non_triggered = list(parsed.get("non_triggered_conditions") or [])
+            triggered = tuple(_normalize_condition(c) for c in raw_triggered if _normalize_condition(c))
+            non_triggered = tuple(_normalize_condition(c) for c in raw_non_triggered if _normalize_condition(c))
+            verdict = parsed.get("should_invalidate")
+            if verdict is None:
+                # Conservative: never auto-invalidate. Aggressive: any trigger invalidates.
+                should_invalidate = bool(triggered) and not effective_policy.conservative
+            else:
+                should_invalidate = bool(verdict)
+            if effective_policy.conservative and not triggered:
+                # Override LLM verdict: no triggered conditions means no invalidation.
+                should_invalidate = False
         else:
-            should_invalidate = bool(verdict)
-        if effective_policy.conservative and not triggered:
-            # Override LLM verdict: no triggered conditions means no invalidation.
-            should_invalidate = False
-    else:
-        parse_failed = True
-        # Conservative fallback: surface no triggers, do not invalidate.
+            parse_failed = True
+            # Conservative fallback: surface no triggers, do not invalidate.
 
-    if rule_ids:
-        seen = set(triggered) | set(non_triggered)
-        unseen = tuple(rid for rid in rule_ids if rid not in seen)
-        non_triggered = non_triggered + unseen
+        if rule_ids:
+            seen = set(triggered) | set(non_triggered)
+            unseen = tuple(rid for rid in rule_ids if rid not in seen)
+            non_triggered = non_triggered + unseen
 
-    usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
-    return FalsificationResult(
-        triggered_conditions=triggered,
-        non_triggered_conditions=non_triggered,
-        should_invalidate=should_invalidate,
-        trace={
-            "conservative": effective_policy.conservative,
-            "rule_ids": rule_ids,
-            "parse_failed": parse_failed,
-            "raw_triggered": tuple(str(c) for c in raw_triggered),
-            "raw_non_triggered": tuple(str(c) for c in raw_non_triggered),
-            "tokens_used": int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0),
-            "claim_id": str((claim or {}).get("claim_id") or (claim or {}).get("id") or ""),
-        },
-    )
+        usage = dict(response.get("usage") or {}) if isinstance(response, Mapping) else {}
+        tokens_used = int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0)
+
+        if port_bundle.event_sink is not None:
+            event_name = (
+                "reasoning.falsification.parse_failed"
+                if parse_failed
+                else "reasoning.falsification.completed"
+            )
+            await port_bundle.event_sink.emit(
+                event_name,
+                "extracted_reasoning_core.check_falsification",
+                {
+                    "triggered_count": len(triggered),
+                    "should_invalidate": should_invalidate,
+                    "tokens_used": tokens_used,
+                    "claim_id": claim_id,
+                },
+                entity_type="claim",
+                entity_id=claim_id,
+            )
+        if trace_sink is not None and span is not None:
+            trace_sink.end_span(
+                span,
+                status="error" if parse_failed else "ok",
+                metadata={
+                    "triggered_count": len(triggered),
+                    "should_invalidate": should_invalidate,
+                    "tokens_used": tokens_used,
+                    "parse_failed": parse_failed,
+                },
+            )
+
+        return FalsificationResult(
+            triggered_conditions=triggered,
+            non_triggered_conditions=non_triggered,
+            should_invalidate=should_invalidate,
+            trace={
+                "conservative": effective_policy.conservative,
+                "rule_ids": rule_ids,
+                "parse_failed": parse_failed,
+                "raw_triggered": tuple(str(c) for c in raw_triggered),
+                "raw_non_triggered": tuple(str(c) for c in raw_non_triggered),
+                "tokens_used": tokens_used,
+                "claim_id": claim_id,
+            },
+        )
+    except Exception:
+        if trace_sink is not None and span is not None:
+            trace_sink.end_span(span, status="error", metadata={"stage": "exception"})
+        raise
 
 
 def _resolve_falsification_prompt() -> str:

--- a/extracted_reasoning_core/skills/digest/reasoning_falsification.md
+++ b/extracted_reasoning_core/skills/digest/reasoning_falsification.md
@@ -1,0 +1,25 @@
+You evaluate whether new evidence falsifies a prior reasoning claim.
+
+You receive:
+- claim: the prior claim (with claim text, confidence, source ids, etc.)
+- fresh_evidence: new evidence items the prior claim has not seen yet
+- rules: a list of falsification rules. Each rule has at least an "id" and
+  describes a condition under which the claim should be considered
+  invalid (e.g., "renewal_signal_lost", "competitor_won_segment")
+- conservative: boolean. When true, only invalidate when the evidence is
+  unambiguous; when false, invalidate as soon as any rule's condition is
+  met by the fresh evidence.
+
+For each rule, decide whether the fresh evidence triggers its condition.
+Then produce a single verdict on whether the prior claim should be
+invalidated.
+
+Return ONLY a JSON object with these keys:
+- triggered_conditions (array of strings): rule ids whose condition the
+  fresh evidence triggers
+- non_triggered_conditions (array of strings): rule ids the fresh
+  evidence does NOT trigger
+- should_invalidate (boolean): the final verdict. Honor the conservative
+  flag — if true and the evidence is ambiguous, return false.
+
+Do not include any prose outside the JSON object.

--- a/extracted_reasoning_core/types.py
+++ b/extracted_reasoning_core/types.py
@@ -207,6 +207,8 @@ class ReasoningPack:
 class FalsificationPolicy:
     rules: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     conservative: bool = True
+    max_tokens: int = 4096
+    temperature: float = 0.1
 
 
 @dataclass(frozen=True)

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -46,6 +46,7 @@ pytest \
   tests/test_extracted_reasoning_core_api.py \
   tests/test_extracted_reasoning_core_run_reasoning.py \
   tests/test_extracted_reasoning_core_continue_reasoning.py \
+  tests/test_extracted_reasoning_core_check_falsification.py \
   tests/test_extracted_reasoning_core_archetypes.py \
   tests/test_extracted_reasoning_core_evidence_engine.py \
   tests/test_extracted_reasoning_core_event_trace_ports.py \

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -239,5 +239,5 @@ async def test_stubbed_async_entry_points_fail_closed_until_consolidated() -> No
     with pytest.raises(api.ConfigurationError):
         await api.continue_reasoning({"status": "completed"}, {"event_type": "noop"})
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(api.ConfigurationError):
         await api.check_falsification({}, (evidence,))

--- a/tests/test_extracted_reasoning_core_check_falsification.py
+++ b/tests/test_extracted_reasoning_core_check_falsification.py
@@ -195,6 +195,60 @@ async def test_check_falsification_synthesizes_ids_for_anonymous_rules() -> None
 
 
 @pytest.mark.asyncio
+async def test_check_falsification_id_synthesis_skips_explicit_rule_n_collisions() -> None:
+    """If a host explicitly names a rule rule_<i>, synthesized ids skip past it."""
+
+    mixed_rules = (
+        {"id": "rule_0", "predicate": "host already used rule_0 explicitly"},
+        {"predicate": "anonymous A"},
+        {"id": "rule_2", "predicate": "host already used rule_2 explicitly"},
+        {"predicate": "anonymous B"},
+    )
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "triggered_conditions": [],
+                "non_triggered_conditions": [],
+            }),
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    ])
+
+    result = await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=FalsificationPolicy(rules=mixed_rules, conservative=False),
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    sent_ids = [r["id"] for r in json.loads(llm.calls[0]["messages"][1]["content"])["rules"]]
+    # Anonymous rules get rule_1 and rule_3 — synthesizer skips past explicit rule_0 / rule_2.
+    assert sent_ids == ["rule_0", "rule_1", "rule_2", "rule_3"]
+    assert len(set(sent_ids)) == 4  # no duplicates
+    assert result.trace["rule_ids"] == ("rule_0", "rule_1", "rule_2", "rule_3")
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_honors_policy_max_tokens_and_temperature() -> None:
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({"triggered_conditions": [], "non_triggered_conditions": []}),
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    ])
+
+    await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=FalsificationPolicy(rules=_POLICY.rules, max_tokens=128, temperature=0.42),
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    assert llm.calls[0]["max_tokens"] == 128
+    assert llm.calls[0]["temperature"] == pytest.approx(0.42)
+
+
+@pytest.mark.asyncio
 async def test_check_falsification_emits_completed_event_and_trace_span() -> None:
     """Observability parity with run_reasoning / continue_reasoning."""
 

--- a/tests/test_extracted_reasoning_core_check_falsification.py
+++ b/tests/test_extracted_reasoning_core_check_falsification.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from extracted_reasoning_core.api import ConfigurationError, check_falsification
+from extracted_reasoning_core.types import (
+    EvidenceItem,
+    FalsificationPolicy,
+    FalsificationResult,
+    ReasoningPorts,
+)
+
+
+class FakeLLMPort:
+    def __init__(self, responses: Sequence[Mapping[str, Any]]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "messages": tuple(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        return self.responses.pop(0)
+
+
+_CLAIM = {
+    "claim_id": "c1",
+    "claim": "Renewal pricing is the dominant displacement driver.",
+    "confidence": 0.84,
+    "source_ids": ["r1"],
+}
+_EVIDENCE = (
+    EvidenceItem(source_type="ticket", source_id="t-9", text="Customer renewed without protest."),
+)
+_POLICY = FalsificationPolicy(
+    rules=(
+        {"id": "renewal_signal_lost", "predicate": "fresh evidence shows renewal completed"},
+        {"id": "competitor_won_segment", "predicate": "fresh evidence shows displacement"},
+    ),
+    conservative=True,
+)
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_happy_path_returns_structured_result() -> None:
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "triggered_conditions": ["renewal_signal_lost"],
+                "non_triggered_conditions": ["competitor_won_segment"],
+                "should_invalidate": True,
+            }),
+            "usage": {"input_tokens": 5, "output_tokens": 3},
+        }
+    ])
+
+    result = await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=FalsificationPolicy(rules=_POLICY.rules, conservative=False),
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    assert isinstance(result, FalsificationResult)
+    assert result.triggered_conditions == ("renewal_signal_lost",)
+    assert "competitor_won_segment" in result.non_triggered_conditions
+    assert result.should_invalidate is True
+    assert result.trace["rule_ids"] == ("renewal_signal_lost", "competitor_won_segment")
+    assert result.trace["claim_id"] == "c1"
+    assert result.trace["tokens_used"] == 8
+    assert llm.calls[0]["metadata"]["reasoning_mode"] == "falsification_check"
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_conservative_blocks_invalidation_when_no_triggers() -> None:
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "triggered_conditions": [],
+                "non_triggered_conditions": ["renewal_signal_lost", "competitor_won_segment"],
+                "should_invalidate": True,
+            }),
+            "usage": {"input_tokens": 4, "output_tokens": 2},
+        }
+    ])
+
+    result = await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=_POLICY,
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    assert result.triggered_conditions == ()
+    assert result.should_invalidate is False
+    assert result.trace["conservative"] is True
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_parse_failure_is_conservative_no_invalidation() -> None:
+    llm = FakeLLMPort([
+        {"response": "this is not json", "usage": {"input_tokens": 2, "output_tokens": 1}},
+    ])
+
+    result = await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=_POLICY,
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    assert result.triggered_conditions == ()
+    assert result.should_invalidate is False
+    assert result.trace["parse_failed"] is True
+    # All declared rules show as non-triggered when the LLM returns nothing parseable.
+    assert set(result.non_triggered_conditions) == {"renewal_signal_lost", "competitor_won_segment"}
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_missing_llm_port_raises_configuration_error() -> None:
+    with pytest.raises(ConfigurationError, match="ReasoningPorts.llm"):
+        await check_falsification(_CLAIM, _EVIDENCE, policy=_POLICY)

--- a/tests/test_extracted_reasoning_core_check_falsification.py
+++ b/tests/test_extracted_reasoning_core_check_falsification.py
@@ -133,3 +133,131 @@ async def test_check_falsification_parse_failure_is_conservative_no_invalidation
 async def test_check_falsification_missing_llm_port_raises_configuration_error() -> None:
     with pytest.raises(ConfigurationError, match="ReasoningPorts.llm"):
         await check_falsification(_CLAIM, _EVIDENCE, policy=_POLICY)
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_aggressive_derives_verdict_from_triggered_when_llm_omits_it() -> None:
+    """When LLM returns no should_invalidate boolean, aggressive mode invalidates iff anything triggered."""
+
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "triggered_conditions": ["renewal_signal_lost"],
+                "non_triggered_conditions": ["competitor_won_segment"],
+            }),
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        }
+    ])
+
+    result = await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=FalsificationPolicy(rules=_POLICY.rules, conservative=False),
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    assert result.triggered_conditions == ("renewal_signal_lost",)
+    assert result.should_invalidate is True
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_synthesizes_ids_for_anonymous_rules() -> None:
+    """Rules without id/name/condition_id get synthesized rule_{i} ids that flow through."""
+
+    anonymous_rules = (
+        {"predicate": "fresh evidence shows renewal completed"},
+        {"predicate": "fresh evidence shows displacement"},
+    )
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "triggered_conditions": ["rule_0"],
+                "non_triggered_conditions": [],
+                "should_invalidate": True,
+            }),
+            "usage": {"input_tokens": 2, "output_tokens": 1},
+        }
+    ])
+
+    result = await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=FalsificationPolicy(rules=anonymous_rules, conservative=False),
+        ports=ReasoningPorts(llm=llm),
+    )
+
+    # Synthesized ids appear in the result coverage and the LLM payload.
+    assert result.trace["rule_ids"] == ("rule_0", "rule_1")
+    assert result.triggered_conditions == ("rule_0",)
+    assert "rule_1" in result.non_triggered_conditions
+    sent_payload = json.loads(llm.calls[0]["messages"][1]["content"])
+    assert [r["id"] for r in sent_payload["rules"]] == ["rule_0", "rule_1"]
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_emits_completed_event_and_trace_span() -> None:
+    """Observability parity with run_reasoning / continue_reasoning."""
+
+    events: list[dict[str, Any]] = []
+    spans: list[dict[str, Any]] = []
+
+    class FakeEventSink:
+        async def emit(self, name: str, source: str, payload: Mapping[str, Any], **kwargs: Any) -> None:
+            events.append({"name": name, "source": source, "payload": dict(payload), "kwargs": dict(kwargs)})
+
+    class FakeTraceSink:
+        def start_span(self, name: str, *, metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
+            span = {"name": name, "start_metadata": dict(metadata or {}), "end_metadata": None, "status": None}
+            spans.append(span)
+            return span
+
+        def end_span(self, span: dict[str, Any], *, status: str, metadata: Mapping[str, Any] | None = None) -> None:
+            span["status"] = status
+            span["end_metadata"] = dict(metadata or {})
+
+    llm = FakeLLMPort([
+        {
+            "response": json.dumps({
+                "triggered_conditions": ["renewal_signal_lost"],
+                "non_triggered_conditions": ["competitor_won_segment"],
+                "should_invalidate": True,
+            }),
+            "usage": {"input_tokens": 4, "output_tokens": 2},
+        }
+    ])
+
+    await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=FalsificationPolicy(rules=_POLICY.rules, conservative=False),
+        ports=ReasoningPorts(llm=llm, event_sink=FakeEventSink(), trace_sink=FakeTraceSink()),
+    )
+
+    assert events[0]["name"] == "reasoning.falsification.completed"
+    assert events[0]["payload"]["triggered_count"] == 1
+    assert events[0]["payload"]["should_invalidate"] is True
+    assert spans[0]["name"] == "extracted_reasoning_core.check_falsification"
+    assert spans[0]["status"] == "ok"
+    assert spans[0]["end_metadata"]["triggered_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_check_falsification_emits_parse_failed_event_on_malformed_response() -> None:
+    events: list[dict[str, Any]] = []
+
+    class FakeEventSink:
+        async def emit(self, name: str, source: str, payload: Mapping[str, Any], **kwargs: Any) -> None:
+            events.append({"name": name})
+
+    llm = FakeLLMPort([
+        {"response": "this is not json", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    ])
+
+    await check_falsification(
+        _CLAIM,
+        _EVIDENCE,
+        policy=_POLICY,
+        ports=ReasoningPorts(llm=llm, event_sink=FakeEventSink()),
+    )
+
+    assert events[0]["name"] == "reasoning.falsification.parse_failed"


### PR DESCRIPTION
## Summary

Implements `check_falsification()` — the per-claim refute/confirm pass that complements `continue_reasoning`'s broader refinement loop. Given a prior claim and fresh evidence, the function evaluates which falsification rules trigger and returns a structured `FalsificationResult` with `triggered_conditions`, `non_triggered_conditions`, and a single `should_invalidate` verdict.

This is the third slice of the multi-pass reasoning extraction (PR-D20a #304 = `run_reasoning`, PR-D20b #305 = `continue_reasoning`).

## What changed

- **`extracted_reasoning_core/api.py`** — `check_falsification` real implementation. Builds payload → one LLM call → JSON parse → normalize to `FalsificationResult`. Conservative semantics enforced.
- **`extracted_reasoning_core/_synthesis.py`** — renamed three helpers (`_response_text`, `_clean_reasoning_text`, `_parse_llm_json`) to drop the leading underscore so `api.check_falsification` can reuse them without duplication. They were already private to the underscored `_synthesis` module; the rename just makes them shareable inside the package.
- **`extracted_reasoning_core/skills/digest/reasoning_falsification.md` (new)** — packaged falsification prompt. Host-overridable via skill roots.
- **`tests/test_extracted_reasoning_core_check_falsification.py` (new)** — 4 test cases (see below).
- **`tests/test_extracted_reasoning_core_api.py`** — stub-test updated: `check_falsification` now expects `ConfigurationError` (not `NotImplementedError`) without an LLM port.
- **`scripts/run_extracted_pipeline_checks.sh`** — new test wired into the runner.

## Behavior

**Conservative semantics** (`policy.conservative=True`, the default):
- If LLM returns no triggered conditions → `should_invalidate=False` regardless of LLM verdict.
- If LLM response is malformed → `triggered_conditions=()`, `should_invalidate=False`, `trace.parse_failed=True`. Prior claim survives ambiguity.

**Aggressive** (`conservative=False`):
- If any condition triggers and LLM gives no explicit verdict → `should_invalidate=True`.
- LLM's explicit `should_invalidate` boolean (when present) is honored.

**Rule coverage**: any declared rule id the LLM doesn't classify ends up in `non_triggered_conditions` automatically, so the result always covers the full policy surface.

## Decoupling rules

- Zero direct `atlas_brain` imports at module-load time (verified by AST scan).
- No witness context needed — falsification is self-contained from `claim + fresh_evidence + policy`.

## Test plan

- [x] `python -c "import extracted_reasoning_core; from extracted_reasoning_core.api import check_falsification"` → clean
- [x] AST scan of `extracted_reasoning_core/**/*.py` for `atlas_brain` refs → 0 hits
- [x] `pytest -q tests/test_extracted_reasoning_core_check_falsification.py tests/test_extracted_reasoning_core_run_reasoning.py tests/test_extracted_reasoning_core_continue_reasoning.py tests/test_extracted_reasoning_core_api.py` → 26/26 passing locally
- [ ] CI `extracted-checks` run

## Out of scope (explicitly deferred)

- `build_narrative_plan` — PR-D20d
- `compute_evidence_hash` / `build_semantic_cache_key` — PR-D20e
- `load_reasoning_pack` — PR-D20f
- `validate_reasoning_output` — PR-D20g
- Wiring `extracted_content_pipeline` to call any D20 producer — PR-D21

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_