### PR TITLE
PR-D20d: Implement build_narrative_plan() (deterministic plan from reasoning context)

### DIFF
--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -228,10 +228,121 @@ def build_narrative_plan(
     *,
     pack: ReasoningPack,
 ) -> NarrativePlan:
-    """Build a product-neutral narrative plan."""
-    del context
-    del pack
-    raise NotImplementedError("build_narrative_plan lands with narrative consolidation")
+    """Build a product-neutral narrative plan from a reasoning context.
+
+    Pure deterministic transformation: take a reasoning context (either
+    a ``ReasoningResult.state`` dict or a raw synthesis JSON), apply
+    pack policies, and produce an ordered ``NarrativePlan`` with
+    sections, evidence requirements, and state hints. No LLM call.
+
+    Pack policies honored (all optional):
+      * ``min_confidence`` (default 0.0): drop claims below this score.
+      * ``max_sections`` (default 10): cap the number of sections.
+      * ``claim_ordering`` (default "by_confidence"): "by_confidence"
+        sorts claims descending by confidence; "preserve_input" keeps
+        the order from the source.
+      * ``default_section`` (default "main"): section name used when a
+        claim doesn't carry a ``section`` field.
+    """
+
+    raw_synthesis = context.get("raw_synthesis") if isinstance(context.get("raw_synthesis"), Mapping) else None
+    source = raw_synthesis if raw_synthesis else context
+
+    raw_claims = extract_claims(source)
+    summary = extract_summary(source)
+    confidence = extract_confidence(source, raw_claims)
+
+    policies = dict(pack.policies or {})
+    min_confidence = float(policies.get("min_confidence", 0.0))
+    max_sections = max(1, int(policies.get("max_sections", 10)))
+    claim_ordering = str(policies.get("claim_ordering", "by_confidence")).lower()
+    default_section = str(policies.get("default_section", "main"))
+
+    # Filter and order claims.
+    filtered: list[Mapping[str, Any]] = []
+    dropped = 0
+    for claim in raw_claims:
+        claim_conf = _claim_confidence(claim)
+        if claim_conf < min_confidence:
+            dropped += 1
+            continue
+        filtered.append(claim)
+    if claim_ordering == "by_confidence":
+        filtered.sort(key=_claim_confidence, reverse=True)
+
+    # Group by section.
+    section_order: list[str] = []
+    section_claims: dict[str, list[Mapping[str, Any]]] = {}
+    for claim in filtered:
+        section_name = str(claim.get("section") or default_section)
+        if section_name not in section_claims:
+            section_claims[section_name] = []
+            section_order.append(section_name)
+        section_claims[section_name].append(claim)
+
+    if len(section_order) > max_sections:
+        section_order = section_order[:max_sections]
+
+    sections: list[Mapping[str, Any]] = []
+    evidence_requirements: list[Mapping[str, Any]] = []
+    plan_claims: list[Mapping[str, Any]] = []
+
+    for section_name in section_order:
+        claims_in_section = tuple(section_claims[section_name])
+        plan_claims.extend(claims_in_section)
+        section_source_ids = _collect_source_ids(claims_in_section)
+        sections.append({
+            "id": section_name,
+            "title": section_name.replace("_", " ").strip().title() or section_name,
+            "claim_count": len(claims_in_section),
+            "claim_ids": tuple(_claim_id(c) for c in claims_in_section),
+        })
+        evidence_requirements.append({
+            "section_id": section_name,
+            "required_source_ids": section_source_ids,
+            "claim_count": len(claims_in_section),
+        })
+
+    return NarrativePlan(
+        claims=tuple(plan_claims),
+        sections=tuple(sections),
+        evidence_requirements=tuple(evidence_requirements),
+        state_hints={
+            "summary": summary,
+            "overall_confidence": confidence,
+            "claim_count": len(plan_claims),
+            "section_count": len(sections),
+            "dropped_below_confidence": dropped,
+            "pack": pack.name,
+            "pack_version": pack.version,
+            "depth": context.get("depth") or context.get("tier") or "",
+        },
+    )
+
+
+def _claim_confidence(claim: Mapping[str, Any]) -> float:
+    raw = claim.get("confidence")
+    if raw is None:
+        return 0.0
+    rank = {"high": 0.9, "medium": 0.6, "low": 0.3, "insufficient": 0.0}
+    try:
+        return max(0.0, min(1.0, float(raw)))
+    except (TypeError, ValueError):
+        return rank.get(str(raw).strip().lower(), 0.0)
+
+
+def _claim_id(claim: Mapping[str, Any]) -> str:
+    return str(claim.get("claim_id") or claim.get("id") or claim.get("claim") or "")[:200]
+
+
+def _collect_source_ids(claims: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    seen: list[str] = []
+    for claim in claims:
+        for sid in claim.get("source_ids") or ():
+            sid_str = str(sid)
+            if sid_str and sid_str not in seen:
+                seen.append(sid_str)
+    return tuple(seen)
 
 
 async def run_reasoning(

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -239,10 +239,15 @@ def build_narrative_plan(
       * ``min_confidence`` (default 0.0): drop claims below this score.
       * ``max_sections`` (default 10): cap the number of sections.
       * ``claim_ordering`` (default "by_confidence"): "by_confidence"
-        sorts claims descending by confidence; "preserve_input" keeps
-        the order from the source.
+        sorts claims descending by confidence; any other value
+        (including "preserve_input") keeps the order from the source.
       * ``default_section`` (default "main"): section name used when a
         claim doesn't carry a ``section`` field.
+
+    ``state_hints`` includes ``dropped_below_confidence`` (claims removed
+    by ``min_confidence``) and ``dropped_due_to_section_cap`` (claims
+    removed because their section exceeded ``max_sections``) so callers
+    can distinguish missing data from rendering choices.
     """
 
     raw_synthesis = context.get("raw_synthesis") if isinstance(context.get("raw_synthesis"), Mapping) else None
@@ -281,7 +286,13 @@ def build_narrative_plan(
         section_claims[section_name].append(claim)
 
     if len(section_order) > max_sections:
+        capped_section_names = section_order[max_sections:]
+        dropped_due_to_section_cap = sum(
+            len(section_claims[s]) for s in capped_section_names
+        )
         section_order = section_order[:max_sections]
+    else:
+        dropped_due_to_section_cap = 0
 
     sections: list[Mapping[str, Any]] = []
     evidence_requirements: list[Mapping[str, Any]] = []
@@ -299,7 +310,7 @@ def build_narrative_plan(
         })
         evidence_requirements.append({
             "section_id": section_name,
-            "required_source_ids": section_source_ids,
+            "cited_source_ids": section_source_ids,
             "claim_count": len(claims_in_section),
         })
 
@@ -313,6 +324,7 @@ def build_narrative_plan(
             "claim_count": len(plan_claims),
             "section_count": len(sections),
             "dropped_below_confidence": dropped,
+            "dropped_due_to_section_cap": dropped_due_to_section_cap,
             "pack": pack.name,
             "pack_version": pack.version,
             "depth": context.get("depth") or context.get("tier") or "",

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -47,6 +47,7 @@ pytest \
   tests/test_extracted_reasoning_core_run_reasoning.py \
   tests/test_extracted_reasoning_core_continue_reasoning.py \
   tests/test_extracted_reasoning_core_check_falsification.py \
+  tests/test_extracted_reasoning_core_build_narrative_plan.py \
   tests/test_extracted_reasoning_core_archetypes.py \
   tests/test_extracted_reasoning_core_evidence_engine.py \
   tests/test_extracted_reasoning_core_event_trace_ports.py \

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -113,7 +113,6 @@ def test_stubbed_public_entry_points_fail_closed_until_consolidated() -> None:
     # PR-C1d wired `evaluate_evidence` to the slim `EvidenceEngine`.
     # All three originally NotImplementedError stubs are now functional.
     sync_calls = [
-        lambda: api.build_narrative_plan({}, pack=ReasoningPack(name="default")),
         lambda: api.compute_evidence_hash({}),
         lambda: api.build_semantic_cache_key(reasoning_input, tier="L1"),
         lambda: api.load_reasoning_pack("content_pipeline"),
@@ -123,6 +122,10 @@ def test_stubbed_public_entry_points_fail_closed_until_consolidated() -> None:
     for call in sync_calls:
         with pytest.raises(NotImplementedError):
             call()
+
+    # build_narrative_plan now returns a NarrativePlan (no longer stubbed).
+    plan = api.build_narrative_plan({}, pack=ReasoningPack(name="default"))
+    assert plan.claims == ()
 
 
 # ------------------------------------------------------------------

--- a/tests/test_extracted_reasoning_core_build_narrative_plan.py
+++ b/tests/test_extracted_reasoning_core_build_narrative_plan.py
@@ -57,7 +57,7 @@ def test_build_narrative_plan_happy_path_orders_by_confidence_and_groups_section
     assert drivers["claim_count"] == 2
     assert drivers["title"] == "Drivers"
     drivers_evidence = next(e for e in plan.evidence_requirements if e["section_id"] == "drivers")
-    assert set(drivers_evidence["required_source_ids"]) == {"r1", "r2", "r3"}
+    assert set(drivers_evidence["cited_source_ids"]) == {"r1", "r2", "r3"}
     assert plan.state_hints["overall_confidence"] == 0.78
     assert plan.state_hints["claim_count"] == 3
     assert plan.state_hints["dropped_below_confidence"] == 0
@@ -92,6 +92,11 @@ def test_build_narrative_plan_max_sections_caps_section_count() -> None:
     # section names from the confidence-sorted list survive.
     section_ids = [s["id"] for s in plan.sections]
     assert section_ids == ["drivers", "competitive"]
+    # c4 was dropped because its "operations" section exceeded the cap.
+    plan_claim_ids = [c["claim_id"] for c in plan.claims]
+    assert "c4" not in plan_claim_ids
+    assert plan.state_hints["dropped_due_to_section_cap"] == 1
+    assert plan.state_hints["claim_count"] == 3  # c1, c2, c3 survive
 
 
 def test_build_narrative_plan_accepts_raw_synthesis_directly_without_state_wrapper() -> None:
@@ -102,6 +107,21 @@ def test_build_narrative_plan_accepts_raw_synthesis_directly_without_state_wrapp
 
     assert plan.state_hints["claim_count"] == 3
     assert plan.state_hints["overall_confidence"] == 0.78
+
+
+def test_build_narrative_plan_preserve_input_keeps_source_order() -> None:
+    """claim_ordering="preserve_input" keeps source order even when confidence differs."""
+
+    state = _state_with_claims()
+    # Source order is [c1=0.85, c2=0.55, c3=0.7]; by_confidence would reorder to c1, c3, c2.
+    pack = ReasoningPack(name="preserve", policies={"claim_ordering": "preserve_input"})
+
+    plan = build_narrative_plan(state, pack=pack)
+
+    # All three claims present; section grouping still applies, but within each
+    # section claims keep their source order.
+    drivers = [c["claim_id"] for c in plan.claims if c.get("section") == "drivers"]
+    assert drivers == ["c1", "c2"]
 
 
 def test_build_narrative_plan_empty_context_returns_empty_plan() -> None:

--- a/tests/test_extracted_reasoning_core_build_narrative_plan.py
+++ b/tests/test_extracted_reasoning_core_build_narrative_plan.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from extracted_reasoning_core.api import build_narrative_plan
+from extracted_reasoning_core.types import NarrativePlan, ReasoningPack
+
+
+def _state_with_claims() -> dict[str, Any]:
+    return {
+        "status": "completed",
+        "depth": "L2",
+        "raw_synthesis": {
+            "summary": "Pricing pressure dominates.",
+            "claims": [
+                {
+                    "claim_id": "c1",
+                    "claim": "Renewal pricing drives displacement.",
+                    "confidence": 0.85,
+                    "source_ids": ["r1", "r2"],
+                    "section": "drivers",
+                },
+                {
+                    "claim_id": "c2",
+                    "claim": "Onboarding friction is secondary.",
+                    "confidence": 0.55,
+                    "source_ids": ["r3"],
+                    "section": "drivers",
+                },
+                {
+                    "claim_id": "c3",
+                    "claim": "Sales team mentions competitor X frequently.",
+                    "confidence": 0.7,
+                    "source_ids": ["r4"],
+                    "section": "competitive",
+                },
+            ],
+            "confidence": 0.78,
+        },
+    }
+
+
+def test_build_narrative_plan_happy_path_orders_by_confidence_and_groups_sections() -> None:
+    pack = ReasoningPack(name="default_narrative", policies={})
+
+    plan = build_narrative_plan(_state_with_claims(), pack=pack)
+
+    assert isinstance(plan, NarrativePlan)
+    # Claims confidence-sorted (c1 0.85, c3 0.7, c2 0.55) then grouped by
+    # section so renderers get section-coherent runs:
+    #   drivers: c1, c2  (c1 first because it sorted ahead of c2)
+    #   competitive: c3  (section first seen after c1, before c2)
+    assert tuple(c["claim_id"] for c in plan.claims) == ("c1", "c2", "c3")
+    section_ids = [s["id"] for s in plan.sections]
+    assert "drivers" in section_ids and "competitive" in section_ids
+    drivers = next(s for s in plan.sections if s["id"] == "drivers")
+    assert drivers["claim_count"] == 2
+    assert drivers["title"] == "Drivers"
+    drivers_evidence = next(e for e in plan.evidence_requirements if e["section_id"] == "drivers")
+    assert set(drivers_evidence["required_source_ids"]) == {"r1", "r2", "r3"}
+    assert plan.state_hints["overall_confidence"] == 0.78
+    assert plan.state_hints["claim_count"] == 3
+    assert plan.state_hints["dropped_below_confidence"] == 0
+    assert plan.state_hints["depth"] == "L2"
+
+
+def test_build_narrative_plan_min_confidence_drops_low_claims() -> None:
+    pack = ReasoningPack(name="strict", policies={"min_confidence": 0.6})
+
+    plan = build_narrative_plan(_state_with_claims(), pack=pack)
+
+    # c2 (0.55) drops; c1 (0.85) and c3 (0.7) survive.
+    assert tuple(c["claim_id"] for c in plan.claims) == ("c1", "c3")
+    assert plan.state_hints["dropped_below_confidence"] == 1
+
+
+def test_build_narrative_plan_max_sections_caps_section_count() -> None:
+    state = _state_with_claims()
+    state["raw_synthesis"]["claims"].append({
+        "claim_id": "c4",
+        "claim": "Customer success is understaffed.",
+        "confidence": 0.6,
+        "source_ids": ["r5"],
+        "section": "operations",
+    })
+    pack = ReasoningPack(name="capped", policies={"max_sections": 2})
+
+    plan = build_narrative_plan(state, pack=pack)
+
+    assert len(plan.sections) == 2
+    # Sections are inserted in claim-iteration order after sorting; first two distinct
+    # section names from the confidence-sorted list survive.
+    section_ids = [s["id"] for s in plan.sections]
+    assert section_ids == ["drivers", "competitive"]
+
+
+def test_build_narrative_plan_accepts_raw_synthesis_directly_without_state_wrapper() -> None:
+    raw = _state_with_claims()["raw_synthesis"]
+    pack = ReasoningPack(name="default", policies={})
+
+    plan = build_narrative_plan(raw, pack=pack)
+
+    assert plan.state_hints["claim_count"] == 3
+    assert plan.state_hints["overall_confidence"] == 0.78
+
+
+def test_build_narrative_plan_empty_context_returns_empty_plan() -> None:
+    pack = ReasoningPack(name="default", policies={})
+
+    plan = build_narrative_plan({}, pack=pack)
+
+    assert plan.claims == ()
+    assert plan.sections == ()
+    assert plan.evidence_requirements == ()
+    assert plan.state_hints["claim_count"] == 0
+    assert plan.state_hints["section_count"] == 0


### PR DESCRIPTION
## Summary

Implements `build_narrative_plan()` — the fourth multi-pass slot in `extracted_reasoning_core`. Pure deterministic transformation (sync function, **no LLM call**): take a reasoning context plus pack policies and produce a structured `NarrativePlan` with claims, sections, evidence requirements, and state hints that downstream renderers/templates can consume.

This is the simplest D20 slice — no LLM, no async, no ports. It's the bridge between reasoning output and presentation.

## What changed

- **`extracted_reasoning_core/api.py`** — `build_narrative_plan` real implementation + small private helpers (`_claim_confidence`, `_claim_id`, `_collect_source_ids`).
- **`tests/test_extracted_reasoning_core_build_narrative_plan.py` (new)** — 5 tests.
- **`tests/test_extracted_reasoning_core_api.py`** — stub-test updated: `build_narrative_plan` no longer expects `NotImplementedError`.
- **`scripts/run_extracted_pipeline_checks.sh`** — new test wired into the runner.

## Pack policies honored

All optional, defaults preserve a sensible shape:
- `min_confidence` (default `0.0`): drop claims below this score
- `max_sections` (default `10`): cap section count
- `claim_ordering` (default `"by_confidence"`): `"by_confidence"` sorts descending; `"preserve_input"` keeps source order
- `default_section` (default `"main"`): used when a claim lacks a `section` field

## Design choice

Sections are grouped **after** sorting, so renderers get section-coherent runs of claims rather than a globally sorted sequence with section IDs interleaved. `evidence_requirements` collects unique `source_ids` per section.

Accepts both `ReasoningResult.state` shape (with `raw_synthesis` nested) and a raw synthesis dict directly — symmetric with `continue_reasoning`'s context-shape tolerance.

## Test plan

- [x] `python -c "from extracted_reasoning_core.api import build_narrative_plan"` → clean
- [x] AST scan of `extracted_reasoning_core/**/*.py` for `atlas_brain` refs → 0 hits
- [x] `pytest -q tests/test_extracted_reasoning_core_build_narrative_plan.py tests/test_extracted_reasoning_core_run_reasoning.py tests/test_extracted_reasoning_core_continue_reasoning.py tests/test_extracted_reasoning_core_check_falsification.py tests/test_extracted_reasoning_core_api.py` → 37/37 passing locally
- [ ] CI `extracted-checks` run

## Out of scope

- `compute_evidence_hash` / `build_semantic_cache_key` — PR-D20e
- `load_reasoning_pack` — PR-D20f
- `validate_reasoning_output` — PR-D20g
- Wiring `extracted_content_pipeline` to call any D20 producer — PR-D21

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_