### PR TITLE
PR-D20e: Implement compute_evidence_hash + build_semantic_cache_key (semantic-cache split)

### DIFF
--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -1214,9 +1214,17 @@ def _normalize_condition(value: Any) -> str:
 
 
 def compute_evidence_hash(evidence: Mapping[str, Any]) -> str:
-    """Compute the stable reasoning evidence hash."""
-    del evidence
-    raise NotImplementedError("compute_evidence_hash lands with semantic-cache split")
+    """Compute a stable hex digest for an evidence mapping.
+
+    Delegates to :func:`extracted_reasoning_core.semantic_cache_keys.compute_evidence_hash`
+    so this public surface and the existing semantic-cache primitives
+    produce identical fingerprints. Returns a 16-char hex prefix of the
+    sha256 digest (matches the established ``reasoning_semantic_cache``
+    storage convention).
+    """
+    from .semantic_cache_keys import compute_evidence_hash as _compute
+
+    return _compute(dict(evidence or {}))
 
 
 def build_semantic_cache_key(
@@ -1225,11 +1233,27 @@ def build_semantic_cache_key(
     tier: str,
     pack_name: str | None = None,
 ) -> str:
-    """Build a stable semantic-cache key for a reasoning input."""
-    del reasoning_input
-    del tier
-    del pack_name
-    raise NotImplementedError("build_semantic_cache_key lands with semantic-cache split")
+    """Build a stable semantic-cache key for a reasoning input.
+
+    The key encodes everything that should make two reasoning calls
+    cache-equivalent: entity identity, goal, evidence content, context,
+    pack name, and tier. Format: ``reasoning/{tier}/{pack}/{digest}`` so
+    the leading segments are human-readable while the digest (16-char
+    hex from :func:`compute_evidence_hash`) captures full content
+    sensitivity.
+    """
+    effective_pack = pack_name or reasoning_input.pack_name or "default"
+    payload = {
+        "entity_id": reasoning_input.entity_id,
+        "entity_type": reasoning_input.entity_type,
+        "goal": reasoning_input.goal,
+        "evidence": [evidence_to_mapping(item) for item in reasoning_input.evidence],
+        "context": dict(reasoning_input.context or {}),
+        "pack_name": effective_pack,
+        "tier": tier,
+    }
+    digest = compute_evidence_hash(payload)
+    return f"reasoning/{tier}/{effective_pack}/{digest}"
 
 
 def load_reasoning_pack(name: str) -> ReasoningPack:

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -1241,8 +1241,21 @@ def build_semantic_cache_key(
     the leading segments are human-readable while the digest (16-char
     hex from :func:`compute_evidence_hash`) captures full content
     sensitivity.
+
+    The default pack name (``"reasoning_synthesis"``) matches the fallback
+    that ``run_reasoning`` and ``continue_reasoning`` apply, so cache
+    lookups for inputs without an explicit pack still align with what
+    synthesis actually computed against.
+
+    ``tier`` and ``pack_name`` must not contain ``/`` (raises
+    ``ValueError``) since the slash separates key segments.
     """
-    effective_pack = pack_name or reasoning_input.pack_name or "default"
+    effective_pack = pack_name or reasoning_input.pack_name or "reasoning_synthesis"
+    for label, value in (("tier", tier), ("pack_name", effective_pack)):
+        if "/" in value:
+            raise ValueError(
+                f"semantic cache key {label} cannot contain '/': {value!r}"
+            )
     payload = {
         "entity_id": reasoning_input.entity_id,
         "entity_type": reasoning_input.entity_type,

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -48,6 +48,7 @@ pytest \
   tests/test_extracted_reasoning_core_continue_reasoning.py \
   tests/test_extracted_reasoning_core_check_falsification.py \
   tests/test_extracted_reasoning_core_build_narrative_plan.py \
+  tests/test_extracted_reasoning_core_semantic_cache.py \
   tests/test_extracted_reasoning_core_archetypes.py \
   tests/test_extracted_reasoning_core_evidence_engine.py \
   tests/test_extracted_reasoning_core_event_trace_ports.py \

--- a/tests/test_extracted_reasoning_core_api.py
+++ b/tests/test_extracted_reasoning_core_api.py
@@ -113,8 +113,6 @@ def test_stubbed_public_entry_points_fail_closed_until_consolidated() -> None:
     # PR-C1d wired `evaluate_evidence` to the slim `EvidenceEngine`.
     # All three originally NotImplementedError stubs are now functional.
     sync_calls = [
-        lambda: api.compute_evidence_hash({}),
-        lambda: api.build_semantic_cache_key(reasoning_input, tier="L1"),
         lambda: api.load_reasoning_pack("content_pipeline"),
         lambda: api.validate_reasoning_output(result),
     ]
@@ -126,6 +124,9 @@ def test_stubbed_public_entry_points_fail_closed_until_consolidated() -> None:
     # build_narrative_plan now returns a NarrativePlan (no longer stubbed).
     plan = api.build_narrative_plan({}, pack=ReasoningPack(name="default"))
     assert plan.claims == ()
+    # compute_evidence_hash and build_semantic_cache_key now return strings.
+    assert isinstance(api.compute_evidence_hash({}), str)
+    assert api.build_semantic_cache_key(reasoning_input, tier="L1").startswith("reasoning/L1/")
 
 
 # ------------------------------------------------------------------

--- a/tests/test_extracted_reasoning_core_semantic_cache.py
+++ b/tests/test_extracted_reasoning_core_semantic_cache.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from extracted_reasoning_core.api import (
     build_semantic_cache_key,
     compute_evidence_hash,
@@ -7,13 +9,13 @@ from extracted_reasoning_core.api import (
 from extracted_reasoning_core.types import EvidenceItem, ReasoningInput
 
 
-def _input(*, entity_id: str = "acme", goal: str = "synthesize", pack_name: str | None = None) -> ReasoningInput:
+def _input(*, entity_id: str = "acme", goal: str = "synthesize", pack_name: str | None = None, evidence_text: str = "Pricing concern raised.") -> ReasoningInput:
     return ReasoningInput(
         entity_id=entity_id,
         entity_type="vendor",
         goal=goal,
         evidence=(
-            EvidenceItem(source_type="review", source_id="r1", text="Pricing concern raised."),
+            EvidenceItem(source_type="review", source_id="r1", text=evidence_text),
             EvidenceItem(source_type="ticket", source_id="t9", text="Renewal pending."),
         ),
         pack_name=pack_name,
@@ -54,14 +56,25 @@ def test_build_semantic_cache_key_is_sensitive_to_tier_and_pack() -> None:
     assert base != different_tier
     assert base != different_pack
     assert pack_from_input != pack_default
-    # Default pack name materializes as "default" in the key prefix.
-    assert pack_default.startswith("reasoning/L2/default/")
+    # Default pack name matches run_reasoning / continue_reasoning fallback so
+    # cache lookups for inputs without an explicit pack align with what
+    # synthesis computed against.
+    assert pack_default.startswith("reasoning/L2/reasoning_synthesis/")
 
 
 def test_build_semantic_cache_key_is_sensitive_to_evidence_and_goal() -> None:
     base = build_semantic_cache_key(_input(), tier="L2")
     different_goal = build_semantic_cache_key(_input(goal="different goal"), tier="L2")
     different_entity = build_semantic_cache_key(_input(entity_id="other_vendor"), tier="L2")
+    different_evidence = build_semantic_cache_key(_input(evidence_text="entirely different review text"), tier="L2")
 
     assert base != different_goal
     assert base != different_entity
+    assert base != different_evidence
+
+
+def test_build_semantic_cache_key_rejects_slashes_in_tier_or_pack() -> None:
+    with pytest.raises(ValueError, match="tier"):
+        build_semantic_cache_key(_input(), tier="L2/x")
+    with pytest.raises(ValueError, match="pack_name"):
+        build_semantic_cache_key(_input(), tier="L2", pack_name="bad/pack")

--- a/tests/test_extracted_reasoning_core_semantic_cache.py
+++ b/tests/test_extracted_reasoning_core_semantic_cache.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from extracted_reasoning_core.api import (
+    build_semantic_cache_key,
+    compute_evidence_hash,
+)
+from extracted_reasoning_core.types import EvidenceItem, ReasoningInput
+
+
+def _input(*, entity_id: str = "acme", goal: str = "synthesize", pack_name: str | None = None) -> ReasoningInput:
+    return ReasoningInput(
+        entity_id=entity_id,
+        entity_type="vendor",
+        goal=goal,
+        evidence=(
+            EvidenceItem(source_type="review", source_id="r1", text="Pricing concern raised."),
+            EvidenceItem(source_type="ticket", source_id="t9", text="Renewal pending."),
+        ),
+        pack_name=pack_name,
+    )
+
+
+def test_compute_evidence_hash_is_stable_and_order_independent() -> None:
+    a = compute_evidence_hash({"k1": "v1", "k2": "v2", "nested": {"a": 1, "b": 2}})
+    b = compute_evidence_hash({"k2": "v2", "nested": {"b": 2, "a": 1}, "k1": "v1"})
+    assert a == b
+    # 16-char hex prefix of sha256 (matches semantic_cache_keys storage convention)
+    assert len(a) == 16
+    assert all(c in "0123456789abcdef" for c in a)
+
+
+def test_compute_evidence_hash_distinguishes_different_content() -> None:
+    a = compute_evidence_hash({"k": "v1"})
+    b = compute_evidence_hash({"k": "v2"})
+    assert a != b
+
+
+def test_build_semantic_cache_key_is_deterministic_for_identical_inputs() -> None:
+    k1 = build_semantic_cache_key(_input(), tier="L2", pack_name="reasoning_synthesis")
+    k2 = build_semantic_cache_key(_input(), tier="L2", pack_name="reasoning_synthesis")
+    assert k1 == k2
+    assert k1.startswith("reasoning/L2/reasoning_synthesis/")
+    digest = k1.split("/")[-1]
+    assert len(digest) == 16
+
+
+def test_build_semantic_cache_key_is_sensitive_to_tier_and_pack() -> None:
+    base = build_semantic_cache_key(_input(), tier="L2", pack_name="reasoning_synthesis")
+    different_tier = build_semantic_cache_key(_input(), tier="L3", pack_name="reasoning_synthesis")
+    different_pack = build_semantic_cache_key(_input(), tier="L2", pack_name="other_pack")
+    pack_from_input = build_semantic_cache_key(_input(pack_name="from_input"), tier="L2")
+    pack_default = build_semantic_cache_key(_input(), tier="L2")
+
+    assert base != different_tier
+    assert base != different_pack
+    assert pack_from_input != pack_default
+    # Default pack name materializes as "default" in the key prefix.
+    assert pack_default.startswith("reasoning/L2/default/")
+
+
+def test_build_semantic_cache_key_is_sensitive_to_evidence_and_goal() -> None:
+    base = build_semantic_cache_key(_input(), tier="L2")
+    different_goal = build_semantic_cache_key(_input(goal="different goal"), tier="L2")
+    different_entity = build_semantic_cache_key(_input(entity_id="other_vendor"), tier="L2")
+
+    assert base != different_goal
+    assert base != different_entity


### PR DESCRIPTION
## Summary

Wires the two semantic-cache helpers in `extracted_reasoning_core.api`. Both are sync, deterministic, no LLM call. This is the fifth slice in the D20 series (PR-D20a–d already merged).

## What changed

- **`extracted_reasoning_core/api.py`** — `compute_evidence_hash` and `build_semantic_cache_key` real implementations.
- **`tests/test_extracted_reasoning_core_semantic_cache.py` (new)** — 5 tests.
- **`tests/test_extracted_reasoning_core_api.py`** — stub-test updated.
- **`scripts/run_extracted_pipeline_checks.sh`** — new test wired into the runner.

## Implementation notes

**`compute_evidence_hash`** delegates to the existing `extracted_reasoning_core.semantic_cache_keys.compute_evidence_hash` rather than reimplementing — discovered an existing implementation there with a different output shape (16-char hex prefix matching the `reasoning_semantic_cache` storage convention). Delegating keeps a single source of truth.

**`build_semantic_cache_key`** composes a stable key from entity identity, goal, evidence content, context, pack name, and tier:

```
reasoning/{tier}/{pack}/{16-char digest}
```

Two callers with the same significant inputs always get the same key; any change produces a distinct key.

## Test plan

- [x] `python -c "from extracted_reasoning_core.api import compute_evidence_hash, build_semantic_cache_key"` → clean
- [x] AST scan of `extracted_reasoning_core/**/*.py` for `atlas_brain` refs → 0 hits
- [x] `pytest -q` across the reasoning-core suite → 60/60 passing locally (5 new + 8 existing `semantic_cache_keys` + 47 across the rest)
- [ ] CI `extracted-checks` run

## Out of scope

- `load_reasoning_pack` — PR-D20f
- `validate_reasoning_output` — PR-D20g
- Wiring `extracted_content_pipeline` to call any D20 producer — PR-D21

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_