### PR TITLE
PR-D21b: Chain continue_reasoning per opportunity event in the bridge

### DIFF
--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -128,21 +128,43 @@ class MultiPassCampaignReasoningProvider:
         # continuation that fails validation -- the last successful state
         # is what feeds the campaign context.
         events = list(opportunity.get("events") or ())
+        events_total = len(events)
+        events_consumed = 0
+        chain_halted_on_failure = False
         if self._config.enable_multi_pass and events:
             limit = max(0, int(self._config.max_continuations))
             for event in events[:limit]:
+                if not isinstance(event, Mapping):
+                    raise TypeError(
+                        "opportunity['events'] entries must be mappings with at "
+                        f"least an 'event_type' key; got {type(event).__name__}: "
+                        f"{event!r}"
+                    )
                 next_result = await continue_reasoning(
                     result.state,
-                    event if isinstance(event, Mapping) else {"event_type": str(event), "evidence": ()},
+                    event,
                     ports=self._ports,
                 )
                 if str(next_result.state.get("status") or "") != "completed":
                     # Continuation failed validation -- keep the prior
                     # successful state and stop the chain.
+                    chain_halted_on_failure = True
                     break
                 result = next_result
+                events_consumed += 1
 
-        return _result_to_campaign_context(result, limit=self._config.top_thesis_limit)
+        events_truncated = max(0, events_total - max(0, int(self._config.max_continuations))) if self._config.enable_multi_pass else events_total
+        chain_telemetry = {
+            "events_total": events_total,
+            "events_consumed": events_consumed,
+            "events_truncated": events_truncated,
+            "chain_halted_on_failure": chain_halted_on_failure,
+        }
+        return _result_to_campaign_context(
+            result,
+            limit=self._config.top_thesis_limit,
+            chain_telemetry=chain_telemetry,
+        )
 
 
 def _coerce_evidence(item: Any) -> Any:
@@ -163,7 +185,12 @@ def _coerce_evidence(item: Any) -> Any:
     return EvidenceItem(source_type="unknown", source_id="", text=str(item))
 
 
-def _result_to_campaign_context(result: Any, *, limit: int) -> CampaignReasoningContext:
+def _result_to_campaign_context(
+    result: Any,
+    *,
+    limit: int,
+    chain_telemetry: Mapping[str, Any] | None = None,
+) -> CampaignReasoningContext:
     claims = list(result.claims or ())
     # Top theses ordered by confidence descending (ties keep input order).
     sorted_claims = sorted(
@@ -220,6 +247,7 @@ def _result_to_campaign_context(result: Any, *, limit: int) -> CampaignReasoning
             "pack": result.state.get("pack") or "",
             "tokens_used": int(result.state.get("tokens_used") or 0),
             "attempts_used": int(result.state.get("attempts_used") or 0),
+            **dict(chain_telemetry or {}),
         },
         delta_summary={},
     )

--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -6,13 +6,24 @@ implements ``CampaignReasoningContextProvider`` so any host that
 already consumes the existing port shape gets multi-pass reasoning by
 swapping the provider, without changing any campaign-generation code.
 
-v0 scope: covers the run_reasoning path only. Continuation
-(``continue_reasoning``), falsification (``check_falsification``),
-narrative planning (``build_narrative_plan``), and output validation
-(``validate_reasoning_output``) are reachable through the same shared
-``ReasoningPorts`` and can be layered on by host code or follow-up PRs;
-this provider deliberately keeps a single LLM call per opportunity to
-match the existing provider ergonomics.
+Per-call flow:
+  1. ``run_reasoning`` produces the initial reasoning state from the
+     opportunity's evidence.
+  2. If ``opportunity["events"]`` is non-empty AND
+     ``config.enable_multi_pass`` is true, each event is fed through
+     ``continue_reasoning`` in sequence so later events refine the
+     prior state. The chain stops on the first continuation that fails
+     validation; the last successful state is what feeds the campaign
+     context.
+  3. The final ``ReasoningResult`` is translated into the
+     ``CampaignReasoningContext`` the campaign generator already
+     consumes.
+
+Falsification (``check_falsification``), narrative planning
+(``build_narrative_plan``), and output validation
+(``validate_reasoning_output``) remain reachable via the shared
+``ReasoningPorts`` for host code that wants them; this provider keeps
+its surface narrow.
 """
 
 from __future__ import annotations
@@ -31,6 +42,15 @@ class MultiPassReasoningProviderConfig:
     default_depth: str = "L2"
     pack_name: str | None = None
     top_thesis_limit: int = 5
+    # When true (default), opportunity["events"] are chained through
+    # continue_reasoning so each event refines the prior state. Set to
+    # false to fall back to the single-pass run_reasoning behavior even
+    # when events are present (useful for host-side budget controls).
+    enable_multi_pass: bool = True
+    # Hard cap on how many events from opportunity["events"] are
+    # consumed in one call. Protects against runaway token spend if a
+    # buggy upstream feeds an unbounded list.
+    max_continuations: int = 8
 
 
 class MultiPassCampaignReasoningProvider:
@@ -64,6 +84,7 @@ class MultiPassCampaignReasoningProvider:
         del scope  # tenant scoping is the host's responsibility upstream
 
         from extracted_reasoning_core.api import (
+            continue_reasoning,
             load_reasoning_pack,
             run_reasoning,
         )
@@ -101,6 +122,25 @@ class MultiPassCampaignReasoningProvider:
             # rather than raising; campaign generation handles None / empty
             # context as host-decision territory.
             return None
+
+        # Chain continue_reasoning for any events on the opportunity. Each
+        # event refines the prior state. The chain stops on the first
+        # continuation that fails validation -- the last successful state
+        # is what feeds the campaign context.
+        events = list(opportunity.get("events") or ())
+        if self._config.enable_multi_pass and events:
+            limit = max(0, int(self._config.max_continuations))
+            for event in events[:limit]:
+                next_result = await continue_reasoning(
+                    result.state,
+                    event if isinstance(event, Mapping) else {"event_type": str(event), "evidence": ()},
+                    ports=self._ports,
+                )
+                if str(next_result.state.get("status") or "") != "completed":
+                    # Continuation failed validation -- keep the prior
+                    # successful state and stop the chain.
+                    break
+                result = next_result
 
         return _result_to_campaign_context(result, limit=self._config.top_thesis_limit)
 

--- a/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
+++ b/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
@@ -182,3 +182,155 @@ async def test_multi_pass_provider_honors_per_opportunity_pack_name_override() -
     # The per-opportunity pack_name flows through to the LLM call metadata
     # rather than the provider-bound default.
     assert llm.calls[0]["metadata"]["pack"] == "per_opportunity_override"
+
+
+def _initial_synthesis_response() -> dict[str, Any]:
+    return {
+        "response": json.dumps({
+            "summary": "Initial synthesis: pricing pressure dominates.",
+            "claims": [
+                {"claim": "Renewal pricing drives churn.", "confidence": 0.8, "source_ids": ["r1"]},
+            ],
+            "confidence": 0.8,
+        }),
+        "usage": {"input_tokens": 5, "output_tokens": 3},
+    }
+
+
+def _continuation_response(*, summary: str) -> dict[str, Any]:
+    return {
+        "response": json.dumps({
+            "summary": summary,
+            "claims": [
+                {
+                    "claim": f"Refined claim for {summary}",
+                    "confidence": 0.85,
+                    "source_ids": ["r1", "evt"],
+                    "revised_from": "Renewal pricing drives churn.",
+                },
+            ],
+            "confidence": 0.85,
+        }),
+        "usage": {"input_tokens": 3, "output_tokens": 2},
+    }
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_chains_continue_reasoning_for_each_event() -> None:
+    """opportunity["events"] are chained through continue_reasoning. Generation increments per event."""
+
+    llm = FakeLLMPort([
+        _initial_synthesis_response(),
+        _continuation_response(summary="After event 1"),
+        _continuation_response(summary="After event 2"),
+    ])
+    provider = MultiPassCampaignReasoningProvider(ports=ReasoningPorts(llm=llm))
+
+    opp = _opportunity()
+    opp["events"] = [
+        {"event_type": "support_ticket", "evidence": [{"source_type": "ticket", "source_id": "t1", "text": "x"}]},
+        {"event_type": "renewal_signal", "evidence": []},
+    ]
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=opp,
+    )
+
+    assert context is not None
+    # 1 run_reasoning + 2 continuations = 3 LLM calls
+    assert len(llm.calls) == 3
+    assert llm.calls[0]["metadata"]["reasoning_mode"] == "single_pass_synthesis"
+    assert llm.calls[1]["metadata"]["reasoning_mode"] == "multi_pass_continuation"
+    assert llm.calls[2]["metadata"]["reasoning_mode"] == "multi_pass_continuation"
+    # Final state reflects the last continuation.
+    assert context.canonical_reasoning["summary"] == "After event 2"
+    # Generation increments: 1 (initial) → 2 (event 1) → 3 (event 2).
+    assert context.canonical_reasoning["generation"] == 3
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_skips_continuation_when_enable_multi_pass_is_false() -> None:
+    llm = FakeLLMPort([_initial_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(enable_multi_pass=False),
+    )
+
+    opp = _opportunity()
+    opp["events"] = [{"event_type": "would_be_ignored", "evidence": []}]
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=opp,
+    )
+
+    assert context is not None
+    # Only the run_reasoning call; the event is silently ignored.
+    assert len(llm.calls) == 1
+    assert context.canonical_reasoning["generation"] == 1
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_caps_continuation_chain_at_max_continuations() -> None:
+    llm = FakeLLMPort([
+        _initial_synthesis_response(),
+        _continuation_response(summary="event 1"),
+        _continuation_response(summary="event 2"),
+    ])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(max_continuations=2),
+    )
+
+    opp = _opportunity()
+    # 4 events but cap is 2.
+    opp["events"] = [{"event_type": f"e{i}", "evidence": []} for i in range(4)]
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=opp,
+    )
+
+    assert context is not None
+    # 1 run_reasoning + 2 continuations (capped) = 3 calls; events 3 and 4 ignored.
+    assert len(llm.calls) == 3
+    assert context.canonical_reasoning["generation"] == 3
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_keeps_prior_state_when_continuation_fails_validation() -> None:
+    """If a mid-chain continuation fails validation, the chain stops and the last good state wins."""
+
+    llm = FakeLLMPort([
+        _initial_synthesis_response(),
+        _continuation_response(summary="After event 1"),  # succeeds
+        # Event 2 returns invalid JSON twice (max_attempts=2 default) → validation failure.
+        {"response": json.dumps({"summary": "no claims"}), "usage": {}},
+        {"response": json.dumps({"summary": "still no claims"}), "usage": {}},
+    ])
+    provider = MultiPassCampaignReasoningProvider(ports=ReasoningPorts(llm=llm))
+
+    opp = _opportunity()
+    opp["events"] = [
+        {"event_type": "good", "evidence": []},
+        {"event_type": "broken", "evidence": []},
+    ]
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=opp,
+    )
+
+    assert context is not None
+    # Result reflects event 1 (the last successful state), not event 2.
+    assert context.canonical_reasoning["summary"] == "After event 1"
+    assert context.canonical_reasoning["generation"] == 2

--- a/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
+++ b/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
@@ -249,6 +249,11 @@ async def test_multi_pass_provider_chains_continue_reasoning_for_each_event() ->
     assert context.canonical_reasoning["summary"] == "After event 2"
     # Generation increments: 1 (initial) → 2 (event 1) → 3 (event 2).
     assert context.canonical_reasoning["generation"] == 3
+    # Chain telemetry surfaces in scope_summary.
+    assert context.scope_summary["events_total"] == 2
+    assert context.scope_summary["events_consumed"] == 2
+    assert context.scope_summary["events_truncated"] == 0
+    assert context.scope_summary["chain_halted_on_failure"] is False
 
 
 @pytest.mark.asyncio
@@ -273,6 +278,12 @@ async def test_multi_pass_provider_skips_continuation_when_enable_multi_pass_is_
     # Only the run_reasoning call; the event is silently ignored.
     assert len(llm.calls) == 1
     assert context.canonical_reasoning["generation"] == 1
+    # Telemetry reflects that 1 event was provided but 0 consumed and the
+    # whole list was effectively truncated by the disabled flag.
+    assert context.scope_summary["events_total"] == 1
+    assert context.scope_summary["events_consumed"] == 0
+    assert context.scope_summary["events_truncated"] == 1
+    assert context.scope_summary["chain_halted_on_failure"] is False
 
 
 @pytest.mark.asyncio
@@ -302,6 +313,11 @@ async def test_multi_pass_provider_caps_continuation_chain_at_max_continuations(
     # 1 run_reasoning + 2 continuations (capped) = 3 calls; events 3 and 4 ignored.
     assert len(llm.calls) == 3
     assert context.canonical_reasoning["generation"] == 3
+    # Telemetry surfaces the truncation rather than letting it silently disappear.
+    assert context.scope_summary["events_total"] == 4
+    assert context.scope_summary["events_consumed"] == 2
+    assert context.scope_summary["events_truncated"] == 2
+    assert context.scope_summary["chain_halted_on_failure"] is False
 
 
 @pytest.mark.asyncio
@@ -334,3 +350,25 @@ async def test_multi_pass_provider_keeps_prior_state_when_continuation_fails_val
     # Result reflects event 1 (the last successful state), not event 2.
     assert context.canonical_reasoning["summary"] == "After event 1"
     assert context.canonical_reasoning["generation"] == 2
+    # Telemetry signals the mid-chain validation halt.
+    assert context.scope_summary["events_total"] == 2
+    assert context.scope_summary["events_consumed"] == 1
+    assert context.scope_summary["chain_halted_on_failure"] is True
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_rejects_non_mapping_events_with_clear_error() -> None:
+    """A host accidentally passing strings (or any non-Mapping) gets a TypeError, not silent wrap."""
+
+    llm = FakeLLMPort([_initial_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(ports=ReasoningPorts(llm=llm))
+    opp = _opportunity()
+    opp["events"] = ["accidentally_a_string"]
+
+    with pytest.raises(TypeError, match="event_type"):
+        await provider.read_campaign_reasoning_context(
+            scope=TenantScope(),
+            target_id="acme",
+            target_mode="vendor",
+            opportunity=opp,
+        )


### PR DESCRIPTION
## Summary

Wires `continue_reasoning` into `MultiPassCampaignReasoningProvider` so the multi-pass *loop* is reachable end-to-end through the bridge, not just the producer surface. With this PR, an opportunity carrying a list of events refines its reasoning state event-by-event before producing the final `CampaignReasoningContext`.

## Per-call flow

1. `run_reasoning` produces the initial reasoning state from the opportunity's evidence (unchanged from D21).
2. If `opportunity["events"]` is non-empty AND `config.enable_multi_pass` is true (default), each event is fed through `continue_reasoning` in sequence so later events refine the prior state.
3. The chain stops on the first continuation that fails validation; the last successful state is what feeds the campaign context.
4. Translation into `CampaignReasoningContext` is unchanged. `canonical_reasoning.generation` now reflects chain length.

## New config knobs (additive)

| Field | Default | Purpose |
|---|---|---|
| `enable_multi_pass` | `True` | Set `False` to silently ignore events even when present (host-side budget control). |
| `max_continuations` | `8` | Hard cap on chain length so a buggy upstream feeding an unbounded event list can't run away with token spend. |

Defaults preserve D21 behavior for opportunities that don't carry events.

## Test plan

- [x] `pytest -q tests/test_extracted_campaign_multi_pass_reasoning_provider.py` → 9/9 passing locally
- [ ] CI `extracted-checks` run

New tests (4):
- Chained continuation: 1 `run_reasoning` + 2 continuations across 2 events; asserts call ordering by `reasoning_mode` metadata, final summary reflects the last continuation, `generation == 3`.
- `enable_multi_pass=False`: events ignored, single LLM call, `generation == 1`.
- `max_continuations=2` with 4 events: only first 2 events processed.
- Mid-chain validation failure: returns the last successful state (summary from event 1), does not surface the failed event.

## Out of scope (still)

Host code can call these directly via the shared `ReasoningPorts`; the bridge keeps its surface narrow:

- `check_falsification` (per-claim refute/confirm)
- `build_narrative_plan` (structured plan output)
- `validate_reasoning_output` (output policy enforcement)
- CLI / API endpoint wiring

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_