### PR TITLE
PR-D21c: Wire check_falsification gate into MultiPassCampaignReasoningProvider

### DIFF
--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -28,6 +28,7 @@ its surface narrow.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -99,7 +100,6 @@ class MultiPassCampaignReasoningProvider:
         del scope  # tenant scoping is the host's responsibility upstream
 
         from extracted_reasoning_core.api import (
-            check_falsification,
             continue_reasoning,
             load_reasoning_pack,
             run_reasoning,
@@ -191,25 +191,40 @@ class MultiPassCampaignReasoningProvider:
                 for event in events[:events_consumed]:
                     for item in event.get("evidence") or ():
                         consumed_event_evidence.append(_coerce_evidence(item))
-            fresh_evidence = tuple(evidence_items) + tuple(consumed_event_evidence)
+            fresh_evidence = evidence_items + tuple(consumed_event_evidence)
 
-            falsified_ids: list[str] = []
-            falsification_traces: list[Mapping[str, Any]] = []
-            for claim in result.claims:
-                fr = await check_falsification(
+            # Run falsification checks in parallel -- they're independent
+            # per-claim LLM calls. Each check is wrapped so a single
+            # failure (network blip, LLM error) doesn't cascade and
+            # collapse the whole context; the failed claim's trace
+            # records the error and skips invalidation.
+            checks = [
+                _falsify_one(
                     claim,
                     fresh_evidence,
                     policy=self._config.falsification_policy,
                     ports=self._ports,
                 )
+                for claim in result.claims
+            ]
+            check_outcomes = await asyncio.gather(*checks)
+
+            falsified_ids: list[str] = []
+            falsification_traces: list[Mapping[str, Any]] = []
+            for claim, outcome in zip(result.claims, check_outcomes):
                 claim_id = _claim_identity(claim)
-                falsification_traces.append({
-                    "claim_id": claim_id,
-                    "should_invalidate": fr.should_invalidate,
-                    "triggered_conditions": tuple(fr.triggered_conditions),
-                })
-                if fr.should_invalidate:
-                    falsified_ids.append(claim_id)
+                trace_entry: dict[str, Any] = {"claim_id": claim_id}
+                if outcome["error"] is not None:
+                    trace_entry["should_invalidate"] = False
+                    trace_entry["triggered_conditions"] = ()
+                    trace_entry["error"] = outcome["error"]
+                else:
+                    fr = outcome["result"]
+                    trace_entry["should_invalidate"] = fr.should_invalidate
+                    trace_entry["triggered_conditions"] = tuple(fr.triggered_conditions)
+                    if fr.should_invalidate:
+                        falsified_ids.append(claim_id)
+                falsification_traces.append(trace_entry)
             falsified_claim_ids = tuple(falsified_ids)
             falsification_summary = {
                 "evaluated_claim_count": len(result.claims),
@@ -321,6 +336,32 @@ def _result_to_campaign_context(
         },
         delta_summary={},
     )
+
+
+async def _falsify_one(
+    claim: Mapping[str, Any],
+    fresh_evidence: tuple[Any, ...],
+    *,
+    policy: Any,
+    ports: Any,
+) -> dict[str, Any]:
+    """Run check_falsification for one claim, capturing errors per-claim.
+
+    Returns ``{"result": FalsificationResult, "error": None}`` on success
+    and ``{"result": None, "error": "<exc class>: <msg>"}`` on failure
+    so a single bad claim doesn't collapse the whole bridge call. The
+    ``ConfigurationError`` (missing LLM port) is intentionally left to
+    propagate -- that's a host config problem, not a runtime fault.
+    """
+    from extracted_reasoning_core.api import ConfigurationError, check_falsification
+
+    try:
+        fr = await check_falsification(claim, fresh_evidence, policy=policy, ports=ports)
+        return {"result": fr, "error": None}
+    except ConfigurationError:
+        raise
+    except Exception as exc:  # noqa: BLE001 -- intentional fail-soft per claim
+        return {"result": None, "error": f"{type(exc).__name__}: {exc}"}
 
 
 def _claim_identity(claim: Mapping[str, Any]) -> str:

--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -29,9 +29,12 @@ its surface narrow.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 from ..campaign_ports import CampaignReasoningContext, TenantScope
+
+if TYPE_CHECKING:
+    from extracted_reasoning_core.types import FalsificationPolicy
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,18 @@ class MultiPassReasoningProviderConfig:
     # consumed in one call. Protects against runaway token spend if a
     # buggy upstream feeds an unbounded list.
     max_continuations: int = 8
+    # Optional falsification policy. When set, after the chain completes
+    # each surviving claim is run through check_falsification against the
+    # aggregated evidence (opportunity + event evidence). Falsified
+    # claim ids are surfaced in scope_summary["falsification"]; the
+    # claims are dropped from top_theses iff drop_falsified is True.
+    falsification_policy: "FalsificationPolicy | None" = None
+    # When True (and falsification_policy is set), claims marked
+    # should_invalidate=True are removed from the resulting
+    # top_theses/witness_highlights. When False (default), they remain
+    # but are flagged in scope_summary["falsification"]["falsified_claim_ids"]
+    # so downstream renderers can decide what to do.
+    drop_falsified: bool = False
 
 
 class MultiPassCampaignReasoningProvider:
@@ -84,6 +99,7 @@ class MultiPassCampaignReasoningProvider:
         del scope  # tenant scoping is the host's responsibility upstream
 
         from extracted_reasoning_core.api import (
+            check_falsification,
             continue_reasoning,
             load_reasoning_pack,
             run_reasoning,
@@ -160,10 +176,55 @@ class MultiPassCampaignReasoningProvider:
             "events_truncated": events_truncated,
             "chain_halted_on_failure": chain_halted_on_failure,
         }
+
+        # Optional falsification gate. Aggregates evidence from the
+        # opportunity and every consumed event, then runs
+        # check_falsification on each surviving claim. Falsified claim
+        # ids are surfaced in scope_summary regardless of drop_falsified;
+        # the drop_falsified flag controls whether those claims are also
+        # removed from the rendered top_theses.
+        falsification_summary: Mapping[str, Any] | None = None
+        falsified_claim_ids: tuple[str, ...] = ()
+        if self._config.falsification_policy is not None and result.claims:
+            consumed_event_evidence: list[Any] = []
+            if self._config.enable_multi_pass:
+                for event in events[:events_consumed]:
+                    for item in event.get("evidence") or ():
+                        consumed_event_evidence.append(_coerce_evidence(item))
+            fresh_evidence = tuple(evidence_items) + tuple(consumed_event_evidence)
+
+            falsified_ids: list[str] = []
+            falsification_traces: list[Mapping[str, Any]] = []
+            for claim in result.claims:
+                fr = await check_falsification(
+                    claim,
+                    fresh_evidence,
+                    policy=self._config.falsification_policy,
+                    ports=self._ports,
+                )
+                claim_id = _claim_identity(claim)
+                falsification_traces.append({
+                    "claim_id": claim_id,
+                    "should_invalidate": fr.should_invalidate,
+                    "triggered_conditions": tuple(fr.triggered_conditions),
+                })
+                if fr.should_invalidate:
+                    falsified_ids.append(claim_id)
+            falsified_claim_ids = tuple(falsified_ids)
+            falsification_summary = {
+                "evaluated_claim_count": len(result.claims),
+                "falsified_count": len(falsified_ids),
+                "falsified_claim_ids": falsified_claim_ids,
+                "drop_falsified": self._config.drop_falsified,
+                "traces": tuple(falsification_traces),
+            }
+
         return _result_to_campaign_context(
             result,
             limit=self._config.top_thesis_limit,
             chain_telemetry=chain_telemetry,
+            falsification_summary=falsification_summary,
+            drop_claim_ids=falsified_claim_ids if self._config.drop_falsified else (),
         )
 
 
@@ -190,8 +251,16 @@ def _result_to_campaign_context(
     *,
     limit: int,
     chain_telemetry: Mapping[str, Any] | None = None,
+    falsification_summary: Mapping[str, Any] | None = None,
+    drop_claim_ids: tuple[str, ...] = (),
 ) -> CampaignReasoningContext:
-    claims = list(result.claims or ())
+    raw_claims = list(result.claims or ())
+    drop_set = set(drop_claim_ids)
+    claims = (
+        [c for c in raw_claims if _claim_identity(c) not in drop_set]
+        if drop_set
+        else raw_claims
+    )
     # Top theses ordered by confidence descending (ties keep input order).
     sorted_claims = sorted(
         enumerate(claims),
@@ -248,9 +317,14 @@ def _result_to_campaign_context(
             "tokens_used": int(result.state.get("tokens_used") or 0),
             "attempts_used": int(result.state.get("attempts_used") or 0),
             **dict(chain_telemetry or {}),
+            **({"falsification": dict(falsification_summary)} if falsification_summary is not None else {}),
         },
         delta_summary={},
     )
+
+
+def _claim_identity(claim: Mapping[str, Any]) -> str:
+    return str(claim.get("claim_id") or claim.get("id") or claim.get("claim") or "")[:200]
 
 
 def _claim_confidence(claim: Mapping[str, Any]) -> float:

--- a/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
+++ b/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
@@ -372,3 +372,130 @@ async def test_multi_pass_provider_rejects_non_mapping_events_with_clear_error()
             target_mode="vendor",
             opportunity=opp,
         )
+
+
+def _falsifiable_synthesis_response() -> dict[str, Any]:
+    return {
+        "response": json.dumps({
+            "summary": "Two drivers identified.",
+            "claims": [
+                {"claim_id": "c1", "claim": "Renewal pricing drives churn.", "confidence": 0.8, "source_ids": ["r1"]},
+                {"claim_id": "c2", "claim": "Onboarding friction is secondary.", "confidence": 0.6, "source_ids": ["r2"]},
+            ],
+            "confidence": 0.8,
+        }),
+        "usage": {"input_tokens": 4, "output_tokens": 2},
+    }
+
+
+def _falsification_response(*, triggered: list[str], should_invalidate: bool) -> dict[str, Any]:
+    return {
+        "response": json.dumps({
+            "triggered_conditions": triggered,
+            "non_triggered_conditions": [],
+            "should_invalidate": should_invalidate,
+        }),
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_runs_falsification_gate_when_policy_set() -> None:
+    """With falsification_policy set, each claim is evaluated; falsified ids surfaced."""
+
+    from extracted_reasoning_core.types import FalsificationPolicy
+
+    llm = FakeLLMPort([
+        _falsifiable_synthesis_response(),
+        # Falsification call for c1 → falsified.
+        _falsification_response(triggered=["renewal_signal_lost"], should_invalidate=True),
+        # Falsification call for c2 → not falsified.
+        _falsification_response(triggered=[], should_invalidate=False),
+    ])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            falsification_policy=FalsificationPolicy(
+                rules=({"id": "renewal_signal_lost"},),
+                conservative=False,
+            ),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    f = context.scope_summary["falsification"]
+    assert f["evaluated_claim_count"] == 2
+    assert f["falsified_count"] == 1
+    assert f["falsified_claim_ids"] == ("c1",)
+    assert f["drop_falsified"] is False
+    # drop_falsified=False → falsified claim still in top_theses.
+    top_ids = [t["claim"] for t in context.top_theses]
+    assert "Renewal pricing drives churn." in top_ids
+    # 1 run_reasoning + 2 check_falsification = 3 calls.
+    assert len(llm.calls) == 3
+    assert llm.calls[1]["metadata"]["reasoning_mode"] == "falsification_check"
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_drops_falsified_claims_when_drop_falsified_true() -> None:
+    from extracted_reasoning_core.types import FalsificationPolicy
+
+    llm = FakeLLMPort([
+        _falsifiable_synthesis_response(),
+        _falsification_response(triggered=["renewal_signal_lost"], should_invalidate=True),
+        _falsification_response(triggered=[], should_invalidate=False),
+    ])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            falsification_policy=FalsificationPolicy(
+                rules=({"id": "renewal_signal_lost"},),
+                conservative=False,
+            ),
+            drop_falsified=True,
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    # c1 was falsified and drop_falsified=True → not in top_theses.
+    top_claims = [t["claim"] for t in context.top_theses]
+    assert "Renewal pricing drives churn." not in top_claims
+    assert "Onboarding friction is secondary." in top_claims
+    f = context.scope_summary["falsification"]
+    assert f["falsified_claim_ids"] == ("c1",)
+    assert f["drop_falsified"] is True
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_skips_falsification_when_policy_unset() -> None:
+    """No falsification_policy → no falsification calls (existing D21b behavior preserved)."""
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(ports=ReasoningPorts(llm=llm))
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    # Only the run_reasoning call.
+    assert len(llm.calls) == 1
+    # No falsification key in scope_summary when policy is unset.
+    assert "falsification" not in context.scope_summary

--- a/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
+++ b/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, Mapping, Sequence
 
@@ -499,3 +500,123 @@ async def test_multi_pass_provider_skips_falsification_when_policy_unset() -> No
     assert len(llm.calls) == 1
     # No falsification key in scope_summary when policy is unset.
     assert "falsification" not in context.scope_summary
+
+
+class _RaisingFalsificationLLM:
+    """LLM port that returns a valid synthesis once, then raises on every
+    subsequent call (simulating a network blip during falsification)."""
+
+    def __init__(self, synthesis_response: Mapping[str, Any]) -> None:
+        self._synthesis_response = synthesis_response
+        self._first = True
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({"metadata": dict(metadata or {})})
+        if self._first:
+            self._first = False
+            return self._synthesis_response
+        raise ConnectionError("simulated LLM outage")
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_runs_falsification_checks_in_parallel() -> None:
+    """asyncio.gather is used so N claims = ~1x latency, not Nx."""
+
+    from extracted_reasoning_core.types import FalsificationPolicy
+
+    barrier = asyncio.Event()
+    in_flight = 0
+    max_in_flight = 0
+
+    class TrackingLLM:
+        def __init__(self, responses: list[Mapping[str, Any]]) -> None:
+            self.responses = list(responses)
+            self.calls: list[dict[str, Any]] = []
+
+        async def complete(
+            self,
+            messages: Sequence[Mapping[str, Any]],
+            *,
+            max_tokens: int,
+            temperature: float,
+            metadata: Mapping[str, Any] | None = None,
+        ) -> Mapping[str, Any]:
+            nonlocal in_flight, max_in_flight
+            self.calls.append({"metadata": dict(metadata or {})})
+            mode = (metadata or {}).get("reasoning_mode")
+            if mode == "falsification_check":
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                # Hold each falsification call until barrier fires; if
+                # they were sequential this would deadlock on the first
+                # call. Parallelism means all N enter before the barrier
+                # is set.
+                if in_flight >= 2:
+                    barrier.set()
+                await barrier.wait()
+                in_flight -= 1
+            return self.responses.pop(0)
+
+    llm = TrackingLLM([
+        _falsifiable_synthesis_response(),
+        _falsification_response(triggered=[], should_invalidate=False),
+        _falsification_response(triggered=[], should_invalidate=False),
+    ])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            falsification_policy=FalsificationPolicy(rules=({"id": "x"},), conservative=False),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    # If the calls were sequential, max_in_flight would be 1 (each call
+    # would complete before the next started). Parallelism puts both
+    # falsification calls in flight before either completes.
+    assert max_in_flight >= 2
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_fails_soft_on_check_falsification_error() -> None:
+    """A check_falsification raise on one claim is captured in the trace; the rest still ship."""
+
+    from extracted_reasoning_core.types import FalsificationPolicy
+
+    llm = _RaisingFalsificationLLM(_falsifiable_synthesis_response())
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            falsification_policy=FalsificationPolicy(rules=({"id": "x"},), conservative=False),
+        ),
+    )
+
+    # Should NOT raise -- the connection error is captured per-claim.
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    f = context.scope_summary["falsification"]
+    # Both claims errored, neither falsified.
+    assert f["falsified_count"] == 0
+    assert all(t.get("error", "").startswith("ConnectionError") for t in f["traces"])
+    # Synthesis claims still survive in the rendered context.
+    assert len(context.top_theses) > 0


### PR DESCRIPTION
## Summary

Wires `check_falsification` into the bridge. Hosts that configure a `FalsificationPolicy` get per-claim refute/confirm gating after the `run_reasoning` + `continue_reasoning` chain completes. Falsified claim ids are surfaced in `scope_summary["falsification"]`; optionally dropped from the rendered `top_theses`.

After this PR, three of the four reasoning-core capabilities (`run_reasoning`, `continue_reasoning`, `check_falsification`) are reachable through the bridge with no host-side wiring beyond a config knob.

## New config knobs (additive, both default to no-op)

| Field | Default | Purpose |
|---|---|---|
| `falsification_policy` | `None` | `FalsificationPolicy` instance. When `None`, no falsification calls run — D21b behavior preserved exactly. |
| `drop_falsified` | `False` | When `True` (and policy is set), claims marked `should_invalidate=True` are removed from `top_theses` / `witness_highlights`. When `False`, they stay but get flagged so renderers decide. |

## Per-call flow (cumulative)

1. `run_reasoning` produces initial state (D21).
2. `opportunity["events"]` chain through `continue_reasoning` (D21b).
3. **NEW:** if `falsification_policy` is set, each surviving claim goes through `check_falsification` against aggregated fresh evidence (opportunity evidence + every consumed event's evidence).
4. Translation into `CampaignReasoningContext` (D21).

## `scope_summary["falsification"]` shape (when policy is set)

```python
{
  "evaluated_claim_count": int,
  "falsified_count": int,
  "falsified_claim_ids": tuple[str, ...],
  "drop_falsified": bool,    # echoes config for renderer awareness
  "traces": tuple[Mapping, ...],  # per-claim claim_id / should_invalidate / triggered_conditions
}
```

## Test plan

- [x] AST scan of bridge → 0 `atlas_brain` refs
- [x] `forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `pytest -q tests/test_extracted_campaign_multi_pass_reasoning_provider.py` → 13/13 passing locally
- [ ] CI `extracted-checks` run

New tests (3):
- Falsification policy set: per-claim check fires; falsified id surfaces in `scope_summary`; `drop_falsified=False` keeps the claim in `top_theses`.
- `drop_falsified=True`: falsified claim is removed from `top_theses`; `scope_summary` still surfaces the falsified id.
- No policy: no falsification calls (D21b behavior preserved).

## Out of scope (still)

- `build_narrative_plan` integration — PR-D21d
- `validate_reasoning_output` integration — PR-D21e
- CLI / API endpoint wiring — PR-D21f

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_