### PR TITLE
PR-D21d: Wire build_narrative_plan into MultiPassCampaignReasoningProvider

### DIFF
--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 from ..campaign_ports import CampaignReasoningContext, TenantScope
 
 if TYPE_CHECKING:
-    from extracted_reasoning_core.types import FalsificationPolicy
+    from extracted_reasoning_core.types import FalsificationPolicy, ReasoningPack
 
 
 @dataclass(frozen=True)
@@ -67,6 +67,14 @@ class MultiPassReasoningProviderConfig:
     # but are flagged in scope_summary["falsification"]["falsified_claim_ids"]
     # so downstream renderers can decide what to do.
     drop_falsified: bool = False
+    # Optional ReasoningPack for narrative-plan structuring. When set,
+    # build_narrative_plan runs after the chain (and after falsification
+    # gating, if any) on the final result. The resulting NarrativePlan
+    # is surfaced as canonical_reasoning["narrative_plan"]. Hosts that
+    # want to load a pack from the registry can do so themselves via
+    # extracted_reasoning_core.api.load_reasoning_pack and pass the
+    # result here. When None (default), no narrative plan is produced.
+    narrative_plan_pack: "ReasoningPack | None" = None
 
 
 class MultiPassCampaignReasoningProvider:
@@ -234,12 +242,40 @@ class MultiPassCampaignReasoningProvider:
                 "traces": tuple(falsification_traces),
             }
 
+        # Optional narrative plan. When a pack is configured, run
+        # build_narrative_plan over the final state and surface the
+        # resulting NarrativePlan in canonical_reasoning. If
+        # drop_falsified=True, the narrative-plan input is pre-filtered
+        # to remove falsified claims so the rendered plan stays
+        # consistent with the rendered top_theses.
+        narrative_plan_summary: Mapping[str, Any] | None = None
+        if self._config.narrative_plan_pack is not None:
+            from extracted_reasoning_core.api import build_narrative_plan
+
+            if self._config.drop_falsified and falsified_claim_ids:
+                drop_set = set(falsified_claim_ids)
+                raw = dict(result.state.get("raw_synthesis") or {})
+                raw_claims = list(raw.get("claims") or ())
+                raw["claims"] = [c for c in raw_claims if _claim_identity(c) not in drop_set]
+                narrative_context: Mapping[str, Any] = {**dict(result.state), "raw_synthesis": raw}
+            else:
+                narrative_context = result.state
+
+            plan = build_narrative_plan(narrative_context, pack=self._config.narrative_plan_pack)
+            narrative_plan_summary = {
+                "claims": tuple(dict(c) for c in plan.claims),
+                "sections": tuple(dict(s) for s in plan.sections),
+                "evidence_requirements": tuple(dict(e) for e in plan.evidence_requirements),
+                "state_hints": dict(plan.state_hints),
+            }
+
         return _result_to_campaign_context(
             result,
             limit=self._config.top_thesis_limit,
             chain_telemetry=chain_telemetry,
             falsification_summary=falsification_summary,
             drop_claim_ids=falsified_claim_ids if self._config.drop_falsified else (),
+            narrative_plan=narrative_plan_summary,
         )
 
 
@@ -268,6 +304,7 @@ def _result_to_campaign_context(
     chain_telemetry: Mapping[str, Any] | None = None,
     falsification_summary: Mapping[str, Any] | None = None,
     drop_claim_ids: tuple[str, ...] = (),
+    narrative_plan: Mapping[str, Any] | None = None,
 ) -> CampaignReasoningContext:
     raw_claims = list(result.claims or ())
     drop_set = set(drop_claim_ids)
@@ -306,13 +343,15 @@ def _result_to_campaign_context(
             if sid_str and sid_str not in all_source_ids:
                 all_source_ids.append(sid_str)
 
-    canonical_reasoning = {
+    canonical_reasoning: dict[str, Any] = {
         "summary": result.summary,
         "confidence": result.confidence,
         "tier": result.tier,
         "generation": int(result.state.get("generation") or 1),
         "raw_synthesis": dict(result.state.get("raw_synthesis") or {}),
     }
+    if narrative_plan is not None:
+        canonical_reasoning["narrative_plan"] = dict(narrative_plan)
 
     return CampaignReasoningContext(
         anchor_examples={},

--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -74,6 +74,11 @@ class MultiPassReasoningProviderConfig:
     # want to load a pack from the registry can do so themselves via
     # extracted_reasoning_core.api.load_reasoning_pack and pass the
     # result here. When None (default), no narrative plan is produced.
+    #
+    # Note: pack policies are forwarded to build_narrative_plan as-is.
+    # In particular, ``policies["max_sections"]`` silently drops claims
+    # belonging to over-cap sections from the rendered NarrativePlan
+    # (see D20d). Tune defensively if claim-coverage matters.
     narrative_plan_pack: "ReasoningPack | None" = None
 
 

--- a/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
+++ b/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
@@ -620,3 +620,91 @@ async def test_multi_pass_provider_fails_soft_on_check_falsification_error() -> 
     assert all(t.get("error", "").startswith("ConnectionError") for t in f["traces"])
     # Synthesis claims still survive in the rendered context.
     assert len(context.top_theses) > 0
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_attaches_narrative_plan_when_pack_configured() -> None:
+    """narrative_plan_pack triggers build_narrative_plan; result lands in canonical_reasoning."""
+
+    from extracted_reasoning_core.types import ReasoningPack
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            narrative_plan_pack=ReasoningPack(
+                name="content_ops_default",
+                policies={"max_sections": 3},
+            ),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    plan = context.canonical_reasoning.get("narrative_plan")
+    assert plan is not None
+    # Both synthesis claims are present in the plan output.
+    assert len(plan["claims"]) == 2
+    # Sections derived from the claims' "section" field (or default).
+    assert len(plan["sections"]) >= 1
+    # state_hints surfaces overall metadata.
+    assert plan["state_hints"]["claim_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_skips_narrative_plan_when_pack_unset() -> None:
+    """No narrative_plan_pack → no narrative_plan in canonical_reasoning."""
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(ports=ReasoningPorts(llm=llm))
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    assert "narrative_plan" not in context.canonical_reasoning
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_narrative_plan_excludes_falsified_when_drop_falsified_true() -> None:
+    """drop_falsified=True keeps top_theses and narrative_plan consistent."""
+
+    from extracted_reasoning_core.types import FalsificationPolicy, ReasoningPack
+
+    llm = FakeLLMPort([
+        _falsifiable_synthesis_response(),
+        _falsification_response(triggered=["renewal_signal_lost"], should_invalidate=True),
+        _falsification_response(triggered=[], should_invalidate=False),
+    ])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            falsification_policy=FalsificationPolicy(rules=({"id": "renewal_signal_lost"},), conservative=False),
+            drop_falsified=True,
+            narrative_plan_pack=ReasoningPack(name="default"),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    plan = context.canonical_reasoning["narrative_plan"]
+    plan_claim_ids = [c.get("claim_id") for c in plan["claims"]]
+    # c1 was falsified and drop_falsified=True → not in the narrative plan.
+    assert "c1" not in plan_claim_ids
+    assert "c2" in plan_claim_ids


### PR DESCRIPTION
## Summary

Wires `build_narrative_plan` into the bridge. Hosts that configure a `narrative_plan_pack` get a structured `NarrativePlan` attached to `canonical_reasoning["narrative_plan"]` after the chain + falsification gating. Default is no-op so D21c behavior is preserved exactly.

After this PR, four of the five reasoning-core capabilities (`run_reasoning`, `continue_reasoning`, `check_falsification`, `build_narrative_plan`) are reachable through the bridge with no host-side wiring beyond config knobs.

## New config knob (additive, defaults to no-op)

| Field | Default | Purpose |
|---|---|---|
| `narrative_plan_pack` | `None` | `ReasoningPack` instance. When set, runs `build_narrative_plan(final_state, pack=pack)` and attaches the result to `canonical_reasoning`. When `None`, no narrative plan is produced. |

Hosts that want a registry-loaded pack can call `load_reasoning_pack` themselves and pass the result here — one source of truth for the pack object.

## Falsification consistency

When `drop_falsified=True` AND there are falsified ids, the narrative-plan input is **pre-filtered** to exclude those claims so the rendered plan stays consistent with the rendered `top_theses`. Without this, `drop_falsified` would only half-apply (drop from `top_theses` but leave in `narrative_plan`).

## `canonical_reasoning["narrative_plan"]` shape

```python
{
  "claims": tuple[Mapping, ...],
  "sections": tuple[Mapping, ...],
  "evidence_requirements": tuple[Mapping, ...],
  "state_hints": Mapping[str, Any],
}
```

## Per-call flow (cumulative)

1. `run_reasoning` (D21)
2. `continue_reasoning` chain over `opportunity["events"]` (D21b)
3. `check_falsification` per claim (D21c)
4. **NEW:** `build_narrative_plan` over the final state (this PR)
5. Translation into `CampaignReasoningContext`

## Test plan

- [x] `pytest -q tests/test_extracted_campaign_multi_pass_reasoning_provider.py` → 18/18 passing locally
- [ ] CI `extracted-checks` run

New tests (3):
- `narrative_plan_pack` set: plan attached to `canonical_reasoning`, `claim_count` and `sections` populated.
- No pack: `narrative_plan` key absent from `canonical_reasoning`.
- `drop_falsified=True` with policy: `narrative_plan` claims exclude the falsified claim id (consistency with `top_theses`).

## Out of scope (still)

- `validate_reasoning_output` integration — PR-D21e
- CLI / API endpoint wiring — PR-D21f

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_