### PR TITLE
PR-D21e: Wire validate_reasoning_output into MultiPassCampaignReasoningProvider

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T17:51Z by claude-2026-05-03
+Last updated: 2026-05-06T18:07Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-D21e, in flight) | PR-D21e: Wire validate_reasoning_output into MultiPassCampaignReasoningProvider (5/5 reasoning-core capabilities through the bridge) | EDIT: `extracted_content_pipeline/services/multi_pass_reasoning_provider.py` (+`output_policy` and `block_on_validation_failure` config knobs; validate after narrative-plan; surface report in `canonical_reasoning["validation"]`; pre-filter falsified claims when `drop_falsified=True`). EDIT: `tests/test_extracted_campaign_multi_pass_reasoning_provider.py` (+5 tests). Default no-op preserves D21d behavior. | claude-2026-05-03 | `extracted_content_pipeline/services/multi_pass_reasoning_provider.py`; `tests/test_extracted_campaign_multi_pass_reasoning_provider.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
+++ b/extracted_content_pipeline/services/multi_pass_reasoning_provider.py
@@ -21,21 +21,26 @@ Per-call flow:
 
 Falsification (``check_falsification``), narrative planning
 (``build_narrative_plan``), and output validation
-(``validate_reasoning_output``) remain reachable via the shared
-``ReasoningPorts`` for host code that wants them; this provider keeps
-its surface narrow.
+(``validate_reasoning_output``) are reachable through opt-in config
+knobs (``falsification_policy``, ``narrative_plan_pack``,
+``output_policy``); the provider stays no-op for hosts that don't
+configure them.
 """
 
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Mapping
 
 from ..campaign_ports import CampaignReasoningContext, TenantScope
 
 if TYPE_CHECKING:
-    from extracted_reasoning_core.types import FalsificationPolicy, ReasoningPack
+    from extracted_reasoning_core.types import (
+        FalsificationPolicy,
+        OutputPolicy,
+        ReasoningPack,
+    )
 
 
 @dataclass(frozen=True)
@@ -80,6 +85,20 @@ class MultiPassReasoningProviderConfig:
     # belonging to over-cap sections from the rendered NarrativePlan
     # (see D20d). Tune defensively if claim-coverage matters.
     narrative_plan_pack: "ReasoningPack | None" = None
+    # Optional output policy. When set, the final result is run through
+    # validate_reasoning_output after the chain (and after falsification
+    # gating). The resulting ValidationReport is surfaced as
+    # canonical_reasoning["validation"]. When drop_falsified=True, the
+    # validation target has falsified claims pre-filtered so per-claim
+    # blockers (e.g. claim_missing_citations:N) reference the rendered
+    # claim list, not the unfiltered one (mirrors narrative_plan).
+    output_policy: "OutputPolicy | None" = None
+    # When True (and output_policy is set), a failing ValidationReport
+    # causes the bridge to return None (suppress the context) so
+    # downstream renderers don't ship a known-invalid output. When
+    # False (default), the report is surfaced informationally and the
+    # context is returned regardless -- the host decides what to do.
+    block_on_validation_failure: bool = False
 
 
 class MultiPassCampaignReasoningProvider:
@@ -274,6 +293,37 @@ class MultiPassCampaignReasoningProvider:
                 "state_hints": dict(plan.state_hints),
             }
 
+        # Optional output validation. When an output_policy is configured,
+        # validate the final result against the policy after the chain
+        # (and after falsification gating). The report is surfaced in
+        # canonical_reasoning["validation"]. If block_on_validation_failure
+        # is True and the report fails, return None so downstream
+        # renderers don't ship a known-invalid output.
+        validation_summary: Mapping[str, Any] | None = None
+        if self._config.output_policy is not None:
+            from extracted_reasoning_core.api import validate_reasoning_output
+
+            if self._config.drop_falsified and falsified_claim_ids:
+                drop_set = set(falsified_claim_ids)
+                filtered_claims = tuple(
+                    c for c in result.claims if _claim_identity(c) not in drop_set
+                )
+                validation_target = replace(result, claims=filtered_claims)
+            else:
+                validation_target = result
+
+            report = validate_reasoning_output(
+                validation_target, policy=self._config.output_policy
+            )
+            validation_summary = {
+                "passed": report.passed,
+                "blockers": tuple(report.blockers),
+                "warnings": tuple(report.warnings),
+            }
+
+            if self._config.block_on_validation_failure and not report.passed:
+                return None
+
         return _result_to_campaign_context(
             result,
             limit=self._config.top_thesis_limit,
@@ -281,6 +331,7 @@ class MultiPassCampaignReasoningProvider:
             falsification_summary=falsification_summary,
             drop_claim_ids=falsified_claim_ids if self._config.drop_falsified else (),
             narrative_plan=narrative_plan_summary,
+            validation=validation_summary,
         )
 
 
@@ -310,6 +361,7 @@ def _result_to_campaign_context(
     falsification_summary: Mapping[str, Any] | None = None,
     drop_claim_ids: tuple[str, ...] = (),
     narrative_plan: Mapping[str, Any] | None = None,
+    validation: Mapping[str, Any] | None = None,
 ) -> CampaignReasoningContext:
     raw_claims = list(result.claims or ())
     drop_set = set(drop_claim_ids)
@@ -357,6 +409,8 @@ def _result_to_campaign_context(
     }
     if narrative_plan is not None:
         canonical_reasoning["narrative_plan"] = dict(narrative_plan)
+    if validation is not None:
+        canonical_reasoning["validation"] = dict(validation)
 
     return CampaignReasoningContext(
         anchor_examples={},

--- a/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
+++ b/tests/test_extracted_campaign_multi_pass_reasoning_provider.py
@@ -708,3 +708,151 @@ async def test_multi_pass_provider_narrative_plan_excludes_falsified_when_drop_f
     # c1 was falsified and drop_falsified=True → not in the narrative plan.
     assert "c1" not in plan_claim_ids
     assert "c2" in plan_claim_ids
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_skips_validation_when_output_policy_unset() -> None:
+    """No output_policy → no validation key in canonical_reasoning (no-op preserved)."""
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(ports=ReasoningPorts(llm=llm))
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    assert "validation" not in context.canonical_reasoning
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_surfaces_validation_report_when_policy_passes() -> None:
+    """output_policy set + result passes → validation report surfaced with passed=True."""
+
+    from extracted_reasoning_core.types import OutputPolicy
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            output_policy=OutputPolicy(min_confidence=0.5, require_citations=True),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    validation = context.canonical_reasoning["validation"]
+    assert validation["passed"] is True
+    assert validation["blockers"] == ()
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_surfaces_validation_report_when_policy_fails() -> None:
+    """output_policy fails + block_on_validation_failure=False (default) → context returned with passed=False."""
+
+    from extracted_reasoning_core.types import OutputPolicy
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    # min_confidence=0.99 forces a confidence_below_min blocker (result confidence is 0.8).
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            output_policy=OutputPolicy(min_confidence=0.99),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    validation = context.canonical_reasoning["validation"]
+    assert validation["passed"] is False
+    assert "confidence_below_min" in validation["blockers"]
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_blocks_context_when_validation_fails_and_flag_set() -> None:
+    """block_on_validation_failure=True + failing report → bridge returns None."""
+
+    from extracted_reasoning_core.types import OutputPolicy
+
+    llm = FakeLLMPort([_falsifiable_synthesis_response()])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            output_policy=OutputPolicy(min_confidence=0.99),
+            block_on_validation_failure=True,
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is None
+
+
+@pytest.mark.asyncio
+async def test_multi_pass_provider_validation_excludes_falsified_when_drop_falsified_true() -> None:
+    """drop_falsified=True pre-filters validation target so per-claim blockers reference rendered claims."""
+
+    from extracted_reasoning_core.types import FalsificationPolicy, OutputPolicy
+
+    # c1 has source_ids=["r1"] (cited), c2 will be the test target.
+    # We'll make c2 lack source_ids by emitting a custom synthesis response,
+    # then falsify c2 and drop it. With pre-filter, validation should pass
+    # (no claim_missing_citations on the surviving c1).
+    synthesis_response = {
+        "response": json.dumps({
+            "summary": "Two drivers identified.",
+            "claims": [
+                {"claim_id": "c1", "claim": "Renewal pricing drives churn.", "confidence": 0.8, "source_ids": ["r1"]},
+                {"claim_id": "c2", "claim": "Onboarding friction is secondary.", "confidence": 0.6, "source_ids": []},
+            ],
+            "confidence": 0.8,
+        }),
+        "usage": {"input_tokens": 4, "output_tokens": 2},
+    }
+    llm = FakeLLMPort([
+        synthesis_response,
+        _falsification_response(triggered=[], should_invalidate=False),  # c1 survives
+        _falsification_response(triggered=["x"], should_invalidate=True),  # c2 falsified
+    ])
+    provider = MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            falsification_policy=FalsificationPolicy(rules=({"id": "x"},), conservative=False),
+            drop_falsified=True,
+            output_policy=OutputPolicy(require_citations=True, min_confidence=0.0),
+        ),
+    )
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="acme",
+        target_mode="vendor",
+        opportunity=_opportunity(),
+    )
+
+    assert context is not None
+    validation = context.canonical_reasoning["validation"]
+    # c2 (the unciteable claim) was dropped before validation, so no
+    # claim_missing_citations blocker fires.
+    assert validation["passed"] is True
+    assert validation["blockers"] == ()


### PR DESCRIPTION
## Summary

5th and final reasoning-core capability through the bridge. After this PR, **all five** capabilities are reachable through opt-in config knobs with no host-side wiring beyond config:

| Capability | Knob | Surfaced as |
|---|---|---|
| `run_reasoning` | always-on | `top_theses` / `canonical_reasoning` / `scope_summary` |
| `continue_reasoning` | `enable_multi_pass=True` (default) | chain telemetry in `scope_summary` |
| `check_falsification` | `falsification_policy: FalsificationPolicy` | `scope_summary["falsification"]` |
| `build_narrative_plan` | `narrative_plan_pack: ReasoningPack` | `canonical_reasoning["narrative_plan"]` |
| **`validate_reasoning_output`** | **`output_policy: OutputPolicy`** (this PR) | **`canonical_reasoning["validation"]`** |

## New config knobs (additive, defaults to no-op)

| Field | Default | Purpose |
|---|---|---|
| `output_policy` | `None` | `OutputPolicy` instance. When set, runs `validate_reasoning_output(result, policy=...)` after the chain (and after falsification gating). When `None`, no validation runs. |
| `block_on_validation_failure` | `False` | When `True` AND the report fails, bridge returns `None` so downstream renderers don't ship a known-invalid output. When `False` (default), the report is surfaced informationally and the host decides. |

## Falsification consistency

When `drop_falsified=True` AND there are falsified ids, the validation target has the falsified claims pre-filtered (via `dataclasses.replace` on the frozen `ReasoningResult`). This mirrors the narrative_plan pattern from D21d: per-claim blockers (e.g. `claim_missing_citations:N`) reference the rendered claim list, not the unfiltered one.

## `canonical_reasoning["validation"]` shape

```python
{
  "passed": bool,
  "blockers": tuple[str, ...],
  "warnings": tuple[str, ...],
}
```

`repaired_fields` and `trace` from `ValidationReport` are not surfaced — the validator never mutates and the trace is reserved for future soft checks.

## Per-call flow (cumulative)

1. `run_reasoning` (D21)
2. `continue_reasoning` chain over `opportunity["events"]` (D21b)
3. `check_falsification` per claim (D21c)
4. `build_narrative_plan` over the final state (D21d)
5. **NEW:** `validate_reasoning_output` against the (optionally pre-filtered) result (this PR)
6. Translation into `CampaignReasoningContext`

## Test plan

- [x] `pytest -q tests/test_extracted_campaign_multi_pass_reasoning_provider.py` → 23/23
- [x] `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` → 1002 passed
- [ ] CI `extracted-checks` run

5 new tests (23 total):
- `output_policy=None` → no `validation` key in `canonical_reasoning`.
- `output_policy` passes → report surfaced with `passed=True`.
- `output_policy` fails + `block_on_validation_failure=False` → context returned with `passed=False` in validation.
- `output_policy` fails + `block_on_validation_failure=True` → bridge returns `None`.
- `drop_falsified=True` + `output_policy(require_citations)` → uncited falsified claim excluded from validation; no `claim_missing_citations` blocker fires.

## Out of scope

- CLI / API endpoint wiring — PR-D21f (last queued slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)