### PR TITLE
Drop merged PR-D21e row from inflight coordination

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T18:07Z by claude-2026-05-03
+Last updated: 2026-05-06T18:10Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (PR-D21e, in flight) | PR-D21e: Wire validate_reasoning_output into MultiPassCampaignReasoningProvider (5/5 reasoning-core capabilities through the bridge) | EDIT: `extracted_content_pipeline/services/multi_pass_reasoning_provider.py` (+`output_policy` and `block_on_validation_failure` config knobs; validate after narrative-plan; surface report in `canonical_reasoning["validation"]`; pre-filter falsified claims when `drop_falsified=True`). EDIT: `tests/test_extracted_campaign_multi_pass_reasoning_provider.py` (+5 tests). Default no-op preserves D21d behavior. | claude-2026-05-03 | `extracted_content_pipeline/services/multi_pass_reasoning_provider.py`; `tests/test_extracted_campaign_multi_pass_reasoning_provider.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
## Summary

PR #318 (PR-D21e: `validate_reasoning_output` bridge wiring, 5/5 reasoning-core capabilities) merged at 18:09Z as `ac708bfc`. Per coordination protocol step 4, drops the in-flight row.

## Test plan

- [x] Diff is row removal + stamp bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)