### PR TITLE
PR-D6d: Reconciliation endpoint (5-layer bundle: layer 3)

### DIFF
--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -30,6 +30,7 @@ import json
 import logging
 import time
 import uuid as _uuid
+from datetime import datetime
 from typing import Any, AsyncIterator, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
@@ -73,6 +74,19 @@ _PROVIDERS_THIS_PR = ("anthropic",)
 # check to the gateway's own feature flag rather than the B2B
 # pipeline flag, so the two products stay decoupled.
 _LLM_CHAT_CACHE_NAMESPACE = "llm_gateway.chat"
+
+
+# PR-D6d: maximum span of a reconciliation period. Mirrors the
+# /usage endpoint's 365-day cap -- any longer and the SQL groups
+# get unwieldy and the comparison loses meaning (Anthropic
+# invoices customers monthly, not yearly).
+_RECONCILIATION_MAX_PERIOD_DAYS = 365
+
+# PR-D6d: dollar-difference threshold below which the
+# reconciliation reports "matches the invoice" rather than
+# explaining a delta. A few cents of drift from rounding/timing
+# isn't actionable; saying "matches" is more useful.
+_RECONCILIATION_MATCH_TOLERANCE_USD = 0.01
 
 
 # Metadata key for the would-have-paid USD on a cache-hit row
@@ -189,6 +203,51 @@ class UsageResponse(BaseModel):
     # with clients that don't know about caching.
     total_cache_savings_usd: float = 0.0
     by_provider: list[UsageBreakdownRow]
+
+
+# PR-D6d reconciliation: customer uploads their provider invoice
+# data; we diff against atlas-routed traffic for the same period.
+# Stateless -- one POST returns the diff, no persistence.
+
+
+class ReconciliationByModelRequest(BaseModel):
+    model: str = Field(..., min_length=1, max_length=256)
+    invoice_cost_usd: float = Field(..., ge=0)
+
+
+class ReconciliationRequest(BaseModel):
+    provider: str = Field(default="anthropic", min_length=1, max_length=64)
+    period_start: str = Field(..., description="ISO date YYYY-MM-DD")
+    period_end: str = Field(..., description="ISO date YYYY-MM-DD")
+    invoice_total_usd: float = Field(..., ge=0)
+    currency: str = Field(default="USD", min_length=3, max_length=8)
+    # Cap the per-model list well above the count of models any
+    # provider actually offers, so a malformed payload (or a
+    # compromised key) can't chew memory in the dict
+    # comprehension. Audit fix on PR-D6d.
+    by_model: list[ReconciliationByModelRequest] = Field(
+        default_factory=list,
+        max_length=128,
+    )
+
+
+class ReconciliationByModelRow(BaseModel):
+    model: str
+    atlas_usd: float = 0.0
+    invoice_usd: float = 0.0
+    delta_usd: float = 0.0
+
+
+class ReconciliationResponse(BaseModel):
+    period_start: str
+    period_end: str
+    provider: str
+    currency: str
+    atlas_total_usd: float = 0.0
+    invoice_total_usd: float = 0.0
+    delta_usd: float = 0.0
+    delta_explanation: str = ""
+    by_model: list[ReconciliationByModelRow]
 
 
 # ---- Helpers ------------------------------------------------------------
@@ -562,6 +621,179 @@ async def usage(
         total_cost_usd=total_cost,
         total_cache_savings_usd=total_cache_savings,
         by_provider=breakdown,
+    )
+
+
+# ---- /reconciliation (PR-D6d, layer 3 of cost-control bundle) ----------
+
+
+def _parse_reconciliation_date(name: str, value: str) -> datetime:
+    """Parse an ISO YYYY-MM-DD date; 400 on anything else.
+    Centralized so error messages are consistent across the
+    period_start / period_end checks."""
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{name} must be YYYY-MM-DD ({value!r}: {exc})",
+        )
+
+
+def _reconciliation_delta_explanation(delta: float, currency: str) -> str:
+    """Compose a human-readable explanation of the diff sign.
+
+    Positive delta = invoice > atlas-tracked. Almost always means
+    non-atlas-routed calls under the same Anthropic org/key.
+    Negative delta = atlas-tracked > invoice. Possible pricing-
+    config drift on our end, or the customer reconciled the wrong
+    period -- worth flagging for review either way."""
+    if currency.upper() != "USD":
+        return (
+            f"Currency {currency} not converted to USD; delta reported in "
+            f"{currency}. Convert manually before drawing conclusions."
+        )
+    if abs(delta) < _RECONCILIATION_MATCH_TOLERANCE_USD:
+        return "Atlas-routed traffic matches the invoice within $0.01."
+    if delta > 0:
+        return (
+            f"Anthropic billing exceeds atlas-routed traffic by ${delta:.2f}. "
+            f"Likely from non-atlas calls under the same Anthropic org/key."
+        )
+    return (
+        f"Atlas tracked ${-delta:.2f} more than the invoice. Possible "
+        f"pricing-config drift or wrong reconciliation period; please review."
+    )
+
+
+@router.post("/reconciliation", response_model=ReconciliationResponse)
+async def reconciliation(
+    body: ReconciliationRequest,
+    user: AuthUser = Depends(require_llm_plan("llm_starter")),
+) -> ReconciliationResponse:
+    """Diff customer-supplied provider invoice against atlas-routed traffic.
+
+    The customer extracts their billing data from Anthropic's
+    console / Cost Report API / their own invoice and POSTs the
+    canonical totals + per-model breakdown. We sum llm_usage rows
+    for (account_id, period, provider) excluding cache hits (which
+    cost the customer 0 -- they don't appear on Anthropic's
+    invoice) and return both sides plus a delta.
+
+    Stateless: nothing persisted server-side. Customer keeps the
+    upload data; we just compute the comparison.
+
+    Plan-gated to llm_starter+ -- reconciliation is a paying-
+    customer feature. Trial users see /usage but not this.
+    """
+    if body.provider not in _PROVIDERS_THIS_PR:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Provider '{body.provider}' is not supported for "
+                f"reconciliation in this release. Supported: "
+                f"{sorted(_PROVIDERS_THIS_PR)}."
+            ),
+        )
+    start_dt = _parse_reconciliation_date("period_start", body.period_start)
+    end_dt = _parse_reconciliation_date("period_end", body.period_end)
+    if start_dt > end_dt:
+        raise HTTPException(
+            status_code=400,
+            detail="period_start must be on or before period_end",
+        )
+    span_days = (end_dt - start_dt).days + 1
+    if span_days > _RECONCILIATION_MAX_PERIOD_DAYS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"period span {span_days}d exceeds maximum "
+                f"{_RECONCILIATION_MAX_PERIOD_DAYS}d"
+            ),
+        )
+
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    # Cache-hit exclusion uses JSONB containment (``@>``) rather
+    # than ``->>``-then-cast so a malformed metadata value can't
+    # raise -- same DoS-safety rationale as PR-D6c's
+    # jsonb_typeof guard for cache_savings_usd.
+    #
+    # Period bounds anchor explicitly to UTC: ``created_at`` is
+    # TIMESTAMPTZ but a bare ``$3::date`` cast resolves in the
+    # session timezone, so a non-UTC Postgres deployment would
+    # silently misframe periods. ``AT TIME ZONE 'UTC'`` makes the
+    # UTC-day semantics intentional and matches Anthropic's Cost
+    # Report API (which buckets by UTC days). Audit fix on PR-D6d.
+    rows = await pool.fetch(
+        """
+        SELECT model_name,
+               COALESCE(SUM(cost_usd), 0)::float AS atlas_usd
+        FROM llm_usage
+        WHERE account_id = $1
+          AND model_provider = $2
+          AND created_at >= $3::date AT TIME ZONE 'UTC'
+          AND created_at <  ($4::date + INTERVAL '1 day') AT TIME ZONE 'UTC'
+          AND NOT (metadata @> '{"cache_hit": true}'::jsonb)
+        GROUP BY model_name
+        """,
+        _uuid.UUID(user.account_id),
+        body.provider,
+        body.period_start,
+        body.period_end,
+    )
+
+    atlas_by_model: dict[str, float] = {}
+    for row in rows:
+        model = row["model_name"] or ""
+        atlas_by_model[model] = float(row["atlas_usd"] or 0.0)
+
+    # Sum duplicate model entries instead of dict-comp overwrite.
+    # Customers legitimately have multi-row line items per model
+    # (different price tiers, mid-cycle pricing changes); silently
+    # dropping all but the last would understate their invoice
+    # and they'd have no signal. Audit catch on PR-D6d.
+    invoice_by_model: dict[str, float] = {}
+    for item in body.by_model:
+        invoice_by_model[item.model] = (
+            invoice_by_model.get(item.model, 0.0)
+            + float(item.invoice_cost_usd)
+        )
+
+    # Round to 4 decimals on display: hides floating-point
+    # representation artifacts (5.0 - 4.99 = 1.0000000000509e-10)
+    # while keeping sub-cent drift visible. Anthropic invoices
+    # display 2 decimals, but rounding to 2 here would mask
+    # legitimate small deltas the customer might want to see.
+    breakdown: list[ReconciliationByModelRow] = []
+    atlas_total = 0.0
+    for model in sorted(set(atlas_by_model.keys()) | set(invoice_by_model.keys())):
+        atlas_usd = atlas_by_model.get(model, 0.0)
+        invoice_usd = invoice_by_model.get(model, 0.0)
+        breakdown.append(
+            ReconciliationByModelRow(
+                model=model,
+                atlas_usd=round(atlas_usd, 4),
+                invoice_usd=round(invoice_usd, 4),
+                delta_usd=round(invoice_usd - atlas_usd, 4),
+            )
+        )
+        atlas_total += atlas_usd
+
+    delta = round(body.invoice_total_usd - atlas_total, 4)
+
+    return ReconciliationResponse(
+        period_start=body.period_start,
+        period_end=body.period_end,
+        provider=body.provider,
+        currency=body.currency,
+        atlas_total_usd=round(atlas_total, 4),
+        invoice_total_usd=round(body.invoice_total_usd, 4),
+        delta_usd=delta,
+        delta_explanation=_reconciliation_delta_explanation(delta, body.currency),
+        by_model=breakdown,
     )
 
 

--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -700,6 +700,23 @@ async def reconciliation(
                 f"{sorted(_PROVIDERS_THIS_PR)}."
             ),
         )
+    # Reject non-USD outright. The arithmetic below mixes the
+    # customer's invoice_total (their currency) with atlas's
+    # cost_usd (always USD), so a non-USD body produces
+    # numerically meaningless deltas. The response field
+    # ``delta_explanation`` previously emitted a warning string
+    # but customers parse the numeric ``delta_usd`` programmatically
+    # and would happily consume the wrong number. Codex P2 fix on
+    # PR-D6d. Currency conversion is on the followup list when a
+    # customer asks for it.
+    if body.currency.upper() != "USD":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Currency '{body.currency}' not supported. "
+                f"Convert your invoice to USD before submitting."
+            ),
+        )
     start_dt = _parse_reconciliation_date("period_start", body.period_start)
     end_dt = _parse_reconciliation_date("period_end", body.period_end)
     if start_dt > end_dt:

--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -47,7 +47,7 @@ from ..services.b2b.llm_exact_cache import (
     store_cached_text,
 )
 from ..services.byok_keys import lookup_provider_key_async
-from ..services.llm.anthropic import convert_messages
+from ..services.llm.anthropic import _normalize_anthropic_model, convert_messages
 from ..services.llm_gateway_batch import (
     CustomerBatchItem,
     _estimate_cost_usd,
@@ -745,10 +745,21 @@ async def reconciliation(
         body.period_end,
     )
 
+    # Normalize model names on both sides before keying.
+    # /chat persists ``body.model`` (the customer's input) to
+    # ``llm_usage.model_name`` while Anthropic invoices use the
+    # canonical name AnthropicLLM normalized to. Without this
+    # step, an Anthropic alias on the customer's request would
+    # split into an atlas-only alias row plus an invoice-only
+    # canonical row in the breakdown, falsely suggesting non-
+    # atlas traffic or pricing drift. Codex P2 fix on PR-D6d.
     atlas_by_model: dict[str, float] = {}
     for row in rows:
-        model = row["model_name"] or ""
-        atlas_by_model[model] = float(row["atlas_usd"] or 0.0)
+        model = _normalize_anthropic_model(row["model_name"] or "")
+        atlas_by_model[model] = (
+            atlas_by_model.get(model, 0.0)
+            + float(row["atlas_usd"] or 0.0)
+        )
 
     # Sum duplicate model entries instead of dict-comp overwrite.
     # Customers legitimately have multi-row line items per model
@@ -757,8 +768,9 @@ async def reconciliation(
     # and they'd have no signal. Audit catch on PR-D6d.
     invoice_by_model: dict[str, float] = {}
     for item in body.by_model:
-        invoice_by_model[item.model] = (
-            invoice_by_model.get(item.model, 0.0)
+        normalized = _normalize_anthropic_model(item.model)
+        invoice_by_model[normalized] = (
+            invoice_by_model.get(normalized, 0.0)
             + float(item.invoice_cost_usd)
         )
 

--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -212,14 +212,19 @@ class UsageResponse(BaseModel):
 
 class ReconciliationByModelRequest(BaseModel):
     model: str = Field(..., min_length=1, max_length=256)
-    invoice_cost_usd: float = Field(..., ge=0)
+    # ``allow_inf_nan=False`` rejects ``1e309`` -> inf and NaN at
+    # validation time. Without it the value flows through to the
+    # response, JSON serialization can't encode non-finite floats,
+    # and a 400-bug becomes a 500. Codex P2 fix on PR-D6d.
+    invoice_cost_usd: float = Field(..., ge=0, allow_inf_nan=False)
 
 
 class ReconciliationRequest(BaseModel):
     provider: str = Field(default="anthropic", min_length=1, max_length=64)
     period_start: str = Field(..., description="ISO date YYYY-MM-DD")
     period_end: str = Field(..., description="ISO date YYYY-MM-DD")
-    invoice_total_usd: float = Field(..., ge=0)
+    # Same finite-float guard as invoice_cost_usd above.
+    invoice_total_usd: float = Field(..., ge=0, allow_inf_nan=False)
     currency: str = Field(default="USD", min_length=3, max_length=8)
     # Cap the per-model list well above the count of models any
     # provider actually offers, so a malformed payload (or a

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -803,3 +803,286 @@ def test_usage_handler_threads_savings_into_response():
     assert "total_cache_savings += row_cache_savings" in src
     # And the response object surfaces the total.
     assert "total_cache_savings_usd=total_cache_savings" in src
+
+
+# ---- Reconciliation endpoint (PR-D6d, layer 3) -------------------------
+
+
+def test_reconciliation_endpoint_registered():
+    """The new layer-3 endpoint must be a POST registered under
+    /llm/reconciliation (prefix from the router)."""
+    from atlas_brain.api.llm_gateway import router
+
+    matches = [
+        r for r in router.routes
+        if hasattr(r, "path") and r.path == "/llm/reconciliation"
+    ]
+    assert matches, "/llm/reconciliation route not registered"
+    assert "POST" in matches[0].methods
+
+
+def test_reconciliation_endpoint_plan_gated_to_starter():
+    """Reconciliation is a paying-customer feature -- llm_starter
+    or above. Trial users see /usage but not this."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert 'require_llm_plan("llm_starter")' in src
+
+
+def test_reconciliation_request_schema_shape():
+    """Schema captures everything the customer needs to reconcile
+    against atlas-routed traffic: period bounds, invoice totals,
+    per-model breakdown, currency. Provider defaults to anthropic
+    (the only one currently supported) and currency defaults to
+    USD; the customer rarely needs to set either explicitly."""
+    from atlas_brain.api.llm_gateway import (
+        ReconciliationByModelRequest,
+        ReconciliationRequest,
+    )
+
+    req_fields = ReconciliationRequest.model_fields
+    assert "provider" in req_fields
+    assert req_fields["provider"].default == "anthropic"
+    assert "period_start" in req_fields
+    assert "period_end" in req_fields
+    assert "invoice_total_usd" in req_fields
+    assert "currency" in req_fields
+    assert req_fields["currency"].default == "USD"
+    assert "by_model" in req_fields
+
+    item_fields = ReconciliationByModelRequest.model_fields
+    assert "model" in item_fields
+    assert "invoice_cost_usd" in item_fields
+
+
+def test_reconciliation_response_schema_shape():
+    """Response surfaces both sides plus the delta and a
+    human-readable explanation. The customer compares numbers;
+    the explanation tells them whether the diff is actionable."""
+    from atlas_brain.api.llm_gateway import (
+        ReconciliationByModelRow,
+        ReconciliationResponse,
+    )
+
+    resp_fields = ReconciliationResponse.model_fields
+    for field in (
+        "period_start",
+        "period_end",
+        "provider",
+        "currency",
+        "atlas_total_usd",
+        "invoice_total_usd",
+        "delta_usd",
+        "delta_explanation",
+        "by_model",
+    ):
+        assert field in resp_fields
+
+    row_fields = ReconciliationByModelRow.model_fields
+    for field in ("model", "atlas_usd", "invoice_usd", "delta_usd"):
+        assert field in row_fields
+
+
+def test_reconciliation_sql_filters_by_account_period_provider():
+    """SQL must scope by account_id (PR-D3 isolation), provider
+    (only anthropic for now), and the date range. The full-day
+    semantics on period_end use ``< period_end::date + INTERVAL
+    '1 day'`` so calls made on the period_end day are included."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert "WHERE account_id = $1" in src
+    assert "AND model_provider = $2" in src
+    assert "AND created_at >= $3::date" in src
+    assert "AND created_at <  ($4::date + INTERVAL '1 day')" in src
+
+
+def test_reconciliation_excludes_cache_hits_via_jsonb_containment():
+    """Cache-hit rows have cost_usd=0 so they don't affect the
+    sum, but excluding them is honest -- they don't appear on
+    the Anthropic invoice either. Use JSONB containment (``@>``)
+    rather than ``->>`` cast so malformed metadata can't trigger
+    the same DoS PR-D6c P2 fixed for cache_savings_usd."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert (
+        "AND NOT (metadata @> '{\"cache_hit\": true}'::jsonb)"
+        in src
+    )
+
+
+def test_reconciliation_unions_atlas_and_invoice_models():
+    """The breakdown must include EVERY model from either side
+    so the customer can see (a) atlas-routed traffic for a
+    model not on the invoice (= our drift), and (b) invoice
+    line items for a model with no atlas-routed traffic
+    (= calls made outside atlas)."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert "set(atlas_by_model.keys()) | set(invoice_by_model.keys())" in src
+
+
+def test_reconciliation_delta_explanation_has_three_signed_branches():
+    """Helper composes user-facing text for: (1) match within
+    tolerance, (2) Anthropic > atlas (positive delta, expected
+    case), (3) atlas > Anthropic (negative delta, possible
+    drift to investigate)."""
+    from atlas_brain.api.llm_gateway import (
+        _RECONCILIATION_MATCH_TOLERANCE_USD,
+        _reconciliation_delta_explanation,
+    )
+
+    # Positive branch.
+    pos = _reconciliation_delta_explanation(5.00, "USD")
+    assert "exceeds atlas-routed" in pos.lower()
+    # Negative branch.
+    neg = _reconciliation_delta_explanation(-5.00, "USD")
+    assert "more than the invoice" in neg.lower() or "drift" in neg.lower()
+    # Match-within-tolerance branch.
+    match = _reconciliation_delta_explanation(
+        _RECONCILIATION_MATCH_TOLERANCE_USD / 2, "USD"
+    )
+    assert "matches" in match.lower()
+    # Non-USD branch returns a currency caveat instead of a delta sign.
+    eur = _reconciliation_delta_explanation(5.00, "EUR")
+    assert "EUR" in eur and "convert" in eur.lower()
+
+
+def test_reconciliation_validates_date_format():
+    """Malformed dates 400, not 500. Pin the helper that
+    centralizes the parse + raise so error messages stay
+    consistent and one helper is the single source of truth."""
+    from fastapi import HTTPException
+    from atlas_brain.api.llm_gateway import _parse_reconciliation_date
+
+    # Valid passes through.
+    parsed = _parse_reconciliation_date("period_start", "2026-04-01")
+    assert parsed.year == 2026
+
+    # Malformed raises HTTPException 400.
+    try:
+        _parse_reconciliation_date("period_start", "not-a-date")
+        raise AssertionError("expected HTTPException")
+    except HTTPException as exc:
+        assert exc.status_code == 400
+        assert "period_start" in str(exc.detail)
+
+
+def test_reconciliation_validates_period_ordering():
+    """period_start > period_end must 400 -- otherwise the SQL
+    range produces empty results silently and the customer can't
+    tell why their reconciliation looks blank."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert "period_start must be on or before period_end" in src
+
+
+def test_reconciliation_validates_period_span():
+    """Periods longer than the configured max (365d) must 400.
+    Anthropic invoices customers monthly; reconciling a year of
+    traffic in one POST is a wrong-tool signal, and the SQL
+    grouping loses meaning at that scale."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert "_RECONCILIATION_MAX_PERIOD_DAYS" in src
+    # Default value reasonable for a SaaS billing-cycle product.
+    assert llm_gateway._RECONCILIATION_MAX_PERIOD_DAYS == 365
+
+
+def test_reconciliation_match_tolerance_is_a_module_constant():
+    """The match-within threshold lives as a module constant so
+    it can be tuned without a code-path change. Defaults to
+    $0.01 (penny rounding)."""
+    from atlas_brain.api import llm_gateway
+
+    assert hasattr(llm_gateway, "_RECONCILIATION_MATCH_TOLERANCE_USD")
+    assert llm_gateway._RECONCILIATION_MATCH_TOLERANCE_USD == 0.01
+
+
+# ---- Reconciliation audit fixes (PR-D6d) -------------------------------
+
+
+def test_reconciliation_validates_provider_against_allowlist():
+    """Audit fix on PR-D6d: same provider allowlist as /chat
+    (_PROVIDERS_THIS_PR). Prevents a customer from POSTing
+    provider='openai', getting empty atlas data, and concluding
+    atlas didn't track any of their calls."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert "if body.provider not in _PROVIDERS_THIS_PR:" in src
+    assert "is not supported for" in src
+    assert "reconciliation in this release" in src
+
+
+def test_reconciliation_dedupes_by_model_via_sum_not_overwrite():
+    """Audit fix on PR-D6d: customers can legitimately have
+    multi-row line items per model on their invoice (different
+    price tiers, mid-cycle pricing changes). The dict-comp
+    overwrite pattern would silently drop all but the last and
+    understate the invoice total. Sum instead so duplicates
+    aggregate correctly."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    # The summing pattern.
+    assert "invoice_by_model[item.model] = (" in src
+    assert "invoice_by_model.get(item.model, 0.0)" in src
+    assert "+ float(item.invoice_cost_usd)" in src
+    # The naive dict-comp must not return.
+    assert "invoice_by_model: dict[str, float] = {\n        item.model:" not in src
+
+
+def test_reconciliation_request_caps_by_model_length():
+    """Audit fix on PR-D6d: unbounded by_model list lets a
+    malformed payload chew memory in the dict comprehension.
+    128 is well above any provider's model count so legitimate
+    customers never hit the cap."""
+    from atlas_brain.api.llm_gateway import ReconciliationRequest
+
+    fields = ReconciliationRequest.model_fields
+    by_model_field = fields["by_model"]
+    # max_length sits in the field metadata.
+    constraints = getattr(by_model_field, "metadata", []) or []
+    max_lens = [
+        getattr(c, "max_length", None) for c in constraints
+    ]
+    assert 128 in max_lens, f"max_length=128 missing from by_model constraints: {max_lens}"
+
+
+def test_reconciliation_rounds_dollar_values_to_4_decimals():
+    """Audit fix on PR-D6d: floating-point arithmetic produces
+    representation artifacts (5.0 - 4.99 ~ 1e-10) that are ugly
+    in the response. Round to 4 decimals -- enough to keep
+    sub-cent drift visible (Anthropic invoices show 2 decimals)
+    while hiding the artifacts."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    # Per-row rounding.
+    assert "atlas_usd=round(atlas_usd, 4)" in src
+    assert "invoice_usd=round(invoice_usd, 4)" in src
+    assert "delta_usd=round(invoice_usd - atlas_usd, 4)" in src
+    # Top-level rounding.
+    assert "delta = round(body.invoice_total_usd - atlas_total, 4)" in src
+    assert "atlas_total_usd=round(atlas_total, 4)" in src
+    assert "invoice_total_usd=round(body.invoice_total_usd, 4)" in src
+
+
+def test_reconciliation_sql_anchors_period_to_utc():
+    """Audit fix on PR-D6d: ``$::date`` casts resolve in the
+    session timezone. A non-UTC Postgres deployment would
+    silently misframe periods (calls late in a day might land
+    in the next day's bucket). Explicit ``AT TIME ZONE 'UTC'``
+    matches Anthropic's Cost Report API (UTC-day buckets) and
+    makes the intent legible."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    assert "AND created_at >= $3::date AT TIME ZONE 'UTC'" in src
+    assert "AND created_at <  ($4::date + INTERVAL '1 day') AT TIME ZONE 'UTC'" in src

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -1020,6 +1020,23 @@ def test_reconciliation_validates_provider_against_allowlist():
     assert "reconciliation in this release" in src
 
 
+def test_reconciliation_rejects_non_usd_currency():
+    """Codex P2 round 3 on PR-D6d: the arithmetic in the handler
+    subtracts atlas's USD totals from invoice_total_usd, but the
+    request schema accepted any currency string. A non-USD body
+    produced numerically-meaningless deltas with only a warning
+    string -- customers parsing ``delta_usd`` programmatically
+    would happily consume the wrong number. Reject at the
+    handler so the API can never return a mismatched-unit
+    delta."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    # Explicit non-USD reject.
+    assert 'if body.currency.upper() != "USD":' in src
+    assert "Convert your invoice to USD" in src
+
+
 def test_reconciliation_dedupes_by_model_via_sum_not_overwrite():
     """Audit fix on PR-D6d: customers can legitimately have
     multi-row line items per model on their invoice (different

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -1090,6 +1090,61 @@ def test_reconciliation_sql_anchors_period_to_utc():
     assert "AND created_at <  ($4::date + INTERVAL '1 day') AT TIME ZONE 'UTC'" in src
 
 
+def test_reconciliation_rejects_non_finite_invoice_amounts():
+    """Codex P2 on PR-D6d: a JSON number that overflows to inf
+    (e.g. 1e309) was accepted by Pydantic's default float handling,
+    propagated through the reconciliation arithmetic, and crashed
+    at JSON-serialization time -- turning a bad input into a 500.
+    ``allow_inf_nan=False`` rejects inf/NaN at validation, returning
+    a 422 the client can act on."""
+    import math
+    from pydantic import ValidationError
+    from atlas_brain.api.llm_gateway import (
+        ReconciliationByModelRequest,
+        ReconciliationRequest,
+    )
+
+    # Top-level invoice_total_usd guards against inf.
+    try:
+        ReconciliationRequest(
+            period_start="2026-04-01",
+            period_end="2026-04-30",
+            invoice_total_usd=float("inf"),
+        )
+        raise AssertionError("expected ValidationError on inf invoice_total_usd")
+    except ValidationError:
+        pass
+
+    # NaN also rejected.
+    try:
+        ReconciliationRequest(
+            period_start="2026-04-01",
+            period_end="2026-04-30",
+            invoice_total_usd=math.nan,
+        )
+        raise AssertionError("expected ValidationError on NaN invoice_total_usd")
+    except ValidationError:
+        pass
+
+    # Per-model invoice_cost_usd has the same guard.
+    try:
+        ReconciliationByModelRequest(
+            model="claude-haiku-4-5",
+            invoice_cost_usd=float("inf"),
+        )
+        raise AssertionError("expected ValidationError on inf invoice_cost_usd")
+    except ValidationError:
+        pass
+
+    # Sanity: finite values still pass.
+    valid = ReconciliationRequest(
+        period_start="2026-04-01",
+        period_end="2026-04-30",
+        invoice_total_usd=100.0,
+    )
+    assert valid.invoice_total_usd == 100.0
+
+
 def test_reconciliation_normalizes_model_aliases_on_both_sides():
     """Codex P2 on PR-D6d: /chat persists body.model (customer
     input) to llm_usage.model_name while Anthropic invoices use

--- a/tests/test_llm_gateway_router.py
+++ b/tests/test_llm_gateway_router.py
@@ -1026,13 +1026,15 @@ def test_reconciliation_dedupes_by_model_via_sum_not_overwrite():
     price tiers, mid-cycle pricing changes). The dict-comp
     overwrite pattern would silently drop all but the last and
     understate the invoice total. Sum instead so duplicates
-    aggregate correctly."""
+    aggregate correctly. After the Codex P2 fix the dict key is
+    the normalized model id (so two aliases collapsing to the
+    same canonical model also aggregate cleanly)."""
     from atlas_brain.api import llm_gateway
 
     src = inspect.getsource(llm_gateway.reconciliation)
-    # The summing pattern.
-    assert "invoice_by_model[item.model] = (" in src
-    assert "invoice_by_model.get(item.model, 0.0)" in src
+    # The summing pattern keyed on the normalized model id.
+    assert "invoice_by_model[normalized] = (" in src
+    assert "invoice_by_model.get(normalized, 0.0)" in src
     assert "+ float(item.invoice_cost_usd)" in src
     # The naive dict-comp must not return.
     assert "invoice_by_model: dict[str, float] = {\n        item.model:" not in src
@@ -1086,3 +1088,37 @@ def test_reconciliation_sql_anchors_period_to_utc():
     src = inspect.getsource(llm_gateway.reconciliation)
     assert "AND created_at >= $3::date AT TIME ZONE 'UTC'" in src
     assert "AND created_at <  ($4::date + INTERVAL '1 day') AT TIME ZONE 'UTC'" in src
+
+
+def test_reconciliation_normalizes_model_aliases_on_both_sides():
+    """Codex P2 on PR-D6d: /chat persists body.model (customer
+    input) to llm_usage.model_name while Anthropic invoices use
+    the canonical model id AnthropicLLM normalized to. Without
+    normalizing on read, an alias would split into atlas-only +
+    invoice-only rows in the breakdown -- falsely suggesting
+    non-atlas traffic or pricing drift.
+
+    Both sides go through ``_normalize_anthropic_model`` so the
+    breakdown groups by canonical name. Sum-aggregation handles
+    the case where multiple aliases collapse to the same
+    canonical model."""
+    from atlas_brain.api import llm_gateway
+
+    src = inspect.getsource(llm_gateway.reconciliation)
+    # Normalization helper imported.
+    assert "from ..services.llm.anthropic import _normalize_anthropic_model" in inspect.getsource(llm_gateway)
+    # Atlas-side normalization (with sum-aggregation in case
+    # multiple aliases collapse to the same canonical key).
+    assert "model = _normalize_anthropic_model(row[\"model_name\"] or \"\")" in src
+    assert 'atlas_by_model[model] = (' in src
+    assert "atlas_by_model.get(model, 0.0)" in src
+    # Invoice-side normalization.
+    assert "normalized = _normalize_anthropic_model(item.model)" in src
+    assert "invoice_by_model[normalized] = (" in src
+    # Helper itself collapses aliases (smoke test the round-trip).
+    from atlas_brain.services.llm.anthropic import _normalize_anthropic_model
+    # Empty input gets the default model -- harmless for our path
+    # (empty model strings shouldn't make it past Pydantic min_length
+    # validation on invoice items, and llm_usage rows with NULL
+    # model_name are an edge case worth bucketing somewhere).
+    assert _normalize_anthropic_model("") != ""


### PR DESCRIPTION
## Summary

Closes **layer 3 of the LLM Gateway 5-layer cost-control bundle**: reconciliation against provider billing. Stateless self-service — customer extracts billing data from Anthropic's console / Cost Report API / their own invoice and POSTs canonical JSON; we sum `llm_usage` rows for the period and return both sides plus a delta with a human-readable explanation.

## Why this shape (not server-side Anthropic admin-key sync)

The architectural alternative (Approach A from the planning thread) was per-customer Anthropic admin keys synced server-side. That requires multi-tenant retrofit on the single-tenant cost tables (`llm_provider_daily_costs` has no `account_id`), encrypted admin-key storage, and a sync worker — 2-3 PRs of infra before the customer sees anything.

Approach B (this PR): one PR, customer pastes invoice data, gets the diff. Friction is real but it's the demonstrable layer-3 minimum that proves the pitch. Server-side automation is a follow-up if/when customers ask.

## Endpoint shape

```jsonc
// REQUEST
POST /api/v1/llm/reconciliation
{
  "provider": "anthropic",
  "period_start": "2026-04-01",
  "period_end":   "2026-04-30",
  "invoice_total_usd": 142.30,
  "currency": "USD",
  "by_model": [
    {"model": "claude-haiku-4-5-20251001", "invoice_cost_usd": 80.00},
    {"model": "claude-opus-4-7",            "invoice_cost_usd": 62.30}
  ]
}

// RESPONSE
{
  "period_start": "2026-04-01",
  "period_end":   "2026-04-30",
  "provider": "anthropic",
  "currency": "USD",
  "atlas_total_usd":   139.85,
  "invoice_total_usd": 142.30,
  "delta_usd":            2.45,
  "delta_explanation": "Anthropic billing exceeds atlas-routed traffic by $2.45. Likely from non-atlas calls under the same Anthropic org/key.",
  "by_model": [
    {"model": "claude-haiku-4-5-20251001", "atlas_usd": 78.50, "invoice_usd": 80.00, "delta_usd":  1.50},
    {"model": "claude-opus-4-7",            "atlas_usd": 61.35, "invoice_usd": 62.30, "delta_usd":  0.95}
  ]
}
```

Plan-gated to `llm_starter+` (paying customers).

## Audit fixes applied before first commit

Self + advisor audit caught five issues. All fixed before push:

| # | Issue | Source | Fix |
|---|---|---|---|
| 1 | Provider not validated against allowlist | self | Mirror `_validate_chat_provider` — 400 on unknown providers |
| 2 | Floating-point delta artifacts (`1e-10` in response) | self | `round(..., 4)` on all 6 dollar fields |
| 3 | SQL `::date` resolves in session TZ | self (advisor: fix-not-defer) | Explicit `AT TIME ZONE 'UTC'` on both bounds |
| 4 | **Duplicate `by_model` entries silently overwrite** | advisor | Sum aggregation instead of dict-comp |
| 5 | **`by_model` list unbounded** | advisor | `Field(..., max_length=128)` |

#4 and #5 were real correctness/security issues advisor caught that I missed — exactly the audit value the pattern produces.

## Honest framing

The `delta_explanation` text is signed:
- **Match within $0.01** → "Atlas-routed traffic matches the invoice within $0.01."
- **Positive delta** → "Anthropic billing exceeds atlas-routed traffic by $X. Likely from non-atlas calls under the same Anthropic org/key."
- **Negative delta** → "Atlas tracked $X more than the invoice. Possible pricing-config drift or wrong reconciliation period; please review."
- **Non-USD** → "Currency X not converted to USD; delta reported in X. Convert manually before drawing conclusions."

The positive-delta case (most common) acknowledges the elephant in the room: Anthropic's Cost Report is per-org, not per-API-key. A customer's org-wide spend can include calls outside atlas. The explanation tells them this so they don't expect identical numbers.

## Test plan

- [x] 12 new contract-pin tests + 5 audit-fix tests = **17 total** added in `test_llm_gateway_router.py` (75 total in file, was 58):
  - Endpoint registration, plan gating, request/response schema shapes
  - SQL filters: account_id, provider, date range with UTC anchoring
  - Cache-hit exclusion via JSONB containment
  - Model-union breakdown
  - 4 delta-explanation branches (positive, negative, match, non-USD)
  - Date validation (400 on malformed)
  - Period ordering (400 on `start > end`)
  - Period span (400 over 365 days)
  - Match tolerance constant
  - Audit fixes: provider allowlist, dedupe via sum, `max_length=128`, 4-decimal rounding, UTC anchoring
- [x] Full LLM-gateway + auth + cache regression: 282 passed
- [x] ASCII compliance verified
- [x] No inline hard-coded values (`_RECONCILIATION_MAX_PERIOD_DAYS`, `_RECONCILIATION_MATCH_TOLERANCE_USD` as module constants)
- [ ] Codex / Copilot review

## Out of scope (followups)

- Persisted reconciliation history (`/reconciliation/history`)
- CSV/PDF parsing
- Currency conversion
- Per-day breakdown (currently per-model only)
- Per-customer Anthropic admin-key sync (Approach A from planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
