### PR TITLE
PR-D21f: Wire MultiPassCampaignReasoningProvider into campaign-operations API (final D21 slice)

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T18:10Z by claude-2026-05-03
+Last updated: 2026-05-06T18:15Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (PR-D21f, in flight) | PR-D21f: Wire MultiPassCampaignReasoningProvider into the campaign-operations FastAPI router (final D21 slice) | EDIT: `extracted_content_pipeline/api/campaign_operations.py` (+5 multi-pass config fields, mutually exclusive with single-pass; multi-pass branch in `_generation_reasoning_context`; readiness now reports `multi_pass_configured` / `multi_pass_ready` / `mode="multi_pass"`). EDIT: `tests/test_extracted_campaign_api_operations.py` (+5 tests, +4 readiness-shape updates). Default no-op preserves D21e behavior. Hosts that need typed knobs (FalsificationPolicy, ReasoningPack, OutputPolicy) construct the provider themselves and pass via `reasoning_context_provider` FastAPI dep. | claude-2026-05-03 | `extracted_content_pipeline/api/campaign_operations.py`; `tests/test_extracted_campaign_api_operations.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -33,6 +33,10 @@ from ..campaign_postgres_sequence_progression import (
 )
 from ..campaign_send import CampaignSendConfig
 from ..campaign_sequence_progression import CampaignSequenceProgressionConfig
+from ..services.multi_pass_reasoning_provider import (
+    MultiPassCampaignReasoningProvider,
+    MultiPassReasoningProviderConfig,
+)
 from ..services.single_pass_reasoning_provider import (
     DEFAULT_REASONING_SKILL_NAME,
     SinglePassCampaignReasoningProvider,
@@ -94,6 +98,17 @@ class CampaignOperationsApiConfig:
     generation_reasoning_max_tokens: int = 900
     generation_reasoning_temperature: float = 0.2
     generation_reasoning_include_source_opportunity: bool = True
+    # Multi-pass reasoning (PR-D21f). Mutually exclusive with
+    # generation_single_pass_reasoning. Exposes only the simple knobs;
+    # hosts that need typed knobs (FalsificationPolicy, ReasoningPack,
+    # OutputPolicy) construct MultiPassCampaignReasoningProvider
+    # themselves and pass it via the reasoning_context_provider
+    # FastAPI dependency.
+    generation_multi_pass_reasoning: bool = False
+    generation_multi_pass_pack_name: str | None = None
+    generation_multi_pass_top_thesis_limit: int = 5
+    generation_multi_pass_enable_chain: bool = True
+    generation_multi_pass_max_continuations: int = 8
 
     def __post_init__(self) -> None:
         _validate_default_limit(
@@ -133,6 +148,16 @@ class CampaignOperationsApiConfig:
                 raise ValueError("generation_reasoning_skill_name is required")
             if self.generation_reasoning_max_tokens <= 0:
                 raise ValueError("generation_reasoning_max_tokens must be positive")
+        if self.generation_single_pass_reasoning and self.generation_multi_pass_reasoning:
+            raise ValueError(
+                "generation_single_pass_reasoning and generation_multi_pass_reasoning "
+                "are mutually exclusive"
+            )
+        if self.generation_multi_pass_reasoning:
+            if self.generation_multi_pass_top_thesis_limit <= 0:
+                raise ValueError("generation_multi_pass_top_thesis_limit must be positive")
+            if self.generation_multi_pass_max_continuations < 0:
+                raise ValueError("generation_multi_pass_max_continuations must be non-negative")
 
 
 def _require_fastapi() -> None:
@@ -380,6 +405,20 @@ def _generation_reasoning_context(
 ) -> Any:
     if explicit_reasoning_context is not None:
         return explicit_reasoning_context
+    if config.generation_multi_pass_reasoning:
+        if llm is None:
+            raise HTTPException(status_code=503, detail="Campaign reasoning LLM unavailable")
+        from extracted_reasoning_core.types import ReasoningPorts
+
+        return MultiPassCampaignReasoningProvider(
+            ports=ReasoningPorts(llm=llm),
+            config=MultiPassReasoningProviderConfig(
+                pack_name=config.generation_multi_pass_pack_name,
+                top_thesis_limit=config.generation_multi_pass_top_thesis_limit,
+                enable_multi_pass=config.generation_multi_pass_enable_chain,
+                max_continuations=config.generation_multi_pass_max_continuations,
+            ),
+        )
     if not config.generation_single_pass_reasoning:
         return None
     if llm is None:
@@ -411,12 +450,24 @@ def _operation_readiness(
         and llm_configured
         and skills_configured
     )
+    multi_pass_ready = (
+        bool(config.generation_multi_pass_reasoning) and llm_configured
+    )
     generation_ready = database_available and (
         explicit_reasoning
-        or not config.generation_single_pass_reasoning
+        or (not config.generation_single_pass_reasoning and not config.generation_multi_pass_reasoning)
         or single_pass_ready
+        or multi_pass_ready
     )
     sequence_ready = database_available and bool(_clean(config.sequence_from_email))
+    if explicit_reasoning:
+        reasoning_mode = "explicit_provider"
+    elif config.generation_multi_pass_reasoning:
+        reasoning_mode = "multi_pass"
+    elif config.generation_single_pass_reasoning:
+        reasoning_mode = "single_pass"
+    else:
+        reasoning_mode = "none"
     return {
         "providers": {
             "database": database_available,
@@ -427,13 +478,11 @@ def _operation_readiness(
             "visibility": visibility_provider is not None,
         },
         "reasoning": {
-            "mode": (
-                "explicit_provider"
-                if explicit_reasoning
-                else ("single_pass" if config.generation_single_pass_reasoning else "none")
-            ),
+            "mode": reasoning_mode,
             "single_pass_configured": bool(config.generation_single_pass_reasoning),
             "single_pass_ready": single_pass_ready,
+            "multi_pass_configured": bool(config.generation_multi_pass_reasoning),
+            "multi_pass_ready": multi_pass_ready,
         },
         "features": {
             "draft_generation": generation_ready,

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -387,6 +387,8 @@ def test_campaign_operations_router_reports_status() -> None:
             "mode": "explicit_provider",
             "single_pass_configured": False,
             "single_pass_ready": False,
+            "multi_pass_configured": False,
+            "multi_pass_ready": False,
         },
         "features": {
             "draft_generation": True,
@@ -446,6 +448,8 @@ def test_campaign_operations_router_status_reports_single_pass_readiness() -> No
         "mode": "single_pass",
         "single_pass_configured": True,
         "single_pass_ready": False,
+        "multi_pass_configured": False,
+        "multi_pass_ready": False,
     }
     assert payload["features"]["draft_generation"] is False
 
@@ -464,6 +468,8 @@ def test_campaign_operations_router_status_marks_single_pass_ready() -> None:
         "mode": "single_pass",
         "single_pass_configured": True,
         "single_pass_ready": True,
+        "multi_pass_configured": False,
+        "multi_pass_ready": False,
     }
     assert payload["features"]["draft_generation"] is True
 
@@ -481,6 +487,8 @@ def test_campaign_operations_router_status_treats_explicit_reasoning_as_ready() 
         "mode": "explicit_provider",
         "single_pass_configured": True,
         "single_pass_ready": False,
+        "multi_pass_configured": False,
+        "multi_pass_ready": False,
     }
     assert payload["features"]["draft_generation"] is True
 
@@ -1382,3 +1390,86 @@ def test_campaign_operations_router_requires_fastapi(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="FastAPI is required"):
         create_campaign_operations_router(pool_provider=lambda: None)
+
+
+def test_campaign_operations_router_status_reports_multi_pass_readiness() -> None:
+    response = _client(
+        _Pool(),
+        config=CampaignOperationsApiConfig(generation_multi_pass_reasoning=True),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ready"
+    assert payload["reasoning"] == {
+        "mode": "multi_pass",
+        "single_pass_configured": False,
+        "single_pass_ready": False,
+        "multi_pass_configured": True,
+        "multi_pass_ready": False,
+    }
+    # Configured but no LLM provider -> draft_generation gated off.
+    assert payload["features"]["draft_generation"] is False
+
+
+def test_campaign_operations_router_status_marks_multi_pass_ready() -> None:
+    response = _client(
+        _Pool(),
+        llm=_LLM(),
+        config=CampaignOperationsApiConfig(generation_multi_pass_reasoning=True),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reasoning"] == {
+        "mode": "multi_pass",
+        "single_pass_configured": False,
+        "single_pass_ready": False,
+        "multi_pass_configured": True,
+        "multi_pass_ready": True,
+    }
+    # Multi-pass needs LLM only (no SkillStore required) -> ready when LLM
+    # provider is wired, even without skills.
+    assert payload["features"]["draft_generation"] is True
+
+
+def test_campaign_operations_router_status_explicit_provider_beats_multi_pass() -> None:
+    response = _client(
+        _Pool(),
+        reasoning=_Reasoning(),
+        config=CampaignOperationsApiConfig(generation_multi_pass_reasoning=True),
+    ).get("/campaigns/operations/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    # Explicit provider takes precedence over the multi_pass flag, but the
+    # multi_pass_configured flag still reflects the API config.
+    assert payload["reasoning"] == {
+        "mode": "explicit_provider",
+        "single_pass_configured": False,
+        "single_pass_ready": False,
+        "multi_pass_configured": True,
+        "multi_pass_ready": False,
+    }
+
+
+def test_campaign_operations_api_config_rejects_both_reasoning_modes() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        CampaignOperationsApiConfig(
+            generation_single_pass_reasoning=True,
+            generation_multi_pass_reasoning=True,
+        )
+
+
+def test_campaign_operations_api_config_rejects_invalid_multi_pass_limits() -> None:
+    with pytest.raises(ValueError, match="generation_multi_pass_top_thesis_limit"):
+        CampaignOperationsApiConfig(
+            generation_multi_pass_reasoning=True,
+            generation_multi_pass_top_thesis_limit=0,
+        )
+
+    with pytest.raises(ValueError, match="generation_multi_pass_max_continuations"):
+        CampaignOperationsApiConfig(
+            generation_multi_pass_reasoning=True,
+            generation_multi_pass_max_continuations=-1,
+        )


### PR DESCRIPTION
## Summary

Final D21 slice. The campaign-operations FastAPI router now exposes the multi-pass reasoning bridge as an opt-in alternative to the single-pass provider. After this PR, the D21 series is **complete**:

- 5/5 reasoning-core capabilities reachable through the bridge (`run_reasoning`, `continue_reasoning`, `check_falsification`, `build_narrative_plan`, `validate_reasoning_output` — all via opt-in knobs).
- The bridge itself is reachable through the hosted API via a config flag.

## New API config fields (additive, mutually exclusive with single-pass)

| Field | Default | Purpose |
|---|---|---|
| `generation_multi_pass_reasoning` | `False` | Master toggle for the multi-pass branch. Mutually exclusive with `generation_single_pass_reasoning`. |
| `generation_multi_pass_pack_name` | `None` | Pack name forwarded to `MultiPassReasoningProviderConfig.pack_name`. |
| `generation_multi_pass_top_thesis_limit` | `5` | Cap on `top_theses` in the rendered context. |
| `generation_multi_pass_enable_chain` | `True` | Toggles `continue_reasoning` chain over `opportunity["events"]`. |
| `generation_multi_pass_max_continuations` | `8` | Hard cap on chain length. |

## Validation

- `single_pass=True` AND `multi_pass=True` → `ValueError("mutually exclusive")`
- `multi_pass=True` AND `top_thesis_limit <= 0` → `ValueError`
- `multi_pass=True` AND `max_continuations < 0` → `ValueError`

## Why typed knobs are NOT in API config

`FalsificationPolicy`, `ReasoningPack`, and `OutputPolicy` are typed instances (Sequences of dicts, dataclass with `tuple` fields) — they don't fit cleanly in a `dataclass(frozen=True)` API config. Hosts that need them construct `MultiPassCampaignReasoningProvider` themselves and pass it via the existing `reasoning_context_provider` FastAPI dependency — `explicit_provider` mode takes precedence over the `multi_pass` flag.

## `/campaigns/operations/status` shape change

```diff
 "reasoning": {
   "mode": "explicit_provider" | "multi_pass" | "single_pass" | "none",
   "single_pass_configured": bool,
   "single_pass_ready": bool,
+  "multi_pass_configured": bool,
+  "multi_pass_ready": bool,
 }
```

`multi_pass_ready = multi_pass_configured AND llm_configured`. Multi-pass does NOT require a `SkillStore` (unlike single-pass) — the bridge talks to `extracted_reasoning_core.api.run_reasoning` which carries its own prompts via `ReasoningPack`.

## Test plan

- [x] `pytest -q tests/test_extracted_campaign_api_operations.py` → 51/51 (46 existing + 5 new)
- [x] `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` → 1007 passed
- [ ] CI `extracted-checks` run

5 new tests:
- Status reports `multi_pass` configured-but-not-ready (no LLM provider).
- Status marks `multi_pass` ready (with LLM, no skills required).
- Explicit provider beats the `multi_pass` flag (mode="explicit_provider", `multi_pass_configured` still surfaces).
- API config rejects both reasoning modes simultaneously.
- API config rejects invalid multi-pass limits (zero `top_thesis_limit`, negative `max_continuations`).

4 existing readiness-shape assertions updated to include the new keys.

## Out of scope

- `scripts/run_extracted_campaign_generation_*.py` CLI multi-pass wiring (deferred — CLI is one consumer; the API is the larger surface and where hosts integrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)