### PR TITLE
Drop merged _blog_matching prune row from inflight coordination

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T18:26Z by claude-2026-05-03
+Last updated: 2026-05-06T18:45Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Prune vestigial `_blog_matching` bridge from extracted_competitive_intelligence (Phase 3 progress) | DELETE: `extracted_competitive_intelligence/autonomous/tasks/_blog_matching.py` (23-LOC Phase 1 atlas_brain bridge with zero callers anywhere in the repo). Drops competitive_intelligence atlas_brain import count 13→12. No tests / consumers / manifest entries touched. | claude-2026-05-03 | `extracted_competitive_intelligence/autonomous/tasks/_blog_matching.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.


### PR DESCRIPTION
## Summary

PR #323 (prune vestigial `_blog_matching` bridge from extracted_competitive_intelligence) merged at 18:44Z as `b17f29b2`. Per coordination protocol step 4, drops the in-flight row.

## Test plan

- [x] Diff is row removal + stamp bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)