### PR TITLE
Promote autonomous/visibility from Phase 1 bridge to manifest-synced mirror (Phase 3, 1/7)

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T18:45Z by claude-2026-05-03
+Last updated: 2026-05-06T18:50Z by claude-2026-05-03
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py`). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_competitive_intelligence/autonomous/visibility.py
+++ b/extracted_competitive_intelligence/autonomous/visibility.py
@@ -1,23 +1,344 @@
-"""Phase 1 bridge: re-exports atlas_brain.autonomous.visibility.
+"""Pipeline visibility: emit events, record artifact attempts, quarantines.
 
-Programmatically copies every non-dunder name (including underscore-
-prefixed helpers that from X import * would drop). Required because
-many scaffolded modules import private helpers from atlas_brain peers
-via from .X import _foo lazily inside function bodies. Phase 2
-replaces this with a standalone implementation gated on
-EXTRACTED_COMP_INTEL_STANDALONE=1.
+Thin helpers that pipeline stages call to record operational outcomes.
+All writes are best-effort (never raise, never block the pipeline).
 """
+
 from __future__ import annotations
 
-import importlib as _importlib
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
 
-def _bridge() -> None:
-    src = _importlib.import_module("atlas_brain.autonomous.visibility")
-    g = globals()
-    for name in dir(src):
-        if not name.startswith("__"):
-            g[name] = getattr(src, name)
+logger = logging.getLogger("atlas.visibility")
 
 
-_bridge()
-del _bridge, _importlib
+# ---------------------------------------------------------------------------
+# Fingerprint computation
+# ---------------------------------------------------------------------------
+
+def _fingerprint(
+    stage: str,
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    reason_code: str | None = None,
+    rule_code: str | None = None,
+) -> str:
+    """Deterministic fingerprint for grouping repeated issues."""
+    parts = [stage, event_type, entity_type, entity_id]
+    if reason_code:
+        parts.append(reason_code)
+    if rule_code:
+        parts.append(rule_code)
+    raw = "|".join(str(p) for p in parts)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Event emitter
+# ---------------------------------------------------------------------------
+
+async def emit_event(
+    pool,
+    *,
+    stage: str,
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    summary: str,
+    severity: str = "info",
+    actionable: bool = False,
+    artifact_type: str | None = None,
+    reason_code: str | None = None,
+    rule_code: str | None = None,
+    decision: str | None = None,
+    run_id: str | None = None,
+    detail: dict[str, Any] | None = None,
+    source_table: str | None = None,
+    source_id: str | None = None,
+    update_review_state: bool = True,
+) -> str | None:
+    """Emit an immutable visibility event. Returns event ID or None on failure."""
+    fp = _fingerprint(stage, event_type, entity_type, entity_id, reason_code, rule_code)
+    event_id = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO pipeline_visibility_events
+                (id, occurred_at, run_id, stage, event_type, severity, actionable,
+                 entity_type, entity_id, artifact_type, reason_code, rule_code,
+                 decision, summary, detail, fingerprint, source_table, source_id)
+            VALUES ($1, NOW(), $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                    $14::jsonb, $15, $16, $17)
+            """,
+            event_id, run_id, stage, event_type, severity, actionable,
+            entity_type, entity_id, artifact_type, reason_code, rule_code,
+            decision, summary,
+            json.dumps(detail or {}, default=str),
+            fp, source_table, source_id,
+        )
+        if update_review_state:
+            await pool.execute(
+                """
+                INSERT INTO pipeline_visibility_reviews
+                    (fingerprint, status, latest_event_id, occurrence_count,
+                     first_seen_at, last_seen_at)
+                VALUES ($1, 'open', $2, 1, NOW(), NOW())
+                ON CONFLICT (fingerprint) DO UPDATE SET
+                    latest_event_id = EXCLUDED.latest_event_id,
+                    occurrence_count = pipeline_visibility_reviews.occurrence_count + 1,
+                    last_seen_at = NOW(),
+                    updated_at = NOW(),
+                    status = CASE
+                        WHEN pipeline_visibility_reviews.status IN ('resolved', 'ignored')
+                        THEN 'open'
+                        ELSE pipeline_visibility_reviews.status
+                    END
+                """,
+                fp, event_id,
+            )
+        return event_id
+    except Exception:
+        logger.debug("Failed to emit visibility event: %s/%s", stage, event_type, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Artifact attempt recorder
+# ---------------------------------------------------------------------------
+
+async def record_attempt(
+    pool,
+    *,
+    artifact_type: str,
+    artifact_id: str | None = None,
+    run_id: str | None = None,
+    attempt_no: int = 1,
+    stage: str,
+    status: str,
+    score: int | None = None,
+    threshold: int | None = None,
+    blocker_count: int = 0,
+    warning_count: int = 0,
+    blocking_issues: list[str] | None = None,
+    warnings: list[str] | None = None,
+    feedback_summary: str | None = None,
+    failure_step: str | None = None,
+    error_message: str | None = None,
+) -> str | None:
+    """Record an artifact generation attempt. Returns attempt ID or None."""
+    attempt_id = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO artifact_attempts
+                (id, artifact_type, artifact_id, run_id, attempt_no, stage, status,
+                 score, threshold, blocker_count, warning_count,
+                 blocking_issues, warnings,
+                 feedback_summary, failure_step, error_message,
+                 completed_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                    $12::jsonb, $13::jsonb, $14, $15, $16,
+                    CASE WHEN $7 != 'pending' THEN NOW() ELSE NULL END)
+            """,
+            attempt_id, artifact_type, artifact_id, run_id, attempt_no,
+            stage, status, score, threshold, blocker_count, warning_count,
+            json.dumps(blocking_issues or [], default=str),
+            json.dumps(warnings or [], default=str),
+            feedback_summary, failure_step, error_message,
+        )
+        return attempt_id
+    except Exception:
+        logger.debug("Failed to record artifact attempt: %s/%s", artifact_type, stage, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Enrichment quarantine recorder
+# ---------------------------------------------------------------------------
+
+async def record_quarantine(
+    pool,
+    *,
+    review_id: str | None = None,
+    vendor_name: str | None = None,
+    source: str | None = None,
+    reason_code: str,
+    severity: str = "warning",
+    actionable: bool = False,
+    summary: str | None = None,
+    evidence: dict[str, Any] | None = None,
+    run_id: str | None = None,
+) -> str | None:
+    """Record an enrichment quarantine decision. Returns quarantine ID or None."""
+    qid = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO enrichment_quarantines
+                (id, review_id, vendor_name, source, reason_code, severity,
+                 actionable, summary, evidence, run_id)
+            VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
+            """,
+            qid, review_id, vendor_name, source, reason_code, severity,
+            actionable, summary or reason_code,
+            json.dumps(evidence or {}, default=str),
+            run_id,
+        )
+        await emit_event(
+            pool,
+            stage="enrichment",
+            event_type="quarantine_recorded",
+            entity_type="review",
+            entity_id=str(review_id or vendor_name or qid),
+            summary=summary or reason_code,
+            severity="warning" if severity == "warning" else severity,
+            actionable=actionable,
+            artifact_type="enrichment",
+            reason_code=reason_code,
+            run_id=run_id,
+            detail=evidence or {},
+            source_table="enrichment_quarantines",
+            source_id=qid,
+        )
+        return qid
+    except Exception:
+        logger.debug("Failed to record quarantine: %s/%s", vendor_name, reason_code, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dedup decision recorder
+# ---------------------------------------------------------------------------
+
+async def record_dedup(
+    pool,
+    *,
+    stage: str,
+    entity_type: str,
+    entity_id: str,
+    reason: str,
+    survivor_entity_id: str | None = None,
+    run_id: str | None = None,
+    detail: dict[str, Any] | None = None,
+) -> str | None:
+    """Record a dedup/discard decision as a visibility event."""
+    try:
+        await pool.execute(
+            """
+            INSERT INTO dedup_decisions
+                (run_id, stage, entity_type, survivor_entity_id,
+                 discarded_entity_id, reason_code, comparison_metrics)
+            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+            """,
+            run_id,
+            stage,
+            entity_type,
+            survivor_entity_id,
+            entity_id,
+            "dedup_discard",
+            json.dumps(detail or {}, default=str),
+        )
+    except Exception:
+        logger.debug("Failed to record dedup row: %s/%s", stage, entity_id, exc_info=True)
+    return await emit_event(
+        pool,
+        stage=stage,
+        event_type="dedup_discard",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        summary=reason,
+        severity="info",
+        run_id=run_id,
+        reason_code="dedup_discard",
+        decision="discarded",
+        detail=detail,
+    )
+
+
+async def record_synthesis_validation_results(
+    pool,
+    *,
+    vendor_name: str,
+    as_of_date,
+    analysis_window_days: int,
+    schema_version: str,
+    run_id: str | None,
+    attempt_no: int,
+    results: list[dict[str, Any]],
+) -> None:
+    """Persist one row per synthesis validation rule result."""
+    if not results:
+        return
+    try:
+        await pool.executemany(
+            """
+            INSERT INTO synthesis_validation_results
+                (vendor_name, as_of_date, analysis_window_days, schema_version,
+                 run_id, attempt_no, rule_code, severity, passed, summary,
+                 field_path, detail)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)
+            """,
+            [
+                (
+                    vendor_name,
+                    as_of_date,
+                    analysis_window_days,
+                    schema_version,
+                    run_id,
+                    attempt_no,
+                    str(item.get("rule_code") or ""),
+                    str(item.get("severity") or "warning"),
+                    bool(item.get("passed")),
+                    str(item.get("summary") or ""),
+                    item.get("field_path"),
+                    json.dumps(item.get("detail") or {}, default=str),
+                )
+                for item in results
+                if item.get("rule_code")
+            ],
+        )
+    except Exception:
+        logger.debug("Failed to record synthesis validation rows: %s", vendor_name, exc_info=True)
+
+
+async def record_review_action(
+    pool,
+    *,
+    review_id: str,
+    fingerprint: str,
+    target_entity_type: str,
+    target_entity_id: str,
+    action: str,
+    note: str | None = None,
+    actor_id: str | None = None,
+    actor_type: str = "human",
+) -> str | None:
+    """Persist an immutable operator review action."""
+    action_id = str(uuid4())
+    try:
+        await pool.execute(
+            """
+            INSERT INTO pipeline_review_actions
+                (id, review_id, fingerprint, target_entity_type, target_entity_id,
+                 action, note, actor_id, actor_type)
+            VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9)
+            """,
+            action_id,
+            review_id,
+            fingerprint,
+            target_entity_type,
+            target_entity_id,
+            action,
+            note,
+            actor_id,
+            actor_type,
+        )
+        return action_id
+    except Exception:
+        logger.debug("Failed to record review action: %s/%s", review_id, action, exc_info=True)
+        return None

--- a/extracted_competitive_intelligence/manifest.json
+++ b/extracted_competitive_intelligence/manifest.json
@@ -1,5 +1,6 @@
 {
   "mappings": [
+    {"source": "atlas_brain/autonomous/visibility.py", "target": "extracted_competitive_intelligence/autonomous/visibility.py"},
     {"source": "atlas_brain/autonomous/tasks/b2b_battle_cards.py", "target": "extracted_competitive_intelligence/autonomous/tasks/b2b_battle_cards.py"},
     {"source": "atlas_brain/autonomous/tasks/b2b_vendor_briefing.py", "target": "extracted_competitive_intelligence/autonomous/tasks/b2b_vendor_briefing.py"},
     {"source": "atlas_brain/services/b2b/vendor_briefing_delivery.py", "target": "extracted_competitive_intelligence/services/b2b/vendor_briefing_delivery.py"},

--- a/extracted_competitive_intelligence/manifest.json
+++ b/extracted_competitive_intelligence/manifest.json
@@ -11,6 +11,7 @@
     {"source": "atlas_brain/storage/migrations/147_displacement_velocity.sql", "target": "extracted_competitive_intelligence/storage/migrations/147_displacement_velocity.sql"},
     {"source": "atlas_brain/storage/migrations/158_cross_vendor_conclusions.sql", "target": "extracted_competitive_intelligence/storage/migrations/158_cross_vendor_conclusions.sql"},
     {"source": "atlas_brain/storage/migrations/245_cross_vendor_reasoning_synthesis.sql", "target": "extracted_competitive_intelligence/storage/migrations/245_cross_vendor_reasoning_synthesis.sql"},
+    {"source": "atlas_brain/storage/migrations/246_pipeline_visibility.sql", "target": "extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql"},
     {"source": "atlas_brain/storage/migrations/261_b2b_competitive_sets.sql", "target": "extracted_competitive_intelligence/storage/migrations/261_b2b_competitive_sets.sql"},
     {"source": "atlas_brain/storage/migrations/262_b2b_competitive_set_runs.sql", "target": "extracted_competitive_intelligence/storage/migrations/262_b2b_competitive_set_runs.sql"},
     {"source": "atlas_brain/storage/migrations/263_b2b_competitive_set_run_constraints.sql", "target": "extracted_competitive_intelligence/storage/migrations/263_b2b_competitive_set_run_constraints.sql"}

--- a/extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql
+++ b/extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql
@@ -1,0 +1,118 @@
+-- Pipeline visibility: artifact lifecycle, quarantines, events, reviews
+-- Fixes the core data model gaps identified in GPT Pro review (2026-03-30)
+
+-- 1. Artifact attempts: real lifecycle records for generation/build runs
+CREATE TABLE IF NOT EXISTS artifact_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    artifact_type TEXT NOT NULL,        -- blog_post, battle_card, churn_report, vendor_briefing, campaign
+    artifact_id TEXT,                   -- UUID or slug of the artifact (NULL if never created)
+    run_id TEXT,                        -- execution ID for traceability
+    attempt_no INT NOT NULL DEFAULT 1,
+    stage TEXT NOT NULL,                -- generation, quality_gate, persistence, deploy
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'running', 'succeeded', 'failed', 'rejected', 'skipped')),
+    score INT,                          -- quality score at this stage
+    threshold INT,                      -- threshold that was applied
+    blocker_count INT DEFAULT 0,
+    warning_count INT DEFAULT 0,
+    blocking_issues JSONB DEFAULT '[]'::jsonb,
+    warnings JSONB DEFAULT '[]'::jsonb,
+    feedback_summary TEXT,              -- retry feedback sent to LLM
+    failure_step TEXT,                  -- which check failed
+    error_message TEXT,                 -- human-readable error
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_attempts_type_status
+    ON artifact_attempts (artifact_type, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_artifact_attempts_run
+    ON artifact_attempts (run_id);
+CREATE INDEX IF NOT EXISTS idx_artifact_attempts_artifact
+    ON artifact_attempts (artifact_type, artifact_id);
+
+-- 2. Enrichment quarantines: first-class quarantine decisions
+CREATE TABLE IF NOT EXISTS enrichment_quarantines (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    review_id UUID,                     -- b2b_reviews.id
+    vendor_name TEXT,
+    source TEXT,                        -- g2, reddit, capterra, etc.
+    reason_code TEXT NOT NULL,          -- vendor_absent_noisy_source, thin_social_context, etc.
+    severity TEXT NOT NULL DEFAULT 'warning'
+        CHECK (severity IN ('info', 'warning', 'error')),
+    actionable BOOLEAN NOT NULL DEFAULT FALSE,
+    summary TEXT,
+    evidence JSONB DEFAULT '{}'::jsonb, -- snapshot of what triggered quarantine
+    run_id TEXT,
+    quarantined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    released_at TIMESTAMPTZ,
+    released_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_enrichment_quarantines_vendor
+    ON enrichment_quarantines (vendor_name, reason_code);
+CREATE INDEX IF NOT EXISTS idx_enrichment_quarantines_reason
+    ON enrichment_quarantines (reason_code, quarantined_at DESC);
+CREATE INDEX IF NOT EXISTS idx_enrichment_quarantines_unreleased
+    ON enrichment_quarantines (released_at) WHERE released_at IS NULL;
+
+-- 3. Pipeline visibility events: immutable event ledger
+CREATE TABLE IF NOT EXISTS pipeline_visibility_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    run_id TEXT,
+    stage TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    severity TEXT NOT NULL DEFAULT 'info'
+        CHECK (severity IN ('info', 'warning', 'error', 'critical')),
+    actionable BOOLEAN NOT NULL DEFAULT FALSE,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    artifact_type TEXT,
+    reason_code TEXT,
+    rule_code TEXT,
+    decision TEXT,
+    actor_type TEXT NOT NULL DEFAULT 'system',
+    actor_id TEXT,
+    summary TEXT NOT NULL,
+    detail JSONB NOT NULL DEFAULT '{}'::jsonb,
+    fingerprint TEXT,
+    source_table TEXT,
+    source_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pve_stage_type
+    ON pipeline_visibility_events (stage, event_type, severity, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pve_entity
+    ON pipeline_visibility_events (entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_pve_reason
+    ON pipeline_visibility_events (reason_code) WHERE reason_code IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pve_run
+    ON pipeline_visibility_events (run_id) WHERE run_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pve_fingerprint
+    ON pipeline_visibility_events (fingerprint) WHERE fingerprint IS NOT NULL;
+
+-- 4. Pipeline visibility reviews: separate review state from events
+CREATE TABLE IF NOT EXISTS pipeline_visibility_reviews (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    fingerprint TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'open'
+        CHECK (status IN ('open', 'acknowledged', 'resolved', 'ignored', 'accepted_risk')),
+    assignee TEXT,
+    latest_event_id UUID REFERENCES pipeline_visibility_events(id),
+    occurrence_count INT NOT NULL DEFAULT 1,
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolution_code TEXT,
+    resolution_note TEXT,
+    resolved_at TIMESTAMPTZ,
+    resolved_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pvr_status
+    ON pipeline_visibility_reviews (status, last_seen_at DESC);


### PR DESCRIPTION
## Summary

`extracted_competitive_intelligence/autonomous/visibility.py` was a 23-LOC Phase 1 atlas_brain bridge that ran `_bridge()` at import time to populate globals from `atlas_brain.autonomous.visibility`. Promoted to a **manifest-synced mirror** following the same pattern as `vendor_briefing_delivery.py` / `b2b_vendor_briefing.py`.

**Net effect:** `extracted_competitive_intelligence` atlas_brain import count drops **12 → 11**. **1/7** actively-consumed bridges promoted to Phase 2 mirror. 6 remain.

## Changes

- `manifest.json`: adds `{"source": "atlas_brain/autonomous/visibility.py", "target": "extracted_competitive_intelligence/autonomous/visibility.py"}`
- `autonomous/visibility.py`: the 23-LOC bridge stub is replaced (via `extracted/_shared/scripts/sync_extracted.sh`) with the real 344-LOC content from atlas_brain.

## Why this is safe

- atlas_brain peer is **pure leaf** (zero atlas_brain self-imports, zero relative imports — only `hashlib`, `json`, `logging`, `datetime`, `typing`, `uuid`).
- One internal caller (`autonomous/tasks/b2b_battle_cards.py:3150`: `from ..visibility import record_attempt, emit_event`) is unaffected because package shape is preserved.
- atlas_brain peer remains canonical; extracted copy is byte-identical and refreshed at sync time.

## Remaining bridges (6)

| File | atlas_brain LOC | relative imports | internal callers |
|---|---|---|---|
| `storage/models.py` | 732 | 0 | 4 |
| `_execution_progress.py` | 70 | 1 | 2 |
| `webhook_dispatcher.py` | 1017 | 1 | 1 |
| `_b2b_synthesis_reader.py` | 1767 | 2 | 2 |
| `b2b_churn_intelligence.py` | 5779 | 9 | 2 |
| `_b2b_shared.py` | 19875 | 8 | 3 |

(plus the 5 `EXTRACTED_COMP_INTEL_STANDALONE`-toggled package-`__init__` bridges, already Phase 2.)

## Test plan

- [x] `validate_extracted_competitive_intelligence.sh` → passed
- [x] `check_extracted_competitive_intelligence_imports.py` → 31 modules clean (was 30 — adds the mirror)
- [x] `forbid_atlas_reasoning_imports.py extracted_competitive_intelligence` → clean
- [x] `smoke_extracted_competitive_intelligence_imports.py` → passed
- [x] `smoke_extracted_competitive_intelligence_standalone.py` → passed
- [x] competitive_intelligence pytest suite (22 files) → 80 passed
- [x] `EXTRACTED_PIPELINE_STANDALONE=1 bash scripts/run_extracted_pipeline_checks.sh` → 1007 passed
- [ ] CI `extracted-competitive-intelligence-checks` workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)