### PR TITLE
Expose multi-pass reasoning in content generation CLIs

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T19:20Z by codex-2026-05-06-d22
+Last updated: 2026-05-06T19:35Z by codex-2026-05-06-d23
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| #327 | PR-D22: AI Content Ops host smoke command | `scripts/smoke_extracted_content_pipeline_host.py`, extracted content docs/tests/check runner | codex-2026-05-06-d22 | Avoid editing competitive-intelligence Phase 3 visibility files or cross-product audit docs. |
+| (in flight) | PR-D23: AI Content Ops multi-pass reasoning CLI seam | `scripts/run_extracted_campaign_generation_example.py`, `scripts/run_extracted_campaign_generation_postgres.py`, extracted content reasoning docs/tests | codex-2026-05-06-d23 | Avoid editing competitive-intelligence Phase 3 visibility files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -101,7 +101,9 @@ Reasoning is a host/product boundary, not copied into AI Content Ops. The
 campaign generator consumes already-compressed reasoning through
 `CampaignReasoningContextProvider`; see
 `docs/reasoning_handoff_contract.md` for the accepted context shape and the
-no-direct-import rule.
+no-direct-import rule. Lightweight installs can use the packaged single-pass
+provider; higher-depth installs can opt into the extracted reasoning core
+through the multi-pass provider.
 
 `campaign_opportunities.py` defines the customer-data contract for campaign
 generation. Hosts can pass loose opportunity rows from a CRM, warehouse, or
@@ -169,6 +171,16 @@ configured:
 python scripts/run_extracted_campaign_generation_example.py \
   --llm pipeline \
   --single-pass-reasoning
+```
+
+For multi-step reasoning backed by `extracted_reasoning_core`, use the
+multi-pass provider:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  --llm pipeline \
+  --multi-pass-reasoning \
+  --multi-pass-depth L3
 ```
 
 Use host-provided prompt contracts by pointing at a markdown skill directory:
@@ -263,6 +275,15 @@ Or generate lightweight reasoning context during the DB-backed run:
 python scripts/run_extracted_campaign_generation_postgres.py \
   --account-id acct_123 \
   --single-pass-reasoning
+```
+
+Or opt into extracted reasoning-core multi-pass context:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --multi-pass-reasoning \
+  --multi-pass-depth L3
 ```
 
 Use `--skills-root customer_skills` on the Postgres runner for the same
@@ -472,6 +493,13 @@ packaged single-pass provider:
 
 ```python
 config=CampaignOperationsApiConfig(generation_single_pass_reasoning=True)
+```
+
+Hosts that want extracted reasoning-core orchestration instead can enable the
+multi-pass provider:
+
+```python
+config=CampaignOperationsApiConfig(generation_multi_pass_reasoning=True)
 ```
 
 This adds `POST /campaigns/operations/drafts/generate`,

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -164,9 +164,14 @@
   ports to build one normalized `CampaignReasoningContext` per opportunity with
   the `digest/b2b_campaign_reasoning_context` prompt, without importing Atlas
   reasoning producers or graph state.
+- `services.multi_pass_reasoning_provider.MultiPassCampaignReasoningProvider`
+  bridges extracted reasoning-core producer APIs into the same
+  `CampaignReasoningContextProvider` port for hosts that want multi-step
+  per-opportunity reasoning without changing campaign generation code.
 - Both the offline and Postgres campaign generation runners can consume
   file-backed reasoning through `--reasoning-context`; they can also opt into
-  the packaged single-pass provider with `--single-pass-reasoning` when the
+  the packaged single-pass provider with `--single-pass-reasoning` or the
+  extracted reasoning-core provider with `--multi-pass-reasoning` when the
   product LLM adapter is configured.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -225,9 +225,24 @@ Use `--reasoning-skill-name`, `--reasoning-max-tokens`, and
 `--reasoning-temperature` to tune the provider, or `--skills-root` to override
 the packaged reasoning prompt.
 
+For multi-step reasoning backed by `extracted_reasoning_core`, use the
+multi-pass provider. It uses the product LLM port and can chain opportunity
+events through `continue_reasoning` when the opportunity row includes an
+`events` array:
+
+```bash
+python scripts/run_extracted_campaign_generation_postgres.py \
+  --account-id acct_123 \
+  --multi-pass-reasoning \
+  --multi-pass-depth L3
+```
+
+Use `--multi-pass-pack-name`, `--multi-pass-max-continuations`, and
+`--multi-pass-disable-chain` to tune the provider for host budget and policy.
+
 See `reasoning_handoff_contract.md` for the accepted shape and the no-direct-
-import rule. AI Content Ops consumes compressed reasoning; it does not import a
-reasoning engine.
+import rule. AI Content Ops consumes compressed reasoning through a provider;
+the provider may be file-backed, single-pass, multi-pass, or host-owned.
 
 ## Step 6: Add Optional Prompt Overrides
 
@@ -538,6 +553,11 @@ draft generation route then builds `SinglePassCampaignReasoningProvider` from
 the injected LLM and skill providers before calling the Postgres generation
 runner. Explicit `reasoning_context_provider` injection still takes precedence.
 
+For hosted installs that want extracted reasoning-core orchestration, set
+`generation_multi_pass_reasoning=True`. The route builds
+`MultiPassCampaignReasoningProvider` from the injected LLM provider. Explicit
+`reasoning_context_provider` injection still takes precedence.
+
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/campaigns/operations/status` | Report database availability, provider presence, feature readiness, and configured limits for admin dashboards. |
@@ -595,6 +615,7 @@ DELETE FROM campaign_opportunities WHERE account_id = 'acct_123';
   path yet. Host apps inject auth dependencies into the packaged routers.
 - The runbook covers campaign opportunity generation, not blog generation or
   vendor briefing delivery.
-- Long-running reasoning production remains host-owned. The product includes a
-  single-pass opportunity-level provider for lightweight installs, but it does
-  not compute graph state or multi-hop synthesis.
+- Long-running, persistent reasoning production remains host-owned. The product
+  includes single-pass and extracted reasoning-core multi-pass providers for
+  per-opportunity generation, but it does not own a background evidence
+  collection or graph-state service.

--- a/extracted_content_pipeline/docs/reasoning_handoff_contract.md
+++ b/extracted_content_pipeline/docs/reasoning_handoff_contract.md
@@ -137,13 +137,24 @@ semantic caching, entity locking, or long-running synthesis. Hosts that need
 those behaviors should provide their own reasoning adapter or use a separate
 reasoning product.
 
+## Packaged Multi-Pass Provider
+
+`services.multi_pass_reasoning_provider.MultiPassCampaignReasoningProvider`
+is the bridge to `extracted_reasoning_core`. It implements the same
+`CampaignReasoningContextProvider` Protocol, calls `run_reasoning`, optionally
+chains opportunity events through `continue_reasoning`, and normalizes the
+result into campaign context. The provider is opt-in for hosts that inject an
+LLM port and want extracted reasoning-core orchestration without changing the
+campaign generator.
+
 ## Integration Modes
 
 | Mode | Who produces reasoning? | Content package behavior |
 |---|---|---|
 | Atlas-hosted | Atlas synthesis/compression adapters. | Adapter returns the contract shape above. No direct Atlas imports in product code. |
 | Packaged single-pass | AI Content Ops `SinglePassCampaignReasoningProvider`. | One LLM call per opportunity returns the normalized context shape. No graph state or multi-hop synthesis. |
-| Extracted reasoning product | `extracted_reasoning_core` or a future reasoning-producer package. | Adapter converts reasoning output to `CampaignReasoningContext`. |
+| Packaged multi-pass | AI Content Ops `MultiPassCampaignReasoningProvider` over `extracted_reasoning_core`. | Multi-step reasoning output is converted to `CampaignReasoningContext`. |
+| External reasoning product | Future reasoning-producer package. | Adapter converts reasoning output to `CampaignReasoningContext`. |
 | Buyer-owned reasoning | Customer engine, warehouse job, agent workflow, or CRM scoring layer. | Customer adapter implements the provider port. |
 | No reasoning | No provider configured. | Generator uses embedded opportunity fields only; quality is lower but standalone operation remains valid. |
 
@@ -156,16 +167,17 @@ AI Content Ops may own:
 - Sequence progression, suppression, audit, analytics, webhooks, and send
   orchestration.
 - Prompt-visible reasoning context normalization.
+- Thin provider bridges over explicit reasoning ports.
 - Metadata persistence of the context it consumed.
 
 AI Content Ops must not own:
 
-- Multi-hop reasoning graph traversal.
+- Owning multi-hop reasoning graph traversal internals.
 - Evidence-pool compression.
 - Cross-vendor synthesis.
 - Entity locks, event bus orchestration, or reasoning-agent state.
-- Domain-specific reasoning producer internals from Atlas or the reasoning
-  core product.
+- Domain-specific reasoning producer internals from Atlas or any reasoning
+  product.
 
 ## Fit By Content Type
 

--- a/extracted_content_pipeline/docs/reasoning_state_audit.md
+++ b/extracted_content_pipeline/docs/reasoning_state_audit.md
@@ -122,7 +122,7 @@ normalize into this shape. Reference example payload:
 | `reasoning_context = None` (default) | Generator falls back to `normalize_campaign_reasoning_context` over the opportunity row itself; only fields embedded in the source data flow into the prompt | Lowest. Drafts are generic. |
 | `FileCampaignReasoningContextProvider` (file-backed) | Loads pre-baked reasoning JSON keyed by target_id / company / email / vendor; normalized and threaded into the prompt | High when the source file is well-built. Quality scales with effort the host put into producing the JSON. |
 | `SinglePassCampaignReasoningProvider` | Calls the configured LLM once per opportunity with the packaged reasoning prompt; normalized and threaded into the campaign prompt | Medium. Better than no reasoning, but no multi-hop planning, cache, or falsification. |
-| `MultiPassCampaignReasoningProvider` | Calls extracted reasoning-core `run_reasoning`, optionally chains opportunity events through `continue_reasoning`, and normalizes the final result into campaign context | Higher. Best for hosts that want multi-step per-opportunity reasoning without owning a separate provider. |
+| `MultiPassCampaignReasoningProvider` | Calls extracted reasoning-core `run_reasoning`, optionally chains opportunity events through `continue_reasoning`, and normalizes the final result into campaign context | Higher. Best for hosts that want multi-step per-opportunity reasoning without owning a separate provider. The CLI seam does not configure cache or falsification policy. |
 | Custom `CampaignReasoningContextProvider` (e.g. real producer) | Provider is called once per opportunity; output normalized and threaded in | High. This is the architecturally intended path. |
 
 ## What "add a source and reason over it" costs, by tier
@@ -149,11 +149,14 @@ mistake.
 - Implemented in
   `extracted_content_pipeline/services/multi_pass_reasoning_provider.py`
 - Calls `run_reasoning`, can chain `continue_reasoning` over
-  opportunity events, and can surface falsification / validation / narrative
-  planning when configured
+  opportunity events, and normalizes the final result into campaign context
 - Exposed through hosted operations config and the generation CLIs:
   `--multi-pass-reasoning`
-- Multi-step LLM with state, falsification gating, semantic cache
+- Falsification, output validation, and narrative planning require a
+  host-constructed provider config; the CLI seam does not expose those policy
+  objects.
+- Semantic cache is not part of this CLI seam because the runner constructs
+  `ReasoningPorts(llm=llm)` only.
 
 Trade-off: better reasoning, but higher LLM spend and more host policy to tune
 than the single-pass path.

--- a/extracted_content_pipeline/docs/reasoning_state_audit.md
+++ b/extracted_content_pipeline/docs/reasoning_state_audit.md
@@ -18,14 +18,13 @@ with its own data flow.
   accept a known quality penalty from running without reasoning.
 - The standalone debt audit reports **0 atlas_brain runtime imports**.
 - The reasoning *consumer* surface is complete and clean.
-- The extracted package now includes a Tier 1 opportunity-level reasoning
-  producer: `SinglePassCampaignReasoningProvider`. It does not replace the
-  heavier reasoning-core producer stubs; `extracted_reasoning_core` still has
-  four producer-shaped functions (`run_reasoning`, `continue_reasoning`,
-  `check_falsification`, `build_narrative_plan`) that raise
-  `NotImplementedError`.
-- No branch in flight wires `extracted_reasoning_core` into the
-  content-pipeline generator.
+- The extracted package includes two packaged reasoning providers:
+  `SinglePassCampaignReasoningProvider` for Tier 1 opportunity reasoning and
+  `MultiPassCampaignReasoningProvider` for extracted reasoning-core
+  orchestration through the same campaign context port.
+- The campaign generator still does not import reasoning internals directly.
+  CLIs and hosted APIs opt into providers and pass the normalized
+  `CampaignReasoningContextProvider` dependency into generation.
 
 ## What works today end-to-end without atlas_brain
 
@@ -82,7 +81,7 @@ CLI inventory:
 |---|---|---|
 | `CampaignReasoningContextProvider` port (`campaign_ports.py:171-180`) | Optional Protocol the host implements to inject reasoning into generation | Defined and working; reference adapter `FileCampaignReasoningContextProvider` covers the file-backed case |
 | `extracted_reasoning_core` evaluators (`api.py`) | Score / gate / compute over pre-existing reasoning state. `score_archetypes`, `evaluate_evidence`, `build_temporal_evidence` | Implemented and exported |
-| `extracted_reasoning_core` producers (`api.py`) | Generate reasoning from raw inputs. `run_reasoning`, `continue_reasoning`, `check_falsification`, `build_narrative_plan` | All four raise `NotImplementedError` |
+| `extracted_reasoning_core` producers (`api.py`) | Generate reasoning from raw inputs. `run_reasoning`, `continue_reasoning`, `check_falsification`, `build_narrative_plan` | Implemented and callable through the multi-pass provider |
 
 And the wiring between the layers:
 
@@ -91,8 +90,8 @@ And the wiring between the layers:
 | `extracted_content_pipeline.reasoning.archetypes` re-exports `extracted_reasoning_core.archetypes` | Done |
 | `extracted_content_pipeline.reasoning.wedge_registry` re-exports `extracted_reasoning_core.api` | Done |
 | `campaign_generation.py` actually calls those evaluators | Zero call sites |
-| Adapter that packages `extracted_reasoning_core` output into a `CampaignReasoningContextProvider` instance | Does not exist |
-| Branch in flight building any of the above | None — `git branch -a \| grep -i reason` returns nothing |
+| Adapter that packages `extracted_reasoning_core` output into a `CampaignReasoningContextProvider` instance | Done: `MultiPassCampaignReasoningProvider` |
+| CLI access to the multi-pass adapter | Done: `--multi-pass-reasoning` on offline and Postgres generation runners |
 
 ## What the generator expects (the input shape)
 
@@ -123,6 +122,7 @@ normalize into this shape. Reference example payload:
 | `reasoning_context = None` (default) | Generator falls back to `normalize_campaign_reasoning_context` over the opportunity row itself; only fields embedded in the source data flow into the prompt | Lowest. Drafts are generic. |
 | `FileCampaignReasoningContextProvider` (file-backed) | Loads pre-baked reasoning JSON keyed by target_id / company / email / vendor; normalized and threaded into the prompt | High when the source file is well-built. Quality scales with effort the host put into producing the JSON. |
 | `SinglePassCampaignReasoningProvider` | Calls the configured LLM once per opportunity with the packaged reasoning prompt; normalized and threaded into the campaign prompt | Medium. Better than no reasoning, but no multi-hop planning, cache, or falsification. |
+| `MultiPassCampaignReasoningProvider` | Calls extracted reasoning-core `run_reasoning`, optionally chains opportunity events through `continue_reasoning`, and normalizes the final result into campaign context | Higher. Best for hosts that want multi-step per-opportunity reasoning without owning a separate provider. |
 | Custom `CampaignReasoningContextProvider` (e.g. real producer) | Provider is called once per opportunity; output normalized and threaded in | High. This is the architecturally intended path. |
 
 ## What "add a source and reason over it" costs, by tier
@@ -144,20 +144,19 @@ Trade-off: no multi-step planning, no falsification, no cache. If the
 LLM gets it wrong on the first call, the campaign draft inherits the
 mistake.
 
-### Tier 2: Implement `extracted_reasoning_core` producer stubs
+### Tier 2: Use extracted reasoning-core multi-pass provider
 
-- ~2-3 weeks of work, ~2,000 LOC
-- Fill in `run_reasoning`, `continue_reasoning`, `check_falsification`,
-  `build_narrative_plan` in `extracted_reasoning_core/api.py`
-- Plus an adapter that packages those outputs into a
-  `CampaignReasoningContextProvider`
+- Implemented in
+  `extracted_content_pipeline/services/multi_pass_reasoning_provider.py`
+- Calls `run_reasoning`, can chain `continue_reasoning` over
+  opportunity events, and can surface falsification / validation / narrative
+  planning when configured
+- Exposed through hosted operations config and the generation CLIs:
+  `--multi-pass-reasoning`
 - Multi-step LLM with state, falsification gating, semantic cache
-- This is what the architecture intended when the producer stubs were
-  defined
 
-Trade-off: real reasoning, but you're committing to ~3 weeks of work
-before the primary product ships meaningfully better drafts than the
-single-pass version.
+Trade-off: better reasoning, but higher LLM spend and more host policy to tune
+than the single-pass path.
 
 ### Tier 3: Extract the atlas_brain producer
 
@@ -176,20 +175,17 @@ Not recommended. Captured here for completeness; the cost-benefit on
 Tier 3 only makes sense if the goal is to fold the reasoning engine
 into the content product as a single SKU.
 
-## Decision points after Tier 1
+## Remaining decision points
 
-Tier 1 is now implemented for B2B campaign opportunities. Remaining choices are
-about deeper reasoning, not basic "source row in, reasoned draft out":
+Tier 1 and Tier 2 are implemented for B2B campaign opportunities. Remaining
+choices are about source coverage and product promise, not basic wiring:
 
-1. **Tier 2 scope.** Decide whether to fill the four
-   `extracted_reasoning_core` producer stubs for multi-pass planning,
-   falsification, and cache-aware reasoning.
-2. **Additional source formats.** CRM rows are covered through
+1. **Additional source formats.** CRM rows are covered through
    `campaign_opportunities`; review/complaint data, episode transcripts, and
    sales call transcripts need their own schema-aware adapters.
-3. **Product promise.** If single-pass meets the sold promise, AI Content Ops is
-   operational. If the promise is "multi-pass refinement over your data," Tier
-   2 is the floor.
+2. **Product promise.** If single-pass meets the sold promise, AI Content Ops is
+   operational. If the promise is "multi-pass refinement over your data," the
+   multi-pass provider is the floor.
 
 ## Status verdict
 
@@ -202,12 +198,12 @@ about deeper reasoning, not basic "source row in, reasoned draft out":
 | Buyer can review and export drafts | Yes |
 | Buyer can supply pre-baked reasoning as JSON | Yes |
 | Buyer can supply a custom Python reasoning provider | Yes (port is defined) |
-| The product itself produces reasoning from a source | Yes, single-pass opportunity-level reasoning only |
-| `extracted_reasoning_core` produces reasoning from a source | No (4 stubs raise NotImplementedError) |
+| The product itself produces reasoning from a source | Yes, single-pass or multi-pass opportunity-level reasoning |
+| `extracted_reasoning_core` produces reasoning from a source | Yes, through the multi-pass provider |
 
-The remaining structural gap is multi-step reasoning. Tier 1 now lands the
-buyer at "source in, reasoned drafts out"; Tier 2 is still required for
-multi-pass planning, falsification, cache, and deeper reasoning state.
+The remaining structural gap is source breadth, not reasoning-provider wiring.
+CRM/opportunity rows are operational; richer source types need their own
+schema-aware adapters.
 
 ## References
 

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -126,11 +126,13 @@ instead of calling the copied `b2b_campaign_generation.py` task.
 Reasoning remains a host/product boundary for this slice. The generator accepts
 pre-compressed reasoning through `CampaignReasoningContextProvider` and
 normalizes it with `services.campaign_reasoning_context`; it must not reach into
-Atlas reasoning producers or the extracted reasoning-core internals. The
-contract is documented in `docs/reasoning_handoff_contract.md`. The
-file-backed reference adapter in `campaign_reasoning_data.py` lets standalone
-examples consume host-generated reasoning JSON through that same port without
-adding a reasoning runtime dependency.
+Atlas reasoning producers. The contract is documented in
+`docs/reasoning_handoff_contract.md`. The file-backed reference adapter in
+`campaign_reasoning_data.py` lets standalone examples consume host-generated
+reasoning JSON through that same port without adding a reasoning runtime
+dependency. Hosts that want packaged reasoning can opt into the single-pass
+provider or the extracted reasoning-core multi-pass provider through the same
+port.
 
 `extracted_content_pipeline/campaign_postgres_generation.py` wires the
 database-backed product path. Hosts pass an async Postgres pool and the runner

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -125,6 +125,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--multi-pass-depth",
+        choices=("L1", "L2", "L3", "L4", "L5"),
         default=DEFAULT_MULTI_PASS_CONFIG.default_depth,
         help="Reasoning depth for --multi-pass-reasoning.",
     )
@@ -200,6 +201,8 @@ def _validate_reasoning_args(args: argparse.Namespace) -> None:
         raise SystemExit(
             "reasoning requires --llm pipeline"
         )
+    if args.multi_pass_max_continuations < 0:
+        raise SystemExit("--multi-pass-max-continuations must be >= 0")
 
 
 def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoningConfig:

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -28,12 +28,17 @@ from extracted_content_pipeline.services.single_pass_reasoning_provider import (
     SinglePassCampaignReasoningProvider,
     SinglePassReasoningConfig,
 )
+from extracted_content_pipeline.services.multi_pass_reasoning_provider import (  # noqa: E402
+    MultiPassCampaignReasoningProvider,
+    MultiPassReasoningProviderConfig,
+)
 
 
 DEFAULT_PAYLOAD = (
     ROOT / "extracted_content_pipeline/examples/campaign_generation_payload.json"
 )
 DEFAULT_REASONING_CONFIG = SinglePassReasoningConfig()
+DEFAULT_MULTI_PASS_CONFIG = MultiPassReasoningProviderConfig()
 
 
 def _load_payload(path: Path, *, file_format: str = "auto") -> dict[str, Any]:
@@ -106,6 +111,35 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--multi-pass-reasoning",
+        action="store_true",
+        help=(
+            "Generate campaign reasoning context with extracted_reasoning_core "
+            "multi-pass reasoning. Requires --llm pipeline."
+        ),
+    )
+    parser.add_argument(
+        "--multi-pass-pack-name",
+        default=DEFAULT_MULTI_PASS_CONFIG.pack_name,
+        help="Optional extracted_reasoning_core pack name for --multi-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--multi-pass-depth",
+        default=DEFAULT_MULTI_PASS_CONFIG.default_depth,
+        help="Reasoning depth for --multi-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--multi-pass-max-continuations",
+        type=int,
+        default=DEFAULT_MULTI_PASS_CONFIG.max_continuations,
+        help="Maximum opportunity events consumed by --multi-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--multi-pass-disable-chain",
+        action="store_true",
+        help="Run initial reasoning only, even when opportunity events are present.",
+    )
+    parser.add_argument(
         "--reasoning-skill-name",
         default=DEFAULT_REASONING_CONFIG.skill_name,
         help="Skill name for --single-pass-reasoning.",
@@ -150,12 +184,22 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _validate_reasoning_args(args: argparse.Namespace) -> None:
-    if args.reasoning_context and args.single_pass_reasoning:
+    selected = [
+        bool(args.reasoning_context),
+        bool(args.single_pass_reasoning),
+        bool(args.multi_pass_reasoning),
+    ]
+    if sum(1 for item in selected if item) > 1:
         raise SystemExit(
-            "--reasoning-context and --single-pass-reasoning cannot be combined"
+            "--reasoning-context, --single-pass-reasoning, and "
+            "--multi-pass-reasoning cannot be combined"
         )
-    if args.single_pass_reasoning and args.llm != "pipeline":
-        raise SystemExit("--single-pass-reasoning requires --llm pipeline")
+    if (
+        args.single_pass_reasoning or args.multi_pass_reasoning
+    ) and args.llm != "pipeline":
+        raise SystemExit(
+            "reasoning requires --llm pipeline"
+        )
 
 
 def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoningConfig:
@@ -164,6 +208,15 @@ def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoni
         max_tokens=int(args.reasoning_max_tokens),
         temperature=float(args.reasoning_temperature),
         include_source_opportunity=bool(args.reasoning_include_source_opportunity),
+    )
+
+
+def _multi_pass_config_from_args(args: argparse.Namespace) -> MultiPassReasoningProviderConfig:
+    return MultiPassReasoningProviderConfig(
+        default_depth=str(args.multi_pass_depth or ""),
+        pack_name=args.multi_pass_pack_name or None,
+        enable_multi_pass=not bool(args.multi_pass_disable_chain),
+        max_continuations=int(args.multi_pass_max_continuations),
     )
 
 
@@ -197,6 +250,13 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
             llm=llm,
             skills=skills,
             config=_single_pass_config_from_args(args),
+        )
+    if args.multi_pass_reasoning:
+        from extracted_reasoning_core.types import ReasoningPorts  # noqa: PLC0415
+
+        overrides["reasoning_context"] = MultiPassCampaignReasoningProvider(
+            ports=ReasoningPorts(llm=llm),
+            config=_multi_pass_config_from_args(args),
         )
     return overrides
 

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -121,6 +121,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--multi-pass-depth",
+        choices=("L1", "L2", "L3", "L4", "L5"),
         default=DEFAULT_MULTI_PASS_CONFIG.default_depth,
         help="Reasoning depth for --multi-pass-reasoning.",
     )
@@ -203,6 +204,8 @@ def _validate_reasoning_args(args: argparse.Namespace) -> None:
         raise SystemExit(
             "reasoning requires --llm pipeline"
         )
+    if args.multi_pass_max_continuations < 0:
+        raise SystemExit("--multi-pass-max-continuations must be >= 0")
 
 
 def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoningConfig:

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -42,10 +42,15 @@ from extracted_content_pipeline.services.single_pass_reasoning_provider import (
     SinglePassCampaignReasoningProvider,
     SinglePassReasoningConfig,
 )
+from extracted_content_pipeline.services.multi_pass_reasoning_provider import (  # noqa: E402
+    MultiPassCampaignReasoningProvider,
+    MultiPassReasoningProviderConfig,
+)
 from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
 
 
 DEFAULT_REASONING_CONFIG = SinglePassReasoningConfig()
+DEFAULT_MULTI_PASS_CONFIG = MultiPassReasoningProviderConfig()
 
 
 def _json_object(value: str | None) -> dict[str, Any]:
@@ -102,6 +107,35 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--multi-pass-reasoning",
+        action="store_true",
+        help=(
+            "Generate campaign reasoning context with extracted_reasoning_core "
+            "multi-pass reasoning. Requires --llm pipeline."
+        ),
+    )
+    parser.add_argument(
+        "--multi-pass-pack-name",
+        default=DEFAULT_MULTI_PASS_CONFIG.pack_name,
+        help="Optional extracted_reasoning_core pack name for --multi-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--multi-pass-depth",
+        default=DEFAULT_MULTI_PASS_CONFIG.default_depth,
+        help="Reasoning depth for --multi-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--multi-pass-max-continuations",
+        type=int,
+        default=DEFAULT_MULTI_PASS_CONFIG.max_continuations,
+        help="Maximum opportunity events consumed by --multi-pass-reasoning.",
+    )
+    parser.add_argument(
+        "--multi-pass-disable-chain",
+        action="store_true",
+        help="Run initial reasoning only, even when opportunity events are present.",
+    )
+    parser.add_argument(
         "--reasoning-skill-name",
         default=DEFAULT_REASONING_CONFIG.skill_name,
         help="Skill name for --single-pass-reasoning.",
@@ -153,12 +187,22 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _validate_reasoning_args(args: argparse.Namespace) -> None:
-    if args.reasoning_context and args.single_pass_reasoning:
+    selected = [
+        bool(args.reasoning_context),
+        bool(args.single_pass_reasoning),
+        bool(args.multi_pass_reasoning),
+    ]
+    if sum(1 for item in selected if item) > 1:
         raise SystemExit(
-            "--reasoning-context and --single-pass-reasoning cannot be combined"
+            "--reasoning-context, --single-pass-reasoning, and "
+            "--multi-pass-reasoning cannot be combined"
         )
-    if args.single_pass_reasoning and args.llm != "pipeline":
-        raise SystemExit("--single-pass-reasoning requires --llm pipeline")
+    if (
+        args.single_pass_reasoning or args.multi_pass_reasoning
+    ) and args.llm != "pipeline":
+        raise SystemExit(
+            "reasoning requires --llm pipeline"
+        )
 
 
 def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoningConfig:
@@ -167,6 +211,15 @@ def _single_pass_config_from_args(args: argparse.Namespace) -> SinglePassReasoni
         max_tokens=int(args.reasoning_max_tokens),
         temperature=float(args.reasoning_temperature),
         include_source_opportunity=bool(args.reasoning_include_source_opportunity),
+    )
+
+
+def _multi_pass_config_from_args(args: argparse.Namespace) -> MultiPassReasoningProviderConfig:
+    return MultiPassReasoningProviderConfig(
+        default_depth=str(args.multi_pass_depth or ""),
+        pack_name=args.multi_pass_pack_name or None,
+        enable_multi_pass=not bool(args.multi_pass_disable_chain),
+        max_continuations=int(args.multi_pass_max_continuations),
     )
 
 
@@ -200,6 +253,15 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
             llm=llm,
             skills=skills,
             config=_single_pass_config_from_args(args),
+        )
+    if args.multi_pass_reasoning:
+        from extracted_reasoning_core.types import ReasoningPorts  # noqa: PLC0415
+
+        llm = overrides.get("llm") or create_pipeline_llm_client()
+        overrides["llm"] = llm
+        overrides["reasoning_context"] = MultiPassCampaignReasoningProvider(
+            ports=ReasoningPorts(llm=llm),
+            config=_multi_pass_config_from_args(args),
         )
     if args.llm == "pipeline":
         return overrides

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -19,6 +19,9 @@ from extracted_content_pipeline.campaign_reasoning_data import (
 from extracted_content_pipeline.services.single_pass_reasoning_provider import (
     SinglePassCampaignReasoningProvider,
 )
+from extracted_content_pipeline.services.multi_pass_reasoning_provider import (
+    MultiPassCampaignReasoningProvider,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -339,6 +342,42 @@ def test_campaign_generation_example_cli_wires_single_pass_reasoning(
     assert overrides["skills"] is skills
 
 
+def test_campaign_generation_example_cli_wires_multi_pass_reasoning(
+    monkeypatch,
+) -> None:
+    example_cli = _load_example_cli_module()
+    llm = _InjectedLLM()
+
+    monkeypatch.setattr(
+        "extracted_content_pipeline.campaign_llm_client.create_pipeline_llm_client",
+        lambda: llm,
+    )
+
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--llm",
+        "pipeline",
+        "--multi-pass-reasoning",
+        "--multi-pass-pack-name",
+        "campaign/content",
+        "--multi-pass-depth",
+        "L3",
+        "--multi-pass-max-continuations",
+        "2",
+        "--multi-pass-disable-chain",
+    ])
+    overrides = example_cli._dependency_overrides(args)
+
+    provider = overrides["reasoning_context"]
+    assert isinstance(provider, MultiPassCampaignReasoningProvider)
+    assert provider._ports.llm is llm
+    assert provider._config.pack_name == "campaign/content"
+    assert provider._config.default_depth == "L3"
+    assert provider._config.max_continuations == 2
+    assert provider._config.enable_multi_pass is False
+    assert overrides["llm"] is llm
+
+
 def test_campaign_generation_example_cli_rejects_conflicting_reasoning_modes(
     tmp_path,
 ) -> None:
@@ -366,6 +405,19 @@ def test_campaign_generation_example_cli_rejects_offline_single_pass_reasoning()
         "--llm",
         "offline",
         "--single-pass-reasoning",
+    ])
+
+    with pytest.raises(SystemExit, match="requires --llm pipeline"):
+        example_cli._dependency_overrides(args)
+
+
+def test_campaign_generation_example_cli_rejects_offline_multi_pass_reasoning() -> None:
+    example_cli = _load_example_cli_module()
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--llm",
+        "offline",
+        "--multi-pass-reasoning",
     ])
 
     with pytest.raises(SystemExit, match="requires --llm pipeline"):

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -424,6 +424,33 @@ def test_campaign_generation_example_cli_rejects_offline_multi_pass_reasoning() 
         example_cli._dependency_overrides(args)
 
 
+def test_campaign_generation_example_cli_rejects_invalid_multi_pass_depth() -> None:
+    example_cli = _load_example_cli_module()
+
+    with pytest.raises(SystemExit):
+        example_cli._parse_args([
+            str(EXAMPLE_PAYLOAD),
+            "--multi-pass-reasoning",
+            "--multi-pass-depth",
+            "L6",
+        ])
+
+
+def test_campaign_generation_example_cli_rejects_negative_multi_pass_continuations() -> None:
+    example_cli = _load_example_cli_module()
+    args = example_cli._parse_args([
+        str(EXAMPLE_PAYLOAD),
+        "--llm",
+        "pipeline",
+        "--multi-pass-reasoning",
+        "--multi-pass-max-continuations",
+        "-1",
+    ])
+
+    with pytest.raises(SystemExit, match="must be >= 0"):
+        example_cli._dependency_overrides(args)
+
+
 @pytest.mark.asyncio
 async def test_example_accepts_provider_port_loader(tmp_path) -> None:
     reasoning_path = tmp_path / "reasoning_port.json"

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -15,6 +15,9 @@ from extracted_content_pipeline.campaign_visibility import read_jsonl_visibility
 from extracted_content_pipeline.services.single_pass_reasoning_provider import (
     SinglePassCampaignReasoningProvider,
 )
+from extracted_content_pipeline.services.multi_pass_reasoning_provider import (
+    MultiPassCampaignReasoningProvider,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -382,6 +385,36 @@ def test_postgres_runner_cli_wires_single_pass_reasoning(monkeypatch, tmp_path) 
     assert overrides["skills"] is skills
 
 
+def test_postgres_runner_cli_wires_multi_pass_reasoning(monkeypatch) -> None:
+    postgres_cli = _load_postgres_cli_module()
+    llm = _LLM()
+
+    monkeypatch.setattr(postgres_cli, "create_pipeline_llm_client", lambda: llm)
+
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--multi-pass-reasoning",
+        "--multi-pass-pack-name",
+        "campaign/content",
+        "--multi-pass-depth",
+        "L3",
+        "--multi-pass-max-continuations",
+        "2",
+        "--multi-pass-disable-chain",
+    ])
+    overrides = postgres_cli._dependency_overrides(args)
+
+    provider = overrides["reasoning_context"]
+    assert isinstance(provider, MultiPassCampaignReasoningProvider)
+    assert provider._ports.llm is llm
+    assert provider._config.pack_name == "campaign/content"
+    assert provider._config.default_depth == "L3"
+    assert provider._config.max_continuations == 2
+    assert provider._config.enable_multi_pass is False
+    assert overrides["llm"] is llm
+
+
 def test_postgres_runner_cli_rejects_conflicting_reasoning_modes(tmp_path) -> None:
     postgres_cli = _load_postgres_cli_module()
     reasoning_path = tmp_path / "reasoning.json"
@@ -407,6 +440,20 @@ def test_postgres_runner_cli_rejects_offline_single_pass_reasoning() -> None:
         "--llm",
         "offline",
         "--single-pass-reasoning",
+    ])
+
+    with pytest.raises(SystemExit, match="requires --llm pipeline"):
+        postgres_cli._dependency_overrides(args)
+
+
+def test_postgres_runner_cli_rejects_offline_multi_pass_reasoning() -> None:
+    postgres_cli = _load_postgres_cli_module()
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--llm",
+        "offline",
+        "--multi-pass-reasoning",
     ])
 
     with pytest.raises(SystemExit, match="requires --llm pipeline"):

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -458,3 +458,30 @@ def test_postgres_runner_cli_rejects_offline_multi_pass_reasoning() -> None:
 
     with pytest.raises(SystemExit, match="requires --llm pipeline"):
         postgres_cli._dependency_overrides(args)
+
+
+def test_postgres_runner_cli_rejects_invalid_multi_pass_depth() -> None:
+    postgres_cli = _load_postgres_cli_module()
+
+    with pytest.raises(SystemExit):
+        postgres_cli._parse_args([
+            "--database-url",
+            "postgres://example",
+            "--multi-pass-reasoning",
+            "--multi-pass-depth",
+            "L6",
+        ])
+
+
+def test_postgres_runner_cli_rejects_negative_multi_pass_continuations() -> None:
+    postgres_cli = _load_postgres_cli_module()
+    args = postgres_cli._parse_args([
+        "--database-url",
+        "postgres://example",
+        "--multi-pass-reasoning",
+        "--multi-pass-max-continuations",
+        "-1",
+    ])
+
+    with pytest.raises(SystemExit, match="must be >= 0"):
+        postgres_cli._dependency_overrides(args)


### PR DESCRIPTION
## Summary
- add --multi-pass-reasoning to the offline and Postgres AI Content Ops generation runners
- wire the flag to MultiPassCampaignReasoningProvider over extracted_reasoning_core ReasoningPorts
- document the single-pass vs multi-pass provider modes and refresh the reasoning-state audit
- claim PR-D23 in coordination while removing the merged PR-D22 row

## Verification
- python -m py_compile scripts/run_extracted_campaign_generation_example.py scripts/run_extracted_campaign_generation_postgres.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py
- pytest tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_multi_pass_reasoning_provider.py tests/test_extracted_campaign_api_operations.py
- bash scripts/run_extracted_pipeline_checks.sh (1034 passed, 1 warning)
