### PR TITLE
Add content source-to-opportunity adapter

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T19:35Z by codex-2026-05-06-d23
+Last updated: 2026-05-06T19:50Z by codex-2026-05-06-d24
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | PR-D23: AI Content Ops multi-pass reasoning CLI seam | `scripts/run_extracted_campaign_generation_example.py`, `scripts/run_extracted_campaign_generation_postgres.py`, extracted content reasoning docs/tests | codex-2026-05-06-d23 | Avoid editing competitive-intelligence Phase 3 visibility files. |
+| (in flight) | PR-D24: AI Content Ops source-to-opportunity adapter | `extracted_content_pipeline/campaign_source_adapters.py`, source-adapter docs/tests/scripts | codex-2026-05-06-d24 | Avoid editing competitive-intelligence Phase 3 visibility files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -114,6 +114,11 @@ draft metadata fields while preserving custom columns.
 `FileIntelligenceRepository` so hosts can run the generator directly from
 customer exports before wiring a database integration.
 
+`campaign_source_adapters.py` adds a source-to-opportunity adapter for richer
+review, transcript, complaint, or document rows. It preserves source text as
+campaign evidence and outputs the same payload shape as the customer-data
+adapter.
+
 ## Campaign generation example
 
 Run the standalone campaign generator against the included customer-data
@@ -136,6 +141,17 @@ draft metadata:
 
 ```bash
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.csv --format csv
+```
+
+Review, transcript, complaint, and document source rows can be converted into
+the same opportunity payload first:
+
+```bash
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  customer_sources.jsonl \
+  --output customer_opportunities.json
+
+python scripts/run_extracted_campaign_generation_example.py customer_opportunities.json
 ```
 
 Generate cold-email and follow-up drafts for each opportunity by passing

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -32,6 +32,9 @@
 - `campaign_postgres_import` loads normalized JSON/CSV opportunity rows into
   `campaign_opportunities`, with dry-run validation and optional
   replace-existing semantics for repeatable customer imports.
+- `campaign_source_adapters` converts review, transcript, complaint, or
+  document source rows into normalized campaign opportunities so hosts can feed
+  richer text sources into the same generation/import path.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -22,6 +22,7 @@ _SOURCE_ID_KEYS = ("source_id", "id", "review_id", "transcript_id", "document_id
 _TEXT_KEYS = ("text", "review_text", "transcript", "content", "body", "quote", "complaint")
 _SOURCE_TYPE_KEYS = ("source_type", "type", "kind")
 _SOURCE_TITLE_KEYS = ("source_title", "title", "name")
+_SOURCE_TITLE_COLLISION_KEYS = ("title", "name")
 _PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
 
 
@@ -104,13 +105,17 @@ def source_row_to_campaign_opportunity(
                 "content, body, quote, or complaint."
             ),
         ))
+        return {}, tuple(warnings)
     source_id = _first_text(row, _SOURCE_ID_KEYS)
     source_type = _first_text(row, _SOURCE_TYPE_KEYS) or _infer_source_type(row)
+    source_title = _first_text(row, _SOURCE_TITLE_KEYS)
     opportunity = {
         str(key): value
         for key, value in row.items()
-        if value not in (None, "", [], {})
+        if value not in (None, "", [], {}) and key not in _SOURCE_TITLE_COLLISION_KEYS
     }
+    if source_title:
+        opportunity["source_title"] = source_title
     if source_id and "source_id" not in opportunity:
         opportunity["source_id"] = source_id
     if source_type:
@@ -176,9 +181,9 @@ def _source_evidence(
         evidence["source_id"] = source_id
     if source_type:
         evidence["source_type"] = source_type
-    title = _first_text(row, _SOURCE_TITLE_KEYS)
-    if title:
-        evidence["source_title"] = title
+    source_title = _first_text(row, _SOURCE_TITLE_KEYS)
+    if source_title:
+        evidence["source_title"] = source_title
     return evidence
 
 

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -1,0 +1,234 @@
+"""Convert richer host source rows into campaign opportunities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from .campaign_customer_data import (
+    CampaignOpportunityLoadResult,
+    CampaignOpportunityWarning,
+    normalize_campaign_opportunity_rows,
+)
+from .campaign_opportunities import normalize_campaign_opportunity
+
+
+SourceDataFormat = Literal["auto", "json", "jsonl"]
+
+_ROW_LIST_KEYS = ("sources", "documents", "reviews", "transcripts", "complaints", "rows", "data")
+_SOURCE_ID_KEYS = ("source_id", "id", "review_id", "transcript_id", "document_id")
+_TEXT_KEYS = ("text", "review_text", "transcript", "content", "body", "quote", "complaint")
+_SOURCE_TYPE_KEYS = ("source_type", "type", "kind")
+_SOURCE_TITLE_KEYS = ("source_title", "title", "name")
+_PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
+
+
+def load_source_campaign_opportunities_from_file(
+    path: str | Path,
+    *,
+    file_format: SourceDataFormat = "auto",
+    target_mode: str | None = None,
+    max_text_chars: int = 1200,
+) -> CampaignOpportunityLoadResult:
+    """Load review/transcript/document rows as campaign opportunities."""
+
+    source = Path(path)
+    rows = _load_source_rows(source, file_format=file_format)
+    result = source_rows_to_campaign_opportunities(
+        rows,
+        target_mode=target_mode,
+        max_text_chars=max_text_chars,
+    )
+    return CampaignOpportunityLoadResult(
+        opportunities=result.opportunities,
+        warnings=result.warnings,
+        source=str(source),
+    )
+
+
+def source_rows_to_campaign_opportunities(
+    rows: Sequence[Any],
+    *,
+    target_mode: str | None = None,
+    max_text_chars: int = 1200,
+) -> CampaignOpportunityLoadResult:
+    """Normalize richer source rows into the existing opportunity contract."""
+
+    opportunities: list[dict[str, Any]] = []
+    warnings: list[CampaignOpportunityWarning] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            warnings.append(CampaignOpportunityWarning(
+                code="row_not_object",
+                row_index=index,
+                message="Skipped source row because it is not an object.",
+            ))
+            continue
+        opportunity, row_warnings = source_row_to_campaign_opportunity(
+            row,
+            row_index=index,
+            max_text_chars=max_text_chars,
+        )
+        warnings.extend(row_warnings)
+        if opportunity:
+            opportunities.append(opportunity)
+    normalized = normalize_campaign_opportunity_rows(
+        opportunities,
+        target_mode=target_mode,
+    )
+    return CampaignOpportunityLoadResult(
+        opportunities=normalized.opportunities,
+        warnings=tuple(warnings) + normalized.warnings,
+    )
+
+
+def source_row_to_campaign_opportunity(
+    row: Mapping[str, Any],
+    *,
+    row_index: int | None = None,
+    max_text_chars: int = 1200,
+) -> tuple[dict[str, Any], tuple[CampaignOpportunityWarning, ...]]:
+    """Convert one source row while preserving original non-empty fields."""
+
+    warnings: list[CampaignOpportunityWarning] = []
+    text = _first_text(row, _TEXT_KEYS)
+    if not text:
+        warnings.append(CampaignOpportunityWarning(
+            code="missing_source_text",
+            row_index=row_index,
+            field="text",
+            message=(
+                "Source row did not contain text, review_text, transcript, "
+                "content, body, quote, or complaint."
+            ),
+        ))
+    source_id = _first_text(row, _SOURCE_ID_KEYS)
+    source_type = _first_text(row, _SOURCE_TYPE_KEYS) or _infer_source_type(row)
+    opportunity = {
+        str(key): value
+        for key, value in row.items()
+        if value not in (None, "", [], {})
+    }
+    if source_id and "source_id" not in opportunity:
+        opportunity["source_id"] = source_id
+    if source_type:
+        opportunity["source_type"] = source_type
+    pain_points = _first_text_list(row, _PAIN_KEYS)
+    if pain_points:
+        opportunity["pain_points"] = pain_points
+    evidence = _source_evidence(
+        row,
+        text=text,
+        source_id=source_id,
+        source_type=source_type,
+        max_text_chars=max_text_chars,
+    )
+    if evidence:
+        opportunity["evidence"] = [evidence]
+    return normalize_campaign_opportunity(opportunity), tuple(warnings)
+
+
+def _load_source_rows(path: Path, *, file_format: SourceDataFormat) -> list[Any]:
+    resolved_format = _resolve_format(path, file_format)
+    if resolved_format == "jsonl":
+        rows: list[Any] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            text = line.strip()
+            if text:
+                rows.append(json.loads(text))
+        return rows
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return list(data)
+    if not isinstance(data, Mapping):
+        raise ValueError("Source JSON must be an object or array")
+    for key in _ROW_LIST_KEYS:
+        value = data.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return list(value)
+    return [dict(data)]
+
+
+def _resolve_format(path: Path, file_format: SourceDataFormat) -> Literal["json", "jsonl"]:
+    if file_format != "auto":
+        return file_format
+    if path.suffix.lower() == ".jsonl":
+        return "jsonl"
+    return "json"
+
+
+def _source_evidence(
+    row: Mapping[str, Any],
+    *,
+    text: str,
+    source_id: str,
+    source_type: str,
+    max_text_chars: int,
+) -> dict[str, Any]:
+    if not text:
+        return {}
+    evidence: dict[str, Any] = {
+        "text": text[:max_text_chars],
+    }
+    if source_id:
+        evidence["source_id"] = source_id
+    if source_type:
+        evidence["source_type"] = source_type
+    title = _first_text(row, _SOURCE_TITLE_KEYS)
+    if title:
+        evidence["source_title"] = title
+    return evidence
+
+
+def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        text = str(row.get(key) or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _first_text_list(row: Mapping[str, Any], keys: Sequence[str]) -> list[str]:
+    for key in keys:
+        value = row.get(key)
+        values = _text_list(value)
+        if values:
+            return values
+    return []
+
+
+def _text_list(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, str):
+        items = value.split(",")
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        items = value
+    else:
+        items = (value,)
+    out: list[str] = []
+    for item in items:
+        text = str(item or "").strip()
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _infer_source_type(row: Mapping[str, Any]) -> str:
+    if row.get("review_text") is not None:
+        return "review"
+    if row.get("transcript") is not None:
+        return "transcript"
+    if row.get("complaint") is not None:
+        return "complaint"
+    return "document"
+
+
+__all__ = [
+    "SourceDataFormat",
+    "load_source_campaign_opportunities_from_file",
+    "source_row_to_campaign_opportunity",
+    "source_rows_to_campaign_opportunities",
+]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -132,6 +132,19 @@ Minimum useful columns:
 Unknown columns are preserved in draft metadata and prompt context through the
 normalized opportunity payload.
 
+If a host starts from reviews, transcripts, complaints, or document rows instead
+of ready-made opportunities, convert them first:
+
+```bash
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  customer_sources.jsonl \
+  --output customer_opportunities.json
+```
+
+The source adapter copies `review_text`, `transcript`, `complaint`, `content`,
+`body`, `quote`, or `text` into the opportunity `evidence` field, preserving
+source ids and inferred source types for prompt context and later review.
+
 ## Step 4: Load Opportunities Into Postgres
 
 Preview the import:

--- a/extracted_content_pipeline/docs/long_form_creative_backlog.md
+++ b/extracted_content_pipeline/docs/long_form_creative_backlog.md
@@ -64,11 +64,11 @@ generator reads from Postgres tables specific to its domain:
 | Complaint content | `product_pain_points` (pain_score >= 4.0) | `autonomous/tasks/complaint_content_generation.py:135` |
 | B2B campaign emails | `b2b_reviews`, `b2b_campaigns`, churn views | `autonomous/tasks/b2b_campaign_generation.py:3816-3891` |
 | Vendor briefings | `vendor_targets`, `b2b_intelligence`, evidence vault | `autonomous/tasks/b2b_vendor_briefing.py:3102-3146` |
-| **Campaign generation (standalone)** | **JSON/CSV files** | **`campaign_customer_data.py:77-96`** |
+| **Campaign generation (standalone)** | **JSON/CSV opportunities + source rows** | **`campaign_customer_data.py:77-96`, `campaign_source_adapters.py`** |
 
-`campaign_customer_data.py` is the only file/object-driven loader in the
-package and is the right model to copy when retargeting the pipeline for
-narrative input.
+`campaign_customer_data.py` and `campaign_source_adapters.py` are the
+file/object-driven loaders in the package and are the right model to copy when
+retargeting the pipeline for narrative input.
 
 `EXTRACTED_PIPELINE_STANDALONE=1` skips LLM calls and batch execution but does
 not mock DB reads — the existing tasks still expect a live Postgres. Any

--- a/extracted_content_pipeline/docs/reasoning_state_audit.md
+++ b/extracted_content_pipeline/docs/reasoning_state_audit.md
@@ -184,8 +184,9 @@ Tier 1 and Tier 2 are implemented for B2B campaign opportunities. Remaining
 choices are about source coverage and product promise, not basic wiring:
 
 1. **Additional source formats.** CRM rows are covered through
-   `campaign_opportunities`; review/complaint data, episode transcripts, and
-   sales call transcripts need their own schema-aware adapters.
+   `campaign_opportunities`; review, complaint, transcript, and document rows
+   are covered by the source-to-opportunity adapter. Episode transcripts and
+   richer domain-specific source bundles still need their own adapters.
 2. **Product promise.** If single-pass meets the sold promise, AI Content Ops is
    operational. If the promise is "multi-pass refinement over your data," the
    multi-pass provider is the floor.
@@ -205,8 +206,8 @@ choices are about source coverage and product promise, not basic wiring:
 | `extracted_reasoning_core` produces reasoning from a source | Yes, through the multi-pass provider |
 
 The remaining structural gap is source breadth, not reasoning-provider wiring.
-CRM/opportunity rows are operational; richer source types need their own
-schema-aware adapters.
+CRM/opportunity rows and common text source rows are operational; richer
+domain-specific bundles need their own schema-aware adapters.
 
 ## References
 

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -154,6 +154,12 @@ adapter slice. It loads JSON or CSV opportunity rows, normalizes them through
 the product opportunity contract, returns non-fatal data-quality warnings, and
 exposes `FileIntelligenceRepository` for running generation from customer files.
 
+`extracted_content_pipeline/campaign_source_adapters.py` is the source breadth
+slice for hosts that start from reviews, transcripts, complaints, or documents
+instead of ready-made opportunity rows. It converts source text into
+opportunity evidence and returns the same payload shape consumed by the file,
+import, and generation paths.
+
 `extracted_content_pipeline/campaign_postgres.py` owns the Postgres adapter path
 for customer opportunity reads through `PostgresIntelligenceRepository`. It
 reads the product-owned `campaign_opportunities` table and normalizes rows

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -236,6 +236,9 @@
       "target": "extracted_content_pipeline/campaign_customer_data.py"
     },
     {
+      "target": "extracted_content_pipeline/campaign_source_adapters.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_opportunities.py"
     },
     {

--- a/scripts/build_extracted_campaign_opportunities_from_sources.py
+++ b/scripts/build_extracted_campaign_opportunities_from_sources.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Build campaign opportunities from richer source JSON/JSONL rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert review, transcript, complaint, or document source rows "
+            "into AI Content Ops campaign opportunities."
+        )
+    )
+    parser.add_argument("path", type=Path, help="Source JSON or JSONL file.")
+    parser.add_argument(
+        "--format",
+        choices=("auto", "json", "jsonl"),
+        default="auto",
+        help="Source file format. Defaults to suffix-based detection.",
+    )
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--channel", default="email")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument(
+        "--max-text-chars",
+        type=int,
+        default=1200,
+        help="Maximum source text characters copied into each evidence row.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write opportunity payload JSON to this path instead of stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.max_text_chars < 1:
+        raise SystemExit("--max-text-chars must be positive")
+    loaded = load_source_campaign_opportunities_from_file(
+        args.path,
+        file_format=args.format,
+        target_mode=args.target_mode,
+        max_text_chars=args.max_text_chars,
+    )
+    payload = loaded.as_payload(
+        target_mode=args.target_mode,
+        channel=args.channel,
+        limit=args.limit,
+    )
+    output = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(f"{output}\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -23,6 +23,7 @@ pytest \
   tests/test_extracted_campaign_skill_registry.py \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
+  tests/test_extracted_campaign_source_adapters.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_campaign_llm_bridge.py
+++ b/tests/test_extracted_campaign_llm_bridge.py
@@ -23,6 +23,7 @@ LOCAL_UTILITY_SHIM_PATHS = [
     "extracted_content_pipeline/campaign_generation.py",
     "extracted_content_pipeline/campaign_postgres_generation.py",
     "extracted_content_pipeline/campaign_customer_data.py",
+    "extracted_content_pipeline/campaign_source_adapters.py",
     "extracted_content_pipeline/campaign_ports.py",
     "extracted_content_pipeline/config.py",
     "extracted_content_pipeline/autonomous/tasks/_blog_matching.py",

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -132,6 +132,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_postgres_send.py" in owned
     assert "extracted_content_pipeline/campaign_example.py" in owned
     assert "extracted_content_pipeline/campaign_customer_data.py" in owned
+    assert "extracted_content_pipeline/campaign_source_adapters.py" in owned
     assert "extracted_content_pipeline/campaign_opportunities.py" in owned
     assert "extracted_content_pipeline/settings.py" in owned
     assert "extracted_content_pipeline/api/__init__.py" in owned
@@ -183,6 +184,7 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/campaign_postgres_send.py" not in mapped
     assert "extracted_content_pipeline/campaign_example.py" not in mapped
     assert "extracted_content_pipeline/campaign_customer_data.py" not in mapped
+    assert "extracted_content_pipeline/campaign_source_adapters.py" not in mapped
     assert "extracted_content_pipeline/campaign_opportunities.py" not in mapped
     assert "extracted_content_pipeline/api/__init__.py" not in mapped
     assert "extracted_content_pipeline/api/campaign_webhooks.py" not in mapped

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from extracted_content_pipeline.campaign_source_adapters import (
+    load_source_campaign_opportunities_from_file,
+    source_row_to_campaign_opportunity,
+    source_rows_to_campaign_opportunities,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/build_extracted_campaign_opportunities_from_sources.py"
+
+
+def test_source_row_maps_review_text_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "review_id": "review-1",
+        "reviewer_company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "review_text": "Pricing became hard to justify after renewal.",
+        "pain_category": "pricing pressure",
+        "contact_email": "buyer@example.com",
+    })
+
+    assert warnings == ()
+    assert opportunity["source_id"] == "review-1"
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["vendor"] == "HubSpot"
+    assert opportunity["pain_points"] == ["pricing pressure"]
+    assert opportunity["evidence"] == [{
+        "text": "Pricing became hard to justify after renewal.",
+        "source_id": "review-1",
+        "source_type": "review",
+    }]
+
+
+def test_source_rows_normalize_and_warn_for_missing_text() -> None:
+    loaded = source_rows_to_campaign_opportunities(
+        [
+            {
+                "id": "call-1",
+                "company": "Acme",
+                "vendor": "HubSpot",
+                "transcript": "We are reviewing Salesforce before renewal.",
+                "pain_points": ["renewal pressure"],
+            },
+            {"id": "empty-1", "company": "Beta", "vendor": "Zendesk"},
+        ],
+        target_mode="vendor_retention",
+    )
+
+    assert len(loaded.opportunities) == 2
+    first = loaded.opportunities[0]
+    assert first["target_id"] == "call-1"
+    assert first["target_mode"] == "vendor_retention"
+    assert first["evidence"][0]["source_type"] == "transcript"
+    assert "missing_source_text" in [warning.code for warning in loaded.warnings]
+
+
+def test_load_source_campaign_opportunities_from_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({
+                "id": "review-1",
+                "company": "Acme",
+                "vendor": "HubSpot",
+                "review_text": "Pricing is a problem.",
+            }),
+            json.dumps({
+                "id": "complaint-1",
+                "company": "Beta",
+                "vendor": "Zendesk",
+                "complaint": "Support tickets are taking too long.",
+            }),
+        ]),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert loaded.source == str(path)
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "review-1",
+        "complaint-1",
+    ]
+    assert loaded.opportunities[1]["evidence"][0]["source_type"] == "complaint"
+
+
+def test_source_adapter_cli_outputs_generation_payload(tmp_path: Path) -> None:
+    path = tmp_path / "sources.json"
+    path.write_text(
+        json.dumps({
+            "reviews": [
+                {
+                    "id": "review-1",
+                    "company": "Acme",
+                    "vendor": "HubSpot",
+                    "review_text": "Pricing is a problem.",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--target-mode",
+            "vendor_retention",
+            "--limit",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["target_mode"] == "vendor_retention"
+    assert payload["limit"] == 1
+    assert payload["opportunities"][0]["target_id"] == "review-1"
+    assert payload["opportunities"][0]["evidence"][0]["text"] == "Pricing is a problem."
+
+
+def test_source_adapter_cli_rejects_non_positive_text_limit(tmp_path: Path) -> None:
+    path = tmp_path / "sources.json"
+    path.write_text("[]", encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--max-text-chars",
+            "0",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "--max-text-chars must be positive" in completed.stderr

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -53,12 +53,32 @@ def test_source_rows_normalize_and_warn_for_missing_text() -> None:
         target_mode="vendor_retention",
     )
 
-    assert len(loaded.opportunities) == 2
+    assert len(loaded.opportunities) == 1
     first = loaded.opportunities[0]
     assert first["target_id"] == "call-1"
     assert first["target_mode"] == "vendor_retention"
     assert first["evidence"][0]["source_type"] == "transcript"
     assert "missing_source_text" in [warning.code for warning in loaded.warnings]
+
+
+def test_source_document_title_does_not_become_buyer_fields() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "id": "doc-1",
+        "name": "Q1 churn transcript",
+        "title": "Discovery call notes",
+        "vendor": "HubSpot",
+        "text": "The account is comparing HubSpot with Salesforce.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "doc-1"
+    assert opportunity["source_title"] == "Discovery call notes"
+    assert opportunity["evidence"][0]["source_title"] == "Discovery call notes"
+    assert "company_name" not in opportunity
+    assert "contact_name" not in opportunity
+    assert "contact_title" not in opportunity
+    assert "name" not in opportunity
+    assert "title" not in opportunity
 
 
 def test_load_source_campaign_opportunities_from_jsonl(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a product-owned source adapter that converts review/transcript/complaint/document JSON or JSONL rows into campaign opportunities
- add a host CLI that emits the existing opportunity payload shape for import or offline generation
- register the adapter in the manifest, extracted runner, docs, and coordination claim

## Verification
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py scripts/build_extracted_campaign_opportunities_from_sources.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py
- pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_manifest.py tests/test_extracted_campaign_llm_bridge.py tests/test_extracted_campaign_customer_data.py
- bash scripts/run_extracted_pipeline_checks.sh (1043 passed, 1 warning)
