### PR TITLE
Import source rows through content opportunity loader

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-06T19:50Z by codex-2026-05-06-d24
+Last updated: 2026-05-07T01:11Z by codex-2026-05-07-d25
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | PR-D24: AI Content Ops source-to-opportunity adapter | `extracted_content_pipeline/campaign_source_adapters.py`, source-adapter docs/tests/scripts | codex-2026-05-06-d24 | Avoid editing competitive-intelligence Phase 3 visibility files. |
+| (in flight) | PR-D25: AI Content Ops direct source-row import | `scripts/load_extracted_campaign_opportunities.py`, source-import docs/tests | codex-2026-05-07-d25 | Avoid editing competitive-intelligence Phase 3 visibility files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -154,6 +154,16 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.json
 ```
 
+They can also be loaded directly into the Postgres opportunity table:
+
+```bash
+python scripts/load_extracted_campaign_opportunities.py \
+  customer_sources.jsonl \
+  --source-rows \
+  --source-format jsonl \
+  --account-id acct_123
+```
+
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -34,7 +34,8 @@
   replace-existing semantics for repeatable customer imports.
 - `campaign_source_adapters` converts review, transcript, complaint, or
   document source rows into normalized campaign opportunities so hosts can feed
-  richer text sources into the same generation/import path.
+  richer text sources into the same generation/import path. The Postgres import
+  CLI can consume these source rows directly with `--source-rows`.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -133,7 +133,7 @@ Unknown columns are preserved in draft metadata and prompt context through the
 normalized opportunity payload.
 
 If a host starts from reviews, transcripts, complaints, or document rows instead
-of ready-made opportunities, convert them first:
+of ready-made opportunities, they can preview the normalized opportunity payload:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -163,6 +163,17 @@ Write rows:
 python scripts/load_extracted_campaign_opportunities.py \
   customer_opportunities.csv \
   --format csv \
+  --account-id acct_123
+```
+
+Source rows can be loaded directly without writing the intermediate
+opportunity JSON:
+
+```bash
+python scripts/load_extracted_campaign_opportunities.py \
+  customer_sources.jsonl \
+  --source-rows \
+  --source-format jsonl \
   --account-id acct_123
 ```
 

--- a/scripts/load_extracted_campaign_opportunities.py
+++ b/scripts/load_extracted_campaign_opportunities.py
@@ -22,6 +22,9 @@ from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
 from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
     import_campaign_opportunities,
 )
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -39,6 +42,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=("auto", "json", "csv"),
         default="auto",
         help="Customer data file format.",
+    )
+    parser.add_argument(
+        "--source-rows",
+        action="store_true",
+        help=(
+            "Treat the input as review/transcript/complaint/document source "
+            "rows and convert them into campaign opportunities before import."
+        ),
+    )
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "json", "jsonl"),
+        default="auto",
+        help="Source-row file format when --source-rows is selected.",
+    )
+    parser.add_argument(
+        "--max-source-text-chars",
+        type=int,
+        default=1200,
+        help="Maximum source text characters copied into each evidence row.",
     )
     parser.add_argument(
         "--target-mode",
@@ -85,11 +108,21 @@ async def _create_pool(database_url: str):
 
 async def _main() -> int:
     args = _parse_args()
-    loaded = load_campaign_opportunities_from_file(
-        args.path,
-        file_format=args.format,
-        target_mode=args.target_mode,
-    )
+    if args.source_rows:
+        if args.max_source_text_chars < 1:
+            raise SystemExit("--max-source-text-chars must be positive")
+        loaded = load_source_campaign_opportunities_from_file(
+            args.path,
+            file_format=args.source_format,
+            target_mode=args.target_mode,
+            max_text_chars=args.max_source_text_chars,
+        )
+    else:
+        loaded = load_campaign_opportunities_from_file(
+            args.path,
+            file_format=args.format,
+            target_mode=args.target_mode,
+        )
     pool = None
     if not args.dry_run:
         if not args.database_url:

--- a/tests/test_extracted_campaign_postgres_import.py
+++ b/tests/test_extracted_campaign_postgres_import.py
@@ -207,3 +207,127 @@ async def test_opportunity_import_cli_wires_pool_and_closes(monkeypatch, capsys,
     assert pool.closed is True
     assert output["inserted"] == 1
     assert output["replace_existing"] is True
+
+
+@pytest.mark.asyncio
+async def test_opportunity_import_cli_dry_run_accepts_source_rows(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    data_path = tmp_path / "sources.jsonl"
+    data_path.write_text(
+        json.dumps({
+            "id": "review-1",
+            "company": "Acme",
+            "vendor": "HubSpot",
+            "email": "buyer@example.com",
+            "review_text": "Pricing is a problem.",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "load",
+            str(data_path),
+            "--source-rows",
+            "--source-format",
+            "jsonl",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["dry_run"] is True
+    assert output["inserted"] == 1
+    assert output["target_ids"] == ["review-1"]
+    assert output["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_opportunity_import_cli_wires_source_rows_to_database(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    data_path = tmp_path / "sources.json"
+    data_path.write_text(
+        json.dumps({
+            "reviews": [
+                {
+                    "id": "review-1",
+                    "company": "Acme",
+                    "vendor": "HubSpot",
+                    "email": "buyer@example.com",
+                    "review_text": "Pricing is a problem.",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        assert database_url == "postgres://example"
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "load",
+            str(data_path),
+            "--database-url",
+            "postgres://example",
+            "--source-rows",
+            "--account-id",
+            "acct_1",
+            "--json",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["inserted"] == 1
+    assert pool.closed is True
+    query, args = pool.executed[0]
+    assert "INSERT INTO \"campaign_opportunities\"" in query
+    assert args[0] == "acct_1"
+    assert args[1] == "review-1"
+    assert json.loads(args[12])[0]["text"] == "Pricing is a problem."
+
+
+@pytest.mark.asyncio
+async def test_opportunity_import_cli_rejects_invalid_source_text_limit(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    data_path = tmp_path / "sources.json"
+    data_path.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "load",
+            str(data_path),
+            "--source-rows",
+            "--max-source-text-chars",
+            "0",
+            "--dry-run",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="--max-source-text-chars must be positive"):
+        await cli._main()


### PR DESCRIPTION
## Summary
- add --source-rows support to the content opportunity Postgres import CLI
- route review/transcript/complaint/document source files through the existing source adapter before import
- document direct source-row import in the README, status, and host install runbook

## Verification
- python -m py_compile scripts/load_extracted_campaign_opportunities.py tests/test_extracted_campaign_postgres_import.py
- LC_ALL=C rg -n "[^\x00-\x7F]" scripts/load_extracted_campaign_opportunities.py tests/test_extracted_campaign_postgres_import.py extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/STATUS.md
- pytest tests/test_extracted_campaign_postgres_import.py tests/test_extracted_campaign_source_adapters.py
- bash scripts/run_extracted_pipeline_checks.sh (1047 passed, 1 torch warning)
