### PR TITLE
Generate campaign drafts directly from source rows

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T01:11Z by codex-2026-05-07-d25
+Last updated: 2026-05-07T01:23Z by codex-2026-05-07-d26
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | PR-D25: AI Content Ops direct source-row import | `scripts/load_extracted_campaign_opportunities.py`, source-import docs/tests | codex-2026-05-07-d25 | Avoid editing competitive-intelligence Phase 3 visibility files. |
+| (in flight) | PR-D26: AI Content Ops direct source-row draft generation | `scripts/run_extracted_campaign_generation_example.py`, source-generation docs/tests | codex-2026-05-07-d26 | Avoid editing competitive-intelligence Phase 3 visibility files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -154,6 +154,16 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.json
 ```
 
+For quick offline previews, the generation CLI can consume those source rows
+directly:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  customer_sources.jsonl \
+  --source-rows \
+  --source-format jsonl
+```
+
 They can also be loaded directly into the Postgres opportunity table:
 
 ```bash

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -35,7 +35,8 @@
 - `campaign_source_adapters` converts review, transcript, complaint, or
   document source rows into normalized campaign opportunities so hosts can feed
   richer text sources into the same generation/import path. The Postgres import
-  CLI can consume these source rows directly with `--source-rows`.
+  CLI and offline generation CLI can consume these source rows directly with
+  `--source-rows`.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -145,6 +145,16 @@ The source adapter copies `review_text`, `transcript`, `complaint`, `content`,
 `body`, `quote`, or `text` into the opportunity `evidence` field, preserving
 source ids and inferred source types for prompt context and later review.
 
+For an offline draft preview without writing the intermediate opportunity file:
+
+```bash
+python scripts/run_extracted_campaign_generation_example.py \
+  customer_sources.jsonl \
+  --source-rows \
+  --source-format jsonl \
+  --limit 1
+```
+
 ## Step 4: Load Opportunities Into Postgres
 
 Preview the import:

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -21,6 +21,9 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
 from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
     load_campaign_opportunities_from_file,
 )
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+)
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
 )
@@ -41,7 +44,21 @@ DEFAULT_REASONING_CONFIG = SinglePassReasoningConfig()
 DEFAULT_MULTI_PASS_CONFIG = MultiPassReasoningProviderConfig()
 
 
-def _load_payload(path: Path, *, file_format: str = "auto") -> dict[str, Any]:
+def _load_payload(
+    path: Path,
+    *,
+    file_format: str = "auto",
+    source_rows: bool = False,
+    source_format: str = "auto",
+    max_source_text_chars: int = 1200,
+) -> dict[str, Any]:
+    if source_rows:
+        loaded = load_source_campaign_opportunities_from_file(
+            path,
+            file_format=source_format,
+            max_text_chars=max_source_text_chars,
+        )
+        return loaded.as_payload()
     if file_format == "csv" or (file_format == "auto" and path.suffix.lower() == ".csv"):
         loaded = load_campaign_opportunities_from_file(path, file_format="csv")
         return loaded.as_payload()
@@ -65,7 +82,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         nargs="?",
         type=Path,
         default=DEFAULT_PAYLOAD,
-        help="Path to a campaign generation payload JSON file.",
+        help="Path to a campaign payload, opportunity file, or source-row file.",
     )
     parser.add_argument(
         "--target-mode",
@@ -83,6 +100,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=("auto", "json", "csv"),
         default="auto",
         help="Customer data input format. Defaults to suffix-based auto detection.",
+    )
+    parser.add_argument(
+        "--source-rows",
+        action="store_true",
+        help=(
+            "Treat the input as review/transcript/complaint/document source "
+            "rows and convert them into campaign opportunities before generation."
+        ),
+    )
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "json", "jsonl"),
+        default="auto",
+        help="Source-row file format when --source-rows is selected.",
+    )
+    parser.add_argument(
+        "--max-source-text-chars",
+        type=int,
+        default=1200,
+        help="Maximum source text characters copied into each evidence row.",
     )
     parser.add_argument(
         "--limit",
@@ -267,7 +304,15 @@ def _dependency_overrides(args: argparse.Namespace) -> dict[str, Any]:
 async def _main() -> int:
     args = _parse_args()
     _validate_reasoning_args(args)
-    payload = _load_payload(args.payload, file_format=args.format)
+    if args.source_rows and args.max_source_text_chars < 1:
+        raise SystemExit("--max-source-text-chars must be positive")
+    payload = _load_payload(
+        args.payload,
+        file_format=args.format,
+        source_rows=bool(args.source_rows),
+        source_format=args.source_format,
+        max_source_text_chars=int(args.max_source_text_chars),
+    )
     if args.target_mode:
         payload["target_mode"] = args.target_mode
     if args.channels:

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -236,6 +236,75 @@ def test_campaign_generation_example_cli_outputs_draft_json() -> None:
     assert result["drafts"][0]["metadata"]["generation_model"] == "offline-deterministic"
 
 
+def test_campaign_generation_example_cli_generates_from_source_rows(tmp_path) -> None:
+    source_path = tmp_path / "customer_sources.jsonl"
+    source_path.write_text(
+        json.dumps({
+            "id": "review-1",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "email": "ops@example.com",
+            "review_text": "Pricing is a problem.",
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source_path),
+            "--source-rows",
+            "--source-format",
+            "jsonl",
+            "--channels",
+            "email_cold,email_followup",
+            "--limit",
+            "1",
+            "--llm",
+            "offline",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["result"]["generated"] == 2
+    assert [draft["channel"] for draft in result["drafts"]] == [
+        "email_cold",
+        "email_followup",
+    ]
+    source = result["drafts"][0]["metadata"]["source_opportunity"]
+    assert source["target_id"] == "review-1"
+    assert source["evidence"][0]["text"] == "Pricing is a problem."
+    assert source["contact_email"] == "ops@example.com"
+
+
+def test_campaign_generation_example_cli_rejects_invalid_source_text_limit(tmp_path) -> None:
+    source_path = tmp_path / "customer_sources.json"
+    source_path.write_text("[]", encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source_path),
+            "--source-rows",
+            "--max-source-text-chars",
+            "0",
+            "--llm",
+            "offline",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "--max-source-text-chars must be positive" in completed.stderr
+
+
 def test_campaign_generation_example_cli_accepts_reasoning_context_file(tmp_path) -> None:
     reasoning_path = tmp_path / "reasoning.json"
     reasoning_path.write_text(


### PR DESCRIPTION
## Summary
- add --source-rows support to the offline campaign generation CLI
- route review/transcript/complaint/document source rows through the existing source adapter before draft generation
- document direct source-row preview alongside the Postgres import path

## Verification
- python -m py_compile scripts/run_extracted_campaign_generation_example.py tests/test_extracted_campaign_generation_example.py
- LC_ALL=C rg -n "[^\x00-\x7F]" scripts/run_extracted_campaign_generation_example.py tests/test_extracted_campaign_generation_example.py extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/STATUS.md
- pytest tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_source_adapters.py
- bash scripts/run_extracted_pipeline_checks.sh (1049 passed, 1 torch warning)
