### PR TITLE
Smoke test content source-row generation

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T01:23Z by codex-2026-05-07-d26
+Last updated: 2026-05-07T01:32Z by codex-2026-05-07-d27
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | PR-D26: AI Content Ops direct source-row draft generation | `scripts/run_extracted_campaign_generation_example.py`, source-generation docs/tests | codex-2026-05-07-d26 | Avoid editing competitive-intelligence Phase 3 visibility files. |
+| (in flight) | PR-D27: AI Content Ops source-row host smoke | `scripts/smoke_extracted_content_pipeline_host.py`, host-smoke docs/tests | codex-2026-05-07-d27 | Avoid editing competitive-intelligence Phase 3 visibility files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -241,7 +241,15 @@ python scripts/smoke_extracted_content_pipeline_host.py
 
 The smoke command uses the packaged example payload, offline deterministic LLM,
 and cold-email plus follow-up channels by default. Pass a customer JSON or CSV
-file to validate a host export before wiring Postgres or send providers.
+file to validate a host export before wiring Postgres or send providers. Source
+row exports can use the same smoke command with `--source-rows`:
+
+```bash
+python scripts/smoke_extracted_content_pipeline_host.py \
+  customer_sources.jsonl \
+  --source-rows \
+  --source-format jsonl
+```
 
 To run the same example through the product LLM adapter, configure the
 `EXTRACTED_CAMPAIGN_LLM_*` environment variables and pass `--llm pipeline`:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -43,7 +43,7 @@
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or
-  send side effects.
+  send side effects. It accepts both opportunity files and source-row files.
 - `campaign_postgres_review` provides a product-owned draft review/status
   update path so hosts can approve, queue, cancel, or expire generated
   `b2b_campaigns` rows after export without handwritten SQL.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -112,6 +112,15 @@ the same offline path:
 python scripts/smoke_extracted_content_pipeline_host.py customer_opportunities.csv --format csv
 ```
 
+Source row exports can be smoked directly too:
+
+```bash
+python scripts/smoke_extracted_content_pipeline_host.py \
+  customer_sources.jsonl \
+  --source-rows \
+  --source-format jsonl
+```
+
 The command exits nonzero if the product cannot generate the minimum expected
 draft shape (`subject`, `body`, `target_id`, and `channel`).
 

--- a/scripts/smoke_extracted_content_pipeline_host.py
+++ b/scripts/smoke_extracted_content_pipeline_host.py
@@ -21,6 +21,9 @@ from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
 from extracted_content_pipeline.campaign_example import (  # noqa: E402
     generate_campaign_drafts_from_payload,
 )
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+)
 
 
 DEFAULT_PAYLOAD = (
@@ -28,7 +31,21 @@ DEFAULT_PAYLOAD = (
 )
 
 
-def _load_payload(path: Path, *, file_format: str) -> dict[str, Any]:
+def _load_payload(
+    path: Path,
+    *,
+    file_format: str,
+    source_rows: bool = False,
+    source_format: str = "auto",
+    max_source_text_chars: int = 1200,
+) -> dict[str, Any]:
+    if source_rows:
+        loaded = load_source_campaign_opportunities_from_file(
+            path,
+            file_format=source_format,
+            max_text_chars=max_source_text_chars,
+        )
+        return loaded.as_payload()
     if file_format == "csv" or (file_format == "auto" and path.suffix.lower() == ".csv"):
         loaded = load_campaign_opportunities_from_file(path, file_format="csv")
         return loaded.as_payload()
@@ -59,6 +76,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=("auto", "json", "csv"),
         default="auto",
         help="Input format. Defaults to suffix-based auto detection.",
+    )
+    parser.add_argument(
+        "--source-rows",
+        action="store_true",
+        help=(
+            "Treat the input as review/transcript/complaint/document source "
+            "rows and convert them into campaign opportunities before smoke."
+        ),
+    )
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "json", "jsonl"),
+        default="auto",
+        help="Source-row file format when --source-rows is selected.",
+    )
+    parser.add_argument(
+        "--max-source-text-chars",
+        type=int,
+        default=1200,
+        help="Maximum source text characters copied into each evidence row.",
     )
     parser.add_argument(
         "--channels",
@@ -102,7 +139,15 @@ def _draft_errors(result: dict[str, Any], *, min_drafts: int) -> list[str]:
 
 async def _main() -> int:
     args = _parse_args()
-    payload = _load_payload(args.payload, file_format=args.format)
+    if args.source_rows and args.max_source_text_chars < 1:
+        raise SystemExit("--max-source-text-chars must be positive")
+    payload = _load_payload(
+        args.payload,
+        file_format=args.format,
+        source_rows=bool(args.source_rows),
+        source_format=args.source_format,
+        max_source_text_chars=int(args.max_source_text_chars),
+    )
     payload["limit"] = int(args.limit)
     payload["channels"] = [
         item.strip()

--- a/tests/test_extracted_content_host_smoke.py
+++ b/tests/test_extracted_content_host_smoke.py
@@ -118,6 +118,61 @@ def test_host_smoke_cli_accepts_single_object_json_export(tmp_path) -> None:
     assert "generated=2" in completed.stdout
 
 
+def test_host_smoke_cli_accepts_source_rows(tmp_path) -> None:
+    source_path = tmp_path / "customer_sources.jsonl"
+    source_path.write_text(
+        json.dumps({
+            "id": "review-1",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "email": "ops@example.com",
+            "review_text": "Pricing is a problem.",
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source_path),
+            "--source-rows",
+            "--source-format",
+            "jsonl",
+            "--limit",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "AI Content Ops host smoke passed" in completed.stdout
+    assert "generated=2" in completed.stdout
+
+
+def test_host_smoke_cli_rejects_invalid_source_text_limit(tmp_path) -> None:
+    source_path = tmp_path / "customer_sources.json"
+    source_path.write_text("[]", encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source_path),
+            "--source-rows",
+            "--max-source-text-chars",
+            "0",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "--max-source-text-chars must be positive" in completed.stderr
+
+
 def test_host_smoke_cli_fails_when_min_drafts_not_met() -> None:
     completed = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- add --source-rows support to the host smoke CLI
- validate review/transcript/complaint/document source rows through the offline draft smoke path
- document source-row host smoke examples in the README and install runbook

## Verification
- python -m py_compile scripts/smoke_extracted_content_pipeline_host.py tests/test_extracted_content_host_smoke.py
- LC_ALL=C rg -n "[^\x00-\x7F]" scripts/smoke_extracted_content_pipeline_host.py tests/test_extracted_content_host_smoke.py extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/STATUS.md
- pytest tests/test_extracted_content_host_smoke.py tests/test_extracted_campaign_source_adapters.py
- bash scripts/run_extracted_pipeline_checks.sh (1051 passed, 1 torch warning)
