### PR TITLE
Add opt-in campaign quality revalidation

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T01:49Z by codex-2026-05-07-d28-cleanup
+Last updated: 2026-05-07T02:00Z by codex-2026-05-07-d29
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | PR-D29: AI Content Ops campaign quality revalidation | `extracted_content_pipeline/campaign_generation.py`, campaign quality tests/docs | codex-2026-05-07-d29 | Avoid editing competitive-intelligence Phase 3 visibility files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -219,6 +219,10 @@ python scripts/run_extracted_campaign_generation_example.py \
   --multi-pass-depth L3
 ```
 
+Add `--quality-revalidation` to the offline example when you want the
+standalone campaign specificity gate to reject drafts with placeholder tokens
+or missing configured proof-term support before they are returned.
+
 Use host-provided prompt contracts by pointing at a markdown skill directory:
 
 ```bash
@@ -312,6 +316,9 @@ python scripts/run_extracted_campaign_generation_postgres.py \
   --account-id acct_123 \
   --reasoning-context extracted_content_pipeline/examples/campaign_reasoning_context.json
 ```
+
+Add `--quality-revalidation` to the Postgres runner to run the same campaign
+specificity gate before generated drafts are persisted.
 
 Or generate lightweight reasoning context during the DB-backed run:
 
@@ -525,6 +532,7 @@ app.include_router(
         config=CampaignOperationsApiConfig(
             send_default_from_email="audit@customer.com",
             sequence_from_email="audit@customer.com",
+            generation_quality_revalidation=True,
         ),
         dependencies=[Depends(require_content_ops_admin)],
     )

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -110,7 +110,8 @@
 - `CampaignGenerationService` supports multi-channel draft expansion through
   product config (`channels=("email_cold", "email_followup")`), including
   passing the generated cold-email context into follow-up prompts without
-  importing the copied Atlas campaign task.
+  importing the copied Atlas campaign task. Hosts can opt into product-owned
+  campaign quality revalidation before generated drafts are accepted.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -91,6 +91,7 @@ class CampaignOperationsApiConfig:
     generation_max_tokens: int = 1200
     generation_temperature: float = 0.4
     generation_include_source_opportunity: bool = True
+    generation_quality_revalidation: bool = False
     generation_opportunity_table: str = "campaign_opportunities"
     generation_vendor_targets_table: str = "vendor_targets"
     generation_single_pass_reasoning: bool = False
@@ -382,6 +383,7 @@ def _generation_config(
         max_tokens=config.generation_max_tokens,
         temperature=float(config.generation_temperature),
         include_source_opportunity=config.generation_include_source_opportunity,
+        quality_revalidation_enabled=config.generation_quality_revalidation,
     )
 
 

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -282,6 +282,9 @@ async def generate_campaign_drafts_from_payload(
             channel=channel,
             channels=channels,
             limit=limit,
+            quality_revalidation_enabled=bool(
+                payload.get("quality_revalidation_enabled")
+            ),
         ),
     )
 

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -27,6 +27,7 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
+from .services.campaign_quality import campaign_quality_revalidation
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,7 @@ class CampaignGenerationConfig:
     temperature: float = 0.4
     include_source_opportunity: bool = True
     channels: tuple[str, ...] = ()
+    quality_revalidation_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -199,6 +201,20 @@ class CampaignGenerationService:
                         "reason": "unparseable_response",
                     })
                     continue
+                parsed = self._revalidated_parsed(
+                    parsed,
+                    opportunity=channel_opportunity,
+                    target_mode=target_mode,
+                    channel=channel,
+                )
+                if not parsed:
+                    skipped += 1
+                    errors.append({
+                        "target_id": target_id,
+                        "channel": channel,
+                        "reason": "quality_revalidation_failed",
+                    })
+                    continue
                 if channel == "email_cold":
                     cold_email_context = {
                         "subject": parsed["subject"],
@@ -343,6 +359,37 @@ class CampaignGenerationService:
             "_usage": dict(response.usage or {}),
         }
 
+    def _revalidated_parsed(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        opportunity: Mapping[str, Any],
+        target_mode: str,
+        channel: str,
+    ) -> dict[str, Any] | None:
+        if not self._config.quality_revalidation_enabled:
+            return dict(parsed)
+        context = normalize_campaign_reasoning_context(opportunity)
+        revalidation = campaign_quality_revalidation(
+            campaign={
+                **dict(opportunity),
+                "subject": parsed.get("subject") or "",
+                "body": parsed.get("body") or "",
+                "cta": parsed.get("cta") or "",
+                "channel": channel,
+                "target_mode": target_mode,
+            },
+            boundary="generation",
+            specificity_context=context.as_dict(),
+        )
+        audit = revalidation.get("audit")
+        if isinstance(audit, Mapping) and audit.get("blocking_issues"):
+            return None
+        return {
+            **dict(parsed),
+            "_quality_revalidation": revalidation,
+        }
+
     def _metadata(
         self,
         parsed: Mapping[str, Any],
@@ -353,6 +400,7 @@ class CampaignGenerationService:
             "angle_reasoning": parsed.get("angle_reasoning"),
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},
+            "campaign_revalidation": parsed.get("_quality_revalidation"),
         }
         context = normalize_campaign_reasoning_context(opportunity)
         metadata.update(campaign_reasoning_context_metadata(context))

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -247,6 +247,10 @@ The file-backed reasoning adapter matches rows by target id, company, email, or
 vendor. The generator still works without this file, but output quality is lower
 because prompts only see the opportunity row.
 
+Add `--quality-revalidation` to generation commands when the host wants the
+standalone campaign specificity gate to reject placeholder drafts or drafts
+that miss configured proof-term support before they are saved.
+
 If a host does not already have reasoning JSON, it can configure
 `SinglePassCampaignReasoningProvider` from
 `extracted_content_pipeline.services.single_pass_reasoning_provider`. The

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -127,6 +127,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Override the payload limit.",
     )
     parser.add_argument(
+        "--quality-revalidation",
+        action="store_true",
+        help="Run campaign quality revalidation before accepting generated drafts.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="Write generated draft JSON to this file instead of stdout.",
@@ -323,6 +328,8 @@ async def _main() -> int:
         ]
     if args.limit is not None:
         payload["limit"] = args.limit
+    if args.quality_revalidation:
+        payload["quality_revalidation_enabled"] = True
 
     result = await generate_campaign_drafts_from_payload(
         payload,

--- a/scripts/run_extracted_campaign_generation_postgres.py
+++ b/scripts/run_extracted_campaign_generation_postgres.py
@@ -20,6 +20,9 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
     DeterministicCampaignLLM,
     StaticCampaignSkillStore,
 )
+from extracted_content_pipeline.campaign_generation import (  # noqa: E402
+    CampaignGenerationConfig,
+)
 from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
     generate_campaign_drafts_from_postgres,
 )
@@ -89,6 +92,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--filters-json",
         help="Optional JSON object of opportunity filters.",
+    )
+    parser.add_argument(
+        "--quality-revalidation",
+        action="store_true",
+        help="Run campaign quality revalidation before accepting generated drafts.",
     )
     parser.add_argument(
         "--reasoning-context",
@@ -309,6 +317,12 @@ async def _main() -> int:
             channels=tuple(operation_payload["channels"]),
             limit=args.limit,
             filters=_json_object(args.filters_json),
+            config=CampaignGenerationConfig(
+                channel=args.channel,
+                channels=tuple(operation_payload["channels"]),
+                limit=args.limit,
+                quality_revalidation_enabled=bool(args.quality_revalidation),
+            ),
             **_dependency_overrides(args),
         )
     except Exception as exc:

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -160,6 +160,7 @@ def test_campaign_operations_router_generates_campaign_drafts(monkeypatch) -> No
             generation_skill_name="digest/custom_campaign_generation",
             generation_max_tokens=900,
             generation_temperature=0.3,
+            generation_quality_revalidation=True,
         ),
     ).post(
         "/campaigns/operations/drafts/generate",
@@ -205,6 +206,7 @@ def test_campaign_operations_router_generates_campaign_drafts(monkeypatch) -> No
     assert config.skill_name == "digest/custom_campaign_generation"
     assert config.max_tokens == 900
     assert config.temperature == 0.3
+    assert config.quality_revalidation_enabled is True
 
 
 def test_campaign_operations_router_emits_visibility_for_generation(monkeypatch) -> None:

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -576,6 +576,78 @@ async def test_generate_uses_custom_config_and_omits_source_opportunity():
 
 
 @pytest.mark.asyncio
+async def test_generate_quality_revalidation_is_opt_in() -> None:
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        ['{"subject":"Hi [Name]","body":"Body"}'],
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    assert campaigns.saved[0]["drafts"][0].subject == "Hi [Name]"
+    assert "campaign_revalidation" not in campaigns.saved[0]["drafts"][0].metadata
+
+
+@pytest.mark.asyncio
+async def test_generate_quality_revalidation_blocks_failed_drafts() -> None:
+    config = CampaignGenerationConfig(quality_revalidation_enabled=True)
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        ['{"subject":"Hi [Name]","body":"Body"}'],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == (
+        {
+            "target_id": "opp-1",
+            "channel": "email",
+            "reason": "quality_revalidation_failed",
+        },
+    )
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_quality_revalidation_preserves_pass_audit_metadata() -> None:
+    config = CampaignGenerationConfig(quality_revalidation_enabled=True)
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "anchor_examples": {
+            "pricing": [
+                {"excerpt_text": "Pricing drove evaluation."},
+            ]
+        },
+    }
+    service, _, campaigns, _, _ = _service(
+        [opportunity],
+        [
+            json.dumps({
+                "subject": "Pricing signal",
+                "body": "Pricing drove evaluation.",
+            })
+        ],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    metadata = campaigns.saved[0]["drafts"][0].metadata
+    audit = metadata["campaign_revalidation"]["audit"]
+    assert audit["status"] == "pass"
+    assert audit["used_proof_terms"] == ["Pricing drove evaluation."]
+    assert metadata["campaign_revalidation"]["metadata"]["campaign_proof_terms"] == [
+        "Pricing drove evaluation."
+    ]
+
+
+@pytest.mark.asyncio
 async def test_generate_skips_missing_target_and_unparseable_responses():
     service, _, campaigns, _, _ = _service(
         [

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -239,6 +239,28 @@ def test_campaign_generation_example_cli_outputs_draft_json() -> None:
     assert result["drafts"][0]["metadata"]["generation_model"] == "offline-deterministic"
 
 
+def test_campaign_generation_example_cli_can_enable_quality_revalidation() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(EXAMPLE_PAYLOAD),
+            "--limit",
+            "1",
+            "--llm",
+            "offline",
+            "--quality-revalidation",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+    metadata = result["drafts"][0]["metadata"]
+    assert metadata["campaign_revalidation"]["audit"]["status"] == "pass"
+
+
 def test_campaign_generation_example_cli_generates_from_source_rows() -> None:
     completed = subprocess.run(
         [

--- a/tests/test_extracted_campaign_postgres_generation.py
+++ b/tests/test_extracted_campaign_postgres_generation.py
@@ -275,6 +275,7 @@ async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
             "offline",
             "--reasoning-context",
             str(reasoning_path),
+            "--quality-revalidation",
             "--visibility-jsonl",
             str(visibility_path),
         ],
@@ -293,6 +294,7 @@ async def test_postgres_runner_cli_wires_pool_offline_and_reasoning_context(
         "confidence": "high",
         "wedge": "renewal pressure",
     }
+    assert metadata["campaign_revalidation"]["audit"]["status"] == "pass"
     assert pool.closed is True
     events = read_jsonl_visibility_events(visibility_path)
     assert [row["event_type"] for row in events] == [


### PR DESCRIPTION
## Summary
- add opt-in campaign quality revalidation to CampaignGenerationService before drafts are accepted
- expose the gate through the offline CLI, Postgres CLI, and hosted operations config
- preserve existing generation behavior when the gate is disabled

## Verification
- python -m py_compile extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/campaign_example.py extracted_content_pipeline/api/campaign_operations.py scripts/run_extracted_campaign_generation_example.py scripts/run_extracted_campaign_generation_postgres.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_api_operations.py
- LC_ALL=C rg -n "[^\x00-\x7F]" extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/campaign_example.py extracted_content_pipeline/api/campaign_operations.py scripts/run_extracted_campaign_generation_example.py scripts/run_extracted_campaign_generation_postgres.py tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_api_operations.py extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/STATUS.md
- pytest tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_api_operations.py tests/test_extracted_campaign_generation_seams.py
- bash scripts/run_extracted_pipeline_checks.sh (1056 passed, 1 torch warning)
