### PR TITLE
Seed campaign proof terms before quality revalidation

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T02:15Z by codex-2026-05-07-d29-cleanup
+Last updated: 2026-05-07T02:25Z by codex-2026-05-07-d30
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | PR-D30: AI Content Ops proof-term prompt payload | `extracted_content_pipeline/campaign_generation.py`, campaign generation tests/docs | codex-2026-05-07-d30 | Avoid editing competitive-intelligence Phase 3 visibility files or extracted_reasoning_core PR-C1 files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -221,7 +221,10 @@ python scripts/run_extracted_campaign_generation_example.py \
 
 Add `--quality-revalidation` to the offline example when you want the
 standalone campaign specificity gate to reject drafts with placeholder tokens
-or missing configured proof-term support before they are returned.
+or missing configured proof-term support before they are returned. When
+enabled, the generator also adds normalized `campaign_proof_terms` from
+reasoning anchors/witnesses/proof points to the prompt payload before the LLM
+call.
 
 Use host-provided prompt contracts by pointing at a markdown skill directory:
 
@@ -318,7 +321,9 @@ python scripts/run_extracted_campaign_generation_postgres.py \
 ```
 
 Add `--quality-revalidation` to the Postgres runner to run the same campaign
-specificity gate before generated drafts are persisted.
+specificity gate before generated drafts are persisted. The same flag adds
+normalized proof terms to the prompt payload so generated drafts have the
+evidence terms the gate will later require.
 
 Or generate lightweight reasoning context during the DB-backed run:
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -111,7 +111,9 @@
   product config (`channels=("email_cold", "email_followup")`), including
   passing the generated cold-email context into follow-up prompts without
   importing the copied Atlas campaign task. Hosts can opt into product-owned
-  campaign quality revalidation before generated drafts are accepted.
+  campaign quality revalidation before generated drafts are accepted; when
+  enabled, normalized proof terms are added to the prompt payload before
+  generation and reused by the post-generation gate.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -30,6 +30,48 @@ from .services.campaign_reasoning_context import (
 from .services.campaign_quality import campaign_quality_revalidation
 
 
+_PROOF_TERM_TEXT_KEYS = ("excerpt_text", "quote", "text", "anchor", "value")
+
+
+def _dedupe_terms(terms: Sequence[str], *, limit: int) -> list[str]:
+    if limit <= 0:
+        return []
+    clean: list[str] = []
+    for term in terms:
+        text = str(term or "").strip()
+        if text and text not in clean:
+            clean.append(text)
+        if len(clean) >= limit:
+            break
+    return clean
+
+
+def _clean_term_list(value: Any, *, limit: int) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return _dedupe_terms([str(item or "").strip() for item in value], limit=limit)
+
+
+def _terms_from_rows(value: Any, *, limit: int) -> list[str]:
+    if limit <= 0:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    terms: list[str] = []
+    for row in value:
+        if not isinstance(row, Mapping):
+            continue
+        for key in _PROOF_TERM_TEXT_KEYS:
+            text = str(row.get(key) or "").strip()
+            if text:
+                terms.append(text)
+                break
+        terms = _dedupe_terms(terms, limit=limit)
+        if len(terms) >= limit:
+            break
+    return terms
+
+
 @dataclass(frozen=True)
 class CampaignGenerationConfig:
     skill_name: str = "digest/b2b_campaign_generation"
@@ -40,6 +82,7 @@ class CampaignGenerationConfig:
     include_source_opportunity: bool = True
     channels: tuple[str, ...] = ()
     quality_revalidation_enabled: bool = False
+    quality_prompt_proof_term_limit: int = 5
 
 
 @dataclass(frozen=True)
@@ -273,7 +316,47 @@ class CampaignGenerationService:
                 "subject": str(cold_email_context.get("subject") or ""),
                 "body": str(cold_email_context.get("body") or ""),
             }
+        if self._config.quality_revalidation_enabled:
+            enriched = self._with_quality_prompt_terms(enriched)
         return enriched
+
+    def _with_quality_prompt_terms(
+        self,
+        opportunity: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        enriched = dict(opportunity)
+        context = normalize_campaign_reasoning_context(enriched)
+        terms = self._campaign_proof_terms(
+            context.as_dict(),
+            existing=enriched.get("campaign_proof_terms"),
+        )
+        if terms:
+            enriched["campaign_proof_terms"] = terms
+        return enriched
+
+    def _campaign_proof_terms(
+        self,
+        context: Mapping[str, Any],
+        *,
+        existing: Any = None,
+    ) -> list[str]:
+        limit = max(0, int(self._config.quality_prompt_proof_term_limit or 0))
+        terms = _clean_term_list(existing, limit=limit)
+        if len(terms) >= limit:
+            return terms
+        anchors = context.get("anchor_examples")
+        if isinstance(anchors, Mapping):
+            for rows in anchors.values():
+                terms.extend(_terms_from_rows(rows, limit=limit - len(terms)))
+                terms = _dedupe_terms(terms, limit=limit)
+                if len(terms) >= limit:
+                    return terms
+        for key in ("witness_highlights", "proof_points", "timing_windows"):
+            terms.extend(_terms_from_rows(context.get(key), limit=limit - len(terms)))
+            terms = _dedupe_terms(terms, limit=limit)
+            if len(terms) >= limit:
+                break
+        return terms
 
     async def _opportunity_with_reasoning_context(
         self,
@@ -370,6 +453,16 @@ class CampaignGenerationService:
         if not self._config.quality_revalidation_enabled:
             return dict(parsed)
         context = normalize_campaign_reasoning_context(opportunity)
+        specificity_context = context.as_dict()
+        proof_terms = _clean_term_list(
+            opportunity.get("campaign_proof_terms"),
+            limit=max(0, int(self._config.quality_prompt_proof_term_limit or 0)),
+        )
+        if proof_terms:
+            specificity_context = {
+                **specificity_context,
+                "campaign_proof_terms": proof_terms,
+            }
         revalidation = campaign_quality_revalidation(
             campaign={
                 **dict(opportunity),
@@ -380,7 +473,7 @@ class CampaignGenerationService:
                 "target_mode": target_mode,
             },
             boundary="generation",
-            specificity_context=context.as_dict(),
+            specificity_context=specificity_context,
         )
         audit = revalidation.get("audit")
         if isinstance(audit, Mapping) and audit.get("blocking_issues"):

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -330,6 +330,7 @@ class CampaignGenerationService:
             context.as_dict(),
             existing=enriched.get("campaign_proof_terms"),
         )
+        enriched.pop("campaign_proof_terms", None)
         if terms:
             enriched["campaign_proof_terms"] = terms
         return enriched

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -249,7 +249,9 @@ because prompts only see the opportunity row.
 
 Add `--quality-revalidation` to generation commands when the host wants the
 standalone campaign specificity gate to reject placeholder drafts or drafts
-that miss configured proof-term support before they are saved.
+that miss configured proof-term support before they are saved. The same flag
+adds normalized `campaign_proof_terms` from reasoning anchors/witnesses/proof
+points to the prompt payload before the LLM call.
 
 If a host does not already have reasoning JSON, it can configure
 `SinglePassCampaignReasoningProvider` from

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -648,6 +648,112 @@ async def test_generate_quality_revalidation_preserves_pass_audit_metadata() -> 
 
 
 @pytest.mark.asyncio
+async def test_generate_quality_revalidation_adds_prompt_proof_terms() -> None:
+    config = CampaignGenerationConfig(quality_revalidation_enabled=True)
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "anchor_examples": {
+            "pricing": [
+                {"excerpt_text": "Pricing drove evaluation."},
+            ]
+        },
+    }
+    service, _, campaigns, llm, _ = _service(
+        [opportunity],
+        [
+            json.dumps({
+                "subject": "Pricing signal",
+                "body": "Pricing drove evaluation.",
+            })
+        ],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert '"campaign_proof_terms":["Pricing drove evaluation."]' in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert source["campaign_proof_terms"] == ["Pricing drove evaluation."]
+
+
+@pytest.mark.asyncio
+async def test_generate_quality_revalidation_preserves_existing_prompt_terms() -> None:
+    config = CampaignGenerationConfig(
+        quality_revalidation_enabled=True,
+        quality_prompt_proof_term_limit=2,
+    )
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "campaign_proof_terms": ["Host supplied proof."],
+        "anchor_examples": {
+            "pricing": [
+                {"excerpt_text": "Pricing drove evaluation."},
+            ]
+        },
+    }
+    service, _, campaigns, llm, _ = _service(
+        [opportunity],
+        [
+            json.dumps({
+                "subject": "Proof signal",
+                "body": "Host supplied proof.",
+            })
+        ],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert (
+        '"campaign_proof_terms":["Host supplied proof.","Pricing drove evaluation."]'
+        in prompt
+    )
+    audit = campaigns.saved[0]["drafts"][0].metadata["campaign_revalidation"]["audit"]
+    assert audit["used_proof_terms"] == ["Host supplied proof."]
+
+
+@pytest.mark.asyncio
+async def test_generate_quality_revalidation_allows_zero_prompt_terms() -> None:
+    config = CampaignGenerationConfig(
+        quality_revalidation_enabled=True,
+        quality_prompt_proof_term_limit=0,
+    )
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "anchor_examples": {
+            "pricing": [
+                {"excerpt_text": "Pricing drove evaluation."},
+            ]
+        },
+    }
+    service, _, campaigns, llm, _ = _service(
+        [opportunity],
+        [
+            json.dumps({
+                "subject": "Pricing signal",
+                "body": "Pricing drove evaluation.",
+            })
+        ],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert "campaign_proof_terms" not in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert "campaign_proof_terms" not in source
+
+
+@pytest.mark.asyncio
 async def test_generate_skips_missing_target_and_unparseable_responses():
     service, _, campaigns, _, _ = _service(
         [

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -754,6 +754,42 @@ async def test_generate_quality_revalidation_allows_zero_prompt_terms() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_quality_revalidation_zero_limit_removes_existing_prompt_terms() -> None:
+    config = CampaignGenerationConfig(
+        quality_revalidation_enabled=True,
+        quality_prompt_proof_term_limit=0,
+    )
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "campaign_proof_terms": ["Host supplied proof."],
+        "anchor_examples": {
+            "pricing": [
+                {"excerpt_text": "Pricing drove evaluation."},
+            ]
+        },
+    }
+    service, _, campaigns, llm, _ = _service(
+        [opportunity],
+        [
+            json.dumps({
+                "subject": "Pricing signal",
+                "body": "Pricing drove evaluation.",
+            })
+        ],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert "campaign_proof_terms" not in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert "campaign_proof_terms" not in source
+
+
+@pytest.mark.asyncio
 async def test_generate_skips_missing_target_and_unparseable_responses():
     service, _, campaigns, _, _ = _service(
         [


### PR DESCRIPTION
## Summary
- derive campaign_proof_terms from normalized reasoning anchors, witnesses, proof points, and timing windows when quality revalidation is enabled
- include those proof terms in the LLM prompt payload before generation and reuse them in the post-generation campaign quality gate
- document the opt-in prompt proof-term behavior and claim D30 in coordination

## Verification
- python -m py_compile extracted_content_pipeline/campaign_generation.py tests/test_extracted_campaign_generation.py
- pytest tests/test_extracted_campaign_generation.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_campaign_postgres_generation.py tests/test_extracted_campaign_api_operations.py
- bash scripts/run_extracted_pipeline_checks.sh