### PR TITLE
Expose campaign revalidation failure details

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T02:30Z by codex-2026-05-07-d30-cleanup
+Last updated: 2026-05-07T02:35Z by codex-2026-05-07-d31
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | PR-D31: AI Content Ops revalidation failure details | `extracted_content_pipeline/campaign_generation.py`, campaign generation tests/docs | codex-2026-05-07-d31 | Avoid editing competitive-intelligence Phase 3 visibility files or extracted_reasoning_core PR-C1 files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -224,7 +224,9 @@ standalone campaign specificity gate to reject drafts with placeholder tokens
 or missing configured proof-term support before they are returned. When
 enabled, the generator also adds normalized `campaign_proof_terms` from
 reasoning anchors/witnesses/proof points to the prompt payload before the LLM
-call.
+call. Rejected drafts return `quality_revalidation` details in
+`CampaignGenerationResult.errors`, including blocking issues and unused proof
+terms.
 
 Use host-provided prompt contracts by pointing at a markdown skill directory:
 
@@ -323,7 +325,8 @@ python scripts/run_extracted_campaign_generation_postgres.py \
 Add `--quality-revalidation` to the Postgres runner to run the same campaign
 specificity gate before generated drafts are persisted. The same flag adds
 normalized proof terms to the prompt payload so generated drafts have the
-evidence terms the gate will later require.
+evidence terms the gate will later require. Failed drafts include compact
+revalidation details in the runner result errors.
 
 Or generate lightweight reasoning context during the DB-backed run:
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -113,7 +113,9 @@
   importing the copied Atlas campaign task. Hosts can opt into product-owned
   campaign quality revalidation before generated drafts are accepted; when
   enabled, normalized proof terms are added to the prompt payload before
-  generation and reused by the post-generation gate.
+  generation and reused by the post-generation gate. Rejected drafts include a
+  compact revalidation audit in `CampaignGenerationResult.errors` so hosted
+  runs can explain skipped output without inspecting logs.
 - Small utility shims now default to local extracted implementations:
   `config`, `pipelines.notify`, `reasoning.wedge_registry`,
   `reasoning.archetypes`, `reasoning.evidence_engine`, `reasoning.temporal`,

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -72,6 +72,25 @@ def _terms_from_rows(value: Any, *, limit: int) -> list[str]:
     return terms
 
 
+def _revalidation_error_details(revalidation: Mapping[str, Any]) -> dict[str, Any]:
+    audit = revalidation.get("audit")
+    if not isinstance(audit, Mapping):
+        return {}
+    details = {
+        "status": audit.get("status"),
+        "blocking_issues": list(audit.get("blocking_issues") or []),
+        "warnings": list(audit.get("warnings") or []),
+        "primary_blocker": audit.get("primary_blocker"),
+        "used_proof_terms": list(audit.get("used_proof_terms") or []),
+        "unused_proof_terms": list(audit.get("unused_proof_terms") or []),
+    }
+    return {
+        key: value
+        for key, value in details.items()
+        if value not in (None, "", [], {})
+    }
+
+
 @dataclass(frozen=True)
 class CampaignGenerationConfig:
     skill_name: str = "digest/b2b_campaign_generation"
@@ -244,7 +263,7 @@ class CampaignGenerationService:
                         "reason": "unparseable_response",
                     })
                     continue
-                parsed = self._revalidated_parsed(
+                parsed, revalidation_error = self._revalidated_parsed(
                     parsed,
                     opportunity=channel_opportunity,
                     target_mode=target_mode,
@@ -252,11 +271,14 @@ class CampaignGenerationService:
                 )
                 if not parsed:
                     skipped += 1
-                    errors.append({
+                    error = {
                         "target_id": target_id,
                         "channel": channel,
                         "reason": "quality_revalidation_failed",
-                    })
+                    }
+                    if revalidation_error:
+                        error["quality_revalidation"] = revalidation_error
+                    errors.append(error)
                     continue
                 if channel == "email_cold":
                     cold_email_context = {
@@ -450,9 +472,9 @@ class CampaignGenerationService:
         opportunity: Mapping[str, Any],
         target_mode: str,
         channel: str,
-    ) -> dict[str, Any] | None:
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         if not self._config.quality_revalidation_enabled:
-            return dict(parsed)
+            return dict(parsed), None
         context = normalize_campaign_reasoning_context(opportunity)
         specificity_context = context.as_dict()
         proof_terms = _clean_term_list(
@@ -478,11 +500,11 @@ class CampaignGenerationService:
         )
         audit = revalidation.get("audit")
         if isinstance(audit, Mapping) and audit.get("blocking_issues"):
-            return None
+            return None, _revalidation_error_details(revalidation)
         return {
             **dict(parsed),
             "_quality_revalidation": revalidation,
-        }
+        }, None
 
     def _metadata(
         self,

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -251,7 +251,8 @@ Add `--quality-revalidation` to generation commands when the host wants the
 standalone campaign specificity gate to reject placeholder drafts or drafts
 that miss configured proof-term support before they are saved. The same flag
 adds normalized `campaign_proof_terms` from reasoning anchors/witnesses/proof
-points to the prompt payload before the LLM call.
+points to the prompt payload before the LLM call. Rejected drafts include
+compact `quality_revalidation` details in the generation result errors.
 
 If a host does not already have reasoning JSON, it can configure
 `SinglePassCampaignReasoningProvider` from

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -607,8 +607,45 @@ async def test_generate_quality_revalidation_blocks_failed_drafts() -> None:
             "target_id": "opp-1",
             "channel": "email",
             "reason": "quality_revalidation_failed",
+            "quality_revalidation": {
+                "status": "fail",
+                "blocking_issues": ["placeholder_token"],
+                "primary_blocker": "placeholder_token",
+            },
         },
     )
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_quality_revalidation_failure_includes_proof_term_details() -> None:
+    config = CampaignGenerationConfig(quality_revalidation_enabled=True)
+    opportunity = {
+        "id": "opp-1",
+        "company_name": "Acme",
+        "anchor_examples": {
+            "pricing": [
+                {"excerpt_text": "Pricing drove evaluation."},
+            ]
+        },
+    }
+    service, _, campaigns, _, _ = _service(
+        [opportunity],
+        ['{"subject":"Pricing signal","body":"Generic body."}'],
+        config=config,
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention")
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    error = result.errors[0]
+    assert error["reason"] == "quality_revalidation_failed"
+    assert error["quality_revalidation"]["blocking_issues"] == ["missing_anchor_support"]
+    assert error["quality_revalidation"]["primary_blocker"] == "missing_anchor_support"
+    assert error["quality_revalidation"]["unused_proof_terms"] == [
+        "Pricing drove evaluation."
+    ]
     assert campaigns.saved == []
 
 


### PR DESCRIPTION
## Summary
- include compact quality_revalidation details on skipped draft errors when campaign quality revalidation blocks output
- preserve the existing quality_revalidation_failed reason while adding blocking issues, primary blocker, and proof-term details
- document the error payload and claim D31 in coordination

## Verification
- python -m py_compile extracted_content_pipeline/campaign_generation.py tests/test_extracted_campaign_generation.py
- pytest tests/test_extracted_campaign_generation.py
- bash scripts/run_extracted_pipeline_checks.sh