### PR TITLE
Support CSV source-row campaign ingestion

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T02:40Z by codex-2026-05-07-d31-cleanup
+Last updated: 2026-05-07T02:45Z by codex-2026-05-07-d32
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | PR-D32: AI Content Ops source-row CSV ingestion | `extracted_content_pipeline/campaign_source_adapters.py`, source-row CLIs/tests/docs | codex-2026-05-07-d32 | Avoid editing competitive-intelligence Phase 3 visibility files or extracted_reasoning_core PR-C1 files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -144,7 +144,7 @@ python scripts/run_extracted_campaign_generation_example.py customer_opportuniti
 ```
 
 Review, transcript, complaint, and document source rows can be converted into
-the same opportunity payload first:
+the same opportunity payload first. Source rows can be JSON, JSONL, or CSV:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -173,6 +173,9 @@ python scripts/load_extracted_campaign_opportunities.py \
   --source-format jsonl \
   --account-id acct_123
 ```
+
+For source-row CSV exports, pass `--source-format csv` to the same conversion,
+generation, import, or smoke commands.
 
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:
@@ -259,6 +262,8 @@ python scripts/smoke_extracted_content_pipeline_host.py \
   --source-rows \
   --source-format jsonl
 ```
+
+For source-row CSV exports, use `--source-format csv`.
 
 To run the same example through the product LLM adapter, configure the
 `EXTRACTED_CAMPAIGN_LLM_*` environment variables and pass `--llm pipeline`:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -36,8 +36,8 @@
   document source rows into normalized campaign opportunities so hosts can feed
   richer text sources into the same generation/import path. The Postgres import
   CLI and offline generation CLI can consume these source rows directly with
-  `--source-rows`, and `examples/campaign_source_rows.jsonl` provides a
-  packaged starter input.
+  `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
+  `examples/campaign_source_rows.jsonl` provides a packaged starter input.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+import csv
 import json
 from pathlib import Path
 from typing import Any, Literal
@@ -15,7 +16,7 @@ from .campaign_customer_data import (
 from .campaign_opportunities import normalize_campaign_opportunity
 
 
-SourceDataFormat = Literal["auto", "json", "jsonl"]
+SourceDataFormat = Literal["auto", "json", "jsonl", "csv"]
 
 _ROW_LIST_KEYS = ("sources", "documents", "reviews", "transcripts", "complaints", "rows", "data")
 _SOURCE_ID_KEYS = ("source_id", "id", "review_id", "transcript_id", "document_id")
@@ -137,6 +138,8 @@ def source_row_to_campaign_opportunity(
 
 def _load_source_rows(path: Path, *, file_format: SourceDataFormat) -> list[Any]:
     resolved_format = _resolve_format(path, file_format)
+    if resolved_format == "csv":
+        return _load_source_csv_rows(path)
     if resolved_format == "jsonl":
         rows: list[Any] = []
         for line in path.read_text(encoding="utf-8").splitlines():
@@ -156,11 +159,32 @@ def _load_source_rows(path: Path, *, file_format: SourceDataFormat) -> list[Any]
     return [dict(data)]
 
 
-def _resolve_format(path: Path, file_format: SourceDataFormat) -> Literal["json", "jsonl"]:
+def _load_source_csv_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames:
+            return rows
+        for row in reader:
+            rows.append({
+                str(key): value
+                for key, value in row.items()
+                if key is not None and value not in (None, "")
+            })
+    return rows
+
+
+def _resolve_format(
+    path: Path,
+    file_format: SourceDataFormat,
+) -> Literal["json", "jsonl", "csv"]:
     if file_format != "auto":
         return file_format
-    if path.suffix.lower() == ".jsonl":
+    suffix = path.suffix.lower()
+    if suffix == ".jsonl":
         return "jsonl"
+    if suffix == ".csv":
+        return "csv"
     return "json"
 
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -121,6 +121,9 @@ python scripts/smoke_extracted_content_pipeline_host.py \
   --source-format jsonl
 ```
 
+For source-row CSV exports, pass `--source-format csv` to the same smoke
+command.
+
 The command exits nonzero if the product cannot generate the minimum expected
 draft shape (`subject`, `body`, `target_id`, and `channel`).
 
@@ -153,6 +156,8 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
 The source adapter copies `review_text`, `transcript`, `complaint`, `content`,
 `body`, `quote`, or `text` into the opportunity `evidence` field, preserving
 source ids and inferred source types for prompt context and later review.
+Source rows can be JSON, JSONL, or CSV; pass `--format csv` for CSV source
+exports.
 
 For an offline draft preview without writing the intermediate opportunity file:
 
@@ -195,6 +200,8 @@ python scripts/load_extracted_campaign_opportunities.py \
   --source-format jsonl \
   --account-id acct_123
 ```
+
+For source-row CSV exports, pass `--source-format csv`.
 
 Imports are append-only by default. For repeatable test loads, replace matching
 target ids for the same account and target mode:

--- a/scripts/build_extracted_campaign_opportunities_from_sources.py
+++ b/scripts/build_extracted_campaign_opportunities_from_sources.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build campaign opportunities from richer source JSON/JSONL rows."""
+"""Build campaign opportunities from richer source JSON/JSONL/CSV rows."""
 
 from __future__ import annotations
 
@@ -25,10 +25,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "into AI Content Ops campaign opportunities."
         )
     )
-    parser.add_argument("path", type=Path, help="Source JSON or JSONL file.")
+    parser.add_argument("path", type=Path, help="Source JSON, JSONL, or CSV file.")
     parser.add_argument(
         "--format",
-        choices=("auto", "json", "jsonl"),
+        choices=("auto", "json", "jsonl", "csv"),
         default="auto",
         help="Source file format. Defaults to suffix-based detection.",
     )

--- a/scripts/load_extracted_campaign_opportunities.py
+++ b/scripts/load_extracted_campaign_opportunities.py
@@ -53,7 +53,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--source-format",
-        choices=("auto", "json", "jsonl"),
+        choices=("auto", "json", "jsonl", "csv"),
         default="auto",
         help="Source-row file format when --source-rows is selected.",
     )

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -111,7 +111,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--source-format",
-        choices=("auto", "json", "jsonl"),
+        choices=("auto", "json", "jsonl", "csv"),
         default="auto",
         help="Source-row file format when --source-rows is selected.",
     )

--- a/scripts/smoke_extracted_content_pipeline_host.py
+++ b/scripts/smoke_extracted_content_pipeline_host.py
@@ -87,7 +87,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--source-format",
-        choices=("auto", "json", "jsonl"),
+        choices=("auto", "json", "jsonl", "csv"),
         default="auto",
         help="Source-row file format when --source-rows is selected.",
     )

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -114,6 +114,28 @@ def test_load_source_campaign_opportunities_from_jsonl(tmp_path: Path) -> None:
     assert loaded.opportunities[1]["evidence"][0]["source_type"] == "complaint"
 
 
+def test_load_source_campaign_opportunities_from_csv(tmp_path: Path) -> None:
+    path = tmp_path / "sources.csv"
+    path.write_text(
+        "\n".join([
+            "id,company,vendor,review_text,pain_category",
+            "review-1,Acme,HubSpot,Pricing is a problem,pricing",
+        ]),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert loaded.opportunities[0]["target_id"] == "review-1"
+    assert loaded.opportunities[0]["company_name"] == "Acme"
+    assert loaded.opportunities[0]["pain_points"] == ["pricing"]
+    assert loaded.opportunities[0]["evidence"] == [{
+        "text": "Pricing is a problem",
+        "source_id": "review-1",
+        "source_type": "review",
+    }]
+
+
 def test_packaged_source_rows_example_loads() -> None:
     loaded = load_source_campaign_opportunities_from_file(EXAMPLE_SOURCE_ROWS)
 
@@ -162,6 +184,38 @@ def test_source_adapter_cli_outputs_generation_payload(tmp_path: Path) -> None:
     assert payload["limit"] == 1
     assert payload["opportunities"][0]["target_id"] == "review-1"
     assert payload["opportunities"][0]["evidence"][0]["text"] == "Pricing is a problem."
+
+
+def test_source_adapter_cli_outputs_csv_generation_payload(tmp_path: Path) -> None:
+    path = tmp_path / "sources.csv"
+    path.write_text(
+        "\n".join([
+            "id,company,vendor,transcript,pain_points",
+            "call-1,Acme,HubSpot,Renewal review is active,renewal pressure",
+        ]),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--format",
+            "csv",
+            "--target-mode",
+            "vendor_retention",
+            "--limit",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["opportunities"][0]["target_id"] == "call-1"
+    assert payload["opportunities"][0]["evidence"][0]["source_type"] == "transcript"
 
 
 def test_source_adapter_cli_rejects_non_positive_text_limit(tmp_path: Path) -> None:

--- a/tests/test_extracted_content_host_smoke.py
+++ b/tests/test_extracted_content_host_smoke.py
@@ -142,6 +142,36 @@ def test_host_smoke_cli_accepts_source_rows() -> None:
     assert "generated=2" in completed.stdout
 
 
+def test_host_smoke_cli_accepts_source_row_csv(tmp_path) -> None:
+    source_path = tmp_path / "customer_sources.csv"
+    source_path.write_text(
+        "\n".join([
+            "id,company,vendor,review_text,pain_category",
+            "review-1,Acme,HubSpot,Pricing is a problem,pricing",
+        ]),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source_path),
+            "--source-rows",
+            "--source-format",
+            "csv",
+            "--limit",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "AI Content Ops host smoke passed" in completed.stdout
+    assert "generated=2" in completed.stdout
+
+
 def test_host_smoke_cli_rejects_invalid_source_text_limit(tmp_path) -> None:
     source_path = tmp_path / "customer_sources.json"
     source_path.write_text("[]", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add CSV loading to campaign source-row adapters alongside JSON and JSONL
- expose --source-format csv in source-row conversion, generation, import, and host-smoke CLIs
- document source-row CSV support and claim D32 in coordination

## Verification
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py scripts/build_extracted_campaign_opportunities_from_sources.py scripts/run_extracted_campaign_generation_example.py scripts/load_extracted_campaign_opportunities.py scripts/smoke_extracted_content_pipeline_host.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_host_smoke.py
- pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_host_smoke.py
- bash scripts/run_extracted_pipeline_checks.sh