### PR TITLE
Cover source-row CSV opportunity import

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T02:50Z by codex-2026-05-07-d32-cleanup
+Last updated: 2026-05-07T02:55Z by codex-2026-05-07-d33
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | PR-D33: AI Content Ops source-row CSV import regression | `tests/test_extracted_campaign_postgres_import.py` | codex-2026-05-07-d33 | Avoid editing competitive-intelligence Phase 3 visibility files or extracted_reasoning_core PR-C1 files. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/tests/test_extracted_campaign_postgres_import.py
+++ b/tests/test_extracted_campaign_postgres_import.py
@@ -252,6 +252,45 @@ async def test_opportunity_import_cli_dry_run_accepts_source_rows(
 
 
 @pytest.mark.asyncio
+async def test_opportunity_import_cli_dry_run_accepts_source_row_csv(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    data_path = tmp_path / "sources.csv"
+    data_path.write_text(
+        "\n".join([
+            "id,company,vendor,email,review_text,pain_category",
+            "review-1,Acme,HubSpot,buyer@example.com,Pricing is a problem,pricing",
+        ]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "load",
+            str(data_path),
+            "--source-rows",
+            "--source-format",
+            "csv",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["dry_run"] is True
+    assert output["inserted"] == 1
+    assert output["target_ids"] == ["review-1"]
+    assert output["warnings"] == []
+
+
+@pytest.mark.asyncio
 async def test_opportunity_import_cli_wires_source_rows_to_database(
     monkeypatch,
     capsys,


### PR DESCRIPTION
## Summary
- add regression coverage for source-row CSV dry-run import through load_extracted_campaign_opportunities.py
- keep the D33 coordination claim scoped to the import test surface

## Verification
- python -m py_compile tests/test_extracted_campaign_postgres_import.py
- pytest tests/test_extracted_campaign_postgres_import.py
- bash scripts/run_extracted_pipeline_checks.sh