### PR TITLE
Use python -m pytest in evidence-to-story check script

### DIFF
--- a/scripts/run_extracted_evidence_to_story_checks.sh
+++ b/scripts/run_extracted_evidence_to_story_checks.sh
@@ -6,6 +6,6 @@ cd "$ROOT_DIR"
 
 bash extracted/_shared/scripts/validate_extracted.sh extracted_evidence_to_story
 bash extracted/_shared/scripts/check_ascii_python.sh extracted_evidence_to_story
-pytest tests/test_extracted_evidence_to_story_sources.py
+python -m pytest tests/test_extracted_evidence_to_story_sources.py
 
 echo "All extracted_evidence_to_story checks completed"


### PR DESCRIPTION
## Summary

Bare `pytest` in `scripts/run_extracted_evidence_to_story_checks.sh` resolves to whatever's on `PATH`. In environments where that's a uv-installed pytest tool venv (a separate isolated Python with its own site-packages), the lookup misses the system Python's `pytest-asyncio` package — and `tests/conftest.py` imports `pytest_asyncio` at module load, so collection fails before any Evidence-to-Story test runs.

Switching to `python -m pytest` uses the active interpreter's pytest + plugins, matching the pattern already used by:
- `scripts/run_extracted_competitive_intelligence_checks.sh`
- `scripts/run_extracted_llm_infrastructure_checks.sh`
- `scripts/run_reasoning_provider_port_tests.sh`

## Verified

```
$ bash scripts/run_extracted_evidence_to_story_checks.sh
Validation passed: mapped files for extracted_evidence_to_story match atlas_brain sources
forbid_hard_atlas_imports: clean (extracted_evidence_to_story)
ASCII check passed for extracted_evidence_to_story Python files
============================== 13 passed in 0.20s ==============================
All extracted_evidence_to_story checks completed
```

## Test plan

- [x] Script runs end-to-end (validation + ASCII check + 13/13 tests).
- [ ] CI `extracted-checks`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnEGPVMSNbknRxsagBkBZk)_