### PR TITLE
PR-Reports-1a: Add Reports storage layer (ReportDraft + reports table + repository)

### DIFF
--- a/extracted_content_pipeline/report_ports.py
+++ b/extracted_content_pipeline/report_ports.py
@@ -1,0 +1,114 @@
+"""Standalone ports for the AI Content Ops Reports product.
+
+Reports are the third content asset type in the AI Content Ops surface
+(parallel to email campaigns and blog posts). Where ``CampaignDraft`` is
+shaped for short-form transactional output (subject + body), a
+``ReportDraft`` carries a typed structured payload (title, summary,
+ordered sections, cited references) so renderers can consume the report
+without parsing markdown.
+
+Storage lives in the ``reports`` table (migration 273) with the same
+status-lifecycle semantics as ``b2b_campaigns``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class ReportSection:
+    """A single ordered section within a structured report.
+
+    The shape mirrors ``extracted_reasoning_core.types.NarrativePlan.sections``
+    so reports produced from a multi-pass reasoning output can pass the
+    bridge's pre-structured plan straight through with minimal reshaping.
+    """
+
+    id: str
+    title: str
+    body_markdown: str
+    claim_ids: Sequence[str] = field(default_factory=tuple)
+    evidence_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "body_markdown": self.body_markdown,
+            "claim_ids": list(self.claim_ids),
+            "evidence_ids": list(self.evidence_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ReportDraft:
+    """A generated, not-yet-approved structured report.
+
+    Persists into the ``reports`` table via ``ReportRepository.save_drafts``.
+    """
+
+    target_id: str
+    target_mode: str
+    report_type: str
+    title: str
+    summary: str
+    sections: Sequence[ReportSection] = field(default_factory=tuple)
+    reference_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "report_type": self.report_type,
+            "title": self.title,
+            "summary": self.summary,
+            "sections": [section.as_dict() for section in self.sections],
+            "reference_ids": list(self.reference_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+class ReportRepository(Protocol):
+    """Persistence contract for generated structured reports."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[ReportDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return the assigned report ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        report_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[ReportDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        report_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        """Update a draft's status (draft / queued / approved / rejected / expired)."""
+
+
+__all__ = [
+    "ReportDraft",
+    "ReportRepository",
+    "ReportSection",
+]

--- a/extracted_content_pipeline/report_postgres.py
+++ b/extracted_content_pipeline/report_postgres.py
@@ -1,0 +1,197 @@
+"""Postgres repository adapter for the AI Content Ops Reports product.
+
+Mirrors the shape of ``PostgresCampaignRepository`` (see
+``campaign_postgres.py:240-292``) but persists ``ReportDraft`` rows into
+the ``reports`` table from migration 273. Hosts inject an asyncpg-style
+pool; the adapter does no connection management itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .report_ports import ReportDraft, ReportSection
+
+
+def _jsonb(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
+
+
+def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
+    if isinstance(row, Mapping):
+        return dict(row)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _draft_metadata(draft: ReportDraft, scope: TenantScope) -> JsonDict:
+    """Merge tenant scope into the draft's metadata before persisting."""
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _coerce_section(value: Any) -> ReportSection:
+    if isinstance(value, ReportSection):
+        return value
+    if isinstance(value, Mapping):
+        return ReportSection(
+            id=str(value.get("id") or ""),
+            title=str(value.get("title") or ""),
+            body_markdown=str(value.get("body_markdown") or ""),
+            claim_ids=tuple(str(c) for c in (value.get("claim_ids") or ())),
+            evidence_ids=tuple(str(e) for e in (value.get("evidence_ids") or ())),
+            metadata=dict(value.get("metadata") or {}),
+        )
+    return ReportSection(id="", title="", body_markdown=str(value or ""))
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> ReportDraft:
+    sections_raw = row.get("sections")
+    if isinstance(sections_raw, str):
+        try:
+            sections_raw = json.loads(sections_raw)
+        except (TypeError, ValueError):
+            sections_raw = []
+    if not isinstance(sections_raw, Sequence) or isinstance(sections_raw, (str, bytes)):
+        sections_raw = []
+
+    reference_ids_raw = row.get("reference_ids")
+    if isinstance(reference_ids_raw, str):
+        try:
+            reference_ids_raw = json.loads(reference_ids_raw)
+        except (TypeError, ValueError):
+            reference_ids_raw = []
+    if not isinstance(reference_ids_raw, Sequence) or isinstance(reference_ids_raw, (str, bytes)):
+        reference_ids_raw = []
+
+    metadata_raw = row.get("metadata")
+    if isinstance(metadata_raw, str):
+        try:
+            metadata_raw = json.loads(metadata_raw)
+        except (TypeError, ValueError):
+            metadata_raw = {}
+    if not isinstance(metadata_raw, Mapping):
+        metadata_raw = {}
+
+    return ReportDraft(
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        report_type=str(row.get("report_type") or ""),
+        title=str(row.get("title") or ""),
+        summary=str(row.get("summary") or ""),
+        sections=tuple(_coerce_section(s) for s in sections_raw),
+        reference_ids=tuple(str(r) for r in reference_ids_raw),
+        metadata=dict(metadata_raw),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresReportRepository:
+    """Async Postgres adapter for generated structured reports."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[ReportDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            sections_payload = [_coerce_section(s).as_dict() for s in draft.sections]
+            reference_ids_payload = [str(r) for r in draft.reference_ids]
+            metadata_payload = _draft_metadata(draft, scope)
+            report_id = await self.pool.fetchval(
+                """
+                INSERT INTO reports (
+                    account_id, target_id, target_mode, report_type,
+                    title, summary, sections, reference_ids, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.report_type,
+                draft.title,
+                draft.summary,
+                _jsonb(sections_payload),
+                _jsonb(reference_ids_payload),
+                _jsonb(metadata_payload),
+            )
+            saved.append(str(report_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        report_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[ReportDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if report_type is not None:
+            params.append(report_type)
+            clauses.append(f"report_type = ${len(params)}")
+        sql = (
+            "SELECT target_id, target_mode, report_type, title, summary, "
+            "sections, reference_ids, metadata "
+            "FROM reports WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(_row_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        report_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE reports
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            report_id,
+            status,
+            scope.account_id or "",
+        )
+
+
+__all__ = [
+    "PostgresReportRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/273_reports.sql
+++ b/extracted_content_pipeline/storage/migrations/273_reports.sql
@@ -1,0 +1,34 @@
+-- Reports: customer-facing structured report drafts produced by the AI Content
+-- Ops Reports generator. Parallel to b2b_campaigns but with a richer typed
+-- shape (sections + reference_ids) so renderers can consume the structured
+-- output directly without parsing markdown.
+--
+-- The status lifecycle mirrors b2b_campaigns: drafts start at 'draft', move
+-- through 'queued' / 'approved' / 'rejected' / 'expired' as host workflows
+-- review them. No CHECK constraint on status: hosts may extend with their own
+-- intermediate states (e.g., 'in_review') without a follow-on migration.
+
+CREATE TABLE IF NOT EXISTS reports (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL,
+    target_mode TEXT NOT NULL,
+    report_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    sections JSONB NOT NULL DEFAULT '[]'::jsonb,
+    reference_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reports_target
+    ON reports (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_reports_status
+    ON reports (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reports_type
+    ON reports (account_id, report_type, created_at DESC);

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -24,6 +24,7 @@ pytest \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
+  tests/test_extracted_report_postgres.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_report_postgres.py
+++ b/tests/test_extracted_report_postgres.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.report_ports import ReportDraft, ReportSection
+from extracted_content_pipeline.report_postgres import PostgresReportRepository
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return "OK"
+
+
+def _draft() -> ReportDraft:
+    return ReportDraft(
+        target_id="acme",
+        target_mode="vendor",
+        report_type="vendor_pressure",
+        title="Acme: Q3 Pressure Report",
+        summary="Pricing renewal pressure dominates the displacement signal.",
+        sections=(
+            ReportSection(
+                id="executive_summary",
+                title="Executive Summary",
+                body_markdown="Renewal pricing is the dominant churn driver.",
+                claim_ids=("c1",),
+                evidence_ids=("r1", "r2"),
+            ),
+            ReportSection(
+                id="drivers",
+                title="Pressure Drivers",
+                body_markdown="Onboarding friction is a secondary driver.",
+                claim_ids=("c2",),
+                evidence_ids=("t9",),
+            ),
+        ),
+        reference_ids=("r1", "r2", "t9"),
+        metadata={"generation_model": "fake-llm", "confidence": 0.84},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_each_draft_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["report-uuid-1"]
+    repo = PostgresReportRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("report-uuid-1",)
+    assert len(pool.fetchval_calls) == 1
+    args = pool.fetchval_calls[0]["args"]
+    # Argument order matches the INSERT param list:
+    # account_id, target_id, target_mode, report_type, title, summary, sections, reference_ids, metadata
+    assert args[0] == "acct-1"
+    assert args[1] == "acme"
+    assert args[2] == "vendor"
+    assert args[3] == "vendor_pressure"
+    assert args[4] == "Acme: Q3 Pressure Report"
+    assert "Pricing renewal" in args[5]
+    sections_payload = json.loads(args[6])
+    assert [s["id"] for s in sections_payload] == ["executive_summary", "drivers"]
+    assert sections_payload[0]["evidence_ids"] == ["r1", "r2"]
+    reference_ids_payload = json.loads(args[7])
+    assert reference_ids_payload == ["r1", "r2", "t9"]
+    metadata_payload = json.loads(args[8])
+    assert metadata_payload["target_id"] == "acme"
+    assert metadata_payload["scope"]["account_id"] == "acct-1"
+    assert metadata_payload["confidence"] == 0.84
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_handles_empty_account_id_with_default_scope() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["report-uuid-2"]
+    repo = PostgresReportRepository(pool)
+
+    await repo.save_drafts([_draft()], scope=TenantScope())
+
+    assert pool.fetchval_calls[0]["args"][0] == ""
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_handles_dict_section_input_via_coercion() -> None:
+    """Hosts may pass dict-shaped sections; the repo coerces them defensively."""
+    pool = _Pool()
+    pool.fetchval_results = ["report-uuid-3"]
+    repo = PostgresReportRepository(pool)
+
+    draft = ReportDraft(
+        target_id="acme",
+        target_mode="vendor",
+        report_type="vendor_pressure",
+        title="title",
+        summary="summary",
+        sections=(
+            {
+                "id": "raw_section",
+                "title": "From Dict",
+                "body_markdown": "body",
+                "claim_ids": ["c1"],
+                "evidence_ids": ["r1"],
+            },
+        ),  # type: ignore[arg-type]
+    )
+
+    await repo.save_drafts([draft], scope=TenantScope())
+
+    sections_payload = json.loads(pool.fetchval_calls[0]["args"][6])
+    assert sections_payload[0]["id"] == "raw_section"
+    assert sections_payload[0]["claim_ids"] == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_and_target_mode() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "acme",
+            "target_mode": "vendor",
+            "report_type": "vendor_pressure",
+            "title": "Acme report",
+            "summary": "summary text",
+            "sections": json.dumps([
+                {
+                    "id": "summary",
+                    "title": "Executive Summary",
+                    "body_markdown": "body",
+                    "claim_ids": ["c1"],
+                    "evidence_ids": ["r1"],
+                }
+            ]),
+            "reference_ids": json.dumps(["r1"]),
+            "metadata": json.dumps({"confidence": 0.7}),
+        }
+    ]
+    repo = PostgresReportRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="vendor",
+        report_type="vendor_pressure",
+        limit=20,
+    )
+
+    assert len(drafts) == 1
+    assert drafts[0].target_id == "acme"
+    assert drafts[0].sections[0].id == "summary"
+    assert drafts[0].sections[0].claim_ids == ("c1",)
+    assert drafts[0].reference_ids == ("r1",)
+    assert drafts[0].metadata == {"confidence": 0.7}
+
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "account_id = $1" in sql
+    assert "status = $2" in sql
+    assert "target_mode = $3" in sql
+    assert "report_type = $4" in sql
+    assert "LIMIT $5" in sql
+    assert args == ("acct-1", "draft", "vendor", "vendor_pressure", 20)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
+    """asyncpg with the json codec installed delivers JSONB pre-decoded."""
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "acme",
+            "target_mode": "vendor",
+            "report_type": "vendor_pressure",
+            "title": "title",
+            "summary": "summary",
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],  # already a list
+            "reference_ids": ["r1", "r2"],  # already a list
+            "metadata": {"key": "value"},  # already a dict
+        }
+    ]
+    repo = PostgresReportRepository(pool)
+
+    drafts = await repo.list_drafts(scope=TenantScope())
+
+    assert drafts[0].sections[0].id == "s1"
+    assert drafts[0].reference_ids == ("r1", "r2")
+    assert drafts[0].metadata == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_update_status_runs_scoped_update() -> None:
+    pool = _Pool()
+    repo = PostgresReportRepository(pool)
+
+    await repo.update_status(
+        "report-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert len(pool.execute_calls) == 1
+    args = pool.execute_calls[0]["args"]
+    assert args == ("report-uuid-1", "approved", "acct-1")
+    sql = pool.execute_calls[0]["query"]
+    assert "UPDATE reports" in sql
+    assert "account_id = $3" in sql
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_returns_empty_tuple_for_empty_input() -> None:
+    pool = _Pool()
+    repo = PostgresReportRepository(pool)
+
+    saved = await repo.save_drafts([], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ()
+    assert pool.fetchval_calls == []


### PR DESCRIPTION
## Summary

First slice of Reports content-asset support for AI Content Ops. The landing page promises five content types (blogs, emails, reports, sales briefs, landing pages); today the package ships 2 of 5 (blogs + emails). Reports closes one gap. **This PR lays the storage foundation; the generator service lands in PR-Reports-1b.**

Per planning: **per-opportunity trigger** (mirroring campaigns) and a **new typed `ReportDraft` + `reports` table** rather than overloading `CampaignDraft`. The new `ReportSection` shape is intentionally compatible with `extracted_reasoning_core.types.NarrativePlan.sections` so reports produced from a multi-pass reasoning context can pass the bridge's pre-structured plan straight through to the generator without reshaping.

## What changed

**New files:**

- `extracted_content_pipeline/storage/migrations/273_reports.sql` — `reports` table with `target` / `status` / `report_type` indexes. Status lifecycle mirrors `b2b_campaigns` (`draft` / `queued` / `approved` / `rejected` / `expired`) without a `CHECK` constraint so hosts may add intermediate states (e.g., `in_review`) without a follow-on migration.
- `extracted_content_pipeline/report_ports.py` — `ReportSection` + `ReportDraft` frozen dataclasses + `ReportRepository` Protocol. Surface mirrors `CampaignRepository`: `save_drafts` / `list_drafts` / `update_status`.
- `extracted_content_pipeline/report_postgres.py` — `PostgresReportRepository`. Mirrors `campaign_postgres.py:240-292` `save_drafts` shape (asyncpg pool, `$`-positional INSERT, JSONB encoding via `_jsonb`, scope merged into metadata). `list_drafts` composes WHERE clauses dynamically for `status` / `target_mode` / `report_type` / `limit`. `update_status` is account-scoped to prevent cross-tenant writes. Defensive coercion handles both pre-decoded JSONB and string-shaped JSONB.
- `tests/test_extracted_report_postgres.py` — fake-pool tests, 7 cases.

**Modified files:**
- `scripts/run_extracted_pipeline_checks.sh` — wires the new test into the runner.

## Test plan

- [x] `python -c "from extracted_content_pipeline.report_ports import ReportDraft, ReportSection, ReportRepository; from extracted_content_pipeline.report_postgres import PostgresReportRepository"` → clean import
- [x] AST scan of new files for `atlas_brain` refs → 0 hits
- [x] `bash scripts/validate_extracted_content_pipeline.sh` → passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed
- [x] `pytest tests/test_extracted_report_postgres.py tests/test_extracted_campaign_postgres.py` → 19/19 passing locally
- [ ] CI `extracted-checks` run

Tests cover: save_drafts persists each row with scope-merged metadata; empty `account_id` default; dict-shaped section coercion; list_drafts filter composition; pre-decoded JSONB column handling; update_status SQL shape; empty-input return.

## Out of scope (deferred)

- Generator service (`ReportGenerationService`) → **PR-Reports-1b** (depends on this)
- Packaged skill prompt (`skills/digest/report_generation.md`) → PR-Reports-1b
- Quality pack (`extracted_quality_gate/report_pack.py`) → PR-Reports-1b
- Approval API endpoint (parallel to `api/b2b_campaigns.py` review router) → PR-Reports-2
- CLI flag wiring → PR-Reports-3
- Aggregate reports (one report covering many opportunities) → separate slice
- Sales briefs / landing pages generators → separate slices (gap items #2 and #3 in the corrected build queue)
- Signal extraction → biggest landing-page risk; explicitly out of scope

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_