### PR TITLE
PR-Reports-1b: Add Reports generator + skill prompt + quality pack

### DIFF
--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -45,6 +45,8 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
+from extracted_quality_gate.report_pack import evaluate_report
+from extracted_quality_gate.types import QualityInput
 
 
 @dataclass(frozen=True)
@@ -79,9 +81,12 @@ class ReportGenerationResult:
 def parse_report_response(text: str) -> dict[str, Any] | None:
     """Mirror of ``parse_campaign_draft_response`` for the report shape.
 
-    Strips ``<think>`` blocks and code fences, then extracts the first
-    well-formed JSON object that carries the minimum report fields
-    (``title`` + ``summary`` + non-empty ``sections``).
+    Strips ``<think>`` blocks and code fences, then walks the cleaned
+    text with ``json.JSONDecoder.raw_decode`` (a real JSON parser, so
+    braces inside string values such as ``body_markdown`` template
+    syntax don't trip it up). Returns the first decoded object that
+    carries the minimum report fields (``title`` + ``summary`` +
+    non-empty ``sections``).
     """
 
     cleaned = str(text or "").strip()
@@ -91,27 +96,21 @@ def parse_report_response(text: str) -> dict[str, Any] | None:
     cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
     cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
 
+    decoder = json.JSONDecoder()
     candidates: list[Any] = []
-    try:
-        candidates.append(json.loads(cleaned))
-    except json.JSONDecodeError:
-        pass
-
-    depth = 0
-    start = -1
-    for index, char in enumerate(cleaned):
-        if char == "{":
-            if depth == 0:
-                start = index
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0 and start >= 0:
-                try:
-                    candidates.append(json.loads(cleaned[start : index + 1]))
-                except json.JSONDecodeError:
-                    pass
-                start = -1
+    index = 0
+    length = len(cleaned)
+    while index < length:
+        if cleaned[index] != "{":
+            index += 1
+            continue
+        try:
+            decoded, end = decoder.raw_decode(cleaned, index)
+        except json.JSONDecodeError:
+            index += 1
+            continue
+        candidates.append(decoded)
+        index = end if end > index else index + 1
 
     for candidate in candidates:
         if isinstance(candidate, list):
@@ -289,10 +288,13 @@ class ReportGenerationService:
         target_mode: str,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
+        # Single source for the opportunity payload: in the system prompt
+        # via {opportunity_json}. The user message is structural-only so
+        # the opportunity isn't sent twice (the reasoning-context block
+        # alone can be the largest part of the request).
         system_prompt = (
             prompt_template
             .replace("{target_mode}", target_mode)
-            .replace("{opportunity}", opportunity_json)
             .replace("{opportunity_json}", opportunity_json)
         )
         response = await self._llm.complete(
@@ -300,11 +302,7 @@ class ReportGenerationService:
                 LLMMessage(role="system", content=system_prompt),
                 LLMMessage(
                     role="user",
-                    content=(
-                        "Generate one structured report from this normalized "
-                        f"opportunity.\ntarget_mode={target_mode}\n"
-                        f"opportunity={opportunity_json}"
-                    ),
+                    content="Generate one structured report from the opportunity above.",
                 ),
             ],
             max_tokens=self._config.max_tokens,
@@ -326,9 +324,6 @@ class ReportGenerationService:
         }
 
     def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
-        from extracted_quality_gate.report_pack import evaluate_report
-        from extracted_quality_gate.types import QualityInput
-
         report_input = QualityInput(
             artifact_type="report",
             context={

--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -1,0 +1,404 @@
+"""Standalone Reports generator orchestration.
+
+Parallel to ``CampaignGenerationService``, but produces structured
+``ReportDraft`` rows (title + summary + ordered sections + reference
+ids) instead of email subject/body drafts. Per-opportunity trigger
+shape: each opportunity yields one report.
+
+Reasoning-context aware: when the host provides a multi-pass
+``CampaignReasoningContextProvider`` whose context exposes a
+``canonical_reasoning["narrative_plan"]`` block, the generator hands
+that pre-structured plan to the LLM as the section spine so the model
+writes prose for each section rather than inventing the structure.
+Without a narrative plan, the LLM structures the report itself.
+
+Quality gating runs through ``extracted_quality_gate.report_pack`` —
+deterministic, no LLM, no DB. Drafts that fail the pack are skipped
+and the failure is recorded in the result's ``errors`` payload; the
+caller decides what to do with the rejection (retry, surface to
+operator, etc.).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any
+
+from .campaign_opportunities import (
+    normalize_campaign_opportunity,
+    opportunity_target_id,
+)
+from .campaign_ports import (
+    CampaignReasoningContextProvider,
+    IntelligenceRepository,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
+from .report_ports import ReportDraft, ReportRepository, ReportSection
+from .services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
+    campaign_reasoning_context_payload,
+    normalize_campaign_reasoning_context,
+)
+
+
+@dataclass(frozen=True)
+class ReportGenerationConfig:
+    """Tunable defaults for ``ReportGenerationService``."""
+
+    skill_name: str = "digest/report_generation"
+    default_report_type: str = "vendor_pressure"
+    limit: int = 10
+    max_tokens: int = 4096
+    temperature: float = 0.3
+
+
+@dataclass(frozen=True)
+class ReportGenerationResult:
+    requested: int
+    generated: int
+    skipped: int
+    saved_ids: tuple[str, ...] = ()
+    errors: tuple[Mapping[str, Any], ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "requested": self.requested,
+            "generated": self.generated,
+            "skipped": self.skipped,
+            "saved_ids": list(self.saved_ids),
+            "errors": list(self.errors),
+        }
+
+
+def parse_report_response(text: str) -> dict[str, Any] | None:
+    """Mirror of ``parse_campaign_draft_response`` for the report shape.
+
+    Strips ``<think>`` blocks and code fences, then extracts the first
+    well-formed JSON object that carries the minimum report fields
+    (``title`` + ``summary`` + non-empty ``sections``).
+    """
+
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    candidates: list[Any] = []
+    try:
+        candidates.append(json.loads(cleaned))
+    except json.JSONDecodeError:
+        pass
+
+    depth = 0
+    start = -1
+    for index, char in enumerate(cleaned):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    candidates.append(json.loads(cleaned[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, dict):
+            continue
+        title = str(candidate.get("title") or "").strip()
+        summary = str(candidate.get("summary") or "").strip()
+        sections = candidate.get("sections")
+        if not title or not summary:
+            continue
+        if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
+            continue
+        coerced_sections = [s for s in sections if isinstance(s, Mapping)]
+        if not coerced_sections:
+            continue
+        return {
+            **candidate,
+            "title": title,
+            "summary": summary,
+            "sections": coerced_sections,
+        }
+    return None
+
+
+class ReportGenerationService:
+    """Generate structured report drafts through product-owned ports."""
+
+    def __init__(
+        self,
+        *,
+        intelligence: IntelligenceRepository,
+        reports: ReportRepository,
+        llm: LLMClient,
+        skills: SkillStore,
+        reasoning_context: CampaignReasoningContextProvider | None = None,
+        config: ReportGenerationConfig | None = None,
+    ):
+        self._intelligence = intelligence
+        self._reports = reports
+        self._llm = llm
+        self._skills = skills
+        self._reasoning_context = reasoning_context
+        self._config = config or ReportGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> ReportGenerationResult:
+        prompt_template = self._skills.get_prompt(self._config.skill_name)
+        if not prompt_template:
+            raise ValueError(f"Report generation skill not found: {self._config.skill_name}")
+
+        requested = int(limit or self._config.limit)
+        opportunities = [
+            normalize_campaign_opportunity(row, target_mode=target_mode)
+            for row in await self._intelligence.read_campaign_opportunities(
+                scope=scope,
+                target_mode=target_mode,
+                limit=requested,
+                filters=filters,
+            )
+        ]
+
+        drafts: list[ReportDraft] = []
+        errors: list[dict[str, Any]] = []
+        skipped = 0
+        for opportunity in opportunities:
+            target_id = opportunity_target_id(opportunity)
+            if not target_id:
+                skipped += 1
+                errors.append({"reason": "missing_target_id", "opportunity": opportunity})
+                continue
+            try:
+                opportunity = await self._opportunity_with_reasoning_context(
+                    scope=scope,
+                    target_mode=target_mode,
+                    target_id=target_id,
+                    opportunity=opportunity,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+
+            try:
+                parsed = await self._generate_one(
+                    prompt_template,
+                    opportunity=opportunity,
+                    target_mode=target_mode,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+
+            if not parsed:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": "unparseable_response"})
+                continue
+
+            quality = self._quality_check(parsed)
+            if not quality["passed"]:
+                skipped += 1
+                errors.append({
+                    "target_id": target_id,
+                    "reason": "quality_blocked",
+                    "blockers": quality["blockers"],
+                })
+                continue
+
+            drafts.append(self._build_draft(parsed, target_id=target_id, target_mode=target_mode))
+
+        saved_ids: tuple[str, ...] = ()
+        if drafts:
+            saved_ids = tuple(
+                str(item)
+                for item in await self._reports.save_drafts(drafts, scope=scope)
+            )
+        return ReportGenerationResult(
+            requested=len(opportunities),
+            generated=len(drafts),
+            skipped=skipped,
+            saved_ids=saved_ids,
+            errors=tuple(errors),
+        )
+
+    async def _opportunity_with_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        target_id: str,
+        opportunity: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        # Mirrors CampaignGenerationService._opportunity_with_reasoning_context.
+        context = None
+        if self._reasoning_context is not None:
+            provided = await self._reasoning_context.read_campaign_reasoning_context(
+                scope=scope,
+                target_id=target_id,
+                target_mode=target_mode,
+                opportunity=opportunity,
+            )
+            provided_context = normalize_campaign_reasoning_context(provided)
+            if provided_context.has_content():
+                context = provided_context
+        if context is None:
+            context = normalize_campaign_reasoning_context(opportunity)
+        if not context.has_content():
+            return dict(opportunity)
+        enriched = dict(opportunity)
+        payload = campaign_reasoning_context_payload(context)
+        enriched.update(campaign_reasoning_context_metadata(context))
+        existing_reasoning_context = opportunity.get("reasoning_context")
+        if isinstance(existing_reasoning_context, Mapping):
+            enriched["reasoning_context"] = {
+                **dict(existing_reasoning_context),
+                "campaign_reasoning_context": payload,
+            }
+        else:
+            enriched["reasoning_context"] = payload
+        enriched["campaign_reasoning_context"] = payload
+        return enriched
+
+    async def _generate_one(
+        self,
+        prompt_template: str,
+        *,
+        opportunity: Mapping[str, Any],
+        target_mode: str,
+    ) -> dict[str, Any] | None:
+        opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
+        system_prompt = (
+            prompt_template
+            .replace("{target_mode}", target_mode)
+            .replace("{opportunity}", opportunity_json)
+            .replace("{opportunity_json}", opportunity_json)
+        )
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(
+                    role="user",
+                    content=(
+                        "Generate one structured report from this normalized "
+                        f"opportunity.\ntarget_mode={target_mode}\n"
+                        f"opportunity={opportunity_json}"
+                    ),
+                ),
+            ],
+            max_tokens=self._config.max_tokens,
+            temperature=self._config.temperature,
+            metadata={
+                "target_mode": target_mode,
+                "target_id": opportunity_target_id(opportunity),
+                "skill_name": self._config.skill_name,
+                "asset_type": "report",
+            },
+        )
+        parsed = parse_report_response(response.content)
+        if not parsed:
+            return None
+        return {
+            **parsed,
+            "_model": response.model,
+            "_usage": dict(response.usage or {}),
+        }
+
+    def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
+        from extracted_quality_gate.report_pack import evaluate_report
+        from extracted_quality_gate.types import QualityInput
+
+        report_input = QualityInput(
+            artifact_type="report",
+            context={
+                "title": parsed.get("title"),
+                "summary": parsed.get("summary"),
+                "sections": parsed.get("sections") or (),
+                "reference_ids": parsed.get("reference_ids") or (),
+                "metadata": {
+                    "confidence": parsed.get("confidence"),
+                },
+            },
+        )
+        quality = evaluate_report(report_input)
+        return {
+            "passed": quality.passed,
+            "blockers": tuple(f.message for f in quality.blockers),
+        }
+
+    def _build_draft(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        target_id: str,
+        target_mode: str,
+    ) -> ReportDraft:
+        sections = tuple(
+            ReportSection(
+                id=str(s.get("id") or "").strip(),
+                title=str(s.get("title") or "").strip(),
+                body_markdown=str(s.get("body_markdown") or "").strip(),
+                claim_ids=tuple(str(c) for c in (s.get("claim_ids") or ())),
+                evidence_ids=tuple(str(e) for e in (s.get("evidence_ids") or ())),
+                metadata=dict(s.get("metadata") or {}),
+            )
+            for s in parsed.get("sections") or ()
+            if isinstance(s, Mapping)
+        )
+        # Aggregate reference_ids: explicit list union per-section evidence ids.
+        ref_seen: list[str] = []
+        for value in parsed.get("reference_ids") or ():
+            v = str(value).strip()
+            if v and v not in ref_seen:
+                ref_seen.append(v)
+        for section in sections:
+            for evidence_id in section.evidence_ids:
+                v = str(evidence_id).strip()
+                if v and v not in ref_seen:
+                    ref_seen.append(v)
+        report_type = str(parsed.get("report_type") or self._config.default_report_type)
+        metadata: dict[str, Any] = {
+            "generation_model": parsed.get("_model"),
+            "generation_usage": parsed.get("_usage") or {},
+        }
+        if "confidence" in parsed:
+            metadata["confidence"] = parsed["confidence"]
+        return ReportDraft(
+            target_id=target_id,
+            target_mode=target_mode,
+            report_type=report_type,
+            title=str(parsed.get("title") or "").strip(),
+            summary=str(parsed.get("summary") or "").strip(),
+            sections=sections,
+            reference_ids=tuple(ref_seen),
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "ReportGenerationConfig",
+    "ReportGenerationResult",
+    "ReportGenerationService",
+    "parse_report_response",
+]

--- a/extracted_content_pipeline/skills/digest/report_generation.md
+++ b/extracted_content_pipeline/skills/digest/report_generation.md
@@ -1,0 +1,32 @@
+You generate one structured report from a single normalized opportunity row plus its reasoning context.
+
+The opportunity is JSON-encoded as `{opportunity_json}`. The reasoning context (when present) lives inside the opportunity under the `campaign_reasoning_context` and `reasoning_context` keys. If the reasoning context carries a `narrative_plan` block (top-level under `canonical_reasoning`), use its `sections` array as the section spine — write prose for each section rather than inventing a different structure. If no `narrative_plan` is present, structure the report yourself from the opportunity evidence.
+
+Output ONLY a single JSON object with this exact shape. No prose outside the JSON.
+
+```json
+{
+  "title": "Concise report title (8–12 words)",
+  "summary": "150–300 word executive summary of the report's findings",
+  "sections": [
+    {
+      "id": "snake_case_section_id",
+      "title": "Section Title",
+      "body_markdown": "Markdown body for this section",
+      "claim_ids": ["c1", "c2"],
+      "evidence_ids": ["r1", "t9"]
+    }
+  ],
+  "reference_ids": ["r1", "t9", "..."],
+  "report_type": "vendor_pressure"
+}
+```
+
+Field rules:
+- `title`: descriptive, includes the entity name; do NOT include date stamps unless the opportunity provides one.
+- `summary`: factual, evidence-grounded; no marketing language; reference specific findings rather than restating the opportunity.
+- `sections`: at least one. Each section needs a non-empty `title` and `body_markdown`. Cite supporting evidence in `evidence_ids` using the source ids that appear in the opportunity / reasoning context.
+- `reference_ids`: union of every `evidence_ids` value across sections, plus any opportunity-level source ids you cited. No duplicates.
+- `report_type`: one of `vendor_pressure`, `market_intel`, `customer_health`, `account_brief`, or another snake_case label that fits the opportunity's `target_mode`. Default to `vendor_pressure` when in doubt.
+
+When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent claim ids that aren't in the reasoning context.

--- a/extracted_quality_gate/report_pack.py
+++ b/extracted_quality_gate/report_pack.py
@@ -90,10 +90,22 @@ def _threshold_float(policy: QualityPolicy | None, key: str) -> float:
 
 
 def _blocked_phrases(policy: QualityPolicy | None) -> tuple[str, ...]:
+    """Read ``policy.metadata["blocked_phrasing"]`` defensively.
+
+    A bare string is auto-wrapped into a single-element tuple — a
+    plausible host typo (passing ``"guarantee"`` instead of
+    ``("guarantee",)``) shouldn't silently disable the gate. Any other
+    non-Sequence value returns ``()``.
+    """
     if policy is None:
         return ()
-    raw = policy.metadata.get("blocked_phrasing") or ()
-    if isinstance(raw, str) or not isinstance(raw, Sequence):
+    raw = policy.metadata.get("blocked_phrasing")
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        text = raw.strip()
+        return (text,) if text else ()
+    if not isinstance(raw, Sequence):
         return ()
     return tuple(str(item) for item in raw if str(item).strip())
 

--- a/extracted_quality_gate/report_pack.py
+++ b/extracted_quality_gate/report_pack.py
@@ -1,0 +1,300 @@
+"""Report quality pack: deterministic validators for structured reports.
+
+The Reports content asset (PR-Reports-1) ships an output shape with
+title, summary, ordered sections, and reference ids (see
+``extracted_content_pipeline.report_ports.ReportDraft``). This pack
+runs the deterministic checks that gate that output before persistence
+and human approval.
+
+Pure-function discipline matches the rest of the gate kernel: no DB,
+no clock, no LLM, no network. Sanitization (markdown cleanup, etc.)
+belongs in the wrapper, not here.
+
+Public API:
+
+    evaluate_report(
+        input: QualityInput,
+        *,
+        policy: QualityPolicy | None = None,
+    ) -> QualityReport
+
+The ``input`` carries the structured report payload through
+``input.context`` so the same ``QualityInput`` shape used by other
+packs works unchanged. Recognised ``input.context`` keys:
+
+  - ``title`` (str): report title
+  - ``summary`` (str): executive summary
+  - ``sections`` (Sequence[Mapping]): each section is
+    ``{"id", "title", "body_markdown", "claim_ids", "evidence_ids"}``
+  - ``reference_ids`` (Sequence[str]): cited source ids at the report
+    level
+  - ``metadata`` (Mapping): generation metadata; ``confidence`` may
+    appear here as a float in [0, 1]
+
+Recognised ``policy.thresholds`` keys (all optional, all have defaults):
+  - ``min_confidence`` (float): warn when ``metadata["confidence"]`` is
+    below this threshold; default 0.0 (no floor)
+  - ``min_sections`` (int): blocker when section count is below this;
+    default 1
+  - ``pass_score`` (int): default 70
+  - ``blocking_penalty`` (int): default 18 (per blocker)
+  - ``warning_penalty`` (int): default 6 (per warning)
+
+Recognised ``policy.metadata`` keys:
+  - ``blocked_phrasing`` (Sequence[str]): substrings (matched
+    case-insensitively at word boundaries) that disqualify the report
+    if they appear in the title, summary, or any section's body. Same
+    semantic as ``extracted_reasoning_core.api.validate_reasoning_output``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from .types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+_DEFAULT_THRESHOLDS: Mapping[str, Any] = {
+    "min_confidence": 0.0,
+    "min_sections": 1,
+    "pass_score": 70,
+    "blocking_penalty": 18,
+    "warning_penalty": 6,
+}
+
+
+def _threshold_int(policy: QualityPolicy | None, key: str) -> int:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return int(_DEFAULT_THRESHOLDS[key])
+
+
+def _threshold_float(policy: QualityPolicy | None, key: str) -> float:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return float(_DEFAULT_THRESHOLDS[key])
+
+
+def _blocked_phrases(policy: QualityPolicy | None) -> tuple[str, ...]:
+    if policy is None:
+        return ()
+    raw = policy.metadata.get("blocked_phrasing") or ()
+    if isinstance(raw, str) or not isinstance(raw, Sequence):
+        return ()
+    return tuple(str(item) for item in raw if str(item).strip())
+
+
+def evaluate_report(
+    input: QualityInput,
+    *,
+    policy: QualityPolicy | None = None,
+) -> QualityReport:
+    """Run the deterministic report-quality validators.
+
+    Returns a :class:`QualityReport` with ``decision`` set to
+    ``BLOCK`` when any blocker fires or score < pass_score,
+    ``WARN`` when warnings fire but no blockers, otherwise ``PASS``.
+    """
+
+    context = dict(input.context or {})
+    title = str(context.get("title") or "").strip()
+    summary = str(context.get("summary") or "").strip()
+    sections_raw = context.get("sections") or ()
+    sections: list[Mapping[str, Any]] = [
+        section for section in sections_raw if isinstance(section, Mapping)
+    ]
+    reference_ids: tuple[str, ...] = tuple(
+        str(item).strip()
+        for item in (context.get("reference_ids") or ())
+        if str(item).strip()
+    )
+    metadata: Mapping[str, Any] = (
+        context.get("metadata") if isinstance(context.get("metadata"), Mapping) else {}
+    )
+
+    findings: list[GateFinding] = []
+
+    # ---- Title ----
+    if not title:
+        findings.append(
+            GateFinding(
+                code="no_title",
+                message="no_title",
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+
+    # ---- Summary ----
+    if not summary:
+        findings.append(
+            GateFinding(
+                code="no_summary",
+                message="no_summary",
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+
+    # ---- Sections ----
+    min_sections = _threshold_int(policy, "min_sections")
+    if len(sections) < min_sections:
+        findings.append(
+            GateFinding(
+                code="no_sections",
+                message=f"no_sections:{len(sections)}_below_min_{min_sections}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"section_count": len(sections), "min_sections": min_sections},
+            )
+        )
+
+    section_evidence_present = False
+    for index, section in enumerate(sections):
+        section_title = str(section.get("title") or "").strip()
+        if not section_title:
+            findings.append(
+                GateFinding(
+                    code="section_missing_title",
+                    message=f"section_missing_title:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        section_body = str(section.get("body_markdown") or "").strip()
+        if not section_body:
+            findings.append(
+                GateFinding(
+                    code="section_missing_body",
+                    message=f"section_missing_body:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        evidence_ids = section.get("evidence_ids") or ()
+        if isinstance(evidence_ids, Sequence) and not isinstance(evidence_ids, (str, bytes)):
+            if any(str(item).strip() for item in evidence_ids):
+                section_evidence_present = True
+
+    # ---- References ----
+    if not reference_ids and not section_evidence_present:
+        findings.append(
+            GateFinding(
+                code="no_references",
+                message="no_references",
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+
+    # ---- Confidence floor ----
+    min_confidence = _threshold_float(policy, "min_confidence")
+    raw_confidence = metadata.get("confidence")
+    confidence: float | None = None
+    if isinstance(raw_confidence, (int, float)) and not isinstance(raw_confidence, bool):
+        confidence = max(0.0, min(1.0, float(raw_confidence)))
+    if min_confidence > 0.0:
+        if confidence is None:
+            findings.append(
+                GateFinding(
+                    code="missing_confidence",
+                    message="missing_confidence",
+                    severity=GateSeverity.WARNING,
+                )
+            )
+        elif confidence < min_confidence:
+            findings.append(
+                GateFinding(
+                    code="confidence_below_min",
+                    message=f"confidence_below_min:{confidence:.2f}<{min_confidence:.2f}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"confidence": confidence, "min_confidence": min_confidence},
+                )
+            )
+
+    # ---- Blocked phrasing (case-insensitive word-boundary, mirrors
+    # ---- extracted_reasoning_core.api.validate_reasoning_output) ----
+    phrases = _blocked_phrases(policy)
+    if phrases:
+        haystack_parts: list[str] = []
+        if title:
+            haystack_parts.append(title)
+        if summary:
+            haystack_parts.append(summary)
+        for section in sections:
+            for key in ("title", "body_markdown"):
+                value = section.get(key)
+                if isinstance(value, str) and value.strip():
+                    haystack_parts.append(value)
+        haystack = "\n".join(haystack_parts)
+        for phrase in phrases:
+            phrase_str = str(phrase).strip()
+            if not phrase_str:
+                continue
+            pattern = re.compile(rf"\b{re.escape(phrase_str)}\b", re.IGNORECASE)
+            if pattern.search(haystack):
+                findings.append(
+                    GateFinding(
+                        code="blocked_phrasing",
+                        message=f"blocked_phrasing:{phrase}",
+                        severity=GateSeverity.BLOCKER,
+                        metadata={"phrase": phrase_str},
+                    )
+                )
+
+    return _build_report(findings=findings, sections=sections, policy=policy)
+
+
+def _build_report(
+    *,
+    findings: list[GateFinding],
+    sections: list[Mapping[str, Any]],
+    policy: QualityPolicy | None,
+) -> QualityReport:
+    blockers = [f for f in findings if f.severity == GateSeverity.BLOCKER]
+    warnings = [f for f in findings if f.severity == GateSeverity.WARNING]
+    blocking_penalty = _threshold_int(policy, "blocking_penalty")
+    warning_penalty = _threshold_int(policy, "warning_penalty")
+    pass_score = _threshold_int(policy, "pass_score")
+    score = max(
+        0,
+        100 - (blocking_penalty * len(blockers)) - (warning_penalty * len(warnings)),
+    )
+    passed = (not blockers) and score >= pass_score
+    if blockers or score < pass_score:
+        decision = GateDecision.BLOCK
+    elif warnings:
+        decision = GateDecision.WARN
+    else:
+        decision = GateDecision.PASS
+    metadata = {
+        "score": score,
+        "threshold": pass_score,
+        "status": "pass" if passed else "fail",
+        "blocking_issues": tuple(f.message for f in blockers),
+        "blocking_codes": tuple(f.code for f in blockers),
+        "warnings": tuple(f.message for f in warnings),
+        "warning_codes": tuple(f.code for f in warnings),
+        "section_count": len(sections),
+    }
+    return QualityReport(
+        passed=passed,
+        decision=decision,
+        findings=tuple(findings),
+        metadata=metadata,
+    )
+
+
+__all__ = [
+    "evaluate_report",
+]

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -25,6 +25,8 @@ pytest \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_extracted_report_postgres.py \
+  tests/test_extracted_report_generation.py \
+  tests/test_extracted_quality_gate_report_pack.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_quality_gate_report_pack.py
+++ b/tests/test_extracted_quality_gate_report_pack.py
@@ -138,6 +138,19 @@ def test_evaluate_report_min_confidence_warns_when_missing() -> None:
     assert "missing_confidence" in warning_codes
 
 
+def test_evaluate_report_blocked_phrasing_auto_wraps_bare_string_policy() -> None:
+    """A host passing blocked_phrasing as a bare string (not a sequence) auto-wraps; no silent no-op."""
+    sections = (_section(body="We GUARANTEE results within 30 days."),)
+    # Bare string instead of tuple/list — historical mistake, should still gate.
+    policy = QualityPolicy(
+        name="report_policy",
+        metadata={"blocked_phrasing": "guarantee"},
+    )
+    report = evaluate_report(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
 def test_evaluate_report_metadata_carries_score_and_threshold() -> None:
     report = evaluate_report(_input())
     assert "score" in report.metadata

--- a/tests/test_extracted_quality_gate_report_pack.py
+++ b/tests/test_extracted_quality_gate_report_pack.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from extracted_quality_gate.report_pack import evaluate_report
+from extracted_quality_gate.types import (
+    GateDecision,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+)
+
+
+def _section(*, title: str = "Findings", body: str = "Renewal pricing dominates.", evidence_ids: tuple[str, ...] = ("r1",)) -> dict:
+    return {
+        "id": "findings",
+        "title": title,
+        "body_markdown": body,
+        "claim_ids": ("c1",),
+        "evidence_ids": evidence_ids,
+    }
+
+
+def _input(**overrides) -> QualityInput:
+    context = {
+        "title": "Acme: Q3 Pressure Report",
+        "summary": "Pricing renewal pressure dominates the displacement signal.",
+        "sections": (_section(),),
+        "reference_ids": ("r1", "r2"),
+        "metadata": {"confidence": 0.84},
+    }
+    context.update(overrides)
+    return QualityInput(artifact_type="report", context=context)
+
+
+def test_evaluate_report_happy_path_passes() -> None:
+    report = evaluate_report(_input())
+    assert report.passed is True
+    assert report.decision == GateDecision.PASS
+    assert report.blockers == ()
+    assert report.metadata["section_count"] == 1
+
+
+def test_evaluate_report_no_title_blocks() -> None:
+    report = evaluate_report(_input(title=""))
+    assert report.passed is False
+    assert report.decision == GateDecision.BLOCK
+    codes = {f.code for f in report.blockers}
+    assert "no_title" in codes
+
+
+def test_evaluate_report_no_summary_blocks() -> None:
+    report = evaluate_report(_input(summary=""))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_summary" in codes
+
+
+def test_evaluate_report_no_sections_blocks() -> None:
+    report = evaluate_report(_input(sections=()))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_sections" in codes
+
+
+def test_evaluate_report_section_missing_body_blocks_per_section() -> None:
+    sections = (
+        _section(),
+        _section(title="Drivers", body=""),  # broken
+    )
+    report = evaluate_report(_input(sections=sections))
+    assert report.passed is False
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "section_missing_body:1" in blocker_msgs
+    assert "section_missing_body:0" not in blocker_msgs
+
+
+def test_evaluate_report_section_missing_title_blocks_per_section() -> None:
+    sections = (_section(title=""),)
+    report = evaluate_report(_input(sections=sections))
+    assert report.passed is False
+    assert any(f.code == "section_missing_title" for f in report.blockers)
+
+
+def test_evaluate_report_no_references_blocks_when_neither_top_level_nor_section_evidence() -> None:
+    sections = (_section(evidence_ids=()),)
+    report = evaluate_report(_input(sections=sections, reference_ids=()))
+    assert report.passed is False
+    assert any(f.code == "no_references" for f in report.blockers)
+
+
+def test_evaluate_report_no_references_passes_when_section_evidence_present() -> None:
+    """If a section carries evidence_ids, top-level reference_ids may be empty."""
+    sections = (_section(evidence_ids=("r1",)),)
+    report = evaluate_report(_input(sections=sections, reference_ids=()))
+    codes = {f.code for f in report.blockers}
+    assert "no_references" not in codes
+
+
+def test_evaluate_report_blocked_phrasing_uses_word_boundaries_not_substrings() -> None:
+    """Mirrors validate_reasoning_output regression: 'promise' must not match 'compromise'."""
+    sections = (_section(body="We cannot compromise on quality."),)
+    policy = QualityPolicy(
+        name="report_policy",
+        metadata={"blocked_phrasing": ("promise",)},
+    )
+    report = evaluate_report(_input(sections=sections), policy=policy)
+    blocker_codes = {f.code for f in report.blockers}
+    assert "blocked_phrasing" not in blocker_codes
+
+
+def test_evaluate_report_blocked_phrasing_blocks_with_word_boundary_match() -> None:
+    sections = (_section(body="We GUARANTEE results within 30 days."),)
+    policy = QualityPolicy(
+        name="report_policy",
+        metadata={"blocked_phrasing": ("guarantee",)},
+    )
+    report = evaluate_report(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_report_min_confidence_warns_when_below_threshold() -> None:
+    policy = QualityPolicy(
+        name="report_policy",
+        thresholds={"min_confidence": 0.7},
+    )
+    report = evaluate_report(_input(metadata={"confidence": 0.5}), policy=policy)
+    warning_codes = {f.code for f in report.warnings}
+    assert "confidence_below_min" in warning_codes
+
+
+def test_evaluate_report_min_confidence_warns_when_missing() -> None:
+    policy = QualityPolicy(
+        name="report_policy",
+        thresholds={"min_confidence": 0.7},
+    )
+    report = evaluate_report(_input(metadata={}), policy=policy)
+    warning_codes = {f.code for f in report.warnings}
+    assert "missing_confidence" in warning_codes
+
+
+def test_evaluate_report_metadata_carries_score_and_threshold() -> None:
+    report = evaluate_report(_input())
+    assert "score" in report.metadata
+    assert "threshold" in report.metadata
+    assert report.metadata["status"] == "pass"

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
+from extracted_content_pipeline.report_generation import (
+    ReportGenerationConfig,
+    ReportGenerationService,
+    parse_report_response,
+)
+from extracted_content_pipeline.report_ports import ReportDraft
+
+
+# -----------------------
+# Fake ports (mirror tests/test_extracted_campaign_generation.py:24-120)
+# -----------------------
+
+
+class _Intelligence:
+    def __init__(self, opportunities):
+        self.opportunities = opportunities
+        self.calls = []
+
+    async def read_campaign_opportunities(self, *, scope, target_mode, limit, filters=None):
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": filters,
+        })
+        return self.opportunities
+
+    async def read_vendor_targets(self, *, scope, target_mode, vendor_name=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _Reports:
+    def __init__(self):
+        self.saved = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": list(drafts), "scope": scope})
+        return [f"report-{index + 1}" for index, _ in enumerate(drafts)]
+
+    async def list_drafts(self, *, scope, status=None, target_mode=None, report_type=None, limit=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def update_status(self, report_id, status, *, scope):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _LLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return LLMResponse(
+            content=response,
+            model="test-model",
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+
+class _Skills:
+    def __init__(self, prompts):
+        self.prompts = prompts
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompts.get(name)
+
+
+class _ReasoningProvider:
+    def __init__(self, context):
+        self.context = context
+        self.calls = []
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        self.calls.append({
+            "scope": scope,
+            "target_id": target_id,
+            "target_mode": target_mode,
+        })
+        return self.context
+
+
+def _opportunity():
+    return {
+        "id": "opp-1",
+        "target_id": "vendor-acme",
+        "vendor_name": "Acme",
+        "company_name": "Acme",
+        "evidence": [{"quote": "Renewal pricing is too high"}],
+    }
+
+
+def _valid_report_json(*, title="Acme: Q3 Pressure Report", section_id="findings"):
+    return json.dumps({
+        "title": title,
+        "summary": "Pricing renewal pressure dominates the displacement signal across review cohorts.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": section_id,
+                "title": "Findings",
+                "body_markdown": "Renewal pricing leads displacement.",
+                "claim_ids": ["c1"],
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+
+
+def _service(*, opportunities=None, responses=None, prompts=None, reasoning_context=None, config=None):
+    intelligence = _Intelligence(opportunities or [_opportunity()])
+    reports = _Reports()
+    llm = _LLM(responses or [_valid_report_json()])
+    if prompts is None:
+        prompts = {"digest/report_generation": "TEMPLATE for {target_mode}: {opportunity_json}"}
+    skills = _Skills(prompts)
+    reasoning_provider = (
+        _ReasoningProvider(reasoning_context) if reasoning_context is not None else None
+    )
+    service = ReportGenerationService(
+        intelligence=intelligence,
+        reports=reports,
+        llm=llm,
+        skills=skills,
+        reasoning_context=reasoning_provider,
+        config=config or ReportGenerationConfig(),
+    )
+    return service, intelligence, reports, llm, skills, reasoning_provider
+
+
+# -----------------------
+# parse_report_response unit
+# -----------------------
+
+
+def test_parse_report_response_strips_code_fences_and_extracts_first_object() -> None:
+    text = (
+        "```json\n"
+        + _valid_report_json()
+        + "\n```"
+    )
+    parsed = parse_report_response(text)
+    assert parsed is not None
+    assert parsed["title"] == "Acme: Q3 Pressure Report"
+    assert parsed["sections"][0]["id"] == "findings"
+
+
+def test_parse_report_response_returns_none_when_required_fields_missing() -> None:
+    assert parse_report_response("") is None
+    assert parse_report_response('{"title": "no sections"}') is None
+    assert (
+        parse_report_response('{"title": "t", "summary": "s", "sections": []}')
+        is None
+    )
+
+
+# -----------------------
+# Service: generation
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_one_report_per_opportunity_via_save_drafts() -> None:
+    service, _intel, reports, llm, skills, _rp = _service()
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert result.requested == 1
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.saved_ids == ("report-1",)
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["metadata"]["asset_type"] == "report"
+    saved_drafts = reports.saved[0]["drafts"]
+    assert len(saved_drafts) == 1
+    draft = saved_drafts[0]
+    assert isinstance(draft, ReportDraft)
+    assert draft.target_id == "vendor-acme"
+    assert draft.target_mode == "vendor"
+    assert draft.report_type == "vendor_pressure"
+    assert draft.title == "Acme: Q3 Pressure Report"
+    assert draft.sections[0].id == "findings"
+    assert draft.reference_ids == ("r1",)
+    assert draft.metadata["generation_model"] == "test-model"
+    assert "digest/report_generation" in skills.calls
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_unparseable_response_and_records_error() -> None:
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=["not json garbage"],
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert result.requested == 1
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert reports.saved == []
+    assert any(
+        err.get("reason") == "unparseable_response" for err in result.errors
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_quality_pack_blocks() -> None:
+    """A response missing references AND missing per-section evidence_ids gets blocked."""
+
+    bad_response = json.dumps({
+        "title": "ok",
+        "summary": "non-empty summary",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "Title",
+                "body_markdown": "Body",
+                "claim_ids": [],
+                "evidence_ids": [],
+            }
+        ],
+        "reference_ids": [],
+    })
+    service, _intel, reports, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert reports.saved == []
+    assert any(
+        err.get("reason") == "quality_blocked" for err in result.errors
+    )
+    blockers = result.errors[0]["blockers"]
+    assert any("no_references" in b for b in blockers)
+
+
+@pytest.mark.asyncio
+async def test_generate_consumes_reasoning_context_via_provider() -> None:
+    """When a CampaignReasoningContextProvider is supplied, its context is fetched per opportunity."""
+
+    context = CampaignReasoningContext(
+        top_theses=({"claim": "Renewal pricing", "confidence": 0.9, "source_ids": ["r1"]},),
+        canonical_reasoning={"summary": "narrative summary"},
+    )
+    service, _intel, _reports, _llm, _skills, reasoning_provider = _service(
+        reasoning_context=context,
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert reasoning_provider is not None
+    assert len(reasoning_provider.calls) == 1
+    assert reasoning_provider.calls[0]["target_id"] == "vendor-acme"
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_opportunity_with_missing_target_id() -> None:
+    bad_opportunity = {"id": None, "target_id": None, "vendor_name": ""}
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        opportunities=[bad_opportunity],
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert result.skipped == 1
+    assert reports.saved == []
+    assert any(err.get("reason") == "missing_target_id" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_raises_value_error_when_skill_prompt_missing() -> None:
+    service, _intel, _reports, _llm, _skills, _rp = _service(
+        prompts={},  # skill not registered
+    )
+
+    with pytest.raises(ValueError, match="Report generation skill not found"):
+        await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+
+@pytest.mark.asyncio
+async def test_generate_aggregates_section_evidence_ids_into_reference_ids() -> None:
+    response = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "Section 1",
+                "body_markdown": "body",
+                "evidence_ids": ["r1", "r2"],
+            },
+            {
+                "id": "s2",
+                "title": "Section 2",
+                "body_markdown": "body",
+                "evidence_ids": ["r2", "r3"],
+            },
+        ],
+        "reference_ids": ["r0"],
+    })
+    service, _intel, reports, _llm, _skills, _rp = _service(responses=[response])
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    draft = reports.saved[0]["drafts"][0]
+    # Top-level reference_ids preserved + section evidence ids unioned without dupes.
+    assert draft.reference_ids == ("r0", "r1", "r2", "r3")

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -183,6 +183,54 @@ def test_parse_report_response_returns_none_when_required_fields_missing() -> No
     )
 
 
+def test_parse_report_response_handles_braces_inside_string_values() -> None:
+    """body_markdown with template syntax / set notation must not break the parser."""
+
+    payload = json.dumps({
+        "title": "Title",
+        "summary": "Summary text long enough to be valid.",
+        "report_type": "vendor_pressure",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "Templates",
+                "body_markdown": "Pricing tiers: {basic, pro} models. Use {project_id} placeholders.",
+                "evidence_ids": ["r1"],
+            }
+        ],
+        "reference_ids": ["r1"],
+    })
+    parsed = parse_report_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Title"
+    assert "{basic, pro}" in parsed["sections"][0]["body_markdown"]
+
+
+def test_parse_report_response_strips_think_blocks_before_decoding() -> None:
+    """Reasoner output may include <think>...</think> scratchpad ahead of the JSON."""
+
+    payload = (
+        "<think>Considering the opportunity... draft sections for vendor.</think>\n"
+        + json.dumps({
+            "title": "Title",
+            "summary": "Summary text long enough to be valid.",
+            "report_type": "vendor_pressure",
+            "sections": [
+                {
+                    "id": "s1",
+                    "title": "Body",
+                    "body_markdown": "body",
+                    "evidence_ids": ["r1"],
+                }
+            ],
+            "reference_ids": ["r1"],
+        })
+    )
+    parsed = parse_report_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Title"
+
+
 # -----------------------
 # Service: generation
 # -----------------------
@@ -305,6 +353,27 @@ async def test_generate_raises_value_error_when_skill_prompt_missing() -> None:
 
     with pytest.raises(ValueError, match="Report generation skill not found"):
         await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+
+@pytest.mark.asyncio
+async def test_generate_substitutes_template_placeholders_in_system_prompt_only() -> None:
+    """Opportunity JSON appears in the system prompt (via {opportunity_json}) but NOT duplicated in the user message."""
+
+    service, _intel, _reports, llm, _skills, _rp = _service(
+        prompts={"digest/report_generation": "MODE={target_mode} OPP={opportunity_json}"},
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    messages = llm.calls[0]["messages"]
+    system_msg = messages[0].content
+    user_msg = messages[1].content
+    # Opportunity JSON must appear in the system prompt (via the substituted placeholder)
+    assert '"target_id":"vendor-acme"' in system_msg
+    assert "MODE=vendor" in system_msg
+    # And NOT appear in the user message (no duplication)
+    assert '"target_id":"vendor-acme"' not in user_msg
+    assert "vendor-acme" not in user_msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Second slice of Reports content-asset support for AI Content Ops. PR-Reports-1a (#348) landed the storage layer (`ReportDraft` + `reports` table); this PR wires the **generator** on top so opportunity rows actually produce structured report drafts.

After this lands, **AI Content Ops ships 3 of 5 landing-page content types** (blogs, emails, reports). Sales briefs, landing pages, and signal extraction remain on the gap list.

## What changed

- **`extracted_quality_gate/report_pack.py` (new)** — pure deterministic validator (no LLM, no DB, no clock) for the report shape. Each policy field maps to a specific blocker class:

| Policy / shape | Blocker emitted |
|---|---|
| empty title | `no_title` |
| empty summary | `no_summary` |
| section count below `min_sections` | `no_sections` |
| section with empty title | `section_missing_title:<i>` |
| section with empty body_markdown | `section_missing_body:<i>` |
| no top-level `reference_ids` AND no per-section `evidence_ids` | `no_references` |
| `policy.metadata.blocked_phrasing` word-boundary match in title/summary/sections | `blocked_phrasing:<phrase>` |
| `policy.thresholds.min_confidence` not met (or missing) | `confidence_below_min` / `missing_confidence` (warnings) |

`blocked_phrasing` uses case-insensitive word-boundary regex (mirrors `validate_reasoning_output`): `"promise"` does NOT block `"compromise"`.

- **`extracted_content_pipeline/skills/digest/report_generation.md` (new)** — packaged prompt that asks the LLM for one JSON object with `title` / `summary` / `sections[]` / `reference_ids` / `report_type`. Calls out the narrative-plan synergy: when reasoning context exposes `canonical_reasoning.narrative_plan`, the prompt hands those pre-structured sections to the LLM as the section spine.

- **`extracted_content_pipeline/report_generation.py` (new)** — `ReportGenerationService`. Constructor mirrors `CampaignGenerationService` (`intelligence`, `reports`, `llm`, `skills`, optional `reasoning_context`, `config`). Per-opportunity flow:
  1. `read_campaign_opportunities` → normalize
  2. Attach reasoning context (existing `CampaignReasoningContextProvider` port, reused unchanged)
  3. One LLM call per opportunity with the `digest/report_generation` skill
  4. `parse_report_response` (mirrors `parse_campaign_draft_response`; strips `<think>` blocks + code fences)
  5. `evaluate_report` quality pack as gate
  6. Translate parsed JSON → `ReportDraft` (section `evidence_ids` union'd into `reference_ids` so the renderer always has the complete list)
  7. `ReportRepository.save_drafts` to persist

- **`tests/test_extracted_quality_gate_report_pack.py` (new, 13 tests)** — every blocker class, `blocked_phrasing` word-boundary regression, confidence policy, metadata shape.

- **`tests/test_extracted_report_generation.py` (new, 9 tests)** — `parse_report_response` unit tests + service integration with fake ports (happy path, unparseable response, quality rejection, reasoning-context invocation, missing target_id, missing skill prompt, reference_ids union).

- **`scripts/run_extracted_pipeline_checks.sh`** — wires both new test files into the runner.

## Reasoning-aware shortcut

The new `ReportSection` shape from PR-Reports-1a is intentionally compatible with `extracted_reasoning_core.types.NarrativePlan.sections`. When a host configures the multi-pass reasoning bridge with a `narrative_plan_pack`, the resulting `canonical_reasoning["narrative_plan"]` flows through the existing `campaign_reasoning_context_payload` helper unchanged, into the opportunity dict, and into the LLM prompt. No reshaping needed — the generator gets a free pre-structured plan.

## Test plan

- [x] `python -c "from extracted_content_pipeline.report_generation import ReportGenerationService; from extracted_quality_gate.report_pack import evaluate_report"` → clean import
- [x] AST scan of new files for `atlas_brain` refs → 0 hits
- [x] `bash scripts/validate_extracted_content_pipeline.sh` → passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed
- [x] `pytest tests/test_extracted_report_generation.py tests/test_extracted_quality_gate_report_pack.py tests/test_extracted_report_postgres.py` → 29/29 passing locally
- [ ] CI `extracted-checks` run

## Out of scope (deferred)

- **Approval API endpoint** for reports (parallel to `api/b2b_campaigns.py` review router) → PR-Reports-2
- **CLI flag** `--report-generation` wiring → PR-Reports-3
- **Aggregate reports** (one report covering many opportunities) → separate slice
- **Sales briefs / landing pages** generators → separate slices (gap items #2 and #3 in the corrected build queue)
- **Signal extraction** → biggest landing-page risk; explicitly out of scope

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_