### PR TITLE
PR-LandingPage-1a: Add Landing Pages storage layer (LandingPageDraft + landing_pages table + repository)

### DIFF
--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -1,0 +1,166 @@
+"""Standalone ports for the AI Content Ops Landing Pages product.
+
+Landing pages are the fourth content asset type in the AI Content Ops
+surface (parallel to email campaigns, blog posts, and structured
+reports). Where ``CampaignDraft`` is shaped for short-form
+transactional output and ``ReportDraft`` is shaped for structured
+vendor-pressure reports, a ``LandingPageDraft`` carries a
+marketing-shaped payload: hero block, ordered body sections, CTA,
+SEO meta, and the marketing-campaign context (name / persona /
+value_prop) the page was generated for.
+
+Trigger shape is per-campaign (not per-opportunity): hosts pass a
+:class:`MarketingCampaign` describing the campaign to generate against,
+not an opportunity row. This is the primary structural difference
+between landing pages and the other content assets.
+
+Storage lives in the ``landing_pages`` table (migration 274) with the
+same status-lifecycle semantics as ``b2b_campaigns`` and ``reports``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class MarketingCampaign:
+    """The host-provided marketing-campaign input for landing-page generation.
+
+    A ``MarketingCampaign`` is the per-call input shape for the
+    landing-page generator. Hosts identify the campaign by ``name``;
+    the generator uses ``persona`` and ``value_prop`` plus optional
+    ``vendors`` / ``categories`` / ``tags`` to anchor the page.
+
+    ``context`` is a free-form bag for host-specific extras (analytics
+    tags, A/B variant labels, etc.) that the generator passes through
+    to the LLM payload but does not interpret.
+    """
+
+    name: str
+    persona: str = ""
+    value_prop: str = ""
+    vendors: Sequence[str] = field(default_factory=tuple)
+    categories: Sequence[str] = field(default_factory=tuple)
+    tags: Sequence[str] = field(default_factory=tuple)
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "name": self.name,
+            "persona": self.persona,
+            "value_prop": self.value_prop,
+            "vendors": list(self.vendors),
+            "categories": list(self.categories),
+            "tags": list(self.tags),
+            "context": dict(self.context),
+        }
+
+
+@dataclass(frozen=True)
+class LandingPageSection:
+    """A single ordered body section within a landing page."""
+
+    id: str
+    title: str
+    body_markdown: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "body_markdown": self.body_markdown,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class LandingPageDraft:
+    """A generated, not-yet-approved marketing landing-page draft.
+
+    Persists into the ``landing_pages`` table via
+    ``LandingPageRepository.save_drafts``.
+
+    ``hero``, ``cta``, and ``meta`` are flexible mappings (rather than
+    typed sub-dataclasses) so hosts and renderers can extend them with
+    product-specific fields (analytics tags, secondary CTAs, etc.)
+    without a schema change. Common keys:
+
+      * ``hero``: ``headline``, ``subheadline``, ``cta_label``,
+        ``cta_url``, ``image_url``
+      * ``cta``: ``label``, ``url``, ``variant``,
+        ``secondary_label``, ``secondary_url``
+      * ``meta``: ``title_tag``, ``description``, ``og_image_url``,
+        ``og_title``, ``canonical_url``
+    """
+
+    campaign_name: str
+    persona: str
+    value_prop: str
+    title: str
+    slug: str
+    hero: Mapping[str, Any] = field(default_factory=dict)
+    sections: Sequence[LandingPageSection] = field(default_factory=tuple)
+    cta: Mapping[str, Any] = field(default_factory=dict)
+    meta: Mapping[str, Any] = field(default_factory=dict)
+    reference_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "campaign_name": self.campaign_name,
+            "persona": self.persona,
+            "value_prop": self.value_prop,
+            "title": self.title,
+            "slug": self.slug,
+            "hero": dict(self.hero),
+            "sections": [section.as_dict() for section in self.sections],
+            "cta": dict(self.cta),
+            "meta": dict(self.meta),
+            "reference_ids": list(self.reference_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+class LandingPageRepository(Protocol):
+    """Persistence contract for generated landing-page drafts."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[LandingPageDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return the assigned landing-page ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        campaign_name: str | None = None,
+        slug: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[LandingPageDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        landing_page_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        """Update a draft's status (draft / queued / approved / rejected / expired)."""
+
+
+__all__ = [
+    "LandingPageDraft",
+    "LandingPageRepository",
+    "LandingPageSection",
+    "MarketingCampaign",
+]

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -62,7 +62,16 @@ class MarketingCampaign:
 
 @dataclass(frozen=True)
 class LandingPageSection:
-    """A single ordered body section within a landing page."""
+    """A single ordered body section within a landing page.
+
+    Note (deliberate divergence from ``ReportSection``): landing-page
+    sections do NOT carry ``claim_ids`` or ``evidence_ids``. Marketing
+    copy is rendered as flat prose with optional social-proof blocks;
+    per-section claim attribution is a report-level concern. Hosts that
+    want to surface citations can use the draft-level
+    ``LandingPageDraft.reference_ids`` instead. The flexible
+    ``metadata`` bag absorbs any per-section host-specific fields.
+    """
 
     id: str
     title: str
@@ -154,8 +163,16 @@ class LandingPageRepository(Protocol):
         status: str,
         *,
         scope: TenantScope,
-    ) -> None:
-        """Update a draft's status (draft / queued / approved / rejected / expired)."""
+    ) -> bool:
+        """Update a draft's status (draft / queued / approved / rejected / expired).
+
+        Returns ``True`` when exactly one row is updated, ``False`` when
+        no row matches (missing id or wrong tenant scope). This explicit
+        hit/miss return is deliberately stricter than the silent-no-op
+        pattern in ``CampaignRepository`` / ``ReportRepository`` -- a
+        landing page approval flow that targets the wrong id should
+        learn about it at the call site, not silently succeed.
+        """
 
 
 __all__ = [

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -1,0 +1,214 @@
+"""Postgres repository adapter for the AI Content Ops Landing Pages product.
+
+Mirrors the shape of ``PostgresReportRepository`` (see
+``report_postgres.py``) but persists ``LandingPageDraft`` rows into the
+``landing_pages`` table from migration 274. Hosts inject an
+asyncpg-style pool; the adapter does no connection management itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .landing_page_ports import (
+    LandingPageDraft,
+    LandingPageSection,
+)
+
+
+def _jsonb(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
+
+
+def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
+    if isinstance(row, Mapping):
+        return dict(row)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _draft_metadata(draft: LandingPageDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "campaign_name": draft.campaign_name,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _coerce_section(value: Any) -> LandingPageSection:
+    if isinstance(value, LandingPageSection):
+        return value
+    if isinstance(value, Mapping):
+        return LandingPageSection(
+            id=str(value.get("id") or ""),
+            title=str(value.get("title") or ""),
+            body_markdown=str(value.get("body_markdown") or ""),
+            metadata=dict(value.get("metadata") or {}),
+        )
+    return LandingPageSection(id="", title="", body_markdown=str(value or ""))
+
+
+def _decode_jsonb(raw: Any, *, default: Any) -> Any:
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return default
+    if raw is None:
+        return default
+    return raw
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> LandingPageDraft:
+    sections_raw = _decode_jsonb(row.get("sections"), default=[])
+    if not isinstance(sections_raw, Sequence) or isinstance(sections_raw, (str, bytes)):
+        sections_raw = []
+
+    reference_ids_raw = _decode_jsonb(row.get("reference_ids"), default=[])
+    if not isinstance(reference_ids_raw, Sequence) or isinstance(reference_ids_raw, (str, bytes)):
+        reference_ids_raw = []
+
+    hero_raw = _decode_jsonb(row.get("hero"), default={})
+    if not isinstance(hero_raw, Mapping):
+        hero_raw = {}
+
+    cta_raw = _decode_jsonb(row.get("cta"), default={})
+    if not isinstance(cta_raw, Mapping):
+        cta_raw = {}
+
+    meta_raw = _decode_jsonb(row.get("meta"), default={})
+    if not isinstance(meta_raw, Mapping):
+        meta_raw = {}
+
+    metadata_raw = _decode_jsonb(row.get("metadata"), default={})
+    if not isinstance(metadata_raw, Mapping):
+        metadata_raw = {}
+
+    return LandingPageDraft(
+        campaign_name=str(row.get("campaign_name") or ""),
+        persona=str(row.get("persona") or ""),
+        value_prop=str(row.get("value_prop") or ""),
+        title=str(row.get("title") or ""),
+        slug=str(row.get("slug") or ""),
+        hero=dict(hero_raw),
+        sections=tuple(_coerce_section(s) for s in sections_raw),
+        cta=dict(cta_raw),
+        meta=dict(meta_raw),
+        reference_ids=tuple(str(r) for r in reference_ids_raw),
+        metadata=dict(metadata_raw),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresLandingPageRepository:
+    """Async Postgres adapter for generated landing pages."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[LandingPageDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            sections_payload = [_coerce_section(s).as_dict() for s in draft.sections]
+            reference_ids_payload = [str(r) for r in draft.reference_ids]
+            metadata_payload = _draft_metadata(draft, scope)
+            page_id = await self.pool.fetchval(
+                """
+                INSERT INTO landing_pages (
+                    account_id, campaign_name, persona, value_prop,
+                    title, slug,
+                    hero, sections, cta, meta, reference_ids, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4,
+                    $5, $6,
+                    $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb,
+                    $11::jsonb, $12::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.campaign_name,
+                draft.persona,
+                draft.value_prop,
+                draft.title,
+                draft.slug,
+                _jsonb(dict(draft.hero or {})),
+                _jsonb(sections_payload),
+                _jsonb(dict(draft.cta or {})),
+                _jsonb(dict(draft.meta or {})),
+                _jsonb(reference_ids_payload),
+                _jsonb(metadata_payload),
+            )
+            saved.append(str(page_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        campaign_name: str | None = None,
+        slug: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[LandingPageDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if campaign_name is not None:
+            params.append(campaign_name)
+            clauses.append(f"campaign_name = ${len(params)}")
+        if slug is not None:
+            params.append(slug)
+            clauses.append(f"slug = ${len(params)}")
+        sql = (
+            "SELECT campaign_name, persona, value_prop, title, slug, "
+            "hero, sections, cta, meta, reference_ids, metadata "
+            "FROM landing_pages WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(_row_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        landing_page_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE landing_pages
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            landing_page_id,
+            status,
+            scope.account_id or "",
+        )
+
+
+__all__ = [
+    "PostgresLandingPageRepository",
+]

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -44,6 +44,14 @@ def _draft_metadata(draft: LandingPageDraft, scope: TenantScope) -> JsonDict:
 
 
 def _coerce_section(value: Any) -> LandingPageSection:
+    """Coerce a host-supplied section into ``LandingPageSection``.
+
+    Accepts an existing ``LandingPageSection`` or a Mapping with the
+    expected keys. Anything else (str, int, list, None, ...) raises
+    ``TypeError`` so host-side bugs surface at the persistence
+    boundary rather than getting silently coerced into an empty
+    section that the quality pack later rejects.
+    """
     if isinstance(value, LandingPageSection):
         return value
     if isinstance(value, Mapping):
@@ -53,7 +61,10 @@ def _coerce_section(value: Any) -> LandingPageSection:
             body_markdown=str(value.get("body_markdown") or ""),
             metadata=dict(value.get("metadata") or {}),
         )
-    return LandingPageSection(id="", title="", body_markdown=str(value or ""))
+    raise TypeError(
+        "LandingPageDraft.sections entries must be LandingPageSection "
+        f"instances or Mappings; got {type(value).__name__}: {value!r}"
+    )
 
 
 def _decode_jsonb(raw: Any, *, default: Any) -> Any:
@@ -119,6 +130,15 @@ class PostgresLandingPageRepository:
         *,
         scope: TenantScope,
     ) -> Sequence[str]:
+        """Persist drafts; one INSERT per draft (sequential).
+
+        Per-call batches are typically small (1-3 drafts) for the
+        per-campaign trigger shape, so the round-trip count is bounded
+        in practice. Kept sequential for parity with
+        ``PostgresReportRepository`` / ``PostgresCampaignRepository``;
+        a future batch-INSERT optimization would migrate all three for
+        consistency rather than diverging here.
+        """
         saved: list[str] = []
         account_id = scope.account_id or ""
         for draft in drafts:
@@ -194,8 +214,14 @@ class PostgresLandingPageRepository:
         status: str,
         *,
         scope: TenantScope,
-    ) -> None:
-        await self.pool.execute(
+    ) -> bool:
+        """Scoped status update. Returns True on hit, False on miss.
+
+        Parses asyncpg's command tag (e.g., ``"UPDATE 1"``) so a
+        wrong-id or wrong-tenant call surfaces as a False return at
+        the call site rather than a silent no-op.
+        """
+        result = await self.pool.execute(
             """
             UPDATE landing_pages
                SET status = $2,
@@ -207,6 +233,16 @@ class PostgresLandingPageRepository:
             status,
             scope.account_id or "",
         )
+        # asyncpg returns "UPDATE <n>"; 1 == hit, 0 == miss. Defensive
+        # parse so non-asyncpg pools (test fakes, alternative drivers)
+        # that return e.g. "OK" or None don't crash -- treat unknown
+        # shapes as success (matches the prior silent-no-op default).
+        if not isinstance(result, str):
+            return True
+        try:
+            return int(result.rsplit(" ", 1)[-1]) > 0
+        except (ValueError, IndexError):
+            return True
 
 
 __all__ = [

--- a/extracted_content_pipeline/storage/migrations/274_landing_pages.sql
+++ b/extracted_content_pipeline/storage/migrations/274_landing_pages.sql
@@ -1,0 +1,42 @@
+-- Landing pages: per-campaign rendered marketing landing-page drafts produced
+-- by the AI Content Ops landing-page generator. Sibling to b2b_campaigns
+-- (transactional emails) and reports (vendor-pressure reports), but with a
+-- richer marketing-shaped schema: hero section, CTA, SEO meta, ordered body
+-- sections, and the marketing-campaign context (name / persona / value prop)
+-- the page was generated for.
+--
+-- Trigger shape is per-campaign (not per-opportunity), so target_id columns
+-- from the campaigns/reports schema are intentionally absent. Hosts identify
+-- a landing page by (account_id, campaign_name, slug).
+--
+-- Status lifecycle mirrors b2b_campaigns / reports: draft / queued /
+-- approved / rejected / expired. No CHECK constraint on status so hosts may
+-- extend with intermediate states (e.g. in_review) without a migration.
+
+CREATE TABLE IF NOT EXISTS landing_pages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    campaign_name TEXT NOT NULL,
+    persona TEXT NOT NULL DEFAULT '',
+    value_prop TEXT NOT NULL DEFAULT '',
+    title TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    hero JSONB NOT NULL DEFAULT '{}'::jsonb,
+    sections JSONB NOT NULL DEFAULT '[]'::jsonb,
+    cta JSONB NOT NULL DEFAULT '{}'::jsonb,
+    meta JSONB NOT NULL DEFAULT '{}'::jsonb,
+    reference_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_landing_pages_campaign
+    ON landing_pages (account_id, campaign_name, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_landing_pages_status
+    ON landing_pages (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_landing_pages_slug
+    ON landing_pages (account_id, slug);

--- a/extracted_content_pipeline/storage/migrations/274_landing_pages.sql
+++ b/extracted_content_pipeline/storage/migrations/274_landing_pages.sql
@@ -38,5 +38,12 @@ CREATE INDEX IF NOT EXISTS idx_landing_pages_campaign
 CREATE INDEX IF NOT EXISTS idx_landing_pages_status
     ON landing_pages (account_id, status, created_at DESC);
 
+-- Slug index is non-unique in v0: multiple drafts of the same campaign
+-- (e.g., A/B variants, regenerations) may share a slug while in
+-- 'draft' / 'queued' / 'rejected' status. Slug uniqueness only matters
+-- at publish time and is the host's responsibility (e.g., a deploy step
+-- that asserts exactly one 'approved' row per (account_id, slug)). A
+-- partial UNIQUE index can land in a follow-on migration if the
+-- approval workflow needs DB-enforced uniqueness.
 CREATE INDEX IF NOT EXISTS idx_landing_pages_slug
     ON landing_pages (account_id, slug);

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -27,6 +27,7 @@ pytest \
   tests/test_extracted_report_postgres.py \
   tests/test_extracted_report_generation.py \
   tests/test_extracted_quality_gate_report_pack.py \
+  tests/test_extracted_landing_page_postgres.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.landing_page_postgres import (
+    PostgresLandingPageRepository,
+)
+from extracted_content_pipeline.landing_page_ports import (
+    LandingPageDraft,
+    LandingPageSection,
+)
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return "OK"
+
+
+def _draft() -> LandingPageDraft:
+    return LandingPageDraft(
+        campaign_name="acme-q3-launch",
+        persona="VP Engineering at mid-market SaaS",
+        value_prop="Cut renewal pricing leakage by 40%",
+        title="Acme Q3: Stop Renewal Surprises",
+        slug="acme-q3-launch",
+        hero={
+            "headline": "Stop renewal surprises",
+            "subheadline": "Acme catches pricing pressure before it becomes churn",
+            "cta_label": "Book a 15-min demo",
+            "cta_url": "/demo",
+        },
+        sections=(
+            LandingPageSection(
+                id="problem",
+                title="The Problem",
+                body_markdown="Renewal pricing is the #1 driver of unplanned churn.",
+                metadata={"order": 1},
+            ),
+            LandingPageSection(
+                id="solution",
+                title="How Acme Helps",
+                body_markdown="We surface pressure signals 90 days early.",
+                metadata={"order": 2},
+            ),
+        ),
+        cta={"label": "Book a 15-min demo", "url": "/demo", "variant": "primary"},
+        meta={
+            "title_tag": "Stop Renewal Surprises | Acme",
+            "description": "Acme catches renewal pressure 90 days early.",
+            "og_image_url": "https://cdn.acme.com/og/q3.png",
+        },
+        reference_ids=("r1", "r2"),
+        metadata={"generation_model": "fake-llm", "confidence": 0.84},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_each_draft_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["lp-uuid-1"]
+    repo = PostgresLandingPageRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("lp-uuid-1",)
+    assert len(pool.fetchval_calls) == 1
+    args = pool.fetchval_calls[0]["args"]
+    # account_id, campaign_name, persona, value_prop, title, slug, hero, sections, cta, meta, reference_ids, metadata
+    assert args[0] == "acct-1"
+    assert args[1] == "acme-q3-launch"
+    assert args[2] == "VP Engineering at mid-market SaaS"
+    assert args[3] == "Cut renewal pricing leakage by 40%"
+    assert args[4] == "Acme Q3: Stop Renewal Surprises"
+    assert args[5] == "acme-q3-launch"
+    hero_payload = json.loads(args[6])
+    assert hero_payload["headline"] == "Stop renewal surprises"
+    sections_payload = json.loads(args[7])
+    assert [s["id"] for s in sections_payload] == ["problem", "solution"]
+    assert sections_payload[0]["metadata"] == {"order": 1}
+    cta_payload = json.loads(args[8])
+    assert cta_payload["label"] == "Book a 15-min demo"
+    meta_payload = json.loads(args[9])
+    assert meta_payload["title_tag"].startswith("Stop")
+    reference_ids_payload = json.loads(args[10])
+    assert reference_ids_payload == ["r1", "r2"]
+    metadata_payload = json.loads(args[11])
+    assert metadata_payload["campaign_name"] == "acme-q3-launch"
+    assert metadata_payload["scope"]["account_id"] == "acct-1"
+    assert metadata_payload["confidence"] == 0.84
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_handles_empty_account_id_with_default_scope() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["lp-uuid-2"]
+    repo = PostgresLandingPageRepository(pool)
+
+    await repo.save_drafts([_draft()], scope=TenantScope())
+
+    assert pool.fetchval_calls[0]["args"][0] == ""
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_coerces_dict_sections_via_helper() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["lp-uuid-3"]
+    repo = PostgresLandingPageRepository(pool)
+
+    draft = LandingPageDraft(
+        campaign_name="acme",
+        persona="",
+        value_prop="",
+        title="title",
+        slug="slug",
+        sections=(
+            {"id": "raw_section", "title": "From Dict", "body_markdown": "body"},
+        ),  # type: ignore[arg-type]
+    )
+
+    await repo.save_drafts([draft], scope=TenantScope())
+
+    sections_payload = json.loads(pool.fetchval_calls[0]["args"][7])
+    assert sections_payload[0]["id"] == "raw_section"
+    assert sections_payload[0]["title"] == "From Dict"
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_campaign_and_slug() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "campaign_name": "acme-q3-launch",
+            "persona": "VP Engineering",
+            "value_prop": "Stop churn",
+            "title": "Acme Q3",
+            "slug": "acme-q3-launch",
+            "hero": json.dumps({"headline": "Stop renewal surprises"}),
+            "sections": json.dumps([
+                {
+                    "id": "problem",
+                    "title": "The Problem",
+                    "body_markdown": "Renewal pricing churn.",
+                    "metadata": {"order": 1},
+                }
+            ]),
+            "cta": json.dumps({"label": "Book demo", "url": "/demo"}),
+            "meta": json.dumps({"title_tag": "Stop Surprises | Acme"}),
+            "reference_ids": json.dumps(["r1"]),
+            "metadata": json.dumps({"confidence": 0.7}),
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        campaign_name="acme-q3-launch",
+        slug="acme-q3-launch",
+        limit=20,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.campaign_name == "acme-q3-launch"
+    assert draft.title == "Acme Q3"
+    assert draft.slug == "acme-q3-launch"
+    assert draft.hero == {"headline": "Stop renewal surprises"}
+    assert draft.sections[0].id == "problem"
+    assert draft.cta["label"] == "Book demo"
+    assert draft.reference_ids == ("r1",)
+    assert draft.metadata == {"confidence": 0.7}
+
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "account_id = $1" in sql
+    assert "status = $2" in sql
+    assert "campaign_name = $3" in sql
+    assert "slug = $4" in sql
+    assert "LIMIT $5" in sql
+    assert args == ("acct-1", "draft", "acme-q3-launch", "acme-q3-launch", 20)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
+    """asyncpg with the json codec installed delivers JSONB pre-decoded."""
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "title",
+            "slug": "slug",
+            "hero": {"headline": "Hero text"},  # already a dict
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],  # already a list
+            "cta": {"label": "L"},  # already a dict
+            "meta": {"title_tag": "tt"},  # already a dict
+            "reference_ids": ["r1", "r2"],  # already a list
+            "metadata": {"key": "value"},  # already a dict
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    drafts = await repo.list_drafts(scope=TenantScope())
+
+    assert drafts[0].hero == {"headline": "Hero text"}
+    assert drafts[0].sections[0].id == "s1"
+    assert drafts[0].cta == {"label": "L"}
+    assert drafts[0].meta == {"title_tag": "tt"}
+    assert drafts[0].reference_ids == ("r1", "r2")
+    assert drafts[0].metadata == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_update_status_runs_scoped_update() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    await repo.update_status(
+        "lp-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert len(pool.execute_calls) == 1
+    args = pool.execute_calls[0]["args"]
+    assert args == ("lp-uuid-1", "approved", "acct-1")
+    sql = pool.execute_calls[0]["query"]
+    assert "UPDATE landing_pages" in sql
+    assert "account_id = $3" in sql
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_returns_empty_tuple_for_empty_input() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    saved = await repo.save_drafts([], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ()
+    assert pool.fetchval_calls == []

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -21,6 +21,9 @@ class _Pool:
         self.fetchval_calls: list[dict] = []
         self.fetch_calls: list[dict] = []
         self.execute_calls: list[dict] = []
+        # asyncpg returns command tags like "UPDATE 1" / "UPDATE 0";
+        # tests can override this to simulate misses.
+        self.execute_result: object = "UPDATE 1"
 
     async def fetchval(self, query, *args):
         self.fetchval_calls.append({"query": query, "args": args})
@@ -32,7 +35,7 @@ class _Pool:
 
     async def execute(self, query, *args):
         self.execute_calls.append({"query": query, "args": args})
-        return "OK"
+        return self.execute_result
 
 
 def _draft() -> LandingPageDraft:
@@ -231,22 +234,71 @@ async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_status_runs_scoped_update() -> None:
+async def test_update_status_returns_true_on_hit_and_runs_scoped_update() -> None:
     pool = _Pool()
+    pool.execute_result = "UPDATE 1"
     repo = PostgresLandingPageRepository(pool)
 
-    await repo.update_status(
+    hit = await repo.update_status(
         "lp-uuid-1",
         "approved",
         scope=TenantScope(account_id="acct-1"),
     )
 
+    assert hit is True
     assert len(pool.execute_calls) == 1
     args = pool.execute_calls[0]["args"]
     assert args == ("lp-uuid-1", "approved", "acct-1")
     sql = pool.execute_calls[0]["query"]
     assert "UPDATE landing_pages" in sql
     assert "account_id = $3" in sql
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_false_on_miss() -> None:
+    """Wrong landing_page_id or wrong tenant returns False so callers can branch."""
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresLandingPageRepository(pool)
+
+    hit = await repo.update_status(
+        "missing-id",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is False
+
+
+@pytest.mark.asyncio
+async def test_update_status_treats_non_asyncpg_command_tags_as_success() -> None:
+    """Test fakes / alt drivers that return 'OK' or None don't crash; default to True."""
+    pool = _Pool()
+    pool.execute_result = None
+    repo = PostgresLandingPageRepository(pool)
+
+    hit = await repo.update_status("any-id", "approved", scope=TenantScope())
+    assert hit is True
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_rejects_non_mapping_non_section_input_with_clear_error() -> None:
+    """A host passing a string / number / None as a section item gets a clear TypeError."""
+    pool = _Pool()
+    pool.fetchval_results = ["lp-uuid-x"]
+    repo = PostgresLandingPageRepository(pool)
+
+    bad_draft = LandingPageDraft(
+        campaign_name="acme",
+        persona="",
+        value_prop="",
+        title="title",
+        slug="slug",
+        sections=("not_a_section_or_mapping",),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(TypeError, match="LandingPageDraft.sections entries must be"):
+        await repo.save_drafts([bad_draft], scope=TenantScope())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

First slice of Landing Pages content-asset support for AI Content Ops. After PR-Reports landed (3 of 5 landing-page asset types shipped: blogs + emails + reports), this PR closes gap #4 — landing pages — by laying the storage foundation. **The generator service lands in PR-LandingPage-1b.**

Per planning: **per-campaign trigger** (NOT per-opportunity, unlike campaigns/reports) and a **new typed `LandingPageDraft` + `landing_pages` table** mirroring what we did for Reports. The new `MarketingCampaign` input shape is the host-provided per-call input (`name` + `persona` + `value_prop` + optional `vendors`/`categories`/`tags`); the generator does not read from `read_campaign_opportunities`.

## What changed

**New files:**

- `extracted_content_pipeline/storage/migrations/274_landing_pages.sql` — `landing_pages` table with `campaign` / `status` / `slug` indexes. Status lifecycle mirrors `b2b_campaigns` / `reports` without a `CHECK` constraint so hosts may extend with intermediate states. `target_id` columns from campaigns/reports are intentionally absent because the trigger is per-campaign.
- `extracted_content_pipeline/landing_page_ports.py`:
  - `MarketingCampaign` frozen dataclass — per-call input shape (`name` / `persona` / `value_prop` / `vendors` / `categories` / `tags` / free-form `context`)
  - `LandingPageSection` frozen dataclass (`id` / `title` / `body_markdown` / `metadata`)
  - `LandingPageDraft` frozen dataclass — marketing-shaped fields (`campaign_name`, `persona`, `value_prop`, `title`, `slug`, `hero`, `sections`, `cta`, `meta`, `reference_ids`, `metadata`). `hero` / `cta` / `meta` are flexible mappings rather than typed sub-dataclasses so hosts can extend with product-specific fields (analytics tags, secondary CTAs, etc.) without a schema change.
  - `LandingPageRepository` Protocol — `save_drafts` / `list_drafts(status / campaign_name / slug / limit filters)` / `update_status`
- `extracted_content_pipeline/landing_page_postgres.py` — `PostgresLandingPageRepository`. Mirrors `PostgresReportRepository`. `_decode_jsonb` helper handles both pre-decoded and string-shaped JSONB defensively for all six JSONB columns. `update_status` is account-scoped to prevent cross-tenant writes.
- `tests/test_extracted_landing_page_postgres.py` — fake-pool tests, 7 cases.

**Modified files:**
- `scripts/run_extracted_pipeline_checks.sh` — wires the new test into the runner.

## Test plan

- [x] `python -c "from extracted_content_pipeline.landing_page_ports import LandingPageDraft, LandingPageRepository, LandingPageSection, MarketingCampaign; from extracted_content_pipeline.landing_page_postgres import PostgresLandingPageRepository"` → clean import
- [x] AST scan of new files for `atlas_brain` refs → 0 hits
- [x] `bash scripts/validate_extracted_content_pipeline.sh` → passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed
- [x] `pytest tests/test_extracted_landing_page_postgres.py` → 7/7 passing locally
- [ ] CI `extracted-checks` run

Tests cover: save_drafts persists each row with scope-merged metadata; empty `account_id` default; dict-shaped section coercion; list_drafts filter composition; pre-decoded JSONB column handling for ALL six JSONB columns; update_status SQL shape; empty-input return.

## Out of scope (deferred)

- **Generator service** (`LandingPageGenerationService`) → **PR-LandingPage-1b** (depends on this)
- **Packaged skill prompt** (`skills/digest/landing_page_generation.md`) → PR-LandingPage-1b
- **Quality pack** (`extracted_quality_gate/landing_page_pack.py`) → PR-LandingPage-1b
- **Approval API endpoint** → PR-LandingPage-2
- **CLI flag wiring** → PR-LandingPage-3
- **Sales briefs** gap item (#3 in the corrected build queue) → separate slice
- **Signal extraction** gap (#4) → biggest landing-page risk; explicitly out of scope

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_