### PR TITLE
PR-LandingPage-1b: Add Landing Pages generator + skill prompt + quality pack

### DIFF
--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -1,0 +1,387 @@
+"""Standalone Landing Pages generator orchestration.
+
+Sibling of ``CampaignGenerationService`` (per-opportunity emails) and
+``ReportGenerationService`` (per-opportunity structured reports). Where
+those generators iterate ``read_campaign_opportunities``, this one
+takes a :class:`MarketingCampaign` directly and produces ONE
+``LandingPageDraft``. The trigger shape is the primary structural
+divergence: landing pages are marketing-campaign-driven, not
+opportunity-driven.
+
+Optional reasoning context: hosts may pass a
+``CampaignReasoningContextProvider``. When configured, the marketing
+campaign payload is handed to the provider as the "opportunity" dict
+(keyed by ``target_id=campaign.name``, ``target_mode=marketing_campaign``)
+so the existing multi-pass reasoning bridge can produce a narrative
+plan + claims that the LLM consumes when structuring the page.
+
+Quality gating runs through ``extracted_quality_gate.landing_page_pack``
+-- pure deterministic, no LLM. Failures skip persistence and surface
+in the result's ``errors`` payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any
+
+from .campaign_ports import (
+    CampaignReasoningContextProvider,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
+from .landing_page_ports import (
+    LandingPageDraft,
+    LandingPageRepository,
+    LandingPageSection,
+    MarketingCampaign,
+)
+from .services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
+    campaign_reasoning_context_payload,
+    normalize_campaign_reasoning_context,
+)
+from extracted_quality_gate.landing_page_pack import evaluate_landing_page
+from extracted_quality_gate.types import QualityInput, QualityPolicy
+
+
+_TARGET_MODE = "marketing_campaign"
+
+
+@dataclass(frozen=True)
+class LandingPageGenerationConfig:
+    """Tunable defaults for ``LandingPageGenerationService``."""
+
+    skill_name: str = "digest/landing_page_generation"
+    max_tokens: int = 4096
+    temperature: float = 0.3
+    quality_policy: QualityPolicy | None = None
+
+
+@dataclass(frozen=True)
+class LandingPageGenerationResult:
+    requested: int
+    generated: int
+    skipped: int
+    saved_ids: tuple[str, ...] = ()
+    errors: tuple[Mapping[str, Any], ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "requested": self.requested,
+            "generated": self.generated,
+            "skipped": self.skipped,
+            "saved_ids": list(self.saved_ids),
+            "errors": list(self.errors),
+        }
+
+
+def _slug_default(name: str) -> str:
+    """URL-safe slug fallback when the LLM doesn't provide one."""
+    text = re.sub(r"[^a-zA-Z0-9\-]+", "-", str(name or "")).strip("-").lower()
+    return text or "untitled"
+
+
+def parse_landing_page_response(text: str) -> dict[str, Any] | None:
+    """Extract the first well-formed landing-page JSON object.
+
+    Mirrors ``parse_report_response``: strips ``<think>`` blocks + code
+    fences, then walks the cleaned text with
+    ``json.JSONDecoder.raw_decode`` so braces inside string values
+    (markdown templates, CSS, etc.) don't trip the parser.
+    """
+
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    decoder = json.JSONDecoder()
+    candidates: list[Any] = []
+    index = 0
+    length = len(cleaned)
+    while index < length:
+        if cleaned[index] != "{":
+            index += 1
+            continue
+        try:
+            decoded, end = decoder.raw_decode(cleaned, index)
+        except json.JSONDecodeError:
+            index += 1
+            continue
+        candidates.append(decoded)
+        index = end if end > index else index + 1
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, dict):
+            continue
+        title = str(candidate.get("title") or "").strip()
+        sections = candidate.get("sections")
+        hero = candidate.get("hero")
+        if not title:
+            continue
+        if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
+            continue
+        coerced_sections = [s for s in sections if isinstance(s, Mapping)]
+        if not coerced_sections:
+            continue
+        if not isinstance(hero, Mapping):
+            continue
+        return {
+            **candidate,
+            "title": title,
+            "sections": coerced_sections,
+            "hero": dict(hero),
+        }
+    return None
+
+
+class LandingPageGenerationService:
+    """Generate one structured landing-page draft per marketing campaign."""
+
+    def __init__(
+        self,
+        *,
+        landing_pages: LandingPageRepository,
+        llm: LLMClient,
+        skills: SkillStore,
+        reasoning_context: CampaignReasoningContextProvider | None = None,
+        config: LandingPageGenerationConfig | None = None,
+    ):
+        self._landing_pages = landing_pages
+        self._llm = llm
+        self._skills = skills
+        self._reasoning_context = reasoning_context
+        self._config = config or LandingPageGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        campaign: MarketingCampaign,
+    ) -> LandingPageGenerationResult:
+        prompt_template = self._skills.get_prompt(self._config.skill_name)
+        if not prompt_template:
+            raise ValueError(
+                f"Landing-page generation skill not found: {self._config.skill_name}"
+            )
+
+        if not str(campaign.name or "").strip():
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({"reason": "missing_campaign_name"},),
+            )
+
+        try:
+            campaign_payload = await self._campaign_with_reasoning_context(
+                scope=scope,
+                campaign=campaign,
+            )
+        except Exception as exc:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({"campaign_name": campaign.name, "reason": str(exc)},),
+            )
+
+        try:
+            parsed = await self._generate_one(
+                prompt_template,
+                campaign_payload=campaign_payload,
+            )
+        except Exception as exc:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({"campaign_name": campaign.name, "reason": str(exc)},),
+            )
+
+        if not parsed:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({"campaign_name": campaign.name, "reason": "unparseable_response"},),
+            )
+
+        quality = self._quality_check(parsed)
+        if not quality["passed"]:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({
+                    "campaign_name": campaign.name,
+                    "reason": "quality_blocked",
+                    "blockers": quality["blockers"],
+                },),
+            )
+
+        draft = self._build_draft(parsed, campaign=campaign)
+        saved_ids = tuple(
+            str(item) for item in await self._landing_pages.save_drafts([draft], scope=scope)
+        )
+        return LandingPageGenerationResult(
+            requested=1,
+            generated=1,
+            skipped=0,
+            saved_ids=saved_ids,
+        )
+
+    async def _campaign_with_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        campaign: MarketingCampaign,
+    ) -> dict[str, Any]:
+        """Pass the marketing campaign through the reasoning provider port.
+
+        The existing ``CampaignReasoningContextProvider`` port keys on
+        (target_id, target_mode, opportunity). We adapt by treating the
+        campaign as the "opportunity" payload, with target_id =
+        campaign.name and target_mode = "marketing_campaign". Hosts
+        that don't configure a provider get the bare campaign payload.
+        """
+        payload = campaign.as_dict()
+        if self._reasoning_context is None:
+            return payload
+        provided = await self._reasoning_context.read_campaign_reasoning_context(
+            scope=scope,
+            target_id=campaign.name,
+            target_mode=_TARGET_MODE,
+            opportunity=payload,
+        )
+        provided_context = normalize_campaign_reasoning_context(provided)
+        if not provided_context.has_content():
+            return payload
+        enriched = dict(payload)
+        reasoning_payload = campaign_reasoning_context_payload(provided_context)
+        enriched.update(campaign_reasoning_context_metadata(provided_context))
+        enriched["reasoning_context"] = reasoning_payload
+        enriched["campaign_reasoning_context"] = reasoning_payload
+        return enriched
+
+    async def _generate_one(
+        self,
+        prompt_template: str,
+        *,
+        campaign_payload: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        campaign_json = json.dumps(dict(campaign_payload), separators=(",", ":"), default=str)
+        # Single source for the campaign payload: in the system prompt
+        # via {campaign_json}. User message is structural-only so the
+        # campaign isn't sent twice (matches the report-generator fix).
+        system_prompt = prompt_template.replace("{campaign_json}", campaign_json)
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(
+                    role="user",
+                    content="Generate one landing page from the marketing campaign above.",
+                ),
+            ],
+            max_tokens=self._config.max_tokens,
+            temperature=self._config.temperature,
+            metadata={
+                "campaign_name": campaign_payload.get("name"),
+                "skill_name": self._config.skill_name,
+                "asset_type": "landing_page",
+                "target_mode": _TARGET_MODE,
+            },
+        )
+        parsed = parse_landing_page_response(response.content)
+        if not parsed:
+            return None
+        return {
+            **parsed,
+            "_model": response.model,
+            "_usage": dict(response.usage or {}),
+        }
+
+    def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
+        report_input = QualityInput(
+            artifact_type="landing_page",
+            context={
+                "title": parsed.get("title"),
+                "slug": parsed.get("slug"),
+                "hero": parsed.get("hero") or {},
+                "sections": parsed.get("sections") or (),
+                "cta": parsed.get("cta") or {},
+                "meta": parsed.get("meta") or {},
+            },
+        )
+        report = evaluate_landing_page(report_input, policy=self._config.quality_policy)
+        return {
+            "passed": report.passed,
+            "blockers": tuple(f.message for f in report.blockers),
+        }
+
+    def _build_draft(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        campaign: MarketingCampaign,
+    ) -> LandingPageDraft:
+        sections = tuple(
+            LandingPageSection(
+                id=str(s.get("id") or "").strip(),
+                title=str(s.get("title") or "").strip(),
+                body_markdown=str(s.get("body_markdown") or "").strip(),
+                metadata=dict(s.get("metadata") or {}),
+            )
+            for s in parsed.get("sections") or ()
+            if isinstance(s, Mapping)
+        )
+        title = str(parsed.get("title") or "").strip()
+        slug = str(parsed.get("slug") or "").strip() or _slug_default(campaign.name)
+        hero = (
+            dict(parsed.get("hero") or {}) if isinstance(parsed.get("hero"), Mapping) else {}
+        )
+        cta = (
+            dict(parsed.get("cta") or {}) if isinstance(parsed.get("cta"), Mapping) else {}
+        )
+        meta = (
+            dict(parsed.get("meta") or {}) if isinstance(parsed.get("meta"), Mapping) else {}
+        )
+        reference_ids = tuple(
+            str(r) for r in (parsed.get("reference_ids") or ())
+            if str(r).strip()
+        )
+        metadata: dict[str, Any] = {
+            "generation_model": parsed.get("_model"),
+            "generation_usage": parsed.get("_usage") or {},
+        }
+        return LandingPageDraft(
+            campaign_name=campaign.name,
+            persona=campaign.persona,
+            value_prop=campaign.value_prop,
+            title=title,
+            slug=slug,
+            hero=hero,
+            sections=sections,
+            cta=cta,
+            meta=meta,
+            reference_ids=reference_ids,
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "LandingPageGenerationConfig",
+    "LandingPageGenerationResult",
+    "LandingPageGenerationService",
+    "parse_landing_page_response",
+]

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -23,7 +23,7 @@ in the result's ``errors`` payload.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import json
 import re
 from typing import Any

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -81,12 +81,6 @@ class LandingPageGenerationResult:
         }
 
 
-def _slug_default(name: str) -> str:
-    """URL-safe slug fallback when the LLM doesn't provide one."""
-    text = re.sub(r"[^a-zA-Z0-9\-]+", "-", str(name or "")).strip("-").lower()
-    return text or "untitled"
-
-
 def parse_landing_page_response(text: str) -> dict[str, Any] | None:
     """Extract the first well-formed landing-page JSON object.
 
@@ -94,6 +88,14 @@ def parse_landing_page_response(text: str) -> dict[str, Any] | None:
     fences, then walks the cleaned text with
     ``json.JSONDecoder.raw_decode`` so braces inside string values
     (markdown templates, CSS, etc.) don't trip the parser.
+
+    The parser only enforces what's needed to identify the candidate as
+    a landing-page payload: ``title`` (non-empty) and a non-empty
+    ``sections`` list. Missing or malformed ``hero`` / ``cta`` / ``meta``
+    are NOT rejected here -- the quality pack's specific blockers
+    (``no_hero_headline``, ``no_cta``, etc.) are the right place to
+    surface those failures so callers see exactly what was wrong rather
+    than a generic ``unparseable_response``.
     """
 
     cleaned = str(text or "").strip()
@@ -126,7 +128,6 @@ def parse_landing_page_response(text: str) -> dict[str, Any] | None:
             continue
         title = str(candidate.get("title") or "").strip()
         sections = candidate.get("sections")
-        hero = candidate.get("hero")
         if not title:
             continue
         if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
@@ -134,13 +135,11 @@ def parse_landing_page_response(text: str) -> dict[str, Any] | None:
         coerced_sections = [s for s in sections if isinstance(s, Mapping)]
         if not coerced_sections:
             continue
-        if not isinstance(hero, Mapping):
-            continue
+        # hero / cta / meta validation deferred to the quality pack.
         return {
             **candidate,
             "title": title,
             "sections": coerced_sections,
-            "hero": dict(hero),
         }
     return None
 
@@ -346,7 +345,7 @@ class LandingPageGenerationService:
             if isinstance(s, Mapping)
         )
         title = str(parsed.get("title") or "").strip()
-        slug = str(parsed.get("slug") or "").strip() or _slug_default(campaign.name)
+        slug = str(parsed.get("slug") or "").strip()
         hero = (
             dict(parsed.get("hero") or {}) if isinstance(parsed.get("hero"), Mapping) else {}
         )

--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -1,0 +1,51 @@
+You generate ONE marketing landing page for a single marketing campaign.
+
+The marketing campaign is JSON-encoded as `{campaign_json}`. Optional reasoning context (when present) lives inside the campaign payload under `reasoning_context` / `campaign_reasoning_context`. If the reasoning context carries a `narrative_plan` block under `canonical_reasoning`, use its `sections` array as the section spine; otherwise structure the page yourself from the campaign's persona and value_prop.
+
+Output ONLY a single JSON object with this exact shape. No prose outside the JSON.
+
+```json
+{
+  "title": "Page H1 / browser title (8-12 words)",
+  "slug": "url-safe-slug-derived-from-campaign-name",
+  "hero": {
+    "headline": "Lead headline (max ~10 words)",
+    "subheadline": "One-sentence subheadline that reinforces the value prop",
+    "cta_label": "Book a demo",
+    "cta_url": "/demo"
+  },
+  "sections": [
+    {
+      "id": "snake_case_section_id",
+      "title": "Section heading",
+      "body_markdown": "Section body in markdown",
+      "metadata": {"order": 1}
+    }
+  ],
+  "cta": {
+    "label": "Primary CTA label",
+    "url": "/demo",
+    "variant": "primary"
+  },
+  "meta": {
+    "title_tag": "<title> tag (50-60 chars)",
+    "description": "<meta description> (120-160 chars)",
+    "og_image_url": ""
+  },
+  "reference_ids": ["customer-logo-1", "case-study-2"]
+}
+```
+
+Field rules:
+- `title`: descriptive H1; reflects the campaign's value_prop; do NOT include date stamps.
+- `slug`: lowercase, hyphenated, derived from `campaign.name`. URL-safe ASCII only.
+- `hero.headline`: punchy, persona-aware. Subheadline reinforces the value prop in one sentence.
+- `hero.cta_label` / `hero.cta_url`: the hero's primary CTA. Reuse for the page-level `cta` block unless the page uses a hero-CTA + sticky-footer-CTA pattern.
+- `sections`: 3-6 ordered sections. Common shapes: problem / solution / social-proof / how-it-works / pricing / FAQ. Each section needs a non-empty `title` and `body_markdown`.
+- `cta`: page-level primary CTA (label + url required). Optional `secondary_label` / `secondary_url`.
+- `meta.description`: SEO meta description, 120-160 characters. Skip the title tag if it's identical to `title`.
+- `reference_ids`: customer logos, case studies, testimonials, or other social-proof source ids the page cites. Empty when none.
+
+When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids`. Persona-tailor the headline + subheadline for `campaign.persona`.
+
+Avoid: weasel words ("powerful", "robust", "leverage"), promises that can't be backed up, comparative claims about specific competitors unless the campaign provides them.

--- a/extracted_quality_gate/landing_page_pack.py
+++ b/extracted_quality_gate/landing_page_pack.py
@@ -1,0 +1,281 @@
+"""Landing-page quality pack: deterministic validators for marketing pages.
+
+Sibling to ``report_pack`` (PR-Reports-1b) and ``campaign_pack`` /
+``blog_pack``. Validates the structured ``LandingPageDraft`` shape from
+``extracted_content_pipeline.landing_page_ports``: title, slug, hero,
+ordered sections, CTA, SEO meta. Pure-function discipline (no DB, no
+LLM, no clock) -- sanitization belongs in the wrapper.
+
+Public API:
+
+    evaluate_landing_page(
+        input: QualityInput,
+        *,
+        policy: QualityPolicy | None = None,
+    ) -> QualityReport
+
+The ``input`` carries the structured landing-page payload through
+``input.context``. Recognised keys:
+
+  - ``title`` (str)
+  - ``slug`` (str)
+  - ``hero`` (Mapping): expected keys ``headline``, ``subheadline``,
+    ``cta_label``, ``cta_url``
+  - ``sections`` (Sequence[Mapping]): each ``{"id", "title",
+    "body_markdown", ...}``
+  - ``cta`` (Mapping): expected keys ``label``, ``url``
+  - ``meta`` (Mapping): expected keys ``title_tag``, ``description``
+
+Recognised ``policy.thresholds`` keys:
+  - ``min_sections`` (int): default 1
+  - ``min_meta_description_chars`` (int): warn when meta.description is
+    below this; default 0 (no floor). 120-160 is the SEO sweet spot.
+  - ``pass_score`` (int): default 70
+  - ``blocking_penalty`` (int): default 18 (per blocker)
+  - ``warning_penalty`` (int): default 6 (per warning)
+
+Recognised ``policy.metadata`` keys:
+  - ``blocked_phrasing`` (Sequence[str] | str): word-boundary blocked
+    phrases. Bare string is auto-wrapped (mirrors report_pack).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from .types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+_DEFAULT_THRESHOLDS: Mapping[str, Any] = {
+    "min_sections": 1,
+    "min_meta_description_chars": 0,
+    "pass_score": 70,
+    "blocking_penalty": 18,
+    "warning_penalty": 6,
+}
+
+
+def _threshold_int(policy: QualityPolicy | None, key: str) -> int:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return int(_DEFAULT_THRESHOLDS[key])
+
+
+def _blocked_phrases(policy: QualityPolicy | None) -> tuple[str, ...]:
+    """Mirror of ``report_pack._blocked_phrases``: bare string auto-wraps."""
+    if policy is None:
+        return ()
+    raw = policy.metadata.get("blocked_phrasing")
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        text = raw.strip()
+        return (text,) if text else ()
+    if not isinstance(raw, Sequence):
+        return ()
+    return tuple(str(item) for item in raw if str(item).strip())
+
+
+def evaluate_landing_page(
+    input: QualityInput,
+    *,
+    policy: QualityPolicy | None = None,
+) -> QualityReport:
+    """Run the deterministic landing-page-quality validators."""
+
+    context = dict(input.context or {})
+    title = str(context.get("title") or "").strip()
+    slug = str(context.get("slug") or "").strip()
+    hero = context.get("hero") if isinstance(context.get("hero"), Mapping) else {}
+    cta = context.get("cta") if isinstance(context.get("cta"), Mapping) else {}
+    meta = context.get("meta") if isinstance(context.get("meta"), Mapping) else {}
+    sections_raw = context.get("sections") or ()
+    sections: list[Mapping[str, Any]] = [
+        section for section in sections_raw if isinstance(section, Mapping)
+    ]
+
+    findings: list[GateFinding] = []
+
+    # ---- Title / slug ----
+    if not title:
+        findings.append(GateFinding(code="no_title", message="no_title", severity=GateSeverity.BLOCKER))
+    if not slug:
+        findings.append(GateFinding(code="no_slug", message="no_slug", severity=GateSeverity.BLOCKER))
+
+    # ---- Hero ----
+    headline = str(hero.get("headline") or "").strip()
+    if not headline:
+        findings.append(
+            GateFinding(
+                code="no_hero_headline",
+                message="no_hero_headline",
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+    subheadline = str(hero.get("subheadline") or "").strip()
+    if not subheadline:
+        findings.append(
+            GateFinding(
+                code="no_hero_subheadline",
+                message="no_hero_subheadline",
+                severity=GateSeverity.WARNING,
+            )
+        )
+
+    # ---- CTA ----
+    cta_label = str(cta.get("label") or "").strip()
+    cta_url = str(cta.get("url") or "").strip()
+    if not cta_label or not cta_url:
+        findings.append(
+            GateFinding(
+                code="no_cta",
+                message="no_cta",
+                severity=GateSeverity.BLOCKER,
+                metadata={"has_label": bool(cta_label), "has_url": bool(cta_url)},
+            )
+        )
+
+    # ---- Sections ----
+    min_sections = _threshold_int(policy, "min_sections")
+    if len(sections) < min_sections:
+        findings.append(
+            GateFinding(
+                code="no_sections",
+                message=f"no_sections:{len(sections)}_below_min_{min_sections}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"section_count": len(sections), "min_sections": min_sections},
+            )
+        )
+    for index, section in enumerate(sections):
+        section_title = str(section.get("title") or "").strip()
+        if not section_title:
+            findings.append(
+                GateFinding(
+                    code="section_missing_title",
+                    message=f"section_missing_title:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        section_body = str(section.get("body_markdown") or "").strip()
+        if not section_body:
+            findings.append(
+                GateFinding(
+                    code="section_missing_body",
+                    message=f"section_missing_body:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+
+    # ---- SEO meta description ----
+    min_meta_chars = _threshold_int(policy, "min_meta_description_chars")
+    description = str(meta.get("description") or "").strip()
+    if min_meta_chars > 0:
+        if not description:
+            findings.append(
+                GateFinding(
+                    code="missing_meta_description",
+                    message="missing_meta_description",
+                    severity=GateSeverity.WARNING,
+                )
+            )
+        elif len(description) < min_meta_chars:
+            findings.append(
+                GateFinding(
+                    code="meta_description_too_short",
+                    message=f"meta_description_too_short:{len(description)}<{min_meta_chars}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"length": len(description), "min": min_meta_chars},
+                )
+            )
+
+    # ---- Blocked phrasing (case-insensitive word-boundary) ----
+    phrases = _blocked_phrases(policy)
+    if phrases:
+        haystack_parts: list[str] = []
+        if title:
+            haystack_parts.append(title)
+        if headline:
+            haystack_parts.append(headline)
+        if subheadline:
+            haystack_parts.append(subheadline)
+        if cta_label:
+            haystack_parts.append(cta_label)
+        for section in sections:
+            for key in ("title", "body_markdown"):
+                value = section.get(key)
+                if isinstance(value, str) and value.strip():
+                    haystack_parts.append(value)
+        haystack = "\n".join(haystack_parts)
+        for phrase in phrases:
+            phrase_str = str(phrase).strip()
+            if not phrase_str:
+                continue
+            pattern = re.compile(rf"\b{re.escape(phrase_str)}\b", re.IGNORECASE)
+            if pattern.search(haystack):
+                findings.append(
+                    GateFinding(
+                        code="blocked_phrasing",
+                        message=f"blocked_phrasing:{phrase}",
+                        severity=GateSeverity.BLOCKER,
+                        metadata={"phrase": phrase_str},
+                    )
+                )
+
+    return _build_report(findings=findings, sections=sections, policy=policy)
+
+
+def _build_report(
+    *,
+    findings: list[GateFinding],
+    sections: list[Mapping[str, Any]],
+    policy: QualityPolicy | None,
+) -> QualityReport:
+    blockers = [f for f in findings if f.severity == GateSeverity.BLOCKER]
+    warnings = [f for f in findings if f.severity == GateSeverity.WARNING]
+    blocking_penalty = _threshold_int(policy, "blocking_penalty")
+    warning_penalty = _threshold_int(policy, "warning_penalty")
+    pass_score = _threshold_int(policy, "pass_score")
+    score = max(
+        0,
+        100 - (blocking_penalty * len(blockers)) - (warning_penalty * len(warnings)),
+    )
+    passed = (not blockers) and score >= pass_score
+    if blockers or score < pass_score:
+        decision = GateDecision.BLOCK
+    elif warnings:
+        decision = GateDecision.WARN
+    else:
+        decision = GateDecision.PASS
+    metadata = {
+        "score": score,
+        "threshold": pass_score,
+        "status": "pass" if passed else "fail",
+        "blocking_issues": tuple(f.message for f in blockers),
+        "blocking_codes": tuple(f.code for f in blockers),
+        "warnings": tuple(f.message for f in warnings),
+        "warning_codes": tuple(f.code for f in warnings),
+        "section_count": len(sections),
+    }
+    return QualityReport(
+        passed=passed,
+        decision=decision,
+        findings=tuple(findings),
+        metadata=metadata,
+    )
+
+
+__all__ = ["evaluate_landing_page"]

--- a/extracted_quality_gate/landing_page_pack.py
+++ b/extracted_quality_gate/landing_page_pack.py
@@ -212,8 +212,22 @@ def evaluate_landing_page(
             haystack_parts.append(headline)
         if subheadline:
             haystack_parts.append(subheadline)
+        # Hero CTA label is separate from the page-level CTA -- both get
+        # scanned because either can land banned copy on the page.
+        hero_cta_label = str(hero.get("cta_label") or "").strip()
+        if hero_cta_label:
+            haystack_parts.append(hero_cta_label)
         if cta_label:
             haystack_parts.append(cta_label)
+        # SEO meta is the most public-facing surface (search snippets,
+        # social cards). Banned phrases in title_tag / description hurt
+        # most when they leak there.
+        meta_title_tag = str(meta.get("title_tag") or "").strip()
+        meta_description = str(meta.get("description") or "").strip()
+        if meta_title_tag:
+            haystack_parts.append(meta_title_tag)
+        if meta_description:
+            haystack_parts.append(meta_description)
         for section in sections:
             for key in ("title", "body_markdown"):
                 value = section.get(key)

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -28,6 +28,8 @@ pytest \
   tests/test_extracted_report_generation.py \
   tests/test_extracted_quality_gate_report_pack.py \
   tests/test_extracted_landing_page_postgres.py \
+  tests/test_extracted_landing_page_generation.py \
+  tests/test_extracted_quality_gate_landing_page_pack.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -163,8 +163,8 @@ def test_parse_landing_page_response_strips_code_fences_and_extracts_first_objec
 
 def test_parse_landing_page_response_returns_none_when_required_fields_missing() -> None:
     assert parse_landing_page_response("") is None
-    assert parse_landing_page_response('{"title": "x"}') is None  # no sections / hero
-    assert parse_landing_page_response('{"title": "x", "sections": [], "hero": {}}') is None
+    assert parse_landing_page_response('{"title": "x"}') is None  # no sections
+    assert parse_landing_page_response('{"title": "x", "sections": []}') is None  # empty sections
 
 
 def test_parse_landing_page_response_handles_braces_inside_string_values() -> None:

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -196,6 +196,45 @@ def test_parse_landing_page_response_strips_think_blocks_before_decoding() -> No
     assert parsed["title"] == "Acme Q3: Stop Renewal Surprises"
 
 
+def test_parse_landing_page_response_accepts_missing_hero_for_quality_pack_to_judge() -> None:
+    """Missing/non-mapping hero is NOT a parser-level rejection -- the quality pack
+    raises ``no_hero_headline`` so callers see exactly what was wrong rather than a
+    generic ``unparseable_response``."""
+    payload = json.dumps({
+        "title": "Title",
+        "slug": "slug",
+        # hero intentionally omitted
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {"label": "L", "url": "/u"},
+        "meta": {},
+    })
+    parsed = parse_landing_page_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Title"
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_with_no_hero_headline_when_response_omits_hero() -> None:
+    """End-to-end: parser accepts the candidate, quality pack fires no_hero_headline."""
+    response = json.dumps({
+        "title": "Acme Q3: Stop Renewal Surprises",
+        "slug": "acme-q3-launch",
+        # hero omitted -> must surface as a quality blocker, not unparseable_response
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {"label": "L", "url": "/u"},
+        "meta": {},
+    })
+    service, landing_pages, _llm, _skills, _rp = _service(responses=[response])
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert landing_pages.saved == []
+    assert result.errors[0]["reason"] == "quality_blocked"
+    blockers = result.errors[0]["blockers"]
+    assert any("no_hero_headline" in b for b in blockers)
+
+
 # -----------------------
 # Service: generation
 # -----------------------

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
+from extracted_content_pipeline.landing_page_generation import (
+    LandingPageGenerationConfig,
+    LandingPageGenerationService,
+    parse_landing_page_response,
+)
+from extracted_content_pipeline.landing_page_ports import (
+    LandingPageDraft,
+    MarketingCampaign,
+)
+
+
+# -----------------------
+# Fake ports
+# -----------------------
+
+
+class _LandingPages:
+    def __init__(self):
+        self.saved = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": list(drafts), "scope": scope})
+        return [f"lp-{index + 1}" for index, _ in enumerate(drafts)]
+
+    async def list_drafts(self, *, scope, status=None, campaign_name=None, slug=None, limit=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def update_status(self, landing_page_id, status, *, scope):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _LLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return LLMResponse(
+            content=response,
+            model="test-model",
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+
+class _Skills:
+    def __init__(self, prompts):
+        self.prompts = prompts
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompts.get(name)
+
+
+class _ReasoningProvider:
+    def __init__(self, context):
+        self.context = context
+        self.calls = []
+
+    async def read_campaign_reasoning_context(self, *, scope, target_id, target_mode, opportunity):
+        self.calls.append({
+            "scope": scope,
+            "target_id": target_id,
+            "target_mode": target_mode,
+        })
+        return self.context
+
+
+def _campaign() -> MarketingCampaign:
+    return MarketingCampaign(
+        name="acme-q3-launch",
+        persona="VP Engineering at mid-market SaaS",
+        value_prop="Cut renewal pricing leakage by 40%",
+        vendors=("Acme",),
+        tags=("growth", "renewal"),
+    )
+
+
+def _valid_response(*, slug="acme-q3-launch") -> str:
+    return json.dumps({
+        "title": "Acme Q3: Stop Renewal Surprises",
+        "slug": slug,
+        "hero": {
+            "headline": "Stop renewal surprises",
+            "subheadline": "Acme catches pressure 90 days early",
+            "cta_label": "Book a 15-min demo",
+            "cta_url": "/demo",
+        },
+        "sections": [
+            {
+                "id": "problem",
+                "title": "The Problem",
+                "body_markdown": "Renewal pricing is the #1 churn driver.",
+                "metadata": {"order": 1},
+            },
+            {
+                "id": "solution",
+                "title": "The Solution",
+                "body_markdown": "Acme surfaces pressure signals in the first 30 days.",
+                "metadata": {"order": 2},
+            },
+        ],
+        "cta": {"label": "Book a 15-min demo", "url": "/demo", "variant": "primary"},
+        "meta": {
+            "title_tag": "Stop Renewal Surprises | Acme",
+            "description": "Acme catches renewal pressure 90 days early so you can prevent unplanned churn.",
+        },
+        "reference_ids": ["customer-logo-1"],
+    })
+
+
+def _service(*, responses=None, prompts=None, reasoning_context=None, config=None):
+    landing_pages = _LandingPages()
+    llm = _LLM(responses or [_valid_response()])
+    if prompts is None:
+        prompts = {"digest/landing_page_generation": "TEMPLATE: {campaign_json}"}
+    skills = _Skills(prompts)
+    reasoning_provider = (
+        _ReasoningProvider(reasoning_context) if reasoning_context is not None else None
+    )
+    service = LandingPageGenerationService(
+        landing_pages=landing_pages,
+        llm=llm,
+        skills=skills,
+        reasoning_context=reasoning_provider,
+        config=config or LandingPageGenerationConfig(),
+    )
+    return service, landing_pages, llm, skills, reasoning_provider
+
+
+# -----------------------
+# parse_landing_page_response
+# -----------------------
+
+
+def test_parse_landing_page_response_strips_code_fences_and_extracts_first_object() -> None:
+    text = "```json\n" + _valid_response() + "\n```"
+    parsed = parse_landing_page_response(text)
+    assert parsed is not None
+    assert parsed["title"] == "Acme Q3: Stop Renewal Surprises"
+    assert parsed["sections"][0]["id"] == "problem"
+
+
+def test_parse_landing_page_response_returns_none_when_required_fields_missing() -> None:
+    assert parse_landing_page_response("") is None
+    assert parse_landing_page_response('{"title": "x"}') is None  # no sections / hero
+    assert parse_landing_page_response('{"title": "x", "sections": [], "hero": {}}') is None
+
+
+def test_parse_landing_page_response_handles_braces_inside_string_values() -> None:
+    """body_markdown with template syntax / set notation must not break the parser."""
+    payload = json.dumps({
+        "title": "Title",
+        "slug": "slug",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [
+            {
+                "id": "s1",
+                "title": "Templates",
+                "body_markdown": "Pricing tiers: {basic, pro} models. Use {project_id} placeholders.",
+            }
+        ],
+        "cta": {"label": "L", "url": "/u"},
+        "meta": {},
+        "reference_ids": [],
+    })
+    parsed = parse_landing_page_response(payload)
+    assert parsed is not None
+    assert "{basic, pro}" in parsed["sections"][0]["body_markdown"]
+
+
+def test_parse_landing_page_response_strips_think_blocks_before_decoding() -> None:
+    payload = "<think>thinking aloud about the campaign...</think>\n" + _valid_response()
+    parsed = parse_landing_page_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Acme Q3: Stop Renewal Surprises"
+
+
+# -----------------------
+# Service: generation
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_one_landing_page_per_call_via_save_drafts() -> None:
+    service, landing_pages, llm, _skills, _rp = _service()
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.requested == 1
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.saved_ids == ("lp-1",)
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["metadata"]["asset_type"] == "landing_page"
+    assert llm.calls[0]["metadata"]["target_mode"] == "marketing_campaign"
+    saved_drafts = landing_pages.saved[0]["drafts"]
+    assert len(saved_drafts) == 1
+    draft = saved_drafts[0]
+    assert isinstance(draft, LandingPageDraft)
+    assert draft.campaign_name == "acme-q3-launch"
+    assert draft.persona == "VP Engineering at mid-market SaaS"
+    assert draft.title == "Acme Q3: Stop Renewal Surprises"
+    assert draft.slug == "acme-q3-launch"
+    assert draft.hero["headline"] == "Stop renewal surprises"
+    assert draft.cta["label"] == "Book a 15-min demo"
+    assert draft.sections[0].id == "problem"
+    assert draft.metadata["generation_model"] == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_generate_substitutes_campaign_json_into_system_prompt_only() -> None:
+    """Campaign payload appears in system content via {campaign_json} and NOT in user content."""
+    service, _lp, llm, _skills, _rp = _service(
+        prompts={"digest/landing_page_generation": "C={campaign_json}"},
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    system_msg = llm.calls[0]["messages"][0].content
+    user_msg = llm.calls[0]["messages"][1].content
+    assert '"name":"acme-q3-launch"' in system_msg
+    assert '"name":"acme-q3-launch"' not in user_msg
+    assert "acme-q3-launch" not in user_msg
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_unparseable_response() -> None:
+    service, landing_pages, _llm, _skills, _rp = _service(responses=["not json garbage"])
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert landing_pages.saved == []
+    assert any(err.get("reason") == "unparseable_response" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_quality_pack_blocks() -> None:
+    """Response missing CTA gets blocked by the quality pack."""
+    bad_response = json.dumps({
+        "title": "ok",
+        "slug": "ok",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {},  # missing CTA -> no_cta blocker
+        "meta": {},
+        "reference_ids": [],
+    })
+    service, landing_pages, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert landing_pages.saved == []
+    assert any(err.get("reason") == "quality_blocked" for err in result.errors)
+    blockers = result.errors[0]["blockers"]
+    assert any("no_cta" in b for b in blockers)
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_campaign_name_empty() -> None:
+    service, landing_pages, llm, _skills, _rp = _service()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        campaign=MarketingCampaign(name=""),
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert landing_pages.saved == []
+    assert llm.calls == []  # no LLM round-trip
+    assert any(err.get("reason") == "missing_campaign_name" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_consumes_reasoning_context_via_provider() -> None:
+    """When a CampaignReasoningContextProvider is supplied, its context is fetched per campaign."""
+    context = CampaignReasoningContext(
+        top_theses=({"claim": "Renewal pricing", "confidence": 0.9, "source_ids": ["r1"]},),
+        canonical_reasoning={"summary": "narrative summary"},
+    )
+    service, _lp, _llm, _skills, reasoning_provider = _service(reasoning_context=context)
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert reasoning_provider is not None
+    assert len(reasoning_provider.calls) == 1
+    call = reasoning_provider.calls[0]
+    assert call["target_id"] == "acme-q3-launch"
+    assert call["target_mode"] == "marketing_campaign"
+
+
+@pytest.mark.asyncio
+async def test_generate_raises_value_error_when_skill_prompt_missing() -> None:
+    service, _lp, _llm, _skills, _rp = _service(prompts={})
+
+    with pytest.raises(ValueError, match="Landing-page generation skill not found"):
+        await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_when_llm_omits_slug() -> None:
+    """Empty slug from the LLM hits the quality pack's no_slug blocker."""
+    response = _valid_response(slug="")
+    service, landing_pages, _llm, _skills, _rp = _service(responses=[response])
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert landing_pages.saved == []
+    blockers = result.errors[0]["blockers"]
+    assert any("no_slug" in b for b in blockers)

--- a/tests/test_extracted_quality_gate_landing_page_pack.py
+++ b/tests/test_extracted_quality_gate_landing_page_pack.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from extracted_quality_gate.landing_page_pack import evaluate_landing_page
+from extracted_quality_gate.types import (
+    GateDecision,
+    QualityInput,
+    QualityPolicy,
+)
+
+
+def _section(*, title: str = "Problem", body: str = "Renewal pricing is the #1 churn driver."):
+    return {
+        "id": "problem",
+        "title": title,
+        "body_markdown": body,
+        "metadata": {"order": 1},
+    }
+
+
+def _input(**overrides) -> QualityInput:
+    context = {
+        "title": "Acme Q3: Stop Renewal Surprises",
+        "slug": "acme-q3-launch",
+        "hero": {
+            "headline": "Stop renewal surprises",
+            "subheadline": "Acme catches pricing pressure 90 days early",
+            "cta_label": "Book a 15-min demo",
+            "cta_url": "/demo",
+        },
+        "sections": (_section(),),
+        "cta": {"label": "Book a 15-min demo", "url": "/demo"},
+        "meta": {
+            "title_tag": "Stop Renewal Surprises | Acme",
+            "description": "Acme catches renewal pressure 90 days early so you can prevent unplanned churn at scale.",
+        },
+    }
+    context.update(overrides)
+    return QualityInput(artifact_type="landing_page", context=context)
+
+
+def test_evaluate_landing_page_happy_path_passes() -> None:
+    report = evaluate_landing_page(_input())
+    assert report.passed is True
+    assert report.decision == GateDecision.PASS
+    assert report.blockers == ()
+
+
+def test_evaluate_landing_page_no_title_blocks() -> None:
+    report = evaluate_landing_page(_input(title=""))
+    codes = {f.code for f in report.blockers}
+    assert "no_title" in codes
+
+
+def test_evaluate_landing_page_no_slug_blocks() -> None:
+    report = evaluate_landing_page(_input(slug=""))
+    codes = {f.code for f in report.blockers}
+    assert "no_slug" in codes
+
+
+def test_evaluate_landing_page_no_hero_headline_blocks() -> None:
+    report = evaluate_landing_page(_input(hero={"subheadline": "x", "cta_label": "y", "cta_url": "/z"}))
+    codes = {f.code for f in report.blockers}
+    assert "no_hero_headline" in codes
+
+
+def test_evaluate_landing_page_no_hero_subheadline_warns_only() -> None:
+    """Subheadline absence is a warning, not a blocker (some heroes are headline-only)."""
+    report = evaluate_landing_page(
+        _input(hero={"headline": "h", "cta_label": "y", "cta_url": "/z"})
+    )
+    blocker_codes = {f.code for f in report.blockers}
+    warning_codes = {f.code for f in report.warnings}
+    assert "no_hero_subheadline" not in blocker_codes
+    assert "no_hero_subheadline" in warning_codes
+
+
+def test_evaluate_landing_page_no_cta_blocks() -> None:
+    report = evaluate_landing_page(_input(cta={}))
+    codes = {f.code for f in report.blockers}
+    assert "no_cta" in codes
+
+
+def test_evaluate_landing_page_partial_cta_still_blocks() -> None:
+    """CTA needs both label and url; either alone is incomplete."""
+    report = evaluate_landing_page(_input(cta={"label": "Demo"}))
+    assert any(f.code == "no_cta" for f in report.blockers)
+
+
+def test_evaluate_landing_page_no_sections_blocks() -> None:
+    report = evaluate_landing_page(_input(sections=()))
+    codes = {f.code for f in report.blockers}
+    assert "no_sections" in codes
+
+
+def test_evaluate_landing_page_section_missing_title_blocks_per_section() -> None:
+    sections = (_section(), _section(title=""))
+    report = evaluate_landing_page(_input(sections=sections))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "section_missing_title:1" in blocker_msgs
+    assert "section_missing_title:0" not in blocker_msgs
+
+
+def test_evaluate_landing_page_section_missing_body_blocks_per_section() -> None:
+    sections = (_section(), _section(body=""))
+    report = evaluate_landing_page(_input(sections=sections))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "section_missing_body:1" in blocker_msgs
+
+
+def test_evaluate_landing_page_meta_description_too_short_warns() -> None:
+    """Below the configured min for SEO."""
+    policy = QualityPolicy(name="lp_policy", thresholds={"min_meta_description_chars": 200})
+    report = evaluate_landing_page(_input(), policy=policy)
+    codes = {f.code for f in report.warnings}
+    assert "meta_description_too_short" in codes
+
+
+def test_evaluate_landing_page_meta_description_missing_warns() -> None:
+    policy = QualityPolicy(name="lp_policy", thresholds={"min_meta_description_chars": 100})
+    report = evaluate_landing_page(_input(meta={}), policy=policy)
+    codes = {f.code for f in report.warnings}
+    assert "missing_meta_description" in codes
+
+
+def test_evaluate_landing_page_blocked_phrasing_word_boundary_does_not_match_substring() -> None:
+    sections = (_section(body="We cannot compromise on quality."),)
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": ("promise",)})
+    report = evaluate_landing_page(_input(sections=sections), policy=policy)
+    codes = {f.code for f in report.blockers}
+    assert "blocked_phrasing" not in codes
+
+
+def test_evaluate_landing_page_blocked_phrasing_blocks_with_word_boundary() -> None:
+    sections = (_section(body="We GUARANTEE results within 30 days."),)
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": ("guarantee",)})
+    report = evaluate_landing_page(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_landing_page_blocked_phrasing_auto_wraps_bare_string_policy() -> None:
+    sections = (_section(body="We GUARANTEE results."),)
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": "guarantee"})
+    report = evaluate_landing_page(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_landing_page_blocked_phrasing_scans_hero_and_cta() -> None:
+    """Blocked-phrase scan covers hero (headline + subheadline) and CTA label, not just sections."""
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": ("guarantee",)})
+    report = evaluate_landing_page(
+        _input(hero={"headline": "We guarantee results", "subheadline": "x", "cta_label": "y", "cta_url": "/z"}),
+        policy=policy,
+    )
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_landing_page_metadata_carries_score_and_section_count() -> None:
+    report = evaluate_landing_page(_input())
+    assert "score" in report.metadata
+    assert report.metadata["section_count"] == 1
+    assert report.metadata["status"] == "pass"

--- a/tests/test_extracted_quality_gate_landing_page_pack.py
+++ b/tests/test_extracted_quality_gate_landing_page_pack.py
@@ -157,6 +157,56 @@ def test_evaluate_landing_page_blocked_phrasing_scans_hero_and_cta() -> None:
     assert "blocked_phrasing:guarantee" in blocker_msgs
 
 
+def test_evaluate_landing_page_blocked_phrasing_scans_hero_cta_label() -> None:
+    """Hero CTA label is its own surface (separate from page-level cta.label) and must be scanned."""
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": ("guarantee",)})
+    report = evaluate_landing_page(
+        _input(
+            hero={
+                "headline": "Stop renewal surprises",
+                "subheadline": "x",
+                "cta_label": "Book a guarantee call",
+                "cta_url": "/demo",
+            },
+        ),
+        policy=policy,
+    )
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_landing_page_blocked_phrasing_scans_meta_description() -> None:
+    """SEO meta description is the most public-facing surface; banned phrases there must block."""
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": ("guarantee",)})
+    report = evaluate_landing_page(
+        _input(
+            meta={
+                "title_tag": "Stop Renewal Surprises | Acme",
+                "description": "We guarantee renewal pricing predictability for every customer.",
+            },
+        ),
+        policy=policy,
+    )
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_landing_page_blocked_phrasing_scans_meta_title_tag() -> None:
+    """Title tag leaks into search snippets and social cards."""
+    policy = QualityPolicy(name="lp_policy", metadata={"blocked_phrasing": ("guarantee",)})
+    report = evaluate_landing_page(
+        _input(
+            meta={
+                "title_tag": "Guarantee Renewal Savings | Acme",
+                "description": "Acme catches renewal pressure 90 days early so you can prevent unplanned churn at scale.",
+            },
+        ),
+        policy=policy,
+    )
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
 def test_evaluate_landing_page_metadata_carries_score_and_section_count() -> None:
     report = evaluate_landing_page(_input())
     assert "score" in report.metadata


### PR DESCRIPTION
## Summary

Second slice of Landing Pages content-asset support. PR-LandingPage-1a (#351) landed the storage layer; this PR wires the generator on top.

**After this lands, AI Content Ops ships 4 of 5 landing-page content types** (blogs, emails, reports, landing pages). Sales briefs and the signal-extraction layer remain on the gap list.

**Per-campaign trigger** (mirrors the storage decision from #351; differs from per-opportunity Reports/Campaigns). The service takes a `MarketingCampaign` directly; one call produces one `LandingPageDraft`.

## What changed

**`extracted_quality_gate/landing_page_pack.py` (new)** — pure deterministic validator. Marketing-shaped blockers:

| Field / shape | Blocker / Warning |
|---|---|
| empty title | `no_title` (blocker) |
| empty slug | `no_slug` (blocker) |
| empty hero.headline | `no_hero_headline` (blocker) |
| empty hero.subheadline | `no_hero_subheadline` (warning — some heroes are headline-only) |
| missing CTA (label or url) | `no_cta` (blocker) |
| section count below `min_sections` | `no_sections` (blocker) |
| section with empty title | `section_missing_title:<i>` (blocker) |
| section with empty body_markdown | `section_missing_body:<i>` (blocker) |
| meta.description below `min_meta_description_chars` | `meta_description_too_short` (warning) |
| `blocked_phrasing` word-boundary match in title/hero/CTA/sections | `blocked_phrasing:<phrase>` (blocker) |

`blocked_phrasing` uses case-insensitive word-boundary regex (mirrors `validate_reasoning_output` + `report_pack`); bare-string policy auto-wraps. **Scan covers hero (headline + subheadline) and CTA label** in addition to sections — landing pages put the strongest claims in the hero, not just the body.

**`extracted_content_pipeline/skills/digest/landing_page_generation.md` (new)** — packaged prompt asking the LLM for `{title, slug, hero, sections, cta, meta, reference_ids}`. Calls out narrative-plan synergy, persona-tailoring, and a weasel-word avoidance list.

**`extracted_content_pipeline/landing_page_generation.py` (new)** — `LandingPageGenerationService` with **per-campaign API**:

```python
async def generate(
    self,
    *,
    scope: TenantScope,
    campaign: MarketingCampaign,
) -> LandingPageGenerationResult
```

Reasoning-context port adapter: passes the marketing campaign as the "opportunity" payload with `target_id=campaign.name`, `target_mode="marketing_campaign"`, so the existing `CampaignReasoningContextProvider` port (and the multi-pass reasoning bridge) works unchanged.

`parse_landing_page_response` uses `json.JSONDecoder.raw_decode` so braces inside `body_markdown` / CSS / template syntax don't trip the parser (matches the report-generator fix). System prompt embeds `{campaign_json}` once; user message is structural-only (no payload duplication).

**`tests/test_extracted_quality_gate_landing_page_pack.py` (new, 17 tests)** — every blocker class, warning, word-boundary regression, bare-string auto-wrap, hero/CTA scan coverage.

**`tests/test_extracted_landing_page_generation.py` (new, 12 tests)** — parse helper unit tests + service integration with fake ports.

**`scripts/run_extracted_pipeline_checks.sh`** — wires both new test files into the runner.

## Test plan

- [x] `python -c "from extracted_content_pipeline.landing_page_generation import LandingPageGenerationService; from extracted_quality_gate.landing_page_pack import evaluate_landing_page"` → clean import
- [x] AST scan of new files for `atlas_brain` refs → 0 hits
- [x] `bash scripts/validate_extracted_content_pipeline.sh` → passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed
- [x] `pytest tests/test_extracted_landing_page_generation.py tests/test_extracted_quality_gate_landing_page_pack.py tests/test_extracted_landing_page_postgres.py` → 39/39 passing locally
- [ ] CI `extracted-checks` run

## Out of scope (deferred)

- Approval API endpoint → PR-LandingPage-2
- CLI flag wiring → PR-LandingPage-3
- Variant generation (A/B headlines, persona variants per campaign) → separate slice
- Sales briefs (gap item #3) → separate slice
- Signal extraction (gap #4) → biggest landing-page risk; out of scope

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_