### PR TITLE
Scaffold AI Content Ops control surfaces

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -15,6 +15,7 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..control_surfaces import OUTPUT_CATALOG, PRESETS, preview_from_mapping
+from ..generation_plan import build_generation_plan_from_mapping
 
 
 def _require_fastapi() -> None:
@@ -91,6 +92,10 @@ def create_content_ops_control_surface_router(
     @router.post("/preview")
     async def preview_generation(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
         return preview_from_mapping(payload)
+
+    @router.post("/plan")
+    async def plan_generation(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+        return build_generation_plan_from_mapping(payload)
 
     return router
 

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1,0 +1,101 @@
+"""FastAPI router factory for AI Content Ops control-surface previews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+try:
+    from fastapi import APIRouter, Body
+except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
+    APIRouter = None
+    Body = None
+    _FASTAPI_IMPORT_ERROR: ImportError | None = exc
+else:
+    _FASTAPI_IMPORT_ERROR = None
+
+from ..control_surfaces import OUTPUT_CATALOG, PRESETS, preview_from_mapping
+
+
+def _require_fastapi() -> None:
+    if _FASTAPI_IMPORT_ERROR is None:
+        return
+    raise RuntimeError(
+        "FastAPI is required to create AI Content Ops control-surface routes. "
+        "Install fastapi in the host application environment."
+    ) from _FASTAPI_IMPORT_ERROR
+
+
+@dataclass(frozen=True)
+class ContentOpsControlSurfaceApiConfig:
+    """Host-owned API defaults for content-ops planning routes."""
+
+    prefix: str = "/content-ops"
+    tags: tuple[str, ...] = ("content-ops",)
+
+    def __post_init__(self) -> None:
+        if not str(self.prefix or "").strip().startswith("/"):
+            raise ValueError("prefix must start with /")
+
+
+def create_content_ops_control_surface_router(
+    *,
+    config: ContentOpsControlSurfaceApiConfig | None = None,
+    dependencies: Sequence[Any] | None = None,
+) -> APIRouter:
+    """Create host-mounted AI Content Ops control-surface routes.
+
+    These routes are intentionally preflight-only. They do not invoke LLMs,
+    mutate storage, or kick off autonomous jobs. Revolutionary, apparently.
+    """
+
+    _require_fastapi()
+    resolved_config = config or ContentOpsControlSurfaceApiConfig()
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+        dependencies=list(dependencies or ()),
+    )
+
+    @router.get("/control-surfaces")
+    async def describe_control_surfaces() -> dict[str, Any]:
+        return {
+            "outputs": [
+                {
+                    "id": item.id,
+                    "label": item.label,
+                    "description": item.description,
+                    "implemented": item.implemented,
+                    "estimated_unit_cost_usd": item.estimated_unit_cost_usd,
+                    "required_inputs": list(item.required_inputs),
+                    "default_max_items": item.default_max_items,
+                }
+                for item in OUTPUT_CATALOG.values()
+            ],
+            "presets": [
+                {
+                    "id": item.id,
+                    "label": item.label,
+                    "description": item.description,
+                    "outputs": list(item.outputs),
+                }
+                for item in PRESETS.values()
+            ],
+            "ingestion_profiles": [
+                "domain_specific",
+                "manual",
+                "existing_evidence",
+            ],
+        }
+
+    @router.post("/preview")
+    async def preview_generation(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+        return preview_from_mapping(payload)
+
+    return router
+
+
+__all__ = [
+    "ContentOpsControlSurfaceApiConfig",
+    "create_content_ops_control_surface_router",
+]

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -39,7 +39,7 @@ class ControlSurfacePreset:
 class ContentOpsRequest:
     """Normalized request shape produced by UI/API control surfaces."""
 
-    target_mode: str = "b2b"
+    target_mode: str = "vendor_retention"
     preset: str | None = None
     outputs: tuple[str, ...] = ()
     limit: int = 1
@@ -99,7 +99,7 @@ OUTPUT_CATALOG: dict[str, OutputDefinition] = {
         id="blog_post",
         label="Blog Post",
         description="Long-form blog draft from intelligence and evidence.",
-        implemented=True,
+        implemented=False,
         estimated_unit_cost_usd=0.45,
         required_inputs=("topic",),
     ),
@@ -115,7 +115,7 @@ OUTPUT_CATALOG: dict[str, OutputDefinition] = {
         id="landing_page",
         label="Landing Page",
         description="Landing page sections for a specific offer and audience.",
-        implemented=False,
+        implemented=True,
         estimated_unit_cost_usd=0.65,
         required_inputs=("offer", "audience"),
     ),
@@ -123,7 +123,7 @@ OUTPUT_CATALOG: dict[str, OutputDefinition] = {
         id="sales_brief",
         label="Sales Brief",
         description="Sales enablement brief from account intelligence.",
-        implemented=False,
+        implemented=True,
         estimated_unit_cost_usd=0.35,
         required_inputs=("target_account",),
     ),
@@ -133,7 +133,7 @@ OUTPUT_CATALOG: dict[str, OutputDefinition] = {
         description="Extracted opportunity or churn signals from source evidence.",
         implemented=False,
         estimated_unit_cost_usd=0.25,
-        required_inputs=("source_material"),
+        required_inputs=("source_material",),
     ),
 }
 
@@ -161,7 +161,7 @@ PRESETS: dict[str, ControlSurfacePreset] = {
         id="lead_gen_campaign",
         label="Lead Gen Campaign",
         outputs=("email_campaign", "landing_page"),
-        description="Outreach plus landing page. Landing page is gated until implemented.",
+        description="Outreach plus landing page.",
     ),
     "full_campaign": ControlSurfacePreset(
         id="full_campaign",
@@ -200,7 +200,8 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
     """Build a ContentOpsRequest from a plain dict payload."""
 
     return ContentOpsRequest(
-        target_mode=str(payload.get("target_mode") or "b2b").strip() or "b2b",
+        target_mode=str(payload.get("target_mode") or "vendor_retention").strip()
+        or "vendor_retention",
         preset=(str(payload.get("preset")).strip() or None)
         if payload.get("preset") is not None
         else None,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -1,0 +1,341 @@
+"""Control-surface primitives for AI Content Ops generation.
+
+This module is intentionally pure and deterministic. It does not call an LLM,
+read a database, or know about HTTP. The UI/API layer should use it to turn
+user-facing choices into a validated generation plan before any expensive work
+runs. Apparently civilization needs a receipt before burning tokens. Fair.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class OutputDefinition:
+    """Catalog entry for one generated content asset type."""
+
+    id: str
+    label: str
+    description: str
+    implemented: bool
+    estimated_unit_cost_usd: float
+    required_inputs: tuple[str, ...] = ()
+    default_max_items: int = 1
+
+
+@dataclass(frozen=True)
+class ControlSurfacePreset:
+    """Named output bundle for product-safe defaults."""
+
+    id: str
+    label: str
+    outputs: tuple[str, ...]
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class ContentOpsRequest:
+    """Normalized request shape produced by UI/API control surfaces."""
+
+    target_mode: str = "b2b"
+    preset: str | None = None
+    outputs: tuple[str, ...] = ()
+    limit: int = 1
+    max_cost_usd: float | None = None
+    inputs: Mapping[str, Any] = field(default_factory=dict)
+    ingestion_profile: str = "domain_specific"
+    require_quality_gates: bool = True
+    allow_unimplemented_outputs: bool = False
+
+
+@dataclass(frozen=True)
+class ControlSurfacePreview:
+    """Plan preview returned before generation starts."""
+
+    can_run: bool
+    outputs: tuple[str, ...]
+    estimated_cost_usd: float
+    missing_inputs: tuple[str, ...] = ()
+    blocked_outputs: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    normalized_request: ContentOpsRequest | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "can_run": self.can_run,
+            "outputs": list(self.outputs),
+            "estimated_cost_usd": round(self.estimated_cost_usd, 4),
+            "missing_inputs": list(self.missing_inputs),
+            "blocked_outputs": list(self.blocked_outputs),
+            "warnings": list(self.warnings),
+            "normalized_request": None
+            if self.normalized_request is None
+            else {
+                "target_mode": self.normalized_request.target_mode,
+                "preset": self.normalized_request.preset,
+                "outputs": list(self.normalized_request.outputs),
+                "limit": self.normalized_request.limit,
+                "max_cost_usd": self.normalized_request.max_cost_usd,
+                "ingestion_profile": self.normalized_request.ingestion_profile,
+                "require_quality_gates": self.normalized_request.require_quality_gates,
+                "allow_unimplemented_outputs": self.normalized_request.allow_unimplemented_outputs,
+            },
+        }
+
+
+OUTPUT_CATALOG: dict[str, OutputDefinition] = {
+    "email_campaign": OutputDefinition(
+        id="email_campaign",
+        label="Email Campaign",
+        description="Cold email and follow-up campaign drafts.",
+        implemented=True,
+        estimated_unit_cost_usd=0.18,
+        required_inputs=("target_account", "offer"),
+        default_max_items=3,
+    ),
+    "blog_post": OutputDefinition(
+        id="blog_post",
+        label="Blog Post",
+        description="Long-form blog draft from intelligence and evidence.",
+        implemented=True,
+        estimated_unit_cost_usd=0.45,
+        required_inputs=("topic",),
+    ),
+    "report": OutputDefinition(
+        id="report",
+        label="Report",
+        description="Structured intelligence report with references.",
+        implemented=True,
+        estimated_unit_cost_usd=0.55,
+        required_inputs=("opportunity_id",),
+    ),
+    "landing_page": OutputDefinition(
+        id="landing_page",
+        label="Landing Page",
+        description="Landing page sections for a specific offer and audience.",
+        implemented=False,
+        estimated_unit_cost_usd=0.65,
+        required_inputs=("offer", "audience"),
+    ),
+    "sales_brief": OutputDefinition(
+        id="sales_brief",
+        label="Sales Brief",
+        description="Sales enablement brief from account intelligence.",
+        implemented=False,
+        estimated_unit_cost_usd=0.35,
+        required_inputs=("target_account",),
+    ),
+    "signal_extraction": OutputDefinition(
+        id="signal_extraction",
+        label="Signal Extraction",
+        description="Extracted opportunity or churn signals from source evidence.",
+        implemented=False,
+        estimated_unit_cost_usd=0.25,
+        required_inputs=("source_material"),
+    ),
+}
+
+
+PRESETS: dict[str, ControlSurfacePreset] = {
+    "email_only": ControlSurfacePreset(
+        id="email_only",
+        label="Email Only",
+        outputs=("email_campaign",),
+        description="Lowest-cost outreach draft run.",
+    ),
+    "intelligence_report": ControlSurfacePreset(
+        id="intelligence_report",
+        label="Intelligence Report",
+        outputs=("report",),
+        description="Reference-backed report generation.",
+    ),
+    "content_marketing": ControlSurfacePreset(
+        id="content_marketing",
+        label="Content Marketing",
+        outputs=("blog_post", "report"),
+        description="Blog plus report using the same evidence base.",
+    ),
+    "lead_gen_campaign": ControlSurfacePreset(
+        id="lead_gen_campaign",
+        label="Lead Gen Campaign",
+        outputs=("email_campaign", "landing_page"),
+        description="Outreach plus landing page. Landing page is gated until implemented.",
+    ),
+    "full_campaign": ControlSurfacePreset(
+        id="full_campaign",
+        label="Full Campaign",
+        outputs=(
+            "email_campaign",
+            "blog_post",
+            "report",
+            "landing_page",
+            "sales_brief",
+        ),
+        description="Full bundle, expensive by design. Product managers adore these traps.",
+    ),
+}
+
+
+def normalize_outputs(raw_outputs: str | Iterable[str] | None) -> tuple[str, ...]:
+    """Normalize user/API output selection into stable unique ids."""
+
+    if raw_outputs is None:
+        return ()
+    if isinstance(raw_outputs, str):
+        candidates: Sequence[str] = raw_outputs.split(",")
+    else:
+        candidates = tuple(raw_outputs)
+
+    normalized: list[str] = []
+    for item in candidates:
+        value = str(item or "").strip().lower().replace("-", "_")
+        if value and value not in normalized:
+            normalized.append(value)
+    return tuple(normalized)
+
+
+def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
+    """Build a ContentOpsRequest from a plain dict payload."""
+
+    return ContentOpsRequest(
+        target_mode=str(payload.get("target_mode") or "b2b").strip() or "b2b",
+        preset=(str(payload.get("preset")).strip() or None)
+        if payload.get("preset") is not None
+        else None,
+        outputs=normalize_outputs(payload.get("outputs")),
+        limit=max(1, int(payload.get("limit") or 1)),
+        max_cost_usd=(
+            float(payload["max_cost_usd"])
+            if payload.get("max_cost_usd") is not None
+            else None
+        ),
+        inputs=payload.get("inputs") if isinstance(payload.get("inputs"), Mapping) else {},
+        ingestion_profile=str(payload.get("ingestion_profile") or "domain_specific").strip()
+        or "domain_specific",
+        require_quality_gates=bool(payload.get("require_quality_gates", True)),
+        allow_unimplemented_outputs=bool(payload.get("allow_unimplemented_outputs", False)),
+    )
+
+
+def resolve_outputs(request: ContentOpsRequest) -> tuple[str, ...]:
+    """Resolve explicit outputs, falling back to a preset when provided."""
+
+    if request.outputs:
+        return normalize_outputs(request.outputs)
+    if request.preset:
+        preset = PRESETS.get(request.preset)
+        if preset:
+            return preset.outputs
+    return PRESETS["email_only"].outputs
+
+
+def estimate_cost_usd(outputs: Sequence[str], *, limit: int) -> float:
+    """Estimate cost from selected outputs and opportunity limit.
+
+    The estimates are intentionally conservative placeholders. They create a
+    product contract now and can be replaced later with real token accounting.
+    """
+
+    total = 0.0
+    for output_id in outputs:
+        definition = OUTPUT_CATALOG.get(output_id)
+        if not definition:
+            continue
+        total += definition.estimated_unit_cost_usd * max(1, limit)
+    return total
+
+
+def missing_required_inputs(
+    outputs: Sequence[str],
+    provided_inputs: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return required input names missing for selected outputs."""
+
+    missing: list[str] = []
+    for output_id in outputs:
+        definition = OUTPUT_CATALOG.get(output_id)
+        if not definition:
+            continue
+        for input_name in definition.required_inputs:
+            value = provided_inputs.get(input_name)
+            if value in (None, "", [], {}):
+                if input_name not in missing:
+                    missing.append(input_name)
+    return tuple(missing)
+
+
+def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview:
+    """Validate a generation request and return a preflight plan."""
+
+    outputs = resolve_outputs(request)
+    warnings: list[str] = []
+    blocked: list[str] = []
+
+    unknown_outputs = tuple(output for output in outputs if output not in OUTPUT_CATALOG)
+    for output_id in unknown_outputs:
+        blocked.append(output_id)
+        warnings.append(f"Unknown output type: {output_id}")
+
+    for output_id in outputs:
+        definition = OUTPUT_CATALOG.get(output_id)
+        if not definition:
+            continue
+        if not definition.implemented and not request.allow_unimplemented_outputs:
+            blocked.append(output_id)
+            warnings.append(f"Output not implemented yet: {output_id}")
+
+    selected_outputs = tuple(output for output in outputs if output not in blocked)
+    missing = missing_required_inputs(selected_outputs, request.inputs)
+    estimated_cost = estimate_cost_usd(selected_outputs, limit=request.limit)
+
+    if request.max_cost_usd is not None and estimated_cost > request.max_cost_usd:
+        warnings.append(
+            "Estimated cost exceeds max_cost_usd: "
+            f"{estimated_cost:.2f} > {request.max_cost_usd:.2f}"
+        )
+
+    if request.ingestion_profile not in {"domain_specific", "manual", "existing_evidence"}:
+        warnings.append(
+            "Unknown ingestion_profile; expected one of "
+            "domain_specific, manual, existing_evidence"
+        )
+
+    can_run = (
+        bool(selected_outputs)
+        and not missing
+        and not blocked
+        and (
+            request.max_cost_usd is None
+            or estimated_cost <= request.max_cost_usd
+        )
+    )
+
+    normalized_request = ContentOpsRequest(
+        target_mode=request.target_mode,
+        preset=request.preset,
+        outputs=selected_outputs,
+        limit=request.limit,
+        max_cost_usd=request.max_cost_usd,
+        inputs=request.inputs,
+        ingestion_profile=request.ingestion_profile,
+        require_quality_gates=request.require_quality_gates,
+        allow_unimplemented_outputs=request.allow_unimplemented_outputs,
+    )
+
+    return ControlSurfacePreview(
+        can_run=can_run,
+        outputs=selected_outputs,
+        estimated_cost_usd=estimated_cost,
+        missing_inputs=missing,
+        blocked_outputs=tuple(dict.fromkeys(blocked)),
+        warnings=tuple(warnings),
+        normalized_request=normalized_request,
+    )
+
+
+def preview_from_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Dict-friendly wrapper for API routes and UI smoke tests."""
+
+    return preview_control_surface(request_from_mapping(payload)).as_dict()

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -57,10 +57,10 @@ Current output ids:
 | Output | Status | Notes |
 |---|---|---|
 | `email_campaign` | Implemented | Existing campaign draft path. |
-| `blog_post` | Implemented | Existing content asset path, but not yet service-shaped for the unified planner. |
+| `blog_post` | Not implemented | Existing autonomous task path, but not yet service-shaped for the unified planner. |
 | `report` | Implemented | Structured report draft path. |
-| `landing_page` | Not implemented | Included in catalog but blocked by default. |
-| `sales_brief` | Not implemented | Included in catalog but blocked by default. |
+| `landing_page` | Implemented | Landing page generation service path. |
+| `sales_brief` | Implemented | Sales brief generation service path. |
 | `signal_extraction` | Not implemented | Included in catalog but blocked by default. |
 
 Future outputs should be added to the catalog first, then exposed through
@@ -76,7 +76,7 @@ Current preset ids:
 | `email_only` | `email_campaign` | Lowest-cost outreach draft run. |
 | `intelligence_report` | `report` | Reference-backed report generation. |
 | `content_marketing` | `blog_post`, `report` | Blog plus report from the same evidence base. |
-| `lead_gen_campaign` | `email_campaign`, `landing_page` | Outreach plus landing page. Landing page remains gated until implemented. |
+| `lead_gen_campaign` | `email_campaign`, `landing_page` | Outreach plus landing page. |
 | `full_campaign` | `email_campaign`, `blog_post`, `report`, `landing_page`, `sales_brief` | Full bundle. Expensive and partially gated. |
 
 ## Preview Payload
@@ -110,7 +110,7 @@ preset.
   "blocked_outputs": [],
   "warnings": [],
   "normalized_request": {
-    "target_mode": "b2b",
+    "target_mode": "vendor_retention",
     "preset": null,
     "outputs": ["email_campaign", "report"],
     "limit": 2,
@@ -135,7 +135,7 @@ show the selected plan, but it should not enable the generate button until
 ```json
 {
   "can_execute": true,
-  "target_mode": "b2b",
+  "target_mode": "vendor_retention",
   "limit": 2,
   "steps": [
     {
@@ -180,9 +180,8 @@ show the selected plan, but it should not enable the generate button until
 
 `can_execute` is stricter than `preview.can_run`. It only becomes true when the
 preview passes and every selected output maps to a runnable service-shaped step.
-For example, `blog_post` can pass preview but currently returns a `planned` step
-because the blog path exists as an autonomous task rather than the same
-service/port interface used by campaigns and reports.
+`blog_post` is blocked at preview time until it exposes the same service/port
+interface used by campaigns, reports, landing pages, and sales briefs.
 
 ## UI Contract
 

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -1,0 +1,167 @@
+# AI Content Ops Control-Surface Preview API
+
+Date: 2026-05-07
+
+This document covers the pre-generation control surface for AI Content Ops.
+It is intentionally separate from generation, sending, approval, and storage.
+The point is to let a host UI ask what can run, what it will cost, and what is
+missing before the product burns tokens like a tiny ceremonial bonfire.
+
+## Why This Exists
+
+The product can generate multiple content assets: email campaigns, blog posts,
+reports, landing pages, sales briefs, and signal extraction. Not every run
+should produce every asset. The UI needs a backend-owned contract for output
+selection, presets, budget checks, missing input checks, and implementation
+status.
+
+The control-surface preview is that contract.
+
+## Host Mount
+
+Mount the router in the host FastAPI app and inject the same auth dependency the
+host uses for other Content Ops routes:
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.control_surfaces import (
+    create_content_ops_control_surface_router,
+)
+
+
+app.include_router(
+    create_content_ops_control_surface_router(
+        dependencies=[Depends(require_content_ops_user)],
+    )
+)
+```
+
+The router is preflight-only. It does not call an LLM, read or write Postgres,
+or start an autonomous task.
+
+## Routes
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/content-ops/control-surfaces` | List output types, presets, required inputs, implementation status, cost estimates, and ingestion profiles. |
+| `POST` | `/content-ops/preview` | Validate a requested preset/output selection and return cost, missing inputs, warnings, and blocked outputs. |
+
+## Output Catalog
+
+Current output ids:
+
+| Output | Status | Notes |
+|---|---|---|
+| `email_campaign` | Implemented | Existing campaign draft path. |
+| `blog_post` | Implemented | Existing content asset path. |
+| `report` | Implemented | Structured report draft path. |
+| `landing_page` | Not implemented | Included in catalog but blocked by default. |
+| `sales_brief` | Not implemented | Included in catalog but blocked by default. |
+| `signal_extraction` | Not implemented | Included in catalog but blocked by default. |
+
+Future outputs should be added to the catalog first, then exposed through
+presets only after the implementation and quality gate exist. Yes, this is less
+exciting than shipping a toggle that lies to users. That is the point.
+
+## Presets
+
+Current preset ids:
+
+| Preset | Outputs | Purpose |
+|---|---|---|
+| `email_only` | `email_campaign` | Lowest-cost outreach draft run. |
+| `intelligence_report` | `report` | Reference-backed report generation. |
+| `content_marketing` | `blog_post`, `report` | Blog plus report from the same evidence base. |
+| `lead_gen_campaign` | `email_campaign`, `landing_page` | Outreach plus landing page. Landing page remains gated until implemented. |
+| `full_campaign` | `email_campaign`, `blog_post`, `report`, `landing_page`, `sales_brief` | Full bundle. Expensive and partially gated. |
+
+## Preview Payload
+
+```json
+{
+  "outputs": ["email_campaign", "report"],
+  "limit": 2,
+  "max_cost_usd": 2.0,
+  "inputs": {
+    "target_account": "Acme",
+    "offer": "Churn intelligence audit",
+    "opportunity_id": "opp_123"
+  },
+  "ingestion_profile": "domain_specific",
+  "require_quality_gates": true
+}
+```
+
+A caller may use either `outputs` or `preset`. Explicit `outputs` win over a
+preset.
+
+## Preview Response
+
+```json
+{
+  "can_run": true,
+  "outputs": ["email_campaign", "report"],
+  "estimated_cost_usd": 1.46,
+  "missing_inputs": [],
+  "blocked_outputs": [],
+  "warnings": [],
+  "normalized_request": {
+    "target_mode": "b2b",
+    "preset": null,
+    "outputs": ["email_campaign", "report"],
+    "limit": 2,
+    "max_cost_usd": 2.0,
+    "ingestion_profile": "domain_specific",
+    "require_quality_gates": true,
+    "allow_unimplemented_outputs": false
+  }
+}
+```
+
+Treat `can_run=false` as a hard stop for generation controls. The UI can still
+show the selected plan, but it should not enable the generate button until
+`missing_inputs`, `blocked_outputs`, and budget warnings are resolved.
+
+## UI Contract
+
+The UI should call `/content-ops/preview` whenever any of these change:
+
+- selected preset
+- selected outputs
+- limit
+- max budget
+- source inputs
+- ingestion profile
+
+The first UI should be boring in the useful way:
+
+1. choose a preset or outputs
+2. add required inputs
+3. show estimated cost and warnings
+4. disable generation until `can_run=true`
+5. pass the normalized request into the generation endpoint added in a later slice
+
+Do not put prompt settings, retrieval knobs, model choices, or chunking strategy
+in the first UI. Those are backend controls until there is a real product reason
+to expose them.
+
+## Cost Notes
+
+The current cost estimates are conservative placeholders. They exist to create
+the product contract now. Replace the placeholder estimates with real token or
+provider accounting later without changing the UI contract.
+
+## Ingestion Profiles
+
+Supported values:
+
+| Profile | Meaning |
+|---|---|
+| `domain_specific` | Default path. Use product/domain assumptions and existing evidence model. |
+| `manual` | Caller supplies the inputs directly. |
+| `existing_evidence` | Caller references already-ingested evidence or opportunities. |
+
+Do not expose arbitrary ingestion-pipeline configuration in the first UI. Domain
+specific ingestion is the sane default until the product has enough repeated use
+to justify more knobs.

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -15,7 +15,9 @@ should produce every asset. The UI needs a backend-owned contract for output
 selection, presets, budget checks, missing input checks, and implementation
 status.
 
-The control-surface preview is that contract.
+The control-surface preview is that contract. The generation plan endpoint is
+the next layer: it turns a passing preview into deterministic service steps
+without executing them.
 
 ## Host Mount
 
@@ -46,6 +48,7 @@ or start an autonomous task.
 |---|---|---|
 | `GET` | `/content-ops/control-surfaces` | List output types, presets, required inputs, implementation status, cost estimates, and ingestion profiles. |
 | `POST` | `/content-ops/preview` | Validate a requested preset/output selection and return cost, missing inputs, warnings, and blocked outputs. |
+| `POST` | `/content-ops/plan` | Convert a previewable request into deterministic generation steps. Does not execute generation. |
 
 ## Output Catalog
 
@@ -54,7 +57,7 @@ Current output ids:
 | Output | Status | Notes |
 |---|---|---|
 | `email_campaign` | Implemented | Existing campaign draft path. |
-| `blog_post` | Implemented | Existing content asset path. |
+| `blog_post` | Implemented | Existing content asset path, but not yet service-shaped for the unified planner. |
 | `report` | Implemented | Structured report draft path. |
 | `landing_page` | Not implemented | Included in catalog but blocked by default. |
 | `sales_brief` | Not implemented | Included in catalog but blocked by default. |
@@ -123,6 +126,64 @@ Treat `can_run=false` as a hard stop for generation controls. The UI can still
 show the selected plan, but it should not enable the generate button until
 `missing_inputs`, `blocked_outputs`, and budget warnings are resolved.
 
+## Plan Payload
+
+`POST /content-ops/plan` accepts the same payload as `/content-ops/preview`.
+
+## Plan Response
+
+```json
+{
+  "can_execute": true,
+  "target_mode": "b2b",
+  "limit": 2,
+  "steps": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "status": "runnable",
+      "config": {
+        "skill_name": "digest/b2b_campaign_generation",
+        "channels": ["email_cold", "email_followup"],
+        "limit": 2,
+        "max_tokens": 1200,
+        "temperature": 0.4,
+        "quality_revalidation_enabled": true,
+        "quality_prompt_proof_term_limit": 5
+      },
+      "reason": ""
+    },
+    {
+      "output": "report",
+      "runner": "ReportGenerationService.generate",
+      "status": "runnable",
+      "config": {
+        "skill_name": "digest/report_generation",
+        "default_report_type": "vendor_pressure",
+        "limit": 2,
+        "max_tokens": 4096,
+        "temperature": 0.3
+      },
+      "reason": ""
+    }
+  ],
+  "preview": {
+    "can_run": true,
+    "outputs": ["email_campaign", "report"],
+    "estimated_cost_usd": 1.46,
+    "missing_inputs": [],
+    "blocked_outputs": [],
+    "warnings": []
+  }
+}
+```
+
+`can_execute` is stricter than `preview.can_run`. It only becomes true when the
+preview passes and every selected output maps to a runnable service-shaped step.
+For example, `blog_post` can pass preview but currently returns a `planned` step
+because the blog path exists as an autonomous task rather than the same
+service/port interface used by campaigns and reports.
+
 ## UI Contract
 
 The UI should call `/content-ops/preview` whenever any of these change:
@@ -140,7 +201,8 @@ The first UI should be boring in the useful way:
 2. add required inputs
 3. show estimated cost and warnings
 4. disable generation until `can_run=true`
-5. pass the normalized request into the generation endpoint added in a later slice
+5. call `/content-ops/plan` to show the concrete steps before generation
+6. pass the normalized request into the generation endpoint added in a later slice
 
 Do not put prompt settings, retrieval knobs, model choices, or chunking strategy
 in the first UI. Those are backend controls until there is a real product reason

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -1,0 +1,187 @@
+"""Map AI Content Ops control-surface requests into generation plans.
+
+This module is the bridge between preflight preview and actual execution. It
+still does not run LLMs or touch storage. It converts a validated control
+surface request into asset-specific execution steps that future API handlers can
+call. Thrilling bureaucracy, but the useful kind.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from .campaign_generation import CampaignGenerationConfig
+from .control_surfaces import (
+    ContentOpsRequest,
+    ControlSurfacePreview,
+    preview_control_surface,
+    request_from_mapping,
+)
+from .report_generation import ReportGenerationConfig
+
+
+@dataclass(frozen=True)
+class GenerationPlanStep:
+    """One runnable or planned asset generation step."""
+
+    output: str
+    runner: str
+    status: str
+    config: Mapping[str, Any] = field(default_factory=dict)
+    reason: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "output": self.output,
+            "runner": self.runner,
+            "status": self.status,
+            "config": dict(self.config),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class GenerationPlan:
+    """Resolved generation plan for a normalized content-ops request."""
+
+    can_execute: bool
+    target_mode: str
+    limit: int
+    steps: tuple[GenerationPlanStep, ...]
+    preview: ControlSurfacePreview
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "can_execute": self.can_execute,
+            "target_mode": self.target_mode,
+            "limit": self.limit,
+            "steps": [step.as_dict() for step in self.steps],
+            "preview": self.preview.as_dict(),
+        }
+
+
+def _campaign_config_for_request(request: ContentOpsRequest) -> CampaignGenerationConfig:
+    channels = request.inputs.get("channels")
+    if channels is None:
+        channels = request.inputs.get("campaign_channels")
+    if isinstance(channels, str):
+        channel_tuple = tuple(
+            item.strip()
+            for item in channels.split(",")
+            if item.strip()
+        )
+    elif isinstance(channels, Sequence) and not isinstance(channels, (bytes, bytearray)):
+        channel_tuple = tuple(
+            str(item or "").strip()
+            for item in channels
+            if str(item or "").strip()
+        )
+    else:
+        channel_tuple = ("email_cold", "email_followup")
+
+    return CampaignGenerationConfig(
+        channels=channel_tuple,
+        limit=request.limit,
+        quality_revalidation_enabled=request.require_quality_gates,
+    )
+
+
+def _report_config_for_request(request: ContentOpsRequest) -> ReportGenerationConfig:
+    report_type = str(
+        request.inputs.get("report_type")
+        or "vendor_pressure"
+    ).strip() or "vendor_pressure"
+    return ReportGenerationConfig(
+        default_report_type=report_type,
+        limit=request.limit,
+    )
+
+
+def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanStep:
+    if output == "email_campaign":
+        config = _campaign_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="CampaignGenerationService.generate",
+            status="runnable",
+            config={
+                "skill_name": config.skill_name,
+                "channels": list(config.channels),
+                "limit": config.limit,
+                "max_tokens": config.max_tokens,
+                "temperature": config.temperature,
+                "quality_revalidation_enabled": config.quality_revalidation_enabled,
+                "quality_prompt_proof_term_limit": config.quality_prompt_proof_term_limit,
+            },
+        )
+    if output == "report":
+        config = _report_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="ReportGenerationService.generate",
+            status="runnable",
+            config={
+                "skill_name": config.skill_name,
+                "default_report_type": config.default_report_type,
+                "limit": config.limit,
+                "max_tokens": config.max_tokens,
+                "temperature": config.temperature,
+            },
+        )
+    if output == "blog_post":
+        return GenerationPlanStep(
+            output=output,
+            runner="extracted_content_pipeline.autonomous.tasks.blog_post_generation",
+            status="planned",
+            config={
+                "skill_name": "digest/blog_post_generation",
+                "limit": request.limit,
+                "topic": request.inputs.get("topic"),
+            },
+            reason=(
+                "Blog generation exists as an autonomous task path, but does not "
+                "yet expose the same service/port interface as campaign and report generation."
+            ),
+        )
+    return GenerationPlanStep(
+        output=output,
+        runner="",
+        status="blocked",
+        reason="No generation runner is mapped for this output.",
+    )
+
+
+def build_generation_plan(request: ContentOpsRequest) -> GenerationPlan:
+    """Build an execution plan from a content-ops request.
+
+    The plan only becomes executable when preview passes and every selected step
+    is runnable. Planned steps are deliberately not executed by future callers
+    until they get service-shaped adapters.
+    """
+
+    preview = preview_control_surface(request)
+    normalized = preview.normalized_request or request
+    steps = tuple(_step_for_output(output, normalized) for output in preview.outputs)
+    can_execute = preview.can_run and all(step.status == "runnable" for step in steps)
+    return GenerationPlan(
+        can_execute=can_execute,
+        target_mode=normalized.target_mode,
+        limit=normalized.limit,
+        steps=steps,
+        preview=preview,
+    )
+
+
+def build_generation_plan_from_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Dict-friendly wrapper for API routes and UI smoke tests."""
+
+    return build_generation_plan(request_from_mapping(payload)).as_dict()
+
+
+__all__ = [
+    "GenerationPlan",
+    "GenerationPlanStep",
+    "build_generation_plan",
+    "build_generation_plan_from_mapping",
+]

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -155,15 +155,19 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
 def build_generation_plan(request: ContentOpsRequest) -> GenerationPlan:
     """Build an execution plan from a content-ops request.
 
-    The plan only becomes executable when preview passes and every selected step
-    is runnable. Planned steps are deliberately not executed by future callers
-    until they get service-shaped adapters.
+    The plan only becomes executable when preview passes, no selected output was
+    blocked, and every selected step is runnable. Planned steps are deliberately
+    not executed by future callers until they get service-shaped adapters.
     """
 
     preview = preview_control_surface(request)
     normalized = preview.normalized_request or request
     steps = tuple(_step_for_output(output, normalized) for output in preview.outputs)
-    can_execute = preview.can_run and all(step.status == "runnable" for step in steps)
+    can_execute = (
+        preview.can_run
+        and not preview.blocked_outputs
+        and all(step.status == "runnable" for step in steps)
+    )
     return GenerationPlan(
         can_execute=can_execute,
         target_mode=normalized.target_mode,

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -18,7 +18,9 @@ from .control_surfaces import (
     preview_control_surface,
     request_from_mapping,
 )
+from .landing_page_generation import LandingPageGenerationConfig
 from .report_generation import ReportGenerationConfig
+from .sales_brief_generation import SalesBriefGenerationConfig
 
 
 @dataclass(frozen=True)
@@ -98,6 +100,22 @@ def _report_config_for_request(request: ContentOpsRequest) -> ReportGenerationCo
     )
 
 
+def _landing_page_config_for_request(request: ContentOpsRequest) -> LandingPageGenerationConfig:
+    del request
+    return LandingPageGenerationConfig()
+
+
+def _sales_brief_config_for_request(request: ContentOpsRequest) -> SalesBriefGenerationConfig:
+    brief_type = str(
+        request.inputs.get("brief_type")
+        or "pre_call"
+    ).strip() or "pre_call"
+    return SalesBriefGenerationConfig(
+        default_brief_type=brief_type,
+        limit=request.limit,
+    )
+
+
 def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanStep:
     if output == "email_campaign":
         config = _campaign_config_for_request(request)
@@ -127,6 +145,34 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "limit": config.limit,
                 "max_tokens": config.max_tokens,
                 "temperature": config.temperature,
+            },
+        )
+    if output == "landing_page":
+        config = _landing_page_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="LandingPageGenerationService.generate",
+            status="runnable",
+            config={
+                "skill_name": config.skill_name,
+                "max_tokens": config.max_tokens,
+                "temperature": config.temperature,
+                "quality_gates_enabled": request.require_quality_gates,
+            },
+        )
+    if output == "sales_brief":
+        config = _sales_brief_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="SalesBriefGenerationService.generate",
+            status="runnable",
+            config={
+                "skill_name": config.skill_name,
+                "default_brief_type": config.default_brief_type,
+                "limit": config.limit,
+                "max_tokens": config.max_tokens,
+                "temperature": config.temperature,
+                "quality_gates_enabled": request.require_quality_gates,
             },
         )
     if output == "blog_post":

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -1,0 +1,418 @@
+"""Standalone Sales Briefs generator orchestration.
+
+Sibling of ``CampaignGenerationService`` (per-opportunity emails) and
+``ReportGenerationService`` (per-opportunity structured reports). Same
+per-opportunity trigger shape as Reports: the service iterates
+``intelligence.read_campaign_opportunities`` and produces one
+``SalesBriefDraft`` per opportunity row.
+
+Distinct from Reports:
+- Output carries a one-line ``headline`` (elevator pitch, ~140 chars)
+  instead of a longer paragraph ``summary``.
+- ``brief_type`` (pre_call / renewal / displacement / discovery)
+  classifies the brief shape; defaults to ``pre_call`` when the LLM
+  doesn't supply one.
+- The skill prompt frames the output as sales-facing internal copy
+  rather than a customer-facing analytical document.
+
+Reasoning-context aware: when the host provides a multi-pass
+``CampaignReasoningContextProvider`` whose context exposes a
+``canonical_reasoning["narrative_plan"]`` block, the generator hands
+that pre-structured plan to the LLM as the section spine so the model
+writes prose for each section rather than inventing the structure.
+Without a narrative plan, the LLM structures the brief itself.
+
+Quality gating runs through ``extracted_quality_gate.sales_brief_pack``
+-- pure deterministic, no LLM. Failures skip persistence and surface
+in the result's ``errors`` payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+import re
+from typing import Any
+
+from .campaign_opportunities import (
+    normalize_campaign_opportunity,
+    opportunity_target_id,
+)
+from .campaign_ports import (
+    CampaignReasoningContextProvider,
+    IntelligenceRepository,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
+from .sales_brief_ports import (
+    SalesBriefDraft,
+    SalesBriefRepository,
+    SalesBriefSection,
+)
+from .services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
+    campaign_reasoning_context_payload,
+    normalize_campaign_reasoning_context,
+)
+from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
+from extracted_quality_gate.types import QualityInput, QualityPolicy
+
+
+@dataclass(frozen=True)
+class SalesBriefGenerationConfig:
+    """Tunable defaults for ``SalesBriefGenerationService``."""
+
+    skill_name: str = "digest/sales_brief_generation"
+    default_brief_type: str = "pre_call"
+    limit: int = 10
+    max_tokens: int = 4096
+    temperature: float = 0.3
+    quality_policy: QualityPolicy | None = None
+
+
+@dataclass(frozen=True)
+class SalesBriefGenerationResult:
+    requested: int
+    generated: int
+    skipped: int
+    saved_ids: tuple[str, ...] = ()
+    errors: tuple[Mapping[str, Any], ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "requested": self.requested,
+            "generated": self.generated,
+            "skipped": self.skipped,
+            "saved_ids": list(self.saved_ids),
+            "errors": list(self.errors),
+        }
+
+
+def parse_sales_brief_response(text: str) -> dict[str, Any] | None:
+    """Extract the first well-formed sales-brief JSON object.
+
+    Mirrors ``parse_report_response``: strips ``<think>`` blocks + code
+    fences, then walks the cleaned text with
+    ``json.JSONDecoder.raw_decode`` so braces inside string values
+    (markdown templates, etc.) don't trip the parser.
+
+    The parser only enforces what's needed to identify the candidate as
+    a sales-brief payload: ``title`` (non-empty) and a non-empty
+    ``sections`` list. Missing or malformed ``headline`` / ``brief_type``
+    are NOT rejected here -- the quality pack's specific blockers
+    (``no_headline``, etc.) surface those failures so callers see
+    exactly what was wrong rather than a generic ``unparseable_response``.
+    """
+
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    decoder = json.JSONDecoder()
+    candidates: list[Any] = []
+    index = 0
+    length = len(cleaned)
+    while index < length:
+        if cleaned[index] != "{":
+            index += 1
+            continue
+        try:
+            decoded, end = decoder.raw_decode(cleaned, index)
+        except json.JSONDecodeError:
+            index += 1
+            continue
+        candidates.append(decoded)
+        index = end if end > index else index + 1
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, dict):
+            continue
+        title = str(candidate.get("title") or "").strip()
+        sections = candidate.get("sections")
+        if not title:
+            continue
+        if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
+            continue
+        coerced_sections = [s for s in sections if isinstance(s, Mapping)]
+        if not coerced_sections:
+            continue
+        return {
+            **candidate,
+            "title": title,
+            "sections": coerced_sections,
+        }
+    return None
+
+
+class SalesBriefGenerationService:
+    """Generate sales-brief drafts through product-owned ports."""
+
+    def __init__(
+        self,
+        *,
+        intelligence: IntelligenceRepository,
+        sales_briefs: SalesBriefRepository,
+        llm: LLMClient,
+        skills: SkillStore,
+        reasoning_context: CampaignReasoningContextProvider | None = None,
+        config: SalesBriefGenerationConfig | None = None,
+    ):
+        self._intelligence = intelligence
+        self._sales_briefs = sales_briefs
+        self._llm = llm
+        self._skills = skills
+        self._reasoning_context = reasoning_context
+        self._config = config or SalesBriefGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> SalesBriefGenerationResult:
+        prompt_template = self._skills.get_prompt(self._config.skill_name)
+        if not prompt_template:
+            raise ValueError(
+                f"Sales-brief generation skill not found: {self._config.skill_name}"
+            )
+
+        requested = int(limit or self._config.limit)
+        opportunities = [
+            normalize_campaign_opportunity(row, target_mode=target_mode)
+            for row in await self._intelligence.read_campaign_opportunities(
+                scope=scope,
+                target_mode=target_mode,
+                limit=requested,
+                filters=filters,
+            )
+        ]
+
+        drafts: list[SalesBriefDraft] = []
+        errors: list[dict[str, Any]] = []
+        skipped = 0
+        for opportunity in opportunities:
+            target_id = opportunity_target_id(opportunity)
+            if not target_id:
+                skipped += 1
+                errors.append({"reason": "missing_target_id", "opportunity": opportunity})
+                continue
+            try:
+                opportunity = await self._opportunity_with_reasoning_context(
+                    scope=scope,
+                    target_mode=target_mode,
+                    target_id=target_id,
+                    opportunity=opportunity,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+
+            try:
+                parsed = await self._generate_one(
+                    prompt_template,
+                    opportunity=opportunity,
+                    target_mode=target_mode,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+
+            if not parsed:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": "unparseable_response"})
+                continue
+
+            quality = self._quality_check(parsed)
+            if not quality["passed"]:
+                skipped += 1
+                errors.append({
+                    "target_id": target_id,
+                    "reason": "quality_blocked",
+                    "blockers": quality["blockers"],
+                })
+                continue
+
+            drafts.append(
+                self._build_draft(parsed, target_id=target_id, target_mode=target_mode)
+            )
+
+        saved_ids: tuple[str, ...] = ()
+        if drafts:
+            saved_ids = tuple(
+                str(item)
+                for item in await self._sales_briefs.save_drafts(drafts, scope=scope)
+            )
+        return SalesBriefGenerationResult(
+            requested=len(opportunities),
+            generated=len(drafts),
+            skipped=skipped,
+            saved_ids=saved_ids,
+            errors=tuple(errors),
+        )
+
+    async def _opportunity_with_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        target_id: str,
+        opportunity: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        # Mirrors ReportGenerationService._opportunity_with_reasoning_context.
+        context = None
+        if self._reasoning_context is not None:
+            provided = await self._reasoning_context.read_campaign_reasoning_context(
+                scope=scope,
+                target_id=target_id,
+                target_mode=target_mode,
+                opportunity=opportunity,
+            )
+            provided_context = normalize_campaign_reasoning_context(provided)
+            if provided_context.has_content():
+                context = provided_context
+        if context is None:
+            context = normalize_campaign_reasoning_context(opportunity)
+        if not context.has_content():
+            return dict(opportunity)
+        enriched = dict(opportunity)
+        payload = campaign_reasoning_context_payload(context)
+        enriched.update(campaign_reasoning_context_metadata(context))
+        existing_reasoning_context = opportunity.get("reasoning_context")
+        if isinstance(existing_reasoning_context, Mapping):
+            enriched["reasoning_context"] = {
+                **dict(existing_reasoning_context),
+                "campaign_reasoning_context": payload,
+            }
+        else:
+            enriched["reasoning_context"] = payload
+        enriched["campaign_reasoning_context"] = payload
+        return enriched
+
+    async def _generate_one(
+        self,
+        prompt_template: str,
+        *,
+        opportunity: Mapping[str, Any],
+        target_mode: str,
+    ) -> dict[str, Any] | None:
+        opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
+        # Single source for the opportunity payload: in the system prompt
+        # via {opportunity_json}. User message is structural-only so the
+        # opportunity isn't sent twice (matches the report-generator fix).
+        system_prompt = (
+            prompt_template
+            .replace("{target_mode}", target_mode)
+            .replace("{opportunity_json}", opportunity_json)
+        )
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(
+                    role="user",
+                    content="Generate one sales brief from the opportunity above.",
+                ),
+            ],
+            max_tokens=self._config.max_tokens,
+            temperature=self._config.temperature,
+            metadata={
+                "target_mode": target_mode,
+                "target_id": opportunity_target_id(opportunity),
+                "skill_name": self._config.skill_name,
+                "asset_type": "sales_brief",
+            },
+        )
+        parsed = parse_sales_brief_response(response.content)
+        if not parsed:
+            return None
+        return {
+            **parsed,
+            "_model": response.model,
+            "_usage": dict(response.usage or {}),
+        }
+
+    def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
+        brief_input = QualityInput(
+            artifact_type="sales_brief",
+            context={
+                "title": parsed.get("title"),
+                "headline": parsed.get("headline"),
+                "sections": parsed.get("sections") or (),
+                "reference_ids": parsed.get("reference_ids") or (),
+                "metadata": {
+                    "confidence": parsed.get("confidence"),
+                },
+            },
+        )
+        report = evaluate_sales_brief(brief_input, policy=self._config.quality_policy)
+        return {
+            "passed": report.passed,
+            "blockers": tuple(f.message for f in report.blockers),
+        }
+
+    def _build_draft(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        target_id: str,
+        target_mode: str,
+    ) -> SalesBriefDraft:
+        sections = tuple(
+            SalesBriefSection(
+                id=str(s.get("id") or "").strip(),
+                title=str(s.get("title") or "").strip(),
+                body_markdown=str(s.get("body_markdown") or "").strip(),
+                claim_ids=tuple(str(c) for c in (s.get("claim_ids") or ())),
+                evidence_ids=tuple(str(e) for e in (s.get("evidence_ids") or ())),
+                metadata=dict(s.get("metadata") or {}),
+            )
+            for s in parsed.get("sections") or ()
+            if isinstance(s, Mapping)
+        )
+        # Aggregate reference_ids: explicit list union per-section evidence ids.
+        ref_seen: list[str] = []
+        for value in parsed.get("reference_ids") or ():
+            v = str(value).strip()
+            if v and v not in ref_seen:
+                ref_seen.append(v)
+        for section in sections:
+            for evidence_id in section.evidence_ids:
+                v = str(evidence_id).strip()
+                if v and v not in ref_seen:
+                    ref_seen.append(v)
+        brief_type = str(parsed.get("brief_type") or self._config.default_brief_type)
+        metadata: dict[str, Any] = {
+            "generation_model": parsed.get("_model"),
+            "generation_usage": parsed.get("_usage") or {},
+        }
+        if "confidence" in parsed:
+            metadata["confidence"] = parsed["confidence"]
+        return SalesBriefDraft(
+            target_id=target_id,
+            target_mode=target_mode,
+            brief_type=brief_type,
+            title=str(parsed.get("title") or "").strip(),
+            headline=str(parsed.get("headline") or "").strip(),
+            sections=sections,
+            reference_ids=tuple(ref_seen),
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "SalesBriefGenerationConfig",
+    "SalesBriefGenerationResult",
+    "SalesBriefGenerationService",
+    "parse_sales_brief_response",
+]

--- a/extracted_content_pipeline/sales_brief_ports.py
+++ b/extracted_content_pipeline/sales_brief_ports.py
@@ -1,0 +1,132 @@
+"""Standalone ports for the AI Content Ops Sales Briefs product.
+
+Sales briefs are the fifth content asset type in the AI Content Ops
+surface (parallel to email campaigns, blog posts, structured reports,
+and marketing landing pages). Where ``ReportDraft`` is shaped for a
+customer-facing analytical document with a long executive summary, a
+``SalesBriefDraft`` is tuned for a salesperson preparing for a specific
+opportunity: a punchy one-line ``headline`` ("why this account, why
+now") plus ordered sections (account context, signals, talking points,
+risks, next actions).
+
+Section shape mirrors ``ReportSection`` -- ``id`` / ``title`` /
+``body_markdown`` / ``claim_ids`` / ``evidence_ids`` / ``metadata`` --
+so renderers can reuse the same component for both reports and briefs.
+
+Storage lives in the ``sales_briefs`` table (migration 275) with the
+same status-lifecycle semantics as ``b2b_campaigns`` / ``reports`` /
+``landing_pages``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class SalesBriefSection:
+    """A single ordered section within a sales brief.
+
+    Shape is identical to ``ReportSection`` so a future shared renderer
+    can consume both. The semantic content differs (a brief's section
+    is sales-facing copy; a report's is customer-facing prose) but the
+    typed shape is the same -- ``claim_ids`` / ``evidence_ids`` allow
+    briefs produced from a multi-pass reasoning output to carry through
+    the same provenance the reports pipeline already supports.
+    """
+
+    id: str
+    title: str
+    body_markdown: str
+    claim_ids: Sequence[str] = field(default_factory=tuple)
+    evidence_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "body_markdown": self.body_markdown,
+            "claim_ids": list(self.claim_ids),
+            "evidence_ids": list(self.evidence_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class SalesBriefDraft:
+    """A generated, not-yet-approved sales brief.
+
+    Persists into the ``sales_briefs`` table via
+    ``SalesBriefRepository.save_drafts``.
+
+    Distinct from ``ReportDraft``:
+    - ``brief_type`` (pre_call, renewal, displacement, discovery, ...)
+      vs. ``report_type`` (vendor_pressure, market_intel, ...)
+    - ``headline`` -- a one-line punchy framing (~140 chars) instead
+      of a longer ``summary`` paragraph. The elevator pitch the rep
+      reads in the 30 seconds before walking into the meeting.
+    """
+
+    target_id: str
+    target_mode: str
+    brief_type: str
+    title: str
+    headline: str
+    sections: Sequence[SalesBriefSection] = field(default_factory=tuple)
+    reference_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "brief_type": self.brief_type,
+            "title": self.title,
+            "headline": self.headline,
+            "sections": [section.as_dict() for section in self.sections],
+            "reference_ids": list(self.reference_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+class SalesBriefRepository(Protocol):
+    """Persistence contract for generated sales briefs."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[SalesBriefDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return the assigned brief ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        brief_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[SalesBriefDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        brief_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft's status. Returns True on hit, False on miss."""
+
+
+__all__ = [
+    "SalesBriefDraft",
+    "SalesBriefRepository",
+    "SalesBriefSection",
+]

--- a/extracted_content_pipeline/sales_brief_postgres.py
+++ b/extracted_content_pipeline/sales_brief_postgres.py
@@ -1,0 +1,224 @@
+"""Postgres repository adapter for the AI Content Ops Sales Briefs product.
+
+Mirrors the shape of ``PostgresLandingPageRepository`` (see
+``landing_page_postgres.py``) but persists ``SalesBriefDraft`` rows into
+the ``sales_briefs`` table from migration 275. Hosts inject an
+asyncpg-style pool; the adapter does no connection management itself.
+
+Carries forward the ergonomic improvements added during the
+landing-pages slice: ``_coerce_section`` raises ``TypeError`` on
+non-Mapping input rather than silently producing an empty section, and
+``update_status`` returns a boolean parsed from asyncpg's command tag
+so wrong-id / wrong-tenant calls surface as ``False`` at the call site
+rather than a silent no-op.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .sales_brief_ports import SalesBriefDraft, SalesBriefSection
+
+
+def _jsonb(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
+
+
+def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
+    if isinstance(row, Mapping):
+        return dict(row)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _draft_metadata(draft: SalesBriefDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _coerce_section(value: Any) -> SalesBriefSection:
+    """Coerce a host-supplied section into ``SalesBriefSection``.
+
+    Accepts an existing ``SalesBriefSection`` or a Mapping with the
+    expected keys. Anything else raises ``TypeError`` so host-side bugs
+    surface at the persistence boundary rather than getting silently
+    coerced into an empty section the quality pack later rejects.
+    """
+    if isinstance(value, SalesBriefSection):
+        return value
+    if isinstance(value, Mapping):
+        return SalesBriefSection(
+            id=str(value.get("id") or ""),
+            title=str(value.get("title") or ""),
+            body_markdown=str(value.get("body_markdown") or ""),
+            claim_ids=tuple(str(c) for c in (value.get("claim_ids") or ())),
+            evidence_ids=tuple(str(e) for e in (value.get("evidence_ids") or ())),
+            metadata=dict(value.get("metadata") or {}),
+        )
+    raise TypeError(
+        "SalesBriefDraft.sections entries must be SalesBriefSection "
+        f"instances or Mappings; got {type(value).__name__}: {value!r}"
+    )
+
+
+def _decode_jsonb(raw: Any, *, default: Any) -> Any:
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return default
+    if raw is None:
+        return default
+    return raw
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> SalesBriefDraft:
+    sections_raw = _decode_jsonb(row.get("sections"), default=[])
+    if not isinstance(sections_raw, Sequence) or isinstance(sections_raw, (str, bytes)):
+        sections_raw = []
+
+    reference_ids_raw = _decode_jsonb(row.get("reference_ids"), default=[])
+    if not isinstance(reference_ids_raw, Sequence) or isinstance(reference_ids_raw, (str, bytes)):
+        reference_ids_raw = []
+
+    metadata_raw = _decode_jsonb(row.get("metadata"), default={})
+    if not isinstance(metadata_raw, Mapping):
+        metadata_raw = {}
+
+    return SalesBriefDraft(
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        brief_type=str(row.get("brief_type") or ""),
+        title=str(row.get("title") or ""),
+        headline=str(row.get("headline") or ""),
+        sections=tuple(_coerce_section(s) for s in sections_raw),
+        reference_ids=tuple(str(r) for r in reference_ids_raw),
+        metadata=dict(metadata_raw),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresSalesBriefRepository:
+    """Async Postgres adapter for generated sales briefs."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[SalesBriefDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            sections_payload = [_coerce_section(s).as_dict() for s in draft.sections]
+            reference_ids_payload = [str(r) for r in draft.reference_ids]
+            metadata_payload = _draft_metadata(draft, scope)
+            brief_id = await self.pool.fetchval(
+                """
+                INSERT INTO sales_briefs (
+                    account_id, target_id, target_mode, brief_type,
+                    title, headline,
+                    sections, reference_ids, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4,
+                    $5, $6,
+                    $7::jsonb, $8::jsonb, $9::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.brief_type,
+                draft.title,
+                draft.headline,
+                _jsonb(sections_payload),
+                _jsonb(reference_ids_payload),
+                _jsonb(metadata_payload),
+            )
+            saved.append(str(brief_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        brief_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[SalesBriefDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if brief_type is not None:
+            params.append(brief_type)
+            clauses.append(f"brief_type = ${len(params)}")
+        sql = (
+            "SELECT target_id, target_mode, brief_type, title, headline, "
+            "sections, reference_ids, metadata "
+            "FROM sales_briefs WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(_row_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        brief_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Scoped status update. Returns True on hit, False on miss.
+
+        Parses asyncpg's command tag (e.g., ``"UPDATE 1"``) so a
+        wrong-id or wrong-tenant call surfaces as a False return at
+        the call site rather than a silent no-op.
+        """
+        result = await self.pool.execute(
+            """
+            UPDATE sales_briefs
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            brief_id,
+            status,
+            scope.account_id or "",
+        )
+        if not isinstance(result, str):
+            return True
+        try:
+            return int(result.rsplit(" ", 1)[-1]) > 0
+        except (ValueError, IndexError):
+            return True
+
+
+__all__ = [
+    "PostgresSalesBriefRepository",
+]

--- a/extracted_content_pipeline/skills/digest/sales_brief_generation.md
+++ b/extracted_content_pipeline/skills/digest/sales_brief_generation.md
@@ -1,0 +1,53 @@
+You generate ONE sales brief from a single normalized opportunity row plus its reasoning context.
+
+A sales brief is what a salesperson reads in the 30 seconds before walking into a meeting or call -- a punchy elevator-line `headline` ("why this account, why now") plus 3-5 ordered sections (account context, recent signals, talking points, risks/objections, next actions). NOT a report (no long executive summary). NOT a marketing landing page (no public-facing copy). Sales-facing internal copy.
+
+The opportunity is JSON-encoded as `{opportunity_json}`. The reasoning context (when present) lives inside the opportunity under the `campaign_reasoning_context` and `reasoning_context` keys. If the reasoning context carries a `narrative_plan` block (top-level under `canonical_reasoning`), use its `sections` array as the section spine -- write prose for each section rather than inventing a different structure. If no `narrative_plan` is present, structure the brief yourself from the opportunity evidence.
+
+Output ONLY a single JSON object with this exact shape. No prose outside the JSON.
+
+```json
+{
+  "title": "Pre-call brief: <Account name> -- <2-4 word framing>",
+  "headline": "One-line elevator -- why this account, why now (~140 chars)",
+  "brief_type": "pre_call",
+  "sections": [
+    {
+      "id": "account_context",
+      "title": "Account Context",
+      "body_markdown": "Mid-market SaaS, Series C, 350 seats. Renewal Q3 ...",
+      "claim_ids": ["c1"],
+      "evidence_ids": ["r1"],
+      "metadata": {"order": 1}
+    },
+    {
+      "id": "recent_signals",
+      "title": "Recent Signals",
+      "body_markdown": "Two competitor evals in last 30 days. ...",
+      "claim_ids": ["c2", "c3"],
+      "evidence_ids": ["r2", "r3"]
+    },
+    {
+      "id": "talking_points",
+      "title": "Talking Points",
+      "body_markdown": "Lead with renewal-pressure framing ...",
+      "claim_ids": [],
+      "evidence_ids": []
+    }
+  ],
+  "reference_ids": ["r1", "r2", "r3"],
+  "confidence": 0.82
+}
+```
+
+Field rules:
+- `title`: short, descriptive; lead with the brief shape (e.g., "Pre-call brief", "Renewal brief", "Displacement brief"). Includes the account/entity name. No date stamps.
+- `headline`: ONE line, ~140 chars max, sales-facing. The elevator the rep reads while walking to the meeting room. Punchy, not analytical. NOT the same shape as a report's `summary`.
+- `brief_type`: one of `pre_call`, `renewal`, `displacement`, `discovery`, or another snake_case label that fits the opportunity's `target_mode`. Default to `pre_call` when in doubt.
+- `sections`: 3-6 ordered. Common shapes: `account_context` / `recent_signals` / `talking_points` / `risks_and_objections` / `next_actions`. Each section needs a non-empty `title` and `body_markdown`. Cite supporting evidence in `evidence_ids` using the source ids that appear in the opportunity / reasoning context.
+- `reference_ids`: union of every `evidence_ids` value across sections, plus any opportunity-level source ids you cited. No duplicates. A brief without references is a brief the rep can't trust.
+- `confidence`: optional float in [0, 1]; reflects how solid the underlying signals are.
+
+When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent claim ids that aren't in the reasoning context.
+
+Avoid: weasel words ("powerful", "robust", "synergy"), promises that can't be backed up, comparative claims about specific competitors unless the opportunity provides them. The rep is the one who has to defend every word in the room.

--- a/extracted_content_pipeline/storage/migrations/275_sales_briefs.sql
+++ b/extracted_content_pipeline/storage/migrations/275_sales_briefs.sql
@@ -1,0 +1,36 @@
+-- Sales briefs: per-opportunity pre-call/account/renewal briefs produced by the
+-- AI Content Ops Sales Briefs generator. Parallel to reports (273) but tuned
+-- for the sales surface: a punchy one-line headline plus ordered sections
+-- (account context, signals, talking points, risks, next actions). Section
+-- shape mirrors reports.sections so renderers can reuse the same component.
+--
+-- The status lifecycle mirrors b2b_campaigns / reports / landing_pages: drafts
+-- start at 'draft', move through 'queued' / 'approved' / 'rejected' / 'expired'
+-- as host workflows review them. No CHECK constraint on status: hosts may
+-- extend with their own intermediate states (e.g., 'in_review',
+-- 'ready_for_call') without a follow-on migration.
+
+CREATE TABLE IF NOT EXISTS sales_briefs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL,
+    target_mode TEXT NOT NULL,
+    brief_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    headline TEXT NOT NULL,
+    sections JSONB NOT NULL DEFAULT '[]'::jsonb,
+    reference_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sales_briefs_target
+    ON sales_briefs (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_sales_briefs_status
+    ON sales_briefs (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sales_briefs_type
+    ON sales_briefs (account_id, brief_type, created_at DESC);

--- a/extracted_quality_gate/sales_brief_pack.py
+++ b/extracted_quality_gate/sales_brief_pack.py
@@ -1,0 +1,304 @@
+"""Sales-brief quality pack: deterministic validators for sales briefs.
+
+Sibling to ``report_pack`` (PR-Reports-1b), ``landing_page_pack``
+(PR-LandingPage-1b), and ``campaign_pack`` / ``blog_pack``. Validates
+the structured ``SalesBriefDraft`` shape from
+``extracted_content_pipeline.sales_brief_ports``: title, headline,
+ordered sections, reference ids. Pure-function discipline (no DB, no
+LLM, no clock) -- sanitization belongs in the wrapper.
+
+Public API:
+
+    evaluate_sales_brief(
+        input: QualityInput,
+        *,
+        policy: QualityPolicy | None = None,
+    ) -> QualityReport
+
+The ``input`` carries the structured sales-brief payload through
+``input.context``. Recognised keys:
+
+  - ``title`` (str)
+  - ``headline`` (str): one-line punchy framing
+  - ``sections`` (Sequence[Mapping]): each ``{"id", "title",
+    "body_markdown", "claim_ids", "evidence_ids", ...}`` (mirrors
+    ``report_pack``)
+  - ``reference_ids`` (Sequence[str]): cited source ids at the
+    brief level
+  - ``metadata`` (Mapping): generation metadata; ``confidence`` may
+    appear here as a float in [0, 1]
+
+Recognised ``policy.thresholds`` keys:
+  - ``min_sections`` (int): default 1
+  - ``max_headline_chars`` (int): warn when ``headline`` is above this;
+    default 280 (a reasonable elevator-line ceiling -- the rep should
+    be able to skim it in 5 seconds before walking into the meeting).
+    Note the deliberate asymmetry with the skill prompt, which tells
+    the LLM to aim for ~140 chars (a tighter "punchy" target). The
+    pack ceiling is the harder bound: the LLM can overshoot the
+    aspirational prompt target by ~2x and still pass the gate, but a
+    rambling 300-char "headline" warns. Two-tier guidance: aim short
+    in the prompt, tolerate up to 280 in the gate.
+  - ``min_confidence`` (float): warn when ``metadata["confidence"]`` is
+    below this; default 0.0 (no floor)
+  - ``pass_score`` (int): default 70
+  - ``blocking_penalty`` (int): default 18 (per blocker)
+  - ``warning_penalty`` (int): default 6 (per warning)
+
+Recognised ``policy.metadata`` keys:
+  - ``blocked_phrasing`` (Sequence[str] | str): word-boundary blocked
+    phrases. Bare string is auto-wrapped (mirrors report_pack).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from .types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+_DEFAULT_THRESHOLDS: Mapping[str, Any] = {
+    "min_sections": 1,
+    "max_headline_chars": 280,
+    "min_confidence": 0.0,
+    "pass_score": 70,
+    "blocking_penalty": 18,
+    "warning_penalty": 6,
+}
+
+
+def _threshold_int(policy: QualityPolicy | None, key: str) -> int:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return int(_DEFAULT_THRESHOLDS[key])
+
+
+def _threshold_float(policy: QualityPolicy | None, key: str) -> float:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return float(_DEFAULT_THRESHOLDS[key])
+
+
+def _blocked_phrases(policy: QualityPolicy | None) -> tuple[str, ...]:
+    """Mirror of ``report_pack._blocked_phrases``: bare string auto-wraps."""
+    if policy is None:
+        return ()
+    raw = policy.metadata.get("blocked_phrasing")
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        text = raw.strip()
+        return (text,) if text else ()
+    if not isinstance(raw, Sequence):
+        return ()
+    return tuple(str(item) for item in raw if str(item).strip())
+
+
+def evaluate_sales_brief(
+    input: QualityInput,
+    *,
+    policy: QualityPolicy | None = None,
+) -> QualityReport:
+    """Run the deterministic sales-brief-quality validators."""
+
+    context = dict(input.context or {})
+    title = str(context.get("title") or "").strip()
+    headline = str(context.get("headline") or "").strip()
+    sections_raw = context.get("sections") or ()
+    sections: list[Mapping[str, Any]] = [
+        section for section in sections_raw if isinstance(section, Mapping)
+    ]
+    reference_ids: tuple[str, ...] = tuple(
+        str(item).strip()
+        for item in (context.get("reference_ids") or ())
+        if str(item).strip()
+    )
+    metadata: Mapping[str, Any] = (
+        context.get("metadata") if isinstance(context.get("metadata"), Mapping) else {}
+    )
+
+    findings: list[GateFinding] = []
+
+    # ---- Title / headline ----
+    if not title:
+        findings.append(GateFinding(code="no_title", message="no_title", severity=GateSeverity.BLOCKER))
+    if not headline:
+        findings.append(
+            GateFinding(code="no_headline", message="no_headline", severity=GateSeverity.BLOCKER)
+        )
+    else:
+        max_headline_chars = _threshold_int(policy, "max_headline_chars")
+        if max_headline_chars > 0 and len(headline) > max_headline_chars:
+            findings.append(
+                GateFinding(
+                    code="headline_too_long",
+                    message=f"headline_too_long:{len(headline)}>{max_headline_chars}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"length": len(headline), "max": max_headline_chars},
+                )
+            )
+
+    # ---- Sections ----
+    min_sections = _threshold_int(policy, "min_sections")
+    if len(sections) < min_sections:
+        findings.append(
+            GateFinding(
+                code="no_sections",
+                message=f"no_sections:{len(sections)}_below_min_{min_sections}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"section_count": len(sections), "min_sections": min_sections},
+            )
+        )
+
+    section_evidence_present = False
+    for index, section in enumerate(sections):
+        section_title = str(section.get("title") or "").strip()
+        if not section_title:
+            findings.append(
+                GateFinding(
+                    code="section_missing_title",
+                    message=f"section_missing_title:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        section_body = str(section.get("body_markdown") or "").strip()
+        if not section_body:
+            findings.append(
+                GateFinding(
+                    code="section_missing_body",
+                    message=f"section_missing_body:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        evidence_ids = section.get("evidence_ids") or ()
+        if isinstance(evidence_ids, Sequence) and not isinstance(evidence_ids, (str, bytes)):
+            if any(str(item).strip() for item in evidence_ids):
+                section_evidence_present = True
+
+    # ---- References ----
+    # A sales brief without source ids is useless to the rep -- they
+    # need to know where the claims come from before walking into the
+    # meeting. Mirrors the report_pack rule.
+    if not reference_ids and not section_evidence_present:
+        findings.append(
+            GateFinding(
+                code="no_references",
+                message="no_references",
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+
+    # ---- Confidence floor ----
+    min_confidence = _threshold_float(policy, "min_confidence")
+    raw_confidence = metadata.get("confidence")
+    confidence: float | None = None
+    if isinstance(raw_confidence, (int, float)) and not isinstance(raw_confidence, bool):
+        confidence = max(0.0, min(1.0, float(raw_confidence)))
+    if min_confidence > 0.0:
+        if confidence is None:
+            findings.append(
+                GateFinding(
+                    code="missing_confidence",
+                    message="missing_confidence",
+                    severity=GateSeverity.WARNING,
+                )
+            )
+        elif confidence < min_confidence:
+            findings.append(
+                GateFinding(
+                    code="confidence_below_min",
+                    message=f"confidence_below_min:{confidence:.2f}<{min_confidence:.2f}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"confidence": confidence, "min_confidence": min_confidence},
+                )
+            )
+
+    # ---- Blocked phrasing (case-insensitive word-boundary) ----
+    phrases = _blocked_phrases(policy)
+    if phrases:
+        haystack_parts: list[str] = []
+        if title:
+            haystack_parts.append(title)
+        if headline:
+            haystack_parts.append(headline)
+        for section in sections:
+            for key in ("title", "body_markdown"):
+                value = section.get(key)
+                if isinstance(value, str) and value.strip():
+                    haystack_parts.append(value)
+        haystack = "\n".join(haystack_parts)
+        for phrase in phrases:
+            phrase_str = str(phrase).strip()
+            if not phrase_str:
+                continue
+            pattern = re.compile(rf"\b{re.escape(phrase_str)}\b", re.IGNORECASE)
+            if pattern.search(haystack):
+                findings.append(
+                    GateFinding(
+                        code="blocked_phrasing",
+                        message=f"blocked_phrasing:{phrase}",
+                        severity=GateSeverity.BLOCKER,
+                        metadata={"phrase": phrase_str},
+                    )
+                )
+
+    return _build_report(findings=findings, sections=sections, policy=policy)
+
+
+def _build_report(
+    *,
+    findings: list[GateFinding],
+    sections: list[Mapping[str, Any]],
+    policy: QualityPolicy | None,
+) -> QualityReport:
+    blockers = [f for f in findings if f.severity == GateSeverity.BLOCKER]
+    warnings = [f for f in findings if f.severity == GateSeverity.WARNING]
+    blocking_penalty = _threshold_int(policy, "blocking_penalty")
+    warning_penalty = _threshold_int(policy, "warning_penalty")
+    pass_score = _threshold_int(policy, "pass_score")
+    score = max(
+        0,
+        100 - (blocking_penalty * len(blockers)) - (warning_penalty * len(warnings)),
+    )
+    passed = (not blockers) and score >= pass_score
+    if blockers or score < pass_score:
+        decision = GateDecision.BLOCK
+    elif warnings:
+        decision = GateDecision.WARN
+    else:
+        decision = GateDecision.PASS
+    metadata = {
+        "score": score,
+        "threshold": pass_score,
+        "status": "pass" if passed else "fail",
+        "blocking_issues": tuple(f.message for f in blockers),
+        "blocking_codes": tuple(f.code for f in blockers),
+        "warnings": tuple(f.message for f in warnings),
+        "warning_codes": tuple(f.code for f in warnings),
+        "section_count": len(sections),
+    }
+    return QualityReport(
+        passed=passed,
+        decision=decision,
+        findings=tuple(findings),
+        metadata=metadata,
+    )
+
+
+__all__ = ["evaluate_sales_brief"]

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -30,6 +30,7 @@ pytest \
   tests/test_extracted_landing_page_postgres.py \
   tests/test_extracted_landing_page_generation.py \
   tests/test_extracted_quality_gate_landing_page_pack.py \
+  tests/test_extracted_sales_brief_postgres.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -31,6 +31,8 @@ pytest \
   tests/test_extracted_landing_page_generation.py \
   tests/test_extracted_quality_gate_landing_page_pack.py \
   tests/test_extracted_sales_brief_postgres.py \
+  tests/test_extracted_sales_brief_generation.py \
+  tests/test_extracted_quality_gate_sales_brief_pack.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -64,6 +64,30 @@ async def test_preview_generation_route_returns_preflight_plan():
     assert payload["missing_inputs"] == []
 
 
+@pytest.mark.asyncio
+async def test_plan_generation_route_returns_execution_plan():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/plan", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+            "max_cost_usd": 1.0,
+        }
+    )
+
+    assert payload["can_execute"] is True
+    assert payload["steps"][0]["runner"] == "CampaignGenerationService.generate"
+    assert payload["steps"][0]["status"] == "runnable"
+    assert payload["preview"]["can_run"] is True
+
+
 def test_config_requires_absolute_prefix():
     with pytest.raises(ValueError, match="prefix must start with /"):
         ContentOpsControlSurfaceApiConfig(prefix="content-ops")

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1,0 +1,69 @@
+import pytest
+
+import extracted_content_pipeline.api.control_surfaces as api_module
+from extracted_content_pipeline.api.control_surfaces import (
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    api_module.APIRouter is None,
+    reason="fastapi is not installed in this test environment",
+)
+
+
+def _route(router, path: str, method: str):
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method.upper() in getattr(route, "methods", set()):
+            return route
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+@pytest.mark.asyncio
+async def test_describe_control_surfaces_route_returns_catalog_and_presets():
+    router = create_content_ops_control_surface_router()
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    output_ids = {item["id"] for item in payload["outputs"]}
+    preset_ids = {item["id"] for item in payload["presets"]}
+    assert "email_campaign" in output_ids
+    assert "landing_page" in output_ids
+    assert "email_only" in preset_ids
+    assert "lead_gen_campaign" in preset_ids
+    assert payload["ingestion_profiles"] == [
+        "domain_specific",
+        "manual",
+        "existing_evidence",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_returns_preflight_plan():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+            "max_cost_usd": 1.0,
+        }
+    )
+
+    assert payload["can_run"] is True
+    assert payload["outputs"] == ["email_campaign"]
+    assert payload["estimated_cost_usd"] == 0.18
+    assert payload["missing_inputs"] == []
+
+
+def test_config_requires_absolute_prefix():
+    with pytest.raises(ValueError, match="prefix must start with /"):
+        ContentOpsControlSurfaceApiConfig(prefix="content-ops")

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -44,49 +44,46 @@ def test_preview_allows_implemented_outputs_under_budget():
 def test_preview_blocks_unimplemented_outputs_by_default():
     preview = preview_from_mapping(
         {
-            "preset": "lead_gen_campaign",
+            "outputs": ["signal_extraction"],
             "inputs": {
-                "target_account": "Acme",
-                "offer": "Churn intelligence audit",
+                "source_material": "review export",
             },
         }
     )
 
     assert preview["can_run"] is False
-    assert preview["outputs"] == ["email_campaign"]
-    assert preview["blocked_outputs"] == ["landing_page"]
-    assert "Output not implemented yet: landing_page" in preview["warnings"]
+    assert preview["outputs"] == []
+    assert preview["blocked_outputs"] == ["signal_extraction"]
+    assert "Output not implemented yet: signal_extraction" in preview["warnings"]
 
 
 def test_preview_blocks_when_estimate_exceeds_budget():
     preview = preview_from_mapping(
-        {
-            "outputs": ["blog_post", "report"],
-            "limit": 2,
-            "max_cost_usd": 0.25,
-            "inputs": {
-                "topic": "Churn risk",
-                "opportunity_id": "opp_123",
-            },
-        }
-    )
+            {
+                "outputs": ["report"],
+                "limit": 2,
+                "max_cost_usd": 0.25,
+                "inputs": {
+                    "opportunity_id": "opp_123",
+                },
+            }
+        )
 
     assert preview["can_run"] is False
-    assert "Estimated cost exceeds max_cost_usd: 2.00 > 0.25" in preview["warnings"]
+    assert "Estimated cost exceeds max_cost_usd: 1.10 > 0.25" in preview["warnings"]
 
 
 def test_preview_can_include_future_outputs_when_explicitly_allowed():
     preview = preview_from_mapping(
         {
-            "outputs": ["landing_page"],
+            "outputs": ["signal_extraction"],
             "allow_unimplemented_outputs": True,
             "inputs": {
-                "offer": "Churn intelligence audit",
-                "audience": "B2B SaaS founders",
+                "source_material": "review export",
             },
         }
     )
 
     assert preview["can_run"] is True
-    assert preview["outputs"] == ["landing_page"]
+    assert preview["outputs"] == ["signal_extraction"]
     assert preview["blocked_outputs"] == []

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -1,0 +1,92 @@
+from extracted_content_pipeline.control_surfaces import (
+    normalize_outputs,
+    preview_from_mapping,
+)
+
+
+def test_normalize_outputs_accepts_csv_and_dedupes():
+    assert normalize_outputs("email-campaign, blog_post, email_campaign") == (
+        "email_campaign",
+        "blog_post",
+    )
+
+
+def test_preview_defaults_to_email_only_and_reports_missing_inputs():
+    preview = preview_from_mapping({})
+
+    assert preview["can_run"] is False
+    assert preview["outputs"] == ["email_campaign"]
+    assert preview["missing_inputs"] == ["target_account", "offer"]
+    assert preview["estimated_cost_usd"] == 0.18
+
+
+def test_preview_allows_implemented_outputs_under_budget():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["email_campaign", "report"],
+            "limit": 2,
+            "max_cost_usd": 2.0,
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn intelligence audit",
+                "opportunity_id": "opp_123",
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["email_campaign", "report"]
+    assert preview["estimated_cost_usd"] == 1.46
+    assert preview["missing_inputs"] == []
+    assert preview["blocked_outputs"] == []
+
+
+def test_preview_blocks_unimplemented_outputs_by_default():
+    preview = preview_from_mapping(
+        {
+            "preset": "lead_gen_campaign",
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn intelligence audit",
+            },
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert preview["outputs"] == ["email_campaign"]
+    assert preview["blocked_outputs"] == ["landing_page"]
+    assert "Output not implemented yet: landing_page" in preview["warnings"]
+
+
+def test_preview_blocks_when_estimate_exceeds_budget():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["blog_post", "report"],
+            "limit": 2,
+            "max_cost_usd": 0.25,
+            "inputs": {
+                "topic": "Churn risk",
+                "opportunity_id": "opp_123",
+            },
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert "Estimated cost exceeds max_cost_usd: 2.00 > 0.25" in preview["warnings"]
+
+
+def test_preview_can_include_future_outputs_when_explicitly_allowed():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "allow_unimplemented_outputs": True,
+            "inputs": {
+                "offer": "Churn intelligence audit",
+                "audience": "B2B SaaS founders",
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["landing_page"]
+    assert preview["blocked_outputs"] == []

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -15,7 +15,7 @@ def test_plan_maps_email_campaign_to_campaign_generation_service():
     )
 
     assert plan["can_execute"] is True
-    assert plan["target_mode"] == "b2b"
+    assert plan["target_mode"] == "vendor_retention"
     assert plan["limit"] == 2
     assert plan["steps"] == [
         {
@@ -70,12 +70,10 @@ def test_plan_marks_blog_as_planned_not_executable_until_service_adapter_exists(
         }
     )
 
-    assert plan["preview"]["can_run"] is True
+    assert plan["preview"]["can_run"] is False
     assert plan["can_execute"] is False
-    assert plan["steps"][0]["output"] == "blog_post"
-    assert plan["steps"][0]["status"] == "planned"
-    assert plan["steps"][0]["runner"] == "extracted_content_pipeline.autonomous.tasks.blog_post_generation"
-    assert "does not yet expose the same service/port interface" in plan["steps"][0]["reason"]
+    assert plan["preview"]["blocked_outputs"] == ["blog_post"]
+    assert plan["steps"] == []
 
 
 def test_plan_stays_non_executable_when_preview_fails_budget():
@@ -95,33 +93,53 @@ def test_plan_stays_non_executable_when_preview_fails_budget():
     assert plan["steps"][0]["status"] == "runnable"
 
 
-def test_plan_omits_blocked_future_outputs_from_steps():
+def test_plan_maps_landing_page_to_landing_page_generation_service():
     plan = build_generation_plan_from_mapping(
         {
             "preset": "lead_gen_campaign",
             "inputs": {
                 "target_account": "Acme",
                 "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
             },
         }
     )
 
-    assert plan["preview"]["blocked_outputs"] == ["landing_page"]
-    assert plan["steps"] == [
-        {
-            "output": "email_campaign",
-            "runner": "CampaignGenerationService.generate",
-            "status": "runnable",
-            "config": {
-                "skill_name": "digest/b2b_campaign_generation",
-                "channels": ["email_cold", "email_followup"],
-                "limit": 1,
-                "max_tokens": 1200,
-                "temperature": 0.4,
-                "quality_revalidation_enabled": True,
-                "quality_prompt_proof_term_limit": 5,
-            },
-            "reason": "",
-        }
+    assert plan["can_execute"] is True
+    assert [step["output"] for step in plan["steps"]] == [
+        "email_campaign",
+        "landing_page",
     ]
-    assert plan["can_execute"] is False
+    assert plan["steps"][1]["runner"] == "LandingPageGenerationService.generate"
+    assert plan["steps"][1]["status"] == "runnable"
+    assert plan["steps"][1]["config"] == {
+        "skill_name": "digest/landing_page_generation",
+        "max_tokens": 4096,
+        "temperature": 0.3,
+        "quality_gates_enabled": True,
+    }
+
+
+def test_plan_maps_sales_brief_to_sales_brief_generation_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "limit": 2,
+            "inputs": {
+                "target_account": "Acme",
+                "brief_type": "renewal",
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "SalesBriefGenerationService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "skill_name": "digest/sales_brief_generation",
+        "default_brief_type": "renewal",
+        "limit": 2,
+        "max_tokens": 4096,
+        "temperature": 0.3,
+        "quality_gates_enabled": True,
+    }

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -1,0 +1,127 @@
+from extracted_content_pipeline.generation_plan import build_generation_plan_from_mapping
+
+
+def test_plan_maps_email_campaign_to_campaign_generation_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "limit": 2,
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "channels": ["email_cold", "email_followup"],
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["target_mode"] == "b2b"
+    assert plan["limit"] == 2
+    assert plan["steps"] == [
+        {
+            "output": "email_campaign",
+            "runner": "CampaignGenerationService.generate",
+            "status": "runnable",
+            "config": {
+                "skill_name": "digest/b2b_campaign_generation",
+                "channels": ["email_cold", "email_followup"],
+                "limit": 2,
+                "max_tokens": 1200,
+                "temperature": 0.4,
+                "quality_revalidation_enabled": True,
+                "quality_prompt_proof_term_limit": 5,
+            },
+            "reason": "",
+        }
+    ]
+
+
+def test_plan_maps_report_to_report_generation_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["report"],
+            "limit": 3,
+            "inputs": {
+                "opportunity_id": "opp_123",
+                "report_type": "competitive_pressure",
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "ReportGenerationService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "skill_name": "digest/report_generation",
+        "default_report_type": "competitive_pressure",
+        "limit": 3,
+        "max_tokens": 4096,
+        "temperature": 0.3,
+    }
+
+
+def test_plan_marks_blog_as_planned_not_executable_until_service_adapter_exists():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {
+                "topic": "Churn pressure",
+            },
+        }
+    )
+
+    assert plan["preview"]["can_run"] is True
+    assert plan["can_execute"] is False
+    assert plan["steps"][0]["output"] == "blog_post"
+    assert plan["steps"][0]["status"] == "planned"
+    assert plan["steps"][0]["runner"] == "extracted_content_pipeline.autonomous.tasks.blog_post_generation"
+    assert "does not yet expose the same service/port interface" in plan["steps"][0]["reason"]
+
+
+def test_plan_stays_non_executable_when_preview_fails_budget():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "max_cost_usd": 0.01,
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        }
+    )
+
+    assert plan["preview"]["can_run"] is False
+    assert plan["can_execute"] is False
+    assert plan["steps"][0]["status"] == "runnable"
+
+
+def test_plan_omits_blocked_future_outputs_from_steps():
+    plan = build_generation_plan_from_mapping(
+        {
+            "preset": "lead_gen_campaign",
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        }
+    )
+
+    assert plan["preview"]["blocked_outputs"] == ["landing_page"]
+    assert plan["steps"] == [
+        {
+            "output": "email_campaign",
+            "runner": "CampaignGenerationService.generate",
+            "status": "runnable",
+            "config": {
+                "skill_name": "digest/b2b_campaign_generation",
+                "channels": ["email_cold", "email_followup"],
+                "limit": 1,
+                "max_tokens": 1200,
+                "temperature": 0.4,
+                "quality_revalidation_enabled": True,
+                "quality_prompt_proof_term_limit": 5,
+            },
+            "reason": "",
+        }
+    ]
+    assert plan["can_execute"] is False

--- a/tests/test_extracted_quality_gate_sales_brief_pack.py
+++ b/tests/test_extracted_quality_gate_sales_brief_pack.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
+from extracted_quality_gate.types import (
+    GateDecision,
+    QualityInput,
+    QualityPolicy,
+)
+
+
+def _section(
+    *,
+    title: str = "Account Context",
+    body: str = "Mid-market SaaS, Series C, 350 seats.",
+    evidence_ids: tuple[str, ...] = ("r1",),
+) -> dict:
+    return {
+        "id": "account_context",
+        "title": title,
+        "body_markdown": body,
+        "claim_ids": ("c1",),
+        "evidence_ids": evidence_ids,
+    }
+
+
+def _input(**overrides) -> QualityInput:
+    context = {
+        "title": "Pre-call brief: Acme renewal",
+        "headline": "Renewal Q3 -- 90-day pressure window opens this week",
+        "sections": (_section(),),
+        "reference_ids": ("r1", "r2"),
+        "metadata": {"confidence": 0.82},
+    }
+    context.update(overrides)
+    return QualityInput(artifact_type="sales_brief", context=context)
+
+
+def test_evaluate_sales_brief_happy_path_passes() -> None:
+    report = evaluate_sales_brief(_input())
+    assert report.passed is True
+    assert report.decision == GateDecision.PASS
+    assert report.blockers == ()
+    assert report.metadata["section_count"] == 1
+
+
+def test_evaluate_sales_brief_no_title_blocks() -> None:
+    report = evaluate_sales_brief(_input(title=""))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_title" in codes
+
+
+def test_evaluate_sales_brief_no_headline_blocks() -> None:
+    report = evaluate_sales_brief(_input(headline=""))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_headline" in codes
+
+
+def test_evaluate_sales_brief_no_sections_blocks() -> None:
+    report = evaluate_sales_brief(_input(sections=()))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_sections" in codes
+
+
+def test_evaluate_sales_brief_section_missing_body_blocks_per_section() -> None:
+    sections = (_section(), _section(title="Signals", body=""))
+    report = evaluate_sales_brief(_input(sections=sections))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "section_missing_body:1" in blocker_msgs
+    assert "section_missing_body:0" not in blocker_msgs
+
+
+def test_evaluate_sales_brief_section_missing_title_blocks_per_section() -> None:
+    sections = (_section(title=""),)
+    report = evaluate_sales_brief(_input(sections=sections))
+    assert any(f.code == "section_missing_title" for f in report.blockers)
+
+
+def test_evaluate_sales_brief_no_references_blocks_when_neither_top_nor_section_evidence() -> None:
+    """A sales brief with no source ids is useless to the rep."""
+    sections = (_section(evidence_ids=()),)
+    report = evaluate_sales_brief(_input(sections=sections, reference_ids=()))
+    assert any(f.code == "no_references" for f in report.blockers)
+
+
+def test_evaluate_sales_brief_no_references_passes_when_section_evidence_present() -> None:
+    """Section evidence alone is sufficient -- top-level reference_ids may be empty."""
+    sections = (_section(evidence_ids=("r1",)),)
+    report = evaluate_sales_brief(_input(sections=sections, reference_ids=()))
+    codes = {f.code for f in report.blockers}
+    assert "no_references" not in codes
+
+
+def test_evaluate_sales_brief_headline_too_long_warns_only() -> None:
+    """Default ceiling is 280 chars; over that warns but doesn't block."""
+    long_headline = "x" * 300
+    report = evaluate_sales_brief(_input(headline=long_headline))
+    blocker_codes = {f.code for f in report.blockers}
+    warning_codes = {f.code for f in report.warnings}
+    assert "headline_too_long" not in blocker_codes
+    assert "headline_too_long" in warning_codes
+
+
+def test_evaluate_sales_brief_headline_within_ceiling_no_warning() -> None:
+    report = evaluate_sales_brief(_input(headline="Short and punchy."))
+    warning_codes = {f.code for f in report.warnings}
+    assert "headline_too_long" not in warning_codes
+
+
+def test_evaluate_sales_brief_headline_ceiling_is_configurable() -> None:
+    """Hosts can tighten or loosen the ceiling via policy.thresholds."""
+    policy = QualityPolicy(name="brief_policy", thresholds={"max_headline_chars": 50})
+    report = evaluate_sales_brief(
+        _input(headline="x" * 80),
+        policy=policy,
+    )
+    warning_codes = {f.code for f in report.warnings}
+    assert "headline_too_long" in warning_codes
+
+
+def test_evaluate_sales_brief_blocked_phrasing_uses_word_boundaries_not_substrings() -> None:
+    """Mirrors validate_reasoning_output regression: 'promise' must not match 'compromise'."""
+    sections = (_section(body="We cannot compromise on quality."),)
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": ("promise",)},
+    )
+    report = evaluate_sales_brief(_input(sections=sections), policy=policy)
+    blocker_codes = {f.code for f in report.blockers}
+    assert "blocked_phrasing" not in blocker_codes
+
+
+def test_evaluate_sales_brief_blocked_phrasing_blocks_with_word_boundary_match() -> None:
+    sections = (_section(body="We GUARANTEE results within 30 days."),)
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": ("guarantee",)},
+    )
+    report = evaluate_sales_brief(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_sales_brief_blocked_phrasing_scans_headline_and_title() -> None:
+    """Blocked-phrase scan covers title + headline, not just sections."""
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": ("guarantee",)},
+    )
+    report = evaluate_sales_brief(
+        _input(headline="We guarantee renewal -- pressure window opens"),
+        policy=policy,
+    )
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_sales_brief_blocked_phrasing_auto_wraps_bare_string_policy() -> None:
+    """Bare-string policy auto-wraps -- a host typo shouldn't silently disable the gate."""
+    sections = (_section(body="We GUARANTEE results."),)
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": "guarantee"},
+    )
+    report = evaluate_sales_brief(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_sales_brief_min_confidence_warns_when_below_threshold() -> None:
+    policy = QualityPolicy(name="brief_policy", thresholds={"min_confidence": 0.7})
+    report = evaluate_sales_brief(_input(metadata={"confidence": 0.5}), policy=policy)
+    warning_codes = {f.code for f in report.warnings}
+    assert "confidence_below_min" in warning_codes
+
+
+def test_evaluate_sales_brief_min_confidence_warns_when_missing() -> None:
+    policy = QualityPolicy(name="brief_policy", thresholds={"min_confidence": 0.7})
+    report = evaluate_sales_brief(_input(metadata={}), policy=policy)
+    warning_codes = {f.code for f in report.warnings}
+    assert "missing_confidence" in warning_codes
+
+
+def test_evaluate_sales_brief_metadata_carries_score_and_threshold() -> None:
+    report = evaluate_sales_brief(_input())
+    assert "score" in report.metadata
+    assert "threshold" in report.metadata
+    assert report.metadata["status"] == "pass"

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
+from extracted_content_pipeline.sales_brief_generation import (
+    SalesBriefGenerationConfig,
+    SalesBriefGenerationService,
+    parse_sales_brief_response,
+)
+from extracted_content_pipeline.sales_brief_ports import SalesBriefDraft
+
+
+# -----------------------
+# Fake ports (mirror tests/test_extracted_report_generation.py:24-120)
+# -----------------------
+
+
+class _Intelligence:
+    def __init__(self, opportunities):
+        self.opportunities = opportunities
+        self.calls = []
+
+    async def read_campaign_opportunities(self, *, scope, target_mode, limit, filters=None):
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": filters,
+        })
+        return self.opportunities
+
+    async def read_vendor_targets(self, *, scope, target_mode, vendor_name=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _SalesBriefs:
+    def __init__(self):
+        self.saved = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": list(drafts), "scope": scope})
+        return [f"sb-{index + 1}" for index, _ in enumerate(drafts)]
+
+    async def list_drafts(self, *, scope, status=None, target_mode=None, brief_type=None, limit=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def update_status(self, brief_id, status, *, scope):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _LLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return LLMResponse(
+            content=response,
+            model="test-model",
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+
+class _Skills:
+    def __init__(self, prompts):
+        self.prompts = prompts
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompts.get(name)
+
+
+class _ReasoningProvider:
+    def __init__(self, context):
+        self.context = context
+        self.calls = []
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        self.calls.append({
+            "scope": scope,
+            "target_id": target_id,
+            "target_mode": target_mode,
+        })
+        return self.context
+
+
+def _opportunity():
+    return {
+        "id": "opp-1",
+        "target_id": "vendor-acme",
+        "vendor_name": "Acme",
+        "company_name": "Acme",
+        "evidence": [{"quote": "Renewal pricing is too high"}],
+    }
+
+
+def _valid_brief_json(*, title="Pre-call brief: Acme renewal", brief_type="pre_call"):
+    return json.dumps({
+        "title": title,
+        "headline": "Renewal Q3 -- 90-day pressure window opens this week",
+        "brief_type": brief_type,
+        "sections": [
+            {
+                "id": "account_context",
+                "title": "Account Context",
+                "body_markdown": "Mid-market SaaS, Series C, 350 seats.",
+                "claim_ids": ["c1"],
+                "evidence_ids": ["r1"],
+                "metadata": {"order": 1},
+            },
+            {
+                "id": "talking_points",
+                "title": "Talking Points",
+                "body_markdown": "Lead with renewal-pressure framing.",
+                "claim_ids": [],
+                "evidence_ids": [],
+                "metadata": {"order": 2},
+            },
+        ],
+        "reference_ids": ["r1"],
+        "confidence": 0.82,
+    })
+
+
+def _service(
+    *,
+    opportunities=None,
+    responses=None,
+    prompts=None,
+    reasoning_context=None,
+    config=None,
+):
+    intelligence = _Intelligence(opportunities or [_opportunity()])
+    sales_briefs = _SalesBriefs()
+    llm = _LLM(responses or [_valid_brief_json()])
+    if prompts is None:
+        prompts = {
+            "digest/sales_brief_generation": "TEMPLATE for {target_mode}: {opportunity_json}"
+        }
+    skills = _Skills(prompts)
+    reasoning_provider = (
+        _ReasoningProvider(reasoning_context) if reasoning_context is not None else None
+    )
+    service = SalesBriefGenerationService(
+        intelligence=intelligence,
+        sales_briefs=sales_briefs,
+        llm=llm,
+        skills=skills,
+        reasoning_context=reasoning_provider,
+        config=config or SalesBriefGenerationConfig(),
+    )
+    return service, intelligence, sales_briefs, llm, skills, reasoning_provider
+
+
+# -----------------------
+# parse_sales_brief_response
+# -----------------------
+
+
+def test_parse_sales_brief_response_strips_code_fences_and_extracts_first_object() -> None:
+    text = "```json\n" + _valid_brief_json() + "\n```"
+    parsed = parse_sales_brief_response(text)
+    assert parsed is not None
+    assert parsed["title"] == "Pre-call brief: Acme renewal"
+    assert parsed["sections"][0]["id"] == "account_context"
+
+
+def test_parse_sales_brief_response_returns_none_when_required_fields_missing() -> None:
+    assert parse_sales_brief_response("") is None
+    assert parse_sales_brief_response('{"title": "x"}') is None  # no sections
+    assert parse_sales_brief_response('{"title": "x", "sections": []}') is None  # empty sections
+
+
+def test_parse_sales_brief_response_handles_braces_inside_string_values() -> None:
+    """body_markdown with template syntax must not break the parser."""
+    payload = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "Templates",
+                "body_markdown": "Pricing tiers: {basic, pro} models. Use {project_id} placeholders.",
+            }
+        ],
+    })
+    parsed = parse_sales_brief_response(payload)
+    assert parsed is not None
+    assert "{basic, pro}" in parsed["sections"][0]["body_markdown"]
+
+
+def test_parse_sales_brief_response_strips_think_blocks_before_decoding() -> None:
+    payload = "<think>thinking aloud...</think>\n" + _valid_brief_json()
+    parsed = parse_sales_brief_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Pre-call brief: Acme renewal"
+
+
+def test_parse_sales_brief_response_accepts_missing_headline_for_quality_pack_to_judge() -> None:
+    """Missing headline isn't a parser-level rejection -- the quality pack
+    fires ``no_headline`` so callers see exactly what was wrong."""
+    payload = json.dumps({
+        "title": "Brief",
+        # headline intentionally omitted
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+    })
+    parsed = parse_sales_brief_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Brief"
+
+
+# -----------------------
+# Service: generation
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_one_brief_per_opportunity_via_save_drafts() -> None:
+    service, intelligence, sales_briefs, llm, _skills, _rp = _service()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.requested == 1
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.saved_ids == ("sb-1",)
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["metadata"]["asset_type"] == "sales_brief"
+    assert llm.calls[0]["metadata"]["target_mode"] == "vendor"
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert len(saved_drafts) == 1
+    draft = saved_drafts[0]
+    assert isinstance(draft, SalesBriefDraft)
+    assert draft.target_id == "vendor-acme"
+    assert draft.target_mode == "vendor"
+    assert draft.brief_type == "pre_call"
+    assert draft.title == "Pre-call brief: Acme renewal"
+    assert draft.headline.startswith("Renewal Q3")
+    assert draft.sections[0].id == "account_context"
+    assert draft.metadata["generation_model"] == "test-model"
+    assert draft.metadata["confidence"] == 0.82
+
+
+@pytest.mark.asyncio
+async def test_generate_substitutes_opportunity_json_into_system_prompt_only() -> None:
+    """Opportunity payload appears in system content and NOT in user content."""
+    service, _intel, _sb, llm, _skills, _rp = _service(
+        prompts={"digest/sales_brief_generation": "TEMPLATE {target_mode}: {opportunity_json}"},
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    system_msg = llm.calls[0]["messages"][0].content
+    user_msg = llm.calls[0]["messages"][1].content
+    assert '"target_id":"vendor-acme"' in system_msg
+    assert "vendor-acme" not in user_msg
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_unparseable_response() -> None:
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=["not json garbage"]
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert any(err.get("reason") == "unparseable_response" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_quality_pack_blocks_no_references() -> None:
+    """A brief with no reference_ids and no per-section evidence is blocked."""
+    bad_response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "brief_type": "pre_call",
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": []}
+        ],
+        "reference_ids": [],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert any(err.get("reason") == "quality_blocked" for err in result.errors)
+    assert any("no_references" in b for b in result.errors[0]["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_when_response_omits_headline() -> None:
+    """End-to-end: parser accepts the candidate, quality pack fires no_headline."""
+    response = json.dumps({
+        "title": "Pre-call brief: Acme",
+        # headline omitted
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": ["r1"]}
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert sales_briefs.saved == []
+    assert any("no_headline" in b for b in result.errors[0]["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_target_id_missing() -> None:
+    # No id-shaped key and no name-shaped key -> opportunity_target_id returns ""
+    bad_opp = {"evidence": [{"quote": "no target"}]}
+    service, _intel, sales_briefs, llm, _skills, _rp = _service(opportunities=[bad_opp])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert llm.calls == []  # no LLM round-trip
+    assert any(err.get("reason") == "missing_target_id" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_consumes_reasoning_context_via_provider() -> None:
+    """When a CampaignReasoningContextProvider is supplied, its context is fetched per opp."""
+    context = CampaignReasoningContext(
+        top_theses=({"claim": "Renewal pricing", "confidence": 0.9, "source_ids": ["r1"]},),
+        canonical_reasoning={"summary": "narrative summary"},
+    )
+    service, _intel, _sb, _llm, _skills, reasoning_provider = _service(
+        reasoning_context=context
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert reasoning_provider is not None
+    assert len(reasoning_provider.calls) == 1
+    call = reasoning_provider.calls[0]
+    assert call["target_id"] == "vendor-acme"
+    assert call["target_mode"] == "vendor"
+
+
+@pytest.mark.asyncio
+async def test_generate_raises_value_error_when_skill_prompt_missing() -> None:
+    service, _intel, _sb, _llm, _skills, _rp = _service(prompts={})
+
+    with pytest.raises(ValueError, match="Sales-brief generation skill not found"):
+        await service.generate(
+            scope=TenantScope(account_id="acct-1"),
+            target_mode="vendor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_defaults_brief_type_when_llm_omits_it() -> None:
+    """Config.default_brief_type fills in when the LLM doesn't supply brief_type."""
+    response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        # brief_type omitted
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": ["r1"]}
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=SalesBriefGenerationConfig(default_brief_type="discovery"),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 1
+    draft = sales_briefs.saved[0]["drafts"][0]
+    assert draft.brief_type == "discovery"
+
+
+@pytest.mark.asyncio
+async def test_generate_aggregates_section_evidence_into_reference_ids_no_duplicates() -> None:
+    """reference_ids should be the union of explicit list + per-section evidence ids."""
+    response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "brief_type": "pre_call",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "T",
+                "body_markdown": "b",
+                "evidence_ids": ["r1", "r2"],
+            },
+            {
+                "id": "s2",
+                "title": "U",
+                "body_markdown": "c",
+                "evidence_ids": ["r2", "r3"],  # r2 dup
+            },
+        ],
+        "reference_ids": ["r1", "r4"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[response])
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    draft = sales_briefs.saved[0]["drafts"][0]
+    # Order preserved: explicit list first, then section evidence ids in insertion order
+    assert draft.reference_ids == ("r1", "r4", "r2", "r3")

--- a/tests/test_extracted_sales_brief_postgres.py
+++ b/tests/test_extracted_sales_brief_postgres.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.sales_brief_postgres import (
+    PostgresSalesBriefRepository,
+)
+from extracted_content_pipeline.sales_brief_ports import (
+    SalesBriefDraft,
+    SalesBriefSection,
+)
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+        # asyncpg returns command tags like "UPDATE 1" / "UPDATE 0";
+        # tests can override this to simulate misses.
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
+
+
+def _draft() -> SalesBriefDraft:
+    return SalesBriefDraft(
+        target_id="opp-42",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        title="Pre-call brief: Acme renewal",
+        headline="Renewal Q3 -- 90-day pressure window opens this week",
+        sections=(
+            SalesBriefSection(
+                id="account_context",
+                title="Account Context",
+                body_markdown="Mid-market SaaS, Series C, 350 seats.",
+                metadata={"order": 1},
+            ),
+            SalesBriefSection(
+                id="signals",
+                title="Recent Signals",
+                body_markdown="Two competitor evals in last 30 days.",
+                claim_ids=("c1", "c2"),
+                evidence_ids=("e1",),
+                metadata={"order": 2},
+            ),
+            SalesBriefSection(
+                id="talking_points",
+                title="Talking Points",
+                body_markdown="Lead with renewal-pressure framing.",
+                metadata={"order": 3},
+            ),
+        ),
+        reference_ids=("r1", "r2"),
+        metadata={"generation_model": "fake-llm", "confidence": 0.82},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_each_draft_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-1"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("sb-uuid-1",)
+    assert len(pool.fetchval_calls) == 1
+    args = pool.fetchval_calls[0]["args"]
+    # account_id, target_id, target_mode, brief_type, title, headline,
+    # sections, reference_ids, metadata
+    assert args[0] == "acct-1"
+    assert args[1] == "opp-42"
+    assert args[2] == "opportunity"
+    assert args[3] == "pre_call"
+    assert args[4] == "Pre-call brief: Acme renewal"
+    assert args[5].startswith("Renewal Q3")
+    sections_payload = json.loads(args[6])
+    assert [s["id"] for s in sections_payload] == [
+        "account_context",
+        "signals",
+        "talking_points",
+    ]
+    assert sections_payload[1]["claim_ids"] == ["c1", "c2"]
+    assert sections_payload[1]["evidence_ids"] == ["e1"]
+    reference_ids_payload = json.loads(args[7])
+    assert reference_ids_payload == ["r1", "r2"]
+    metadata_payload = json.loads(args[8])
+    assert metadata_payload["target_id"] == "opp-42"
+    assert metadata_payload["target_mode"] == "opportunity"
+    assert metadata_payload["scope"]["account_id"] == "acct-1"
+    assert metadata_payload["confidence"] == 0.82
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_handles_empty_account_id_with_default_scope() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-2"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    await repo.save_drafts([_draft()], scope=TenantScope())
+
+    assert pool.fetchval_calls[0]["args"][0] == ""
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_coerces_dict_sections_via_helper() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-3"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    draft = SalesBriefDraft(
+        target_id="opp-1",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        title="title",
+        headline="headline",
+        sections=(
+            {"id": "raw_section", "title": "From Dict", "body_markdown": "body"},
+        ),  # type: ignore[arg-type]
+    )
+
+    await repo.save_drafts([draft], scope=TenantScope())
+
+    sections_payload = json.loads(pool.fetchval_calls[0]["args"][6])
+    assert sections_payload[0]["id"] == "raw_section"
+    assert sections_payload[0]["title"] == "From Dict"
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_target_mode_and_brief_type() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-42",
+            "target_mode": "opportunity",
+            "brief_type": "pre_call",
+            "title": "Pre-call brief: Acme",
+            "headline": "Renewal pressure window opens",
+            "sections": json.dumps([
+                {
+                    "id": "account_context",
+                    "title": "Account Context",
+                    "body_markdown": "Mid-market SaaS",
+                    "claim_ids": [],
+                    "evidence_ids": [],
+                    "metadata": {"order": 1},
+                }
+            ]),
+            "reference_ids": json.dumps(["r1"]),
+            "metadata": json.dumps({"confidence": 0.7}),
+        }
+    ]
+    repo = PostgresSalesBriefRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        limit=20,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.target_id == "opp-42"
+    assert draft.brief_type == "pre_call"
+    assert draft.title == "Pre-call brief: Acme"
+    assert draft.headline.startswith("Renewal pressure")
+    assert draft.sections[0].id == "account_context"
+    assert draft.reference_ids == ("r1",)
+    assert draft.metadata == {"confidence": 0.7}
+
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "account_id = $1" in sql
+    assert "status = $2" in sql
+    assert "target_mode = $3" in sql
+    assert "brief_type = $4" in sql
+    assert "LIMIT $5" in sql
+    assert args == ("acct-1", "draft", "opportunity", "pre_call", 20)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
+    """asyncpg with the json codec installed delivers JSONB pre-decoded."""
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-1",
+            "target_mode": "opportunity",
+            "brief_type": "pre_call",
+            "title": "title",
+            "headline": "headline",
+            "sections": [
+                {"id": "s1", "title": "T", "body_markdown": "B", "claim_ids": [], "evidence_ids": []}
+            ],  # already a list
+            "reference_ids": ["r1", "r2"],  # already a list
+            "metadata": {"key": "value"},  # already a dict
+        }
+    ]
+    repo = PostgresSalesBriefRepository(pool)
+
+    drafts = await repo.list_drafts(scope=TenantScope())
+
+    assert drafts[0].sections[0].id == "s1"
+    assert drafts[0].reference_ids == ("r1", "r2")
+    assert drafts[0].metadata == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_true_on_hit_and_runs_scoped_update() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 1"
+    repo = PostgresSalesBriefRepository(pool)
+
+    hit = await repo.update_status(
+        "sb-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is True
+    assert len(pool.execute_calls) == 1
+    args = pool.execute_calls[0]["args"]
+    assert args == ("sb-uuid-1", "approved", "acct-1")
+    sql = pool.execute_calls[0]["query"]
+    assert "UPDATE sales_briefs" in sql
+    assert "account_id = $3" in sql
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_false_on_miss() -> None:
+    """Wrong brief_id or wrong tenant returns False so callers can branch."""
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresSalesBriefRepository(pool)
+
+    hit = await repo.update_status(
+        "missing-id",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is False
+
+
+@pytest.mark.asyncio
+async def test_update_status_treats_non_asyncpg_command_tags_as_success() -> None:
+    """Test fakes / alt drivers that return 'OK' or None don't crash; default to True."""
+    pool = _Pool()
+    pool.execute_result = None
+    repo = PostgresSalesBriefRepository(pool)
+
+    hit = await repo.update_status("any-id", "approved", scope=TenantScope())
+    assert hit is True
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_rejects_non_mapping_non_section_input_with_clear_error() -> None:
+    """A host passing a string / number / None as a section item gets a clear TypeError."""
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-x"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    bad_draft = SalesBriefDraft(
+        target_id="opp-1",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        title="title",
+        headline="headline",
+        sections=("not_a_section_or_mapping",),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(TypeError, match="SalesBriefDraft.sections entries must be"):
+        await repo.save_drafts([bad_draft], scope=TenantScope())
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_returns_empty_tuple_for_empty_input() -> None:
+    pool = _Pool()
+    repo = PostgresSalesBriefRepository(pool)
+
+    saved = await repo.save_drafts([], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ()
+    assert pool.fetchval_calls == []


### PR DESCRIPTION
## Summary

Adds a first-pass, backend-owned control-surface scaffold for AI Content Ops before wiring more UI.

This introduces a pure deterministic module, a preflight FastAPI router, and a generation-plan mapper so UI/API layers can preview and plan a generation request before any expensive LLM work runs.

## What changed

- Added `extracted_content_pipeline/control_surfaces.py`
  - output catalog for `email_campaign`, `blog_post`, `report`, `landing_page`, `sales_brief`, and `signal_extraction`
  - preset bundles like `email_only`, `content_marketing`, `lead_gen_campaign`, and `full_campaign`
  - normalized request object
  - preflight preview object
  - output resolution
  - missing required input checks
  - unimplemented-output gating
  - conservative cost estimation
  - dict-friendly `preview_from_mapping()` wrapper for future API/UI use

- Added `extracted_content_pipeline/generation_plan.py`
  - maps validated output selections into deterministic steps
  - `email_campaign` -> `CampaignGenerationService.generate`
  - `report` -> `ReportGenerationService.generate`
  - `blog_post` -> planned/non-executable until it has a service-shaped adapter
  - keeps plans non-executable when preview fails or selected outputs are blocked

- Added `extracted_content_pipeline/api/control_surfaces.py`
  - `GET /content-ops/control-surfaces`
  - `POST /content-ops/preview`
  - `POST /content-ops/plan`
  - preflight/planning only; no LLM calls, no DB reads/writes, no job kickoff

- Added docs
  - `extracted_content_pipeline/docs/control_surface_preview_api.md`
  - host mount example
  - UI contract
  - output catalog and preset definitions
  - example preview payload/response
  - example plan payload/response

- Added tests
  - `tests/test_extracted_content_control_surfaces.py`
  - `tests/test_extracted_content_control_surface_api.py`
  - `tests/test_extracted_content_generation_plan.py`
  - normalization, default behavior, budget guard, unimplemented output blocking, explicit future-output allowance, router behavior, and generation-plan mapping

## Why

The product needs a control surface before a front end. This keeps output selection, cost control, presets, and input validation in the backend instead of hiding product logic inside UI toggles.

## Notes

- Cost numbers are placeholders by design. They create the contract now and can later be replaced with real token/accounting estimates.
- Landing pages, sales briefs, and signal extraction are included in the catalog but gated as unimplemented unless explicitly allowed.
- Runtime generation execution is intentionally out of scope. This slice gives the UI safe preview + plan contracts first.