### PR TITLE
PR-SalesBriefs-1a: Add Sales Briefs storage layer

### DIFF
--- a/extracted_content_pipeline/sales_brief_ports.py
+++ b/extracted_content_pipeline/sales_brief_ports.py
@@ -1,0 +1,132 @@
+"""Standalone ports for the AI Content Ops Sales Briefs product.
+
+Sales briefs are the fifth content asset type in the AI Content Ops
+surface (parallel to email campaigns, blog posts, structured reports,
+and marketing landing pages). Where ``ReportDraft`` is shaped for a
+customer-facing analytical document with a long executive summary, a
+``SalesBriefDraft`` is tuned for a salesperson preparing for a specific
+opportunity: a punchy one-line ``headline`` ("why this account, why
+now") plus ordered sections (account context, signals, talking points,
+risks, next actions).
+
+Section shape mirrors ``ReportSection`` -- ``id`` / ``title`` /
+``body_markdown`` / ``claim_ids`` / ``evidence_ids`` / ``metadata`` --
+so renderers can reuse the same component for both reports and briefs.
+
+Storage lives in the ``sales_briefs`` table (migration 275) with the
+same status-lifecycle semantics as ``b2b_campaigns`` / ``reports`` /
+``landing_pages``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class SalesBriefSection:
+    """A single ordered section within a sales brief.
+
+    Shape is identical to ``ReportSection`` so a future shared renderer
+    can consume both. The semantic content differs (a brief's section
+    is sales-facing copy; a report's is customer-facing prose) but the
+    typed shape is the same -- ``claim_ids`` / ``evidence_ids`` allow
+    briefs produced from a multi-pass reasoning output to carry through
+    the same provenance the reports pipeline already supports.
+    """
+
+    id: str
+    title: str
+    body_markdown: str
+    claim_ids: Sequence[str] = field(default_factory=tuple)
+    evidence_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "body_markdown": self.body_markdown,
+            "claim_ids": list(self.claim_ids),
+            "evidence_ids": list(self.evidence_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class SalesBriefDraft:
+    """A generated, not-yet-approved sales brief.
+
+    Persists into the ``sales_briefs`` table via
+    ``SalesBriefRepository.save_drafts``.
+
+    Distinct from ``ReportDraft``:
+    - ``brief_type`` (pre_call, renewal, displacement, discovery, ...)
+      vs. ``report_type`` (vendor_pressure, market_intel, ...)
+    - ``headline`` -- a one-line punchy framing (~140 chars) instead
+      of a longer ``summary`` paragraph. The elevator pitch the rep
+      reads in the 30 seconds before walking into the meeting.
+    """
+
+    target_id: str
+    target_mode: str
+    brief_type: str
+    title: str
+    headline: str
+    sections: Sequence[SalesBriefSection] = field(default_factory=tuple)
+    reference_ids: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "brief_type": self.brief_type,
+            "title": self.title,
+            "headline": self.headline,
+            "sections": [section.as_dict() for section in self.sections],
+            "reference_ids": list(self.reference_ids),
+            "metadata": dict(self.metadata),
+        }
+
+
+class SalesBriefRepository(Protocol):
+    """Persistence contract for generated sales briefs."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[SalesBriefDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return the assigned brief ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        brief_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[SalesBriefDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        brief_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft's status. Returns True on hit, False on miss."""
+
+
+__all__ = [
+    "SalesBriefDraft",
+    "SalesBriefRepository",
+    "SalesBriefSection",
+]

--- a/extracted_content_pipeline/sales_brief_postgres.py
+++ b/extracted_content_pipeline/sales_brief_postgres.py
@@ -1,0 +1,224 @@
+"""Postgres repository adapter for the AI Content Ops Sales Briefs product.
+
+Mirrors the shape of ``PostgresLandingPageRepository`` (see
+``landing_page_postgres.py``) but persists ``SalesBriefDraft`` rows into
+the ``sales_briefs`` table from migration 275. Hosts inject an
+asyncpg-style pool; the adapter does no connection management itself.
+
+Carries forward the ergonomic improvements added during the
+landing-pages slice: ``_coerce_section`` raises ``TypeError`` on
+non-Mapping input rather than silently producing an empty section, and
+``update_status`` returns a boolean parsed from asyncpg's command tag
+so wrong-id / wrong-tenant calls surface as ``False`` at the call site
+rather than a silent no-op.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .sales_brief_ports import SalesBriefDraft, SalesBriefSection
+
+
+def _jsonb(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
+
+
+def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
+    if isinstance(row, Mapping):
+        return dict(row)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _draft_metadata(draft: SalesBriefDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _coerce_section(value: Any) -> SalesBriefSection:
+    """Coerce a host-supplied section into ``SalesBriefSection``.
+
+    Accepts an existing ``SalesBriefSection`` or a Mapping with the
+    expected keys. Anything else raises ``TypeError`` so host-side bugs
+    surface at the persistence boundary rather than getting silently
+    coerced into an empty section the quality pack later rejects.
+    """
+    if isinstance(value, SalesBriefSection):
+        return value
+    if isinstance(value, Mapping):
+        return SalesBriefSection(
+            id=str(value.get("id") or ""),
+            title=str(value.get("title") or ""),
+            body_markdown=str(value.get("body_markdown") or ""),
+            claim_ids=tuple(str(c) for c in (value.get("claim_ids") or ())),
+            evidence_ids=tuple(str(e) for e in (value.get("evidence_ids") or ())),
+            metadata=dict(value.get("metadata") or {}),
+        )
+    raise TypeError(
+        "SalesBriefDraft.sections entries must be SalesBriefSection "
+        f"instances or Mappings; got {type(value).__name__}: {value!r}"
+    )
+
+
+def _decode_jsonb(raw: Any, *, default: Any) -> Any:
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return default
+    if raw is None:
+        return default
+    return raw
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> SalesBriefDraft:
+    sections_raw = _decode_jsonb(row.get("sections"), default=[])
+    if not isinstance(sections_raw, Sequence) or isinstance(sections_raw, (str, bytes)):
+        sections_raw = []
+
+    reference_ids_raw = _decode_jsonb(row.get("reference_ids"), default=[])
+    if not isinstance(reference_ids_raw, Sequence) or isinstance(reference_ids_raw, (str, bytes)):
+        reference_ids_raw = []
+
+    metadata_raw = _decode_jsonb(row.get("metadata"), default={})
+    if not isinstance(metadata_raw, Mapping):
+        metadata_raw = {}
+
+    return SalesBriefDraft(
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        brief_type=str(row.get("brief_type") or ""),
+        title=str(row.get("title") or ""),
+        headline=str(row.get("headline") or ""),
+        sections=tuple(_coerce_section(s) for s in sections_raw),
+        reference_ids=tuple(str(r) for r in reference_ids_raw),
+        metadata=dict(metadata_raw),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresSalesBriefRepository:
+    """Async Postgres adapter for generated sales briefs."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[SalesBriefDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            sections_payload = [_coerce_section(s).as_dict() for s in draft.sections]
+            reference_ids_payload = [str(r) for r in draft.reference_ids]
+            metadata_payload = _draft_metadata(draft, scope)
+            brief_id = await self.pool.fetchval(
+                """
+                INSERT INTO sales_briefs (
+                    account_id, target_id, target_mode, brief_type,
+                    title, headline,
+                    sections, reference_ids, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4,
+                    $5, $6,
+                    $7::jsonb, $8::jsonb, $9::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.brief_type,
+                draft.title,
+                draft.headline,
+                _jsonb(sections_payload),
+                _jsonb(reference_ids_payload),
+                _jsonb(metadata_payload),
+            )
+            saved.append(str(brief_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        brief_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[SalesBriefDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if brief_type is not None:
+            params.append(brief_type)
+            clauses.append(f"brief_type = ${len(params)}")
+        sql = (
+            "SELECT target_id, target_mode, brief_type, title, headline, "
+            "sections, reference_ids, metadata "
+            "FROM sales_briefs WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(_row_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        brief_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Scoped status update. Returns True on hit, False on miss.
+
+        Parses asyncpg's command tag (e.g., ``"UPDATE 1"``) so a
+        wrong-id or wrong-tenant call surfaces as a False return at
+        the call site rather than a silent no-op.
+        """
+        result = await self.pool.execute(
+            """
+            UPDATE sales_briefs
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            brief_id,
+            status,
+            scope.account_id or "",
+        )
+        if not isinstance(result, str):
+            return True
+        try:
+            return int(result.rsplit(" ", 1)[-1]) > 0
+        except (ValueError, IndexError):
+            return True
+
+
+__all__ = [
+    "PostgresSalesBriefRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/275_sales_briefs.sql
+++ b/extracted_content_pipeline/storage/migrations/275_sales_briefs.sql
@@ -1,0 +1,36 @@
+-- Sales briefs: per-opportunity pre-call/account/renewal briefs produced by the
+-- AI Content Ops Sales Briefs generator. Parallel to reports (273) but tuned
+-- for the sales surface: a punchy one-line headline plus ordered sections
+-- (account context, signals, talking points, risks, next actions). Section
+-- shape mirrors reports.sections so renderers can reuse the same component.
+--
+-- The status lifecycle mirrors b2b_campaigns / reports / landing_pages: drafts
+-- start at 'draft', move through 'queued' / 'approved' / 'rejected' / 'expired'
+-- as host workflows review them. No CHECK constraint on status: hosts may
+-- extend with their own intermediate states (e.g., 'in_review',
+-- 'ready_for_call') without a follow-on migration.
+
+CREATE TABLE IF NOT EXISTS sales_briefs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL,
+    target_mode TEXT NOT NULL,
+    brief_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    headline TEXT NOT NULL,
+    sections JSONB NOT NULL DEFAULT '[]'::jsonb,
+    reference_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sales_briefs_target
+    ON sales_briefs (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_sales_briefs_status
+    ON sales_briefs (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sales_briefs_type
+    ON sales_briefs (account_id, brief_type, created_at DESC);

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -30,6 +30,7 @@ pytest \
   tests/test_extracted_landing_page_postgres.py \
   tests/test_extracted_landing_page_generation.py \
   tests/test_extracted_quality_gate_landing_page_pack.py \
+  tests/test_extracted_sales_brief_postgres.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_sales_brief_postgres.py
+++ b/tests/test_extracted_sales_brief_postgres.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.sales_brief_postgres import (
+    PostgresSalesBriefRepository,
+)
+from extracted_content_pipeline.sales_brief_ports import (
+    SalesBriefDraft,
+    SalesBriefSection,
+)
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+        # asyncpg returns command tags like "UPDATE 1" / "UPDATE 0";
+        # tests can override this to simulate misses.
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
+
+
+def _draft() -> SalesBriefDraft:
+    return SalesBriefDraft(
+        target_id="opp-42",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        title="Pre-call brief: Acme renewal",
+        headline="Renewal Q3 -- 90-day pressure window opens this week",
+        sections=(
+            SalesBriefSection(
+                id="account_context",
+                title="Account Context",
+                body_markdown="Mid-market SaaS, Series C, 350 seats.",
+                metadata={"order": 1},
+            ),
+            SalesBriefSection(
+                id="signals",
+                title="Recent Signals",
+                body_markdown="Two competitor evals in last 30 days.",
+                claim_ids=("c1", "c2"),
+                evidence_ids=("e1",),
+                metadata={"order": 2},
+            ),
+            SalesBriefSection(
+                id="talking_points",
+                title="Talking Points",
+                body_markdown="Lead with renewal-pressure framing.",
+                metadata={"order": 3},
+            ),
+        ),
+        reference_ids=("r1", "r2"),
+        metadata={"generation_model": "fake-llm", "confidence": 0.82},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_each_draft_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-1"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("sb-uuid-1",)
+    assert len(pool.fetchval_calls) == 1
+    args = pool.fetchval_calls[0]["args"]
+    # account_id, target_id, target_mode, brief_type, title, headline,
+    # sections, reference_ids, metadata
+    assert args[0] == "acct-1"
+    assert args[1] == "opp-42"
+    assert args[2] == "opportunity"
+    assert args[3] == "pre_call"
+    assert args[4] == "Pre-call brief: Acme renewal"
+    assert args[5].startswith("Renewal Q3")
+    sections_payload = json.loads(args[6])
+    assert [s["id"] for s in sections_payload] == [
+        "account_context",
+        "signals",
+        "talking_points",
+    ]
+    assert sections_payload[1]["claim_ids"] == ["c1", "c2"]
+    assert sections_payload[1]["evidence_ids"] == ["e1"]
+    reference_ids_payload = json.loads(args[7])
+    assert reference_ids_payload == ["r1", "r2"]
+    metadata_payload = json.loads(args[8])
+    assert metadata_payload["target_id"] == "opp-42"
+    assert metadata_payload["target_mode"] == "opportunity"
+    assert metadata_payload["scope"]["account_id"] == "acct-1"
+    assert metadata_payload["confidence"] == 0.82
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_handles_empty_account_id_with_default_scope() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-2"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    await repo.save_drafts([_draft()], scope=TenantScope())
+
+    assert pool.fetchval_calls[0]["args"][0] == ""
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_coerces_dict_sections_via_helper() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-3"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    draft = SalesBriefDraft(
+        target_id="opp-1",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        title="title",
+        headline="headline",
+        sections=(
+            {"id": "raw_section", "title": "From Dict", "body_markdown": "body"},
+        ),  # type: ignore[arg-type]
+    )
+
+    await repo.save_drafts([draft], scope=TenantScope())
+
+    sections_payload = json.loads(pool.fetchval_calls[0]["args"][6])
+    assert sections_payload[0]["id"] == "raw_section"
+    assert sections_payload[0]["title"] == "From Dict"
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_target_mode_and_brief_type() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-42",
+            "target_mode": "opportunity",
+            "brief_type": "pre_call",
+            "title": "Pre-call brief: Acme",
+            "headline": "Renewal pressure window opens",
+            "sections": json.dumps([
+                {
+                    "id": "account_context",
+                    "title": "Account Context",
+                    "body_markdown": "Mid-market SaaS",
+                    "claim_ids": [],
+                    "evidence_ids": [],
+                    "metadata": {"order": 1},
+                }
+            ]),
+            "reference_ids": json.dumps(["r1"]),
+            "metadata": json.dumps({"confidence": 0.7}),
+        }
+    ]
+    repo = PostgresSalesBriefRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        limit=20,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.target_id == "opp-42"
+    assert draft.brief_type == "pre_call"
+    assert draft.title == "Pre-call brief: Acme"
+    assert draft.headline.startswith("Renewal pressure")
+    assert draft.sections[0].id == "account_context"
+    assert draft.reference_ids == ("r1",)
+    assert draft.metadata == {"confidence": 0.7}
+
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "account_id = $1" in sql
+    assert "status = $2" in sql
+    assert "target_mode = $3" in sql
+    assert "brief_type = $4" in sql
+    assert "LIMIT $5" in sql
+    assert args == ("acct-1", "draft", "opportunity", "pre_call", 20)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
+    """asyncpg with the json codec installed delivers JSONB pre-decoded."""
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "target_id": "opp-1",
+            "target_mode": "opportunity",
+            "brief_type": "pre_call",
+            "title": "title",
+            "headline": "headline",
+            "sections": [
+                {"id": "s1", "title": "T", "body_markdown": "B", "claim_ids": [], "evidence_ids": []}
+            ],  # already a list
+            "reference_ids": ["r1", "r2"],  # already a list
+            "metadata": {"key": "value"},  # already a dict
+        }
+    ]
+    repo = PostgresSalesBriefRepository(pool)
+
+    drafts = await repo.list_drafts(scope=TenantScope())
+
+    assert drafts[0].sections[0].id == "s1"
+    assert drafts[0].reference_ids == ("r1", "r2")
+    assert drafts[0].metadata == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_true_on_hit_and_runs_scoped_update() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 1"
+    repo = PostgresSalesBriefRepository(pool)
+
+    hit = await repo.update_status(
+        "sb-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is True
+    assert len(pool.execute_calls) == 1
+    args = pool.execute_calls[0]["args"]
+    assert args == ("sb-uuid-1", "approved", "acct-1")
+    sql = pool.execute_calls[0]["query"]
+    assert "UPDATE sales_briefs" in sql
+    assert "account_id = $3" in sql
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_false_on_miss() -> None:
+    """Wrong brief_id or wrong tenant returns False so callers can branch."""
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresSalesBriefRepository(pool)
+
+    hit = await repo.update_status(
+        "missing-id",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is False
+
+
+@pytest.mark.asyncio
+async def test_update_status_treats_non_asyncpg_command_tags_as_success() -> None:
+    """Test fakes / alt drivers that return 'OK' or None don't crash; default to True."""
+    pool = _Pool()
+    pool.execute_result = None
+    repo = PostgresSalesBriefRepository(pool)
+
+    hit = await repo.update_status("any-id", "approved", scope=TenantScope())
+    assert hit is True
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_rejects_non_mapping_non_section_input_with_clear_error() -> None:
+    """A host passing a string / number / None as a section item gets a clear TypeError."""
+    pool = _Pool()
+    pool.fetchval_results = ["sb-uuid-x"]
+    repo = PostgresSalesBriefRepository(pool)
+
+    bad_draft = SalesBriefDraft(
+        target_id="opp-1",
+        target_mode="opportunity",
+        brief_type="pre_call",
+        title="title",
+        headline="headline",
+        sections=("not_a_section_or_mapping",),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(TypeError, match="SalesBriefDraft.sections entries must be"):
+        await repo.save_drafts([bad_draft], scope=TenantScope())
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_returns_empty_tuple_for_empty_input() -> None:
+    pool = _Pool()
+    repo = PostgresSalesBriefRepository(pool)
+
+    saved = await repo.save_drafts([], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ()
+    assert pool.fetchval_calls == []


### PR DESCRIPTION
## Summary

First slice of Sales Briefs content-asset support. Lands the typed schema, migration, and repository so PR-SalesBriefs-1b can wire the generator on top.

Sales briefs are the **fifth and final** content asset type promised by AI Content Ops (after blogs, emails, reports, landing pages). After PR-SalesBriefs-1b lands, the landing-page asset story will be fully truthful (5 of 5).

**Per-opportunity trigger** (mirrors Reports / Campaigns; differs from per-marketing-campaign Landing Pages). The existing `intelligence.read_campaign_opportunities` port works unchanged.

## What changed

**`storage/migrations/275_sales_briefs.sql` (new)** — `sales_briefs` table with the same status-lifecycle shape as `reports` / `landing_pages`. No CHECK on status — hosts can extend with intermediate states (e.g., `ready_for_call`, `in_review`) without a follow-on migration. Three indexes:

- `(account_id, target_mode, target_id)` — tenant-scoped target lookup
- `(account_id, status, created_at DESC)` — review queue
- `(account_id, brief_type, created_at DESC)` — per-type history

**`sales_brief_ports.py` (new)** — `SalesBriefDraft` + `SalesBriefSection` dataclasses + `SalesBriefRepository` Protocol.

```python
@dataclass(frozen=True)
class SalesBriefDraft:
    target_id: str
    target_mode: str         # opportunity / account / vendor
    brief_type: str          # pre_call / renewal / displacement / discovery
    title: str
    headline: str            # one-line punchy framing (~140 chars)
    sections: Sequence[SalesBriefSection]
    reference_ids: Sequence[str]
    metadata: JsonDict
```

`SalesBriefSection` shape is identical to `ReportSection` (`id`, `title`, `body_markdown`, `claim_ids`, `evidence_ids`, `metadata`) so a future shared renderer can consume both. `brief_type` is the per-row taxonomy column; `headline` is a one-line punchy framing distinct from the longer `summary` a report carries.

**`sales_brief_postgres.py` (new)** — `PostgresSalesBriefRepository` carrying forward the ergonomic improvements from the landing-pages slice:

- `_coerce_section` raises `TypeError` on non-Mapping input instead of silently producing empty rows.
- `update_status` parses asyncpg's command tag (`"UPDATE 1"` / `"UPDATE 0"`) and returns a bool so wrong-id / wrong-tenant calls surface as `False` rather than a silent no-op.
- `_decode_jsonb` handles both pre-decoded (asyncpg with json codec) and string-form JSONB columns defensively.

**`tests/test_extracted_sales_brief_postgres.py` (new, 10 tests)** — save/list/update_status, dict-section coercion, default scope, pre-decoded jsonb columns, hit-vs-miss on update_status, TypeError rejection, empty input.

**`scripts/run_extracted_pipeline_checks.sh`** — wires the new test file into the pipeline runner.

## Test plan

- [x] `python -c "from extracted_content_pipeline.sales_brief_postgres import PostgresSalesBriefRepository"` → clean import
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed
- [x] `pytest tests/test_extracted_sales_brief_postgres.py` → 10/10 passing locally
- [ ] CI `extracted-checks` run

## Out of scope (deferred to PR-SalesBriefs-1b)

- `SalesBriefGenerationService` orchestration
- packaged skill prompt (`skills/digest/sales_brief_generation.md`)
- `extracted_quality_gate.sales_brief_pack` deterministic validator (blockers tuned for the brief shape: `no_headline`, `no_sections`, brief-type taxonomy validation, etc.)
- Generator + quality-pack tests

After 1b: AI Content Ops ships **5 of 5** promised content types.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_