### PR TITLE
PR-SalesBriefs-1b: Add Sales Briefs generator + skill prompt + quality pack

### DIFF
--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -1,0 +1,418 @@
+"""Standalone Sales Briefs generator orchestration.
+
+Sibling of ``CampaignGenerationService`` (per-opportunity emails) and
+``ReportGenerationService`` (per-opportunity structured reports). Same
+per-opportunity trigger shape as Reports: the service iterates
+``intelligence.read_campaign_opportunities`` and produces one
+``SalesBriefDraft`` per opportunity row.
+
+Distinct from Reports:
+- Output carries a one-line ``headline`` (elevator pitch, ~140 chars)
+  instead of a longer paragraph ``summary``.
+- ``brief_type`` (pre_call / renewal / displacement / discovery)
+  classifies the brief shape; defaults to ``pre_call`` when the LLM
+  doesn't supply one.
+- The skill prompt frames the output as sales-facing internal copy
+  rather than a customer-facing analytical document.
+
+Reasoning-context aware: when the host provides a multi-pass
+``CampaignReasoningContextProvider`` whose context exposes a
+``canonical_reasoning["narrative_plan"]`` block, the generator hands
+that pre-structured plan to the LLM as the section spine so the model
+writes prose for each section rather than inventing the structure.
+Without a narrative plan, the LLM structures the brief itself.
+
+Quality gating runs through ``extracted_quality_gate.sales_brief_pack``
+-- pure deterministic, no LLM. Failures skip persistence and surface
+in the result's ``errors`` payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+import re
+from typing import Any
+
+from .campaign_opportunities import (
+    normalize_campaign_opportunity,
+    opportunity_target_id,
+)
+from .campaign_ports import (
+    CampaignReasoningContextProvider,
+    IntelligenceRepository,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
+from .sales_brief_ports import (
+    SalesBriefDraft,
+    SalesBriefRepository,
+    SalesBriefSection,
+)
+from .services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
+    campaign_reasoning_context_payload,
+    normalize_campaign_reasoning_context,
+)
+from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
+from extracted_quality_gate.types import QualityInput, QualityPolicy
+
+
+@dataclass(frozen=True)
+class SalesBriefGenerationConfig:
+    """Tunable defaults for ``SalesBriefGenerationService``."""
+
+    skill_name: str = "digest/sales_brief_generation"
+    default_brief_type: str = "pre_call"
+    limit: int = 10
+    max_tokens: int = 4096
+    temperature: float = 0.3
+    quality_policy: QualityPolicy | None = None
+
+
+@dataclass(frozen=True)
+class SalesBriefGenerationResult:
+    requested: int
+    generated: int
+    skipped: int
+    saved_ids: tuple[str, ...] = ()
+    errors: tuple[Mapping[str, Any], ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "requested": self.requested,
+            "generated": self.generated,
+            "skipped": self.skipped,
+            "saved_ids": list(self.saved_ids),
+            "errors": list(self.errors),
+        }
+
+
+def parse_sales_brief_response(text: str) -> dict[str, Any] | None:
+    """Extract the first well-formed sales-brief JSON object.
+
+    Mirrors ``parse_report_response``: strips ``<think>`` blocks + code
+    fences, then walks the cleaned text with
+    ``json.JSONDecoder.raw_decode`` so braces inside string values
+    (markdown templates, etc.) don't trip the parser.
+
+    The parser only enforces what's needed to identify the candidate as
+    a sales-brief payload: ``title`` (non-empty) and a non-empty
+    ``sections`` list. Missing or malformed ``headline`` / ``brief_type``
+    are NOT rejected here -- the quality pack's specific blockers
+    (``no_headline``, etc.) surface those failures so callers see
+    exactly what was wrong rather than a generic ``unparseable_response``.
+    """
+
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s*```\s*$", "", cleaned, flags=re.MULTILINE).strip()
+
+    decoder = json.JSONDecoder()
+    candidates: list[Any] = []
+    index = 0
+    length = len(cleaned)
+    while index < length:
+        if cleaned[index] != "{":
+            index += 1
+            continue
+        try:
+            decoded, end = decoder.raw_decode(cleaned, index)
+        except json.JSONDecodeError:
+            index += 1
+            continue
+        candidates.append(decoded)
+        index = end if end > index else index + 1
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            candidate = candidate[0] if candidate else None
+        if not isinstance(candidate, dict):
+            continue
+        title = str(candidate.get("title") or "").strip()
+        sections = candidate.get("sections")
+        if not title:
+            continue
+        if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
+            continue
+        coerced_sections = [s for s in sections if isinstance(s, Mapping)]
+        if not coerced_sections:
+            continue
+        return {
+            **candidate,
+            "title": title,
+            "sections": coerced_sections,
+        }
+    return None
+
+
+class SalesBriefGenerationService:
+    """Generate sales-brief drafts through product-owned ports."""
+
+    def __init__(
+        self,
+        *,
+        intelligence: IntelligenceRepository,
+        sales_briefs: SalesBriefRepository,
+        llm: LLMClient,
+        skills: SkillStore,
+        reasoning_context: CampaignReasoningContextProvider | None = None,
+        config: SalesBriefGenerationConfig | None = None,
+    ):
+        self._intelligence = intelligence
+        self._sales_briefs = sales_briefs
+        self._llm = llm
+        self._skills = skills
+        self._reasoning_context = reasoning_context
+        self._config = config or SalesBriefGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> SalesBriefGenerationResult:
+        prompt_template = self._skills.get_prompt(self._config.skill_name)
+        if not prompt_template:
+            raise ValueError(
+                f"Sales-brief generation skill not found: {self._config.skill_name}"
+            )
+
+        requested = int(limit or self._config.limit)
+        opportunities = [
+            normalize_campaign_opportunity(row, target_mode=target_mode)
+            for row in await self._intelligence.read_campaign_opportunities(
+                scope=scope,
+                target_mode=target_mode,
+                limit=requested,
+                filters=filters,
+            )
+        ]
+
+        drafts: list[SalesBriefDraft] = []
+        errors: list[dict[str, Any]] = []
+        skipped = 0
+        for opportunity in opportunities:
+            target_id = opportunity_target_id(opportunity)
+            if not target_id:
+                skipped += 1
+                errors.append({"reason": "missing_target_id", "opportunity": opportunity})
+                continue
+            try:
+                opportunity = await self._opportunity_with_reasoning_context(
+                    scope=scope,
+                    target_mode=target_mode,
+                    target_id=target_id,
+                    opportunity=opportunity,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+
+            try:
+                parsed = await self._generate_one(
+                    prompt_template,
+                    opportunity=opportunity,
+                    target_mode=target_mode,
+                )
+            except Exception as exc:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": str(exc)})
+                continue
+
+            if not parsed:
+                skipped += 1
+                errors.append({"target_id": target_id, "reason": "unparseable_response"})
+                continue
+
+            quality = self._quality_check(parsed)
+            if not quality["passed"]:
+                skipped += 1
+                errors.append({
+                    "target_id": target_id,
+                    "reason": "quality_blocked",
+                    "blockers": quality["blockers"],
+                })
+                continue
+
+            drafts.append(
+                self._build_draft(parsed, target_id=target_id, target_mode=target_mode)
+            )
+
+        saved_ids: tuple[str, ...] = ()
+        if drafts:
+            saved_ids = tuple(
+                str(item)
+                for item in await self._sales_briefs.save_drafts(drafts, scope=scope)
+            )
+        return SalesBriefGenerationResult(
+            requested=len(opportunities),
+            generated=len(drafts),
+            skipped=skipped,
+            saved_ids=saved_ids,
+            errors=tuple(errors),
+        )
+
+    async def _opportunity_with_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        target_id: str,
+        opportunity: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        # Mirrors ReportGenerationService._opportunity_with_reasoning_context.
+        context = None
+        if self._reasoning_context is not None:
+            provided = await self._reasoning_context.read_campaign_reasoning_context(
+                scope=scope,
+                target_id=target_id,
+                target_mode=target_mode,
+                opportunity=opportunity,
+            )
+            provided_context = normalize_campaign_reasoning_context(provided)
+            if provided_context.has_content():
+                context = provided_context
+        if context is None:
+            context = normalize_campaign_reasoning_context(opportunity)
+        if not context.has_content():
+            return dict(opportunity)
+        enriched = dict(opportunity)
+        payload = campaign_reasoning_context_payload(context)
+        enriched.update(campaign_reasoning_context_metadata(context))
+        existing_reasoning_context = opportunity.get("reasoning_context")
+        if isinstance(existing_reasoning_context, Mapping):
+            enriched["reasoning_context"] = {
+                **dict(existing_reasoning_context),
+                "campaign_reasoning_context": payload,
+            }
+        else:
+            enriched["reasoning_context"] = payload
+        enriched["campaign_reasoning_context"] = payload
+        return enriched
+
+    async def _generate_one(
+        self,
+        prompt_template: str,
+        *,
+        opportunity: Mapping[str, Any],
+        target_mode: str,
+    ) -> dict[str, Any] | None:
+        opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
+        # Single source for the opportunity payload: in the system prompt
+        # via {opportunity_json}. User message is structural-only so the
+        # opportunity isn't sent twice (matches the report-generator fix).
+        system_prompt = (
+            prompt_template
+            .replace("{target_mode}", target_mode)
+            .replace("{opportunity_json}", opportunity_json)
+        )
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(
+                    role="user",
+                    content="Generate one sales brief from the opportunity above.",
+                ),
+            ],
+            max_tokens=self._config.max_tokens,
+            temperature=self._config.temperature,
+            metadata={
+                "target_mode": target_mode,
+                "target_id": opportunity_target_id(opportunity),
+                "skill_name": self._config.skill_name,
+                "asset_type": "sales_brief",
+            },
+        )
+        parsed = parse_sales_brief_response(response.content)
+        if not parsed:
+            return None
+        return {
+            **parsed,
+            "_model": response.model,
+            "_usage": dict(response.usage or {}),
+        }
+
+    def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
+        brief_input = QualityInput(
+            artifact_type="sales_brief",
+            context={
+                "title": parsed.get("title"),
+                "headline": parsed.get("headline"),
+                "sections": parsed.get("sections") or (),
+                "reference_ids": parsed.get("reference_ids") or (),
+                "metadata": {
+                    "confidence": parsed.get("confidence"),
+                },
+            },
+        )
+        report = evaluate_sales_brief(brief_input, policy=self._config.quality_policy)
+        return {
+            "passed": report.passed,
+            "blockers": tuple(f.message for f in report.blockers),
+        }
+
+    def _build_draft(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        target_id: str,
+        target_mode: str,
+    ) -> SalesBriefDraft:
+        sections = tuple(
+            SalesBriefSection(
+                id=str(s.get("id") or "").strip(),
+                title=str(s.get("title") or "").strip(),
+                body_markdown=str(s.get("body_markdown") or "").strip(),
+                claim_ids=tuple(str(c) for c in (s.get("claim_ids") or ())),
+                evidence_ids=tuple(str(e) for e in (s.get("evidence_ids") or ())),
+                metadata=dict(s.get("metadata") or {}),
+            )
+            for s in parsed.get("sections") or ()
+            if isinstance(s, Mapping)
+        )
+        # Aggregate reference_ids: explicit list union per-section evidence ids.
+        ref_seen: list[str] = []
+        for value in parsed.get("reference_ids") or ():
+            v = str(value).strip()
+            if v and v not in ref_seen:
+                ref_seen.append(v)
+        for section in sections:
+            for evidence_id in section.evidence_ids:
+                v = str(evidence_id).strip()
+                if v and v not in ref_seen:
+                    ref_seen.append(v)
+        brief_type = str(parsed.get("brief_type") or self._config.default_brief_type)
+        metadata: dict[str, Any] = {
+            "generation_model": parsed.get("_model"),
+            "generation_usage": parsed.get("_usage") or {},
+        }
+        if "confidence" in parsed:
+            metadata["confidence"] = parsed["confidence"]
+        return SalesBriefDraft(
+            target_id=target_id,
+            target_mode=target_mode,
+            brief_type=brief_type,
+            title=str(parsed.get("title") or "").strip(),
+            headline=str(parsed.get("headline") or "").strip(),
+            sections=sections,
+            reference_ids=tuple(ref_seen),
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "SalesBriefGenerationConfig",
+    "SalesBriefGenerationResult",
+    "SalesBriefGenerationService",
+    "parse_sales_brief_response",
+]

--- a/extracted_content_pipeline/skills/digest/sales_brief_generation.md
+++ b/extracted_content_pipeline/skills/digest/sales_brief_generation.md
@@ -1,0 +1,53 @@
+You generate ONE sales brief from a single normalized opportunity row plus its reasoning context.
+
+A sales brief is what a salesperson reads in the 30 seconds before walking into a meeting or call -- a punchy elevator-line `headline` ("why this account, why now") plus 3-5 ordered sections (account context, recent signals, talking points, risks/objections, next actions). NOT a report (no long executive summary). NOT a marketing landing page (no public-facing copy). Sales-facing internal copy.
+
+The opportunity is JSON-encoded as `{opportunity_json}`. The reasoning context (when present) lives inside the opportunity under the `campaign_reasoning_context` and `reasoning_context` keys. If the reasoning context carries a `narrative_plan` block (top-level under `canonical_reasoning`), use its `sections` array as the section spine -- write prose for each section rather than inventing a different structure. If no `narrative_plan` is present, structure the brief yourself from the opportunity evidence.
+
+Output ONLY a single JSON object with this exact shape. No prose outside the JSON.
+
+```json
+{
+  "title": "Pre-call brief: <Account name> -- <2-4 word framing>",
+  "headline": "One-line elevator -- why this account, why now (~140 chars)",
+  "brief_type": "pre_call",
+  "sections": [
+    {
+      "id": "account_context",
+      "title": "Account Context",
+      "body_markdown": "Mid-market SaaS, Series C, 350 seats. Renewal Q3 ...",
+      "claim_ids": ["c1"],
+      "evidence_ids": ["r1"],
+      "metadata": {"order": 1}
+    },
+    {
+      "id": "recent_signals",
+      "title": "Recent Signals",
+      "body_markdown": "Two competitor evals in last 30 days. ...",
+      "claim_ids": ["c2", "c3"],
+      "evidence_ids": ["r2", "r3"]
+    },
+    {
+      "id": "talking_points",
+      "title": "Talking Points",
+      "body_markdown": "Lead with renewal-pressure framing ...",
+      "claim_ids": [],
+      "evidence_ids": []
+    }
+  ],
+  "reference_ids": ["r1", "r2", "r3"],
+  "confidence": 0.82
+}
+```
+
+Field rules:
+- `title`: short, descriptive; lead with the brief shape (e.g., "Pre-call brief", "Renewal brief", "Displacement brief"). Includes the account/entity name. No date stamps.
+- `headline`: ONE line, ~140 chars max, sales-facing. The elevator the rep reads while walking to the meeting room. Punchy, not analytical. NOT the same shape as a report's `summary`.
+- `brief_type`: one of `pre_call`, `renewal`, `displacement`, `discovery`, or another snake_case label that fits the opportunity's `target_mode`. Default to `pre_call` when in doubt.
+- `sections`: 3-6 ordered. Common shapes: `account_context` / `recent_signals` / `talking_points` / `risks_and_objections` / `next_actions`. Each section needs a non-empty `title` and `body_markdown`. Cite supporting evidence in `evidence_ids` using the source ids that appear in the opportunity / reasoning context.
+- `reference_ids`: union of every `evidence_ids` value across sections, plus any opportunity-level source ids you cited. No duplicates. A brief without references is a brief the rep can't trust.
+- `confidence`: optional float in [0, 1]; reflects how solid the underlying signals are.
+
+When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent claim ids that aren't in the reasoning context.
+
+Avoid: weasel words ("powerful", "robust", "synergy"), promises that can't be backed up, comparative claims about specific competitors unless the opportunity provides them. The rep is the one who has to defend every word in the room.

--- a/extracted_quality_gate/sales_brief_pack.py
+++ b/extracted_quality_gate/sales_brief_pack.py
@@ -1,0 +1,298 @@
+"""Sales-brief quality pack: deterministic validators for sales briefs.
+
+Sibling to ``report_pack`` (PR-Reports-1b), ``landing_page_pack``
+(PR-LandingPage-1b), and ``campaign_pack`` / ``blog_pack``. Validates
+the structured ``SalesBriefDraft`` shape from
+``extracted_content_pipeline.sales_brief_ports``: title, headline,
+ordered sections, reference ids. Pure-function discipline (no DB, no
+LLM, no clock) -- sanitization belongs in the wrapper.
+
+Public API:
+
+    evaluate_sales_brief(
+        input: QualityInput,
+        *,
+        policy: QualityPolicy | None = None,
+    ) -> QualityReport
+
+The ``input`` carries the structured sales-brief payload through
+``input.context``. Recognised keys:
+
+  - ``title`` (str)
+  - ``headline`` (str): one-line punchy framing
+  - ``sections`` (Sequence[Mapping]): each ``{"id", "title",
+    "body_markdown", "claim_ids", "evidence_ids", ...}`` (mirrors
+    ``report_pack``)
+  - ``reference_ids`` (Sequence[str]): cited source ids at the
+    brief level
+  - ``metadata`` (Mapping): generation metadata; ``confidence`` may
+    appear here as a float in [0, 1]
+
+Recognised ``policy.thresholds`` keys:
+  - ``min_sections`` (int): default 1
+  - ``max_headline_chars`` (int): warn when ``headline`` is above this;
+    default 280 (a reasonable elevator-line ceiling -- the rep should
+    be able to skim it in 5 seconds before walking into the meeting)
+  - ``min_confidence`` (float): warn when ``metadata["confidence"]`` is
+    below this; default 0.0 (no floor)
+  - ``pass_score`` (int): default 70
+  - ``blocking_penalty`` (int): default 18 (per blocker)
+  - ``warning_penalty`` (int): default 6 (per warning)
+
+Recognised ``policy.metadata`` keys:
+  - ``blocked_phrasing`` (Sequence[str] | str): word-boundary blocked
+    phrases. Bare string is auto-wrapped (mirrors report_pack).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from .types import (
+    GateDecision,
+    GateFinding,
+    GateSeverity,
+    QualityInput,
+    QualityPolicy,
+    QualityReport,
+)
+
+
+_DEFAULT_THRESHOLDS: Mapping[str, Any] = {
+    "min_sections": 1,
+    "max_headline_chars": 280,
+    "min_confidence": 0.0,
+    "pass_score": 70,
+    "blocking_penalty": 18,
+    "warning_penalty": 6,
+}
+
+
+def _threshold_int(policy: QualityPolicy | None, key: str) -> int:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return int(_DEFAULT_THRESHOLDS[key])
+
+
+def _threshold_float(policy: QualityPolicy | None, key: str) -> float:
+    if policy is not None:
+        value = policy.thresholds.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return float(_DEFAULT_THRESHOLDS[key])
+
+
+def _blocked_phrases(policy: QualityPolicy | None) -> tuple[str, ...]:
+    """Mirror of ``report_pack._blocked_phrases``: bare string auto-wraps."""
+    if policy is None:
+        return ()
+    raw = policy.metadata.get("blocked_phrasing")
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        text = raw.strip()
+        return (text,) if text else ()
+    if not isinstance(raw, Sequence):
+        return ()
+    return tuple(str(item) for item in raw if str(item).strip())
+
+
+def evaluate_sales_brief(
+    input: QualityInput,
+    *,
+    policy: QualityPolicy | None = None,
+) -> QualityReport:
+    """Run the deterministic sales-brief-quality validators."""
+
+    context = dict(input.context or {})
+    title = str(context.get("title") or "").strip()
+    headline = str(context.get("headline") or "").strip()
+    sections_raw = context.get("sections") or ()
+    sections: list[Mapping[str, Any]] = [
+        section for section in sections_raw if isinstance(section, Mapping)
+    ]
+    reference_ids: tuple[str, ...] = tuple(
+        str(item).strip()
+        for item in (context.get("reference_ids") or ())
+        if str(item).strip()
+    )
+    metadata: Mapping[str, Any] = (
+        context.get("metadata") if isinstance(context.get("metadata"), Mapping) else {}
+    )
+
+    findings: list[GateFinding] = []
+
+    # ---- Title / headline ----
+    if not title:
+        findings.append(GateFinding(code="no_title", message="no_title", severity=GateSeverity.BLOCKER))
+    if not headline:
+        findings.append(
+            GateFinding(code="no_headline", message="no_headline", severity=GateSeverity.BLOCKER)
+        )
+    else:
+        max_headline_chars = _threshold_int(policy, "max_headline_chars")
+        if max_headline_chars > 0 and len(headline) > max_headline_chars:
+            findings.append(
+                GateFinding(
+                    code="headline_too_long",
+                    message=f"headline_too_long:{len(headline)}>{max_headline_chars}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"length": len(headline), "max": max_headline_chars},
+                )
+            )
+
+    # ---- Sections ----
+    min_sections = _threshold_int(policy, "min_sections")
+    if len(sections) < min_sections:
+        findings.append(
+            GateFinding(
+                code="no_sections",
+                message=f"no_sections:{len(sections)}_below_min_{min_sections}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"section_count": len(sections), "min_sections": min_sections},
+            )
+        )
+
+    section_evidence_present = False
+    for index, section in enumerate(sections):
+        section_title = str(section.get("title") or "").strip()
+        if not section_title:
+            findings.append(
+                GateFinding(
+                    code="section_missing_title",
+                    message=f"section_missing_title:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        section_body = str(section.get("body_markdown") or "").strip()
+        if not section_body:
+            findings.append(
+                GateFinding(
+                    code="section_missing_body",
+                    message=f"section_missing_body:{index}",
+                    severity=GateSeverity.BLOCKER,
+                    metadata={"section_index": index},
+                )
+            )
+        evidence_ids = section.get("evidence_ids") or ()
+        if isinstance(evidence_ids, Sequence) and not isinstance(evidence_ids, (str, bytes)):
+            if any(str(item).strip() for item in evidence_ids):
+                section_evidence_present = True
+
+    # ---- References ----
+    # A sales brief without source ids is useless to the rep -- they
+    # need to know where the claims come from before walking into the
+    # meeting. Mirrors the report_pack rule.
+    if not reference_ids and not section_evidence_present:
+        findings.append(
+            GateFinding(
+                code="no_references",
+                message="no_references",
+                severity=GateSeverity.BLOCKER,
+            )
+        )
+
+    # ---- Confidence floor ----
+    min_confidence = _threshold_float(policy, "min_confidence")
+    raw_confidence = metadata.get("confidence")
+    confidence: float | None = None
+    if isinstance(raw_confidence, (int, float)) and not isinstance(raw_confidence, bool):
+        confidence = max(0.0, min(1.0, float(raw_confidence)))
+    if min_confidence > 0.0:
+        if confidence is None:
+            findings.append(
+                GateFinding(
+                    code="missing_confidence",
+                    message="missing_confidence",
+                    severity=GateSeverity.WARNING,
+                )
+            )
+        elif confidence < min_confidence:
+            findings.append(
+                GateFinding(
+                    code="confidence_below_min",
+                    message=f"confidence_below_min:{confidence:.2f}<{min_confidence:.2f}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"confidence": confidence, "min_confidence": min_confidence},
+                )
+            )
+
+    # ---- Blocked phrasing (case-insensitive word-boundary) ----
+    phrases = _blocked_phrases(policy)
+    if phrases:
+        haystack_parts: list[str] = []
+        if title:
+            haystack_parts.append(title)
+        if headline:
+            haystack_parts.append(headline)
+        for section in sections:
+            for key in ("title", "body_markdown"):
+                value = section.get(key)
+                if isinstance(value, str) and value.strip():
+                    haystack_parts.append(value)
+        haystack = "\n".join(haystack_parts)
+        for phrase in phrases:
+            phrase_str = str(phrase).strip()
+            if not phrase_str:
+                continue
+            pattern = re.compile(rf"\b{re.escape(phrase_str)}\b", re.IGNORECASE)
+            if pattern.search(haystack):
+                findings.append(
+                    GateFinding(
+                        code="blocked_phrasing",
+                        message=f"blocked_phrasing:{phrase}",
+                        severity=GateSeverity.BLOCKER,
+                        metadata={"phrase": phrase_str},
+                    )
+                )
+
+    return _build_report(findings=findings, sections=sections, policy=policy)
+
+
+def _build_report(
+    *,
+    findings: list[GateFinding],
+    sections: list[Mapping[str, Any]],
+    policy: QualityPolicy | None,
+) -> QualityReport:
+    blockers = [f for f in findings if f.severity == GateSeverity.BLOCKER]
+    warnings = [f for f in findings if f.severity == GateSeverity.WARNING]
+    blocking_penalty = _threshold_int(policy, "blocking_penalty")
+    warning_penalty = _threshold_int(policy, "warning_penalty")
+    pass_score = _threshold_int(policy, "pass_score")
+    score = max(
+        0,
+        100 - (blocking_penalty * len(blockers)) - (warning_penalty * len(warnings)),
+    )
+    passed = (not blockers) and score >= pass_score
+    if blockers or score < pass_score:
+        decision = GateDecision.BLOCK
+    elif warnings:
+        decision = GateDecision.WARN
+    else:
+        decision = GateDecision.PASS
+    metadata = {
+        "score": score,
+        "threshold": pass_score,
+        "status": "pass" if passed else "fail",
+        "blocking_issues": tuple(f.message for f in blockers),
+        "blocking_codes": tuple(f.code for f in blockers),
+        "warnings": tuple(f.message for f in warnings),
+        "warning_codes": tuple(f.code for f in warnings),
+        "section_count": len(sections),
+    }
+    return QualityReport(
+        passed=passed,
+        decision=decision,
+        findings=tuple(findings),
+        metadata=metadata,
+    )
+
+
+__all__ = ["evaluate_sales_brief"]

--- a/extracted_quality_gate/sales_brief_pack.py
+++ b/extracted_quality_gate/sales_brief_pack.py
@@ -32,7 +32,13 @@ Recognised ``policy.thresholds`` keys:
   - ``min_sections`` (int): default 1
   - ``max_headline_chars`` (int): warn when ``headline`` is above this;
     default 280 (a reasonable elevator-line ceiling -- the rep should
-    be able to skim it in 5 seconds before walking into the meeting)
+    be able to skim it in 5 seconds before walking into the meeting).
+    Note the deliberate asymmetry with the skill prompt, which tells
+    the LLM to aim for ~140 chars (a tighter "punchy" target). The
+    pack ceiling is the harder bound: the LLM can overshoot the
+    aspirational prompt target by ~2x and still pass the gate, but a
+    rambling 300-char "headline" warns. Two-tier guidance: aim short
+    in the prompt, tolerate up to 280 in the gate.
   - ``min_confidence`` (float): warn when ``metadata["confidence"]`` is
     below this; default 0.0 (no floor)
   - ``pass_score`` (int): default 70

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -31,6 +31,8 @@ pytest \
   tests/test_extracted_landing_page_generation.py \
   tests/test_extracted_quality_gate_landing_page_pack.py \
   tests/test_extracted_sales_brief_postgres.py \
+  tests/test_extracted_sales_brief_generation.py \
+  tests/test_extracted_quality_gate_sales_brief_pack.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_quality_gate_sales_brief_pack.py
+++ b/tests/test_extracted_quality_gate_sales_brief_pack.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
+from extracted_quality_gate.types import (
+    GateDecision,
+    QualityInput,
+    QualityPolicy,
+)
+
+
+def _section(
+    *,
+    title: str = "Account Context",
+    body: str = "Mid-market SaaS, Series C, 350 seats.",
+    evidence_ids: tuple[str, ...] = ("r1",),
+) -> dict:
+    return {
+        "id": "account_context",
+        "title": title,
+        "body_markdown": body,
+        "claim_ids": ("c1",),
+        "evidence_ids": evidence_ids,
+    }
+
+
+def _input(**overrides) -> QualityInput:
+    context = {
+        "title": "Pre-call brief: Acme renewal",
+        "headline": "Renewal Q3 -- 90-day pressure window opens this week",
+        "sections": (_section(),),
+        "reference_ids": ("r1", "r2"),
+        "metadata": {"confidence": 0.82},
+    }
+    context.update(overrides)
+    return QualityInput(artifact_type="sales_brief", context=context)
+
+
+def test_evaluate_sales_brief_happy_path_passes() -> None:
+    report = evaluate_sales_brief(_input())
+    assert report.passed is True
+    assert report.decision == GateDecision.PASS
+    assert report.blockers == ()
+    assert report.metadata["section_count"] == 1
+
+
+def test_evaluate_sales_brief_no_title_blocks() -> None:
+    report = evaluate_sales_brief(_input(title=""))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_title" in codes
+
+
+def test_evaluate_sales_brief_no_headline_blocks() -> None:
+    report = evaluate_sales_brief(_input(headline=""))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_headline" in codes
+
+
+def test_evaluate_sales_brief_no_sections_blocks() -> None:
+    report = evaluate_sales_brief(_input(sections=()))
+    assert report.passed is False
+    codes = {f.code for f in report.blockers}
+    assert "no_sections" in codes
+
+
+def test_evaluate_sales_brief_section_missing_body_blocks_per_section() -> None:
+    sections = (_section(), _section(title="Signals", body=""))
+    report = evaluate_sales_brief(_input(sections=sections))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "section_missing_body:1" in blocker_msgs
+    assert "section_missing_body:0" not in blocker_msgs
+
+
+def test_evaluate_sales_brief_section_missing_title_blocks_per_section() -> None:
+    sections = (_section(title=""),)
+    report = evaluate_sales_brief(_input(sections=sections))
+    assert any(f.code == "section_missing_title" for f in report.blockers)
+
+
+def test_evaluate_sales_brief_no_references_blocks_when_neither_top_nor_section_evidence() -> None:
+    """A sales brief with no source ids is useless to the rep."""
+    sections = (_section(evidence_ids=()),)
+    report = evaluate_sales_brief(_input(sections=sections, reference_ids=()))
+    assert any(f.code == "no_references" for f in report.blockers)
+
+
+def test_evaluate_sales_brief_no_references_passes_when_section_evidence_present() -> None:
+    """Section evidence alone is sufficient -- top-level reference_ids may be empty."""
+    sections = (_section(evidence_ids=("r1",)),)
+    report = evaluate_sales_brief(_input(sections=sections, reference_ids=()))
+    codes = {f.code for f in report.blockers}
+    assert "no_references" not in codes
+
+
+def test_evaluate_sales_brief_headline_too_long_warns_only() -> None:
+    """Default ceiling is 280 chars; over that warns but doesn't block."""
+    long_headline = "x" * 300
+    report = evaluate_sales_brief(_input(headline=long_headline))
+    blocker_codes = {f.code for f in report.blockers}
+    warning_codes = {f.code for f in report.warnings}
+    assert "headline_too_long" not in blocker_codes
+    assert "headline_too_long" in warning_codes
+
+
+def test_evaluate_sales_brief_headline_within_ceiling_no_warning() -> None:
+    report = evaluate_sales_brief(_input(headline="Short and punchy."))
+    warning_codes = {f.code for f in report.warnings}
+    assert "headline_too_long" not in warning_codes
+
+
+def test_evaluate_sales_brief_headline_ceiling_is_configurable() -> None:
+    """Hosts can tighten or loosen the ceiling via policy.thresholds."""
+    policy = QualityPolicy(name="brief_policy", thresholds={"max_headline_chars": 50})
+    report = evaluate_sales_brief(
+        _input(headline="x" * 80),
+        policy=policy,
+    )
+    warning_codes = {f.code for f in report.warnings}
+    assert "headline_too_long" in warning_codes
+
+
+def test_evaluate_sales_brief_blocked_phrasing_uses_word_boundaries_not_substrings() -> None:
+    """Mirrors validate_reasoning_output regression: 'promise' must not match 'compromise'."""
+    sections = (_section(body="We cannot compromise on quality."),)
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": ("promise",)},
+    )
+    report = evaluate_sales_brief(_input(sections=sections), policy=policy)
+    blocker_codes = {f.code for f in report.blockers}
+    assert "blocked_phrasing" not in blocker_codes
+
+
+def test_evaluate_sales_brief_blocked_phrasing_blocks_with_word_boundary_match() -> None:
+    sections = (_section(body="We GUARANTEE results within 30 days."),)
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": ("guarantee",)},
+    )
+    report = evaluate_sales_brief(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_sales_brief_blocked_phrasing_scans_headline_and_title() -> None:
+    """Blocked-phrase scan covers title + headline, not just sections."""
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": ("guarantee",)},
+    )
+    report = evaluate_sales_brief(
+        _input(headline="We guarantee renewal -- pressure window opens"),
+        policy=policy,
+    )
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_sales_brief_blocked_phrasing_auto_wraps_bare_string_policy() -> None:
+    """Bare-string policy auto-wraps -- a host typo shouldn't silently disable the gate."""
+    sections = (_section(body="We GUARANTEE results."),)
+    policy = QualityPolicy(
+        name="brief_policy",
+        metadata={"blocked_phrasing": "guarantee"},
+    )
+    report = evaluate_sales_brief(_input(sections=sections), policy=policy)
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "blocked_phrasing:guarantee" in blocker_msgs
+
+
+def test_evaluate_sales_brief_min_confidence_warns_when_below_threshold() -> None:
+    policy = QualityPolicy(name="brief_policy", thresholds={"min_confidence": 0.7})
+    report = evaluate_sales_brief(_input(metadata={"confidence": 0.5}), policy=policy)
+    warning_codes = {f.code for f in report.warnings}
+    assert "confidence_below_min" in warning_codes
+
+
+def test_evaluate_sales_brief_min_confidence_warns_when_missing() -> None:
+    policy = QualityPolicy(name="brief_policy", thresholds={"min_confidence": 0.7})
+    report = evaluate_sales_brief(_input(metadata={}), policy=policy)
+    warning_codes = {f.code for f in report.warnings}
+    assert "missing_confidence" in warning_codes
+
+
+def test_evaluate_sales_brief_metadata_carries_score_and_threshold() -> None:
+    report = evaluate_sales_brief(_input())
+    assert "score" in report.metadata
+    assert "threshold" in report.metadata
+    assert report.metadata["status"] == "pass"

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
+from extracted_content_pipeline.sales_brief_generation import (
+    SalesBriefGenerationConfig,
+    SalesBriefGenerationService,
+    parse_sales_brief_response,
+)
+from extracted_content_pipeline.sales_brief_ports import SalesBriefDraft
+
+
+# -----------------------
+# Fake ports (mirror tests/test_extracted_report_generation.py:24-120)
+# -----------------------
+
+
+class _Intelligence:
+    def __init__(self, opportunities):
+        self.opportunities = opportunities
+        self.calls = []
+
+    async def read_campaign_opportunities(self, *, scope, target_mode, limit, filters=None):
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": filters,
+        })
+        return self.opportunities
+
+    async def read_vendor_targets(self, *, scope, target_mode, vendor_name=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _SalesBriefs:
+    def __init__(self):
+        self.saved = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": list(drafts), "scope": scope})
+        return [f"sb-{index + 1}" for index, _ in enumerate(drafts)]
+
+    async def list_drafts(self, *, scope, status=None, target_mode=None, brief_type=None, limit=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+    async def update_status(self, brief_id, status, *, scope):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _LLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return LLMResponse(
+            content=response,
+            model="test-model",
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+
+class _Skills:
+    def __init__(self, prompts):
+        self.prompts = prompts
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompts.get(name)
+
+
+class _ReasoningProvider:
+    def __init__(self, context):
+        self.context = context
+        self.calls = []
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        self.calls.append({
+            "scope": scope,
+            "target_id": target_id,
+            "target_mode": target_mode,
+        })
+        return self.context
+
+
+def _opportunity():
+    return {
+        "id": "opp-1",
+        "target_id": "vendor-acme",
+        "vendor_name": "Acme",
+        "company_name": "Acme",
+        "evidence": [{"quote": "Renewal pricing is too high"}],
+    }
+
+
+def _valid_brief_json(*, title="Pre-call brief: Acme renewal", brief_type="pre_call"):
+    return json.dumps({
+        "title": title,
+        "headline": "Renewal Q3 -- 90-day pressure window opens this week",
+        "brief_type": brief_type,
+        "sections": [
+            {
+                "id": "account_context",
+                "title": "Account Context",
+                "body_markdown": "Mid-market SaaS, Series C, 350 seats.",
+                "claim_ids": ["c1"],
+                "evidence_ids": ["r1"],
+                "metadata": {"order": 1},
+            },
+            {
+                "id": "talking_points",
+                "title": "Talking Points",
+                "body_markdown": "Lead with renewal-pressure framing.",
+                "claim_ids": [],
+                "evidence_ids": [],
+                "metadata": {"order": 2},
+            },
+        ],
+        "reference_ids": ["r1"],
+        "confidence": 0.82,
+    })
+
+
+def _service(
+    *,
+    opportunities=None,
+    responses=None,
+    prompts=None,
+    reasoning_context=None,
+    config=None,
+):
+    intelligence = _Intelligence(opportunities or [_opportunity()])
+    sales_briefs = _SalesBriefs()
+    llm = _LLM(responses or [_valid_brief_json()])
+    if prompts is None:
+        prompts = {
+            "digest/sales_brief_generation": "TEMPLATE for {target_mode}: {opportunity_json}"
+        }
+    skills = _Skills(prompts)
+    reasoning_provider = (
+        _ReasoningProvider(reasoning_context) if reasoning_context is not None else None
+    )
+    service = SalesBriefGenerationService(
+        intelligence=intelligence,
+        sales_briefs=sales_briefs,
+        llm=llm,
+        skills=skills,
+        reasoning_context=reasoning_provider,
+        config=config or SalesBriefGenerationConfig(),
+    )
+    return service, intelligence, sales_briefs, llm, skills, reasoning_provider
+
+
+# -----------------------
+# parse_sales_brief_response
+# -----------------------
+
+
+def test_parse_sales_brief_response_strips_code_fences_and_extracts_first_object() -> None:
+    text = "```json\n" + _valid_brief_json() + "\n```"
+    parsed = parse_sales_brief_response(text)
+    assert parsed is not None
+    assert parsed["title"] == "Pre-call brief: Acme renewal"
+    assert parsed["sections"][0]["id"] == "account_context"
+
+
+def test_parse_sales_brief_response_returns_none_when_required_fields_missing() -> None:
+    assert parse_sales_brief_response("") is None
+    assert parse_sales_brief_response('{"title": "x"}') is None  # no sections
+    assert parse_sales_brief_response('{"title": "x", "sections": []}') is None  # empty sections
+
+
+def test_parse_sales_brief_response_handles_braces_inside_string_values() -> None:
+    """body_markdown with template syntax must not break the parser."""
+    payload = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "Templates",
+                "body_markdown": "Pricing tiers: {basic, pro} models. Use {project_id} placeholders.",
+            }
+        ],
+    })
+    parsed = parse_sales_brief_response(payload)
+    assert parsed is not None
+    assert "{basic, pro}" in parsed["sections"][0]["body_markdown"]
+
+
+def test_parse_sales_brief_response_strips_think_blocks_before_decoding() -> None:
+    payload = "<think>thinking aloud...</think>\n" + _valid_brief_json()
+    parsed = parse_sales_brief_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Pre-call brief: Acme renewal"
+
+
+def test_parse_sales_brief_response_accepts_missing_headline_for_quality_pack_to_judge() -> None:
+    """Missing headline isn't a parser-level rejection -- the quality pack
+    fires ``no_headline`` so callers see exactly what was wrong."""
+    payload = json.dumps({
+        "title": "Brief",
+        # headline intentionally omitted
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+    })
+    parsed = parse_sales_brief_response(payload)
+    assert parsed is not None
+    assert parsed["title"] == "Brief"
+
+
+# -----------------------
+# Service: generation
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_one_brief_per_opportunity_via_save_drafts() -> None:
+    service, intelligence, sales_briefs, llm, _skills, _rp = _service()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.requested == 1
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.saved_ids == ("sb-1",)
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["metadata"]["asset_type"] == "sales_brief"
+    assert llm.calls[0]["metadata"]["target_mode"] == "vendor"
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert len(saved_drafts) == 1
+    draft = saved_drafts[0]
+    assert isinstance(draft, SalesBriefDraft)
+    assert draft.target_id == "vendor-acme"
+    assert draft.target_mode == "vendor"
+    assert draft.brief_type == "pre_call"
+    assert draft.title == "Pre-call brief: Acme renewal"
+    assert draft.headline.startswith("Renewal Q3")
+    assert draft.sections[0].id == "account_context"
+    assert draft.metadata["generation_model"] == "test-model"
+    assert draft.metadata["confidence"] == 0.82
+
+
+@pytest.mark.asyncio
+async def test_generate_substitutes_opportunity_json_into_system_prompt_only() -> None:
+    """Opportunity payload appears in system content and NOT in user content."""
+    service, _intel, _sb, llm, _skills, _rp = _service(
+        prompts={"digest/sales_brief_generation": "TEMPLATE {target_mode}: {opportunity_json}"},
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    system_msg = llm.calls[0]["messages"][0].content
+    user_msg = llm.calls[0]["messages"][1].content
+    assert '"target_id":"vendor-acme"' in system_msg
+    assert "vendor-acme" not in user_msg
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_unparseable_response() -> None:
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=["not json garbage"]
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert any(err.get("reason") == "unparseable_response" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_quality_pack_blocks_no_references() -> None:
+    """A brief with no reference_ids and no per-section evidence is blocked."""
+    bad_response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "brief_type": "pre_call",
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": []}
+        ],
+        "reference_ids": [],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert any(err.get("reason") == "quality_blocked" for err in result.errors)
+    assert any("no_references" in b for b in result.errors[0]["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_when_response_omits_headline() -> None:
+    """End-to-end: parser accepts the candidate, quality pack fires no_headline."""
+    response = json.dumps({
+        "title": "Pre-call brief: Acme",
+        # headline omitted
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": ["r1"]}
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert sales_briefs.saved == []
+    assert any("no_headline" in b for b in result.errors[0]["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_target_id_missing() -> None:
+    # No id-shaped key and no name-shaped key -> opportunity_target_id returns ""
+    bad_opp = {"evidence": [{"quote": "no target"}]}
+    service, _intel, sales_briefs, llm, _skills, _rp = _service(opportunities=[bad_opp])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert llm.calls == []  # no LLM round-trip
+    assert any(err.get("reason") == "missing_target_id" for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_generate_consumes_reasoning_context_via_provider() -> None:
+    """When a CampaignReasoningContextProvider is supplied, its context is fetched per opp."""
+    context = CampaignReasoningContext(
+        top_theses=({"claim": "Renewal pricing", "confidence": 0.9, "source_ids": ["r1"]},),
+        canonical_reasoning={"summary": "narrative summary"},
+    )
+    service, _intel, _sb, _llm, _skills, reasoning_provider = _service(
+        reasoning_context=context
+    )
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert reasoning_provider is not None
+    assert len(reasoning_provider.calls) == 1
+    call = reasoning_provider.calls[0]
+    assert call["target_id"] == "vendor-acme"
+    assert call["target_mode"] == "vendor"
+
+
+@pytest.mark.asyncio
+async def test_generate_raises_value_error_when_skill_prompt_missing() -> None:
+    service, _intel, _sb, _llm, _skills, _rp = _service(prompts={})
+
+    with pytest.raises(ValueError, match="Sales-brief generation skill not found"):
+        await service.generate(
+            scope=TenantScope(account_id="acct-1"),
+            target_mode="vendor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_defaults_brief_type_when_llm_omits_it() -> None:
+    """Config.default_brief_type fills in when the LLM doesn't supply brief_type."""
+    response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        # brief_type omitted
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": ["r1"]}
+        ],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=SalesBriefGenerationConfig(default_brief_type="discovery"),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+    )
+
+    assert result.generated == 1
+    draft = sales_briefs.saved[0]["drafts"][0]
+    assert draft.brief_type == "discovery"
+
+
+@pytest.mark.asyncio
+async def test_generate_aggregates_section_evidence_into_reference_ids_no_duplicates() -> None:
+    """reference_ids should be the union of explicit list + per-section evidence ids."""
+    response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "brief_type": "pre_call",
+        "sections": [
+            {
+                "id": "s1",
+                "title": "T",
+                "body_markdown": "b",
+                "evidence_ids": ["r1", "r2"],
+            },
+            {
+                "id": "s2",
+                "title": "U",
+                "body_markdown": "c",
+                "evidence_ids": ["r2", "r3"],  # r2 dup
+            },
+        ],
+        "reference_ids": ["r1", "r4"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[response])
+
+    await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    draft = sales_briefs.saved[0]["drafts"][0]
+    # Order preserved: explicit list first, then section evidence ids in insertion order
+    assert draft.reference_ids == ("r1", "r4", "r2", "r3")


### PR DESCRIPTION
## Summary

Second slice of Sales Briefs content-asset support. PR-SalesBriefs-1a (#354) landed the storage layer; this PR wires the generator on top.

**After this lands, AI Content Ops ships 5 of 5 promised content types** (blogs, emails, reports, landing pages, sales briefs). The landing-page asset story will be fully truthful for the first time.

**Per-opportunity trigger** (mirrors Reports / Campaigns; differs from per-marketing-campaign Landing Pages). The service iterates `intelligence.read_campaign_opportunities` and produces one `SalesBriefDraft` per opportunity row.

## What changed

**`extracted_quality_gate/sales_brief_pack.py` (new)** — pure deterministic validator.

| Field / shape | Blocker / Warning |
|---|---|
| empty title | `no_title` (blocker) |
| empty headline | `no_headline` (blocker) |
| section count below `min_sections` | `no_sections` (blocker) |
| section with empty title | `section_missing_title:<i>` (blocker) |
| section with empty body_markdown | `section_missing_body:<i>` (blocker) |
| no `reference_ids` AND no per-section `evidence_ids` | `no_references` (blocker — a brief without sources is useless to the rep) |
| headline above `max_headline_chars` (default 280) | `headline_too_long` (warning) |
| confidence below `min_confidence` | `confidence_below_min` (warning) |
| `blocked_phrasing` word-boundary match in title/headline/sections | `blocked_phrasing:` (blocker) |

`blocked_phrasing` uses case-insensitive word-boundary regex (mirrors `report_pack` + `landing_page_pack` + `validate_reasoning_output`); bare-string policy auto-wraps.

**`extracted_content_pipeline/skills/digest/sales_brief_generation.md` (new)** — packaged prompt asking the LLM for `{title, headline, brief_type, sections, reference_ids, confidence}`. Frames the output as sales-facing internal copy (NOT customer-facing analytical prose). Calls out narrative-plan synergy and a weasel-word avoidance list.

**`extracted_content_pipeline/sales_brief_generation.py` (new)** — `SalesBriefGenerationService` mirroring `ReportGenerationService`:

```python
async def generate(
    self,
    *,
    scope: TenantScope,
    target_mode: str,
    limit: int | None = None,
    filters: Mapping[str, Any] | None = None,
) -> SalesBriefGenerationResult
```

- Per-opportunity iteration via the existing `intelligence.read_campaign_opportunities` port (no new port needed).
- Reasoning-context aware: when the host provides a `CampaignReasoningContextProvider` whose context exposes a `canonical_reasoning["narrative_plan"]` block, the generator hands that pre-structured plan to the LLM as the section spine.
- Fail-soft per row — one bad opportunity doesn't poison the batch.
- `parse_sales_brief_response` uses `json.JSONDecoder.raw_decode` (mirrors PR-Reports-1b / PR-LandingPage-1b parser fix) so braces inside `body_markdown` template syntax don't trip the parser.
- System prompt embeds `{opportunity_json}` once; user message is structural-only.
- `brief_type` defaults to `config.default_brief_type` (`"pre_call"`) when the LLM omits it.

**`tests/test_extracted_quality_gate_sales_brief_pack.py` (new, 18 tests)** — every blocker class, every warning, word-boundary regression, bare-string auto-wrap, hero/title/section scan, configurable headline ceiling.

**`tests/test_extracted_sales_brief_generation.py` (new, 15 tests)** — parser unit tests + service integration with fake ports.

**`scripts/run_extracted_pipeline_checks.sh`** — wires both new test files into the pipeline runner.

## Test plan

- [x] `python -c "from extracted_content_pipeline.sales_brief_generation import SalesBriefGenerationService; from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief"` → clean import
- [x] AST scan of new files for `atlas_brain` refs → 0 hits
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed
- [x] `pytest tests/test_extracted_sales_brief_generation.py tests/test_extracted_quality_gate_sales_brief_pack.py tests/test_extracted_sales_brief_postgres.py` → 43/43 passing locally
- [ ] CI `extracted-checks` run

## Out of scope (deferred)

- Approval API endpoint → PR-SalesBriefs-2
- CLI flag wiring → PR-SalesBriefs-3
- Variant generation (per-rep persona variants) → separate slice
- **PR-ContentAssets-Consistency-1** — atomic coordination across all four content-asset adapters: bool-returning `update_status` (Reports + Campaigns), shared `_jsonb_helpers.py` module, `Literal` type aliases (`BriefType`, `ReportType`, shared `TargetMode`). Surfaced from PR-#354 review threads, queued as the next slice.

After this PR lands: **AI Content Ops ships 5 of 5** promised content types. Asset story complete.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_