### PR TITLE
PR-OptionA-1: thread plan step.config to execution (channels, report_type, brief_type)

### DIFF
--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -248,6 +248,7 @@ class CampaignGenerationService:
         target_mode: str,
         limit: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        channels: Sequence[str] | None = None,
     ) -> CampaignGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -267,7 +268,7 @@ class CampaignGenerationService:
         drafts: list[CampaignDraft] = []
         errors: list[dict[str, Any]] = []
         skipped = 0
-        channels = self._channels()
+        resolved_channels = self._channels(override=channels)
         for opportunity in opportunities:
             target_id = opportunity_target_id(opportunity)
             if not target_id:
@@ -286,7 +287,7 @@ class CampaignGenerationService:
                 errors.append({"target_id": target_id, "reason": str(exc)})
                 continue
             cold_email_context: dict[str, str] | None = None
-            for channel in channels:
+            for channel in resolved_channels:
                 channel_opportunity = self._opportunity_for_channel(
                     opportunity,
                     channel=channel,
@@ -362,14 +363,29 @@ class CampaignGenerationService:
             errors=tuple(errors),
         )
 
-    def _channels(self) -> tuple[str, ...]:
+    def _channels(self, *, override: Sequence[str] | None = None) -> tuple[str, ...]:
+        # Per-call override (when present) wins over the construction-time
+        # config. PR-OptionA-1: makes the plan's step.config["channels"]
+        # load-bearing at dispatch time so the control surface preview's
+        # channel selection actually reaches the service. None or an empty
+        # override falls through to the existing config-then-default chain.
+        if override is not None:
+            override_list = list(override)
+            if override_list:
+                channels: list[str] = []
+                for item in override_list:
+                    channel = str(item or "").strip()
+                    if channel and channel not in channels:
+                        channels.append(channel)
+                if channels:
+                    return tuple(channels)
         raw_value = self._config.channels or (self._config.channel,)
         raw: Sequence[str]
         if isinstance(raw_value, str):
             raw = raw_value.split(",")
         else:
             raw = raw_value
-        channels: list[str] = []
+        channels = []
         for item in raw:
             channel = str(item or "").strip()
             if channel and channel not in channels:

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -33,6 +33,21 @@ from .services.campaign_quality import campaign_quality_revalidation
 _PROOF_TERM_TEXT_KEYS = ("excerpt_text", "quote", "text", "anchor", "value")
 
 
+def _normalize_channels(items: Sequence[Any]) -> tuple[str, ...]:
+    """Strip + dedupe channel ids while preserving insertion order.
+
+    Shared between the per-call override path and the construction-time
+    config fallback so both apply identical normalization. Empty / blank
+    items are dropped silently. Empty input yields an empty tuple.
+    """
+    seen: list[str] = []
+    for item in items:
+        channel = str(item or "").strip()
+        if channel and channel not in seen:
+            seen.append(channel)
+    return tuple(seen)
+
+
 def _dedupe_terms(terms: Sequence[str], *, limit: int) -> list[str]:
     if limit <= 0:
         return []
@@ -370,27 +385,16 @@ class CampaignGenerationService:
         # channel selection actually reaches the service. None or an empty
         # override falls through to the existing config-then-default chain.
         if override is not None:
-            override_list = list(override)
-            if override_list:
-                channels: list[str] = []
-                for item in override_list:
-                    channel = str(item or "").strip()
-                    if channel and channel not in channels:
-                        channels.append(channel)
-                if channels:
-                    return tuple(channels)
+            override_channels = _normalize_channels(override)
+            if override_channels:
+                return override_channels
         raw_value = self._config.channels or (self._config.channel,)
-        raw: Sequence[str]
         if isinstance(raw_value, str):
-            raw = raw_value.split(",")
+            raw: Sequence[str] = raw_value.split(",")
         else:
             raw = raw_value
-        channels = []
-        for item in raw:
-            channel = str(item or "").strip()
-            if channel and channel not in channels:
-                channels.append(channel)
-        return tuple(channels or ("email",))
+        normalized = _normalize_channels(raw)
+        return normalized or ("email",)
 
     def _opportunity_for_channel(
         self,

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -185,17 +185,151 @@ async def _run_step(
     scope: TenantScope,
     filters: Mapping[str, Any] | None,
 ) -> Any:
-    if step.output == "landing_page":
-        return await service.generate(
-            scope=scope,
-            campaign=_marketing_campaign_from_inputs(request.inputs),
-        )
+    """Dispatch a step to its per-output handler.
+
+    PR-OptionA-1 refactor: replaces the previous "landing_page special-case
+    + everything-else generic" branch with a per-output handler table so
+    each output's `step.config` can be threaded into its service signature
+    without growing more `if step.output == ...` branches. New outputs
+    register a one-line handler entry instead of editing this function.
+    """
+    handler = _DISPATCH.get(step.output, _dispatch_default)
+    return await handler(
+        step=step,
+        service=service,
+        request=request,
+        scope=scope,
+        filters=filters,
+    )
+
+
+async def _dispatch_email_campaign(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        limit=request.limit,
+        filters=filters,
+        channels=_step_config_sequence(step.config, "channels"),
+    )
+
+
+async def _dispatch_report(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        limit=request.limit,
+        filters=filters,
+        default_report_type=_step_config_text(step.config, "default_report_type"),
+    )
+
+
+async def _dispatch_sales_brief(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        limit=request.limit,
+        filters=filters,
+        default_brief_type=_step_config_text(step.config, "default_brief_type"),
+    )
+
+
+async def _dispatch_landing_page(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    del step, filters  # unused: landing pages take a campaign, not a target_mode
+    return await service.generate(
+        scope=scope,
+        campaign=_marketing_campaign_from_inputs(request.inputs),
+    )
+
+
+async def _dispatch_default(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    """Fallback for outputs that don't yet thread step.config kwargs.
+
+    Currently used by `blog_post`. Future outputs that need per-call
+    config kwargs should register their own handler in `_DISPATCH`.
+    """
+    del step  # config is informational for outputs without per-call overrides
     return await service.generate(
         scope=scope,
         target_mode=request.target_mode,
         limit=request.limit,
         filters=filters,
     )
+
+
+_DISPATCH: Mapping[str, Any] = {
+    "email_campaign": _dispatch_email_campaign,
+    "report": _dispatch_report,
+    "sales_brief": _dispatch_sales_brief,
+    "landing_page": _dispatch_landing_page,
+}
+
+
+def _step_config_text(config: Mapping[str, Any], key: str) -> str | None:
+    """Pull a non-empty string from step.config or return None."""
+    raw = config.get(key) if isinstance(config, Mapping) else None
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _step_config_sequence(
+    config: Mapping[str, Any],
+    key: str,
+) -> tuple[str, ...] | None:
+    """Pull a non-empty string sequence from step.config or return None.
+
+    Accepts either a list/tuple or a comma-separated string. Empty values
+    return None so the service falls through to its construction-time
+    default rather than coercing to an empty channel set.
+    """
+    if not isinstance(config, Mapping):
+        return None
+    raw = config.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        items = [item.strip() for item in raw.split(",") if item.strip()]
+    elif isinstance(raw, Sequence) and not isinstance(raw, (bytes, bytearray)):
+        items = [str(item).strip() for item in raw if str(item).strip()]
+    else:
+        return None
+    return tuple(items) if items else None
 
 
 def _filters_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:

--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -205,6 +205,7 @@ class ReportGenerationService:
         target_mode: str,
         limit: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        default_report_type: str | None = None,
     ) -> ReportGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -268,7 +269,12 @@ class ReportGenerationService:
                 })
                 continue
 
-            drafts.append(self._build_draft(parsed, target_id=target_id, target_mode=target_mode))
+            drafts.append(self._build_draft(
+                parsed,
+                target_id=target_id,
+                target_mode=target_mode,
+                default_report_type=default_report_type,
+            ))
 
         saved_ids: tuple[str, ...] = ()
         if drafts:
@@ -398,6 +404,7 @@ class ReportGenerationService:
         *,
         target_id: str,
         target_mode: str,
+        default_report_type: str | None = None,
     ) -> ReportDraft:
         sections = tuple(
             ReportSection(
@@ -422,7 +429,13 @@ class ReportGenerationService:
                 v = str(evidence_id).strip()
                 if v and v not in ref_seen:
                     ref_seen.append(v)
-        report_type = str(parsed.get("report_type") or self._config.default_report_type)
+        # Per-call override (when present and non-empty) wins over the
+        # construction-time default. PR-OptionA-1: makes the plan's
+        # step.config["default_report_type"] load-bearing at dispatch time.
+        # The LLM's own `report_type` JSON field still wins when present;
+        # this only affects what fills in when the LLM omits it.
+        configured_default = (default_report_type or "").strip() or self._config.default_report_type
+        report_type = str(parsed.get("report_type") or configured_default)
         metadata: dict[str, Any] = {
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -221,6 +221,7 @@ class SalesBriefGenerationService:
         target_mode: str,
         limit: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        default_brief_type: str | None = None,
     ) -> SalesBriefGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -287,7 +288,12 @@ class SalesBriefGenerationService:
                 continue
 
             drafts.append(
-                self._build_draft(parsed, target_id=target_id, target_mode=target_mode)
+                self._build_draft(
+                    parsed,
+                    target_id=target_id,
+                    target_mode=target_mode,
+                    default_brief_type=default_brief_type,
+                )
             )
 
         saved_ids: tuple[str, ...] = ()
@@ -420,6 +426,7 @@ class SalesBriefGenerationService:
         *,
         target_id: str,
         target_mode: str,
+        default_brief_type: str | None = None,
     ) -> SalesBriefDraft:
         sections = tuple(
             SalesBriefSection(
@@ -444,7 +451,12 @@ class SalesBriefGenerationService:
                 v = str(evidence_id).strip()
                 if v and v not in ref_seen:
                     ref_seen.append(v)
-        brief_type = str(parsed.get("brief_type") or self._config.default_brief_type)
+        # Per-call override (when present and non-empty) wins over the
+        # construction-time default. PR-OptionA-1: makes the plan's
+        # step.config["default_brief_type"] load-bearing at dispatch time.
+        # The LLM's own `brief_type` JSON field still wins when present.
+        configured_default = (default_brief_type or "").strip() or self._config.default_brief_type
+        brief_type = str(parsed.get("brief_type") or configured_default)
         metadata: dict[str, Any] = {
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},

--- a/plans/PR-OptionA-1.md
+++ b/plans/PR-OptionA-1.md
@@ -1,0 +1,183 @@
+# PR-OptionA-1: Thread plan step config to execution (channels, report_type, brief_type)
+
+## Why this slice exists
+
+Closes the BLOCKER from the AI Content Ops post-merge audit
+(`docs/audits/ai_content_ops_post_merge_audit_2026-05.md`,
+`content_ops_execution.py` section): `_run_step` ignores `step.config`
+entirely. The control surface preview promises the user "channels:
+[email_cold]" and the plan records it in `step.config`, but the
+executor calls `service.generate(scope, target_mode, limit, filters)`
+with no per-call channel override. The service uses whatever was
+injected at construction time (default `("email_cold",
+"email_followup")`), so the user gets both an `email_cold` draft AND
+an `email_followup` draft despite asking for cold-only in the UI.
+
+The user picked **Option A** from the audit's decision request:
+plan-as-execution-contract -- step config is load-bearing; the
+executor reads it and passes per-call config to services. The control
+surface becomes a real control surface.
+
+## Scope (this PR)
+
+Tight first-cut. Promotes ONLY the smoking-gun fields the audit
+specifically called out as breaking the trust contract:
+
+- `channels` (email_campaign) -- the audit's specific failure-mode
+  example
+- `default_report_type` (report) -- operator-visible enum, drives
+  `report_type` column on persisted drafts
+- `default_brief_type` (sales_brief) -- operator-visible enum, drives
+  `brief_type` column on persisted drafts
+
+Plus: refactor `_run_step` to a per-output dispatch table, which kills
+the `landing_page` hard-coded special-case MAJOR (same surface, not
+drive-by creep -- the dispatcher rewrite IS the fix shape).
+
+Lower-stakes per-call fields (`skill_name`, `temperature`,
+`max_tokens`, `parse_retry_attempts`, `topic`,
+`quality_revalidation_enabled`, `quality_gates_enabled`) stay
+informational in `step.config` for now and get promoted in
+PR-OptionA-2.
+
+## Mechanism
+
+Each affected service signature gains an optional kwarg matching the
+plan's `step.config` field name. When the executor passes it, the
+service uses the override; when it doesn't, the service falls back to
+`self._config` (its construction-time default). No breaking change to
+existing callers.
+
+```python
+# Before
+async def generate(*, scope, target_mode, limit=None, filters=None):
+    channels = self._channels()  # reads self._config.channels
+
+# After
+async def generate(*, scope, target_mode, limit=None, filters=None,
+                   channels=None):  # NEW
+    resolved_channels = self._channels(override=channels)
+```
+
+`_run_step` becomes a per-output dispatch table:
+
+```python
+_DISPATCH = {
+    "email_campaign": _dispatch_campaign,
+    "report": _dispatch_report,
+    "sales_brief": _dispatch_sales_brief,
+    "landing_page": _dispatch_landing_page,
+    "blog_post": _dispatch_blog_post,
+}
+
+async def _run_step(step, *, request, service, scope, filters):
+    handler = _DISPATCH.get(step.output, _dispatch_default)
+    return await handler(step=step, service=service, request=request,
+                         scope=scope, filters=filters)
+```
+
+Each handler reads the relevant `step.config` field and threads it
+through to its service's `generate()` call. The `landing_page`
+handler keeps its existing campaign-from-inputs shape; new outputs
+get a one-line registry entry instead of a new `if` branch.
+
+## Files touched
+
+1. `extracted_content_pipeline/campaign_generation.py` --
+   `generate(channels=None)` kwarg, threaded through `_channels()`
+2. `extracted_content_pipeline/report_generation.py` --
+   `generate(default_report_type=None)` kwarg, threaded through
+   `_build_draft()`
+3. `extracted_content_pipeline/sales_brief_generation.py` --
+   `generate(default_brief_type=None)` kwarg, threaded through
+   `_build_draft()`
+4. `extracted_content_pipeline/content_ops_execution.py` --
+   per-output dispatch table; threads the three new kwargs from
+   `step.config`
+5. `tests/test_extracted_campaign_generation.py` -- tests for
+   per-call `channels` override
+6. `tests/test_extracted_report_generation.py` -- tests for per-call
+   `default_report_type` override
+7. `tests/test_extracted_sales_brief_generation.py` -- tests for
+   per-call `default_brief_type` override
+8. `tests/test_extracted_content_ops_execution.py` -- tests for the
+   dispatch-table refactor + plan->service config threading
+
+## Intentional (looks wrong but is deliberate)
+
+- **Per-field kwargs, not a `config_override: Mapping[str, Any]`
+  dict.** A dict-shaped override would be more general but makes the
+  contract opaque -- callers can't statically see which fields are
+  load-bearing vs informational. Per-field kwargs make the surface
+  type-checkable and the load-bearing fields explicit at the
+  signature level.
+- **`landing_page` and `blog_post` get no per-call overrides this
+  PR.** Their plan configs are still emitted but stay informational
+  for now. Promoting them to load-bearing in PR-OptionA-1 would
+  double the LOC budget and pull in two more
+  audit-flagged-but-out-of-scope MAJORs (MarketingCampaign.context
+  leak, blog topic threading). The dispatch-table makes adding them
+  later a one-handler-edit.
+- **`default_report_type` / `default_brief_type` keep their
+  ``default_`` prefix.** That naming captures the "fallback if LLM
+  omits the type from JSON" semantic; the LLM's output still wins
+  when present. The plan and the service agree on this semantic. UI
+  copy should call them "Default report type" / "Default brief type"
+  (not "Report type" / "Brief type" -- those imply the value is
+  forced regardless of LLM output).
+- **No new abstraction layer for "config override."** The dispatch
+  table is the only new structure. Each service reads one or two
+  optional kwargs; no `ConfigOverride` dataclass, no
+  `apply_overrides_to(config)` helper. Three services with three
+  one-field overrides isn't enough surface to justify a shared
+  abstraction.
+
+## Deferred (looks missing but is on purpose)
+
+- **Promoting the rest of the plan's `step.config` fields to
+  load-bearing.** PR-OptionA-2 will tackle `temperature`,
+  `max_tokens`, `parse_retry_attempts`, and the
+  `quality_revalidation_enabled` / `quality_gates_enabled` boolean
+  flags. Same per-field-kwarg pattern. ~5 services x 2-3 fields each.
+- **`MarketingCampaign.context` leak.** The audit flagged that
+  `_marketing_campaign_from_inputs` dumps every non-{name, persona,
+  value_prop, vendors, categories, tags} input field into
+  `MarketingCampaign.context`. PR-OptionA-3.
+- **`channel`/`channels` legacy dual-field on
+  `CampaignGenerationConfig`.** The audit flagged the legacy
+  `channel: str` field still exists alongside `channels: tuple[str,
+  ...]`. Removing it is a separate cleanup PR -- not in scope here.
+- **The 9 MINOR + 2 NIT findings.** All catalogued in the audit doc;
+  each gets a focused follow-up.
+- **PR-ContentAssets-Consistency-2.** Still owed from the PR-#356
+  review threads (3 more adapters with byte-identical
+  `_jsonb`/`_row_dict`).
+
+## Verification
+
+- `pytest` on the four touched test files + the existing
+  `test_extracted_content_control_surfaces.py` /
+  `test_extracted_content_generation_plan.py` to confirm no
+  regression on the upstream layers.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline` -> clean
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` ->
+  Atlas runtime import findings: 0
+- `bash scripts/check_ascii_python.sh` -> passed
+- AST scan of the three touched generators: no new `atlas_brain`
+  references.
+
+End-to-end smoke (manual, against fake services): a plan with
+`channels: ["email_cold"]` results in `service.generate` receiving
+`channels=("email_cold",)`, not the construction-time default.
+
+## Sibling references
+
+- Audit doc:
+  `docs/audits/ai_content_ops_post_merge_audit_2026-05.md` (lives on
+  PR #367)
+- UI contract:
+  `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- Source PR for the control-surface scaffold being fixed: #353
+- Audit doc PR: #367 (will close after the BLOCKER + dispatch-table
+  MAJOR are fixed by this PR)

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -986,3 +986,80 @@ async def test_generate_raises_clear_error_when_skill_missing():
 
     with pytest.raises(ValueError, match="Campaign generation skill not found"):
         await service.generate(scope=TenantScope(), target_mode="churning_company")
+
+
+# -----------------------
+# PR-OptionA-1: per-call channels override (plan-as-execution-contract)
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_channels_override_wins_over_construction_config():
+    """When the executor threads `channels=` from step.config, the call wins
+    over the construction-time config. PR-OptionA-1 makes this load-bearing."""
+
+    service, _intel, campaigns, llm, _skills = _service(
+        [{"id": "opp-1"}],
+        ['{"subject":"Hi","body":"Body"}'],
+        config=CampaignGenerationConfig(channels=("email_cold", "email_followup")),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="churning_company",
+        channels=["email_cold"],  # plan picks cold-only
+    )
+
+    # The construction-time config had two channels; the per-call override
+    # narrowed it to one, so the LLM is invoked exactly once.
+    assert len(llm.calls) == 1
+    drafts = campaigns.saved[0]["drafts"]
+    assert len(drafts) == 1
+    assert drafts[0].channel == "email_cold"
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_channels_override_falls_back_when_none():
+    """A None override leaves the construction-time channels config in place."""
+
+    service, _intel, campaigns, llm, _skills = _service(
+        [{"id": "opp-1"}],
+        [
+            '{"subject":"Hi","body":"Body"}',
+            '{"subject":"Hi","body":"Body"}',
+        ],
+        config=CampaignGenerationConfig(channels=("email_cold", "email_followup")),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="churning_company",
+        channels=None,  # no per-call override
+    )
+
+    # Both channels from the construction-time config were used.
+    assert len(llm.calls) == 2
+    assert {d.channel for d in campaigns.saved[0]["drafts"]} == {"email_cold", "email_followup"}
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_channels_override_empty_falls_back_to_default():
+    """An empty override is treated as "no override", not "no channels"."""
+
+    service, _intel, campaigns, llm, _skills = _service(
+        [{"id": "opp-1"}],
+        [
+            '{"subject":"Hi","body":"Body"}',
+            '{"subject":"Hi","body":"Body"}',
+        ],
+        config=CampaignGenerationConfig(channels=("email_cold", "email_followup")),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="churning_company",
+        channels=[],  # empty override -> fall back, don't zero out
+    )
+
+    assert len(llm.calls) == 2
+    assert {d.channel for d in campaigns.saved[0]["drafts"]} == {"email_cold", "email_followup"}

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -132,6 +132,9 @@ async def test_execute_runs_email_and_report_services_with_scope_and_filters() -
     # Plan default channels reach the service even without per-request override.
     assert campaign_call["channels"] == ("email_cold", "email_followup")
     assert campaign_call["default_report_type"] is None
+    # extras locks the kwarg surface: a typo'd kwarg in PR-OptionA-2/3 would
+    # silently land here and never reach the right service field.
+    assert campaign_call["extras"] == {}
     assert len(report.calls) == 1
     report_call = report.calls[0]
     assert report_call["scope"] == scope
@@ -141,6 +144,7 @@ async def test_execute_runs_email_and_report_services_with_scope_and_filters() -
     # Plan default report type reaches the service.
     assert report_call["default_report_type"] == "vendor_pressure"
     assert report_call["channels"] is None
+    assert report_call["extras"] == {}
 
 
 @pytest.mark.asyncio
@@ -239,6 +243,7 @@ async def test_execute_runs_blog_post_service_with_scope_and_filters() -> None:
     assert blog_call["channels"] is None
     assert blog_call["default_report_type"] is None
     assert blog_call["default_brief_type"] is None
+    assert blog_call["extras"] == {}
 
 
 @pytest.mark.asyncio
@@ -308,6 +313,7 @@ async def test_execute_threads_user_selected_channels_into_email_campaign_servic
 
     assert result["status"] == "completed"
     assert campaign.calls[0]["channels"] == ("email_cold",)
+    assert campaign.calls[0]["extras"] == {}
 
 
 @pytest.mark.asyncio
@@ -330,6 +336,7 @@ async def test_execute_falls_back_to_plan_default_channels_when_request_omits_th
 
     assert result["status"] == "completed"
     assert campaign.calls[0]["channels"] == ("email_cold", "email_followup")
+    assert campaign.calls[0]["extras"] == {}
 
 
 @pytest.mark.asyncio
@@ -350,6 +357,7 @@ async def test_execute_threads_user_selected_report_type_into_report_service() -
 
     assert result["status"] == "completed"
     assert report.calls[0]["default_report_type"] == "customer_health"
+    assert report.calls[0]["extras"] == {}
 
 
 @pytest.mark.asyncio
@@ -370,6 +378,7 @@ async def test_execute_threads_user_selected_brief_type_into_sales_brief_service
 
     assert result["status"] == "completed"
     assert sales_brief.calls[0]["default_brief_type"] == "renewal"
+    assert sales_brief.calls[0]["extras"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -22,6 +22,13 @@ class _Result:
 
 
 class _OpportunityService:
+    """Records every kwarg the executor passes; tolerates new optional kwargs.
+
+    Accepts the smoking-gun per-call overrides PR-OptionA-1 threads through
+    (`channels`, `default_report_type`, `default_brief_type`) plus a generic
+    `**extras` so future overrides don't require touching this fake.
+    """
+
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
@@ -32,12 +39,20 @@ class _OpportunityService:
         target_mode: str,
         limit: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        channels: Any | None = None,
+        default_report_type: str | None = None,
+        default_brief_type: str | None = None,
+        **extras: Any,
     ) -> _Result:
         self.calls.append({
             "scope": scope,
             "target_mode": target_mode,
             "limit": limit,
             "filters": dict(filters or {}),
+            "channels": channels,
+            "default_report_type": default_report_type,
+            "default_brief_type": default_brief_type,
+            "extras": dict(extras),
         })
         return _Result()
 
@@ -70,7 +85,9 @@ class _BarrierOpportunityService:
         target_mode: str,
         limit: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        **extras: Any,
     ) -> _Result:
+        del extras  # PR-OptionA-1 may pass channels/default_*type kwargs.
         self.starts.append(self.name)
         if len(self.starts) == 2:
             self.all_started.set()
@@ -102,13 +119,28 @@ async def test_execute_runs_email_and_report_services_with_scope_and_filters() -
 
     assert result["status"] == "completed"
     assert [step["output"] for step in result["steps"]] == ["email_campaign", "report"]
-    assert campaign.calls == [{
-        "scope": scope,
-        "target_mode": "vendor_retention",
-        "limit": 2,
-        "filters": {"status": "ready"},
-    }]
-    assert report.calls == campaign.calls
+    # Both services receive scope, target_mode, limit, filters; the executor
+    # also threads each output's smoking-gun step.config field as a kwarg
+    # (channels for email_campaign, default_report_type for report).
+    # PR-OptionA-1: this is what makes plan-as-execution-contract real.
+    assert len(campaign.calls) == 1
+    campaign_call = campaign.calls[0]
+    assert campaign_call["scope"] == scope
+    assert campaign_call["target_mode"] == "vendor_retention"
+    assert campaign_call["limit"] == 2
+    assert campaign_call["filters"] == {"status": "ready"}
+    # Plan default channels reach the service even without per-request override.
+    assert campaign_call["channels"] == ("email_cold", "email_followup")
+    assert campaign_call["default_report_type"] is None
+    assert len(report.calls) == 1
+    report_call = report.calls[0]
+    assert report_call["scope"] == scope
+    assert report_call["target_mode"] == "vendor_retention"
+    assert report_call["limit"] == 2
+    assert report_call["filters"] == {"status": "ready"}
+    # Plan default report type reaches the service.
+    assert report_call["default_report_type"] == "vendor_pressure"
+    assert report_call["channels"] is None
 
 
 @pytest.mark.asyncio
@@ -196,12 +228,17 @@ async def test_execute_runs_blog_post_service_with_scope_and_filters() -> None:
 
     assert result["status"] == "completed"
     assert result["steps"][0]["output"] == "blog_post"
-    assert service.calls == [{
-        "scope": scope,
-        "target_mode": "vendor_retention",
-        "limit": 2,
-        "filters": {"topic_type": "vendor_alternative"},
-    }]
+    # blog_post stays on the default dispatcher in PR-OptionA-1; per-call
+    # config kwargs are deferred to PR-OptionA-2 (see plans/PR-OptionA-1.md).
+    assert len(service.calls) == 1
+    blog_call = service.calls[0]
+    assert blog_call["scope"] == scope
+    assert blog_call["target_mode"] == "vendor_retention"
+    assert blog_call["limit"] == 2
+    assert blog_call["filters"] == {"topic_type": "vendor_alternative"}
+    assert blog_call["channels"] is None
+    assert blog_call["default_report_type"] is None
+    assert blog_call["default_brief_type"] is None
 
 
 @pytest.mark.asyncio
@@ -241,3 +278,118 @@ async def test_execute_reports_service_without_generate_as_not_configured() -> N
     assert result["errors"] == [
         {"output": "email_campaign", "reason": "service_not_configured"}
     ]
+
+
+# -----------------------
+# PR-OptionA-1: smoking-gun fields (channels, default_report_type,
+# default_brief_type) flow from plan into the service call.
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_user_selected_channels_into_email_campaign_service() -> None:
+    """The audit's specific failure mode: user picks channels=['email_cold'] in the
+    control surface, plan records it in step.config, and the executor MUST pass
+    it to the service. Before PR-OptionA-1, the service used its construction-
+    time default and the user's selection was silently dropped."""
+
+    campaign = _OpportunityService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "channels": ["email_cold"],
+            },
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["status"] == "completed"
+    assert campaign.calls[0]["channels"] == ("email_cold",)
+
+
+@pytest.mark.asyncio
+async def test_execute_falls_back_to_plan_default_channels_when_request_omits_them() -> None:
+    """No request-level override -> plan emits the construction-time default
+    channels and the executor still threads them through (so the service
+    behavior is identical, but the plan is now the single source of truth)."""
+
+    campaign = _OpportunityService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["status"] == "completed"
+    assert campaign.calls[0]["channels"] == ("email_cold", "email_followup")
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_user_selected_report_type_into_report_service() -> None:
+    report = _OpportunityService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["report"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "opportunity_id": "opp-1",
+                "report_type": "customer_health",
+            },
+        },
+        services=ContentOpsExecutionServices(report=report),
+    )
+
+    assert result["status"] == "completed"
+    assert report.calls[0]["default_report_type"] == "customer_health"
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_user_selected_brief_type_into_sales_brief_service() -> None:
+    sales_brief = _OpportunityService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "opportunity_id": "opp-1",
+                "brief_type": "renewal",
+            },
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+
+    assert result["status"] == "completed"
+    assert sales_brief.calls[0]["default_brief_type"] == "renewal"
+
+
+@pytest.mark.asyncio
+async def test_execute_landing_page_dispatcher_unchanged_no_per_call_overrides() -> None:
+    """Landing page still gets the campaign-from-inputs dispatch (no per-call
+    overrides in this PR; deferred to PR-OptionA-2)."""
+
+    landing = _LandingPageService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "campaign_name": "Q3 audit",
+                "offer": "Audit",
+                "audience": "VPs",
+            },
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    assert result["status"] == "completed"
+    assert len(landing.calls) == 1
+    assert landing.calls[0]["campaign"].name == "Q3 audit"

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -469,3 +469,81 @@ async def test_generate_aggregates_section_evidence_ids_into_reference_ids() -> 
     draft = reports.saved[0]["drafts"][0]
     # Top-level reference_ids preserved + section evidence ids unioned without dupes.
     assert draft.reference_ids == ("r0", "r1", "r2", "r3")
+
+
+# -----------------------
+# PR-OptionA-1: per-call default_report_type override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_default_report_type_override_when_llm_omits_type():
+    """When the LLM doesn't include a `report_type` in its JSON, the per-call
+    override (from the plan's step.config) wins over the construction-time
+    default. The LLM-supplied value still wins when present (tested below)."""
+
+    response = json.dumps({
+        "title": "Acme",
+        "summary": "Findings.",
+        # report_type intentionally omitted from LLM output
+        "sections": [{"id": "s1", "title": "S", "body_markdown": "b", "evidence_ids": ["r1"]}],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=ReportGenerationConfig(default_report_type="vendor_pressure"),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor",
+        default_report_type="customer_health",  # plan-supplied override
+    )
+
+    saved_drafts = reports.saved[0]["drafts"]
+    assert saved_drafts[0].report_type == "customer_health"
+
+
+@pytest.mark.asyncio
+async def test_generate_llm_supplied_report_type_still_wins_over_per_call_override():
+    """The per-call override only fills in when the LLM omits `report_type`.
+    LLM JSON value still wins so model-driven type selection remains intact."""
+
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[_valid_report_json()],  # already includes report_type=vendor_pressure
+        config=ReportGenerationConfig(default_report_type="vendor_pressure"),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor",
+        default_report_type="customer_health",  # ignored: LLM supplied vendor_pressure
+    )
+
+    saved_drafts = reports.saved[0]["drafts"]
+    assert saved_drafts[0].report_type == "vendor_pressure"
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_default_report_type_falls_back_when_none():
+    """A None override leaves the construction-time default in place."""
+
+    response = json.dumps({
+        "title": "Acme",
+        "summary": "Findings.",
+        "sections": [{"id": "s1", "title": "S", "body_markdown": "b", "evidence_ids": ["r1"]}],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, reports, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=ReportGenerationConfig(default_report_type="vendor_pressure"),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor",
+        default_report_type=None,
+    )
+
+    saved_drafts = reports.saved[0]["drafts"]
+    assert saved_drafts[0].report_type == "vendor_pressure"

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -528,3 +528,80 @@ async def test_generate_aggregates_section_evidence_into_reference_ids_no_duplic
     draft = sales_briefs.saved[0]["drafts"][0]
     # Order preserved: explicit list first, then section evidence ids in insertion order
     assert draft.reference_ids == ("r1", "r4", "r2", "r3")
+
+
+# -----------------------
+# PR-OptionA-1: per-call default_brief_type override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_default_brief_type_override_when_llm_omits_type():
+    """When the LLM doesn't include a `brief_type` in its JSON, the per-call
+    override (from the plan's step.config) wins over the construction-time
+    default."""
+
+    response = json.dumps({
+        "title": "Acme",
+        "headline": "elevator",
+        # brief_type intentionally omitted
+        "sections": [{"id": "s1", "title": "S", "body_markdown": "b", "evidence_ids": ["r1"]}],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=SalesBriefGenerationConfig(default_brief_type="pre_call"),
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        default_brief_type="renewal",  # plan-supplied override
+    )
+
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert saved_drafts[0].brief_type == "renewal"
+
+
+@pytest.mark.asyncio
+async def test_generate_llm_supplied_brief_type_still_wins_over_per_call_override():
+    """The per-call override only fills in when the LLM omits `brief_type`."""
+
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[_valid_brief_json(brief_type="pre_call")],
+        config=SalesBriefGenerationConfig(default_brief_type="pre_call"),
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        default_brief_type="renewal",  # ignored: LLM supplied pre_call
+    )
+
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert saved_drafts[0].brief_type == "pre_call"
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_default_brief_type_falls_back_when_none():
+    """A None override leaves the construction-time default in place."""
+
+    response = json.dumps({
+        "title": "Acme",
+        "headline": "elevator",
+        "sections": [{"id": "s1", "title": "S", "body_markdown": "b", "evidence_ids": ["r1"]}],
+        "reference_ids": ["r1"],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=SalesBriefGenerationConfig(default_brief_type="pre_call"),
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        default_brief_type=None,
+    )
+
+    saved_drafts = sales_briefs.saved[0]["drafts"]
+    assert saved_drafts[0].brief_type == "pre_call"


### PR DESCRIPTION
**Plan:** [`plans/PR-OptionA-1.md`](../blob/claude/pr-option-a-1-thread-step-config/plans/PR-OptionA-1.md)

## Summary

Closes the BLOCKER from the AI Content Ops post-merge audit (`content_ops_execution.py` section). `_run_step` ignored `step.config` entirely, so the user picking `channels=[email_cold]` in the control surface silently produced both an `email_cold` AND `email_followup` draft because the campaign service used its construction-time default — preview lied to the operator.

User picked **Option A** from the audit's decision request (plan-as-execution-contract). This PR closes the trust contract for the smoking-gun fields the audit specifically called out. Lower-stakes fields (`temperature`, `max_tokens`, `parse_retry_attempts`, etc.) stay informational and get promoted in PR-OptionA-2.

## What changed

**Smoking-gun per-call overrides** — each service's `generate()` gains an optional kwarg matching the plan's `step.config` field name; when the executor passes it, the service uses the override; when it doesn't, the service falls back to `self._config` (construction-time default). No breaking change to existing callers.

| Output | New kwarg on `service.generate()` |
|---|---|
| `email_campaign` | `channels: Sequence[str] \| None = None` |
| `report` | `default_report_type: str \| None = None` |
| `sales_brief` | `default_brief_type: str \| None = None` |

**`_run_step` refactored to per-output dispatch table** — kills the audit's "landing_page is special-cased; everything else falls through" MAJOR. New outputs register a one-line handler entry in `_DISPATCH` instead of growing more `if step.output == ...` branches. Two helpers (`_step_config_text`, `_step_config_sequence`) handle the boilerplate of pulling fields out of `step.config` defensively.

## Intentional (looks wrong but is deliberate)

- **Per-field kwargs, not a `config_override: Mapping[str, Any]` dict.** A dict-shaped override would be more general but makes the contract opaque — callers can't statically see which fields are load-bearing vs informational. Per-field kwargs make the surface type-checkable and the load-bearing fields explicit at the signature level.
- **`landing_page` and `blog_post` get no per-call overrides this PR.** Their plan configs are still emitted but stay informational. Promoting them would double the LOC budget and pull in two more audit-flagged-but-out-of-scope MAJORs (MarketingCampaign.context leak, blog topic threading). The dispatch table makes adding them later a one-handler edit.
- **`default_report_type` / `default_brief_type` keep their `default_` prefix.** Captures "fallback if LLM omits the type from JSON" semantic; LLM's output still wins when present. UI copy should call them "Default report type" / "Default brief type" — not "Report type" / "Brief type" (those imply the value is forced regardless of LLM output).
- **Empty override (`channels=[]`) is treated as "no override", not "no channels"**, so it falls back to construction-time config. Prevents a host UI bug ("they unselected all channels") from silently zeroing out generation.
- **No new abstraction layer for "config override."** The dispatch table is the only new structure. Three services with one-field overrides each isn't enough surface to justify a shared `apply_overrides_to(config)` helper.
- **Tests update existing fakes' `generate(...)` signatures to accept the new kwargs (with `**extras` catch-alls for forward-compat).** This is required for the executor refactor; without it the existing tests would crash with `TypeError`. Fakes are now resilient to PR-OptionA-2 adding more kwargs.

## Deferred (looks missing but is on purpose)

- **Promoting the rest of `step.config` fields to load-bearing.** PR-OptionA-2 will tackle `temperature`, `max_tokens`, `parse_retry_attempts`, the `quality_*_enabled` boolean flags, and `topic` (blog_post). Same per-field-kwarg pattern.
- **`MarketingCampaign.context` leak** — the audit flagged that `_marketing_campaign_from_inputs` dumps every non-{name, persona, value_prop, vendors, categories, tags} input field into `MarketingCampaign.context`. PR-OptionA-3.
- **`channel`/`channels` legacy dual-field** on `CampaignGenerationConfig`. Separate cleanup PR.
- **The 9 MINOR + 2 NIT findings** from the audit. Catalogued in the audit doc; each gets a focused follow-up.
- **`PR-ContentAssets-Consistency-2`** — still owed from PR #356 review threads.

## Verification

- `pytest tests/test_extracted_campaign_generation.py tests/test_extracted_report_generation.py tests/test_extracted_sales_brief_generation.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py` → 94 passed, 10 skipped (pre-existing)
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Size: ~200 LOC source + ~410 LOC tests + ~210 LOC plan doc = ~800 LOC across 9 files. **Over the 400-LOC ceiling.** Tests are 14 new regression tests, each tied to a specific behavior assertion (override-wins-over-construction, LLM-supplied-still-wins, None-falls-back, plan-default-flows-through, smoking-gun-from-audit). Trimming would weaken verification of the trust-contract fix.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_