### PR TITLE
PR-OptionA-3: promote quality + retry-excerpt knobs to load-bearing

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -147,6 +147,7 @@ class BlogPostGenerationService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
     ) -> BlogPostGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -163,6 +164,11 @@ class BlogPostGenerationService:
             self._config.parse_retry_attempts
             if parse_retry_attempts is None
             else int(parse_retry_attempts)
+        )
+        resolved_parse_retry_response_excerpt_chars = (
+            self._config.parse_retry_response_excerpt_chars
+            if parse_retry_response_excerpt_chars is None
+            else int(parse_retry_response_excerpt_chars)
         )
 
         requested = int(limit or self._config.limit)
@@ -187,6 +193,7 @@ class BlogPostGenerationService:
                     temperature=resolved_temperature,
                     max_tokens=resolved_max_tokens,
                     parse_retry_attempts=resolved_parse_retry_attempts,
+                    parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                 )
             except Exception as exc:
                 skipped += 1
@@ -230,6 +237,7 @@ class BlogPostGenerationService:
         temperature: float,
         max_tokens: int,
         parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
     ) -> dict[str, Any] | None:
         blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
         if "{blueprint_json}" in prompt_template:
@@ -274,7 +282,7 @@ class BlogPostGenerationService:
                 }
             last_response = _clip_invalid_response(
                 response.content,
-                limit=max(0, int(self._config.parse_retry_response_excerpt_chars or 0)),
+                limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )
         return None
 

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -267,6 +267,9 @@ class CampaignGenerationService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        quality_revalidation_enabled: bool | None = None,
+        quality_prompt_proof_term_limit: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
     ) -> CampaignGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -286,6 +289,22 @@ class CampaignGenerationService:
             self._config.parse_retry_attempts
             if parse_retry_attempts is None
             else int(parse_retry_attempts)
+        )
+        # PR-OptionA-3: quality + retry-excerpt knobs. Same shape.
+        resolved_quality_revalidation_enabled = (
+            self._config.quality_revalidation_enabled
+            if quality_revalidation_enabled is None
+            else bool(quality_revalidation_enabled)
+        )
+        resolved_quality_prompt_proof_term_limit = (
+            self._config.quality_prompt_proof_term_limit
+            if quality_prompt_proof_term_limit is None
+            else int(quality_prompt_proof_term_limit)
+        )
+        resolved_parse_retry_response_excerpt_chars = (
+            self._config.parse_retry_response_excerpt_chars
+            if parse_retry_response_excerpt_chars is None
+            else int(parse_retry_response_excerpt_chars)
         )
 
         requested = int(limit or self._config.limit)
@@ -326,6 +345,8 @@ class CampaignGenerationService:
                     opportunity,
                     channel=channel,
                     cold_email_context=cold_email_context,
+                    quality_revalidation_enabled=resolved_quality_revalidation_enabled,
+                    quality_prompt_proof_term_limit=resolved_quality_prompt_proof_term_limit,
                 )
                 try:
                     parsed = await self._generate_one(
@@ -336,6 +357,7 @@ class CampaignGenerationService:
                         temperature=resolved_temperature,
                         max_tokens=resolved_max_tokens,
                         parse_retry_attempts=resolved_parse_retry_attempts,
+                        parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                     )
                 except Exception as exc:
                     skipped += 1
@@ -358,6 +380,8 @@ class CampaignGenerationService:
                     opportunity=channel_opportunity,
                     target_mode=target_mode,
                     channel=channel,
+                    quality_revalidation_enabled=resolved_quality_revalidation_enabled,
+                    quality_prompt_proof_term_limit=resolved_quality_prompt_proof_term_limit,
                 )
                 if not parsed:
                     skipped += 1
@@ -424,6 +448,8 @@ class CampaignGenerationService:
         *,
         channel: str,
         cold_email_context: Mapping[str, Any] | None = None,
+        quality_revalidation_enabled: bool,
+        quality_prompt_proof_term_limit: int,
     ) -> dict[str, Any]:
         enriched = dict(opportunity)
         enriched["channel"] = channel
@@ -432,19 +458,25 @@ class CampaignGenerationService:
                 "subject": str(cold_email_context.get("subject") or ""),
                 "body": str(cold_email_context.get("body") or ""),
             }
-        if self._config.quality_revalidation_enabled:
-            enriched = self._with_quality_prompt_terms(enriched)
+        if quality_revalidation_enabled:
+            enriched = self._with_quality_prompt_terms(
+                enriched,
+                quality_prompt_proof_term_limit=quality_prompt_proof_term_limit,
+            )
         return enriched
 
     def _with_quality_prompt_terms(
         self,
         opportunity: Mapping[str, Any],
+        *,
+        quality_prompt_proof_term_limit: int,
     ) -> dict[str, Any]:
         enriched = dict(opportunity)
         context = normalize_campaign_reasoning_context(enriched)
         terms = self._campaign_proof_terms(
             context.as_dict(),
             existing=enriched.get("campaign_proof_terms"),
+            quality_prompt_proof_term_limit=quality_prompt_proof_term_limit,
         )
         enriched.pop("campaign_proof_terms", None)
         if terms:
@@ -456,8 +488,9 @@ class CampaignGenerationService:
         context: Mapping[str, Any],
         *,
         existing: Any = None,
+        quality_prompt_proof_term_limit: int,
     ) -> list[str]:
-        limit = max(0, int(self._config.quality_prompt_proof_term_limit or 0))
+        limit = max(0, int(quality_prompt_proof_term_limit or 0))
         terms = _clean_term_list(existing, limit=limit)
         if len(terms) >= limit:
             return terms
@@ -522,6 +555,7 @@ class CampaignGenerationService:
         temperature: float,
         max_tokens: int,
         parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         system_prompt = (
@@ -569,7 +603,7 @@ class CampaignGenerationService:
                 }
             last_response = _clip_invalid_response(
                 response.content,
-                limit=max(0, int(self._config.parse_retry_response_excerpt_chars or 0)),
+                limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )
         return None
 
@@ -580,14 +614,16 @@ class CampaignGenerationService:
         opportunity: Mapping[str, Any],
         target_mode: str,
         channel: str,
+        quality_revalidation_enabled: bool,
+        quality_prompt_proof_term_limit: int,
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-        if not self._config.quality_revalidation_enabled:
+        if not quality_revalidation_enabled:
             return dict(parsed), None
         context = normalize_campaign_reasoning_context(opportunity)
         specificity_context = context.as_dict()
         proof_terms = _clean_term_list(
             opportunity.get("campaign_proof_terms"),
-            limit=max(0, int(self._config.quality_prompt_proof_term_limit or 0)),
+            limit=max(0, int(quality_prompt_proof_term_limit or 0)),
         )
         if proof_terms:
             specificity_context = {

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -220,6 +220,15 @@ async def _dispatch_email_campaign(
         temperature=_step_config_float(step.config, "temperature"),
         max_tokens=_step_config_int(step.config, "max_tokens"),
         parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
+        quality_revalidation_enabled=_step_config_bool(
+            step.config, "quality_revalidation_enabled"
+        ),
+        quality_prompt_proof_term_limit=_step_config_int(
+            step.config, "quality_prompt_proof_term_limit"
+        ),
+        parse_retry_response_excerpt_chars=_step_config_int(
+            step.config, "parse_retry_response_excerpt_chars"
+        ),
     )
 
 
@@ -240,6 +249,9 @@ async def _dispatch_report(
         temperature=_step_config_float(step.config, "temperature"),
         max_tokens=_step_config_int(step.config, "max_tokens"),
         parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
+        parse_retry_response_excerpt_chars=_step_config_int(
+            step.config, "parse_retry_response_excerpt_chars"
+        ),
     )
 
 
@@ -260,6 +272,9 @@ async def _dispatch_sales_brief(
         temperature=_step_config_float(step.config, "temperature"),
         max_tokens=_step_config_int(step.config, "max_tokens"),
         parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
+        parse_retry_response_excerpt_chars=_step_config_int(
+            step.config, "parse_retry_response_excerpt_chars"
+        ),
     )
 
 
@@ -278,6 +293,9 @@ async def _dispatch_landing_page(
         temperature=_step_config_float(step.config, "temperature"),
         max_tokens=_step_config_int(step.config, "max_tokens"),
         parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
+        parse_retry_response_excerpt_chars=_step_config_int(
+            step.config, "parse_retry_response_excerpt_chars"
+        ),
     )
 
 
@@ -301,6 +319,9 @@ async def _dispatch_blog_post(
         temperature=_step_config_float(step.config, "temperature"),
         max_tokens=_step_config_int(step.config, "max_tokens"),
         parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
+        parse_retry_response_excerpt_chars=_step_config_int(
+            step.config, "parse_retry_response_excerpt_chars"
+        ),
     )
 
 
@@ -378,6 +399,23 @@ def _step_config_float(config: Mapping[str, Any], key: str) -> float | None:
         return float(raw)
     except (TypeError, ValueError):
         return None
+
+
+def _step_config_bool(config: Mapping[str, Any], key: str) -> bool | None:
+    """Pull a bool from step.config or return None.
+
+    Used for ``quality_revalidation_enabled``. Returns None on missing
+    key or non-bool values; we deliberately avoid coercing strings like
+    ``"yes"`` / ``"true"`` because a mis-typed step.config entry should
+    fall through to the service's config default rather than silently
+    landing the wrong value.
+    """
+    if not isinstance(config, Mapping):
+        return None
+    raw = config.get(key)
+    if isinstance(raw, bool):
+        return raw
+    return None
 
 
 def _step_config_sequence(

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -212,6 +212,7 @@ class LandingPageGenerationService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
     ) -> LandingPageGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -230,6 +231,11 @@ class LandingPageGenerationService:
             self._config.parse_retry_attempts
             if parse_retry_attempts is None
             else int(parse_retry_attempts)
+        )
+        resolved_parse_retry_response_excerpt_chars = (
+            self._config.parse_retry_response_excerpt_chars
+            if parse_retry_response_excerpt_chars is None
+            else int(parse_retry_response_excerpt_chars)
         )
 
         if not str(campaign.name or "").strip():
@@ -260,6 +266,7 @@ class LandingPageGenerationService:
                 temperature=resolved_temperature,
                 max_tokens=resolved_max_tokens,
                 parse_retry_attempts=resolved_parse_retry_attempts,
+                parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
             )
         except Exception as exc:
             return LandingPageGenerationResult(
@@ -342,6 +349,7 @@ class LandingPageGenerationService:
         temperature: float,
         max_tokens: int,
         parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
     ) -> dict[str, Any] | None:
         campaign_json = json.dumps(dict(campaign_payload), separators=(",", ":"), default=str)
         # Single source for the campaign payload: in the system prompt
@@ -381,7 +389,7 @@ class LandingPageGenerationService:
                 }
             last_response = _clip_invalid_response(
                 response.content,
-                limit=max(0, int(self._config.parse_retry_response_excerpt_chars or 0)),
+                limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )
         return None
 

--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -209,6 +209,7 @@ class ReportGenerationService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
     ) -> ReportGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -225,6 +226,11 @@ class ReportGenerationService:
             self._config.parse_retry_attempts
             if parse_retry_attempts is None
             else int(parse_retry_attempts)
+        )
+        resolved_parse_retry_response_excerpt_chars = (
+            self._config.parse_retry_response_excerpt_chars
+            if parse_retry_response_excerpt_chars is None
+            else int(parse_retry_response_excerpt_chars)
         )
 
         requested = int(limit or self._config.limit)
@@ -267,6 +273,7 @@ class ReportGenerationService:
                     temperature=resolved_temperature,
                     max_tokens=resolved_max_tokens,
                     parse_retry_attempts=resolved_parse_retry_attempts,
+                    parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                 )
             except Exception as exc:
                 skipped += 1
@@ -356,6 +363,7 @@ class ReportGenerationService:
         temperature: float,
         max_tokens: int,
         parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         # Single source for the opportunity payload: in the system prompt
@@ -397,7 +405,7 @@ class ReportGenerationService:
                 }
             last_response = _clip_invalid_response(
                 response.content,
-                limit=max(0, int(self._config.parse_retry_response_excerpt_chars or 0)),
+                limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )
         return None
 

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -225,6 +225,7 @@ class SalesBriefGenerationService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
     ) -> SalesBriefGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -243,6 +244,11 @@ class SalesBriefGenerationService:
             self._config.parse_retry_attempts
             if parse_retry_attempts is None
             else int(parse_retry_attempts)
+        )
+        resolved_parse_retry_response_excerpt_chars = (
+            self._config.parse_retry_response_excerpt_chars
+            if parse_retry_response_excerpt_chars is None
+            else int(parse_retry_response_excerpt_chars)
         )
 
         requested = int(limit or self._config.limit)
@@ -285,6 +291,7 @@ class SalesBriefGenerationService:
                     temperature=resolved_temperature,
                     max_tokens=resolved_max_tokens,
                     parse_retry_attempts=resolved_parse_retry_attempts,
+                    parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
                 )
             except Exception as exc:
                 skipped += 1
@@ -376,6 +383,7 @@ class SalesBriefGenerationService:
         temperature: float,
         max_tokens: int,
         parse_retry_attempts: int,
+        parse_retry_response_excerpt_chars: int,
     ) -> dict[str, Any] | None:
         opportunity_json = json.dumps(dict(opportunity), separators=(",", ":"), default=str)
         # Single source for the opportunity payload: in the system prompt
@@ -419,7 +427,7 @@ class SalesBriefGenerationService:
                 }
             last_response = _clip_invalid_response(
                 response.content,
-                limit=max(0, int(self._config.parse_retry_response_excerpt_chars or 0)),
+                limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )
         return None
 

--- a/plans/PR-OptionA-3.md
+++ b/plans/PR-OptionA-3.md
@@ -1,0 +1,116 @@
+# PR-OptionA-3: Promote quality + retry-excerpt knobs to load-bearing
+
+## Why this slice exists
+
+PR-OptionA-2 (#369) closed the LLM-tuning trio (`temperature`,
+`max_tokens`, `parse_retry_attempts`) across all five generated-asset
+services. That PR's plan doc deferred the remaining `step.config`
+fields to "PR-OptionA-3."
+
+This PR closes the next clean subset: the per-field knobs that have a
+direct dataclass field in their service config and are referenced
+inside the generation flow. Concretely:
+
+- `quality_revalidation_enabled` (campaign) -- gate on whether the
+  campaign service runs quality revalidation after parse
+- `quality_prompt_proof_term_limit` (campaign) -- cap on proof-term
+  count in revalidation prompts
+- `parse_retry_response_excerpt_chars` (all five services) -- max
+  characters of the prior invalid response to include in retry user
+  prompts
+
+After this lands, an operator picking "skip revalidation for this
+batch" or "show longer error excerpts in retry prompts" actually
+changes behavior. Before, those fields were emitted in
+`step.config` but silently ignored.
+
+## Scope (this PR)
+
+Three fields. Same per-field-kwarg pattern as PR-OptionA-1 / -2:
+optional kwarg on `generate()`, resolved at the top, threaded down
+to the inner helper that uses it. `None` falls through to
+`self._config.X`.
+
+| Service | New `generate()` kwargs |
+|---|---|
+| `CampaignGenerationService` | `quality_revalidation_enabled`, `quality_prompt_proof_term_limit`, `parse_retry_response_excerpt_chars` |
+| `ReportGenerationService` | `parse_retry_response_excerpt_chars` |
+| `SalesBriefGenerationService` | `parse_retry_response_excerpt_chars` |
+| `LandingPageGenerationService` | `parse_retry_response_excerpt_chars` |
+| `BlogPostGenerationService` | `parse_retry_response_excerpt_chars` |
+
+`content_ops_execution.py` adds `_step_config_bool` helper for
+the boolean flag and threads the three fields from `step.config`
+into the `email_campaign` dispatcher (which owns all three). Other
+dispatchers thread only `parse_retry_response_excerpt_chars`.
+
+## Intentional (looks wrong but is deliberate)
+
+- **Same per-field-kwarg pattern as the rest of the OptionA series.**
+  Nine load-bearing per-call fields total now (`channels`,
+  `default_report_type`, `default_brief_type`, `temperature`,
+  `max_tokens`, `parse_retry_attempts` from prior PRs +
+  `quality_revalidation_enabled`, `quality_prompt_proof_term_limit`,
+  `parse_retry_response_excerpt_chars` from this PR). Still using the
+  same `kwarg=None falls back to self._config.kwarg` pattern. No
+  shared abstraction; no dataclass override surface. The pattern
+  compresses well by repetition, and a future "config override"
+  abstraction would now have at least nine fields to wrap if it ever
+  becomes worth introducing.
+- **`quality_gates_enabled` (sales_brief / landing_page) deferred to
+  PR-OptionA-4.** The plan layer emits `quality_gates_enabled` in
+  step.config but neither service has a config field for it -- it's
+  a phantom plan field. Implementing it per-call requires actually
+  adding a "skip quality gate" path to the service generate flow,
+  which is a behavior change beyond pure plumbing. Different shape;
+  separate slice.
+- **`topic` (blog_post) deferred to PR-OptionA-4.** The plan emits
+  `topic` from `request.inputs`, but the blog service reads topic
+  from `blueprint.get("topic")` -- it's content input, not a config
+  knob. The override semantic is "force this topic for this call,
+  ignoring the blueprint" which is conceptually different from the
+  config-knob pattern of every other OptionA field.
+- **Boolean kwarg defaults to None, not False.** A `False` default
+  would be ambiguous: did the operator pick False, or did they leave
+  it alone? `None` makes the override-vs-fallthrough distinction
+  explicit at the call site, matching the pattern from the other
+  OptionA kwargs.
+- **`_step_config_bool` rejects non-bool values rather than coercing
+  with `bool(...)`.** A mis-typed `step.config["quality_revalidation_enabled"]
+  = "yes"` would coerce truthy under `bool(...)` and silently land
+  the wrong value at the service. Defensive: returns None on anything
+  that isn't actually a bool, lets the service fall through to its
+  config default.
+
+## Deferred (looks missing but is on purpose)
+
+- **`quality_gates_enabled`** (phantom field) -- PR-OptionA-4.
+- **`topic` for blog_post** (content-input shape) -- PR-OptionA-4.
+- **`MarketingCampaign.context` leak** -- audit MAJOR; PR-OptionA-4.
+- **`channel`/`channels` legacy dual-field cleanup** -- PR-OptionA-4
+  or separate cleanup PR.
+- **`skill_name` per-call** -- bigger UX question (which prompt
+  template to use), deferred indefinitely.
+- **The 9 MINOR + 2 NIT findings from the audit** -- separate batch
+  cleanup PR.
+- **`PR-ContentAssets-Consistency-2`** -- still owed; migrate
+  `campaign_postgres_review.py` / `campaign_postgres_import.py` /
+  `podcast_postgres.py` to the shared `_jsonb_helpers.py`.
+
+## Verification
+
+- `pytest` across all touched suites + the upstream control-surface /
+  generation-plan tests
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline` -> clean
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> 0
+- `bash scripts/check_ascii_python.sh` -> passed
+
+## Sibling references
+
+- PR-OptionA-1 plan: `plans/PR-OptionA-1.md`
+- PR-OptionA-2 plan: `plans/PR-OptionA-2.md`
+- Audit doc:
+  `docs/audits/ai_content_ops_post_merge_audit_2026-05.md`
+- UI contract:
+  `extracted_content_pipeline/docs/control_surface_preview_api.md`

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -368,3 +368,31 @@ async def test_generate_llm_tuning_kwargs_none_falls_back_to_construction_config
 
     assert llm.calls[0]["temperature"] == 0.7
     assert llm.calls[0]["max_tokens"] == 999
+
+
+# -----------------------
+# PR-OptionA-3: per-call parse_retry_response_excerpt_chars override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
+    long_invalid = "X" * 5000
+    service, _bps, _drafts, llm, _skills = _service(
+        responses=[long_invalid, _valid_blog_json()],
+        config=BlogPostGenerationConfig(
+            parse_retry_attempts=1,
+            parse_retry_response_excerpt_chars=200,
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor",
+        parse_retry_response_excerpt_chars=50,
+    )
+
+    retry_user_prompt = llm.calls[1]["messages"][1].content
+    assert "XXX" in retry_user_prompt
+    excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
+    assert len(excerpt_section.rstrip()) <= 50

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -1131,3 +1131,70 @@ async def test_generate_llm_tuning_kwargs_none_falls_back_to_construction_config
 
     assert llm.calls[0]["temperature"] == 0.7
     assert llm.calls[0]["max_tokens"] == 999
+
+
+# -----------------------
+# PR-OptionA-3: per-call quality + retry-excerpt overrides
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_quality_revalidation_enabled_override():
+    """When the executor passes quality_revalidation_enabled=False, the
+    revalidation step is skipped even though config has it on (and vice
+    versa). The smoking-gun: an operator picking 'skip revalidation' in
+    the control surface actually skips it."""
+
+    valid = '{"subject":"Hi","body":"Body"}'
+    service, _, _, llm, _ = _service(
+        [{"id": "opp-1"}],
+        [valid],
+        config=CampaignGenerationConfig(
+            quality_revalidation_enabled=True,  # construction default
+            channels=("email_cold",),
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="churning_company",
+        quality_revalidation_enabled=False,  # override to skip
+    )
+
+    # When revalidation is skipped, no revalidation LLM call happens; only
+    # the initial generation LLM call. (Construction-time True would have
+    # forced an extra revalidation call for each generated draft.)
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
+    """The override controls how much of a prior invalid response gets
+    embedded in the retry user prompt."""
+
+    long_invalid = "X" * 5000
+    service, _, _, llm, _ = _service(
+        [{"id": "opp-1"}],
+        [long_invalid, '{"subject":"Hi","body":"Body"}'],
+        config=CampaignGenerationConfig(
+            channels=("email_cold",),
+            parse_retry_attempts=1,
+            parse_retry_response_excerpt_chars=200,  # construction default
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="churning_company",
+        parse_retry_response_excerpt_chars=50,  # tighter cap
+    )
+
+    # Second LLM call's user message should contain at most 50 chars of
+    # the prior invalid response.
+    retry_user_prompt = llm.calls[1]["messages"][1].content
+    # Prompt format: "...Previous response excerpt:\n<excerpt>"
+    assert "XXX" in retry_user_prompt  # excerpt is present
+    excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
+    # Excerpt is clipped to 50 chars; the construction-time default of 200
+    # would have shown 200 chars.
+    assert len(excerpt_section.rstrip()) <= 50

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -1198,3 +1198,35 @@ async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
     # Excerpt is clipped to 50 chars; the construction-time default of 200
     # would have shown 200 chars.
     assert len(excerpt_section.rstrip()) <= 50
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_quality_prompt_proof_term_limit_override():
+    """The override caps how many proof terms reach the prompt. With 5 terms
+    in the opportunity and an override of 2, only 2 terms should land in the
+    system prompt's serialized opportunity payload. Catches typos in the
+    deep helper chain (_with_quality_prompt_terms -> _campaign_proof_terms)
+    where the threaded param could be dropped."""
+
+    service, _, _, llm, _ = _service(
+        [{"id": "opp-1", "campaign_proof_terms": ["t1", "t2", "t3", "t4", "t5"]}],
+        ['{"subject":"Hi","body":"Body"}'],
+        config=CampaignGenerationConfig(
+            quality_revalidation_enabled=True,
+            quality_prompt_proof_term_limit=5,  # construction default would allow all 5
+            channels=("email_cold",),
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="churning_company",
+        quality_prompt_proof_term_limit=2,  # override caps at 2
+    )
+
+    # Proof terms surface in the system prompt via the opportunity JSON.
+    system_prompt = llm.calls[0]["messages"][0].content
+    found_terms = [term for term in ("t1", "t2", "t3", "t4", "t5") if term in system_prompt]
+    assert len(found_terms) <= 2, (
+        f"override should cap proof terms at 2; saw {len(found_terms)}: {found_terms}"
+    )

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -45,6 +45,9 @@ class _OpportunityService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        quality_revalidation_enabled: bool | None = None,
+        quality_prompt_proof_term_limit: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -58,6 +61,9 @@ class _OpportunityService:
             "temperature": temperature,
             "max_tokens": max_tokens,
             "parse_retry_attempts": parse_retry_attempts,
+            "quality_revalidation_enabled": quality_revalidation_enabled,
+            "quality_prompt_proof_term_limit": quality_prompt_proof_term_limit,
+            "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "extras": dict(extras),
         })
         return _Result()
@@ -75,6 +81,7 @@ class _LandingPageService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -83,6 +90,7 @@ class _LandingPageService:
             "temperature": temperature,
             "max_tokens": max_tokens,
             "parse_retry_attempts": parse_retry_attempts,
+            "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "extras": dict(extras),
         })
         return _Result()
@@ -531,3 +539,88 @@ async def test_execute_threads_llm_tuning_kwargs_into_blog_post() -> None:
     assert call["max_tokens"] == 4096
     assert call["parse_retry_attempts"] == 1
     assert call["extras"] == {}
+
+
+# -----------------------
+# PR-OptionA-3: quality + retry-excerpt knobs
+# (quality_revalidation_enabled / quality_prompt_proof_term_limit /
+# parse_retry_response_excerpt_chars) flow from plan defaults into
+# every service call.
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_quality_and_excerpt_kwargs_into_email_campaign() -> None:
+    """Plan defaults for the campaign-only quality knobs reach the service.
+    The bool flag, the int term-limit, and the int excerpt-chars all flow
+    through the email_campaign dispatcher."""
+
+    campaign = _OpportunityService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    call = campaign.calls[0]
+    # CampaignGenerationConfig defaults
+    assert call["quality_revalidation_enabled"] is True
+    assert call["quality_prompt_proof_term_limit"] == 5
+    assert call["parse_retry_response_excerpt_chars"] == 800
+    assert call["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_excerpt_kwarg_into_report_sales_brief_blog_landing() -> None:
+    """parse_retry_response_excerpt_chars reaches every service via its
+    dispatcher; quality_revalidation_enabled / proof_term_limit are
+    campaign-only and stay None for the others."""
+
+    report = _OpportunityService()
+    sales_brief = _OpportunityService()
+    blog = _OpportunityService()
+    landing = _LandingPageService()
+
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["report"],
+            "inputs": {"target_account": "Acme", "offer": "Audit", "opportunity_id": "opp-1"},
+        },
+        services=ContentOpsExecutionServices(report=report),
+    )
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "inputs": {"target_account": "Acme", "offer": "Audit", "opportunity_id": "opp-1"},
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {"target_account": "Acme", "topic": "Churn"},
+        },
+        services=ContentOpsExecutionServices(blog_post=blog),
+    )
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {"campaign_name": "Q3", "offer": "Audit", "audience": "VPs"},
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    for label, call in (
+        ("report", report.calls[0]),
+        ("sales_brief", sales_brief.calls[0]),
+        ("blog_post", blog.calls[0]),
+        ("landing_page", landing.calls[0]),
+    ):
+        assert call["parse_retry_response_excerpt_chars"] == 800, label
+        assert call["extras"] == {}, label
+        # Campaign-only kwargs are absent on the non-campaign services.
+        if label != "landing_page":
+            assert call.get("quality_revalidation_enabled") is None, label
+            assert call.get("quality_prompt_proof_term_limit") is None, label

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -493,3 +493,31 @@ async def test_generate_llm_tuning_kwargs_none_falls_back_to_construction_config
 
     assert llm.calls[0]["temperature"] == 0.7
     assert llm.calls[0]["max_tokens"] == 999
+
+
+# -----------------------
+# PR-OptionA-3: per-call parse_retry_response_excerpt_chars override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
+    long_invalid = "X" * 5000
+    service, _lp, llm, _skills, _rp = _service(
+        responses=[long_invalid, _valid_response()],
+        config=LandingPageGenerationConfig(
+            parse_retry_attempts=1,
+            parse_retry_response_excerpt_chars=200,
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        campaign=_campaign(),
+        parse_retry_response_excerpt_chars=50,
+    )
+
+    retry_user_prompt = llm.calls[1]["messages"][1].content
+    assert "XXX" in retry_user_prompt
+    excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
+    assert len(excerpt_section.rstrip()) <= 50

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -603,3 +603,34 @@ async def test_generate_llm_tuning_kwargs_none_falls_back_to_construction_config
 
     assert llm.calls[0]["temperature"] == 0.7
     assert llm.calls[0]["max_tokens"] == 999
+
+
+# -----------------------
+# PR-OptionA-3: per-call parse_retry_response_excerpt_chars override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
+    """The override controls how much of a prior invalid response gets
+    embedded in the retry user prompt."""
+
+    long_invalid = "X" * 5000
+    service, _intel, _reports, llm, _skills, _rp = _service(
+        responses=[long_invalid, _valid_report_json()],
+        config=ReportGenerationConfig(
+            parse_retry_attempts=1,
+            parse_retry_response_excerpt_chars=200,
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor",
+        parse_retry_response_excerpt_chars=50,
+    )
+
+    retry_user_prompt = llm.calls[1]["messages"][1].content
+    assert "XXX" in retry_user_prompt
+    excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
+    assert len(excerpt_section.rstrip()) <= 50

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -659,3 +659,31 @@ async def test_generate_llm_tuning_kwargs_none_falls_back_to_construction_config
 
     assert llm.calls[0]["temperature"] == 0.7
     assert llm.calls[0]["max_tokens"] == 999
+
+
+# -----------------------
+# PR-OptionA-3: per-call parse_retry_response_excerpt_chars override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
+    long_invalid = "X" * 5000
+    service, _intel, _briefs, llm, _skills, _rp = _service(
+        responses=[long_invalid, _valid_brief_json()],
+        config=SalesBriefGenerationConfig(
+            parse_retry_attempts=1,
+            parse_retry_response_excerpt_chars=200,
+        ),
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        parse_retry_response_excerpt_chars=50,
+    )
+
+    retry_user_prompt = llm.calls[1]["messages"][1].content
+    assert "XXX" in retry_user_prompt
+    excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
+    assert len(excerpt_section.rstrip()) <= 50


### PR DESCRIPTION
**Plan:** [`plans/PR-OptionA-3.md`](../blob/claude/pr-option-a-3-quality-and-retry-knobs/plans/PR-OptionA-3.md)

## Summary

Continues the trust-contract work from PR-OptionA-1 (#368) and PR-OptionA-2 (#369). Closes the next clean subset of plan `step.config` fields: those that have a direct dataclass field in their service config and are referenced inside the generation flow.

## What changed

| Service | New `generate()` kwargs |
|---|---|
| `CampaignGenerationService` | `quality_revalidation_enabled`, `quality_prompt_proof_term_limit`, `parse_retry_response_excerpt_chars` |
| `ReportGenerationService` | `parse_retry_response_excerpt_chars` |
| `SalesBriefGenerationService` | `parse_retry_response_excerpt_chars` |
| `LandingPageGenerationService` | `parse_retry_response_excerpt_chars` |
| `BlogPostGenerationService` | `parse_retry_response_excerpt_chars` |

Same per-field-kwarg pattern as the prior OptionA PRs. For campaign, threading goes deeper — through `_opportunity_for_channel` / `_with_quality_prompt_terms` / `_campaign_proof_terms` / `_revalidated_parsed` — because those helpers all access the quality config directly.

**`content_ops_execution.py`**: new `_step_config_bool` helper rejects non-bool values rather than coercing with `bool(...)` so a mis-typed `step.config["quality_revalidation_enabled"] = "yes"` falls through to the service's config default rather than silently landing the wrong value. The `email_campaign` dispatcher threads all 3 new fields; the other 4 dispatchers thread only `parse_retry_response_excerpt_chars`.

## Intentional (looks wrong but is deliberate)

- **Same per-field-kwarg pattern as the rest of the OptionA series.** Nine load-bearing per-call fields total now; still using the same `kwarg=None falls back to self._config.kwarg` shape. No shared abstraction yet.
- **Boolean kwarg defaults to None, not False.** `False` would be ambiguous: did the operator pick False, or did they leave it alone? `None` makes the override-vs-fallthrough distinction explicit.
- **`_step_config_bool` rejects non-bool values rather than coercing.** A mis-typed `"yes"` would coerce truthy under `bool(...)` and silently land the wrong value. Defensive: returns None on anything that isn't actually a bool.
- **Threading goes deep into campaign's helper chain.** `_opportunity_for_channel` / `_with_quality_prompt_terms` / `_campaign_proof_terms` / `_revalidated_parsed` all gain new params. Could be done with a "use this effective config" pattern via `dataclasses.replace`, but that adds a layer that costs more than it saves — these helpers already explicitly read individual config fields.

## Deferred (looks missing but is on purpose)

- **`quality_gates_enabled`** (sales_brief / landing_page) — phantom field in step.config; neither service has a config field for it. Implementing per-call requires actually adding a "skip quality gate" path to the service generate flow, which is a behavior change beyond pure plumbing. Different shape; **PR-OptionA-4**.
- **`topic` for blog_post** — content input from blueprint, different semantic. The override means "force this topic, ignoring the blueprint" which is conceptually different from the config-knob pattern. **PR-OptionA-4**.
- **`MarketingCampaign.context` leak** — audit MAJOR. **PR-OptionA-4**.
- **`channel`/`channels` legacy dual-field cleanup.**
- **`skill_name` per-call** — bigger UX question.
- **9 MINOR + 2 NIT findings from the audit.**
- **`PR-ContentAssets-Consistency-2`** — still owed; migrate `campaign_postgres_review.py` / `campaign_postgres_import.py` / `podcast_postgres.py` to the shared `_jsonb_helpers.py`.

## Test plan

- [x] `pytest` across all touched suites + the upstream control-surface / generation-plan tests → 143 passed, 10 skipped (pre-existing)
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Size: ~120 LOC source + ~285 LOC tests + ~110 LOC plan doc = ~507 LOC total across 13 files (12 modified + 1 new plan). Tests are 8 new regression tests (2 dispatcher + 6 per-service), each tied to a specific behavior. Source-only is small (~120 LOC, mostly mechanical kwarg threading).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_