### PR TITLE
PR-OptionA-4: close audit MAJORs (quality_gates_enabled + MarketingCampaign.context leak)

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -456,9 +456,17 @@ def _filters_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:
 # filters, ...) all flowed into the landing-page service's campaign payload
 # as if they were intentional context. Audit MAJOR.
 #
-# This list starts conservative -- domain-context fields the landing-page
-# prompt actually consumes. New entries are added explicitly; unrelated
-# request inputs no longer leak by default.
+# The allowlist is "fields the LLM is allowed to see in campaign.context,"
+# not "fields the prompt consumes by name." The packaged landing-page
+# prompt uses ``{campaign_json}`` as a generic JSON dump, so the LLM sees
+# whatever is in context whether or not the prompt names it. The list
+# starts conservative (domain-context fields hosts have asked for) and
+# grows by explicit additions; unrelated request inputs no longer leak.
+#
+# Backwards-compat note: hosts whose custom landing-page prompts reference
+# context fields outside this allowlist will see empty values post-fix.
+# Add the field here to restore visibility -- see
+# ``plans/PR-OptionA-4.md`` Migration section.
 _MARKETING_CAMPAIGN_CONTEXT_FIELDS: frozenset[str] = frozenset({
     "industry",
     "pain_points",

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -275,6 +275,7 @@ async def _dispatch_sales_brief(
         parse_retry_response_excerpt_chars=_step_config_int(
             step.config, "parse_retry_response_excerpt_chars"
         ),
+        quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
     )
 
 
@@ -296,6 +297,7 @@ async def _dispatch_landing_page(
         parse_retry_response_excerpt_chars=_step_config_int(
             step.config, "parse_retry_response_excerpt_chars"
         ),
+        quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
     )
 
 
@@ -447,6 +449,27 @@ def _filters_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:
     return filters if isinstance(filters, Mapping) else None
 
 
+# PR-OptionA-4: explicit allowlist of MarketingCampaign.context fields.
+# Prior shape was a "negative-list inversion" -- everything not on a small
+# excluded set leaked into context. That meant standard control-surface
+# inputs (target_account, opportunity_id, channels, report_type, brief_type,
+# filters, ...) all flowed into the landing-page service's campaign payload
+# as if they were intentional context. Audit MAJOR.
+#
+# This list starts conservative -- domain-context fields the landing-page
+# prompt actually consumes. New entries are added explicitly; unrelated
+# request inputs no longer leak by default.
+_MARKETING_CAMPAIGN_CONTEXT_FIELDS: frozenset[str] = frozenset({
+    "industry",
+    "pain_points",
+    "differentiators",
+    "customer_segments",
+    "key_metrics",
+    "proof_points",
+    "competitive_alternatives",
+})
+
+
 def _marketing_campaign_from_inputs(inputs: Mapping[str, Any]) -> MarketingCampaign:
     offer = _clean(inputs.get("offer"))
     audience = _clean(inputs.get("audience"))
@@ -461,7 +484,7 @@ def _marketing_campaign_from_inputs(inputs: Mapping[str, Any]) -> MarketingCampa
         context={
             str(key): value
             for key, value in inputs.items()
-            if key not in {"campaign_name", "offer", "audience", "vendors", "categories", "tags"}
+            if key in _MARKETING_CAMPAIGN_CONTEXT_FIELDS
         },
     )
 

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -61,6 +61,7 @@ class LandingPageGenerationConfig:
     max_tokens: int = 4096
     temperature: float = 0.3
     quality_policy: QualityPolicy | None = None
+    quality_gates_enabled: bool = True
     parse_retry_attempts: int = 1
     parse_retry_response_excerpt_chars: int = 800
 
@@ -213,6 +214,7 @@ class LandingPageGenerationService:
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        quality_gates_enabled: bool | None = None,
     ) -> LandingPageGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -236,6 +238,13 @@ class LandingPageGenerationService:
             self._config.parse_retry_response_excerpt_chars
             if parse_retry_response_excerpt_chars is None
             else int(parse_retry_response_excerpt_chars)
+        )
+        # PR-OptionA-4: when False, skip the quality gate entirely. Lets
+        # operators opt out of gating per call without changing config.
+        resolved_quality_gates_enabled = (
+            self._config.quality_gates_enabled
+            if quality_gates_enabled is None
+            else bool(quality_gates_enabled)
         )
 
         if not str(campaign.name or "").strip():
@@ -284,7 +293,10 @@ class LandingPageGenerationService:
                 errors=({"campaign_name": campaign.name, "reason": "unparseable_response"},),
             )
 
-        quality = self._quality_check(parsed)
+        quality = self._quality_check(
+            parsed,
+            quality_gates_enabled=resolved_quality_gates_enabled,
+        )
         if not quality["passed"]:
             return LandingPageGenerationResult(
                 requested=1,
@@ -393,7 +405,18 @@ class LandingPageGenerationService:
             )
         return None
 
-    def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
+    def _quality_check(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        quality_gates_enabled: bool = True,
+    ) -> dict[str, Any]:
+        # PR-OptionA-4: opt out of the quality gate per call. The plan
+        # emits ``quality_gates_enabled`` in step.config so the executor
+        # can route the operator's choice to the service. False short-
+        # circuits the gate; True (the default) preserves prior behavior.
+        if not quality_gates_enabled:
+            return {"passed": True, "blockers": ()}
         report_input = QualityInput(
             artifact_type="landing_page",
             context={

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -71,6 +71,7 @@ class SalesBriefGenerationConfig:
     max_tokens: int = 4096
     temperature: float = 0.3
     quality_policy: QualityPolicy | None = None
+    quality_gates_enabled: bool = True
     parse_retry_attempts: int = 1
     parse_retry_response_excerpt_chars: int = 800
 
@@ -226,6 +227,7 @@ class SalesBriefGenerationService:
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        quality_gates_enabled: bool | None = None,
     ) -> SalesBriefGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -249,6 +251,12 @@ class SalesBriefGenerationService:
             self._config.parse_retry_response_excerpt_chars
             if parse_retry_response_excerpt_chars is None
             else int(parse_retry_response_excerpt_chars)
+        )
+        # PR-OptionA-4: per-call quality gate opt-out.
+        resolved_quality_gates_enabled = (
+            self._config.quality_gates_enabled
+            if quality_gates_enabled is None
+            else bool(quality_gates_enabled)
         )
 
         requested = int(limit or self._config.limit)
@@ -303,7 +311,10 @@ class SalesBriefGenerationService:
                 errors.append({"target_id": target_id, "reason": "unparseable_response"})
                 continue
 
-            quality = self._quality_check(parsed)
+            quality = self._quality_check(
+                parsed,
+                quality_gates_enabled=resolved_quality_gates_enabled,
+            )
             if not quality["passed"]:
                 skipped += 1
                 errors.append({
@@ -431,7 +442,16 @@ class SalesBriefGenerationService:
             )
         return None
 
-    def _quality_check(self, parsed: Mapping[str, Any]) -> dict[str, Any]:
+    def _quality_check(
+        self,
+        parsed: Mapping[str, Any],
+        *,
+        quality_gates_enabled: bool = True,
+    ) -> dict[str, Any]:
+        # PR-OptionA-4: opt out of the quality gate per call. Same shape
+        # as the landing-page service.
+        if not quality_gates_enabled:
+            return {"passed": True, "blockers": ()}
         brief_input = QualityInput(
             artifact_type="sales_brief",
             context={

--- a/plans/PR-OptionA-4.md
+++ b/plans/PR-OptionA-4.md
@@ -57,6 +57,15 @@ touch it.
 
 ### MarketingCampaign.context
 
+**Backwards-compat note:** this is a breaking change for hosts whose
+customized landing-page prompts reference context fields outside the
+new allowlist. The packaged prompt uses ``{campaign_json}`` as a
+generic JSON-dump substitution, so the LLM sees whatever is in
+``campaign.context``; if a host customized the prompt to reference,
+e.g., ``{campaign_json.context.target_account}``, post-fix that
+reference resolves to empty. Migration path is in the Migration
+section below.
+
 Current `_marketing_campaign_from_inputs`:
 
 ```python
@@ -74,9 +83,29 @@ excluded leaks. Standard control-surface inputs (`target_account`,
 `channels`, etc.) all flow into `campaign.context`.
 
 New shape: explicit allowlist of context-meaningful fields. Anything
-not on the allowlist stays out. The allowlist starts conservative
-(domain context fields the landing-page prompt actually consumes)
-and can grow as the contract evolves.
+not on the allowlist stays out. The allowlist is "fields the LLM is
+allowed to see in ``campaign.context``" (the packaged prompt uses a
+generic JSON dump, not field-by-name reference) -- not "fields the
+prompt consumes." It starts conservative and grows by explicit
+additions.
+
+## Migration
+
+Hosts on the prior shape who customized their landing-page prompt
+template to reference context fields not in
+``_MARKETING_CAMPAIGN_CONTEXT_FIELDS`` will see empty values for
+those references post-fix. To restore visibility:
+
+1. Identify the field name your custom prompt references (e.g.,
+   ``target_account``).
+2. Add it to ``_MARKETING_CAMPAIGN_CONTEXT_FIELDS`` in
+   ``content_ops_execution.py``. The list is meant to grow.
+3. Optionally update
+   ``extracted_content_pipeline/docs/control_surface_preview_api.md``
+   to advertise the field as part of the context contract.
+
+Hosts using the packaged prompt unchanged are unaffected -- the
+packaged prompt does not reference context fields by name.
 
 ## Intentional (looks wrong but is deliberate)
 
@@ -107,6 +136,19 @@ and can grow as the contract evolves.
 
 ## Deferred (looks missing but is on purpose)
 
+- **`quality_gates_enabled` for ``report`` and ``blog_post``.** This
+  PR adds it to ``sales_brief`` and ``landing_page`` only, leaving
+  three different per-call gate-skip mechanisms across the five
+  services: ``email_campaign`` uses ``quality_revalidation_enabled``
+  (PR-OptionA-3), ``sales_brief`` / ``landing_page`` use
+  ``quality_gates_enabled`` (this PR), ``report`` / ``blog_post``
+  have no per-call skip. Operators picking "skip quality gates" in
+  the control surface get inconsistent behavior depending on output.
+  **PR-OptionA-5** will add ``quality_gates_enabled`` to
+  ``ReportGenerationConfig`` and ``BlogPostGenerationConfig`` for
+  symmetry. (Could be folded into this PR, but the structural fixes
+  here are tightly scoped; symmetry-completion belongs in its own
+  slice.)
 - `topic` for blog_post (see Intentional).
 - `channel`/`channels` legacy dual-field cleanup -- separate slice.
 - 9 MINOR + 2 NIT findings from the audit -- batch cleanup PR.

--- a/plans/PR-OptionA-4.md
+++ b/plans/PR-OptionA-4.md
@@ -33,11 +33,35 @@ PR closes the remaining audit MAJORs that don't fit that pattern:
 
 ## Scope (this PR)
 
-Only the two items above. The remaining audit findings
-(`topic` for blog_post -- no service-side landing surface;
-`channel`/`channels` legacy dual-field on
+Only the two items above, plus a smoke-CLI mock fix that became
+necessary mid-PR (see "CI fix piggybacked" below). The remaining
+audit findings (`topic` for blog_post -- no service-side landing
+surface; `channel`/`channels` legacy dual-field on
 `CampaignGenerationConfig`; the 9 MINOR + 2 NIT findings) defer to
 follow-ups.
+
+### CI fix piggybacked
+
+PR #366 (codex/content-ops-execution-smoke) added
+``scripts/smoke_extracted_content_ops_execution.py`` plus
+``tests/test_extracted_content_ops_execution_smoke.py`` to the
+extracted-pipeline CI gate. The smoke fakes
+(``_OpportunityAssetService``, ``_LandingPageAssetService``) had
+strict signatures that pre-dated PR-OptionA-1/2/3, so they reject
+the per-call kwargs the dispatcher now threads through
+(``channels``, ``default_report_type``, ``default_brief_type``,
+temperature/max_tokens/parse-retry knobs, the quality-gate flags).
+#366 merged after #368/#369/#370 but did not update the fakes; this
+PR (#371) is the first PR running CI after that merge, so the
+breakage surfaced here.
+
+Fix: the smoke fakes accept ``**extras`` and discard them. The
+smoke CLI exists to verify the seam end-to-end -- strict per-kwarg
+contract assertions live in
+``tests/test_extracted_content_ops_execution.py``. Folding this
+fix into #371 instead of opening a separate PR avoids a serialized
+3-PR train (#371-fix -> #371-rebase -> #371-merge) for what is
+ultimately a 4-line patch.
 
 ### `quality_gates_enabled`
 

--- a/plans/PR-OptionA-4.md
+++ b/plans/PR-OptionA-4.md
@@ -1,0 +1,121 @@
+# PR-OptionA-4: Close audit MAJORs (quality_gates_enabled, MarketingCampaign.context leak)
+
+## Why this slice exists
+
+PR-OptionA-1/2/3 closed the per-field plan-as-execution-contract
+trust gap for the fields that had a clean dataclass mapping. This
+PR closes the remaining audit MAJORs that don't fit that pattern:
+
+1. **`quality_gates_enabled`** (sales_brief, landing_page) is a
+   phantom field -- the plan emits it in `step.config` but neither
+   service has a config field for it, so the executor can't route an
+   override even if it tried. The audit flagged this as a trust-
+   contract break: operator picks "skip quality gates" in the
+   control surface, plan records it, executor drops it on the
+   floor. Fix: add `quality_gates_enabled: bool = True` to
+   `LandingPageGenerationConfig` and `SalesBriefGenerationConfig`,
+   teach `_quality_check` to short-circuit when False, thread per-
+   call override through `generate()`, route through the dispatcher.
+
+2. **`MarketingCampaign.context` leak** -- the audit flagged that
+   `_marketing_campaign_from_inputs` in `content_ops_execution.py`
+   dumps every non-{name, persona, value_prop, vendors, categories,
+   tags} input field into `MarketingCampaign.context`. So if the
+   request inputs include `target_account`, `offer`,
+   `opportunity_id`, `topic`, `audience`, etc. (the standard
+   control-surface input bag), all of them leak into the landing-
+   page service's `campaign.context` -- which the prompt template
+   then sees as if it were intentional context. Fix: replace the
+   "everything except known fields" inversion with an explicit
+   allowlist of context-shaped fields (`industry`, `pain_points`,
+   `differentiators`, etc.) so unrelated inputs stay out of the
+   campaign payload.
+
+## Scope (this PR)
+
+Only the two items above. The remaining audit findings
+(`topic` for blog_post -- no service-side landing surface;
+`channel`/`channels` legacy dual-field on
+`CampaignGenerationConfig`; the 9 MINOR + 2 NIT findings) defer to
+follow-ups.
+
+### `quality_gates_enabled`
+
+Both services already have an optional `quality_policy: QualityPolicy
+| None`. Currently the gate runs unconditionally when `_quality_check`
+is called (which happens after every parse). The new field gates
+that call: when False, skip evaluation entirely and treat the parse
+as passed.
+
+Per-call override follows the established OptionA shape:
+`generate(quality_gates_enabled: bool | None = None)`, resolved at
+the top of `generate()` against `self._config.quality_gates_enabled`.
+
+The campaign service has its own `quality_revalidation_enabled`
+field which already covers the equivalent gate; this PR doesn't
+touch it.
+
+### MarketingCampaign.context
+
+Current `_marketing_campaign_from_inputs`:
+
+```python
+context={
+    str(key): value
+    for key, value in inputs.items()
+    if key not in {"campaign_name", "offer", "audience", "vendors",
+                   "categories", "tags"}
+}
+```
+
+This is a "negative-list inversion" -- everything not explicitly
+excluded leaks. Standard control-surface inputs (`target_account`,
+`opportunity_id`, `topic`, `filters`, `report_type`, `brief_type`,
+`channels`, etc.) all flow into `campaign.context`.
+
+New shape: explicit allowlist of context-meaningful fields. Anything
+not on the allowlist stays out. The allowlist starts conservative
+(domain context fields the landing-page prompt actually consumes)
+and can grow as the contract evolves.
+
+## Intentional (looks wrong but is deliberate)
+
+- **`quality_gates_enabled` defaults to True**, not False.
+  Backwards-compat: existing hosts that don't set the field get the
+  current always-on behavior. The override is the new affordance,
+  not a behavior change for default callers.
+- **The MarketingCampaign.context allowlist starts small.**
+  `industry`, `pain_points`, `differentiators`, `customer_segments`,
+  `key_metrics`. The audit's leak example was overly broad; the fix
+  is to narrow rather than to fix the leak field-by-field. If hosts
+  need additional context fields they're added here, not by
+  whitelisting them at the call site.
+- **`topic` is not promoted to per-call.** The plan emits it in
+  `step.config["topic"]` but
+  `BlogPostGenerationService._generate_one` doesn't reference
+  `topic` anywhere -- it reads from `blueprint`. Adding a service
+  kwarg with no landing surface would be plumbing for nothing.
+  Closing this gap requires the blog service to actually consume
+  `topic` in its prompt template, which is content-shape work, not
+  trust-contract work.
+- **`_step_config_bool` already handles `quality_gates_enabled`
+  defensively.** Helper added in PR-OptionA-3; reused here.
+- **`channel`/`channels` legacy dual-field cleanup is deferred.**
+  Real cleanup but doesn't fit this slice's "close audit MAJORs"
+  framing -- it's a private-implementation cleanup, not a trust-
+  contract break.
+
+## Deferred (looks missing but is on purpose)
+
+- `topic` for blog_post (see Intentional).
+- `channel`/`channels` legacy dual-field cleanup -- separate slice.
+- 9 MINOR + 2 NIT findings from the audit -- batch cleanup PR.
+- `PR-ContentAssets-Consistency-2` -- still owed.
+
+## Verification
+
+- `pytest` across all touched suites
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline` -> clean
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> 0
+- `bash scripts/check_ascii_python.sh` -> passed

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -21,6 +21,14 @@ from extracted_content_pipeline.content_ops_execution import (  # noqa: E402
 )
 
 
+# PR-OptionA-1/2/3 graduated several plan-step fields to load-bearing kwargs
+# (channels, default_report_type, default_brief_type, temperature,
+# max_tokens, parse_retry_attempts, parse_retry_response_excerpt_chars,
+# quality_revalidation_enabled, quality_prompt_proof_term_limit,
+# quality_gates_enabled). The smoke fakes accept (and ignore) those via
+# ``**extras`` -- this CLI exercises the seam end-to-end, not the kwargs
+# contract. Strict per-kwarg assertions live in the dispatcher tests in
+# ``tests/test_extracted_content_ops_execution.py``.
 class _OpportunityAssetService:
     def __init__(self, name: str) -> None:
         self.name = name
@@ -32,8 +40,9 @@ class _OpportunityAssetService:
         target_mode: str,
         limit: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        **extras: Any,
     ) -> dict[str, Any]:
-        del scope
+        del scope, extras
         return {
             "generated": int(limit or 1),
             "asset": self.name,
@@ -44,8 +53,14 @@ class _OpportunityAssetService:
 
 
 class _LandingPageAssetService:
-    async def generate(self, *, scope: Any, campaign: Any) -> dict[str, Any]:
-        del scope
+    async def generate(
+        self,
+        *,
+        scope: Any,
+        campaign: Any,
+        **extras: Any,
+    ) -> dict[str, Any]:
+        del scope, extras
         return {
             "generated": 1,
             "asset": "landing_page",

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -48,6 +48,7 @@ class _OpportunityService:
         quality_revalidation_enabled: bool | None = None,
         quality_prompt_proof_term_limit: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        quality_gates_enabled: bool | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -64,6 +65,7 @@ class _OpportunityService:
             "quality_revalidation_enabled": quality_revalidation_enabled,
             "quality_prompt_proof_term_limit": quality_prompt_proof_term_limit,
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
+            "quality_gates_enabled": quality_gates_enabled,
             "extras": dict(extras),
         })
         return _Result()
@@ -82,6 +84,7 @@ class _LandingPageService:
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        quality_gates_enabled: bool | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -91,6 +94,7 @@ class _LandingPageService:
             "max_tokens": max_tokens,
             "parse_retry_attempts": parse_retry_attempts,
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
+            "quality_gates_enabled": quality_gates_enabled,
             "extras": dict(extras),
         })
         return _Result()
@@ -624,3 +628,86 @@ async def test_execute_threads_excerpt_kwarg_into_report_sales_brief_blog_landin
         if label != "landing_page":
             assert call.get("quality_revalidation_enabled") is None, label
             assert call.get("quality_prompt_proof_term_limit") is None, label
+
+
+# -----------------------
+# PR-OptionA-4: quality_gates_enabled + MarketingCampaign.context leak fix
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_quality_gates_enabled_into_sales_brief() -> None:
+    """When the plan emits quality_gates_enabled in step.config, the executor
+    threads it through. Default is True; this test only confirms threading."""
+
+    sales_brief = _OpportunityService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "inputs": {"target_account": "Acme", "offer": "Audit", "opportunity_id": "opp-1"},
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+
+    call = sales_brief.calls[0]
+    # Plan default emits quality_gates_enabled=True (from request.require_quality_gates).
+    assert call["quality_gates_enabled"] is True
+    assert call["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_quality_gates_enabled_into_landing_page() -> None:
+    landing = _LandingPageService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {"campaign_name": "Q3", "offer": "Audit", "audience": "VPs"},
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    call = landing.calls[0]
+    assert call["quality_gates_enabled"] is True
+    assert call["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_marketing_campaign_context_does_not_leak_unrelated_inputs() -> None:
+    """Audit MAJOR fix: prior shape dumped every non-{name, persona,
+    value_prop, vendors, categories, tags} input field into
+    campaign.context. Now context is an explicit allowlist; standard
+    control-surface inputs (target_account, opportunity_id, channels,
+    filters, etc.) stay out."""
+
+    landing = _LandingPageService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "campaign_name": "Q3",
+                "offer": "Audit",
+                "audience": "VPs",
+                "target_account": "Acme",  # was leaking pre-fix
+                "opportunity_id": "opp-1",  # was leaking pre-fix
+                "filters": {"status": "ready"},  # was leaking pre-fix
+                "channels": ["email_cold"],  # was leaking pre-fix
+                # Allowlisted fields DO flow through:
+                "industry": "fintech",
+                "pain_points": ["churn", "renewal"],
+            },
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    campaign = landing.calls[0]["campaign"]
+    context = dict(campaign.context)
+
+    # Allowlisted fields land in context.
+    assert context.get("industry") == "fintech"
+    assert context.get("pain_points") == ["churn", "renewal"]
+
+    # Pre-fix leakers stay out.
+    assert "target_account" not in context
+    assert "opportunity_id" not in context
+    assert "filters" not in context
+    assert "channels" not in context

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -521,3 +521,62 @@ async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
     assert "XXX" in retry_user_prompt
     excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
     assert len(excerpt_section.rstrip()) <= 50
+
+
+# -----------------------
+# PR-OptionA-4: per-call quality_gates_enabled override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_quality_gates_enabled_false_skips_quality_gate() -> None:
+    """When the executor passes quality_gates_enabled=False, the service
+    short-circuits the quality gate. A response that would normally fail
+    the gate (e.g., missing CTA) now lands as generated."""
+
+    bad_response = json.dumps({
+        "title": "ok",
+        "slug": "ok",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {},  # would normally hit no_cta blocker
+        "meta": {},
+        "reference_ids": [],
+    })
+    service, landing_pages, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        campaign=_campaign(),
+        quality_gates_enabled=False,
+    )
+
+    # Gate skipped -> the bad parse is persisted.
+    assert result.generated == 1
+    assert len(landing_pages.saved[0]["drafts"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_quality_gates_enabled_true_still_blocks() -> None:
+    """When the executor passes True (or None falls back to construction
+    default), the gate still runs. Behavior parity with prior PRs."""
+
+    bad_response = json.dumps({
+        "title": "ok",
+        "slug": "ok",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {},
+        "meta": {},
+        "reference_ids": [],
+    })
+    service, landing_pages, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        campaign=_campaign(),
+        quality_gates_enabled=True,
+    )
+
+    assert result.generated == 0
+    assert landing_pages.saved == []

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -687,3 +687,58 @@ async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
     assert "XXX" in retry_user_prompt
     excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
     assert len(excerpt_section.rstrip()) <= 50
+
+
+# -----------------------
+# PR-OptionA-4: per-call quality_gates_enabled override
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_quality_gates_enabled_false_skips_quality_gate() -> None:
+    """quality_gates_enabled=False short-circuits the quality gate, even on
+    parses that would normally fail (e.g., missing reference_ids)."""
+
+    bad_response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "brief_type": "pre_call",
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": []}
+        ],
+        "reference_ids": [],  # would normally hit no_references blocker
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        quality_gates_enabled=False,
+    )
+
+    # Gate skipped -> the bad parse is persisted.
+    assert result.generated == 1
+    assert len(sales_briefs.saved[0]["drafts"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_quality_gates_enabled_true_still_blocks() -> None:
+    bad_response = json.dumps({
+        "title": "Brief",
+        "headline": "punchy",
+        "brief_type": "pre_call",
+        "sections": [
+            {"id": "s1", "title": "T", "body_markdown": "b", "evidence_ids": []}
+        ],
+        "reference_ids": [],
+    })
+    service, _intel, sales_briefs, _llm, _skills, _rp = _service(responses=[bad_response])
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor",
+        quality_gates_enabled=True,
+    )
+
+    assert result.generated == 0
+    assert sales_briefs.saved == []


### PR DESCRIPTION
**Plan:** [`plans/PR-OptionA-4.md`](../blob/claude/pr-option-a-4-structural-fixes/plans/PR-OptionA-4.md)

## Summary

Closes the remaining audit MAJORs that don't fit the per-field-kwarg pattern from PR-OptionA-1/2/3.

**1. `quality_gates_enabled`** (sales_brief, landing_page) was a phantom field — plan emitted it in step.config but neither service had a config field for it, so the executor couldn't route an override even if it tried. Operator picking "skip quality gates" in the control surface was silently dropped.

**2. `MarketingCampaign.context` leak** — audit MAJOR. `_marketing_campaign_from_inputs` used a "negative-list inversion" so standard control-surface inputs (`target_account`, `opportunity_id`, `channels`, `filters`, etc.) all leaked into the landing-page service's campaign payload as if they were intentional context.

## What changed

### `quality_gates_enabled`

- Added `quality_gates_enabled: bool = True` to `LandingPageGenerationConfig` and `SalesBriefGenerationConfig`.
- `_quality_check` short-circuits (`passed=True`, `blockers=()`) when False.
- Per-call override threaded through `generate()` using the established OptionA shape.
- Dispatchers route the field via the existing `_step_config_bool` helper.
- Default True preserves current always-on behavior; override is the new affordance.

### `MarketingCampaign.context` leak

Replaced the negative-list inversion with an explicit allowlist:

```python
_MARKETING_CAMPAIGN_CONTEXT_FIELDS: frozenset[str] = frozenset({
    "industry",
    "pain_points",
    "differentiators",
    "customer_segments",
    "key_metrics",
    "proof_points",
    "competitive_alternatives",
})
```

Anything not on the allowlist stays out of `campaign.context`. New fields are added explicitly.

## Intentional (looks wrong but is deliberate)

- **`quality_gates_enabled` defaults to True**, not False — backwards compat.
- **The MarketingCampaign.context allowlist starts small.** Domain-context fields the landing-page prompt actually consumes. New entries are added explicitly; unrelated request inputs no longer leak by default.
- **`topic` for blog_post is not promoted to per-call.** Plan emits `topic` in step.config but `BlogPostGenerationService._generate_one` doesn't reference it anywhere — the blog service reads from `blueprint`. Adding a service kwarg with no landing surface would be plumbing for nothing.
- **`channel`/`channels` legacy dual-field cleanup is deferred.** Real cleanup but doesn't fit this slice's "close audit MAJORs" framing — it's a private-implementation cleanup, not a trust-contract break.

## Deferred (looks missing but is on purpose)

- `topic` for blog_post (see Intentional).
- `channel`/`channels` legacy dual-field cleanup — separate slice.
- 9 MINOR + 2 NIT findings from the audit — batch cleanup PR.
- `PR-ContentAssets-Consistency-2` — still owed.

## Test plan

- [x] `pytest` across all touched suites + the upstream control-surface / generation-plan tests → 151 passed, 10 skipped (pre-existing)
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Size: ~80 LOC source + ~200 LOC tests + ~120 LOC plan doc = ~400 LOC across 7 files. Right at the budget. Source-only is small (~80 LOC) — this slice is well-scoped because the structural fixes are tight, not because tests were trimmed.

7 new tests: 3 dispatcher tests (quality_gates_enabled threading + leak fix) + 4 per-service tests (2 each for sales_brief and landing_page covering quality_gates_enabled=False/True smoking gun).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_