### PR TITLE
PR-ContentAssets-Consistency-2: migrate 3 adapters to shared _jsonb_helpers

### DIFF
--- a/extracted_content_pipeline/campaign_postgres_import.py
+++ b/extracted_content_pipeline/campaign_postgres_import.py
@@ -1,12 +1,19 @@
-"""Postgres importer for standalone campaign opportunity data."""
+"""Postgres importer for standalone campaign opportunity data.
+
+Shared JSONB helper lives in
+``extracted_content_pipeline.storage._jsonb_helpers`` (extracted in
+PR-ContentAssets-Consistency-1). Local ``_jsonb`` is now a thin
+alias for the shared helper -- backwards-compat shim for any in-tree
+caller that imported the private name.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-import json
 from typing import Any
 
+from .storage._jsonb_helpers import json_dump_jsonb as _jsonb
 from .campaign_customer_data import (
     CampaignOpportunityLoadResult,
     CampaignOpportunityWarning,
@@ -161,8 +168,6 @@ def _loaded_rows(
     )
 
 
-def _jsonb(value: Any) -> str:
-    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
 
 
 def _clean(value: Any) -> str | None:

--- a/extracted_content_pipeline/campaign_postgres_review.py
+++ b/extracted_content_pipeline/campaign_postgres_review.py
@@ -1,14 +1,24 @@
-"""Postgres draft review helpers for the standalone campaign product."""
+"""Postgres draft review helpers for the standalone campaign product.
+
+Shared JSONB / row-coercion helpers live in
+``extracted_content_pipeline.storage._jsonb_helpers`` (extracted in
+PR-ContentAssets-Consistency-1). The local ``_jsonb`` / ``_row_dict``
+are now thin aliases for the shared helpers -- backwards-compat shim
+for any in-tree caller that imported the private names.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-import json
 from typing import Any
 
 from .campaign_ports import TenantScope
 from .campaign_postgres_generation import tenant_scope_from_mapping
+from .storage._jsonb_helpers import (
+    json_dump_jsonb as _jsonb,
+    row_to_dict as _row_dict,
+)
 
 
 JsonDict = dict[str, Any]
@@ -184,10 +194,6 @@ def _normalize_status(value: str) -> str:
     return status
 
 
-def _jsonb(value: Any) -> str:
-    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
-
-
 def _serializable_row(row: Mapping[str, Any]) -> JsonDict:
     return {key: _json_ready(value) for key, value in row.items()}
 
@@ -200,15 +206,6 @@ def _json_ready(value: Any) -> Any:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     return str(value)
-
-
-def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
-    if isinstance(row, Mapping):
-        return dict(row)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/podcast_postgres.py
+++ b/extracted_content_pipeline/podcast_postgres.py
@@ -1,4 +1,13 @@
-"""Postgres repository adapters for podcast repurposing."""
+"""Postgres repository adapters for podcast repurposing.
+
+Shared JSONB / row-coercion helpers live in
+``extracted_content_pipeline.storage._jsonb_helpers`` (extracted in
+PR-ContentAssets-Consistency-1). Local ``_jsonb`` / ``_row_dict`` are
+now thin aliases for the shared helpers -- backwards-compat shim for
+any in-tree caller that imported the private names. ``import json``
+stays because ``_json_value`` below uses ``json.loads`` directly for
+string-form JSONB column hardening.
+"""
 
 from __future__ import annotations
 
@@ -13,13 +22,13 @@ from .podcast_ports import (
     PodcastTranscript,
     TenantScope,
 )
+from .storage._jsonb_helpers import (
+    json_dump_jsonb as _jsonb,
+    row_to_dict as _row_dict,
+)
 
 
 JsonDict = dict[str, Any]
-
-
-def _jsonb(value: Any) -> str:
-    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
 
 
 def _clean(value: Any) -> str | None:
@@ -35,15 +44,6 @@ def _identifier(value: str) -> str:
         if not all(char.isalnum() or char == "_" for char in part):
             raise ValueError(f"invalid SQL identifier: {value!r}")
     return ".".join(f'"{part}"' for part in parts)
-
-
-def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
-    if isinstance(row, Mapping):
-        return dict(row)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
 
 
 def _json_value(value: Any) -> Any:

--- a/plans/PR-ContentAssets-Consistency-2.md
+++ b/plans/PR-ContentAssets-Consistency-2.md
@@ -1,0 +1,102 @@
+# PR-ContentAssets-Consistency-2: migrate 3 remaining adapters to shared _jsonb_helpers
+
+## Why this slice exists
+
+Owed since PR #356. PR-ContentAssets-Consistency-1 extracted shared
+JSONB / asyncpg helpers into
+``extracted_content_pipeline/storage/_jsonb_helpers.py`` and migrated
+the four content-asset draft adapters (campaigns, reports, landing
+pages, sales briefs). PR #356's review caught that three more
+adapters in the package have **byte-identical** ``_jsonb`` /
+``_row_dict`` definitions and weren't migrated:
+
+- ``extracted_content_pipeline/campaign_postgres_review.py``
+- ``extracted_content_pipeline/campaign_postgres_import.py``
+- ``extracted_content_pipeline/podcast_postgres.py``
+
+PR #356's plan doc explicitly listed this as the Consistency-2
+follow-up. This PR closes it.
+
+## Scope (this PR)
+
+Pure refactor / cleanup. No behavior change. No new abstraction --
+just import the existing shared helpers in place of the local
+copy-pastes.
+
+| Adapter | Local helpers replaced |
+|---|---|
+| ``campaign_postgres_review.py`` | ``_jsonb``, ``_row_dict`` |
+| ``campaign_postgres_import.py`` | ``_jsonb`` (no ``_row_dict``) |
+| ``podcast_postgres.py`` | ``_jsonb``, ``_row_dict`` |
+
+Shim pattern matches ``campaign_postgres.py`` from PR #356:
+
+```python
+from .storage._jsonb_helpers import (
+    json_dump_jsonb as _jsonb,
+    row_to_dict as _row_dict,
+)
+```
+
+The aliased import lets call sites continue to use the private
+``_jsonb(...)`` / ``_row_dict(...)`` names without touching every
+call site -- pure imports change. Backward-compat shim for any
+in-tree caller that imported the private names directly (same
+rationale as #356's choice for the campaign adapter).
+
+## Intentional (looks wrong but is deliberate)
+
+- **Backwards-compat shim instead of renaming all call sites.** The
+  private helper names (``_jsonb``, ``_row_dict``) were referenced
+  inside the adapters; renaming every call site would balloon the
+  diff with mechanical changes that don't add value. The
+  ``import-as`` shim is zero-runtime-cost and keeps the diff focused
+  on the helper-source migration.
+- **No new abstraction** -- this is the consolidation slice for the
+  existing helpers, not a place to introduce a new pattern.
+- **No tests added.** The adapters' behavior is unchanged (same
+  helpers, same call sites). Existing tests for these three
+  adapters lock the behavior; passing those is sufficient
+  verification. Adding tests that assert "the import comes from
+  ``_jsonb_helpers``" would test the implementation, not the
+  contract.
+- **``import json`` stays in ``podcast_postgres.py``** because it
+  uses ``json.loads`` directly outside the helper functions. The
+  other two adapters drop ``import json`` since the helpers now
+  cover all JSON needs. (Verified by grep before the edit.)
+
+## Deferred (still on purpose)
+
+- **Five more adapters with the same duplication.** Self-audit
+  during this PR found additional local ``_jsonb`` / ``_row_dict``
+  definitions in:
+  - ``campaign_postgres_export.py`` (``_row_dict``)
+  - ``campaign_postgres_seller_targets.py`` (``_row_dict``)
+  - ``campaign_postgres_seller_opportunities.py`` (both)
+  - ``campaign_postgres_seller_category_intelligence.py`` (both)
+  - ``podcast_postgres_import.py`` (``_jsonb``)
+
+  The original PR #356 review only flagged three; the actual
+  duplication landscape is wider. Not migrated here to keep this
+  slice scoped to what the original review-trail promised. Follow-up
+  ``PR-ContentAssets-Consistency-3`` migrates these five in one
+  atomic move.
+- ``topic`` for blog_post -- still no service-side landing surface.
+- ``channel``/``channels`` legacy dual-field cleanup on
+  ``CampaignGenerationConfig`` -- separate slice.
+- 9 MINOR + 2 NIT findings from the Content Ops audit -- batch
+  cleanup PR.
+
+## Verification
+
+- ``pytest`` on the three touched adapter test suites
+- ``python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`` -> clean
+- ``python scripts/audit_extracted_standalone.py --fail-on-debt`` -> 0
+- ``bash scripts/check_ascii_python.sh`` -> passed
+
+## Sibling references
+
+- PR #356 plan: ``plans/PR-ContentAssets-Consistency-1.md``
+- Shared helpers source:
+  ``extracted_content_pipeline/storage/_jsonb_helpers.py``


### PR DESCRIPTION
**Plan:** [`plans/PR-ContentAssets-Consistency-2.md`](../blob/claude/pr-content-assets-consistency-2/plans/PR-ContentAssets-Consistency-2.md)

## Summary

Owed since PR #356. PR-ContentAssets-Consistency-1 extracted shared JSONB / asyncpg helpers into `storage/_jsonb_helpers.py` and migrated the four content-asset draft adapters. PR #356's review caught that three more adapters had byte-identical `_jsonb` / `_row_dict` definitions and weren't migrated:

- `campaign_postgres_review.py` (both helpers)
- `campaign_postgres_import.py` (just `_jsonb`)
- `podcast_postgres.py` (both helpers)

This PR closes the follow-up. Pure refactor — no behavior change.

## What changed

Local helpers replaced with thin `import-as` aliases for backwards compat (matches the shim pattern from #356's `campaign_postgres.py` migration):

```python
from .storage._jsonb_helpers import (
    json_dump_jsonb as _jsonb,
    row_to_dict as _row_dict,
)
```

The aliased import lets call sites continue to use the private `_jsonb(...)` / `_row_dict(...)` names without touching every call site.

## Intentional (looks wrong but is deliberate)

- **Backwards-compat shim instead of renaming all call sites.** Pure imports change; zero-runtime-cost insurance against any in-tree caller that imported the private names. Same rationale as #356.
- **No new abstraction.** This is the consolidation slice for the existing helpers, not a place to introduce a new pattern.
- **No tests added.** Behavior unchanged; existing tests for these three adapters lock the contract. Adding "the import comes from `_jsonb_helpers`" tests would test implementation, not contract.
- **`import json` stays in `podcast_postgres.py`** because `_json_value` uses `json.loads` directly outside the helpers. The other two adapters drop `import json` cleanly.

## Self-audit found 5 more adapters with the same duplication

Surfaced during this PR (the original #356 review didn't flag them):

- `campaign_postgres_export.py` (`_row_dict`)
- `campaign_postgres_seller_targets.py` (`_row_dict`)
- `campaign_postgres_seller_opportunities.py` (both)
- `campaign_postgres_seller_category_intelligence.py` (both)
- `podcast_postgres_import.py` (`_jsonb`)

**Not migrated here** — keeping this slice scoped to what the original review-trail promised. Captured in the plan doc's Deferred section and queued as `PR-ContentAssets-Consistency-3` to migrate the five in one atomic move.

## Deferred (still on purpose)

- The 5 newly-discovered adapters → `PR-ContentAssets-Consistency-3`
- `topic` for blog_post (still no service-side landing surface)
- `channel`/`channels` legacy dual-field cleanup
- 9 MINOR + 2 NIT findings from the Content Ops audit

## Test plan

- [x] `pytest` on the three touched adapter test suites + the shared-helpers tests → 88 passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Size: ~35 LOC source net + ~95 LOC plan doc = ~135 LOC across 4 files. Source-only is small (mechanical replacement of local helpers with import aliases).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_