### PR TITLE
PR-ContentAssets-Consistency-3: migrate 5 more adapters to shared _jsonb_helpers

### DIFF
--- a/extracted_content_pipeline/campaign_postgres_export.py
+++ b/extracted_content_pipeline/campaign_postgres_export.py
@@ -1,4 +1,9 @@
-"""Postgres draft export helpers for the standalone campaign product."""
+"""Postgres draft export helpers for the standalone campaign product.
+
+Shared row-coercion helper lives in
+``extracted_content_pipeline.storage._jsonb_helpers``. ``_row_dict``
+is a thin alias for backwards compat.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +16,7 @@ from typing import Any
 
 from .campaign_ports import TenantScope
 from .campaign_postgres_generation import tenant_scope_from_mapping
+from .storage._jsonb_helpers import row_to_dict as _row_dict
 
 
 JsonDict = dict[str, Any]
@@ -160,15 +166,6 @@ def _csv_value(value: Any) -> Any:
     if isinstance(value, (Mapping, list, tuple)):
         return json.dumps(value, default=str, separators=(",", ":"))
     return "" if value is None else value
-
-
-def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
-    if isinstance(row, Mapping):
-        return dict(row)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/campaign_postgres_seller_category_intelligence.py
+++ b/extracted_content_pipeline/campaign_postgres_seller_category_intelligence.py
@@ -1,11 +1,20 @@
-"""Refresh Amazon seller category intelligence snapshots from review data."""
+"""Refresh Amazon seller category intelligence snapshots from review data.
+
+Shared JSONB / row-coercion helpers live in
+``extracted_content_pipeline.storage._jsonb_helpers``. ``_jsonb`` /
+``_row_dict`` are thin aliases for backwards compat.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-import json
 from typing import Any
+
+from .storage._jsonb_helpers import (
+    json_dump_jsonb as _jsonb,
+    row_to_dict as _row_dict,
+)
 
 
 JsonDict = dict[str, Any]
@@ -711,10 +720,6 @@ async def _fetch_top_root_causes(
     ]
 
 
-def _jsonb(value: Any) -> str:
-    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
-
-
 def _clean_sequence(values: Sequence[Any]) -> tuple[str, ...]:
     seen: set[str] = set()
     items: list[str] = []
@@ -742,15 +747,6 @@ def _normalize_limit(value: Any, field_name: str) -> int:
     if limit < 0:
         raise ValueError(f"{field_name} must be non-negative")
     return limit
-
-
-def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
-    if isinstance(row, Mapping):
-        return dict(row)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
 
 
 def _identifier(value: str) -> str:

--- a/extracted_content_pipeline/campaign_postgres_seller_opportunities.py
+++ b/extracted_content_pipeline/campaign_postgres_seller_opportunities.py
@@ -1,4 +1,11 @@
-"""Build Amazon seller campaign opportunities from seller targets."""
+"""Build Amazon seller campaign opportunities from seller targets.
+
+Shared JSONB / row-coercion helpers live in
+``extracted_content_pipeline.storage._jsonb_helpers``. ``_jsonb`` /
+``_row_dict`` are thin aliases for backwards compat. ``import json``
+stays because this file uses ``json.loads`` / ``json.JSONDecodeError``
+directly outside the shared helpers.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +15,11 @@ from datetime import date, datetime
 import json
 import re
 from typing import Any
+
+from .storage._jsonb_helpers import (
+    json_dump_jsonb as _jsonb,
+    row_to_dict as _row_dict,
+)
 
 
 JsonDict = dict[str, Any]
@@ -362,23 +374,10 @@ def _json_sequence(value: Any) -> list[Any]:
     return [value]
 
 
-def _jsonb(value: Any) -> str:
-    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
-
-
 def _json_ready(value: Any) -> Any:
     if isinstance(value, (date, datetime)):
         return value.isoformat()
     return value
-
-
-def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
-    if isinstance(row, Mapping):
-        return dict(row)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
 
 
 def _unique(values: Sequence[Any] | Any) -> tuple[str, ...]:

--- a/extracted_content_pipeline/campaign_postgres_seller_targets.py
+++ b/extracted_content_pipeline/campaign_postgres_seller_targets.py
@@ -1,4 +1,9 @@
-"""Postgres seller target helpers for the standalone campaign product."""
+"""Postgres seller target helpers for the standalone campaign product.
+
+Shared row-coercion helper lives in
+``extracted_content_pipeline.storage._jsonb_helpers``. ``_row_dict``
+is a thin alias for backwards compat.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +12,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 from uuid import UUID
+
+from .storage._jsonb_helpers import row_to_dict as _row_dict
 
 
 JsonDict = dict[str, Any]
@@ -275,15 +282,6 @@ def _json_ready(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_json_ready(item) for item in value]
     return value
-
-
-def _row_dict(row: Mapping[str, Any] | Any) -> JsonDict:
-    if isinstance(row, Mapping):
-        return dict(row)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/podcast_postgres_import.py
+++ b/extracted_content_pipeline/podcast_postgres_import.py
@@ -1,13 +1,18 @@
-"""Postgres importer for podcast transcripts."""
+"""Postgres importer for podcast transcripts.
+
+Shared JSONB helper lives in
+``extracted_content_pipeline.storage._jsonb_helpers``. ``_jsonb`` is
+a thin alias for backwards compat.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-import json
 from typing import Any
 
 from .campaign_ports import TenantScope
+from .storage._jsonb_helpers import json_dump_jsonb as _jsonb
 from .podcast_transcript_data import (
     PodcastTranscriptLoadResult,
     PodcastTranscriptWarning,
@@ -151,8 +156,6 @@ def _loaded_rows(
     )
 
 
-def _jsonb(value: Any) -> str:
-    return json.dumps(value if value is not None else {}, default=str, separators=(",", ":"))
 
 
 def _clean(value: Any) -> str | None:

--- a/extracted_content_pipeline/podcast_postgres_import.py
+++ b/extracted_content_pipeline/podcast_postgres_import.py
@@ -156,8 +156,6 @@ def _loaded_rows(
     )
 
 
-
-
 def _clean(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None

--- a/plans/PR-ContentAssets-Consistency-3.md
+++ b/plans/PR-ContentAssets-Consistency-3.md
@@ -1,0 +1,91 @@
+# PR-ContentAssets-Consistency-3: migrate 5 more adapters to shared _jsonb_helpers
+
+## Why this slice exists
+
+PR-ContentAssets-Consistency-2 (#380) migrated the three adapters
+flagged in PR #356's original review: ``campaign_postgres_review``,
+``campaign_postgres_import``, ``podcast_postgres``. Self-audit
+during that PR found **five more adapters** with the same byte-
+identical ``_jsonb`` / ``_row_dict`` definitions:
+
+- ``campaign_postgres_export.py`` (``_row_dict``)
+- ``campaign_postgres_seller_targets.py`` (``_row_dict``)
+- ``campaign_postgres_seller_opportunities.py`` (both)
+- ``campaign_postgres_seller_category_intelligence.py`` (both)
+- ``podcast_postgres_import.py`` (``_jsonb``)
+
+This PR closes that fan-out. After this lands the package has a
+single source of truth for these four helpers
+(``json_dump_jsonb`` / ``decode_jsonb_field`` / ``parse_command_tag``
+/ ``row_to_dict``) -- no remaining local copies in any
+``extracted_content_pipeline/*.py`` file.
+
+## Scope (this PR)
+
+Pure refactor / cleanup. No behavior change. Same ``import-as`` shim
+pattern as Consistency-1 / -2.
+
+| Adapter | Local helpers replaced | ``import json`` |
+|---|---|---|
+| ``campaign_postgres_export.py`` | ``_row_dict`` | kept (custom serializer uses ``json.dumps``) |
+| ``campaign_postgres_seller_targets.py`` | ``_row_dict`` | n/a (file didn't import json) |
+| ``campaign_postgres_seller_opportunities.py`` | both | kept (uses ``json.loads`` / ``JSONDecodeError`` outside helpers) |
+| ``campaign_postgres_seller_category_intelligence.py`` | both | dropped (no other json. usage) |
+| ``podcast_postgres_import.py`` | ``_jsonb`` | dropped (no other json. usage) |
+
+The ``import-as`` shim:
+
+```python
+from .storage._jsonb_helpers import (
+    json_dump_jsonb as _jsonb,
+    row_to_dict as _row_dict,
+)
+```
+
+Call sites continue to use the private ``_jsonb(...)`` / ``_row_dict(...)``
+names; only the helper source changes. Same backwards-compat
+rationale as the prior consistency PRs.
+
+## Intentional (looks wrong but is deliberate)
+
+- **Backwards-compat shim instead of renaming all call sites.**
+  Pure imports change. Same shim pattern as Consistency-1 / -2.
+- **No new abstraction.** Helpers exist; we're just consolidating
+  the adapter end of the wire.
+- **No tests added.** Behavior unchanged; existing adapter tests
+  lock the contract. Adding "the import comes from _jsonb_helpers"
+  tests would test implementation, not contract -- same rationale
+  as Consistency-2.
+- **Per-file ``import json`` decision documented in the table.**
+  Three files retain ``import json`` because they use
+  ``json.loads`` / ``json.JSONDecodeError`` / a custom
+  ``json.dumps`` serializer outside the shared helpers; two drop
+  the import cleanly.
+
+## Deferred (still on purpose)
+
+- ``topic`` for blog_post -- still no service-side landing surface.
+- ``channel``/``channels`` legacy dual-field cleanup on
+  ``CampaignGenerationConfig`` -- separate slice.
+- 9 MINOR + 2 NIT findings from the Content Ops audit -- batch
+  cleanup PR.
+
+## Verification
+
+- ``pytest`` on the touched adapter test suites
+- ``python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`` -> clean
+- ``python scripts/audit_extracted_standalone.py --fail-on-debt`` -> 0
+- ``bash scripts/check_ascii_python.sh`` -> passed
+- Final grep: ``grep -rn "^def _jsonb\|^def _row_dict"
+  extracted_content_pipeline/`` returns zero remaining local
+  definitions in any ``*_postgres*.py`` adapter.
+
+## Sibling references
+
+- PR-ContentAssets-Consistency-1 plan:
+  ``plans/PR-ContentAssets-Consistency-1.md``
+- PR-ContentAssets-Consistency-2 plan:
+  ``plans/PR-ContentAssets-Consistency-2.md``
+- Shared helpers source:
+  ``extracted_content_pipeline/storage/_jsonb_helpers.py``


### PR DESCRIPTION
**Plan:** [`plans/PR-ContentAssets-Consistency-3.md`](../blob/claude/pr-content-assets-consistency-3/plans/PR-ContentAssets-Consistency-3.md)

## Summary

Closes the fan-out from PR #380's self-audit. PR-Consistency-2 migrated the three adapters originally flagged in #356's review; the self-audit found **five more adapters** with the same byte-identical `_jsonb` / `_row_dict` definitions:

- `campaign_postgres_export.py` (`_row_dict`)
- `campaign_postgres_seller_targets.py` (`_row_dict`)
- `campaign_postgres_seller_opportunities.py` (both)
- `campaign_postgres_seller_category_intelligence.py` (both)
- `podcast_postgres_import.py` (`_jsonb`)

After this lands, **no remaining local `_jsonb` / `_row_dict` definitions exist in any `extracted_content_pipeline/*.py` postgres adapter.** The package has a single source of truth for these four helpers.

## What changed

Same `import-as` shim pattern as Consistency-1/-2:

```python
from .storage._jsonb_helpers import (
    json_dump_jsonb as _jsonb,
    row_to_dict as _row_dict,
)
```

Per-file `import json` decision:

| Adapter | `import json` |
|---|---|
| `campaign_postgres_export.py` | kept (custom serializer uses `json.dumps`) |
| `campaign_postgres_seller_targets.py` | n/a (file didn't import json) |
| `campaign_postgres_seller_opportunities.py` | kept (uses `json.loads` / `JSONDecodeError`) |
| `campaign_postgres_seller_category_intelligence.py` | dropped |
| `podcast_postgres_import.py` | dropped |

## Intentional (looks wrong but is deliberate)

- **`import-as` shim instead of renaming all call sites.** Pure imports change. Same shim rationale as #356/#380 — zero-runtime-cost insurance against any in-tree caller importing the private names.
- **No new abstraction.** Helpers exist; this is the consolidation slice for the adapter end of the wire.
- **No tests added.** Behavior unchanged. Adding "the import comes from `_jsonb_helpers`" tests would test implementation, not contract.
- **Per-file `import json` decision documented case-by-case** because the right answer differs based on whether the file uses `json.loads` / a custom serializer outside the shared helpers.

## Verification

- [x] `pytest` on the 5 touched adapter test suites + the shared-helpers tests → 73 passed
- [x] `grep -rn "^def _jsonb\|^def _row_dict" extracted_content_pipeline/` → zero matches in postgres adapters (only `_jsonb_list` in `b2b_vendor_briefing.py` remains, which is a different function unrelated to this consolidation)
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `python scripts/audit_extracted_standalone.py --fail-on-debt` → Atlas runtime import findings: 0
- [x] `bash scripts/check_ascii_python.sh` → passed

## Deferred (still on purpose)

- `topic` for blog_post (still no service-side landing surface).
- `channel`/`channels` legacy dual-field cleanup on `CampaignGenerationConfig`.
- 9 MINOR + 2 NIT findings from the Content Ops audit.

## Self-audit notes

Size: ~85 LOC source net + ~95 LOC plan doc = ~180 LOC across 6 files. Source-only is small (mechanical replacement; ~85 net was source removal). Comfortably under budget.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_