### PR TITLE
Deprecate legacy `channel` field on CampaignGenerationConfig

### DIFF
--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -159,6 +159,12 @@ def _accumulate_usage(
 @dataclass(frozen=True)
 class CampaignGenerationConfig:
     skill_name: str = "digest/b2b_campaign_generation"
+    # Legacy single-channel field. Hosts should construct with the
+    # ``channels`` tuple instead. ``_channels()`` keeps a fallback
+    # (``self._config.channels or (self._config.channel,)``) so
+    # existing hosts keep working, but new code should not set
+    # ``channel=``. Removal is queued for a future versioned breaking-
+    # change slice -- see plans/PR-Campaign-Channel-Legacy-Cleanup.md.
     channel: str = "email"
     limit: int = 20
     max_tokens: int = 1200

--- a/plans/PR-Campaign-Channel-Legacy-Cleanup.md
+++ b/plans/PR-Campaign-Channel-Legacy-Cleanup.md
@@ -1,0 +1,92 @@
+# PR: deprecate the legacy `channel` field on CampaignGenerationConfig
+
+## Why this slice exists
+
+``CampaignGenerationConfig`` carries two channel-shape fields:
+
+```python
+channel: str = "email"               # legacy (single-channel)
+channels: tuple[str, ...] = ()       # newer (multi-channel)
+```
+
+The ``_channels()`` resolver does ``self._config.channels or (self._config.channel,)``
+-- if ``channels`` is empty, it falls back to a one-tuple from
+``channel``. Both fields work; the dual surface has been a noted
+deferred-cleanup item across multiple PRs (PR-OptionA-1 through
+PR-Consistency-3 all listed it under "Deferred").
+
+The Content Ops post-merge audit flagged the duplication. This PR
+does the smallest cleanup that closes the audit item without
+breaking existing hosts:
+
+1. Mark ``channel`` as deprecated in the dataclass docstring.
+2. Migrate the one in-tree test that constructs
+   ``CampaignGenerationConfig(channel=...)`` to use ``channels=``
+   instead, so the package's own tests don't exercise the legacy
+   path.
+3. Document the removal path so the breaking change can land in a
+   future versioned slice.
+
+## Scope (this PR)
+
+Documentation + test migration only. **No field removal.** The
+fallback chain in ``_channels()`` stays so existing hosts that
+construct ``CampaignGenerationConfig(channel="...")`` still work --
+they just hit a deprecated path documented in the dataclass.
+
+| Change | File | Lines |
+|---|---|---|
+| Field-level deprecation note | ``campaign_generation.py`` | 1 |
+| Test migration (``channel="linkedin"`` -> ``channels=("linkedin",)``) | ``tests/test_extracted_campaign_generation.py`` | 1 |
+| Plan doc (this file) | ``plans/PR-Campaign-Channel-Legacy-Cleanup.md`` | new |
+
+That's it. The internal fallback at
+``campaign_generation.py`` line 437 stays intact.
+
+## Intentional (looks wrong but is deliberate)
+
+- **No field removal.** Removing ``channel`` from the dataclass
+  would break any host constructing
+  ``CampaignGenerationConfig(channel="...")`` with a
+  ``TypeError``. Frozen dataclasses don't accept unknown kwargs.
+  We don't know who's still on the legacy field. Removal belongs in
+  a versioned breaking-change slice, not a quiet cleanup PR.
+- **No ``warnings.warn`` deprecation runtime hook.** Could be added
+  but adds noise to test logs and host telemetry without much
+  benefit until we're committed to actual removal. The dataclass
+  docstring + this plan doc are the audit-trail breadcrumb hosts
+  will see.
+- **In-tree test migration moves to the supported path.** The one
+  test that used ``channel="linkedin"`` now constructs
+  ``channels=("linkedin",)``. Same generated behavior; package's
+  own tests stop exercising the legacy fallback.
+- **The fallback in ``_channels()`` stays.** ``self._config.channels
+  or (self._config.channel,)``. That's the contract for hosts on
+  the legacy field. Removing it is the actual breaking change.
+
+## Removal path (deferred)
+
+Future breaking-change PR (``PR-Campaign-Config-V2`` or similar):
+1. Drop ``channel: str = "email"`` from the dataclass.
+2. Drop the ``or (self._config.channel,)`` fallback in
+   ``_channels()``.
+3. Bump the package version (semver-major or equivalent host
+   coordination).
+
+Out of scope here.
+
+## Verification
+
+- ``pytest tests/test_extracted_campaign_generation.py`` -> all
+  passing (the migrated test still asserts the same behavior).
+- No need to re-run the full extracted-pipeline suite; the change is
+  scoped to a docstring + a single test param.
+
+## Sibling references
+
+- ``CampaignGenerationConfig`` lives in
+  ``extracted_content_pipeline/campaign_generation.py``.
+- The ``Deferred`` sections of ``plans/PR-OptionA-1.md`` through
+  ``plans/PR-OptionA-5.md`` and
+  ``plans/PR-ContentAssets-Consistency-2.md`` all listed this
+  cleanup as pending.

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -560,7 +560,7 @@ async def test_generate_uses_provider_canonical_reasoning_context_without_other_
 async def test_generate_uses_custom_config_and_omits_source_opportunity():
     config = CampaignGenerationConfig(
         skill_name="custom",
-        channel="linkedin",
+        channels=("linkedin",),  # supported multi-channel field
         max_tokens=300,
         temperature=0.2,
         include_source_opportunity=False,

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -1230,3 +1230,31 @@ async def test_generate_per_call_quality_prompt_proof_term_limit_override():
     assert len(found_terms) <= 2, (
         f"override should cap proof terms at 2; saw {len(found_terms)}: {found_terms}"
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_legacy_channel_field_still_resolves_when_channels_unset():
+    """Lock the legacy ``channel`` field's fallback contract until the
+    breaking-change removal slice lands. ``_channels()`` does
+    ``self._config.channels or (self._config.channel,)`` -- when ``channels``
+    is empty, ``channel`` should still resolve as a one-tuple. After
+    PR-Campaign-Config-V2 removes the field this test goes away with it.
+
+    See plans/PR-Campaign-Channel-Legacy-Cleanup.md.
+    """
+
+    config = CampaignGenerationConfig(channel="legacy_only")  # no channels=
+    service, _, campaigns, llm, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({"subject": "Hi", "body": "<p>Body</p>"})],
+        config=config,
+    )
+
+    await service.generate(scope=TenantScope(), target_mode="churning_company")
+
+    # Single LLM call (one channel) using the legacy field's value.
+    assert len(llm.calls) == 1
+    assert "channel=legacy_only" in llm.calls[0]["messages"][1].content
+    drafts = campaigns.saved[0]["drafts"]
+    assert len(drafts) == 1
+    assert drafts[0].channel == "legacy_only"


### PR DESCRIPTION
**Plan:** [`plans/PR-Campaign-Channel-Legacy-Cleanup.md`](../blob/claude/pr-campaign-channel-legacy-cleanup/plans/PR-Campaign-Channel-Legacy-Cleanup.md)

## Summary

`CampaignGenerationConfig` carries two channel-shape fields. The `_channels()` resolver falls back from `channels` to `channel` when `channels` is empty. Both fields work; the duplication has been a deferred-cleanup item across the OptionA and Consistency PR series.

This PR does the smallest cleanup that closes the audit item **without breaking existing hosts**:

1. Mark `channel` as deprecated in the dataclass docstring (pointing at the removal-path plan).
2. Migrate the one in-tree test that constructed `CampaignGenerationConfig(channel="linkedin")` to use `channels=("linkedin",)`.

## Intentional (looks wrong but is deliberate)

- **No field removal.** Removing `channel` from the dataclass would break any host constructing `CampaignGenerationConfig(channel="...")` with a `TypeError` — frozen dataclasses don't accept unknown kwargs. Removal belongs in a versioned breaking-change slice, not a quiet cleanup PR.
- **No `warnings.warn` runtime hook.** Adds noise to test logs and host telemetry without much benefit until removal is actually committed. The dataclass docstring + plan doc are the audit-trail breadcrumb.
- **The fallback in `_channels()` stays.** That's the contract for hosts on the legacy field. Removing it is the actual breaking change.

## Removal path (deferred)

Future `PR-Campaign-Config-V2` (breaking change):
1. Drop `channel: str = "email"` from the dataclass.
2. Drop the `or (self._config.channel,)` fallback in `_channels()`.
3. Bump the package version.

## Verification

- [x] `pytest tests/test_extracted_campaign_generation.py` → 37 passed (the migrated test still asserts the same behavior)
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Tiny PR: ~10 LOC source change + ~85 LOC plan doc = ~95 LOC across 3 files. Pure docs + 1-line test migration; the actual code change is a docstring update.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_