### PR TITLE
PR-Audit-MINOR-Batch-2: parser strictness + slug length cap (blog_generation)

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -71,8 +71,16 @@ def parse_blog_post_response(text: str) -> dict[str, Any] | None:
         if not isinstance(decoded, Mapping):
             continue
         title = str(decoded.get("title") or "").strip()
-        content = str(decoded.get("content") or "").strip()
-        if title and content:
+        # PR-Audit-MINOR-Batch-2: parser identifies a candidate (non-empty
+        # ``title``); the quality pack judges the rest. Pre-fix required
+        # both ``title`` AND ``content`` so a missing-content draft would
+        # collapse to ``unparseable_response`` -- a missing-content blocker
+        # at the quality-pack layer is more useful. (Empty content fires
+        # ``content_too_short`` because zero words is below any min_words.)
+        # ``content`` is still stripped here when present so downstream
+        # consumers see normalized whitespace.
+        if title:
+            content = str(decoded.get("content") or "").strip()
             return {**dict(decoded), "title": title, "content": content}
     return None
 
@@ -393,9 +401,20 @@ def _blueprint_id(blueprint: Mapping[str, Any]) -> str:
     ).strip()
 
 
+# PR-Audit-MINOR-Batch-2: cap slug length at 100 chars. Pre-fix, a
+# 2000-char title produced a 2000-char slug -- valid but unwieldy for
+# CMS / URL routing (most expect <100). Truncation rather than
+# rejection: a long-title draft is still valid; the slug just gets
+# clipped. ``rstrip("-")`` after the cut prevents trailing-hyphen
+# artifacts (``"a-very-long--"``).
+_MAX_SLUG_CHARS = 100
+
+
 def _slugify(value: Any) -> str:
     text = str(value or "blog-post").strip().lower()
     slug = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    if len(slug) > _MAX_SLUG_CHARS:
+        slug = slug[:_MAX_SLUG_CHARS].rstrip("-")
     return slug or "blog-post"
 
 

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -94,7 +94,7 @@ def _blog_generation_user_prompt(
         return (
             f"{base_prompt}\n\n"
             "The previous response could not be parsed as the required JSON object. "
-            "Return one JSON object with non-empty title and content. "
+            "Return one JSON object with a non-empty title. "
             f"Previous response excerpt:\n{prior_invalid_response}"
         )
     return base_prompt

--- a/plans/PR-Audit-MINOR-Batch-2.md
+++ b/plans/PR-Audit-MINOR-Batch-2.md
@@ -1,0 +1,111 @@
+# PR-Audit-MINOR-Batch-2: parser strictness + slug length cap (blog_generation)
+
+## Why this slice exists
+
+Two related audit MINORs in ``blog_generation.py``. Several other
+audit findings I considered for this batch turned out to be already
+addressed by intermediate PRs (the API status-code split / provider
+exception wrapping / scope sequence stripping all landed in
+later commits). This batch closes the two genuinely-still-open
+findings in the blog generator.
+
+1. **MINOR — ``parse_blog_post_response`` rejects valid JSON missing
+   title or content.** The parser requires BOTH ``title`` and
+   ``content`` to be non-empty before returning a candidate. If the
+   LLM emits ``{"title": "..."}`` but no ``content`` (or vice versa),
+   the parser returns ``None`` and the executor reports
+   ``unparseable_response``. A specific blocker would be more useful.
+   The audit's prescribed fix matches the
+   ``landing_page_generation.py`` pattern from PR-OptionA-1: parser
+   identifies "is this a candidate" minimally; the quality pack
+   judges the rest.
+2. **MINOR — Slug has no length limit.** ``_slugify`` returns
+   whatever the input title-or-fallback produces. A 2000-char title
+   becomes a 2000-char slug. Most CMS / URL routing expects slugs
+   ``<100`` chars.
+
+## Scope (this PR)
+
+Two small fixes in ``extracted_content_pipeline/blog_generation.py``
+plus regression tests.
+
+### Fix 1: relax parser to ``if title:``
+
+```python
+# Before
+title = str(decoded.get("title") or "").strip()
+content = str(decoded.get("content") or "").strip()
+if title and content:
+    return {**dict(decoded), "title": title, "content": content}
+
+# After
+title = str(decoded.get("title") or "").strip()
+if title:
+    return {**dict(decoded), "title": title}
+```
+
+Empty ``content`` now flows to the quality pack which already fires
+``content_too_short`` when the body is empty (zero words is below
+``min_words`` regardless of threshold). Operators see a precise
+blocker instead of ``unparseable_response``.
+
+The parser still requires ``title`` because that's the minimum
+"is this a blog-post candidate" filter -- otherwise any well-formed
+JSON object could be picked up.
+
+### Fix 2: cap slug length at 100
+
+```python
+_MAX_SLUG_CHARS = 100  # CMS / URL convention; same shape as SEO meta limit
+
+def _slugify(value: Any) -> str:
+    text = str(value or "blog-post").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    if len(slug) > _MAX_SLUG_CHARS:
+        slug = slug[:_MAX_SLUG_CHARS].rstrip("-")
+    return slug or "blog-post"
+```
+
+Trailing hyphen strip after truncation prevents ``"a-very-long-..."``
+becoming ``"a-very-long--"``.
+
+## Intentional (looks wrong but is deliberate)
+
+- **Parser keeps ``title`` as the minimum filter.** Could relax
+  further (any well-formed JSON object), but that risks picking up
+  unrelated objects in the response (e.g., a metadata block before
+  the actual blog draft). Title is the cheapest "this is a blog
+  candidate" signal.
+- **100-char slug cap is the standard convention.** Not configurable
+  per call -- that would be plumbing without a real driver. If a
+  host wants a different cap, they can post-process the slug
+  before persistence.
+- **Truncation rather than rejection.** A 200-char title is still
+  a valid blog post; the slug just gets clipped. Rejection would
+  drop drafts unnecessarily.
+
+## Deferred (still on purpose)
+
+- ``_accumulate_usage`` cumulative-usage assumption (audit MINOR).
+- ``_landing_page_config_for_request`` discards request (audit
+  MINOR).
+- Host concurrency assumption documentation (audit MINOR).
+- ``for_output`` if/elif chain (audit NIT).
+- ``describe_control_surfaces`` calls execution-services per request
+  (audit MINOR) -- needs separate caching design.
+- ``topic`` for blog_post.
+- ``PR-Campaign-Config-V2``.
+
+## Verification
+
+- ``pytest tests/test_extracted_blog_generation.py`` -> all passing
+- ``python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`` -> clean
+- ``bash scripts/check_ascii_python.sh`` -> passed
+
+## Sibling references
+
+- Audit doc:
+  ``docs/audits/ai_content_ops_post_merge_audit_2026-05.md``
+- Same parser-strictness pattern fixed in PR-OptionA-1 (review
+  finding on ``parse_landing_page_response``).

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -173,9 +173,17 @@ def test_parse_blog_post_response_strips_code_fences() -> None:
 
 
 def test_parse_blog_post_response_returns_none_when_required_fields_missing() -> None:
+    """PR-Audit-MINOR-Batch-2: parser only requires ``title`` as the
+    "is this a candidate" filter; ``content`` is delegated to the
+    quality pack (empty content fires ``content_too_short``)."""
     assert parse_blog_post_response("") is None
-    assert parse_blog_post_response('{"title": "No content"}') is None
+    # Missing title -> not a candidate.
     assert parse_blog_post_response('{"content": "No title"}') is None
+    # Missing content -> still a candidate; the quality pack judges it.
+    parsed = parse_blog_post_response('{"title": "No content"}')
+    assert parsed is not None
+    assert parsed["title"] == "No content"
+    assert parsed["content"] == ""
 
 
 @pytest.mark.asyncio
@@ -396,3 +404,39 @@ async def test_generate_per_call_parse_retry_response_excerpt_chars_override():
     assert "XXX" in retry_user_prompt
     excerpt_section = retry_user_prompt.split("excerpt:")[1].lstrip()
     assert len(excerpt_section.rstrip()) <= 50
+
+
+# -----------------------
+# PR-Audit-MINOR-Batch-2: slug length cap + parser-strictness loosening
+# -----------------------
+
+
+def test_slugify_truncates_to_100_chars():
+    """A long title produces a clipped slug, not a 2000-char monstrosity."""
+    from extracted_content_pipeline.blog_generation import _slugify
+
+    long_title = "this is a very long blog post title " * 20  # ~700 chars
+    slug = _slugify(long_title)
+    assert len(slug) <= 100
+    # No trailing hyphen artifact from the truncation point.
+    assert not slug.endswith("-")
+
+
+def test_slugify_short_input_unchanged():
+    from extracted_content_pipeline.blog_generation import _slugify
+
+    assert _slugify("Short Title") == "short-title"
+    assert _slugify("") == "blog-post"
+    assert _slugify(None) == "blog-post"
+
+
+def test_parse_blog_post_response_accepts_missing_content_for_quality_pack_to_judge():
+    """End-to-end shape: a JSON candidate with title but no content
+    is still returned by the parser; the executor passes it to the
+    quality pack which fires ``content_too_short`` on empty content.
+    Pre-fix, missing content collapsed to ``unparseable_response``."""
+    parsed = parse_blog_post_response('{"title": "Has title only"}')
+    assert parsed is not None
+    assert parsed["title"] == "Has title only"
+    # Content is normalized to "" -- quality pack handles the rest.
+    assert parsed["content"] == ""

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -248,6 +248,29 @@ async def test_generate_blocks_low_quality_posts_without_saving() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_routes_missing_content_to_quality_blocked_not_unparseable() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload.pop("content")
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        responses=[json.dumps(payload)],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 70},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert any("content_too_short" in blocker for blocker in result.errors[0]["blockers"])
+    assert blog_posts.saved == []
+
+
+@pytest.mark.asyncio
 async def test_generate_reports_unparseable_responses() -> None:
     service, _blueprints, blog_posts, _llm, _skills = _service(
         responses=["not json", "still not json"]


### PR DESCRIPTION
**Plan:** [`plans/PR-Audit-MINOR-Batch-2.md`](../blob/claude/pr-audit-minor-batch-2/plans/PR-Audit-MINOR-Batch-2.md)

## Summary

Two audit MINORs in `blog_generation.py`. Several other audit findings I considered for this batch turned out to already be addressed by intermediate PRs (API status-code split, provider exception wrapping, scope sequence stripping all landed in later commits).

## What changed

### Fix 1: `parse_blog_post_response` — relax to `if title:`

Pre-fix required both `title` AND `content` non-empty; missing-content drafts collapsed to `unparseable_response`. Now the parser identifies "is this a candidate" via non-empty `title`; the quality pack judges the rest (`content_too_short` fires on empty body). Same shape as the parser-strictness fix in PR-OptionA-1 for `parse_landing_page_response`.

### Fix 2: `_slugify` — cap at 100 chars

Pre-fix produced unbounded slugs (2000-char title → 2000-char slug). Capped at `_MAX_SLUG_CHARS = 100` with `rstrip("-")` to prevent trailing-hyphen artifacts after truncation.

## Intentional (looks wrong but is deliberate)

- **Parser keeps `title` as the minimum filter.** Could relax further (any well-formed JSON object), but that risks picking up unrelated objects in the response. Title is the cheapest "this is a blog candidate" signal.
- **100-char slug cap is the standard convention.** Not configurable per call — that would be plumbing without a real driver. If a host wants a different cap, they post-process before persistence.
- **Truncation rather than rejection.** A long-title draft is still valid; the slug just gets clipped.
- **`content` is still stripped on the parser path** (when present) so downstream consumers see normalized whitespace. Not gating, just normalizing.

## Deferred (still on purpose)

- `_accumulate_usage` cumulative-usage assumption (audit MINOR).
- `_landing_page_config_for_request` discards request (audit MINOR).
- Host concurrency assumption documentation (audit MINOR).
- `for_output` if/elif chain (audit NIT).
- `describe_control_surfaces` calls execution-services per request (audit MINOR) — needs separate caching design.
- `topic` for blog_post.
- `PR-Campaign-Config-V2`.

## Test plan

- [x] `pytest tests/test_extracted_blog_generation.py` → 15 passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Size: ~25 LOC source + ~50 LOC tests + ~95 LOC plan doc = ~170 LOC across 3 files. Comfortably under budget; the two fixes are small and the tests are tightly scoped.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_