### PR TITLE
Parameterize signal extraction smoke source row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-07T03:00Z by codex-2026-05-07-d33-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-smoke-config
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Parameterize signal extraction smoke source row | EDIT: `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py` | codex-content-ops-signal-smoke-config | Avoid editing the Content Ops execution smoke CLI/test while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-smoke-config
+Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-smoke-config-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Parameterize signal extraction smoke source row | EDIT: `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py` | codex-content-ops-signal-smoke-config | Avoid editing the Content Ops execution smoke CLI/test while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -93,6 +93,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--source-material",
         default="Pricing became hard to justify after renewal.",
     )
+    parser.add_argument("--source-id", default="source-smoke-1")
+    parser.add_argument("--source-vendor", default="HubSpot")
+    parser.add_argument("--source-contact-email", default="buyer@example.com")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 
@@ -110,11 +113,11 @@ def _payload(args: argparse.Namespace) -> dict[str, Any]:
             "campaign_name": args.campaign_name,
             "source_material": [
                 {
-                    "id": "source-smoke-1",
+                    "id": str(args.source_id or "").strip() or "source-smoke-1",
                     "company": args.target_account,
-                    "vendor": "HubSpot",
+                    "vendor": args.source_vendor,
                     "text": args.source_material,
-                    "contact_email": "buyer@example.com",
+                    "contact_email": args.source_contact_email,
                 }
             ],
         },

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -93,6 +93,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--source-material",
         default="Pricing became hard to justify after renewal.",
     )
+    parser.add_argument("--source-id", default="source-smoke-1")
+    parser.add_argument("--source-vendor", default="HubSpot")
+    parser.add_argument("--source-contact-email", default="buyer@example.com")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 
@@ -110,11 +113,11 @@ def _payload(args: argparse.Namespace) -> dict[str, Any]:
             "campaign_name": args.campaign_name,
             "source_material": [
                 {
-                    "id": "source-smoke-1",
+                    "id": args.source_id,
                     "company": args.target_account,
-                    "vendor": "HubSpot",
+                    "vendor": args.source_vendor,
                     "text": args.source_material,
-                    "contact_email": "buyer@example.com",
+                    "contact_email": args.source_contact_email,
                 }
             ],
         },

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -88,6 +88,35 @@ def test_content_ops_execution_smoke_cli_runs_signal_extraction_json() -> None:
     )
 
 
+def test_content_ops_execution_smoke_cli_parameterizes_signal_source_row() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--outputs",
+            "signal_extraction",
+            "--source-id",
+            "source-42",
+            "--source-vendor",
+            "Salesforce",
+            "--source-contact-email",
+            "ops@example.com",
+            "--source-material",
+            "The renewal created finance pressure.",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    opportunity = payload["steps"][0]["result"]["opportunities"][0]
+    assert opportunity["target_id"] == "source-42"
+    assert opportunity["vendor"] == "Salesforce"
+    assert opportunity["contact_email"] == "ops@example.com"
+
+
 def test_content_ops_execution_smoke_fails_when_required_inputs_missing() -> None:
     completed = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- add source id, vendor, and contact email flags to the Content Ops execution smoke CLI
- wire those values into the signal extraction source-material payload
- cover the configurable source row path in the smoke CLI tests

## Verification
- pytest tests/test_extracted_content_ops_execution_smoke.py -q
- python -m py_compile scripts/smoke_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py
- git diff --check
- ASCII grep on edited Python files
- bash scripts/run_extracted_pipeline_checks.sh