### PR TITLE
Document signal extraction execution smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-smoke-config-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-execution-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Document signal extraction execution smoke path | EDIT: `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `extracted_content_pipeline/STATUS.md` | codex-content-ops-signal-execution-docs | Avoid editing Content Ops signal-extraction execution docs while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -585,10 +585,12 @@ smoke before wiring real asset services:
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --json
 ```
 
-This validates the full campaign preset through host-injected deterministic
-services without opening database, network, sender, or LLM handles.
+This validates the full campaign preset and the deterministic source-material
+normalization path through host-injected services without opening database,
+network, sender, or LLM handles.
 
 Hosts can inject a `visibility_provider` when mounting the router. The four
 POST operation routes emit best-effort `campaign_operation_started`,

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -98,12 +98,13 @@
 - `content_ops_execution` provides the host-injected execution seam for
   runnable AI Content Ops control-surface plans. It dispatches executable
   outputs to configured campaign, blog-post, report, landing-page, and
-  sales-brief services without constructing hidden database, LLM, or Atlas
-  dependencies.
+  sales-brief services, plus deterministic signal extraction, without
+  constructing hidden database, LLM, or Atlas dependencies.
 - `scripts/smoke_extracted_content_ops_execution.py` provides a no-network,
   no-database smoke for the multi-asset Content Ops execution seam. It runs the
-  full campaign preset through injected offline services so hosts can validate
-  execution wiring separately from real provider credentials.
+  full campaign preset and signal-extraction path through injected offline
+  services so hosts can validate execution wiring separately from real provider
+  credentials.
 - `campaign_generation` retries unparseable LLM JSON once by default through
   product config, improving draft yield without moving provider retry policy
   into Atlas runtime code.

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -217,11 +217,14 @@ Before wiring real providers, hosts can run the offline execution smoke:
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --json
 ```
 
 The smoke uses injected deterministic services and exercises the same
 `execute_content_ops_from_mapping(...)` seam as the API route. It does not
-open network, database, sender, or LLM handles.
+open network, database, sender, or LLM handles. The signal extraction command
+validates the deterministic source-material-to-opportunity path through the
+same execution seam.
 
 Runnable outputs dispatch to:
 
@@ -232,6 +235,7 @@ Runnable outputs dispatch to:
 | `report` | `ReportGenerationService.generate(...)` |
 | `landing_page` | `LandingPageGenerationService.generate(...)` |
 | `sales_brief` | `SalesBriefGenerationService.generate(...)` |
+| `signal_extraction` | `SignalExtractionService.generate(...)` |
 
 Non-executable plans return HTTP 400 with the blocked execution result. Missing
 or failing execution/scope providers return HTTP 503. Service-level failures are


### PR DESCRIPTION
## Summary
- add the signal extraction execution smoke command to the Content Ops README and control-surface docs
- document SignalExtractionService in the runnable output dispatch table
- update STATUS so the execution seam reflects deterministic signal extraction alongside generated assets

## Verification
- git diff --check
- ASCII grep on touched docs
- rg verification for signal extraction smoke/service references