### PR TITLE
Expose signal extraction source text cap

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-text-cap
+Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-text-cap-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Expose signal extraction source text cap | EDIT: `extracted_content_pipeline/generation_plan.py`; `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_generation_plan.py`; `tests/test_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py`; docs if needed | codex-content-ops-signal-text-cap | Avoid editing signal extraction plan/smoke text-cap handling while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-execution-docs
+Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-text-cap
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Document signal extraction execution smoke path | EDIT: `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `extracted_content_pipeline/STATUS.md` | codex-content-ops-signal-execution-docs | Avoid editing Content Ops signal-extraction execution docs while this PR is active. |
+| (in flight) | Expose signal extraction source text cap | EDIT: `extracted_content_pipeline/generation_plan.py`; `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_generation_plan.py`; `tests/test_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py`; docs if needed | codex-content-ops-signal-text-cap | Avoid editing signal extraction plan/smoke text-cap handling while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -585,7 +585,7 @@ smoke before wiring real asset services:
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
-python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 1200 --json
 ```
 
 This validates the full campaign preset and the deterministic source-material

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -585,7 +585,7 @@ smoke before wiring real asset services:
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
-python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 1200 --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
 ```
 
 This validates the full campaign preset and the deterministic source-material

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -189,7 +189,10 @@ def create_content_ops_control_surface_router(
     async def plan_generation(
         payload: ContentOpsRequestModel = Body(...),
     ) -> dict[str, Any]:
-        return build_generation_plan_from_mapping(_payload_to_mapping(payload))
+        try:
+            return build_generation_plan_from_mapping(_payload_to_mapping(payload))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/execute")
     async def execute_generation(
@@ -207,11 +210,14 @@ def create_content_ops_control_surface_router(
                 detail="Content Ops execution services are not configured.",
             )
         scope = await _resolve_scope(scope_provider)
-        result = await execute_content_ops_from_mapping(
-            _payload_to_mapping(payload),
-            services=services,
-            scope=scope,
-        )
+        try:
+            result = await execute_content_ops_from_mapping(
+                _payload_to_mapping(payload),
+                services=services,
+                scope=scope,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         result = _sanitize_execution_result(result)
         if result["status"] == "blocked":
             raise HTTPException(status_code=400, detail=result)

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -217,7 +217,7 @@ Before wiring real providers, hosts can run the offline execution smoke:
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
-python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 1200 --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
 ```
 
 The smoke uses injected deterministic services and exercises the same

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -217,7 +217,7 @@ Before wiring real providers, hosts can run the offline execution smoke:
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
-python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 1200 --json
 ```
 
 The smoke uses injected deterministic services and exercises the same

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -125,7 +125,29 @@ def _blog_post_config_for_request(request: ContentOpsRequest) -> BlogPostGenerat
 def _signal_extraction_config_for_request(
     request: ContentOpsRequest,
 ) -> SignalExtractionConfig:
-    return SignalExtractionConfig(limit=request.limit)
+    config = SignalExtractionConfig(limit=request.limit)
+    max_text_chars = _positive_int_input(request.inputs, "source_max_text_chars")
+    if max_text_chars is None:
+        return config
+    return SignalExtractionConfig(
+        limit=config.limit,
+        max_text_chars=max_text_chars,
+    )
+
+
+def _positive_int_input(inputs: Mapping[str, Any], key: str) -> int | None:
+    raw = inputs.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        raise ValueError(f"{key} must be an integer")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be an integer") from None
+    if value < 1:
+        raise ValueError(f"{key} must be at least 1; got {value}")
+    return value
 
 
 def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanStep:

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -139,7 +139,7 @@ def _positive_int_input(inputs: Mapping[str, Any], key: str) -> int | None:
     raw = inputs.get(key)
     if raw is None:
         return None
-    if isinstance(raw, bool):
+    if isinstance(raw, (bool, float)):
         raise ValueError(f"{key} must be an integer")
     try:
         value = int(raw)

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -96,6 +96,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--source-id", default="source-smoke-1")
     parser.add_argument("--source-vendor", default="HubSpot")
     parser.add_argument("--source-contact-email", default="buyer@example.com")
+    parser.add_argument("--source-max-text-chars", type=int)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 
@@ -122,6 +123,8 @@ def _payload(args: argparse.Namespace) -> dict[str, Any]:
             ],
         },
     }
+    if args.source_max_text_chars is not None:
+        payload["inputs"]["source_max_text_chars"] = args.source_max_text_chars
     if args.outputs:
         payload["outputs"] = [
             item.strip()

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -96,7 +96,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--source-id", default="source-smoke-1")
     parser.add_argument("--source-vendor", default="HubSpot")
     parser.add_argument("--source-contact-email", default="buyer@example.com")
-    parser.add_argument("--source-max-text-chars", type=int)
+    parser.add_argument(
+        "--source-max-text-chars",
+        type=int,
+        help=(
+            "Cap evidence text at this many characters before signal extraction. "
+            "Omit to use the service default (1200)."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -208,6 +208,28 @@ async def test_plan_generation_route_returns_execution_plan():
 
 
 @pytest.mark.asyncio
+async def test_plan_generation_route_rejects_invalid_signal_text_cap_as_400():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/plan", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["signal_extraction"],
+                "inputs": {
+                    "source_material": "Pricing pressure came up at renewal.",
+                    "source_max_text_chars": 0,
+                },
+            }
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "source_max_text_chars must be at least 1; got 0"
+
+
+@pytest.mark.asyncio
 async def test_execute_generation_route_runs_configured_services():
     service = _CampaignService()
     router = create_content_ops_control_surface_router(
@@ -241,6 +263,31 @@ async def test_execute_generation_route_runs_configured_services():
     assert service.calls[0]["target_mode"] == "vendor_retention"
     assert service.calls[0]["limit"] == 2
     assert service.calls[0]["filters"] == {"status": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_rejects_invalid_signal_text_cap_as_400():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            signal_extraction=_CampaignService()
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["signal_extraction"],
+                "inputs": {
+                    "source_material": "Pricing pressure came up at renewal.",
+                    "source_max_text_chars": 0,
+                },
+            }
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "source_max_text_chars must be at least 1; got 0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -208,14 +208,25 @@ def test_plan_threads_signal_extraction_source_text_cap():
     assert plan["steps"][0]["config"]["max_text_chars"] == 12
 
 
-def test_plan_rejects_invalid_signal_extraction_source_text_cap():
-    with pytest.raises(ValueError, match="source_max_text_chars must be at least 1"):
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (True, "source_max_text_chars must be an integer"),
+        (False, "source_max_text_chars must be an integer"),
+        ("abc", "source_max_text_chars must be an integer"),
+        (3.7, "source_max_text_chars must be an integer"),
+        (-1, "source_max_text_chars must be at least 1"),
+        (0, "source_max_text_chars must be at least 1"),
+    ],
+)
+def test_plan_rejects_invalid_signal_extraction_source_text_cap(value, message):
+    with pytest.raises(ValueError, match=message):
         build_generation_plan_from_mapping(
             {
                 "outputs": ["signal_extraction"],
                 "inputs": {
                     "source_material": "Pricing pressure came up at renewal.",
-                    "source_max_text_chars": 0,
+                    "source_max_text_chars": value,
                 },
             }
         )

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -1,3 +1,5 @@
+import pytest
+
 from extracted_content_pipeline.generation_plan import build_generation_plan_from_mapping
 
 
@@ -189,3 +191,31 @@ def test_plan_maps_signal_extraction_to_signal_extraction_service():
         "limit": 3,
         "max_text_chars": 1200,
     }
+
+
+def test_plan_threads_signal_extraction_source_text_cap():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["signal_extraction"],
+            "inputs": {
+                "source_material": "Pricing pressure came up at renewal.",
+                "source_max_text_chars": 12,
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["config"]["max_text_chars"] == 12
+
+
+def test_plan_rejects_invalid_signal_extraction_source_text_cap():
+    with pytest.raises(ValueError, match="source_max_text_chars must be at least 1"):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": ["signal_extraction"],
+                "inputs": {
+                    "source_material": "Pricing pressure came up at renewal.",
+                    "source_max_text_chars": 0,
+                },
+            }
+        )

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -287,6 +287,7 @@ async def test_execute_runs_signal_extraction_service_from_source_material() -> 
         {
             "outputs": ["signal_extraction"],
             "inputs": {
+                "source_max_text_chars": 7,
                 "source_material": [
                     {
                         "id": "review-1",
@@ -307,7 +308,9 @@ async def test_execute_runs_signal_extraction_service_from_source_material() -> 
     step = result["steps"][0]
     assert step["output"] == "signal_extraction"
     assert step["result"]["generated"] == 1
-    assert step["result"]["opportunities"][0]["target_id"] == "review-1"
+    opportunity = step["result"]["opportunities"][0]
+    assert opportunity["target_id"] == "review-1"
+    assert opportunity["evidence"][0]["text"] == "Pricing"
     assert step["result"]["warnings"] == []
 
 

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -101,6 +101,8 @@ def test_content_ops_execution_smoke_cli_parameterizes_signal_source_row() -> No
             "Salesforce",
             "--source-contact-email",
             "ops@example.com",
+            "--source-max-text-chars",
+            "11",
             "--source-material",
             "The renewal created finance pressure.",
             "--json",
@@ -115,6 +117,7 @@ def test_content_ops_execution_smoke_cli_parameterizes_signal_source_row() -> No
     assert opportunity["target_id"] == "source-42"
     assert opportunity["vendor"] == "Salesforce"
     assert opportunity["contact_email"] == "ops@example.com"
+    assert opportunity["evidence"][0]["text"] == "The renewal"
 
 
 def test_content_ops_execution_smoke_fails_when_required_inputs_missing() -> None:


### PR DESCRIPTION
## Summary
- thread `inputs.source_max_text_chars` into the signal extraction generation plan
- add `--source-max-text-chars` to the offline Content Ops execution smoke CLI
- cover plan config, execution truncation, invalid input, and smoke CLI behavior
- clear the stale #387 coordination row while claiming this slice

## Verification
- `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py tests/test_extracted_signal_extraction.py -q`
- `python -m py_compile extracted_content_pipeline/generation_plan.py scripts/smoke_extracted_content_ops_execution.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py`
- `git diff --check`
- ASCII grep on edited Python/docs files
- `bash scripts/run_extracted_pipeline_checks.sh`