### PR TITLE
Expose Content Ops reasoning requirement catalog

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-signal-text-cap-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-reasoning-catalog
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Expose Content Ops reasoning requirement in output catalog | EDIT: `extracted_content_pipeline/control_surfaces.py`; `extracted_content_pipeline/api/control_surfaces.py`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; related tests/status docs | codex-content-ops-reasoning-catalog | Avoid editing Content Ops output catalog reasoning fields while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-reasoning-catalog
+Last updated: 2026-05-08T00:00Z by codex-content-ops-reasoning-catalog-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Expose Content Ops reasoning requirement in output catalog | EDIT: `extracted_content_pipeline/control_surfaces.py`; `extracted_content_pipeline/api/control_surfaces.py`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; related tests/status docs | codex-content-ops-reasoning-catalog | Avoid editing Content Ops output catalog reasoning fields while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -121,7 +121,9 @@
   multi-asset AI Content Ops control surfaces. The execute route is disabled
   unless the host supplies execution services. The catalog route reports which
   implemented outputs are actually wired to host execution services so admin
-  UIs do not confuse package implementation status with runtime readiness.
+  UIs do not confuse package implementation status with runtime readiness. The
+  output catalog also reports whether each output can consume host-provided
+  reasoning context or does not use the reasoning-provider path.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -156,6 +156,7 @@ def create_content_ops_control_surface_router(
                     ),
                     "required_inputs": list(item.required_inputs),
                     "default_max_items": item.default_max_items,
+                    "reasoning_requirement": item.reasoning_requirement,
                 }
                 for item in OUTPUT_CATALOG.values()
             ],

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -24,6 +24,7 @@ class OutputDefinition:
     estimated_unit_cost_usd: float
     required_inputs: tuple[str, ...] = ()
     default_max_items: int = 1
+    reasoning_requirement: str = "absent"
     # Must mirror each *GenerationConfig.parse_retry_attempts default used in
     # generation_plan.py. If a service raises retries, update this field too.
     default_parse_retry_attempts: int = 1
@@ -103,6 +104,7 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         estimated_unit_cost_usd=0.18,
         required_inputs=("target_account", "offer"),
         default_max_items=3,
+        reasoning_requirement="optional_host_context",
     ),
     "blog_post": OutputDefinition(
         id="blog_post",
@@ -119,6 +121,7 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         implemented=True,
         estimated_unit_cost_usd=0.55,
         required_inputs=("opportunity_id",),
+        reasoning_requirement="optional_host_context",
     ),
     "landing_page": OutputDefinition(
         id="landing_page",
@@ -127,6 +130,7 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         implemented=True,
         estimated_unit_cost_usd=0.65,
         required_inputs=("offer", "audience"),
+        reasoning_requirement="optional_host_context",
     ),
     "sales_brief": OutputDefinition(
         id="sales_brief",
@@ -135,6 +139,7 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         implemented=True,
         estimated_unit_cost_usd=0.35,
         required_inputs=("target_account",),
+        reasoning_requirement="optional_host_context",
     ),
     "signal_extraction": OutputDefinition(
         id="signal_extraction",

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -61,18 +61,21 @@ size and nesting limits.
 
 Current output ids:
 
-| Output | Status | Notes |
-|---|---|---|
-| `email_campaign` | Implemented | Existing campaign draft path. |
-| `blog_post` | Implemented | Blog-post generation service path. |
-| `report` | Implemented | Structured report draft path. |
-| `landing_page` | Implemented | Landing page generation service path. |
-| `sales_brief` | Implemented | Sales brief generation service path. |
-| `signal_extraction` | Implemented | Deterministic source-row normalization into campaign opportunities; no LLM call. |
+| Output | Status | Reasoning | Notes |
+|---|---|---|---|
+| `email_campaign` | Implemented | `optional_host_context` | Existing campaign draft path. |
+| `blog_post` | Implemented | `absent` | Blog-post generation service path. |
+| `report` | Implemented | `optional_host_context` | Structured report draft path. |
+| `landing_page` | Implemented | `optional_host_context` | Landing page generation service path. |
+| `sales_brief` | Implemented | `optional_host_context` | Sales brief generation service path. |
+| `signal_extraction` | Implemented | `absent` | Deterministic source-row normalization into campaign opportunities; no LLM call. |
 
 Future outputs should be added to the catalog first, then exposed through
 presets only after the implementation and quality gate exist. Yes, this is less
 exciting than shipping a toggle that lies to users. That is the point.
+`optional_host_context` means the output can consume precomputed reasoning from
+a host or separate reasoning product, but does not run synthesis internally.
+`absent` means the output does not use the reasoning-provider path.
 
 ## Presets
 

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -60,6 +60,9 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["email_campaign"]["estimated_unit_cost_usd"] == 0.18
     assert outputs["email_campaign"]["default_parse_retry_attempts"] == 1
     assert outputs["email_campaign"]["estimated_retry_adjusted_unit_cost_usd"] == 0.36
+    assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
+    assert outputs["blog_post"]["reasoning_requirement"] == "absent"
+    assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
     assert payload["execution"] == {"configured": False, "configured_outputs": []}
     assert "email_only" in preset_ids
     assert "lead_gen_campaign" in preset_ids

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -157,6 +157,17 @@ def test_preview_keeps_signal_extraction_blocked_without_source_material():
     assert preview["missing_inputs"] == ["source_material"]
 
 
+def test_output_catalog_states_reasoning_requirement():
+    from extracted_content_pipeline.control_surfaces import OUTPUT_CATALOG
+
+    assert OUTPUT_CATALOG["email_campaign"].reasoning_requirement == "optional_host_context"
+    assert OUTPUT_CATALOG["report"].reasoning_requirement == "optional_host_context"
+    assert OUTPUT_CATALOG["landing_page"].reasoning_requirement == "optional_host_context"
+    assert OUTPUT_CATALOG["sales_brief"].reasoning_requirement == "optional_host_context"
+    assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "absent"
+    assert OUTPUT_CATALOG["signal_extraction"].reasoning_requirement == "absent"
+
+
 def test_request_from_mapping_rejects_zero_limit():
     with pytest.raises(ValueError, match="limit must be at least 1; got 0"):
         request_from_mapping({"limit": 0})


### PR DESCRIPTION
## Summary
- add `reasoning_requirement` to the Content Ops output catalog
- expose the field through `/content-ops/control-surfaces`
- document which outputs can consume host-provided reasoning context versus no reasoning-provider path

## Verification
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q`
- `python -m py_compile extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py`
- `git diff --check`
- ASCII grep on edited Python/docs files
- `bash scripts/run_extracted_pipeline_checks.sh`
