### PR TITLE
Add target mode override to Content Ops smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-reasoning-catalog-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add target-mode override to Content Ops execution smoke | EDIT: `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py`; docs if needed | codex-content-ops-smoke-target-mode | Avoid editing the Content Ops execution smoke CLI target-mode handling while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode
+Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add target-mode override to Content Ops execution smoke | EDIT: `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py`; docs if needed | codex-content-ops-smoke-target-mode | Avoid editing the Content Ops execution smoke CLI target-mode handling while this PR is active. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -83,6 +83,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Comma-separated output ids. Overrides --preset when supplied.",
     )
     parser.add_argument("--limit", type=int, default=1)
+    parser.add_argument("--target-mode", default="vendor_retention")
     parser.add_argument("--target-account", default="Acme")
     parser.add_argument("--offer", default="Churn intelligence audit")
     parser.add_argument("--topic", default="Churn pressure")
@@ -111,6 +112,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def _payload(args: argparse.Namespace) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "preset": str(args.preset or "").strip() or "full_campaign",
+        "target_mode": str(args.target_mode or "").strip() or "vendor_retention",
         "limit": max(1, int(args.limit or 1)),
         "inputs": {
             "target_account": args.target_account,

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -47,7 +47,7 @@ def test_content_ops_execution_smoke_cli_accepts_output_subset_json() -> None:
             "--outputs",
             "email_campaign,report",
             "--target-mode",
-            "account_expansion",
+            "challenger_intel",
             "--limit",
             "2",
             "--json",
@@ -64,8 +64,8 @@ def test_content_ops_execution_smoke_cli_accepts_output_subset_json() -> None:
         "report",
     ]
     assert payload["steps"][0]["result"]["generated"] == 2
-    assert payload["steps"][0]["result"]["target_mode"] == "account_expansion"
-    assert payload["steps"][1]["result"]["target_mode"] == "account_expansion"
+    assert payload["steps"][0]["result"]["target_mode"] == "challenger_intel"
+    assert payload["steps"][1]["result"]["target_mode"] == "challenger_intel"
 
 
 def test_content_ops_execution_smoke_cli_runs_signal_extraction_json() -> None:

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -46,6 +46,8 @@ def test_content_ops_execution_smoke_cli_accepts_output_subset_json() -> None:
             str(CLI),
             "--outputs",
             "email_campaign,report",
+            "--target-mode",
+            "account_expansion",
             "--limit",
             "2",
             "--json",
@@ -62,6 +64,8 @@ def test_content_ops_execution_smoke_cli_accepts_output_subset_json() -> None:
         "report",
     ]
     assert payload["steps"][0]["result"]["generated"] == 2
+    assert payload["steps"][0]["result"]["target_mode"] == "account_expansion"
+    assert payload["steps"][1]["result"]["target_mode"] == "account_expansion"
 
 
 def test_content_ops_execution_smoke_cli_runs_signal_extraction_json() -> None:


### PR DESCRIPTION
## Summary
- add `--target-mode` to the offline Content Ops execution smoke CLI
- include the selected target mode in the generated request payload
- assert the override reaches generated asset service results

## Verification
- `pytest tests/test_extracted_content_ops_execution_smoke.py -q`
- `python -m py_compile scripts/smoke_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py`
- `git diff --check`
- ASCII grep on edited Python files
- `bash scripts/run_extracted_pipeline_checks.sh`
