### PR TITLE
Expose quality-gate toggle in Content Ops smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-quality-gates
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Expose quality-gate toggle in Content Ops execution smoke | EDIT: `scripts/smoke_extracted_content_ops_execution.py`; EDIT: `tests/test_extracted_content_ops_execution_smoke.py`; EDIT: `extracted_content_pipeline/README.md`; EDIT: `extracted_content_pipeline/docs/control_surface_preview_api.md` | codex-content-ops-smoke-quality-gates | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-quality-gates
+Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Expose quality-gate toggle in Content Ops execution smoke | EDIT: `scripts/smoke_extracted_content_ops_execution.py`; EDIT: `tests/test_extracted_content_ops_execution_smoke.py`; EDIT: `extracted_content_pipeline/README.md`; EDIT: `extracted_content_pipeline/docs/control_surface_preview_api.md` | codex-content-ops-smoke-quality-gates | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -584,13 +584,15 @@ smoke before wiring real asset services:
 
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
-python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --target-mode challenger_intel --no-quality-gates --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
 ```
 
 This validates the full campaign preset and the deterministic source-material
 normalization path through host-injected services without opening database,
-network, sender, or LLM handles.
+network, sender, or LLM handles. `--no-quality-gates` is an execution-smoke
+override for checking the request wiring; production hosts should leave quality
+gates enabled unless they intentionally disable them in their own policy layer.
 
 Hosts can inject a `visibility_provider` when mounting the router. The four
 POST operation routes emit best-effort `campaign_operation_started`,

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -219,7 +219,7 @@ Before wiring real providers, hosts can run the offline execution smoke:
 
 ```bash
 python scripts/smoke_extracted_content_ops_execution.py
-python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --target-mode challenger_intel --no-quality-gates --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
 ```
 
@@ -227,7 +227,9 @@ The smoke uses injected deterministic services and exercises the same
 `execute_content_ops_from_mapping(...)` seam as the API route. It does not
 open network, database, sender, or LLM handles. The signal extraction command
 validates the deterministic source-material-to-opportunity path through the
-same execution seam.
+same execution seam. `--no-quality-gates` verifies request wiring for hosts
+that need to smoke-test policy overrides; production hosts should leave quality
+gates enabled unless their own policy layer disables them.
 
 Runnable outputs dispatch to:
 

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -26,7 +26,7 @@ from extracted_content_pipeline.signal_extraction import SignalExtractionService
 # (channels, default_report_type, default_brief_type, temperature,
 # max_tokens, parse_retry_attempts, parse_retry_response_excerpt_chars,
 # quality_revalidation_enabled, quality_prompt_proof_term_limit,
-# quality_gates_enabled). The smoke fakes accept (and ignore) those via
+# quality_gates_enabled). The smoke fakes accept those via
 # ``**extras`` -- this CLI exercises the seam end-to-end, not the kwargs
 # contract. Strict per-kwarg assertions live in the dispatcher tests in
 # ``tests/test_extracted_content_ops_execution.py``.
@@ -43,14 +43,21 @@ class _OpportunityAssetService:
         filters: Mapping[str, Any] | None = None,
         **extras: Any,
     ) -> dict[str, Any]:
-        del scope, extras
-        return {
+        del scope
+        result = {
             "generated": int(limit or 1),
             "asset": self.name,
             "target_mode": target_mode,
             "filters": dict(filters or {}),
             "saved_ids": [f"{self.name}-draft-1"],
         }
+        if "quality_gates_enabled" in extras:
+            result["quality_gates_enabled"] = extras["quality_gates_enabled"]
+        if "quality_revalidation_enabled" in extras:
+            result["quality_revalidation_enabled"] = extras[
+                "quality_revalidation_enabled"
+            ]
+        return result
 
 
 class _LandingPageAssetService:
@@ -61,13 +68,16 @@ class _LandingPageAssetService:
         campaign: Any,
         **extras: Any,
     ) -> dict[str, Any]:
-        del scope, extras
-        return {
+        del scope
+        result = {
             "generated": 1,
             "asset": "landing_page",
             "campaign_name": getattr(campaign, "name", ""),
             "saved_ids": ["landing-page-draft-1"],
         }
+        if "quality_gates_enabled" in extras:
+            result["quality_gates_enabled"] = extras["quality_gates_enabled"]
+        return result
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -83,7 +93,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Comma-separated output ids. Overrides --preset when supplied.",
     )
     parser.add_argument("--limit", type=int, default=1)
-    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument(
+        "--target-mode",
+        default="vendor_retention",
+        help="Target mode to pass through the execution request.",
+    )
+    parser.add_argument(
+        "--no-quality-gates",
+        action="store_true",
+        help="Set require_quality_gates=false in the execution request.",
+    )
     parser.add_argument("--target-account", default="Acme")
     parser.add_argument("--offer", default="Churn intelligence audit")
     parser.add_argument("--topic", default="Churn pressure")
@@ -113,6 +132,7 @@ def _payload(args: argparse.Namespace) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "preset": str(args.preset or "").strip() or "full_campaign",
         "target_mode": str(args.target_mode or "").strip() or "vendor_retention",
+        "require_quality_gates": not bool(args.no_quality_gates),
         "limit": max(1, int(args.limit or 1)),
         "inputs": {
             "target_account": args.target_account,

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -48,6 +48,7 @@ def test_content_ops_execution_smoke_cli_accepts_output_subset_json() -> None:
             "email_campaign,report",
             "--target-mode",
             "challenger_intel",
+            "--no-quality-gates",
             "--limit",
             "2",
             "--json",
@@ -66,6 +67,12 @@ def test_content_ops_execution_smoke_cli_accepts_output_subset_json() -> None:
     assert payload["steps"][0]["result"]["generated"] == 2
     assert payload["steps"][0]["result"]["target_mode"] == "challenger_intel"
     assert payload["steps"][1]["result"]["target_mode"] == "challenger_intel"
+    assert payload["steps"][0]["result"]["quality_revalidation_enabled"] is False
+    assert payload["steps"][1]["result"]["quality_gates_enabled"] is False
+    assert (
+        payload["plan"]["preview"]["normalized_request"]["require_quality_gates"]
+        is False
+    )
 
 
 def test_content_ops_execution_smoke_cli_runs_signal_extraction_json() -> None:


### PR DESCRIPTION
## Summary
- add a --no-quality-gates override to the offline Content Ops execution smoke
- echo dispatched quality flags from smoke fake services so subprocess coverage verifies request threading
- document the target-mode + quality-gate smoke command in Content Ops docs

## Tests
- python -m py_compile scripts/smoke_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py
- pytest tests/test_extracted_content_ops_execution_smoke.py -q
- bash scripts/run_extracted_pipeline_checks.sh
- git diff --check

## Coordination
- Claimed in docs/extraction/coordination/inflight.md; no competitive-intelligence files touched.