### PR TITLE
Consolidate Content Ops parse retry helpers

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-parse-retry-helpers
+Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Consolidate Content Ops parse-retry helpers | NEW: `extracted_content_pipeline/services/_parse_retry_helpers.py`; EDIT: `extracted_content_pipeline/campaign_generation.py`; EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `extracted_content_pipeline/report_generation.py`; EDIT: `extracted_content_pipeline/landing_page_generation.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; NEW: `tests/test_extracted_parse_retry_helpers.py` | codex-content-ops-parse-retry-helpers | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-parse-retry-helpers
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Consolidate Content Ops parse-retry helpers | NEW: `extracted_content_pipeline/services/_parse_retry_helpers.py`; EDIT: `extracted_content_pipeline/campaign_generation.py`; EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `extracted_content_pipeline/report_generation.py`; EDIT: `extracted_content_pipeline/landing_page_generation.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; NEW: `tests/test_extracted_parse_retry_helpers.py` | codex-content-ops-parse-retry-helpers | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from .blog_ports import BlogBlueprintRepository, BlogPostDraft, BlogPostRepository
 from .campaign_ports import LLMClient, LLMMessage, SkillStore, TenantScope
+from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
 from extracted_quality_gate.blog_pack import evaluate_blog_post
 from extracted_quality_gate.types import QualityInput, QualityPolicy
 
@@ -98,34 +99,6 @@ def _blog_generation_user_prompt(
             f"Previous response excerpt:\n{prior_invalid_response}"
         )
     return base_prompt
-
-
-def _clip_invalid_response(text: str, *, limit: int) -> str:
-    cleaned = str(text or "").strip()
-    if len(cleaned) <= limit:
-        return cleaned
-    return cleaned[:limit].rstrip()
-
-
-def _accumulate_usage(
-    total: Mapping[str, Any],
-    usage: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    accumulated = dict(total)
-    if not isinstance(usage, Mapping):
-        return accumulated
-    for key, value in usage.items():
-        if isinstance(value, bool):
-            accumulated[key] = value
-        elif isinstance(value, (int, float)):
-            prior = accumulated.get(key)
-            if isinstance(prior, (int, float)) and not isinstance(prior, bool):
-                accumulated[key] = prior + value
-            else:
-                accumulated[key] = value
-        else:
-            accumulated[key] = value
-    return accumulated
 
 
 class BlogPostGenerationService:
@@ -292,7 +265,7 @@ class BlogPostGenerationService:
                     "attempt_no": attempt_no,
                 },
             )
-            total_usage = _accumulate_usage(total_usage, response.usage)
+            total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_blog_post_response(response.content)
             if parsed:
                 return {
@@ -301,7 +274,7 @@ class BlogPostGenerationService:
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                 }
-            last_response = _clip_invalid_response(
+            last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -28,6 +28,7 @@ from .services.campaign_reasoning_context import (
     normalize_campaign_reasoning_context,
 )
 from .services.campaign_quality import campaign_quality_revalidation
+from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
 
 
 _PROOF_TERM_TEXT_KEYS = ("excerpt_text", "quote", "text", "anchor", "value")
@@ -126,34 +127,6 @@ def _campaign_generation_user_prompt(
             f"Previous response excerpt:\n{prior_invalid_response}"
         )
     return prompt
-
-
-def _clip_invalid_response(text: str, *, limit: int) -> str:
-    cleaned = str(text or "").strip()
-    if len(cleaned) <= limit:
-        return cleaned
-    return cleaned[:limit].rstrip()
-
-
-def _accumulate_usage(
-    total: Mapping[str, Any],
-    usage: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    accumulated = dict(total)
-    if not isinstance(usage, Mapping):
-        return accumulated
-    for key, value in usage.items():
-        if isinstance(value, bool):
-            accumulated[key] = value
-        elif isinstance(value, (int, float)):
-            prior = accumulated.get(key)
-            if isinstance(prior, (int, float)) and not isinstance(prior, bool):
-                accumulated[key] = prior + value
-            else:
-                accumulated[key] = value
-        else:
-            accumulated[key] = value
-    return accumulated
 
 
 @dataclass(frozen=True)
@@ -598,7 +571,7 @@ class CampaignGenerationService:
                     "attempt_no": attempt_no,
                 },
             )
-            total_usage = _accumulate_usage(total_usage, response.usage)
+            total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_campaign_draft_response(response.content)
             if parsed:
                 return {
@@ -607,7 +580,7 @@ class CampaignGenerationService:
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                 }
-            last_response = _clip_invalid_response(
+            last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -46,6 +46,7 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
+from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
 from extracted_quality_gate.landing_page_pack import evaluate_landing_page
 from extracted_quality_gate.types import QualityInput, QualityPolicy
 
@@ -157,34 +158,6 @@ def _landing_page_user_prompt(prior_invalid_response: str = "") -> str:
             f"Previous response excerpt:\n{prior_invalid_response}"
         )
     return prompt
-
-
-def _clip_invalid_response(text: str, *, limit: int) -> str:
-    cleaned = str(text or "").strip()
-    if len(cleaned) <= limit:
-        return cleaned
-    return cleaned[:limit].rstrip()
-
-
-def _accumulate_usage(
-    total: Mapping[str, Any],
-    usage: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    accumulated = dict(total)
-    if not isinstance(usage, Mapping):
-        return accumulated
-    for key, value in usage.items():
-        if isinstance(value, bool):
-            accumulated[key] = value
-        elif isinstance(value, (int, float)):
-            prior = accumulated.get(key)
-            if isinstance(prior, (int, float)) and not isinstance(prior, bool):
-                accumulated[key] = prior + value
-            else:
-                accumulated[key] = value
-        else:
-            accumulated[key] = value
-    return accumulated
 
 
 class LandingPageGenerationService:
@@ -390,7 +363,7 @@ class LandingPageGenerationService:
                     "attempt_no": attempt_no,
                 },
             )
-            total_usage = _accumulate_usage(total_usage, response.usage)
+            total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_landing_page_response(response.content)
             if parsed:
                 return {
@@ -399,7 +372,7 @@ class LandingPageGenerationService:
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                 }
-            last_response = _clip_invalid_response(
+            last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -368,6 +368,9 @@
       "target": "extracted_content_pipeline/services/campaign_quality.py"
     },
     {
+      "target": "extracted_content_pipeline/services/_parse_retry_helpers.py"
+    },
+    {
       "target": "extracted_content_pipeline/templates/__init__.py"
     },
     {

--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -45,6 +45,7 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
+from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
 from extracted_quality_gate.report_pack import evaluate_report
 from extracted_quality_gate.types import QualityInput
 
@@ -149,34 +150,6 @@ def _report_user_prompt(prior_invalid_response: str = "") -> str:
             f"Previous response excerpt:\n{prior_invalid_response}"
         )
     return prompt
-
-
-def _clip_invalid_response(text: str, *, limit: int) -> str:
-    cleaned = str(text or "").strip()
-    if len(cleaned) <= limit:
-        return cleaned
-    return cleaned[:limit].rstrip()
-
-
-def _accumulate_usage(
-    total: Mapping[str, Any],
-    usage: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    accumulated = dict(total)
-    if not isinstance(usage, Mapping):
-        return accumulated
-    for key, value in usage.items():
-        if isinstance(value, bool):
-            accumulated[key] = value
-        elif isinstance(value, (int, float)):
-            prior = accumulated.get(key)
-            if isinstance(prior, (int, float)) and not isinstance(prior, bool):
-                accumulated[key] = prior + value
-            else:
-                accumulated[key] = value
-        else:
-            accumulated[key] = value
-    return accumulated
 
 
 class ReportGenerationService:
@@ -406,7 +379,7 @@ class ReportGenerationService:
                     "attempt_no": attempt_no,
                 },
             )
-            total_usage = _accumulate_usage(total_usage, response.usage)
+            total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_report_response(response.content)
             if parsed:
                 return {
@@ -415,7 +388,7 @@ class ReportGenerationService:
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                 }
-            last_response = _clip_invalid_response(
+            last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -57,6 +57,7 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
+from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
 from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
 from extracted_quality_gate.types import QualityInput, QualityPolicy
 
@@ -165,34 +166,6 @@ def _sales_brief_user_prompt(prior_invalid_response: str = "") -> str:
             f"Previous response excerpt:\n{prior_invalid_response}"
         )
     return prompt
-
-
-def _clip_invalid_response(text: str, *, limit: int) -> str:
-    cleaned = str(text or "").strip()
-    if len(cleaned) <= limit:
-        return cleaned
-    return cleaned[:limit].rstrip()
-
-
-def _accumulate_usage(
-    total: Mapping[str, Any],
-    usage: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    accumulated = dict(total)
-    if not isinstance(usage, Mapping):
-        return accumulated
-    for key, value in usage.items():
-        if isinstance(value, bool):
-            accumulated[key] = value
-        elif isinstance(value, (int, float)):
-            prior = accumulated.get(key)
-            if isinstance(prior, (int, float)) and not isinstance(prior, bool):
-                accumulated[key] = prior + value
-            else:
-                accumulated[key] = value
-        else:
-            accumulated[key] = value
-    return accumulated
 
 
 class SalesBriefGenerationService:
@@ -427,7 +400,7 @@ class SalesBriefGenerationService:
                     "attempt_no": attempt_no,
                 },
             )
-            total_usage = _accumulate_usage(total_usage, response.usage)
+            total_usage = accumulate_usage(total_usage, response.usage)
             parsed = parse_sales_brief_response(response.content)
             if parsed:
                 return {
@@ -436,7 +409,7 @@ class SalesBriefGenerationService:
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
                 }
-            last_response = _clip_invalid_response(
+            last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )

--- a/extracted_content_pipeline/services/_parse_retry_helpers.py
+++ b/extracted_content_pipeline/services/_parse_retry_helpers.py
@@ -1,0 +1,38 @@
+"""Shared parse-retry helpers for generated content asset services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def clip_invalid_response(text: str, *, limit: int) -> str:
+    """Return a stripped response excerpt capped to ``limit`` characters."""
+
+    cleaned = str(text or "").strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[:limit].rstrip()
+
+
+def accumulate_usage(
+    total: Mapping[str, Any],
+    usage: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Accumulate numeric usage fields while preserving non-numeric metadata."""
+
+    accumulated = dict(total)
+    if not isinstance(usage, Mapping):
+        return accumulated
+    for key, value in usage.items():
+        if isinstance(value, bool):
+            accumulated[key] = value
+        elif isinstance(value, (int, float)):
+            prior = accumulated.get(key)
+            if isinstance(prior, (int, float)) and not isinstance(prior, bool):
+                accumulated[key] = prior + value
+            else:
+                accumulated[key] = value
+        else:
+            accumulated[key] = value
+    return accumulated

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -30,6 +30,7 @@ pytest \
   tests/test_extracted_content_control_surface_api.py \
   tests/test_extracted_content_ops_execution.py \
   tests/test_extracted_content_ops_execution_smoke.py \
+  tests/test_extracted_parse_retry_helpers.py \
   tests/test_extracted_report_postgres.py \
   tests/test_extracted_report_generation.py \
   tests/test_extracted_quality_gate_report_pack.py \

--- a/tests/test_extracted_parse_retry_helpers.py
+++ b/tests/test_extracted_parse_retry_helpers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+)
+
+
+def test_clip_invalid_response_strips_and_caps_text() -> None:
+    assert clip_invalid_response("  abcdef  ", limit=4) == "abcd"
+
+
+def test_clip_invalid_response_returns_cleaned_text_when_within_limit() -> None:
+    assert clip_invalid_response("  ok  ", limit=10) == "ok"
+
+
+def test_accumulate_usage_adds_numeric_fields() -> None:
+    assert accumulate_usage(
+        {"input_tokens": 10, "output_tokens": 5},
+        {"input_tokens": 2, "output_tokens": 3},
+    ) == {"input_tokens": 12, "output_tokens": 8}
+
+
+def test_accumulate_usage_preserves_bool_and_metadata_fields() -> None:
+    assert accumulate_usage(
+        {"cached": False, "model": "first"},
+        {"cached": True, "model": "second", "provider": "host"},
+    ) == {"cached": True, "model": "second", "provider": "host"}
+
+
+def test_accumulate_usage_ignores_non_mapping_usage() -> None:
+    assert accumulate_usage({"input_tokens": 10}, None) == {"input_tokens": 10}


### PR DESCRIPTION
## Summary
- add a shared parse-retry helper module for clipping invalid LLM responses and accumulating usage metadata
- replace duplicated helper copies in campaign, blog, report, landing-page, and sales-brief generators
- add helper unit coverage and include it in extracted pipeline checks

## Tests
- python -m py_compile extracted_content_pipeline/services/_parse_retry_helpers.py extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/blog_generation.py extracted_content_pipeline/report_generation.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/sales_brief_generation.py tests/test_extracted_parse_retry_helpers.py
- pytest tests/test_extracted_parse_retry_helpers.py tests/test_extracted_campaign_generation.py tests/test_extracted_blog_generation.py tests/test_extracted_report_generation.py tests/test_extracted_landing_page_generation.py tests/test_extracted_sales_brief_generation.py tests/test_extracted_campaign_manifest.py -q
- bash scripts/run_extracted_pipeline_checks.sh
- git diff --check

## Coordination
- Claimed in docs/extraction/coordination/inflight.md; no competitive-intelligence files touched.