### PR TITLE
Centralize Content Ops parse retry attempt count

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-parse-attempt-limit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Centralize Content Ops parse retry attempt count | EDIT: `extracted_content_pipeline/services/_parse_retry_helpers.py`; EDIT: `extracted_content_pipeline/campaign_generation.py`; EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `extracted_content_pipeline/report_generation.py`; EDIT: `extracted_content_pipeline/landing_page_generation.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; EDIT: `tests/test_extracted_parse_retry_helpers.py` | codex-content-ops-parse-attempt-limit | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-parse-attempt-limit
+Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Centralize Content Ops parse retry attempt count | EDIT: `extracted_content_pipeline/services/_parse_retry_helpers.py`; EDIT: `extracted_content_pipeline/campaign_generation.py`; EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `extracted_content_pipeline/report_generation.py`; EDIT: `extracted_content_pipeline/landing_page_generation.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; EDIT: `tests/test_extracted_parse_retry_helpers.py` | codex-content-ops-parse-attempt-limit | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -10,7 +10,11 @@ from typing import Any
 
 from .blog_ports import BlogBlueprintRepository, BlogPostDraft, BlogPostRepository
 from .campaign_ports import LLMClient, LLMMessage, SkillStore, TenantScope
-from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
+from .services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+    parse_attempt_limit,
+)
 from extracted_quality_gate.blog_pack import evaluate_blog_post
 from extracted_quality_gate.types import QualityInput, QualityPolicy
 
@@ -240,7 +244,7 @@ class BlogPostGenerationService:
         else:
             system_prompt = prompt_template
             base_user_prompt = f"Generate one blog post from this blueprint JSON:\n{blueprint_json}"
-        attempts = max(1, int(parse_retry_attempts or 0) + 1)
+        attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
         for attempt_no in range(1, attempts + 1):

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -28,7 +28,11 @@ from .services.campaign_reasoning_context import (
     normalize_campaign_reasoning_context,
 )
 from .services.campaign_quality import campaign_quality_revalidation
-from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
+from .services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+    parse_attempt_limit,
+)
 
 
 _PROOF_TERM_TEXT_KEYS = ("excerpt_text", "quote", "text", "anchor", "value")
@@ -544,7 +548,7 @@ class CampaignGenerationService:
             .replace("{opportunity}", opportunity_json)
             .replace("{opportunity_json}", opportunity_json)
         )
-        attempts = max(1, int(parse_retry_attempts or 0) + 1)
+        attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
         for attempt_no in range(1, attempts + 1):

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -46,7 +46,11 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
-from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
+from .services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+    parse_attempt_limit,
+)
 from extracted_quality_gate.landing_page_pack import evaluate_landing_page
 from extracted_quality_gate.types import QualityInput, QualityPolicy
 
@@ -341,7 +345,7 @@ class LandingPageGenerationService:
         # via {campaign_json}. User message is structural-only so the
         # campaign isn't sent twice (matches the report-generator fix).
         system_prompt = prompt_template.replace("{campaign_json}", campaign_json)
-        attempts = max(1, int(parse_retry_attempts or 0) + 1)
+        attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
         for attempt_no in range(1, attempts + 1):

--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -45,7 +45,11 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
-from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
+from .services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+    parse_attempt_limit,
+)
 from extracted_quality_gate.report_pack import evaluate_report
 from extracted_quality_gate.types import QualityInput
 
@@ -360,7 +364,7 @@ class ReportGenerationService:
             .replace("{target_mode}", target_mode)
             .replace("{opportunity_json}", opportunity_json)
         )
-        attempts = max(1, int(parse_retry_attempts or 0) + 1)
+        attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
         for attempt_no in range(1, attempts + 1):

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -57,7 +57,11 @@ from .services.campaign_reasoning_context import (
     campaign_reasoning_context_payload,
     normalize_campaign_reasoning_context,
 )
-from .services._parse_retry_helpers import accumulate_usage, clip_invalid_response
+from .services._parse_retry_helpers import (
+    accumulate_usage,
+    clip_invalid_response,
+    parse_attempt_limit,
+)
 from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
 from extracted_quality_gate.types import QualityInput, QualityPolicy
 
@@ -378,7 +382,7 @@ class SalesBriefGenerationService:
             .replace("{target_mode}", target_mode)
             .replace("{opportunity_json}", opportunity_json)
         )
-        attempts = max(1, int(parse_retry_attempts or 0) + 1)
+        attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
         for attempt_no in range(1, attempts + 1):

--- a/extracted_content_pipeline/services/_parse_retry_helpers.py
+++ b/extracted_content_pipeline/services/_parse_retry_helpers.py
@@ -15,6 +15,12 @@ def clip_invalid_response(text: str, *, limit: int) -> str:
     return cleaned[:limit].rstrip()
 
 
+def parse_attempt_limit(parse_retry_attempts: int) -> int:
+    """Return total parse attempts: one initial attempt plus configured retries."""
+
+    return max(1, int(parse_retry_attempts or 0) + 1)
+
+
 def accumulate_usage(
     total: Mapping[str, Any],
     usage: Mapping[str, Any] | None,

--- a/tests/test_extracted_parse_retry_helpers.py
+++ b/tests/test_extracted_parse_retry_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from extracted_content_pipeline.services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
+    parse_attempt_limit,
 )
 
 
@@ -12,6 +13,16 @@ def test_clip_invalid_response_strips_and_caps_text() -> None:
 
 def test_clip_invalid_response_returns_cleaned_text_when_within_limit() -> None:
     assert clip_invalid_response("  ok  ", limit=10) == "ok"
+
+
+def test_parse_attempt_limit_counts_initial_attempt_plus_retries() -> None:
+    assert parse_attempt_limit(0) == 1
+    assert parse_attempt_limit(1) == 2
+    assert parse_attempt_limit(2) == 3
+
+
+def test_parse_attempt_limit_clamps_negative_values_to_initial_attempt() -> None:
+    assert parse_attempt_limit(-3) == 1
 
 
 def test_accumulate_usage_adds_numeric_fields() -> None:


### PR DESCRIPTION
## Summary
- add parse_attempt_limit() to the shared Content Ops parse-retry helpers
- replace duplicated retry-loop attempt count calculations across campaign, blog, report, landing-page, and sales-brief generators
- pin the shared attempt-count contract in helper tests

## Tests
- python -m py_compile extracted_content_pipeline/services/_parse_retry_helpers.py extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/blog_generation.py extracted_content_pipeline/report_generation.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/sales_brief_generation.py tests/test_extracted_parse_retry_helpers.py
- pytest tests/test_extracted_parse_retry_helpers.py tests/test_extracted_campaign_generation.py tests/test_extracted_blog_generation.py tests/test_extracted_report_generation.py tests/test_extracted_landing_page_generation.py tests/test_extracted_sales_brief_generation.py -q
- bash scripts/run_extracted_pipeline_checks.sh
- git diff --check

## Coordination
- Claimed in docs/extraction/coordination/inflight.md; no competitive-intelligence files touched.