### PR TITLE
Centralize Content Ops parse retry prompt appendix

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-08T00:00Z by codex-content-ops-smoke-target-mode-cleanup
+Last updated: 2026-05-08T00:00Z by codex-content-ops-parse-retry-prompt-helper
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Centralize Content Ops parse retry prompt appendix | EDIT: `extracted_content_pipeline/services/_parse_retry_helpers.py`; EDIT: `extracted_content_pipeline/campaign_generation.py`; EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `extracted_content_pipeline/report_generation.py`; EDIT: `extracted_content_pipeline/landing_page_generation.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; EDIT: `tests/test_extracted_parse_retry_helpers.py` | codex-content-ops-parse-retry-prompt-helper | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -14,6 +14,7 @@ from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
+    retry_prompt_with_invalid_response,
 )
 from extracted_quality_gate.blog_pack import evaluate_blog_post
 from extracted_quality_gate.types import QualityInput, QualityPolicy
@@ -95,14 +96,14 @@ def _blog_generation_user_prompt(
     base_prompt: str,
     prior_invalid_response: str = "",
 ) -> str:
-    if prior_invalid_response:
-        return (
-            f"{base_prompt}\n\n"
+    return retry_prompt_with_invalid_response(
+        base_prompt,
+        prior_invalid_response=prior_invalid_response,
+        instruction=(
             "The previous response could not be parsed as the required JSON object. "
-            "Return one JSON object with a non-empty title. "
-            f"Previous response excerpt:\n{prior_invalid_response}"
-        )
-    return base_prompt
+            "Return one JSON object with a non-empty title."
+        ),
+    )
 
 
 class BlogPostGenerationService:

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -32,6 +32,7 @@ from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
+    retry_prompt_with_invalid_response,
 )
 
 
@@ -124,13 +125,14 @@ def _campaign_generation_user_prompt(
         f"channel={channel}\n"
         f"opportunity={opportunity_json}"
     )
-    if prior_invalid_response:
-        prompt += (
-            "\n\nThe previous response was not valid campaign JSON. "
-            "Return one JSON object with non-empty subject and body. "
-            f"Previous response excerpt:\n{prior_invalid_response}"
-        )
-    return prompt
+    return retry_prompt_with_invalid_response(
+        prompt,
+        prior_invalid_response=prior_invalid_response,
+        instruction=(
+            "The previous response was not valid campaign JSON. "
+            "Return one JSON object with non-empty subject and body."
+        ),
+    )
 
 
 @dataclass(frozen=True)

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -50,6 +50,7 @@ from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
+    retry_prompt_with_invalid_response,
 )
 from extracted_quality_gate.landing_page_pack import evaluate_landing_page
 from extracted_quality_gate.types import QualityInput, QualityPolicy
@@ -154,14 +155,14 @@ def parse_landing_page_response(text: str) -> dict[str, Any] | None:
 
 def _landing_page_user_prompt(prior_invalid_response: str = "") -> str:
     prompt = "Generate one landing page from the marketing campaign above."
-    if prior_invalid_response:
-        return (
-            f"{prompt}\n\n"
+    return retry_prompt_with_invalid_response(
+        prompt,
+        prior_invalid_response=prior_invalid_response,
+        instruction=(
             "The previous response could not be parsed as the required JSON object. "
-            "Return one JSON object with non-empty title and sections. "
-            f"Previous response excerpt:\n{prior_invalid_response}"
-        )
-    return prompt
+            "Return one JSON object with non-empty title and sections."
+        ),
+    )
 
 
 class LandingPageGenerationService:

--- a/extracted_content_pipeline/report_generation.py
+++ b/extracted_content_pipeline/report_generation.py
@@ -49,6 +49,7 @@ from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
+    retry_prompt_with_invalid_response,
 )
 from extracted_quality_gate.report_pack import evaluate_report
 from extracted_quality_gate.types import QualityInput
@@ -146,14 +147,14 @@ def parse_report_response(text: str) -> dict[str, Any] | None:
 
 def _report_user_prompt(prior_invalid_response: str = "") -> str:
     prompt = "Generate one structured report from the opportunity above."
-    if prior_invalid_response:
-        return (
-            f"{prompt}\n\n"
+    return retry_prompt_with_invalid_response(
+        prompt,
+        prior_invalid_response=prior_invalid_response,
+        instruction=(
             "The previous response could not be parsed as the required JSON object. "
-            "Return one JSON object with non-empty title, summary, and sections. "
-            f"Previous response excerpt:\n{prior_invalid_response}"
-        )
-    return prompt
+            "Return one JSON object with non-empty title, summary, and sections."
+        ),
+    )
 
 
 class ReportGenerationService:

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -61,6 +61,7 @@ from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
+    retry_prompt_with_invalid_response,
 )
 from extracted_quality_gate.sales_brief_pack import evaluate_sales_brief
 from extracted_quality_gate.types import QualityInput, QualityPolicy
@@ -162,14 +163,14 @@ def parse_sales_brief_response(text: str) -> dict[str, Any] | None:
 
 def _sales_brief_user_prompt(prior_invalid_response: str = "") -> str:
     prompt = "Generate one sales brief from the opportunity above."
-    if prior_invalid_response:
-        return (
-            f"{prompt}\n\n"
+    return retry_prompt_with_invalid_response(
+        prompt,
+        prior_invalid_response=prior_invalid_response,
+        instruction=(
             "The previous response could not be parsed as the required JSON object. "
-            "Return one JSON object with non-empty title and sections. "
-            f"Previous response excerpt:\n{prior_invalid_response}"
-        )
-    return prompt
+            "Return one JSON object with non-empty title and sections."
+        ),
+    )
 
 
 class SalesBriefGenerationService:

--- a/extracted_content_pipeline/services/_parse_retry_helpers.py
+++ b/extracted_content_pipeline/services/_parse_retry_helpers.py
@@ -21,6 +21,23 @@ def parse_attempt_limit(parse_retry_attempts: int) -> int:
     return max(1, int(parse_retry_attempts or 0) + 1)
 
 
+def retry_prompt_with_invalid_response(
+    base_prompt: str,
+    *,
+    prior_invalid_response: str,
+    instruction: str,
+) -> str:
+    """Append the standard invalid-response retry context when needed."""
+
+    if not prior_invalid_response:
+        return base_prompt
+    return (
+        f"{base_prompt}\n\n"
+        f"{instruction} "
+        f"Previous response excerpt:\n{prior_invalid_response}"
+    )
+
+
 def accumulate_usage(
     total: Mapping[str, Any],
     usage: Mapping[str, Any] | None,

--- a/tests/test_extracted_parse_retry_helpers.py
+++ b/tests/test_extracted_parse_retry_helpers.py
@@ -4,6 +4,7 @@ from extracted_content_pipeline.services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
+    retry_prompt_with_invalid_response,
 )
 
 
@@ -23,6 +24,22 @@ def test_parse_attempt_limit_counts_initial_attempt_plus_retries() -> None:
 
 def test_parse_attempt_limit_clamps_negative_values_to_initial_attempt() -> None:
     assert parse_attempt_limit(-3) == 1
+
+
+def test_retry_prompt_with_invalid_response_returns_base_without_prior() -> None:
+    assert retry_prompt_with_invalid_response(
+        "Base prompt",
+        prior_invalid_response="",
+        instruction="Return JSON.",
+    ) == "Base prompt"
+
+
+def test_retry_prompt_with_invalid_response_appends_instruction_and_excerpt() -> None:
+    assert retry_prompt_with_invalid_response(
+        "Base prompt",
+        prior_invalid_response="{bad",
+        instruction="Return JSON.",
+    ) == "Base prompt\n\nReturn JSON. Previous response excerpt:\n{bad"
 
 
 def test_accumulate_usage_adds_numeric_fields() -> None:


### PR DESCRIPTION
## Summary
- add retry_prompt_with_invalid_response() to the shared parse-retry helper module
- route campaign, blog, report, landing-page, and sales-brief retry prompts through the shared appendix helper
- preserve each asset service's existing retry instruction text

## Tests
- python -m py_compile extracted_content_pipeline/services/_parse_retry_helpers.py extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/blog_generation.py extracted_content_pipeline/report_generation.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/sales_brief_generation.py tests/test_extracted_parse_retry_helpers.py
- pytest tests/test_extracted_parse_retry_helpers.py tests/test_extracted_campaign_generation.py tests/test_extracted_blog_generation.py tests/test_extracted_report_generation.py tests/test_extracted_landing_page_generation.py tests/test_extracted_sales_brief_generation.py -q
- bash scripts/run_extracted_pipeline_checks.sh
- git diff --check

## Coordination
- Claimed in docs/extraction/coordination/inflight.md; no competitive-intelligence files touched.