### PR TITLE
PR-Audit-MINOR-Batch-3: document the assumptions (concurrency, per-call usage, landing-page config)

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -15,7 +15,16 @@ from .landing_page_ports import MarketingCampaign
 
 @dataclass(frozen=True)
 class ContentOpsExecutionServices:
-    """Host-provided services for runnable content-ops outputs."""
+    """Host-provided services for runnable content-ops outputs.
+
+    Services bundled here run **concurrently** when multiple outputs
+    are requested in a single plan -- the executor uses
+    ``asyncio.gather`` over plan steps. Each service must therefore be
+    safe under concurrent ``generate()`` invocation. Pure functions
+    and pool-backed services are fine; services with shared in-memory
+    state need locking or per-call scoping. See
+    ``execute_content_ops_request`` for the full concurrency contract.
+    """
 
     campaign: Any | None = None
     blog_post: Any | None = None
@@ -98,7 +107,19 @@ async def execute_content_ops_request(
     services: ContentOpsExecutionServices,
     scope: TenantScope | None = None,
 ) -> ContentOpsExecutionResult:
-    """Execute a runnable content-ops plan using host-provided services."""
+    """Execute a runnable content-ops plan using host-provided services.
+
+    **Concurrency contract (PR-Audit-MINOR-Batch-3):** plan steps run
+    concurrently via ``asyncio.gather``. Host-injected services may
+    therefore see overlapping ``generate()`` calls. Hosts must inject
+    services that are **safe under concurrent invocation** -- pure
+    functions, services backed by a connection pool, or services with
+    appropriate locks. A service that maintains in-memory state
+    (counters, queues, caches without per-call scoping) will race
+    silently. Hosts migrating from a single-step execution path
+    should audit their service for shared state before adopting the
+    control surface.
+    """
 
     plan = build_generation_plan(request)
     if not plan.can_execute:

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -103,7 +103,19 @@ def _report_config_for_request(request: ContentOpsRequest) -> ReportGenerationCo
 
 
 def _landing_page_config_for_request(request: ContentOpsRequest) -> LandingPageGenerationConfig:
-    del request
+    """Return defaults; the request is intentionally not consumed.
+
+    Other ``_*_config_for_request`` helpers thread ``request.inputs``
+    or ``request.limit`` into their config. Landing pages are
+    per-campaign single-shot (one MarketingCampaign in, one draft
+    out) so ``limit`` doesn't apply, and per-call inputs land on the
+    ``MarketingCampaign`` payload built by
+    ``content_ops_execution._marketing_campaign_from_inputs`` rather
+    than on the config dataclass. Discarding the request here is
+    deliberate -- documented to close the audit-trail gap on the
+    helper-shape asymmetry (PR-Audit-MINOR-Batch-3).
+    """
+    del request  # intentional; see docstring
     return LandingPageGenerationConfig()
 
 

--- a/extracted_content_pipeline/services/_parse_retry_helpers.py
+++ b/extracted_content_pipeline/services/_parse_retry_helpers.py
@@ -42,7 +42,18 @@ def accumulate_usage(
     total: Mapping[str, Any],
     usage: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
-    """Accumulate numeric usage fields while preserving non-numeric metadata."""
+    """Accumulate numeric usage fields while preserving non-numeric metadata.
+
+    **Assumes per-call usage.** ``usage`` is treated as the cost of *this
+    call only*; numeric fields are summed across calls. If the host's
+    LLM client returns *cumulative* session usage instead (some clients
+    do), retried generations will double-count tokens and inflate
+    ``metadata.generation_usage.input_tokens`` etc. Doesn't break
+    upstream behavior -- the field is informational -- but operators
+    debugging cost reports will see inflated numbers. If your client
+    emits cumulative usage, normalize to per-call before passing to
+    this helper.
+    """
 
     accumulated = dict(total)
     if not isinstance(usage, Mapping):

--- a/plans/PR-Audit-MINOR-Batch-3.md
+++ b/plans/PR-Audit-MINOR-Batch-3.md
@@ -1,0 +1,88 @@
+# PR-Audit-MINOR-Batch-3: document the assumptions
+
+## Why this slice exists
+
+Three audit MINORs that share a "document-the-assumption" shape.
+The fixes are docstring updates -- no behavior change. Scoping
+keeps the diff focused on three closely-related findings rather
+than a grab-bag.
+
+1. **MINOR -- ``accumulate_usage`` assumes per-call usage from the
+   LLM client.** Helper accumulates ``input_tokens`` across retry
+   attempts under the assumption that each ``llm.complete()`` call
+   returns *just that call's* usage. Some LLM clients return
+   *cumulative* session usage; on those, retries double-count.
+   Failure mode: inflated ``metadata.generation_usage.input_tokens``.
+   Doesn't break anything upstream, but operators debugging cost
+   reports will be confused.
+2. **MINOR -- ``_landing_page_config_for_request`` discards the
+   request.** Other ``_*_config_for_request`` helpers consume
+   ``request.inputs`` and ``request.limit``; this one
+   ``del request`` -s and returns defaults. Confusing to readers
+   comparing the helpers; documenting the asymmetry closes the
+   audit-trail gap. (Acting on the request would mean adding a
+   ``limit`` field to ``LandingPageGenerationConfig`` -- but
+   landing pages are per-campaign single-shot, so the field
+   wouldn't have a sensible meaning.)
+3. **MINOR -- Host service concurrency assumption is undocumented.**
+   ``execute_content_ops_request`` calls
+   ``asyncio.gather(*step_executions)`` -- host-injected services
+   run concurrently. A host that built their service against the
+   old single-step path may not realize this; if their service
+   maintains in-memory state, they get silent races.
+
+## Scope (this PR)
+
+Pure documentation. No behavior change. No new tests (these are
+docstring updates -- existing tests already lock the behavior).
+
+### Fix 1: ``accumulate_usage`` docstring
+
+Append a note to the existing helper's docstring about the per-call
+usage assumption.
+
+### Fix 2: ``_landing_page_config_for_request`` docstring
+
+Replace ``del request`` with a short docstring explaining why the
+request is intentionally discarded for this output.
+
+### Fix 3: ``ContentOpsExecutionServices`` / ``execute_content_ops_request`` docstring
+
+Add a docstring note to ``execute_content_ops_request`` (the public
+entry point) about concurrent service invocation and the
+re-entrancy expectation. Also touch the
+``ContentOpsExecutionServices`` dataclass docstring so hosts see it
+when constructing their service bundle.
+
+## Intentional (looks wrong but is deliberate)
+
+- **No new tests.** Three docstring updates; behavior is unchanged.
+  Adding tests that assert "the docstring contains certain text"
+  tests prose, not contract. The audit's request was to surface
+  the assumptions, not to add behavior.
+- **No cumulative-usage detection on ``accumulate_usage``.** The
+  audit suggested "detect cumulative usage by checking if
+  ``input_tokens`` is monotonically increasing" as an alternative
+  to the docstring fix. Detection adds heuristic logic that could
+  itself be wrong (a single retry with the same prompt may emit
+  the same token count both times). The docstring path is
+  cheaper, no chance of false positives, and surfaces the
+  assumption to hosts -- which is what the audit actually flagged.
+- **No new ``limit`` field on ``LandingPageGenerationConfig``.**
+  Landing pages are per-campaign single-shot; ``limit`` doesn't
+  apply. Documenting why is the right move.
+
+## Deferred (still on purpose)
+
+- ``for_output`` if/elif chain (audit NIT).
+- ``describe_control_surfaces`` calls execution-services per
+  request (audit MINOR) -- needs a separate caching design.
+- ``topic`` for blog_post.
+- ``PR-Campaign-Config-V2``.
+
+## Verification
+
+- ``python -c "from extracted_content_pipeline.services._parse_retry_helpers import accumulate_usage"`` -> imports
+- ``python -c "from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices, execute_content_ops_request"`` -> imports
+- ``python -c "from extracted_content_pipeline.generation_plan import build_generation_plan"`` -> imports
+- Existing tests on the touched files still pass (no behavior change).


### PR DESCRIPTION
**Plan:** [`plans/PR-Audit-MINOR-Batch-3.md`](../blob/claude/pr-audit-minor-batch-3/plans/PR-Audit-MINOR-Batch-3.md)

## Summary

Three audit MINORs that share a "document-the-assumption" shape. **Pure documentation — no behavior change, no new tests.**

## What changed

### 1. `accumulate_usage` — per-call usage assumption

Helper sums numeric usage fields across retry attempts on the assumption that each `llm.complete()` call returns *just that call's* usage. Some LLM clients return *cumulative* session usage instead; on those, retries double-count tokens and inflate `metadata.generation_usage.input_tokens`. Doesn't break upstream behavior — the field is informational — but operators debugging cost reports will be confused. Docstring now flags the assumption.

### 2. `_landing_page_config_for_request` — intentionally discards the request

Other `_*_config_for_request` helpers thread `request.inputs` / `request.limit` into their config; this one `del request` -s. Documenting why: landing pages are per-campaign single-shot (no `limit` applies), and per-call inputs land on the `MarketingCampaign` payload built by `_marketing_campaign_from_inputs` rather than on the config dataclass.

### 3. `ContentOpsExecutionServices` / `execute_content_ops_request` — concurrency contract

`execute_content_ops_request` calls `asyncio.gather(*step_executions)`. Host-injected services run concurrently. New docstrings on both the dataclass and the public entry-point spell out the re-entrancy expectation: pure functions or pool-backed services are fine; services with shared in-memory state need locking or per-call scoping.

## Intentional (looks wrong but is deliberate)

- **No new tests.** Three docstring updates; behavior is unchanged. Tests asserting docstring text would test prose, not contract.
- **No cumulative-usage detection on `accumulate_usage`.** Audit suggested "detect by checking if `input_tokens` is monotonically increasing" as an alternative. Detection adds heuristic logic that could itself be wrong (a single retry with the same prompt may emit the same token count both times). Docstring path: cheaper, no false positives, surfaces the assumption — which is what the audit actually flagged.
- **No new `limit` field on `LandingPageGenerationConfig`.** Landing pages are per-campaign single-shot; `limit` doesn't apply. Documenting why is the right move.

## Deferred (still on purpose)

- `for_output` if/elif chain (audit NIT).
- `describe_control_surfaces` calls execution-services per request (audit MINOR) — needs separate caching design.
- `topic` for blog_post.
- `PR-Campaign-Config-V2`.

## Test plan

- [x] `pytest tests/test_extracted_content_ops_execution.py tests/test_extracted_content_generation_plan.py tests/test_extracted_parse_retry_helpers.py tests/test_extracted_blog_generation.py tests/test_extracted_landing_page_generation.py` → 86 passed
- [x] `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` → clean
- [x] `bash scripts/check_ascii_python.sh` → passed

## Self-audit notes

Size: ~30 LOC source (docstrings only) + ~100 LOC plan doc = ~130 LOC across 4 files. Well under budget. Pure docs — exactly the audit's prescribed fix shape.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_