### PR TITLE
PR-Blog-Topic-Per-Call: thread per-call topic kwarg through blog generator

### DIFF
--- a/atlas_brain/skills/digest/blog_post_generation.md
+++ b/atlas_brain/skills/digest/blog_post_generation.md
@@ -10,6 +10,12 @@ version: 2
 
 You are an expert data journalist and product analyst. Given a structured blueprint containing real data from aggregated product reviews, write an engaging, authoritative blog post that helps consumers make informed purchasing decisions.
 
+## Operator focus
+
+{topic}
+
+(If the line above is empty, no operator-supplied topic was given for this generation; structure the post from the blueprint's `topic_type` and `suggested_title` alone. When a topic is present, weight the post toward that focus while staying faithful to the blueprint's evidence.)
+
 ## Input
 
 ```json

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -136,6 +136,7 @@ class BlogPostGenerationService:
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
+        topic: str | None = None,
     ) -> BlogPostGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -165,6 +166,9 @@ class BlogPostGenerationService:
             if quality_gates_enabled is None
             else bool(quality_gates_enabled)
         )
+        # PR-Blog-Topic-Per-Call: operator-supplied topic for this run.
+        # Empty string when None so prompt substitution is a clean no-op.
+        resolved_topic = (topic or "").strip()
 
         requested = int(limit or self._config.limit)
         rows = await self._blueprints.read_blog_blueprints(
@@ -189,6 +193,7 @@ class BlogPostGenerationService:
                     max_tokens=resolved_max_tokens,
                     parse_retry_attempts=resolved_parse_retry_attempts,
                     parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
+                    topic=resolved_topic,
                 )
             except Exception as exc:
                 skipped += 1
@@ -237,6 +242,7 @@ class BlogPostGenerationService:
         max_tokens: int,
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
+        topic: str = "",
     ) -> dict[str, Any] | None:
         blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
         if "{blueprint_json}" in prompt_template:
@@ -245,6 +251,11 @@ class BlogPostGenerationService:
         else:
             system_prompt = prompt_template
             base_user_prompt = f"Generate one blog post from this blueprint JSON:\n{blueprint_json}"
+        # PR-Blog-Topic-Per-Call: operator-supplied topic substitutes into
+        # the ``{topic}`` placeholder. Empty topic resolves to "" so hosts
+        # on the prior prompt (without ``{topic}``) are unaffected -- the
+        # ``replace()`` is a no-op when the placeholder isn't present.
+        system_prompt = system_prompt.replace("{topic}", topic)
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -347,6 +347,9 @@ async def _dispatch_blog_post(
     # handler so the LLM-tuning kwargs (temperature/max_tokens/
     # parse_retry_attempts) reach BlogPostGenerationService.generate. The
     # generic dispatcher remains for genuinely no-config future outputs.
+    # PR-Blog-Topic-Per-Call: ``topic`` is now load-bearing too; the plan
+    # emits ``step.config["topic"]`` from ``request.inputs.get("topic")``
+    # and the service's prompt has a ``{topic}`` placeholder.
     return await service.generate(
         scope=scope,
         target_mode=request.target_mode,
@@ -359,6 +362,7 @@ async def _dispatch_blog_post(
             step.config, "parse_retry_response_excerpt_chars"
         ),
         quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
+        topic=_step_config_text(step.config, "topic"),
     )
 
 

--- a/extracted_content_pipeline/skills/digest/blog_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/blog_post_generation.md
@@ -10,6 +10,12 @@ version: 2
 
 You are an expert data journalist and product analyst. Given a structured blueprint containing real data from aggregated product reviews, write an engaging, authoritative blog post that helps consumers make informed purchasing decisions.
 
+## Operator focus
+
+{topic}
+
+(If the line above is empty, no operator-supplied topic was given for this generation; structure the post from the blueprint's `topic_type` and `suggested_title` alone. When a topic is present, weight the post toward that focus while staying faithful to the blueprint's evidence.)
+
 ## Input
 
 ```json

--- a/plans/PR-Blog-Topic-Per-Call.md
+++ b/plans/PR-Blog-Topic-Per-Call.md
@@ -1,0 +1,113 @@
+# PR: thread `topic` per-call kwarg through BlogPostGenerationService
+
+## Why this slice exists
+
+Closes the "topic for blog_post" item that was deferred across the
+OptionA series. The plan layer emits ``step.config["topic"]`` from
+``request.inputs.get("topic")``, but the blog service has no service-
+side surface that consumes it -- the kwarg gets dropped at the
+executor and the prompt never sees the operator's topic.
+
+This PR:
+1. Adds a ``{topic}`` placeholder to the blog skill prompt.
+2. Adds ``topic: str | None = None`` to
+   ``BlogPostGenerationService.generate()``.
+3. Threads the resolved value through ``_generate_one`` into the
+   prompt-template substitution.
+4. Routes ``step.config["topic"]`` through the executor's blog
+   dispatcher.
+
+After this lands the operator's per-call topic actually steers the
+LLM. Same per-field-kwarg shape as OptionA-1 through OptionA-5.
+
+## Scope (this PR)
+
+Per-call ``topic`` kwarg only. No new abstraction; no other blog
+service surface changes. Skill prompt change is additive: a single
+``{topic}`` line at the input-context section.
+
+### Files touched
+
+1. ``extracted_content_pipeline/skills/digest/blog_post_generation.md``
+   -- add ``{topic}`` placeholder.
+2. ``extracted_content_pipeline/blog_generation.py`` -- new kwarg
+   on ``generate()``; resolved + threaded to ``_generate_one``;
+   prompt template substitution at the existing
+   ``{blueprint_json}`` site (or appended if no placeholder).
+3. ``extracted_content_pipeline/content_ops_execution.py`` -- blog
+   dispatcher gains ``topic=_step_config_text(step.config, "topic")``.
+4. Test fakes in ``tests/test_extracted_content_ops_execution.py``
+   (the ``_OpportunityService`` fake) gain ``topic`` as a named
+   kwarg so the existing ``extras == {}`` assertions stay accurate.
+5. New tests in ``tests/test_extracted_blog_generation.py`` and
+   ``tests/test_extracted_content_ops_execution.py``.
+
+## Mechanism
+
+```python
+# Service signature (added kwarg)
+async def generate(
+    self, *, scope, target_mode, limit=None, filters=None,
+    # ... existing OptionA-2/3/4/5 kwargs ...
+    topic: str | None = None,
+) -> BlogPostGenerationResult:
+    ...
+    resolved_topic = (topic or "").strip()  # empty string when None
+    ...
+    parsed = await self._generate_one(
+        prompt_template,
+        blueprint=blueprint,
+        target_mode=target_mode,
+        # ... resolved kwargs ...
+        topic=resolved_topic,
+    )
+
+# _generate_one (new param)
+async def _generate_one(
+    self, prompt_template, *, blueprint, target_mode, ..., topic: str,
+) -> dict[str, Any] | None:
+    system_prompt = prompt_template.replace("{topic}", topic)
+    ...
+```
+
+Prompt placeholder: empty topic resolves to ``""`` (silent no-op when
+the operator doesn't supply one). Hosts on the existing skill prompt
+without ``{topic}`` are unaffected -- the ``replace()`` no-ops.
+
+## Intentional (looks wrong but is deliberate)
+
+- **Resolved topic is a stripped string, not Optional[str].** The
+  service uses it for prompt substitution; ``None`` would propagate
+  weird types. Empty string is the clean "no override" sentinel for
+  prompt text.
+- **No fallback to ``blueprint.get("topic")``.** The blueprint's
+  ``topic`` field is an internal blog-blueprint concept (used for
+  ``_blueprint_id`` only, see ``blog_generation.py`` L378).
+  ``request.inputs["topic"]`` is operator-supplied per-call; mixing
+  the two surfaces would conflate unrelated concerns.
+- **Skill prompt change is additive.** Adding a ``{topic}``
+  placeholder doesn't break hosts on the prior version of the
+  prompt. If they pull updated skills, they get the new behavior;
+  if they don't, ``replace("{topic}", topic)`` is a no-op on their
+  unchanged prompt.
+- **No `default_topic` config field on
+  ``BlogPostGenerationConfig``.** Topic is per-call, not a
+  configuration knob. Operators set it per generation, not per
+  service-startup.
+
+## Deferred (still on purpose)
+
+- Reasoning context wiring on the new control-surface execute route
+  -- separate slice (PR-Reasoning-Wiring-1).
+- ``PR-Campaign-Config-V2`` (breaking change to remove the legacy
+  ``channel`` field).
+- Last few audit MINORs not yet touched.
+
+## Verification
+
+- ``pytest tests/test_extracted_blog_generation.py
+  tests/test_extracted_content_ops_execution.py
+  tests/test_extracted_content_generation_plan.py`` -> all passing
+- ``python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`` -> clean
+- ``bash scripts/check_ascii_python.sh`` -> passed

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -463,3 +463,74 @@ def test_parse_blog_post_response_accepts_missing_content_for_quality_pack_to_ju
     assert parsed["title"] == "Has title only"
     # Content is normalized to "" -- quality pack handles the rest.
     assert parsed["content"] == ""
+
+
+# -----------------------
+# PR-Blog-Topic-Per-Call: per-call topic kwarg substitutes into the prompt
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_per_call_topic_substitutes_into_prompt():
+    """Operator-supplied topic reaches the system prompt via the
+    ``{topic}`` placeholder."""
+
+    service, _bps, _drafts, llm, _skills = _service(
+        prompts={
+            "digest/blog_post_generation": "Focus: {topic}\n\nWrite from {blueprint_json}"
+        }
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+        topic="Renewal pricing pressure on mid-market SaaS",
+    )
+
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "Focus: Renewal pricing pressure on mid-market SaaS" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_no_topic_resolves_placeholder_to_empty_string():
+    """No-topic case: the ``{topic}`` placeholder still gets substituted
+    (to ``""``), keeping the prompt structurally clean."""
+
+    service, _bps, _drafts, llm, _skills = _service(
+        prompts={
+            "digest/blog_post_generation": "Focus: {topic}\n\nWrite from {blueprint_json}"
+        }
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+        topic=None,
+    )
+
+    system_prompt = llm.calls[0]["messages"][0].content
+    # Placeholder substituted with empty string -- "Focus: \n\n..." remains.
+    assert "{topic}" not in system_prompt
+    assert "Focus: \n" in system_prompt or "Focus:\n" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_topic_no_placeholder_no_op():
+    """Hosts on the prior prompt without ``{topic}`` are unaffected."""
+
+    service, _bps, _drafts, llm, _skills = _service(
+        prompts={"digest/blog_post_generation": "Write from {blueprint_json}"}
+    )
+
+    await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+        topic="Some topic",
+    )
+
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "Some topic" not in system_prompt  # no placeholder, no substitution
+    assert "{topic}" not in system_prompt

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -50,6 +50,7 @@ class _OpportunityService:
         quality_prompt_proof_term_limit: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
+        topic: str | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -67,6 +68,7 @@ class _OpportunityService:
             "quality_prompt_proof_term_limit": quality_prompt_proof_term_limit,
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "quality_gates_enabled": quality_gates_enabled,
+            "topic": topic,
             "extras": dict(extras),
         })
         return _Result()
@@ -837,3 +839,31 @@ async def test_execute_reports_partial_when_only_some_steps_fail() -> None:
     assert err["runner"] == "ReportGenerationService.generate"
     assert err["error"] == "service_not_configured"
     assert err["reason"] == "service_not_configured"  # backwards-compat alias
+
+
+# -----------------------
+# PR-Blog-Topic-Per-Call: dispatcher threads topic from step.config
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_topic_into_blog_post_dispatcher() -> None:
+    """The plan emits ``step.config["topic"]`` from
+    ``request.inputs.get("topic")``; the executor's blog dispatcher
+    threads it through to ``BlogPostGenerationService.generate``."""
+
+    blog = _OpportunityService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {
+                "target_account": "Acme",
+                "topic": "Renewal pricing pressure",
+            },
+        },
+        services=ContentOpsExecutionServices(blog_post=blog),
+    )
+
+    call = blog.calls[0]
+    assert call["topic"] == "Renewal pricing pressure"
+    assert call["extras"] == {}


### PR DESCRIPTION
Plan: `plans/PR-Blog-Topic-Per-Call.md`

Closes the "topic for blog_post" item that was deferred across the OptionA series. The plan layer was already emitting `step.config["topic"]` from `request.inputs.get("topic")`, but the blog service had no service-side surface that consumed it -- the kwarg got dropped at the executor and the prompt never saw the operator's topic.

## Intentional

- Add `{topic}` placeholder + "Operator focus" block to the blog skill prompt (`atlas_brain/skills/digest/blog_post_generation.md` + extracted mirror).
- `BlogPostGenerationService.generate()` gains `topic: str | None = None` resolved as `(topic or "").strip()`; threaded through `_generate_one` into the prompt-template substitution. Empty topic substitutes the empty string, so hosts on prompts without the placeholder are unaffected.
- Executor's blog dispatcher gains `topic=_step_config_text(step.config, "topic")` per the established OptionA per-field-kwarg pattern.
- Tests: 3 service-level (substitutes into prompt, no-topic resolves to empty, no-placeholder no-op) + 1 dispatcher-level (threads topic from inputs).

## Deferred

- Topic-aware multi-pass reasoning seeding (the topic doesn't yet steer `MultiPassCampaignReasoningProvider` archetype selection).
- Topic synonyms / auto-suggested topics from opportunity context.
- Plan-level enforcement that empty-string topic blocks the request -- already covered by `preview_control_surface` since `topic` is in `OUTPUT_CATALOG["blog_post"].required_inputs`, so the dispatcher only ever sees non-empty values; the service's defensive `(topic or "").strip()` exists for direct callers.

## Verification

- `pytest tests/test_extracted_content_ops_execution.py tests/test_extracted_blog_generation.py` -- 45 passed
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py tests/test_extracted_content_control_surface_api.py` -- 83 passed, 17 skipped
- `bash scripts/validate_extracted_content_pipeline.sh` -- clean
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- clean
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- Atlas runtime import findings: 0
- `bash scripts/check_ascii_python.sh` -- clean

## Diff size

7 files, +241 / -0 (within the <400 LOC PR target).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_