### PR TITLE
PR-Describe-Control-Surfaces-Cache: cache static catalog at import

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -53,6 +53,84 @@ _MAX_INPUT_STRING_CHARS = 10000
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
 
 
+def _build_static_catalog_payload() -> Mapping[str, Any]:
+    # PR-Describe-Control-Surfaces-Cache: the outputs/presets metadata
+    # is a pure function of the immutable OUTPUT_CATALOG and PRESETS
+    # MappingProxyType globals. Computing it once at import lets the
+    # GET /content-ops/control-surfaces hot path skip 6 + 5 per-item
+    # dict constructions per request.
+    return {
+        "outputs": tuple(
+            {
+                "id": item.id,
+                "label": item.label,
+                "description": item.description,
+                "implemented": item.implemented,
+                "estimated_unit_cost_usd": item.estimated_unit_cost_usd,
+                "default_parse_retry_attempts": item.default_parse_retry_attempts,
+                "estimated_retry_adjusted_unit_cost_usd": round(
+                    retry_adjusted_unit_cost_usd(item),
+                    4,
+                ),
+                "required_inputs": tuple(item.required_inputs),
+                "default_max_items": item.default_max_items,
+                "reasoning_requirement": item.reasoning_requirement,
+            }
+            for item in OUTPUT_CATALOG.values()
+        ),
+        "presets": tuple(
+            {
+                "id": item.id,
+                "label": item.label,
+                "description": item.description,
+                "outputs": tuple(item.outputs),
+            }
+            for item in PRESETS.values()
+        ),
+        "ingestion_profiles": (
+            "domain_specific",
+            "manual",
+            "existing_evidence",
+        ),
+    }
+
+
+_STATIC_CATALOG_PAYLOAD: Mapping[str, Any] = _build_static_catalog_payload()
+
+
+def _compose_describe_response(
+    *,
+    static: Mapping[str, Any],
+    configured_outputs: frozenset[str],
+    execution_configured: bool,
+) -> dict[str, Any]:
+    # Re-project the cached static template into a fresh dict tree so
+    # the caller can serialize / mutate without aliasing the module-
+    # level cache. Per-output flags are the only fields that depend
+    # on the host-injected execution services.
+    return {
+        "outputs": [
+            {
+                **base,
+                "required_inputs": list(base["required_inputs"]),
+                "execution_configured": base["id"] in configured_outputs,
+                "can_execute": base["implemented"]
+                and base["id"] in configured_outputs,
+            }
+            for base in static["outputs"]
+        ],
+        "presets": [
+            {**preset, "outputs": list(preset["outputs"])}
+            for preset in static["presets"]
+        ],
+        "execution": {
+            "configured": execution_configured,
+            "configured_outputs": sorted(configured_outputs),
+        },
+        "ingestion_profiles": list(static["ingestion_profiles"]),
+    }
+
+
 def _require_fastapi() -> None:
     if _FASTAPI_IMPORT_ERROR is None:
         return
@@ -134,51 +212,16 @@ def create_content_ops_control_surface_router(
     @router.get("/control-surfaces")
     async def describe_control_surfaces() -> dict[str, Any]:
         execution_services = await _resolve_execution_services(execution_services_provider)
-        configured_outputs = set(
+        configured_outputs = frozenset(
             execution_services.configured_outputs()
             if execution_services is not None
             else ()
         )
-        return {
-            "outputs": [
-                {
-                    "id": item.id,
-                    "label": item.label,
-                    "description": item.description,
-                    "implemented": item.implemented,
-                    "execution_configured": item.id in configured_outputs,
-                    "can_execute": item.implemented and item.id in configured_outputs,
-                    "estimated_unit_cost_usd": item.estimated_unit_cost_usd,
-                    "default_parse_retry_attempts": item.default_parse_retry_attempts,
-                    "estimated_retry_adjusted_unit_cost_usd": round(
-                        retry_adjusted_unit_cost_usd(item),
-                        4,
-                    ),
-                    "required_inputs": list(item.required_inputs),
-                    "default_max_items": item.default_max_items,
-                    "reasoning_requirement": item.reasoning_requirement,
-                }
-                for item in OUTPUT_CATALOG.values()
-            ],
-            "presets": [
-                {
-                    "id": item.id,
-                    "label": item.label,
-                    "description": item.description,
-                    "outputs": list(item.outputs),
-                }
-                for item in PRESETS.values()
-            ],
-            "execution": {
-                "configured": execution_services is not None,
-                "configured_outputs": sorted(configured_outputs),
-            },
-            "ingestion_profiles": [
-                "domain_specific",
-                "manual",
-                "existing_evidence",
-            ],
-        }
+        return _compose_describe_response(
+            static=_STATIC_CATALOG_PAYLOAD,
+            configured_outputs=configured_outputs,
+            execution_configured=execution_services is not None,
+        )
 
     @router.post("/preview")
     async def preview_generation(

--- a/plans/PR-Describe-Control-Surfaces-Cache.md
+++ b/plans/PR-Describe-Control-Surfaces-Cache.md
@@ -1,0 +1,105 @@
+# PR: cache the static portion of `describe_control_surfaces`
+
+## Why this slice exists
+
+`GET /content-ops/control-surfaces` is the UI's catalog endpoint — hit
+on every page load that surfaces output choices. Today it iterates
+`OUTPUT_CATALOG` and `PRESETS` (both immutable `MappingProxyType`s)
+on every request, building 6 + 5 dicts per call. The contents are
+purely a function of module-level globals; only `execution_configured`,
+`can_execute`, and `execution.{configured,configured_outputs}` change
+per-request based on the host-injected services.
+
+This PR factors the static portion into a module-level cached payload
+computed once at import, leaving only the dynamic per-request flags
+to be merged in.
+
+## Scope (this PR)
+
+- One file: `extracted_content_pipeline/api/control_surfaces.py`.
+- One test file: `tests/test_extracted_content_control_surface_api.py`
+  (new mutation-safety test; existing behavior tests stay unchanged).
+- No public-API change. `describe_control_surfaces` returns the same
+  shape; only the implementation is rearranged.
+
+### Files touched
+
+1. `extracted_content_pipeline/api/control_surfaces.py`
+   - Add `_build_static_catalog_payload()` helper that computes the
+     static `outputs` / `presets` / `ingestion_profiles` portion from
+     `OUTPUT_CATALOG` and `PRESETS`.
+   - Add module-level `_STATIC_CATALOG_PAYLOAD` constant computed
+     once at import via the helper.
+   - Add `_compose_describe_response(*, static, configured_outputs,
+     execution_configured)` helper that merges the static cache with
+     the per-request flags into a fresh dict (no shared mutable
+     references with the cache).
+   - Rewrite the `describe_control_surfaces` route body to call
+     `_compose_describe_response` with the resolved
+     `configured_outputs` frozenset.
+
+2. `tests/test_extracted_content_control_surface_api.py`
+   - Add `test_describe_control_surfaces_returns_independent_dict_per_call`:
+     two sequential calls return mutually independent dicts; mutating
+     one does not affect the next call.
+   - Add `test_describe_control_surfaces_static_cache_is_built_once`:
+     spy / assert that `_build_static_catalog_payload` is not invoked
+     per request.
+
+## Mechanism
+
+The cache is just a module-level constant plus a per-request shallow
+re-projection. No `functools.lru_cache`, no TTL, no invalidation —
+the static portion is genuinely immutable for the process lifetime
+because `OUTPUT_CATALOG` and `PRESETS` are `MappingProxyType` over
+module-level globals (`control_surfaces.py:96-194`). If a future PR
+adds a hot-reload mechanism for these catalogs, this cache becomes a
+reset target — but until then, the constant is correct.
+
+The per-request merge produces a fresh outer dict and fresh per-output
+dicts so callers can mutate the response without bleeding into the
+next request. The cached entries themselves are read-only (we copy
+out, never hand them back).
+
+## Intentional
+
+- Static-only caching: the `execution_configured`, `can_execute`, and
+  `execution` block stay per-request because they depend on the
+  host-injected services.
+- Computed at import: `_STATIC_CATALOG_PAYLOAD` is materialized once
+  at module load. No first-request lazy fill, no double-checked
+  locking, no concurrency complexity.
+- Fresh-dict-per-call invariant: protects callers (and FastAPI's
+  serialization layer) from accidentally mutating the cache. Verified
+  by a new mutation-safety test.
+
+## Deferred
+
+- TTL / invalidation hooks (catalogs are process-immutable; if that
+  changes a future slice can add a `clear_static_cache()` helper).
+- `etag` / `If-None-Match` HTTP-level caching at the endpoint
+  boundary — separate concern from the in-process compute cache.
+- `Cache-Control` headers — out of scope; routing concern, not
+  computation.
+- Metrics / counters for cache reuse — premature without a hot-path
+  signal.
+
+## Verification
+
+- `pytest tests/test_extracted_content_control_surface_api.py` — the
+  existing 4 describe tests stay green; 2 new tests pass.
+- `pytest tests/test_extracted_content_ops_execution.py
+   tests/test_extracted_blog_generation.py
+   tests/test_extracted_content_control_surfaces.py
+   tests/test_extracted_content_generation_plan.py` — no regressions.
+- `bash scripts/validate_extracted_content_pipeline.sh` — clean.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+   extracted_content_pipeline` — clean.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` —
+  Atlas runtime import findings: 0.
+- `bash scripts/check_ascii_python.sh` — clean.
+
+## Estimated diff size
+
+~50 LOC + ~30 LOC tests + ~110 LOC plan = ~190 LOC total. Well under
+the 400 LOC target.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -167,9 +167,10 @@ async def test_describe_control_surfaces_returns_independent_dict_per_call():
 
 
 @pytest.mark.asyncio
-async def test_describe_control_surfaces_static_cache_is_built_once(monkeypatch):
+async def test_describe_control_surfaces_static_cache_is_not_rebuilt_per_request(monkeypatch):
     """``_build_static_catalog_payload`` is invoked at import, not per
-    request. Two requests should not call it again."""
+    request. The spy is installed after import, so this asserts the
+    builder is not re-invoked per request (not the import-time call)."""
 
     call_count = {"n": 0}
     original = api_module._build_static_catalog_payload

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -139,6 +139,55 @@ async def test_describe_control_surfaces_ignores_invalid_execution_provider_resu
     assert outputs["email_campaign"]["can_execute"] is False
 
 
+# -----------------------
+# PR-Describe-Control-Surfaces-Cache: static portion is cached at import.
+# Verify two consecutive calls return mutually independent dicts (no
+# aliasing into the cache) and that the cache is computed once.
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_describe_control_surfaces_returns_independent_dict_per_call():
+    """Per-call mutation must not leak into the next call's response."""
+
+    router = create_content_ops_control_surface_router()
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+
+    first = await route.endpoint()
+    first["outputs"][0]["label"] = "MUTATED"
+    first["outputs"][0]["required_inputs"].append("injected_field")
+    first["presets"][0]["outputs"].append("injected_output")
+    first["ingestion_profiles"].append("injected_profile")
+
+    second = await route.endpoint()
+    assert second["outputs"][0]["label"] != "MUTATED"
+    assert "injected_field" not in second["outputs"][0]["required_inputs"]
+    assert "injected_output" not in second["presets"][0]["outputs"]
+    assert "injected_profile" not in second["ingestion_profiles"]
+
+
+@pytest.mark.asyncio
+async def test_describe_control_surfaces_static_cache_is_built_once(monkeypatch):
+    """``_build_static_catalog_payload`` is invoked at import, not per
+    request. Two requests should not call it again."""
+
+    call_count = {"n": 0}
+    original = api_module._build_static_catalog_payload
+
+    def _spy() -> object:
+        call_count["n"] += 1
+        return original()
+
+    monkeypatch.setattr(api_module, "_build_static_catalog_payload", _spy)
+
+    router = create_content_ops_control_surface_router()
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    await route.endpoint()
+    await route.endpoint()
+
+    assert call_count["n"] == 0
+
+
 @pytest.mark.asyncio
 async def test_preview_generation_route_returns_preflight_plan():
     router = create_content_ops_control_surface_router(


### PR DESCRIPTION
Plan: `plans/PR-Describe-Control-Surfaces-Cache.md`

`GET /content-ops/control-surfaces` is the UI's catalog endpoint, hit on every page load. Today it iterates `OUTPUT_CATALOG` (6 entries) and `PRESETS` (5 entries) on every request, building 11 dicts of metadata. Both globals are `MappingProxyType` — process-immutable — so the projection is computed once at import and the per-request hot path only splices in the dynamic execution flags.

## Intentional

- `_build_static_catalog_payload()` builds the immutable outputs + presets + ingestion_profiles projection from `OUTPUT_CATALOG` / `PRESETS`.
- `_STATIC_CATALOG_PAYLOAD` materializes that payload once at module import.
- `_compose_describe_response(*, static, configured_outputs, execution_configured)` re-projects the cache into a fresh dict tree per request, splicing in the dynamic `execution_configured` / `can_execute` flags.
- `describe_control_surfaces` route body shrinks to a 3-line composition call.
- 2 new tests:
  - `test_describe_control_surfaces_returns_independent_dict_per_call` — per-call mutation must not leak into the next response.
  - `test_describe_control_surfaces_static_cache_is_built_once` — the static builder is not invoked per request (monkeypatch spy after import).

## Deferred

- HTTP-level ETag / `If-None-Match` (separate concern from in-process compute caching).
- Cache invalidation hooks. Catalogs are process-immutable today; if that changes a future slice can add `clear_static_cache()`.
- Metrics on cache reuse — premature without a hot-path signal.

## Verification

- `pytest tests/test_extracted_content_control_surface_api.py` — 19 passed (4 existing describe tests + 2 new + 13 other API tests stay green).
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py tests/test_extracted_content_control_surface_api.py` — 102 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — clean.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` — clean.

## Diff size

3 files, +238 / -41 (within the <400 LOC PR target).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_