### PR TITLE
PR-Blog-Reasoning-Parity: bring BlogPostGenerationService to reasoning-context parity with the other 4 generators

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -9,15 +9,33 @@ import re
 from typing import Any
 
 from .blog_ports import BlogBlueprintRepository, BlogPostDraft, BlogPostRepository
-from .campaign_ports import LLMClient, LLMMessage, SkillStore, TenantScope
+from .campaign_ports import (
+    CampaignReasoningContextProvider,
+    LLMClient,
+    LLMMessage,
+    SkillStore,
+    TenantScope,
+)
 from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
     parse_attempt_limit,
     retry_prompt_with_invalid_response,
 )
+from .services.campaign_reasoning_context import (
+    campaign_reasoning_context_metadata,
+    campaign_reasoning_context_payload,
+    normalize_campaign_reasoning_context,
+)
 from extracted_quality_gate.blog_pack import evaluate_blog_post
 from extracted_quality_gate.types import QualityInput, QualityPolicy
+
+
+# PR-Blog-Reasoning-Parity: fixed lookup mode for the reasoning-context
+# port. Mirrors landing_page_generation's _TARGET_MODE constant; the
+# call-site target_mode (e.g. "vendor_retention") is an unrelated
+# tenant-scope concept.
+_BLOG_REASONING_TARGET_MODE = "blog_blueprint"
 
 
 @dataclass(frozen=True)
@@ -116,12 +134,18 @@ class BlogPostGenerationService:
         blog_posts: BlogPostRepository,
         llm: LLMClient,
         skills: SkillStore,
+        reasoning_context: CampaignReasoningContextProvider | None = None,
         config: BlogPostGenerationConfig | None = None,
     ):
         self._blueprints = blueprints
         self._blog_posts = blog_posts
         self._llm = llm
         self._skills = skills
+        # PR-Blog-Reasoning-Parity: brings blog to constructor parity
+        # with the other 4 generators. When wired, supplemental
+        # reasoning context is merged into each blueprint before the
+        # LLM call -- additive enrichment, not replacement.
+        self._reasoning_context = reasoning_context
         self._config = config or BlogPostGenerationConfig()
 
     async def generate(
@@ -182,7 +206,10 @@ class BlogPostGenerationService:
         errors: list[dict[str, Any]] = []
         skipped = 0
         for row in rows:
-            blueprint = dict(row)
+            blueprint = await self._blueprint_with_reasoning_context(
+                scope=scope,
+                blueprint=dict(row),
+            )
             blueprint_id = _blueprint_id(blueprint)
             try:
                 parsed = await self._generate_one(
@@ -231,6 +258,35 @@ class BlogPostGenerationService:
             saved_ids=saved_ids,
             errors=tuple(errors),
         )
+
+    async def _blueprint_with_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        blueprint: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        # PR-Blog-Reasoning-Parity: mirrors landing_page_generation's
+        # _payload_with_reasoning_context shape. When no provider is
+        # wired the blueprint passes through unchanged. When the
+        # provider returns no content the blueprint also passes
+        # through unchanged so empty / missing reasoning is a no-op.
+        if self._reasoning_context is None:
+            return blueprint
+        provided = await self._reasoning_context.read_campaign_reasoning_context(
+            scope=scope,
+            target_id=_blueprint_id(blueprint),
+            target_mode=_BLOG_REASONING_TARGET_MODE,
+            opportunity=blueprint,
+        )
+        provided_context = normalize_campaign_reasoning_context(provided)
+        if not provided_context.has_content():
+            return blueprint
+        enriched = dict(blueprint)
+        enriched["reasoning_context"] = campaign_reasoning_context_payload(
+            provided_context
+        )
+        enriched.update(campaign_reasoning_context_metadata(provided_context))
+        return enriched
 
     async def _generate_one(
         self,
@@ -347,6 +403,18 @@ class BlogPostGenerationService:
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
         }
+        # PR-Blog-Reasoning-Parity: surface reasoning audit fields on
+        # the draft metadata when the blueprint carried merged context.
+        # Mirrors campaign / report / sales_brief metadata threading.
+        for reasoning_key in (
+            "reasoning_context",
+            "reasoning_anchor_examples",
+            "reasoning_witness_highlights",
+            "reasoning_reference_ids",
+            "reasoning_provider",
+        ):
+            if reasoning_key in blueprint:
+                metadata[reasoning_key] = blueprint[reasoning_key]
         return BlogPostDraft(
             slug=slug,
             title=title,

--- a/plans/PR-Blog-Reasoning-Parity.md
+++ b/plans/PR-Blog-Reasoning-Parity.md
@@ -1,0 +1,176 @@
+# PR: bring `BlogPostGenerationService` to reasoning-parity with the other 4 generators
+
+## Why this slice exists
+
+Of the five Content Ops generators, four (`campaign`, `report`,
+`landing_page`, `sales_brief`) accept a uniform constructor kwarg:
+
+```python
+reasoning_context: CampaignReasoningContextProvider | None = None,
+```
+
+and consume it inside their `generate()` flow via an
+`_opportunity_with_reasoning_context` (or `_payload_with_reasoning_context`
+on `landing_page`) helper. Blog is the only generator that has neither
+the kwarg nor the consumption path -- `grep -c "reasoning_context"
+extracted_content_pipeline/blog_generation.py` -> 0 vs. 15-22 for the
+others.
+
+The route slice that comes next (PR-ControlSurfaces-Reasoning-Provider)
+will pass a single `reasoning_context_provider` through the new
+`/execute` route into all five services. That's only useful if all
+five services accept it. Blog needs to land first.
+
+## Scope (this PR)
+
+Two concerns, both narrow:
+
+1. **Constructor surface parity**: blog accepts the same kwarg shape
+   as the other four.
+2. **Generation-time consumption**: when configured, blog merges
+   reasoning context into the blueprint payload before sending it to
+   the LLM, mirroring `landing_page_generation.py`'s
+   `_payload_with_reasoning_context` shape (which is itself the
+   non-opportunity-shaped variant of campaign / report / sales_brief's
+   pattern).
+
+Blog operates on **blueprints**, not opportunities, so the lookup
+key is the blueprint id (existing `_blueprint_id` helper) plus a
+fixed `target_mode="blog_blueprint"` -- mirroring landing_page's
+`target_mode="marketing_campaign"` constant.
+
+### Files touched
+
+1. `extracted_content_pipeline/blog_generation.py`
+   - Import `CampaignReasoningContextProvider` from `campaign_ports`,
+     and `campaign_reasoning_context_metadata`,
+     `campaign_reasoning_context_payload`,
+     `normalize_campaign_reasoning_context` from
+     `services.campaign_reasoning_context`.
+   - Add `_BLOG_REASONING_TARGET_MODE = "blog_blueprint"` constant.
+   - Add `reasoning_context: CampaignReasoningContextProvider | None
+     = None` to `BlogPostGenerationService.__init__`.
+   - Add `_blueprint_with_reasoning_context(scope, blueprint)`
+     helper: fetches context keyed by `_blueprint_id(blueprint)` +
+     the fixed target mode, normalizes via
+     `normalize_campaign_reasoning_context`, and (on non-empty
+     content) returns a copy of the blueprint with merged
+     `reasoning_context` payload + metadata fields.
+   - In `generate()`, before calling `_generate_one`, invoke the
+     helper so the blueprint passed to the LLM already carries
+     reasoning context (same prompt template; the JSON gets richer).
+   - Pass per-draft reasoning metadata through to
+     `BlogPostDraft.metadata` so downstream consumers can see whether
+     reasoning was applied.
+
+2. `tests/test_extracted_blog_generation.py`
+   - 3 new tests:
+     - `test_generate_no_reasoning_provider_passes_blueprint_unchanged`:
+       the existing happy path stays unchanged when no provider is
+       wired.
+     - `test_generate_with_reasoning_provider_merges_context_into_blueprint`:
+       provider returns a non-empty context; blueprint passed to the
+       LLM carries `reasoning_context` payload; draft metadata
+       reports `reasoning_provider`.
+     - `test_generate_with_reasoning_provider_returning_empty_is_noop`:
+       provider returns empty / no-content; blueprint stays
+       unchanged; no reasoning metadata fields on the draft.
+
+## Mechanism
+
+The pattern is lifted from `landing_page_generation.py`:
+
+```python
+async def _blueprint_with_reasoning_context(
+    self,
+    *,
+    scope: TenantScope,
+    blueprint: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if self._reasoning_context is None:
+        return blueprint
+    provided = await self._reasoning_context.read_campaign_reasoning_context(
+        scope=scope,
+        target_id=_blueprint_id(blueprint),
+        target_mode=_BLOG_REASONING_TARGET_MODE,
+        opportunity=blueprint,
+    )
+    provided_context = normalize_campaign_reasoning_context(provided)
+    if not provided_context.has_content():
+        return blueprint
+    enriched = dict(blueprint)
+    enriched["reasoning_context"] = campaign_reasoning_context_payload(
+        provided_context
+    )
+    enriched.update(campaign_reasoning_context_metadata(provided_context))
+    return enriched
+```
+
+The LLM sees the merged blueprint as JSON; the `{topic}` placeholder
+substitution remains untouched. Reasoning context becomes
+**additive** information the LLM can weave into the post -- it does
+not replace the blueprint's own structure.
+
+Blueprint id resolution falls through `_blueprint_id` (existing
+helper at line 383): id -> slug -> topic -> suggested_title -> "".
+Empty id short-circuits the lookup (provider returns nothing), so
+empty-id blueprints continue to behave exactly as today.
+
+## Intentional
+
+- **Same port shape (`CampaignReasoningContextProvider`)** as the
+  other 4 generators. The "campaign" naming is a historical artifact
+  of where the port was first introduced; the port is now the
+  package-wide reasoning-context contract regardless of output
+  type. Don't rename in this slice.
+- **Fixed `target_mode` for the reasoning lookup**, mirroring
+  landing_page. The route-level `target_mode` (e.g.
+  "vendor_retention") is an unrelated tenant-scope concept.
+- **Blueprint mutation is a fresh dict per draft.** No shared
+  mutable state with the source blueprint mapping; keeps callers
+  insulated.
+- **Metadata-only signal in `BlogPostDraft.metadata`** so downstream
+  consumers can audit whether reasoning was applied without
+  inspecting the prompt. Same pattern as the other generators.
+
+## Deferred
+
+- Per-call reasoning-context override on `generate()`. The other
+  generators don't expose this either; if needed, lift it across
+  all five in a follow-up.
+- Blueprint-level lookup keys richer than `_blueprint_id`
+  (e.g. brand-specific or category-specific reasoning context).
+  Possible future slice; today the blueprint id is the right grain.
+- Wiring `MultiPassCampaignReasoningProvider` into the new
+  `api.control_surfaces /execute` route. That's the next slice
+  (PR-ControlSurfaces-Reasoning-Provider) -- can't land until this
+  one closes the service-layer gap.
+
+## Verification
+
+- `pytest tests/test_extracted_blog_generation.py` -- existing tests
+  stay green; 3 new tests pass.
+- `pytest tests/test_extracted_content_ops_execution.py
+   tests/test_extracted_content_control_surfaces.py
+   tests/test_extracted_content_generation_plan.py
+   tests/test_extracted_content_ops_execution_smoke.py
+   tests/test_extracted_content_control_surface_api.py` -- no
+  regressions in the orchestration layer.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- clean.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+   extracted_content_pipeline` -- clean.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` --
+  Atlas runtime import findings: 0.
+- `bash scripts/check_ascii_python.sh` -- clean.
+- `grep -c reasoning_context extracted_content_pipeline/blog_generation.py`
+  -> non-zero (at least 5; was 0).
+
+## Estimated diff size
+
+- `blog_generation.py`: +~50 LOC (imports + constructor kwarg +
+  helper + integration call + metadata threading).
+- `test_extracted_blog_generation.py`: +~120 LOC (3 new tests with
+  fakes for the reasoning provider).
+- Plan doc: ~150 LOC.
+
+Total: ~320 LOC. Within the <400 LOC PR target.

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -10,7 +10,11 @@ from extracted_content_pipeline.blog_generation import (
     parse_blog_post_response,
 )
 from extracted_content_pipeline.blog_ports import BlogPostDraft
-from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
 from extracted_quality_gate.types import QualityPolicy
 
 
@@ -142,7 +146,41 @@ def _valid_blog_json(**overrides):
     return json.dumps(payload)
 
 
-def _service(*, rows=None, responses=None, prompts=None, config=None):
+class _ReasoningProvider:
+    """Fake CampaignReasoningContextProvider for blog tests.
+
+    Mirrors the shape used by tests/test_extracted_landing_page_generation.py.
+    """
+
+    def __init__(self, context):
+        self.context = context
+        self.calls = []
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        self.calls.append({
+            "scope": scope,
+            "target_id": target_id,
+            "target_mode": target_mode,
+            "opportunity": dict(opportunity or {}),
+        })
+        return self.context
+
+
+def _service(
+    *,
+    rows=None,
+    responses=None,
+    prompts=None,
+    config=None,
+    reasoning_context=None,
+):
     blueprints = _Blueprints(rows or [_blueprint()])
     blog_posts = _BlogPosts()
     llm = _LLM(responses or [_valid_blog_json()])
@@ -154,6 +192,7 @@ def _service(*, rows=None, responses=None, prompts=None, config=None):
         blog_posts=blog_posts,
         llm=llm,
         skills=skills,
+        reasoning_context=reasoning_context,
         config=config or BlogPostGenerationConfig(
             quality_policy=QualityPolicy(
                 name="blog_post",
@@ -534,3 +573,92 @@ async def test_generate_topic_no_placeholder_no_op():
     system_prompt = llm.calls[0]["messages"][0].content
     assert "Some topic" not in system_prompt  # no placeholder, no substitution
     assert "{topic}" not in system_prompt
+
+
+# -----------------------
+# PR-Blog-Reasoning-Parity: blog generator accepts an optional
+# reasoning_context provider and merges its payload into the
+# blueprint before the LLM call. Mirrors the pattern in
+# tests/test_extracted_landing_page_generation.py.
+# -----------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_no_reasoning_provider_passes_blueprint_unchanged() -> None:
+    """The default (no provider wired) path leaves the blueprint
+    untouched -- the LLM sees the original JSON, no reasoning_context
+    field is injected."""
+
+    service, _, _, llm, _ = _service()  # no reasoning_context kwarg
+
+    await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "reasoning_context" not in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_with_reasoning_provider_merges_context_into_blueprint() -> None:
+    """When the provider returns non-empty context, the blueprint
+    JSON sent to the LLM gains a ``reasoning_context`` payload, and
+    the draft metadata records the reasoning provider tier."""
+
+    reasoning = _ReasoningProvider(
+        CampaignReasoningContext(
+            top_theses=(
+                {
+                    "claim": "Renewal pricing rose 22 percent",
+                    "confidence": 0.9,
+                    "source_ids": ["r1"],
+                },
+            ),
+            canonical_reasoning={
+                "summary": "HubSpot pricing pressure intensifies in Q3.",
+            },
+        )
+    )
+    service, _, blog_posts, llm, _ = _service(reasoning_context=reasoning)
+
+    await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    # Provider was called with the blueprint id + the fixed reasoning
+    # target_mode (not the call-site target_mode).
+    assert reasoning.calls
+    call = reasoning.calls[0]
+    assert call["target_id"] == "bp-1"
+    assert call["target_mode"] == "blog_blueprint"
+
+    # LLM saw the merged blueprint JSON.
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "reasoning_context" in system_prompt
+    assert "Renewal pricing rose 22 percent" in system_prompt
+
+    # Draft metadata captured reasoning signal.
+    drafts = blog_posts.saved[0]["drafts"]
+    assert drafts
+    metadata = drafts[0].metadata
+    # Metadata fields come from campaign_reasoning_context_metadata; at
+    # minimum the provider tier should be visible to consumers.
+    assert any("reasoning" in str(key) for key in metadata.keys()), metadata
+
+
+@pytest.mark.asyncio
+async def test_generate_with_reasoning_provider_returning_empty_is_noop() -> None:
+    """When the provider returns no content, the blueprint is not
+    enriched -- ``reasoning_context`` does not appear in the prompt
+    and no reasoning metadata is added to the draft."""
+
+    reasoning = _ReasoningProvider(None)  # provider returns nothing
+    service, _, blog_posts, llm, _ = _service(reasoning_context=reasoning)
+
+    await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert reasoning.calls  # the provider was consulted
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert "reasoning_context" not in system_prompt
+
+    drafts = blog_posts.saved[0]["drafts"]
+    assert drafts
+    metadata = drafts[0].metadata
+    # No reasoning-shaped metadata fields when the context was empty.
+    assert not any("reasoning" in str(key) for key in metadata.keys()), metadata


### PR DESCRIPTION
Plan: `plans/PR-Blog-Reasoning-Parity.md`

Brings `BlogPostGenerationService` to constructor + consumption parity with the 4 other Content Ops generators on the `CampaignReasoningContextProvider` port. Pre-fix: `grep -c reasoning_context blog_generation.py` → 0 vs. 15–22 for campaign / report / landing_page / sales_brief.

The new `api.control_surfaces /execute` reasoning-provider seam (next slice) only delivers value when all five services accept the same kwarg shape. This PR closes the service-layer gap so the route slice can wire one provider to all five.

## Intentional

- Add `reasoning_context: CampaignReasoningContextProvider | None = None` to `BlogPostGenerationService.__init__`.
- Add `_blueprint_with_reasoning_context()` helper that mirrors `landing_page_generation`'s `_payload_with_reasoning_context` (the non-opportunity-shaped variant of campaign / report / sales_brief). Looks up context by `_blueprint_id(blueprint)` + fixed `target_mode="blog_blueprint"`. The route-level `target_mode` (e.g. `"vendor_retention"`) is an unrelated tenant-scope concept; this fixed string is for the reasoning lookup only.
- `generate()` calls the helper before `_generate_one` so the blueprint passed to the LLM carries the merged `reasoning_context` payload as additive enrichment.
- `_build_draft()` threads reasoning-shaped metadata fields (`reasoning_context`, `reasoning_anchor_examples`, `reasoning_witness_highlights`, `reasoning_reference_ids`, `reasoning_provider`) onto `BlogPostDraft.metadata` so consumers can audit whether reasoning was applied.
- 3 new tests:
  - `test_generate_no_reasoning_provider_passes_blueprint_unchanged`
  - `test_generate_with_reasoning_provider_merges_context_into_blueprint`
  - `test_generate_with_reasoning_provider_returning_empty_is_noop`

## Deferred

- Per-call reasoning-context override on `generate()`. None of the other 4 generators expose this either; if needed, lift it across all five in a follow-up.
- Wiring `MultiPassCampaignReasoningProvider` into `api.control_surfaces /execute`. That's the next slice (PR-ControlSurfaces-Reasoning-Provider) and depends on this one.
- Blueprint-level lookup keys richer than `_blueprint_id` (e.g. brand-specific or category-specific reasoning context). Possible future slice; today the blueprint id is the right grain.

## Verification

- `pytest tests/test_extracted_blog_generation.py` — 22 passed (19 existing + 3 new).
- `pytest tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution_smoke.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_landing_page_generation.py` — 127 passed (no regressions).
- `bash scripts/validate_extracted_content_pipeline.sh` — clean.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` — clean.
- `grep -c reasoning_context extracted_content_pipeline/blog_generation.py` → 15 (was 0).

## Diff size

3 files, +376 / -4. Within the <400 LOC PR target.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_