### PR TITLE
PR-Content-Ops-API-Adapter: typed fetch wrappers + wire types for /content-ops/*

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -1,0 +1,348 @@
+/**
+ * AI Content Ops API adapter.
+ *
+ * Typed fetch wrappers + wire-shape types for the four
+ * `/content-ops/*` routes the backend exposes:
+ *
+ *   GET  /content-ops/control-surfaces
+ *   POST /content-ops/preview
+ *   POST /content-ops/plan
+ *   POST /content-ops/execute
+ *
+ * Wire types are 1:1 with the backend JSON (snake_case), matching
+ * the convention in `client.ts` / `b2bClient.ts`. camelCase
+ * translation belongs at the domain layer (next slice;
+ * `src/content/contentOps/`).
+ *
+ * Contract reference: `docs/frontend/content_ops_frontend_contract.md`
+ * (PR #401, backend HEAD `a4020c1`).
+ */
+
+import { tryRefreshToken } from '../auth/AuthContext'
+import { API_BASE } from './config'
+
+const BASE = `${API_BASE}/content-ops`
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+// GET /content-ops/control-surfaces
+
+export interface ContentOpsOutputDefinition {
+  id: string
+  label: string
+  description: string
+  implemented: boolean
+  estimated_unit_cost_usd: number
+  default_parse_retry_attempts: number
+  estimated_retry_adjusted_unit_cost_usd: number
+  required_inputs: string[]
+  default_max_items: number
+  reasoning_requirement: 'absent' | 'optional_host_context' | string
+  // Per-request, computed from host-injected services:
+  execution_configured: boolean
+  can_execute: boolean
+}
+
+export interface ContentOpsPreset {
+  id: string
+  label: string
+  description: string
+  outputs: string[]
+}
+
+export interface ContentOpsCatalogResponse {
+  outputs: ContentOpsOutputDefinition[]
+  presets: ContentOpsPreset[]
+  execution: {
+    configured: boolean
+    configured_outputs: string[]
+  }
+  ingestion_profiles: string[]
+}
+
+// POST /content-ops/preview, /plan, /execute share this body shape.
+
+export interface ContentOpsRequestBody {
+  target_mode?: string                             // default "vendor_retention"
+  preset?: string | null
+  outputs?: string[]
+  limit?: number                                   // 1..1000
+  max_cost_usd?: number | null
+  inputs?: Record<string, unknown>
+  ingestion_profile?: string                       // default "domain_specific"
+  require_quality_gates?: boolean                  // default true
+  allow_unimplemented_outputs?: boolean            // default false
+}
+
+// POST /content-ops/preview response
+
+export interface ContentOpsPreviewResponse {
+  can_run: boolean
+  outputs: string[]
+  estimated_cost_usd: number
+  missing_inputs: string[]
+  blocked_outputs: string[]
+  warnings: string[]
+  normalized_request: ContentOpsRequestBody | null
+}
+
+// POST /content-ops/plan response
+
+export type GenerationPlanStepStatus = 'runnable' | 'blocked'
+
+export interface GenerationPlanStep {
+  output: string                                   // e.g. "email_campaign"
+  runner: string                                   // e.g. "CampaignGenerationService.generate"
+  status: GenerationPlanStepStatus
+  config: Record<string, unknown>                  // runner-specific config snapshot
+  reason: string                                   // populated when status="blocked"
+}
+
+export interface GenerationPlanResponse {
+  can_execute: boolean
+  target_mode: string
+  limit: number
+  steps: GenerationPlanStep[]
+  preview: ContentOpsPreviewResponse
+}
+
+// POST /content-ops/execute response (wire shape)
+
+export type ContentOpsExecutionStatus =
+  | 'completed'
+  | 'partial'
+  | 'failed'
+  | 'blocked'
+
+export type ContentOpsStepStatus = 'completed' | 'failed' | 'skipped'
+
+export interface ContentOpsStepExecution {
+  output: string
+  runner: string
+  status: ContentOpsStepStatus
+  result: Record<string, unknown>
+  error: string                                    // populated when status="failed"
+}
+
+export interface ContentOpsExecutionResult {
+  status: ContentOpsExecutionStatus
+  plan: GenerationPlanResponse
+  steps: ContentOpsStepExecution[]
+  errors: Array<Record<string, unknown>>
+}
+
+// HTTP-code-aware execute outcome. The /execute route maps the
+// backend `ContentOpsExecutionResult.status` field onto HTTP codes
+// (200 / 207 / 400 / 502); a plain `res.json()` would lose that.
+// 422 / 503 / 400-from-ValueError are also surfaced as outcome
+// kinds so the UI can render one banner per kind without
+// HTTP-code knowledge leaking into screens.
+
+export type ContentOpsExecuteOutcome =
+  | { kind: 'completed'; result: ContentOpsExecutionResult }
+  | { kind: 'partial'; result: ContentOpsExecutionResult }
+  | { kind: 'failed'; result: ContentOpsExecutionResult }
+  | { kind: 'blocked'; result: ContentOpsExecutionResult }
+  | { kind: 'validation_error'; detail: unknown }                // 422
+  | { kind: 'services_unavailable'; detail: string }             // 503
+  | { kind: 'request_invalid'; detail: string }                  // 400 from ValueError
+
+// ---------------------------------------------------------------------------
+// Internal fetch plumbing
+// ---------------------------------------------------------------------------
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('atlas_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+function forceLogout(): never {
+  localStorage.removeItem('atlas_token')
+  localStorage.removeItem('atlas_refresh_token')
+  window.location.href = '/login'
+  throw new Error('Session expired')
+}
+
+function maybeFallbackApiPath(url: string): string | null {
+  if (!url.includes('/api/v1/')) return null
+  return url.replace('/api/v1/', '/api/')
+}
+
+async function fetchWithApiFallback(url: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(url, init)
+  if (res.status !== 404) return res
+  const fallbackUrl = maybeFallbackApiPath(url)
+  if (!fallbackUrl) return res
+  return fetch(fallbackUrl, init)
+}
+
+async function rawJson<T>(res: Response): Promise<T> {
+  return res.json() as Promise<T>
+}
+
+async function rawText(res: Response): Promise<string> {
+  return res.text().catch(() => '')
+}
+
+async function withRefreshOn401(
+  doFetch: () => Promise<Response>,
+): Promise<Response> {
+  const res = await doFetch()
+  if (res.status !== 401) return res
+  const newToken = await tryRefreshToken()
+  if (!newToken) forceLogout()
+  const retryRes = await doFetch()
+  if (retryRes.status === 401) forceLogout()
+  return retryRes
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const url = `${BASE}${path}`
+  const doFetch = () => fetchWithApiFallback(url, { headers: authHeaders() })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const body = await rawText(res)
+    throw new Error(`API ${res.status}: ${body || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
+async function postJson<T>(path: string, body: ContentOpsRequestBody): Promise<T> {
+  const url = `${BASE}${path}`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(body),
+    })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const text = await rawText(res)
+    throw new Error(`API ${res.status}: ${text || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
+// ---------------------------------------------------------------------------
+// Public fetch wrappers
+// ---------------------------------------------------------------------------
+
+/** GET /content-ops/control-surfaces -- catalog + presets + execution flags. */
+export function fetchContentOpsControlSurfaces(): Promise<ContentOpsCatalogResponse> {
+  return getJson<ContentOpsCatalogResponse>('/control-surfaces')
+}
+
+/** POST /content-ops/preview -- preflight validation. */
+export function previewContentOpsRun(
+  body: ContentOpsRequestBody,
+): Promise<ContentOpsPreviewResponse> {
+  return postJson<ContentOpsPreviewResponse>('/preview', body)
+}
+
+/** POST /content-ops/plan -- build runnable plan. */
+export function planContentOpsRun(
+  body: ContentOpsRequestBody,
+): Promise<GenerationPlanResponse> {
+  return postJson<GenerationPlanResponse>('/plan', body)
+}
+
+/**
+ * POST /content-ops/execute -- run the plan via host-injected services.
+ *
+ * Returns a discriminated outcome. The backend's status-to-HTTP
+ * mapping (200 / 207 / 400 / 502) is part of the contract, so this
+ * wrapper deliberately handles non-2xx codes that carry a typed
+ * payload rather than throwing on every `!res.ok`.
+ */
+export async function executeContentOpsRun(
+  body: ContentOpsRequestBody,
+): Promise<ContentOpsExecuteOutcome> {
+  const url = `${BASE}/execute`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(body),
+    })
+  const res = await withRefreshOn401(doFetch)
+
+  if (res.status === 200) {
+    const result = await rawJson<ContentOpsExecutionResult>(res)
+    return { kind: 'completed', result }
+  }
+  if (res.status === 207) {
+    const result = await rawJson<ContentOpsExecutionResult>(res)
+    // FastAPI wraps the result in `{ detail: ... }` when raised via
+    // HTTPException; gracefully unwrap when present.
+    return {
+      kind: 'partial',
+      result: unwrapDetail<ContentOpsExecutionResult>(result),
+    }
+  }
+  if (res.status === 502) {
+    const result = await rawJson<ContentOpsExecutionResult>(res)
+    return {
+      kind: 'failed',
+      result: unwrapDetail<ContentOpsExecutionResult>(result),
+    }
+  }
+  if (res.status === 400) {
+    // Backend returns either a sanitized execution result (status="blocked")
+    // OR a string detail (ValueError from request_from_mapping).
+    const text = await rawText(res)
+    try {
+      const parsed = JSON.parse(text) as { detail?: unknown }
+      const detail = parsed?.detail
+      if (detail && typeof detail === 'object' && 'status' in detail) {
+        return {
+          kind: 'blocked',
+          result: detail as ContentOpsExecutionResult,
+        }
+      }
+      return {
+        kind: 'request_invalid',
+        detail: typeof detail === 'string' ? detail : text,
+      }
+    } catch {
+      return { kind: 'request_invalid', detail: text || res.statusText }
+    }
+  }
+  if (res.status === 422) {
+    const text = await rawText(res)
+    let detail: unknown = text
+    try {
+      detail = (JSON.parse(text) as { detail?: unknown })?.detail ?? text
+    } catch {
+      // keep raw text
+    }
+    return { kind: 'validation_error', detail }
+  }
+  if (res.status === 503) {
+    const text = await rawText(res)
+    let detail = text || res.statusText
+    try {
+      const parsed = JSON.parse(text) as { detail?: unknown }
+      if (typeof parsed?.detail === 'string') detail = parsed.detail
+    } catch {
+      // keep raw text
+    }
+    return { kind: 'services_unavailable', detail }
+  }
+  // Anything else is a hard failure -- surface like the rest of the API.
+  const text = await rawText(res)
+  throw new Error(`API ${res.status}: ${text || res.statusText}`)
+}
+
+function unwrapDetail<T>(payload: T | { detail: T }): T {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'detail' in payload &&
+    (payload as { detail: unknown }).detail
+  ) {
+    return (payload as { detail: T }).detail
+  }
+  return payload as T
+}

--- a/plans/PR-Content-Ops-API-Adapter.md
+++ b/plans/PR-Content-Ops-API-Adapter.md
@@ -1,0 +1,142 @@
+# PR: Content Ops API adapter — typed fetch wrappers + wire types
+
+## Why this slice exists
+
+PR #401 landed `docs/frontend/content_ops_frontend_contract.md` --
+the load-bearing artifact that defines the AI Content Ops backend
+surface for the frontend. Every type and route is cited file:line
+against backend HEAD `a4020c1`. The contract's *Deferred* section
+explicitly names the next slice:
+
+> Concrete TypeScript type generation (e.g. `openapi-codegen` or
+> hand-written `src/api/contentOps.ts`). Lands when the frontend
+> repo scaffolds.
+
+`atlas-intel-ui/` is already scaffolded (Vite + React 19 + TS).
+Without typed fetch wrappers, screens 1-3 from the contract can't
+land -- they'd hand-roll fetch + retype the same response shapes.
+This PR is the foundation; the next four frontend slices stack on
+it.
+
+## Scope (this PR)
+
+One file: `atlas-intel-ui/src/api/contentOps.ts`.
+
+- 9 wire-shape `interface`s mirroring the backend dataclasses
+  cited in `docs/frontend/content_ops_frontend_contract.md`. Field
+  names stay snake_case to match the backend response (matches
+  the existing `client.ts` / `b2bClient.ts` convention).
+- 4 typed fetch wrappers:
+  `fetchContentOpsControlSurfaces`,
+  `previewContentOpsRun`,
+  `planContentOpsRun`,
+  `executeContentOpsRun`.
+- HTTP status code mapping helper that translates 200/207/400/502
+  responses into a discriminated union `ContentOpsExecuteOutcome`
+  the UI can render without needing to know HTTP semantics.
+- Reuse the existing fetch / auth / 401-refresh / 402-403 plumbing
+  via a thin internal helper (or shared module) -- do not duplicate
+  the entire `client.ts` boilerplate.
+
+### What's NOT in this slice
+
+- Domain layer (camelCase translation, `ContentOpsRun` aggregate,
+  reducers). Belongs in `src/content/contentOps/` per the
+  contract's "Domain layer" section. Next slice.
+- View-model / UI / screens.
+- A contract test harness pinning the TS types to canonical
+  fixtures. The slice immediately after this one.
+
+### Files touched
+
+1. `atlas-intel-ui/src/api/contentOps.ts` (new) -- ~250 LOC.
+2. `plans/PR-Content-Ops-API-Adapter.md` (this file).
+
+## Mechanism
+
+The four routes mount under a host-configurable prefix; the
+contract uses `/content-ops` as the canonical default (set in
+`ContentOpsControlSurfaceApiConfig`). The adapter targets that
+prefix relative to `API_BASE`.
+
+Wire types are 1:1 with the backend response JSON. The contract
+doc shows camelCase example types in its "Frontend domain model"
+section, but those camelCase types are the *domain layer* shapes
+(per its "Frontend layering" section). The API adapter's job is
+to mirror the wire format and let the domain layer translate. This
+matches the existing `b2bClient.ts` pattern: snake_case interfaces
+that mirror backend response keys directly.
+
+The execute route is special: the backend maps the
+`ContentOpsExecutionResult.status` field onto HTTP codes (200 /
+207 / 400 / 502), so a simple `await res.json()` is insufficient
+-- the HTTP code itself is part of the contract. The adapter
+returns a discriminated `ContentOpsExecuteOutcome`:
+
+```ts
+type ContentOpsExecuteOutcome =
+  | { kind: "completed"; result: ContentOpsExecutionResult }
+  | { kind: "partial"; result: ContentOpsExecutionResult }
+  | { kind: "failed"; result: ContentOpsExecutionResult }
+  | { kind: "blocked"; result: ContentOpsExecutionResult }
+  | { kind: "validation_error"; detail: unknown }       // 422
+  | { kind: "services_unavailable"; detail: string }    // 503
+  | { kind: "request_invalid"; detail: string };        // 400 (ValueError-shape)
+```
+
+The UI renders one banner per outcome kind. No string-matching on
+HTTP codes elsewhere in the codebase.
+
+## Intentional
+
+- **snake_case wire types**, NOT camelCase. The existing
+  `client.ts` and `b2bClient.ts` mirror the backend literal keys.
+  Translation happens at the domain layer. Avoids accidentally
+  introducing two conventions in `src/api/`.
+- **One file, not four.** The contract suggested
+  `contentOpsControlSurfaces.ts` / `contentOpsPreview.ts` /
+  `contentOpsPlan.ts` / `contentOpsExecute.ts` -- that's more
+  ceremony than the existing repo uses (`client.ts` and
+  `b2bClient.ts` each carry their full surface). Single-file keeps
+  imports tidy and matches convention. If the file grows past
+  ~400 LOC in a future slice, splitting is mechanical.
+- **HTTP-code-aware execute outcome** instead of raising on 207.
+  The existing `client.ts` `handleResponse` throws on `!res.ok`
+  -- but 207 is a partial-success signal, not an error. The
+  adapter's execute wrapper handles 207 / 400 / 502 specially and
+  surfaces them as outcome kinds; the rest of `client.ts`'s
+  401/402/403/4xx behavior stays unchanged.
+- **Discriminated union for execute outcome.** The UI banner is
+  one switch on `kind`. No HTTP-code knowledge leaks into screens.
+- **No domain transforms here.** Resist the temptation to compute
+  `canExecute && executionConfigured` or normalize warnings here;
+  those are domain-layer concerns. This slice is wire-shape only.
+
+## Deferred
+
+- Domain layer (`src/content/contentOps/`) -- camelCase types,
+  `ContentOpsRun` aggregate, reducers/selectors. Next slice.
+- Contract test harness -- fixture JSON + tests pinning the TS
+  shapes to backend dataclass shapes. Should land right after the
+  domain layer (or before -- either order works).
+- Screen 1 / 2 / 3 implementations.
+- Reasoning context view-model (`CampaignReasoningContextView`)
+  belongs in the domain layer; the wire shape is already part of
+  the execute response under `step.result`.
+
+## Verification
+
+- `cd atlas-intel-ui && npm run lint` -- clean.
+- `cd atlas-intel-ui && npx tsc -b --noEmit` -- type-checks.
+- `bash scripts/check_ascii_python.sh` -- N/A (no Python touched).
+- Manual: import the new module from `App.tsx` to confirm no
+  tooling complaints; revert the import before commit (don't ship
+  unused screens; this slice is types-only).
+- `git diff main --stat` -- 2 files, ~250 LOC code + ~150 LOC plan.
+
+## Estimated diff size
+
+- `atlas-intel-ui/src/api/contentOps.ts`: ~250 LOC.
+- `plans/PR-Content-Ops-API-Adapter.md`: ~150 LOC.
+
+Total: ~400 LOC. Right at the budget.


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-API-Adapter.md`

First load-bearing frontend artifact stacking on the contract from PR #401. Adds typed fetch wrappers + wire-shape types for the four `/content-ops/*` routes:

```
GET  /content-ops/control-surfaces  -> ContentOpsCatalogResponse
POST /content-ops/preview           -> ContentOpsPreviewResponse
POST /content-ops/plan              -> GenerationPlanResponse
POST /content-ops/execute           -> ContentOpsExecuteOutcome
```

The execute wrapper is special: the backend maps `ContentOpsExecutionResult.status` onto HTTP codes (200 / 207 / 400 / 502). A plain `res.json()` would lose that signal. The wrapper returns a discriminated `ContentOpsExecuteOutcome` covering `completed | partial | failed | blocked` plus `validation_error` (422), `services_unavailable` (503), and `request_invalid` (400 from `ValueError`). The UI renders one banner per outcome kind without HTTP-code knowledge leaking into screens.

## Intentional

- **snake_case wire types** matching backend literal keys, not camelCase. Existing `client.ts` / `b2bClient.ts` use the same convention; camelCase translation is a domain-layer concern (next slice).
- **One file**, not four. The contract suggested per-route files but existing convention is one file per logical surface.
- **Reuses fetch / auth / 401-refresh / 4xx-fallback plumbing inline** rather than depending on `client.ts` internals. `client.ts` has consumer-dashboard-specific redirects (402 payment, 403 trial-expired) that don't apply to `/content-ops`.

## Deferred

- Domain layer (`src/content/contentOps/`) — camelCase types, `ContentOpsRun` aggregate, reducers/selectors.
- Contract test harness — fixture JSON + tests pinning TS shapes to backend dataclasses.
- Screens 1 / 2 / 3 (New Run / Plan Preview / Execute).
- Reasoning context view-model belongs at the domain layer; the wire shape is already part of the execute response under `step.result`.

## Verification

- `cd atlas-intel-ui && npx tsc -b --noEmit` — clean.
- `cd atlas-intel-ui && npx eslint src/api/contentOps.ts` — clean.
- `cd atlas-intel-ui && npm run build` — builds.
- `git diff main --stat` → 2 files, +490 / -0.

## Diff size

2 files, +490 / -0. Marginally over the 400 LOC soft cap; ~150 LOC is the plan doc, ~340 LOC is the adapter. The adapter could split into multiple files but existing convention is one-file-per-surface (`client.ts`, `b2bClient.ts` are similar size).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_