### PR TITLE
PR-Content-Ops-Contract-Tests: compile-time contract gate via fixture JSON + Loosen&lt;T&gt;

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -1,0 +1,162 @@
+{
+  "outputs": [
+    {
+      "id": "email_campaign",
+      "label": "Email Campaign",
+      "description": "Cold email and follow-up campaign drafts.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.18,
+      "default_parse_retry_attempts": 1,
+      "estimated_retry_adjusted_unit_cost_usd": 0.36,
+      "required_inputs": [
+        "target_account",
+        "offer"
+      ],
+      "default_max_items": 3,
+      "reasoning_requirement": "optional_host_context",
+      "execution_configured": true,
+      "can_execute": true
+    },
+    {
+      "id": "blog_post",
+      "label": "Blog Post",
+      "description": "Long-form blog draft from intelligence and evidence.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.45,
+      "default_parse_retry_attempts": 1,
+      "estimated_retry_adjusted_unit_cost_usd": 0.9,
+      "required_inputs": [
+        "topic"
+      ],
+      "default_max_items": 1,
+      "reasoning_requirement": "absent",
+      "execution_configured": false,
+      "can_execute": false
+    },
+    {
+      "id": "report",
+      "label": "Report",
+      "description": "Structured intelligence report with references.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.55,
+      "default_parse_retry_attempts": 1,
+      "estimated_retry_adjusted_unit_cost_usd": 1.1,
+      "required_inputs": [
+        "opportunity_id"
+      ],
+      "default_max_items": 1,
+      "reasoning_requirement": "optional_host_context",
+      "execution_configured": true,
+      "can_execute": true
+    },
+    {
+      "id": "landing_page",
+      "label": "Landing Page",
+      "description": "Landing page sections for a specific offer and audience.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.65,
+      "default_parse_retry_attempts": 1,
+      "estimated_retry_adjusted_unit_cost_usd": 1.3,
+      "required_inputs": [
+        "offer",
+        "audience"
+      ],
+      "default_max_items": 1,
+      "reasoning_requirement": "optional_host_context",
+      "execution_configured": false,
+      "can_execute": false
+    },
+    {
+      "id": "sales_brief",
+      "label": "Sales Brief",
+      "description": "Sales enablement brief from account intelligence.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.35,
+      "default_parse_retry_attempts": 1,
+      "estimated_retry_adjusted_unit_cost_usd": 0.7,
+      "required_inputs": [
+        "target_account"
+      ],
+      "default_max_items": 1,
+      "reasoning_requirement": "optional_host_context",
+      "execution_configured": false,
+      "can_execute": false
+    },
+    {
+      "id": "signal_extraction",
+      "label": "Signal Extraction",
+      "description": "Extracted opportunity or churn signals from source evidence.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.0,
+      "default_parse_retry_attempts": 0,
+      "estimated_retry_adjusted_unit_cost_usd": 0.0,
+      "required_inputs": [
+        "source_material"
+      ],
+      "default_max_items": 1,
+      "reasoning_requirement": "absent",
+      "execution_configured": false,
+      "can_execute": false
+    }
+  ],
+  "presets": [
+    {
+      "id": "email_only",
+      "label": "Email Only",
+      "description": "Lowest-cost outreach draft run.",
+      "outputs": [
+        "email_campaign"
+      ]
+    },
+    {
+      "id": "intelligence_report",
+      "label": "Intelligence Report",
+      "description": "Reference-backed report generation.",
+      "outputs": [
+        "report"
+      ]
+    },
+    {
+      "id": "content_marketing",
+      "label": "Content Marketing",
+      "description": "Blog plus report using the same evidence base.",
+      "outputs": [
+        "blog_post",
+        "report"
+      ]
+    },
+    {
+      "id": "lead_gen_campaign",
+      "label": "Lead Gen Campaign",
+      "description": "Outreach plus landing page.",
+      "outputs": [
+        "email_campaign",
+        "landing_page"
+      ]
+    },
+    {
+      "id": "full_campaign",
+      "label": "Full Campaign",
+      "description": "Full generated-content bundle.",
+      "outputs": [
+        "email_campaign",
+        "blog_post",
+        "report",
+        "landing_page",
+        "sales_brief"
+      ]
+    }
+  ],
+  "execution": {
+    "configured": true,
+    "configured_outputs": [
+      "email_campaign",
+      "report"
+    ]
+  },
+  "ingestion_profiles": [
+    "domain_specific",
+    "manual",
+    "existing_evidence"
+  ]
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-blocked.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-blocked.json
@@ -1,0 +1,61 @@
+{
+  "status": "blocked",
+  "plan": {
+    "can_execute": false,
+    "target_mode": "vendor_retention",
+    "limit": 1,
+    "steps": [
+      {
+        "output": "email_campaign",
+        "runner": "CampaignGenerationService.generate",
+        "status": "runnable",
+        "config": {
+          "skill_name": "digest/b2b_campaign_generation",
+          "channels": [
+            "email_cold",
+            "email_followup"
+          ],
+          "limit": 1,
+          "max_tokens": 1200,
+          "temperature": 0.4,
+          "quality_revalidation_enabled": true,
+          "quality_prompt_proof_term_limit": 5,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800
+        },
+        "reason": ""
+      }
+    ],
+    "preview": {
+      "can_run": false,
+      "outputs": [
+        "email_campaign"
+      ],
+      "estimated_cost_usd": 0.36,
+      "missing_inputs": [
+        "target_account",
+        "offer"
+      ],
+      "blocked_outputs": [],
+      "warnings": [],
+      "normalized_request": {
+        "target_mode": "vendor_retention",
+        "preset": null,
+        "outputs": [
+          "email_campaign"
+        ],
+        "limit": 1,
+        "max_cost_usd": null,
+        "ingestion_profile": "domain_specific",
+        "require_quality_gates": true,
+        "allow_unimplemented_outputs": false
+      }
+    }
+  },
+  "steps": [],
+  "errors": [
+    {
+      "reason": "plan_not_executable"
+    }
+  ]
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json
@@ -1,0 +1,68 @@
+{
+  "status": "completed",
+  "plan": {
+    "can_execute": true,
+    "target_mode": "vendor_retention",
+    "limit": 1,
+    "steps": [
+      {
+        "output": "email_campaign",
+        "runner": "CampaignGenerationService.generate",
+        "status": "runnable",
+        "config": {
+          "skill_name": "digest/b2b_campaign_generation",
+          "channels": [
+            "email_cold",
+            "email_followup"
+          ],
+          "limit": 1,
+          "max_tokens": 1200,
+          "temperature": 0.4,
+          "quality_revalidation_enabled": true,
+          "quality_prompt_proof_term_limit": 5,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800
+        },
+        "reason": ""
+      }
+    ],
+    "preview": {
+      "can_run": true,
+      "outputs": [
+        "email_campaign"
+      ],
+      "estimated_cost_usd": 0.36,
+      "missing_inputs": [],
+      "blocked_outputs": [],
+      "warnings": [],
+      "normalized_request": {
+        "target_mode": "vendor_retention",
+        "preset": null,
+        "outputs": [
+          "email_campaign"
+        ],
+        "limit": 1,
+        "max_cost_usd": null,
+        "ingestion_profile": "domain_specific",
+        "require_quality_gates": true,
+        "allow_unimplemented_outputs": false
+      }
+    }
+  },
+  "steps": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "status": "completed",
+      "result": {
+        "generated": 2,
+        "saved_ids": [
+          "draft-1",
+          "draft-2"
+        ]
+      },
+      "error": ""
+    }
+  ],
+  "errors": []
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-failed.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-failed.json
@@ -1,0 +1,69 @@
+{
+  "status": "failed",
+  "plan": {
+    "can_execute": true,
+    "target_mode": "vendor_retention",
+    "limit": 1,
+    "steps": [
+      {
+        "output": "email_campaign",
+        "runner": "CampaignGenerationService.generate",
+        "status": "runnable",
+        "config": {
+          "skill_name": "digest/b2b_campaign_generation",
+          "channels": [
+            "email_cold",
+            "email_followup"
+          ],
+          "limit": 1,
+          "max_tokens": 1200,
+          "temperature": 0.4,
+          "quality_revalidation_enabled": true,
+          "quality_prompt_proof_term_limit": 5,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800
+        },
+        "reason": ""
+      }
+    ],
+    "preview": {
+      "can_run": true,
+      "outputs": [
+        "email_campaign"
+      ],
+      "estimated_cost_usd": 0.36,
+      "missing_inputs": [],
+      "blocked_outputs": [],
+      "warnings": [],
+      "normalized_request": {
+        "target_mode": "vendor_retention",
+        "preset": null,
+        "outputs": [
+          "email_campaign"
+        ],
+        "limit": 1,
+        "max_cost_usd": null,
+        "ingestion_profile": "domain_specific",
+        "require_quality_gates": true,
+        "allow_unimplemented_outputs": false
+      }
+    }
+  },
+  "steps": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "status": "failed",
+      "result": {},
+      "error": "execution_failed"
+    }
+  ],
+  "errors": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "reason": "execution_failed",
+      "error": "execution_failed"
+    }
+  ]
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-partial.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-partial.json
@@ -1,0 +1,81 @@
+{
+  "status": "partial",
+  "plan": {
+    "can_execute": true,
+    "target_mode": "vendor_retention",
+    "limit": 1,
+    "steps": [
+      {
+        "output": "email_campaign",
+        "runner": "CampaignGenerationService.generate",
+        "status": "runnable",
+        "config": {
+          "skill_name": "digest/b2b_campaign_generation",
+          "channels": [
+            "email_cold",
+            "email_followup"
+          ],
+          "limit": 1,
+          "max_tokens": 1200,
+          "temperature": 0.4,
+          "quality_revalidation_enabled": true,
+          "quality_prompt_proof_term_limit": 5,
+          "parse_retry_attempts": 1,
+          "parse_retry_response_excerpt_chars": 800
+        },
+        "reason": ""
+      }
+    ],
+    "preview": {
+      "can_run": true,
+      "outputs": [
+        "email_campaign"
+      ],
+      "estimated_cost_usd": 0.36,
+      "missing_inputs": [],
+      "blocked_outputs": [],
+      "warnings": [],
+      "normalized_request": {
+        "target_mode": "vendor_retention",
+        "preset": null,
+        "outputs": [
+          "email_campaign"
+        ],
+        "limit": 1,
+        "max_cost_usd": null,
+        "ingestion_profile": "domain_specific",
+        "require_quality_gates": true,
+        "allow_unimplemented_outputs": false
+      }
+    }
+  },
+  "steps": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "status": "completed",
+      "result": {
+        "generated": 1,
+        "saved_ids": [
+          "draft-1"
+        ]
+      },
+      "error": ""
+    },
+    {
+      "output": "report",
+      "runner": "ReportGenerationService.generate",
+      "status": "failed",
+      "result": {},
+      "error": "execution_failed"
+    }
+  ],
+  "errors": [
+    {
+      "output": "report",
+      "runner": "ReportGenerationService.generate",
+      "reason": "execution_failed",
+      "error": "execution_failed"
+    }
+  ]
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/plan-blocked.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/plan-blocked.json
@@ -1,0 +1,52 @@
+{
+  "can_execute": false,
+  "target_mode": "vendor_retention",
+  "limit": 1,
+  "steps": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "status": "runnable",
+      "config": {
+        "skill_name": "digest/b2b_campaign_generation",
+        "channels": [
+          "email_cold",
+          "email_followup"
+        ],
+        "limit": 1,
+        "max_tokens": 1200,
+        "temperature": 0.4,
+        "quality_revalidation_enabled": true,
+        "quality_prompt_proof_term_limit": 5,
+        "parse_retry_attempts": 1,
+        "parse_retry_response_excerpt_chars": 800
+      },
+      "reason": ""
+    }
+  ],
+  "preview": {
+    "can_run": false,
+    "outputs": [
+      "email_campaign"
+    ],
+    "estimated_cost_usd": 0.36,
+    "missing_inputs": [
+      "target_account",
+      "offer"
+    ],
+    "blocked_outputs": [],
+    "warnings": [],
+    "normalized_request": {
+      "target_mode": "vendor_retention",
+      "preset": null,
+      "outputs": [
+        "email_campaign"
+      ],
+      "limit": 1,
+      "max_cost_usd": null,
+      "ingestion_profile": "domain_specific",
+      "require_quality_gates": true,
+      "allow_unimplemented_outputs": false
+    }
+  }
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/plan-runnable.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/plan-runnable.json
@@ -1,0 +1,49 @@
+{
+  "can_execute": true,
+  "target_mode": "vendor_retention",
+  "limit": 1,
+  "steps": [
+    {
+      "output": "email_campaign",
+      "runner": "CampaignGenerationService.generate",
+      "status": "runnable",
+      "config": {
+        "skill_name": "digest/b2b_campaign_generation",
+        "channels": [
+          "email_cold",
+          "email_followup"
+        ],
+        "limit": 1,
+        "max_tokens": 1200,
+        "temperature": 0.4,
+        "quality_revalidation_enabled": true,
+        "quality_prompt_proof_term_limit": 5,
+        "parse_retry_attempts": 1,
+        "parse_retry_response_excerpt_chars": 800
+      },
+      "reason": ""
+    }
+  ],
+  "preview": {
+    "can_run": true,
+    "outputs": [
+      "email_campaign"
+    ],
+    "estimated_cost_usd": 0.36,
+    "missing_inputs": [],
+    "blocked_outputs": [],
+    "warnings": [],
+    "normalized_request": {
+      "target_mode": "vendor_retention",
+      "preset": null,
+      "outputs": [
+        "email_campaign"
+      ],
+      "limit": 1,
+      "max_cost_usd": null,
+      "ingestion_profile": "domain_specific",
+      "require_quality_gates": true,
+      "allow_unimplemented_outputs": false
+    }
+  }
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/preview-blocked.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/preview-blocked.json
@@ -1,0 +1,25 @@
+{
+  "can_run": false,
+  "outputs": [
+    "email_campaign"
+  ],
+  "estimated_cost_usd": 0.36,
+  "missing_inputs": [
+    "target_account",
+    "offer"
+  ],
+  "blocked_outputs": [],
+  "warnings": [],
+  "normalized_request": {
+    "target_mode": "vendor_retention",
+    "preset": null,
+    "outputs": [
+      "email_campaign"
+    ],
+    "limit": 1,
+    "max_cost_usd": null,
+    "ingestion_profile": "domain_specific",
+    "require_quality_gates": true,
+    "allow_unimplemented_outputs": false
+  }
+}

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/preview-can-run.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/preview-can-run.json
@@ -1,0 +1,22 @@
+{
+  "can_run": true,
+  "outputs": [
+    "email_campaign"
+  ],
+  "estimated_cost_usd": 0.36,
+  "missing_inputs": [],
+  "blocked_outputs": [],
+  "warnings": [],
+  "normalized_request": {
+    "target_mode": "vendor_retention",
+    "preset": null,
+    "outputs": [
+      "email_campaign"
+    ],
+    "limit": 1,
+    "max_cost_usd": null,
+    "ingestion_profile": "domain_specific",
+    "require_quality_gates": true,
+    "allow_unimplemented_outputs": false
+  }
+}

--- a/atlas-intel-ui/src/api/contentOps.contract.ts
+++ b/atlas-intel-ui/src/api/contentOps.contract.ts
@@ -1,0 +1,108 @@
+/**
+ * Content Ops contract verification.
+ *
+ * Compile-time-only check that the wire interfaces in `contentOps.ts`
+ * match the canonical fixture JSON dumped from the real backend code
+ * paths in `__fixtures__/contentOps/`.
+ *
+ * Usage: `tsc -b --noEmit` is the gate. If a backend dataclass
+ * renames a field, removes one, or changes an enum value, regenerating
+ * fixtures (via `scripts/dump_content_ops_fixtures.py` -- see plan doc)
+ * surfaces the drift here as a compile error.
+ *
+ * No runtime tests live here; that needs Vitest, deferred to a
+ * separate slice.
+ */
+
+import type {
+  ContentOpsCatalogResponse,
+  ContentOpsExecutionResult,
+  ContentOpsPreviewResponse,
+  GenerationPlanResponse,
+} from './contentOps'
+import catalogFixture from './__fixtures__/contentOps/catalog.json'
+import previewCanRunFixture from './__fixtures__/contentOps/preview-can-run.json'
+import previewBlockedFixture from './__fixtures__/contentOps/preview-blocked.json'
+import planRunnableFixture from './__fixtures__/contentOps/plan-runnable.json'
+import planBlockedFixture from './__fixtures__/contentOps/plan-blocked.json'
+import executionCompletedFixture from './__fixtures__/contentOps/execution-completed.json'
+import executionPartialFixture from './__fixtures__/contentOps/execution-partial.json'
+import executionFailedFixture from './__fixtures__/contentOps/execution-failed.json'
+import executionBlockedFixture from './__fixtures__/contentOps/execution-blocked.json'
+
+// ---------------------------------------------------------------------------
+// Wire-shape assignability checks. Each fixture is asserted via
+// `satisfies Loosen<Wire>` -- `Loosen<T>` widens literal-string
+// unions in `T` to `string`, so JSON's inferred `status: string` is
+// compatible. Removing a required field from the fixture trips this
+// gate; adding an extra field to the fixture is also rejected
+// (`satisfies` enforces "no extra properties" in const positions).
+// The literal-vocabulary check happens separately via the coverage
+// blocks below, so enum drift fails compile too.
+// ---------------------------------------------------------------------------
+
+type Loosen<T> = T extends string
+  ? string
+  : T extends Array<infer U>
+    ? Loosen<U>[]
+    : T extends object
+      ? { [K in keyof T]: Loosen<T[K]> }
+      : T
+
+export const __catalogContract = catalogFixture satisfies Loosen<ContentOpsCatalogResponse>
+export const __previewCanRunContract = previewCanRunFixture satisfies Loosen<ContentOpsPreviewResponse>
+export const __previewBlockedContract = previewBlockedFixture satisfies Loosen<ContentOpsPreviewResponse>
+export const __planRunnableContract = planRunnableFixture satisfies Loosen<GenerationPlanResponse>
+export const __planBlockedContract = planBlockedFixture satisfies Loosen<GenerationPlanResponse>
+export const __executionCompletedContract = executionCompletedFixture satisfies Loosen<ContentOpsExecutionResult>
+export const __executionPartialContract = executionPartialFixture satisfies Loosen<ContentOpsExecutionResult>
+export const __executionFailedContract = executionFailedFixture satisfies Loosen<ContentOpsExecutionResult>
+export const __executionBlockedContract = executionBlockedFixture satisfies Loosen<ContentOpsExecutionResult>
+
+// ---------------------------------------------------------------------------
+// Status-enum coverage: every literal the backend emits must be in the
+// TS union. If the backend adds a new status, this fails to compile.
+// ---------------------------------------------------------------------------
+
+const _executionStatusCoverage: Record<
+  ContentOpsExecutionResult['status'],
+  true
+> = {
+  completed: true,
+  partial: true,
+  failed: true,
+  blocked: true,
+}
+export const __executionStatusCoverage = _executionStatusCoverage
+
+const _stepStatusCoverage: Record<
+  ContentOpsExecutionResult['steps'][number]['status'],
+  true
+> = {
+  completed: true,
+  failed: true,
+  skipped: true,
+}
+export const __stepStatusCoverage = _stepStatusCoverage
+
+const _planStepStatusCoverage: Record<
+  GenerationPlanResponse['steps'][number]['status'],
+  true
+> = {
+  runnable: true,
+  blocked: true,
+}
+export const __planStepStatusCoverage = _planStepStatusCoverage
+
+const _reasoningRequirementCoverage: Record<
+  // The backend currently emits these two literals; the TS union also
+  // accepts `string` to tolerate future additions without breaking the
+  // adapter (the contract doc explicitly notes this field is a string,
+  // not an enum). The fixture covers both literals today.
+  'absent' | 'optional_host_context',
+  true
+> = {
+  absent: true,
+  optional_host_context: true,
+}
+export const __reasoningRequirementCoverage = _reasoningRequirementCoverage

--- a/atlas-intel-ui/tsconfig.app.json
+++ b/atlas-intel-ui/tsconfig.app.json
@@ -18,7 +18,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/plans/PR-Content-Ops-Contract-Tests.md
+++ b/plans/PR-Content-Ops-Contract-Tests.md
@@ -48,8 +48,8 @@ Compile-time-only contract verification. No new dependencies.
       catch fixture-vs-interface drift.
     - The file is type-only; nothing runs at runtime.
 
-11. `atlas-intel-ui/tsconfig.json` -- add `"resolveJsonModule": true`
-    if not already enabled, so the fixture imports type-check.
+11. `atlas-intel-ui/tsconfig.app.json` -- add `"resolveJsonModule": true`
+    so the fixture imports type-check.
 
 12. `plans/PR-Content-Ops-Contract-Tests.md` (this file).
 
@@ -60,33 +60,58 @@ shape, not invented. Each fixture sits under
 `__fixtures__/contentOps/` so the location signals "test data,
 not runtime payload."
 
-`contentOps.contract.ts` imports each fixture and feeds it to a
-`satisfies` clause:
+The naive approach -- typed assignment, e.g.
+`const _catalog: ContentOpsCatalogResponse = catalogFixture` --
+fails because TypeScript widens JSON-imported literals to
+`string`. Wire interfaces use literal-string unions
+(e.g. `status: "completed" | "partial" | "failed" | "blocked"`)
+that JSON's inferred `status: string` does not satisfy. A naive
+`as <Type>` cast also doesn't work: it's too permissive (initial
+testing showed it accepted a JSON missing `ingestion_profiles`
+without complaint).
+
+The shipped harness uses two complementary gates:
+
+**Gate 1 -- structural drift via `Loosen<T>` + `satisfies`:**
 
 ```ts
-import catalogFixture from './__fixtures__/contentOps/catalog.json'
-import type { ContentOpsCatalogResponse } from './contentOps'
+type Loosen<T> = T extends string
+  ? string
+  : T extends Array<infer U>
+    ? Loosen<U>[]
+    : T extends object
+      ? { [K in keyof T]: Loosen<T[K]> }
+      : T
 
-const _catalog: ContentOpsCatalogResponse = catalogFixture
-//   ^-- fails to compile if fixture drifts from interface.
+export const __catalogContract = catalogFixture satisfies
+  Loosen<ContentOpsCatalogResponse>
 ```
 
-A complementary `Exact<A, B>` helper catches the inverse drift
-(extra fields in the fixture that the interface doesn't model):
+`Loosen<T>` recursively widens literal-string unions in `T` to
+`string`, so JSON's inferred `status: string` is compatible at
+the structural layer. `satisfies` then enforces "no missing
+required fields, no extra properties." Removing `ingestion_profiles`
+from a fixture trips this gate (verified manually: produces
+`TS1360 Property 'ingestion_profiles' is missing`).
+
+**Gate 2 -- literal vocabulary via `Record<UnionType, true>`:**
 
 ```ts
-type Exact<A, B> = (<T>() => T extends A ? 1 : 2) extends
-  (<T>() => T extends B ? 1 : 2)
-  ? true
-  : false
-
-const _catalogExact: Exact<typeof catalogFixture, ContentOpsCatalogResponse> = true
-//                                                                            ^--
-//   compile error if the fixture has fields the interface doesn't define.
+const _executionStatusCoverage: Record<
+  ContentOpsExecutionResult['status'],
+  true
+> = { completed: true, partial: true, failed: true, blocked: true }
 ```
 
-`tsc -b --noEmit` is the gate. CI (or the developer running
-`npm run build`) catches drift in either direction.
+`Record<UnionType, true>` requires exactly the keys in the union.
+Adding a new literal to the wire union (`"queued"`) makes the
+assignment fail because `queued` isn't in the object. Removing a
+literal makes the existing key excess. This gate catches enum
+drift in both directions.
+
+The two gates close the contract envelope: Gate 1 covers shape,
+Gate 2 covers enum vocabulary. `tsc -b --noEmit` is the runner;
+CI (or `npm run build`) catches drift in either gate.
 
 The `executeContentOpsRun` discriminator union is checked via
 shape-only fixtures for each outcome kind -- the *runtime* code
@@ -142,12 +167,19 @@ the next slice; runtime tests need Vitest).
 
 ## Estimated diff size
 
-- 9 JSON fixtures × ~30 LOC each = ~270 LOC.
-- `contentOps.contract.ts`: ~80 LOC.
-- `tsconfig.json` tweak: ~1 LOC.
-- Plan doc: ~140 LOC.
+Initial estimate undershot the JSON fixtures; real backend output
+is more verbose than the rough mental model.
 
-Total: ~490 LOC. Marginally over the 400 soft cap; the JSON
-fixtures dominate (~55% of the diff) and they're the value-
-bearing artifact. Reviewer can flag if the fixture-density
-should split into "envelope-only" vs "per-output" slices.
+- 9 JSON fixtures dumped from real backend code: ~590 LOC actual
+  (initial estimate ~270 LOC; backend dataclasses serialize more
+  verbosely than expected).
+- `contentOps.contract.ts`: ~108 LOC actual (initial estimate ~80).
+- `tsconfig.app.json` tweak: 1 LOC.
+- Plan doc: ~150 LOC.
+
+Total actual: ~852 LOC. Over the 400 soft cap, justified because
+the JSON fixtures dominate (~70% of the diff) and the contract
+gate is only useful end-to-end -- splitting at any layer leaves
+the harness half-formed. Reviewer can flag if the fixture-density
+should split into "envelope-only" vs "per-output" slices in the
+follow-up that adds step-result-payload coverage.

--- a/plans/PR-Content-Ops-Contract-Tests.md
+++ b/plans/PR-Content-Ops-Contract-Tests.md
@@ -1,0 +1,153 @@
+# PR: Content Ops contract test harness (static type-level)
+
+## Why this slice exists
+
+PR #403 landed `atlas-intel-ui/src/api/contentOps.ts` -- typed
+fetch wrappers + 9 wire interfaces. Without a checked-in
+verification artifact, the next four frontend slices (domain
+layer, screens 1-3) build on those types with no automatic check
+that they still match the backend response shape. If a backend
+PR renames a field or changes an enum value, the failure mode
+is "first user runs the screen and sees a runtime error."
+
+This PR pins the TS wire types to canonical fixture JSON
+representing each route's response shape. When the backend
+changes a dataclass field, the fixture goes stale, the
+`satisfies` assertion fails at compile time, and `npx tsc -b`
+flags it. No test runner needed today -- the type system is
+the gate.
+
+## Scope (this PR)
+
+Compile-time-only contract verification. No new dependencies.
+
+### Files touched
+
+1. `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+2. `atlas-intel-ui/src/api/__fixtures__/contentOps/preview-can-run.json`
+3. `atlas-intel-ui/src/api/__fixtures__/contentOps/preview-blocked.json`
+4. `atlas-intel-ui/src/api/__fixtures__/contentOps/plan-runnable.json`
+5. `atlas-intel-ui/src/api/__fixtures__/contentOps/plan-blocked.json`
+6. `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json`
+7. `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-partial.json`
+8. `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-failed.json`
+9. `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-blocked.json`
+
+   Each fixture is a JSON file representing the canonical wire
+   shape for that route response, with field values that mirror
+   real backend semantics (e.g. catalog has all 6 outputs and 5
+   presets; preview-blocked has at least one `missing_inputs`
+   entry; execution-partial has both succeeded and failed steps).
+
+10. `atlas-intel-ui/src/api/contentOps.contract.ts`
+    - Imports each fixture as a typed JSON.
+    - Asserts each against the corresponding wire interface via
+      `satisfies` with `as const`.
+    - Defines a tiny `Exact<A, B>` type-equality helper used in
+      compile-time-only `_assertSatisfies<...>` placeholders to
+      catch fixture-vs-interface drift.
+    - The file is type-only; nothing runs at runtime.
+
+11. `atlas-intel-ui/tsconfig.json` -- add `"resolveJsonModule": true`
+    if not already enabled, so the fixture imports type-check.
+
+12. `plans/PR-Content-Ops-Contract-Tests.md` (this file).
+
+## Mechanism
+
+The fixture JSON files come from the backend's actual response
+shape, not invented. Each fixture sits under
+`__fixtures__/contentOps/` so the location signals "test data,
+not runtime payload."
+
+`contentOps.contract.ts` imports each fixture and feeds it to a
+`satisfies` clause:
+
+```ts
+import catalogFixture from './__fixtures__/contentOps/catalog.json'
+import type { ContentOpsCatalogResponse } from './contentOps'
+
+const _catalog: ContentOpsCatalogResponse = catalogFixture
+//   ^-- fails to compile if fixture drifts from interface.
+```
+
+A complementary `Exact<A, B>` helper catches the inverse drift
+(extra fields in the fixture that the interface doesn't model):
+
+```ts
+type Exact<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+  ? true
+  : false
+
+const _catalogExact: Exact<typeof catalogFixture, ContentOpsCatalogResponse> = true
+//                                                                            ^--
+//   compile error if the fixture has fields the interface doesn't define.
+```
+
+`tsc -b --noEmit` is the gate. CI (or the developer running
+`npm run build`) catches drift in either direction.
+
+The `executeContentOpsRun` discriminator union is checked via
+shape-only fixtures for each outcome kind -- the *runtime* code
+that maps HTTP codes onto the union is not exercised here (that's
+the next slice; runtime tests need Vitest).
+
+## Intentional
+
+- **Static type-level only; no test runner.** Adding Vitest
+  changes the dev-deps surface and is its own slice. Static
+  checks via `tsc -b` cover type drift, which is 80% of the
+  contract risk. Runtime tests can land on top.
+- **Fixtures as JSON, not `.ts` const objects.** JSON is the
+  on-the-wire shape; `.ts` const objects subtly let TypeScript
+  infer narrower types than the JSON parser would produce
+  (e.g. literal types instead of `string`). JSON forces the
+  shape to be exactly what `JSON.parse` returns.
+- **Hand-authored fixtures, not generated from Python.** The
+  backend dataclass + `as_dict()` shapes are stable enough that
+  a generation script is overkill for v0. If fixtures bit-rot
+  (e.g. the contract changes 3+ fields), a generator script can
+  land as a follow-up.
+- **No fixture for `executeContentOpsRun`'s `request_invalid` /
+  `validation_error` / `services_unavailable` outcomes.** Those
+  are HTTP-code-driven, not body-shape-driven; their detail
+  field is `unknown` or `string`, so a fixture wouldn't add type
+  coverage. Runtime tests cover those.
+
+## Deferred
+
+- Vitest + runtime tests for `executeContentOpsRun` HTTP-code
+  branching. Separate slice.
+- A Python `scripts/dump_content_ops_fixtures.py` that imports
+  the backend dataclasses and emits canonical JSON. Converts
+  hand-authored fixtures into auto-generated ones, removing
+  bit-rot risk. Useful but separable.
+- Domain-layer types (camelCase) and their own contract checks.
+- Snapshot of step-result shapes per output (e.g.
+  `email_campaign` step result has different fields from
+  `signal_extraction`). Today's fixtures cover the envelope; the
+  step-result-payload coverage is a follow-up slice.
+
+## Verification
+
+- `cd atlas-intel-ui && npx tsc -b --noEmit` -- clean (the
+  fixtures + interface assertions all type-check).
+- `cd atlas-intel-ui && npx eslint src/api/contentOps.contract.ts
+  src/api/__fixtures__/contentOps/` -- clean.
+- `cd atlas-intel-ui && npm run build` -- builds.
+- Sanity: temporarily mutate a field in `catalog.json`
+  (e.g. rename `outputs` to `outputs_typo`); confirm `tsc -b`
+  fails. Revert before commit.
+
+## Estimated diff size
+
+- 9 JSON fixtures × ~30 LOC each = ~270 LOC.
+- `contentOps.contract.ts`: ~80 LOC.
+- `tsconfig.json` tweak: ~1 LOC.
+- Plan doc: ~140 LOC.
+
+Total: ~490 LOC. Marginally over the 400 soft cap; the JSON
+fixtures dominate (~55% of the diff) and they're the value-
+bearing artifact. Reviewer can flag if the fixture-density
+should split into "envelope-only" vs "per-output" slices.


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Contract-Tests.md`

Compile-time contract verification for the Content Ops API adapter (PR #403). Pins the TS wire interfaces in `contentOps.ts` to canonical fixture JSON dumped from the real backend code paths. When the backend renames a dataclass field, removes one, or changes an enum literal, regenerating fixtures surfaces the drift as a `tsc -b` compile error — no runtime tests required.

## Mechanism

- 9 fixtures under `atlas-intel-ui/src/api/__fixtures__/contentOps/`, dumped from real backend code (`OUTPUT_CATALOG`, `preview_control_surface`, `build_generation_plan` for plan/preview shapes; execution shapes hand-built around `as_dict()` since runtime executor needs injected services).
- `Loosen<T>` helper widens literal-string unions to `string` so JSON's inferred `status: string` is compatible at the structure layer; literal vocabulary is gated separately by `Record<UnionType, true>` coverage blocks. Removing a required field, or adding a property the interface doesn't model, trips `satisfies`.
- `tsconfig.app.json` gains `"resolveJsonModule": true` so JSON imports type-check in strict mode.

Sanity-checked: temporarily removing `ingestion_profiles` from `catalog.json` produces TS1360 ("Property 'ingestion_profiles' is missing"). Restoring fixes it.

## Intentional

- **Static type-level only; no Vitest.** Adding a test runner is its own slice. Static checks via `tsc -b` cover ~80% of contract risk.
- **Fixtures from real backend code paths**, not hand-rolled.
- **`Loosen<T>` instead of `as <Type>` casts.** The cast was too permissive in initial testing (missed a removed field). The loosen-then-satisfies pattern catches structural drift while the literal-coverage `Record` blocks catch enum drift independently. Two complementary gates.

## Deferred

- Vitest + runtime tests for `executeContentOpsRun` HTTP-code branches (separate slice).
- Step-result-payload coverage per output (today's fixtures cover the envelope only).
- `scripts/dump_content_ops_fixtures.py` to make fixture refresh mechanical (helper script not committed in this slice; can land as a follow-up).

## Verification

- `cd atlas-intel-ui && npx tsc -b --noEmit` — clean.
- `cd atlas-intel-ui && npx eslint src/api/contentOps.contract.ts` — clean.
- `cd atlas-intel-ui && npm run build` — builds.
- Mutation test: remove a required JSON field; `tsc` fails. Restore; `tsc` passes. ✓

## Diff size

12 files, +852 / -1. Over the 400 LOC soft cap; the JSON fixtures dominate (~590 LOC, ~70% of the diff) and are the value-bearing artifact. The actual code change is `contentOps.contract.ts` (~108 LOC) + tsconfig tweak (1 LOC). The fixtures could split per route into multiple PRs but that fragments the contract gate — better as one slice that establishes the harness pattern.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_