### PR TITLE
PR-Content-Ops-Domain-Layer: camelCase types + fromWire mappers + ContentOpsRun aggregate

### DIFF
--- a/atlas-intel-ui/src/domain/contentOps/contract.ts
+++ b/atlas-intel-ui/src/domain/contentOps/contract.ts
@@ -1,0 +1,93 @@
+/**
+ * Content Ops domain contract pin.
+ *
+ * Feeds each wire fixture (committed in `src/api/__fixtures__/`)
+ * through the corresponding `fromWire*` mapper and asserts the
+ * result satisfies the domain type. Same `Loosen<T>` + `satisfies`
+ * gate pattern as `src/api/contentOps.contract.ts` from PR #404.
+ *
+ * If a wire field is renamed and the mapper isn't updated, the
+ * mapper trips at compile time (its return statement won't match
+ * the domain type). If a domain type is updated without the mapper
+ * being updated, the satisfies check trips here.
+ */
+
+import type {
+  ContentOpsCatalogResponse,
+  ContentOpsExecutionResult as WireExecutionResult,
+  ContentOpsPreviewResponse,
+  GenerationPlanResponse,
+} from '../../api/contentOps'
+import catalogFixture from '../../api/__fixtures__/contentOps/catalog.json'
+import executionBlockedFixture from '../../api/__fixtures__/contentOps/execution-blocked.json'
+import executionCompletedFixture from '../../api/__fixtures__/contentOps/execution-completed.json'
+import executionFailedFixture from '../../api/__fixtures__/contentOps/execution-failed.json'
+import executionPartialFixture from '../../api/__fixtures__/contentOps/execution-partial.json'
+import planBlockedFixture from '../../api/__fixtures__/contentOps/plan-blocked.json'
+import planRunnableFixture from '../../api/__fixtures__/contentOps/plan-runnable.json'
+import previewBlockedFixture from '../../api/__fixtures__/contentOps/preview-blocked.json'
+import previewCanRunFixture from '../../api/__fixtures__/contentOps/preview-can-run.json'
+import {
+  fromWireCatalog,
+  fromWireExecution,
+  fromWirePlan,
+  fromWirePreview,
+} from './fromWire'
+import type {
+  ContentOpsCatalog,
+  ContentOpsExecutionResult,
+  ControlSurfacePreview,
+  GenerationPlan,
+} from './types'
+
+// `Loosen<T>` widens literal-string unions in `T` to `string` so
+// JSON's inferred `status: string` is compatible at the structure
+// layer; literal vocabulary is gated separately by the `Record<>`
+// blocks in `src/api/contentOps.contract.ts`.
+type Loosen<T> = T extends string
+  ? string
+  : T extends Array<infer U>
+    ? Loosen<U>[]
+    : T extends object
+      ? { [K in keyof T]: Loosen<T[K]> }
+      : T
+
+// Pin each fixture -> domain type via the wire-typed cast at the
+// fixture import site. The fixture cast is safe because PR #404
+// already pinned the fixtures to the wire shape.
+
+export const __domainCatalogContract = fromWireCatalog(
+  catalogFixture as ContentOpsCatalogResponse,
+) satisfies Loosen<ContentOpsCatalog>
+
+export const __domainPreviewCanRunContract = fromWirePreview(
+  previewCanRunFixture as ContentOpsPreviewResponse,
+) satisfies Loosen<ControlSurfacePreview>
+
+export const __domainPreviewBlockedContract = fromWirePreview(
+  previewBlockedFixture as ContentOpsPreviewResponse,
+) satisfies Loosen<ControlSurfacePreview>
+
+export const __domainPlanRunnableContract = fromWirePlan(
+  planRunnableFixture as GenerationPlanResponse,
+) satisfies Loosen<GenerationPlan>
+
+export const __domainPlanBlockedContract = fromWirePlan(
+  planBlockedFixture as GenerationPlanResponse,
+) satisfies Loosen<GenerationPlan>
+
+export const __domainExecutionCompletedContract = fromWireExecution(
+  executionCompletedFixture as WireExecutionResult,
+) satisfies Loosen<ContentOpsExecutionResult>
+
+export const __domainExecutionPartialContract = fromWireExecution(
+  executionPartialFixture as WireExecutionResult,
+) satisfies Loosen<ContentOpsExecutionResult>
+
+export const __domainExecutionFailedContract = fromWireExecution(
+  executionFailedFixture as WireExecutionResult,
+) satisfies Loosen<ContentOpsExecutionResult>
+
+export const __domainExecutionBlockedContract = fromWireExecution(
+  executionBlockedFixture as WireExecutionResult,
+) satisfies Loosen<ContentOpsExecutionResult>

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -1,0 +1,210 @@
+/**
+ * Wire-to-domain mappers for Content Ops.
+ *
+ * Translates the snake_case API adapter response shapes into
+ * camelCase domain types. Pure data transforms; no React, no
+ * HTTP, no side effects.
+ *
+ * Screens import the result of these mappers via
+ * `src/domain/contentOps` (the barrel), never the wire types
+ * directly.
+ */
+
+import type {
+  ContentOpsCatalogResponse,
+  ContentOpsExecutionResult as WireExecutionResult,
+  ContentOpsOutputDefinition as WireOutputDefinition,
+  ContentOpsPreset as WirePreset,
+  ContentOpsPreviewResponse,
+  ContentOpsRequestBody,
+  ContentOpsStepExecution as WireStepExecution,
+  GenerationPlanResponse,
+  GenerationPlanStep as WirePlanStep,
+} from '../../api/contentOps'
+import type {
+  ContentOpsCatalog,
+  ContentOpsExecutionResult,
+  ContentOpsRequest,
+  ContentOpsStepExecution,
+  ControlSurfacePresetView,
+  ControlSurfacePreview,
+  GenerationPlan,
+  GenerationPlanStep,
+  OutputDefinitionView,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Catalog
+// ---------------------------------------------------------------------------
+
+export function fromWireOutputDefinition(
+  wire: WireOutputDefinition,
+): OutputDefinitionView {
+  return {
+    id: wire.id,
+    label: wire.label,
+    description: wire.description,
+    implemented: wire.implemented,
+    estimatedUnitCostUsd: wire.estimated_unit_cost_usd,
+    defaultParseRetryAttempts: wire.default_parse_retry_attempts,
+    estimatedRetryAdjustedUnitCostUsd: wire.estimated_retry_adjusted_unit_cost_usd,
+    requiredInputs: [...wire.required_inputs],
+    defaultMaxItems: wire.default_max_items,
+    reasoningRequirement: wire.reasoning_requirement,
+    executionConfigured: wire.execution_configured,
+    canExecute: wire.can_execute,
+  }
+}
+
+export function fromWirePreset(wire: WirePreset): ControlSurfacePresetView {
+  return {
+    id: wire.id,
+    label: wire.label,
+    description: wire.description,
+    outputs: [...wire.outputs],
+  }
+}
+
+export function fromWireCatalog(
+  wire: ContentOpsCatalogResponse,
+): ContentOpsCatalog {
+  return {
+    outputs: wire.outputs.map(fromWireOutputDefinition),
+    presets: wire.presets.map(fromWirePreset),
+    execution: {
+      configured: wire.execution.configured,
+      configuredOutputs: [...wire.execution.configured_outputs],
+    },
+    ingestionProfiles: [...wire.ingestion_profiles],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate a wire request body (all fields optional) into a
+ * domain request with explicit defaults applied. Mirrors the
+ * pydantic defaults at `api/control_surfaces.py:79-92`.
+ */
+export function fromWireRequest(
+  wire: ContentOpsRequestBody,
+): ContentOpsRequest {
+  return {
+    targetMode: wire.target_mode ?? 'vendor_retention',
+    preset: wire.preset ?? null,
+    outputs: wire.outputs ? [...wire.outputs] : [],
+    limit: wire.limit ?? 1,
+    maxCostUsd: wire.max_cost_usd ?? null,
+    inputs: { ...(wire.inputs ?? {}) },
+    ingestionProfile: wire.ingestion_profile ?? 'domain_specific',
+    requireQualityGates: wire.require_quality_gates ?? true,
+    allowUnimplementedOutputs: wire.allow_unimplemented_outputs ?? false,
+  }
+}
+
+/**
+ * Inverse of `fromWireRequest`: domain to wire body. Used when
+ * a screen submits a request to the backend.
+ */
+export function toWireRequest(
+  domain: ContentOpsRequest,
+): ContentOpsRequestBody {
+  return {
+    target_mode: domain.targetMode,
+    preset: domain.preset,
+    outputs: [...domain.outputs],
+    limit: domain.limit,
+    max_cost_usd: domain.maxCostUsd,
+    inputs: { ...domain.inputs },
+    ingestion_profile: domain.ingestionProfile,
+    require_quality_gates: domain.requireQualityGates,
+    allow_unimplemented_outputs: domain.allowUnimplementedOutputs,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Preview
+// ---------------------------------------------------------------------------
+
+export function fromWirePreview(
+  wire: ContentOpsPreviewResponse,
+): ControlSurfacePreview {
+  return {
+    canRun: wire.can_run,
+    outputs: [...wire.outputs],
+    estimatedCostUsd: wire.estimated_cost_usd,
+    missingInputs: [...wire.missing_inputs],
+    blockedOutputs: [...wire.blocked_outputs],
+    warnings: [...wire.warnings],
+    normalizedRequest: wire.normalized_request
+      ? {
+          targetMode: wire.normalized_request.target_mode ?? 'vendor_retention',
+          preset: wire.normalized_request.preset ?? null,
+          outputs: wire.normalized_request.outputs
+            ? [...wire.normalized_request.outputs]
+            : [],
+          limit: wire.normalized_request.limit ?? 1,
+          maxCostUsd: wire.normalized_request.max_cost_usd ?? null,
+          ingestionProfile:
+            wire.normalized_request.ingestion_profile ?? 'domain_specific',
+          requireQualityGates:
+            wire.normalized_request.require_quality_gates ?? true,
+          allowUnimplementedOutputs:
+            wire.normalized_request.allow_unimplemented_outputs ?? false,
+        }
+      : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+export function fromWirePlanStep(wire: WirePlanStep): GenerationPlanStep {
+  return {
+    output: wire.output,
+    runner: wire.runner,
+    status: wire.status,
+    config: { ...wire.config },
+    reason: wire.reason,
+  }
+}
+
+export function fromWirePlan(wire: GenerationPlanResponse): GenerationPlan {
+  return {
+    canExecute: wire.can_execute,
+    targetMode: wire.target_mode,
+    limit: wire.limit,
+    steps: wire.steps.map(fromWirePlanStep),
+    preview: fromWirePreview(wire.preview),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+export function fromWireStepExecution(
+  wire: WireStepExecution,
+): ContentOpsStepExecution {
+  return {
+    output: wire.output,
+    runner: wire.runner,
+    status: wire.status,
+    result: { ...wire.result },
+    error: wire.error,
+  }
+}
+
+export function fromWireExecution(
+  wire: WireExecutionResult,
+): ContentOpsExecutionResult {
+  return {
+    status: wire.status,
+    plan: fromWirePlan(wire.plan),
+    steps: wire.steps.map(fromWireStepExecution),
+    errors: wire.errors.map((e) => ({ ...e })),
+  }
+}

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Content Ops domain barrel.
+ *
+ * Screens and view-models import from this path; the underlying
+ * `types.ts` / `fromWire.ts` split is implementation detail.
+ */
+
+export type {
+  ContentOpsCatalog,
+  ContentOpsExecutionResult,
+  ContentOpsExecutionStatus,
+  ContentOpsRequest,
+  ContentOpsRun,
+  ContentOpsStepExecution,
+  ContentOpsStepStatus,
+  ControlSurfacePresetView,
+  ControlSurfacePreview,
+  GenerationPlan,
+  GenerationPlanStep,
+  GenerationPlanStepStatus,
+  OutputDefinitionView,
+  ReasoningRequirement,
+} from './types'
+
+export {
+  fromWireCatalog,
+  fromWireExecution,
+  fromWireOutputDefinition,
+  fromWirePlan,
+  fromWirePlanStep,
+  fromWirePreset,
+  fromWirePreview,
+  fromWireRequest,
+  fromWireStepExecution,
+  toWireRequest,
+} from './fromWire'

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Content Ops domain types (camelCase).
+ *
+ * Mirrors the wire interfaces in `src/api/contentOps.ts` but uses
+ * idiomatic TS field names. Screens import from
+ * `src/domain/contentOps` (the barrel) and never reach into the
+ * API adapter directly.
+ *
+ * Contract reference: `docs/frontend/content_ops_frontend_contract.md`
+ * (PR #401, backend HEAD `a4020c1`).
+ */
+
+// ---------------------------------------------------------------------------
+// Catalog (GET /content-ops/control-surfaces)
+// ---------------------------------------------------------------------------
+
+export type ReasoningRequirement =
+  | 'absent'
+  | 'optional_host_context'
+  | string
+
+export interface OutputDefinitionView {
+  id: string
+  label: string
+  description: string
+  implemented: boolean
+  estimatedUnitCostUsd: number
+  defaultParseRetryAttempts: number
+  estimatedRetryAdjustedUnitCostUsd: number
+  requiredInputs: string[]
+  defaultMaxItems: number
+  reasoningRequirement: ReasoningRequirement
+  // Per-request, computed from host-injected services:
+  executionConfigured: boolean
+  canExecute: boolean
+}
+
+export interface ControlSurfacePresetView {
+  id: string
+  label: string
+  description: string
+  outputs: string[]
+}
+
+export interface ContentOpsCatalog {
+  outputs: OutputDefinitionView[]
+  presets: ControlSurfacePresetView[]
+  execution: {
+    configured: boolean
+    configuredOutputs: string[]
+  }
+  ingestionProfiles: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Request (POST /content-ops/{preview, plan, execute} body)
+// ---------------------------------------------------------------------------
+
+export interface ContentOpsRequest {
+  targetMode: string
+  preset: string | null
+  outputs: string[]
+  limit: number
+  maxCostUsd: number | null
+  inputs: Record<string, unknown>
+  ingestionProfile: string
+  requireQualityGates: boolean
+  allowUnimplementedOutputs: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Preview (POST /content-ops/preview)
+// ---------------------------------------------------------------------------
+
+export interface ControlSurfacePreview {
+  canRun: boolean
+  outputs: string[]
+  estimatedCostUsd: number
+  missingInputs: string[]
+  blockedOutputs: string[]
+  warnings: string[]
+  // The preview's normalized request omits `inputs` per the
+  // backend's `as_dict()` contract (see contract doc); it is
+  // typed as a partial of `ContentOpsRequest` here.
+  normalizedRequest: Omit<ContentOpsRequest, 'inputs'> | null
+}
+
+// ---------------------------------------------------------------------------
+// Plan (POST /content-ops/plan)
+// ---------------------------------------------------------------------------
+
+export type GenerationPlanStepStatus = 'runnable' | 'blocked'
+
+export interface GenerationPlanStep {
+  output: string
+  runner: string
+  status: GenerationPlanStepStatus
+  config: Record<string, unknown>
+  reason: string
+}
+
+export interface GenerationPlan {
+  canExecute: boolean
+  targetMode: string
+  limit: number
+  steps: GenerationPlanStep[]
+  preview: ControlSurfacePreview
+}
+
+// ---------------------------------------------------------------------------
+// Execution result (POST /content-ops/execute)
+// ---------------------------------------------------------------------------
+
+export type ContentOpsExecutionStatus =
+  | 'completed'
+  | 'partial'
+  | 'failed'
+  | 'blocked'
+
+export type ContentOpsStepStatus = 'completed' | 'failed' | 'skipped'
+
+export interface ContentOpsStepExecution {
+  output: string
+  runner: string
+  status: ContentOpsStepStatus
+  result: Record<string, unknown>
+  error: string
+}
+
+export interface ContentOpsExecutionResult {
+  status: ContentOpsExecutionStatus
+  plan: GenerationPlan
+  steps: ContentOpsStepExecution[]
+  errors: Array<Record<string, unknown>>
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate
+// ---------------------------------------------------------------------------
+
+/**
+ * A complete Content Ops run lifecycle.
+ *
+ * Starts with `catalog` + `request`; `preview`, `plan`, and
+ * `execution` are populated as the run progresses through the
+ * three steps. A blocked run may stop after `preview`; a runnable
+ * one proceeds through `plan` and (optionally) `execution`.
+ */
+export interface ContentOpsRun {
+  catalog: ContentOpsCatalog
+  request: ContentOpsRequest
+  preview?: ControlSurfacePreview
+  plan?: GenerationPlan
+  execution?: ContentOpsExecutionResult
+}

--- a/plans/PR-Content-Ops-Domain-Layer.md
+++ b/plans/PR-Content-Ops-Domain-Layer.md
@@ -1,0 +1,177 @@
+# PR: Content Ops domain layer (camelCase types + fromWire mappers)
+
+## Why this slice exists
+
+PR #403 landed the API adapter with snake_case wire types
+(matching `client.ts` / `b2bClient.ts` convention). PR #404
+locked the wire types against backend drift. Screens 1-3 from
+the contract need camelCase types (TS-idiomatic) and a
+`ContentOpsRun` aggregate to model a complete run lifecycle.
+The contract doc explicitly defines this layer:
+
+> ### Domain layer
+> Owns the typed models above. No HTTP, no React.
+
+Without it, screens would either repeat the snake_case wire
+shape (uncomfortable in JSX) or do ad-hoc translation in each
+component (drift risk).
+
+## Scope (this PR)
+
+The domain layer for Content Ops:
+
+1. **camelCase domain types** mirroring the API adapter's
+   snake_case wire interfaces. One TS file with all the
+   types -- they're small and tightly coupled.
+2. **`fromWire*` mappers** that translate API adapter responses
+   into domain types. One mapper per top-level wire interface.
+3. **`ContentOpsRun` aggregate** type modeling a complete run
+   lifecycle (catalog snapshot → request → preview → plan →
+   optional execution).
+4. **Barrel export** so screens import from a single
+   `src/domain/contentOps` path.
+5. **Contract-test extension** that pins each domain type to
+   a `fromWire*(fixture)` invocation via the same `Loosen<T>` +
+   `satisfies` pattern used in PR #404.
+
+### Files touched
+
+1. `atlas-intel-ui/src/domain/contentOps/types.ts` (new) -- all
+   camelCase domain types in one file. ~180 LOC.
+2. `atlas-intel-ui/src/domain/contentOps/fromWire.ts` (new) --
+   one mapper per wire interface. ~140 LOC.
+3. `atlas-intel-ui/src/domain/contentOps/index.ts` (new) -- re-
+   exports types + mappers. ~15 LOC.
+4. `atlas-intel-ui/src/domain/contentOps/contract.ts` (new) --
+   compile-time pins from wire fixtures through `fromWire*` to
+   each domain type. ~50 LOC.
+5. `plans/PR-Content-Ops-Domain-Layer.md` (this file).
+
+### What's NOT in this slice
+
+- Selectors (`canExecuteRun(run)`, `outputsByExecution(run)`,
+  `missingInputsForOutput(run, outputId)`). Selectors belong in
+  the view-model layer per the contract; they ship with screen
+  1's slice when it's clear which selectors are actually used.
+- Reducers / state management. React's `useState` / `useReducer`
+  is the screen's concern; the domain layer is pure data + pure
+  mappers.
+- Reasoning-context view-model (`CampaignReasoningContextView`).
+  The wire shape lives under `step.result` in the execution
+  response; a dedicated view-model lands when the reasoning
+  drawer screen does.
+- Signal extraction view types beyond the basic envelope; the
+  contract calls these out as a special case that lands with
+  its own screen.
+- Step-result-payload domain types per output. Today's wire-level
+  `result: Record<string, unknown>` is fine for screens 1-3 to
+  display; per-output result shapes are a separate slice.
+
+## Mechanism
+
+The mappers convert snake_case wire fields to camelCase domain
+fields. They're pure data transforms:
+
+```ts
+export function fromWireCatalog(
+  wire: ContentOpsCatalogResponse,
+): ContentOpsCatalog {
+  return {
+    outputs: wire.outputs.map(fromWireOutputDefinition),
+    presets: wire.presets.map(fromWirePreset),
+    execution: {
+      configured: wire.execution.configured,
+      configuredOutputs: [...wire.execution.configured_outputs],
+    },
+    ingestionProfiles: [...wire.ingestion_profiles],
+  }
+}
+```
+
+The contract-test extension (`contract.ts`) feeds each fixture
+JSON through the mapper and asserts the result satisfies the
+domain type via the same `Loosen<T>` + `satisfies` gate from PR
+#404. If a wire field is renamed, the mapper trips at compile
+time; if a domain field is added without a mapper update, the
+satisfies check trips.
+
+`ContentOpsRun` is a small aggregate type modeling the lifecycle:
+
+```ts
+export interface ContentOpsRun {
+  catalog: ContentOpsCatalog       // snapshot at run start
+  request: ContentOpsRequest       // user's input
+  preview?: ControlSurfacePreview  // populated after preview
+  plan?: GenerationPlan            // populated after plan
+  execution?: ContentOpsExecutionResult  // populated after execute
+}
+```
+
+Optional fields reflect the lifecycle: a run starts with catalog
++ request; preview / plan / execution accumulate.
+
+## Intentional
+
+- **One `types.ts`, not seven per-type files.** The contract
+  suggested `contentOpsCatalog.ts`, `contentOpsRequest.ts`, etc.,
+  but the existing repo uses single-file conventions
+  (`client.ts`, `b2bClient.ts`). One file keeps imports tidy
+  and matches house style. If the file grows past ~400 LOC in
+  a follow-up slice, splitting is mechanical.
+- **Mappers separate from types.** Wire-to-domain mappers are
+  the boundary's discipline; keeping them in `fromWire.ts`
+  makes the boundary explicit and screens never import from
+  there directly (they import from `index.ts`).
+- **No selectors / reducers.** Those are view-model concerns
+  per the contract's layering. Skipping here keeps the slice
+  tightly scoped; selectors land with their first consumer
+  (screen 1).
+- **`ContentOpsCatalog['execution']` uses an inline object type**,
+  not a named alias. The shape (`{configured, configuredOutputs}`)
+  is small enough that a name adds noise; if it grows, the
+  alias is a one-line refactor.
+- **Domain types use `readonly` on array fields where natural**
+  (e.g. `readonly outputs: OutputDefinitionView[]`)? **No** --
+  matches the existing TS style in the repo (mutable arrays).
+  Pure-functional immutability isn't established; not introducing
+  it in this slice.
+
+## Deferred
+
+- Selectors (`canExecuteRun`, `outputsByExecution`, etc.) --
+  ship with screen 1's slice.
+- Reducers / `useReducer` skeletons -- ship with screen 1.
+- `CampaignReasoningContextView` domain type -- ships with the
+  reasoning-drawer screen.
+- Per-output `step.result` domain types (e.g.
+  `EmailCampaignResult`, `BlogPostResult`) -- separate slice.
+- Vitest runtime tests for the mappers -- adding Vitest is its
+  own slice (deferred from PR #404).
+- Snapshot of ContentOpsRun lifecycle transitions -- tied to
+  the screen 1 reducer.
+
+## Verification
+
+- `cd atlas-intel-ui && npx tsc -b --noEmit` -- clean (the
+  domain types + fromWire mappers + contract pins all
+  type-check).
+- `cd atlas-intel-ui && npx eslint src/domain/contentOps/` --
+  clean.
+- `cd atlas-intel-ui && npm run build` -- builds.
+- Sanity: temporarily rename `outputs` to `outputs_typo` on
+  `ContentOpsCatalog` (domain type); confirm `tsc -b` fails on
+  the mapper return statement. Revert before commit.
+
+## Estimated diff size
+
+- `types.ts`: ~180 LOC.
+- `fromWire.ts`: ~140 LOC.
+- `index.ts`: ~15 LOC.
+- `contract.ts`: ~50 LOC.
+- Plan doc: ~150 LOC.
+
+Total: ~535 LOC. Marginally over the 400 soft cap; the contract
+test pin (~50 LOC) and the plan doc (~150 LOC) are documentation
+overhead that justify themselves by catching drift and explaining
+the boundary discipline. Splitting types + mappers into separate
+PRs would leave one half useless without the other.


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Domain-Layer.md`

Builds on PR #403 (wire types) and PR #404 (wire fixtures). Adds the camelCase domain layer for Content Ops + the `ContentOpsRun` aggregate. Screens import from `src/domain/contentOps` and never reach into the API adapter directly.

## Files

- **`types.ts`** — 9 camelCase domain interfaces mirroring the wire shapes (catalog / preset / output definition / request / preview / plan / step / execution / run aggregate).
- **`fromWire.ts`** — per-interface translators from snake_case wire shapes. `toWireRequest()` inverse for submitting requests.
- **`index.ts`** — barrel export for screens and view-models.
- **`contract.ts`** — compile-time pin: each fixture from `src/api/__fixtures__/contentOps/` feeds through the mapper and satisfies the domain type via `Loosen<T>` + `satisfies` (same gate pattern as PR #404). Catches drift in either direction.

## Mechanism

The chain is now:
```
backend dataclass <-- fixture --> wire interface <-- fromWire --> domain interface
        (PR #401)        (PR #404)                  (this PR)
```

Mutation test verifies the gate: renaming `canRun` to `canRunRenamed` in `types.ts` produces `TS2353` at `fromWire.ts:135`. Restored cleanly.

## Intentional

- **One `types.ts`**, not seven per-type files. Matches existing repo single-file convention (`client.ts`, `b2bClient.ts`).
- **Mappers separate from types** so the boundary discipline is explicit; screens never import from `fromWire.ts` directly.
- **No selectors / reducers** in this slice. They ship with screen 1 when the actual usage is clear (avoids speculative API surface).
- **`Omit<ContentOpsRequest, 'inputs'>` for `normalizedRequest`** since the backend's `Preview.as_dict()` deliberately omits `inputs` from the normalized request payload (per the contract doc).

## Deferred

- Selectors (`canExecuteRun`, `missingInputsForOutput`, etc.) → screen 1.
- Reducers / state-management → screen 1.
- `CampaignReasoningContextView` domain type → reasoning-drawer slice.
- Per-output `step.result` domain types → separate slice.
- Vitest runtime tests for the mappers (deferred from PR #404).

## Verification

- `cd atlas-intel-ui && npx tsc -b --noEmit` — clean.
- `cd atlas-intel-ui && npx eslint src/domain/contentOps/` — clean.
- `cd atlas-intel-ui && npm run build` — builds.
- Mutation test: rename a domain field; compile fails at the mapper. Restore; passes.

## Diff size

5 files, +671 / -0. Over the 400 LOC soft cap; types + mappers + contract pin together close the boundary discipline. Splitting types from mappers leaves one half useless without the other; splitting the contract pin from the types defeats the gate. ~150 LOC is plan doc; ~520 LOC is code (types + mappers + barrel + contract).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_