### PR TITLE
PR-Content-Ops-Screen-2-Plan-Preview: Build plan CTA + PlanPanel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,18 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the application code into the container
 COPY ./atlas_brain ./atlas_brain
 
+# Copy the extracted standalone packages so the host's api package
+# can lazy-import them at startup (Content Ops control-surface
+# routes are mounted in atlas_brain/api/__init__.py via
+# `from extracted_content_pipeline.api.control_surfaces import ...`
+# inside a try/except). When the packages are absent the import
+# logs a warning and the route is skipped, but the prod image
+# should ship them so the new screens are functional.
+COPY ./extracted_content_pipeline ./extracted_content_pipeline
+COPY ./extracted_quality_gate ./extracted_quality_gate
+COPY ./extracted_reasoning_core ./extracted_reasoning_core
+COPY ./extracted ./extracted
+
 # Expose the port the app runs on
 EXPOSE 8000
 

--- a/atlas-intel-ui/src/App.tsx
+++ b/atlas-intel-ui/src/App.tsx
@@ -31,6 +31,7 @@ const CompetitorDisplacement = lazy(() => import('./pages/b2b/CompetitorDisplace
 const B2BReports = lazy(() => import('./pages/b2b/B2BReports'))
 const B2BReviews = lazy(() => import('./pages/b2b/B2BReviews'))
 const B2BCampaigns = lazy(() => import('./pages/b2b/B2BCampaigns'))
+const ContentOpsNewRun = lazy(() => import('./pages/ContentOpsNewRun'))
 
 function renderLazyRoute(Component: ComponentType) {
   return (
@@ -83,6 +84,9 @@ export default function App() {
                     <Route path="/b2b/reports" element={renderLazyRoute(B2BReports)} />
                     <Route path="/b2b/reviews" element={renderLazyRoute(B2BReviews)} />
                     <Route path="/b2b/campaigns" element={renderLazyRoute(B2BCampaigns)} />
+
+                    {/* Content Ops routes */}
+                    <Route path="/content-ops/new" element={renderLazyRoute(ContentOpsNewRun)} />
                   </Routes>
                 </Layout>
               </ProtectedRoute>

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -21,7 +21,13 @@
 import { tryRefreshToken } from '../auth/AuthContext'
 import { API_BASE } from './config'
 
-const BASE = `${API_BASE}/content-ops`
+// Mount under /api/v1/content-ops to match the Vite dev proxy
+// (/api/*) and the existing backend mount convention used by
+// `client.ts` and `b2bClient.ts` (`/api/v1/...`). The host
+// application is expected to mount the content-ops router there
+// via `ContentOpsControlSurfaceApiConfig(prefix="/api/v1/content-ops")`
+// or equivalent.
+const BASE = `${API_BASE}/api/v1/content-ops`
 
 // ---------------------------------------------------------------------------
 // Wire types

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1,18 +1,22 @@
 import { useMemo, useRef, useState } from 'react'
-import { Loader2, Play, RefreshCw } from 'lucide-react'
+import { ChevronRight, Loader2, Play, RefreshCw } from 'lucide-react'
 import { clsx } from 'clsx'
 import {
   fetchContentOpsControlSurfaces,
+  planContentOpsRun,
   previewContentOpsRun,
 } from '../api/contentOps'
 import {
   fromWireCatalog,
+  fromWirePlan,
   fromWirePreview,
   fromWireRequest,
   toWireRequest,
   type ContentOpsCatalog,
   type ContentOpsRequest,
   type ControlSurfacePreview,
+  type GenerationPlan,
+  type GenerationPlanStep,
 } from '../domain/contentOps'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
@@ -24,6 +28,15 @@ type SubmitState =
   | { kind: 'invalid_max_cost'; message: string }
   | { kind: 'error'; message: string }
   | { kind: 'success'; preview: ControlSurfacePreview }
+
+// Screen 2 (Plan Preview): parallel state for the plan response.
+// Lives alongside SubmitState so the user can see preview + plan
+// stacked. Form mutations clear both via markStale().
+type PlanState =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success'; plan: GenerationPlan }
 
 const DEFAULT_INPUTS_JSON = '{\n  \n}'
 
@@ -50,9 +63,11 @@ export default function ContentOpsNewRun() {
   const [maxCostUsdInput, setMaxCostUsdInput] = useState<string>('')
   const [inputsJson, setInputsJson] = useState<string>(DEFAULT_INPUTS_JSON)
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: 'idle' })
-  // Codex P2 fix: request-id ref so a stale in-flight preview response
-  // can't overwrite a verdict the user has since invalidated by editing
-  // the form. Mirrors the pattern in src/hooks/useApiData.ts.
+  const [planState, setPlanState] = useState<PlanState>({ kind: 'idle' })
+  // Codex P2 fix: request-id ref so a stale in-flight preview/plan
+  // response can't overwrite a result the user has since invalidated
+  // by editing the form. Both preview and plan share the same id
+  // namespace -- any form mutation invalidates both.
   const submitRequestIdRef = useRef(0)
 
   if (error) {
@@ -67,13 +82,15 @@ export default function ContentOpsNewRun() {
     )
   }
 
-  // Codex P2 fix: any form mutation invalidates a stale preview verdict so
-  // the user never sees a "Can run" badge that doesn't match the current
-  // form state. Bumping the request id also drops any in-flight preview
-  // response so it can't overwrite the verdict for a newer form state.
+  // Codex P2 fix: any form mutation invalidates a stale preview verdict
+  // and plan panel so the user never sees a "Can run" badge or plan
+  // panel that doesn't match the current form state. Bumping the
+  // request id also drops any in-flight preview / plan response so it
+  // can't overwrite the panels for a newer form state.
   const markStale = () => {
     submitRequestIdRef.current += 1
     setSubmitState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
+    setPlanState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
   }
 
   const togglePreset = (presetId: string) => {
@@ -100,12 +117,18 @@ export default function ContentOpsNewRun() {
     markStale()
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    // Bump the id so any prior in-flight request is ignored on resolve.
-    const requestId = ++submitRequestIdRef.current
-    setSubmitState({ kind: 'submitting' })
+  type ParsedRequest =
+    | { ok: true; domainRequest: ContentOpsRequest }
+    | {
+        ok: false
+        kind: 'invalid_inputs_json' | 'invalid_max_cost'
+        message: string
+      }
 
+  // Shared submit-time parse for both preview and plan. Validates the
+  // inputs JSON and the max-cost string draft against the backend's
+  // pydantic constraints before either round-trip.
+  const buildDomainRequest = (): ParsedRequest => {
     let parsedInputs: Record<string, unknown>
     try {
       const trimmed = inputsJson.trim()
@@ -114,53 +137,83 @@ export default function ContentOpsNewRun() {
         throw new Error('inputs must be a JSON object')
       }
     } catch (err) {
-      if (requestId !== submitRequestIdRef.current) return
-      setSubmitState({
+      return {
+        ok: false,
         kind: 'invalid_inputs_json',
         message: err instanceof Error ? err.message : String(err),
-      })
-      return
+      }
     }
 
-    // Submit-time max-cost parse + normalization. The input is a string
-    // draft (so decimals like "0.50" can be typed); parse here.
-    //
-    // Codex P2 fix: max-cost is a spend cap -- if the user typed a
-    // non-empty unparseable value like "$10", silently dropping the
-    // cap is unsafe (they think they capped spend; reality is no
-    // cap). Reject non-empty unparseable / non-positive input
-    // explicitly. Blank stays "no cap" per the backend's optional
-    // field semantics; the backend's pydantic validator (gt=0) means
-    // 0 / negative would also be rejected -- we surface the rejection
-    // here so the user sees a clear error rather than a silent strip.
     const trimmedMaxCost = maxCostUsdInput.trim()
     let normalizedMaxCost: number | null = null
     if (trimmedMaxCost !== '') {
       const parsed = Number(trimmedMaxCost)
       if (!Number.isFinite(parsed) || parsed <= 0) {
-        if (requestId !== submitRequestIdRef.current) return
-        setSubmitState({
+        return {
+          ok: false,
           kind: 'invalid_max_cost',
           message:
             'Max cost must be a positive number (e.g. 0.50). Leave blank for no cap.',
-        })
-        return
+        }
       }
       normalizedMaxCost = parsed
     }
-    const domainRequest: ContentOpsRequest = {
-      ...request,
-      inputs: parsedInputs,
-      maxCostUsd: normalizedMaxCost,
+
+    return {
+      ok: true,
+      domainRequest: {
+        ...request,
+        inputs: parsedInputs,
+        maxCostUsd: normalizedMaxCost,
+      },
     }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    // Bump the id so any prior in-flight request is ignored on resolve.
+    const requestId = ++submitRequestIdRef.current
+    setSubmitState({ kind: 'submitting' })
+
+    const parsed = buildDomainRequest()
+    if (!parsed.ok) {
+      if (requestId !== submitRequestIdRef.current) return
+      setSubmitState({ kind: parsed.kind, message: parsed.message })
+      return
+    }
+
     try {
-      const wirePreview = await previewContentOpsRun(toWireRequest(domainRequest))
-      // Drop the response if a newer mutation / submission has happened.
+      const wirePreview = await previewContentOpsRun(toWireRequest(parsed.domainRequest))
       if (requestId !== submitRequestIdRef.current) return
       setSubmitState({ kind: 'success', preview: fromWirePreview(wirePreview) })
     } catch (err) {
       if (requestId !== submitRequestIdRef.current) return
       setSubmitState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handlePlan = async () => {
+    // Bump id so a stale plan response can't overwrite a newer one.
+    const requestId = ++submitRequestIdRef.current
+    setPlanState({ kind: 'submitting' })
+
+    const parsed = buildDomainRequest()
+    if (!parsed.ok) {
+      if (requestId !== submitRequestIdRef.current) return
+      setPlanState({ kind: 'error', message: parsed.message })
+      return
+    }
+
+    try {
+      const wirePlan = await planContentOpsRun(toWireRequest(parsed.domainRequest))
+      if (requestId !== submitRequestIdRef.current) return
+      setPlanState({ kind: 'success', plan: fromWirePlan(wirePlan) })
+    } catch (err) {
+      if (requestId !== submitRequestIdRef.current) return
+      setPlanState({
         kind: 'error',
         message: err instanceof Error ? err.message : String(err),
       })
@@ -429,29 +482,78 @@ export default function ContentOpsNewRun() {
         </div>
       )}
       {submitState.kind === 'success' && (
-        <PreviewVerdict preview={submitState.preview} />
+        <PreviewVerdict
+          preview={submitState.preview}
+          planState={planState}
+          onBuildPlan={handlePlan}
+          executionConfigured={catalog.execution.configured}
+        />
+      )}
+      {planState.kind === 'success' && (
+        <PlanPanel
+          plan={planState.plan}
+          executionConfigured={catalog.execution.configured}
+        />
+      )}
+      {planState.kind === 'error' && (
+        <div className="mt-6 rounded-md border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          Plan failed: {planState.message}
+        </div>
       )}
     </div>
   )
 }
 
-function PreviewVerdict({ preview }: { preview: ControlSurfacePreview }) {
+function PreviewVerdict({
+  preview,
+  planState,
+  onBuildPlan,
+  executionConfigured,
+}: {
+  preview: ControlSurfacePreview
+  planState: PlanState
+  onBuildPlan: () => void
+  executionConfigured: boolean
+}) {
+  const planning = planState.kind === 'submitting'
   return (
     <section className="mt-8 rounded-lg border border-slate-800 bg-slate-900/60 p-5">
-      <div className="mb-3 flex items-center gap-3">
-        <span
-          className={clsx(
-            'rounded-full px-3 py-0.5 text-xs font-medium',
-            preview.canRun
-              ? 'bg-emerald-500/20 text-emerald-300'
-              : 'bg-amber-500/20 text-amber-200',
-          )}
-        >
-          {preview.canRun ? 'Can run' : 'Blocked'}
-        </span>
-        <span className="text-sm text-slate-400">
-          Estimated cost: ${preview.estimatedCostUsd.toFixed(2)}
-        </span>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span
+            className={clsx(
+              'rounded-full px-3 py-0.5 text-xs font-medium',
+              preview.canRun
+                ? 'bg-emerald-500/20 text-emerald-300'
+                : 'bg-amber-500/20 text-amber-200',
+            )}
+          >
+            {preview.canRun ? 'Can run' : 'Blocked'}
+          </span>
+          <span className="text-sm text-slate-400">
+            Estimated cost: ${preview.estimatedCostUsd.toFixed(2)}
+          </span>
+        </div>
+        {preview.canRun && (
+          <button
+            type="button"
+            onClick={onBuildPlan}
+            disabled={planning}
+            title={
+              executionConfigured
+                ? 'Build the plan that the backend would execute.'
+                : 'Build a read-only plan (host execution services not configured).'
+            }
+            className="flex items-center gap-2 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1.5 text-xs font-medium text-cyan-200 hover:bg-cyan-500/20 disabled:opacity-50"
+          >
+            {planning ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+            Build plan
+          </button>
+        )}
       </div>
 
       {preview.outputs.length > 0 && (
@@ -510,6 +612,95 @@ function Section({ label, children }: { label: string; children: React.ReactNode
         {label}
       </div>
       {children}
+    </div>
+  )
+}
+
+function PlanPanel({
+  plan,
+  executionConfigured,
+}: {
+  plan: GenerationPlan
+  executionConfigured: boolean
+}) {
+  const canExecute = plan.canExecute && executionConfigured
+  return (
+    <section className="mt-6 rounded-lg border border-slate-800 bg-slate-900/60 p-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span
+            className={clsx(
+              'rounded-full px-3 py-0.5 text-xs font-medium',
+              plan.canExecute
+                ? 'bg-emerald-500/20 text-emerald-300'
+                : 'bg-amber-500/20 text-amber-200',
+            )}
+          >
+            Plan: {plan.canExecute ? 'Can execute' : 'Blocked'}
+          </span>
+          <span className="text-sm text-slate-400">
+            {plan.steps.length} step{plan.steps.length === 1 ? '' : 's'} ·
+            target_mode={plan.targetMode} · limit={plan.limit}
+          </span>
+        </div>
+        <button
+          type="button"
+          disabled
+          title={
+            !plan.canExecute
+              ? 'Plan is blocked; cannot execute.'
+              : !executionConfigured
+                ? 'Host execution services not configured.'
+                : 'Execute screen ships in the next slice.'
+          }
+          className="flex items-center gap-2 rounded-md border border-slate-700 bg-slate-800/40 px-3 py-1.5 text-xs font-medium text-slate-400 disabled:cursor-not-allowed"
+        >
+          <Play className="h-3.5 w-3.5" />
+          Execute {canExecute ? '(coming soon)' : '(disabled)'}
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {plan.steps.map((step) => (
+          <PlanStepCard key={step.output} step={step} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function PlanStepCard({ step }: { step: GenerationPlanStep }) {
+  return (
+    <div className="rounded-md border border-slate-800 bg-slate-950/40 p-3">
+      <div className="mb-2 flex items-center gap-3">
+        <span className="font-mono text-sm text-slate-100">{step.output}</span>
+        <span
+          className={clsx(
+            'rounded px-2 py-0.5 text-[10px] uppercase tracking-wide',
+            step.status === 'runnable'
+              ? 'bg-emerald-500/10 text-emerald-300'
+              : 'bg-amber-500/10 text-amber-200',
+          )}
+        >
+          {step.status}
+        </span>
+        <span className="text-xs text-slate-500">{step.runner}</span>
+      </div>
+      {step.status === 'blocked' && step.reason && (
+        <div className="mb-2 rounded bg-amber-500/5 px-2 py-1 text-xs text-amber-200">
+          Blocked: {step.reason}
+        </div>
+      )}
+      {Object.keys(step.config).length > 0 && (
+        <details className="text-xs text-slate-400">
+          <summary className="cursor-pointer text-slate-500 hover:text-slate-300">
+            Config ({Object.keys(step.config).length} fields)
+          </summary>
+          <pre className="mt-2 overflow-x-auto rounded bg-slate-950/80 p-2 font-mono text-[11px] text-slate-300">
+            {JSON.stringify(step.config, null, 2)}
+          </pre>
+        </details>
+      )}
     </div>
   )
 }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -21,6 +21,7 @@ type SubmitState =
   | { kind: 'idle' }
   | { kind: 'submitting' }
   | { kind: 'invalid_inputs_json'; message: string }
+  | { kind: 'invalid_max_cost'; message: string }
   | { kind: 'error'; message: string }
   | { kind: 'success'; preview: ControlSurfacePreview }
 
@@ -122,18 +123,31 @@ export default function ContentOpsNewRun() {
     }
 
     // Submit-time max-cost parse + normalization. The input is a string
-    // draft (so decimals like "0.50" can be typed); parse here and
-    // collapse 0 / negative / unparseable to null because the backend's
-    // pydantic validator declares max_cost_usd with gt=0
-    // (control_surfaces.py:88).
+    // draft (so decimals like "0.50" can be typed); parse here.
+    //
+    // Codex P2 fix: max-cost is a spend cap -- if the user typed a
+    // non-empty unparseable value like "$10", silently dropping the
+    // cap is unsafe (they think they capped spend; reality is no
+    // cap). Reject non-empty unparseable / non-positive input
+    // explicitly. Blank stays "no cap" per the backend's optional
+    // field semantics; the backend's pydantic validator (gt=0) means
+    // 0 / negative would also be rejected -- we surface the rejection
+    // here so the user sees a clear error rather than a silent strip.
     const trimmedMaxCost = maxCostUsdInput.trim()
-    const parsedMaxCost = trimmedMaxCost === '' ? null : Number(trimmedMaxCost)
-    const normalizedMaxCost =
-      parsedMaxCost === null ||
-      !Number.isFinite(parsedMaxCost) ||
-      parsedMaxCost <= 0
-        ? null
-        : parsedMaxCost
+    let normalizedMaxCost: number | null = null
+    if (trimmedMaxCost !== '') {
+      const parsed = Number(trimmedMaxCost)
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        if (requestId !== submitRequestIdRef.current) return
+        setSubmitState({
+          kind: 'invalid_max_cost',
+          message:
+            'Max cost must be a positive number (e.g. 0.50). Leave blank for no cap.',
+        })
+        return
+      }
+      normalizedMaxCost = parsed
+    }
     const domainRequest: ContentOpsRequest = {
       ...request,
       inputs: parsedInputs,
@@ -402,6 +416,11 @@ export default function ContentOpsNewRun() {
       {submitState.kind === 'invalid_inputs_json' && (
         <div className="mt-6 rounded-md border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
           Invalid inputs JSON: {submitState.message}
+        </div>
+      )}
+      {submitState.kind === 'invalid_max_cost' && (
+        <div className="mt-6 rounded-md border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          Invalid max cost: {submitState.message}
         </div>
       )}
       {submitState.kind === 'error' && (

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -43,6 +43,10 @@ export default function ContentOpsNewRun() {
   const [request, setRequest] = useState<ContentOpsRequest>(() =>
     fromWireRequest({}),
   )
+  // Codex P2 fix v3: keep the max-cost input as a string draft so the
+  // user can type `0.` mid-entry without React re-rendering as `0` and
+  // swallowing the decimal point. Parsed to a number at submit time.
+  const [maxCostUsdInput, setMaxCostUsdInput] = useState<string>('')
   const [inputsJson, setInputsJson] = useState<string>(DEFAULT_INPUTS_JSON)
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: 'idle' })
   // Codex P2 fix: request-id ref so a stale in-flight preview response
@@ -117,15 +121,19 @@ export default function ContentOpsNewRun() {
       return
     }
 
-    // Submit-time normalization: backend's pydantic validator declares
-    // max_cost_usd with gt=0; collapse 0 / negative to null so we never
-    // round-trip a request the API would reject.
+    // Submit-time max-cost parse + normalization. The input is a string
+    // draft (so decimals like "0.50" can be typed); parse here and
+    // collapse 0 / negative / unparseable to null because the backend's
+    // pydantic validator declares max_cost_usd with gt=0
+    // (control_surfaces.py:88).
+    const trimmedMaxCost = maxCostUsdInput.trim()
+    const parsedMaxCost = trimmedMaxCost === '' ? null : Number(trimmedMaxCost)
     const normalizedMaxCost =
-      request.maxCostUsd === null ||
-      !Number.isFinite(request.maxCostUsd) ||
-      request.maxCostUsd <= 0
+      parsedMaxCost === null ||
+      !Number.isFinite(parsedMaxCost) ||
+      parsedMaxCost <= 0
         ? null
-        : request.maxCostUsd
+        : parsedMaxCost
     const domainRequest: ContentOpsRequest = {
       ...request,
       inputs: parsedInputs,
@@ -301,24 +309,16 @@ export default function ContentOpsNewRun() {
             <label className="block text-sm">
               <span className="text-slate-300">Max cost (USD)</span>
               <input
-                type="number"
-                step={0.01}
-                min={0}
-                value={request.maxCostUsd ?? ''}
+                type="text"
+                inputMode="decimal"
+                value={maxCostUsdInput}
                 onChange={(e) => {
-                  // Codex P2 fix v2: keep 0 valid in form state during typing
-                  // so the user can keep keying a sub-dollar value like "0.50"
-                  // (the prior `<= 0 -> null` clobbered the input the moment
-                  // they typed "0"). The submit handler normalizes 0 / negative
-                  // values to null before sending, matching the backend's
-                  // `gt=0` validator (control_surfaces.py:88).
-                  const v = e.target.value
-                  const parsed = v === '' ? null : Number(v)
-                  setRequest((p) => ({
-                    ...p,
-                    maxCostUsd:
-                      parsed === null || !Number.isFinite(parsed) ? null : parsed,
-                  }))
+                  // Codex P2 fix v3: render from the raw string draft
+                  // so the user can type "0.", "0.5", "0.50" without
+                  // mid-keystroke coercion to a number that re-renders
+                  // as "0" and swallows the decimal point. Parsed to a
+                  // number only at submit time.
+                  setMaxCostUsdInput(e.target.value)
                   markStale()
                 }}
                 placeholder="(no cap)"

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -58,6 +58,13 @@ export default function ContentOpsNewRun() {
     )
   }
 
+  // Codex P2 fix: any form mutation invalidates a stale preview verdict so
+  // the user never sees a "Can run" badge that doesn't match the current
+  // form state. Re-submit yields a fresh verdict.
+  const markStale = () => {
+    setSubmitState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
+  }
+
   const togglePreset = (presetId: string) => {
     const preset = catalog.presets.find((p) => p.id === presetId)
     if (!preset) return
@@ -66,6 +73,7 @@ export default function ContentOpsNewRun() {
       preset: prev.preset === presetId ? null : presetId,
       outputs: prev.preset === presetId ? prev.outputs : [...preset.outputs],
     }))
+    markStale()
   }
 
   const toggleOutput = (outputId: string) => {
@@ -78,6 +86,7 @@ export default function ContentOpsNewRun() {
           : [...prev.outputs, outputId],
       }
     })
+    markStale()
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -230,7 +239,10 @@ export default function ContentOpsNewRun() {
           </p>
           <textarea
             value={inputsJson}
-            onChange={(e) => setInputsJson(e.target.value)}
+            onChange={(e) => {
+              setInputsJson(e.target.value)
+              markStale()
+            }}
             rows={6}
             spellCheck={false}
             className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-xs text-slate-200 focus:border-cyan-500 focus:outline-none"
@@ -251,12 +263,13 @@ export default function ContentOpsNewRun() {
                 min={1}
                 max={1000}
                 value={request.limit}
-                onChange={(e) =>
+                onChange={(e) => {
                   setRequest((p) => ({
                     ...p,
                     limit: Math.max(1, Math.min(1000, Number(e.target.value) || 1)),
                   }))
-                }
+                  markStale()
+                }}
                 className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
               />
             </label>
@@ -268,11 +281,20 @@ export default function ContentOpsNewRun() {
                 min={0}
                 value={request.maxCostUsd ?? ''}
                 onChange={(e) => {
+                  // Codex P2 fix: backend pydantic validator declares
+                  // max_cost_usd with gt=0 (control_surfaces.py:88), so
+                  // submitting 0 always fails. Treat 0 / negative / blank
+                  // as "no cap" client-side.
                   const v = e.target.value
+                  const parsed = v === '' ? null : Number(v)
                   setRequest((p) => ({
                     ...p,
-                    maxCostUsd: v === '' ? null : Math.max(0, Number(v) || 0),
+                    maxCostUsd:
+                      parsed === null || !Number.isFinite(parsed) || parsed <= 0
+                        ? null
+                        : parsed,
                   }))
+                  markStale()
                 }}
                 placeholder="(no cap)"
                 className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
@@ -282,9 +304,10 @@ export default function ContentOpsNewRun() {
               <span className="text-slate-300">Ingestion profile</span>
               <select
                 value={request.ingestionProfile}
-                onChange={(e) =>
+                onChange={(e) => {
                   setRequest((p) => ({ ...p, ingestionProfile: e.target.value }))
-                }
+                  markStale()
+                }}
                 className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
               >
                 {catalog.ingestionProfiles.map((profile) => (
@@ -299,9 +322,10 @@ export default function ContentOpsNewRun() {
                 <input
                   type="checkbox"
                   checked={request.requireQualityGates}
-                  onChange={(e) =>
+                  onChange={(e) => {
                     setRequest((p) => ({ ...p, requireQualityGates: e.target.checked }))
-                  }
+                    markStale()
+                  }}
                   className="h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500"
                 />
                 <span className="text-slate-300">Require quality gates</span>
@@ -310,12 +334,13 @@ export default function ContentOpsNewRun() {
                 <input
                   type="checkbox"
                   checked={request.allowUnimplementedOutputs}
-                  onChange={(e) =>
+                  onChange={(e) => {
                     setRequest((p) => ({
                       ...p,
                       allowUnimplementedOutputs: e.target.checked,
                     }))
-                  }
+                    markStale()
+                  }}
                   className="h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500"
                 />
                 <span className="text-slate-300">Allow unimplemented outputs</span>

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1,0 +1,446 @@
+import { useMemo, useState } from 'react'
+import { Loader2, Play, RefreshCw } from 'lucide-react'
+import { clsx } from 'clsx'
+import {
+  fetchContentOpsControlSurfaces,
+  previewContentOpsRun,
+} from '../api/contentOps'
+import {
+  fromWireCatalog,
+  fromWirePreview,
+  fromWireRequest,
+  toWireRequest,
+  type ContentOpsCatalog,
+  type ContentOpsRequest,
+  type ControlSurfacePreview,
+} from '../domain/contentOps'
+import useApiData from '../hooks/useApiData'
+import { PageError } from '../components/ErrorBoundary'
+
+type SubmitState =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'invalid_inputs_json'; message: string }
+  | { kind: 'error'; message: string }
+  | { kind: 'success'; preview: ControlSurfacePreview }
+
+const DEFAULT_INPUTS_JSON = '{\n  \n}'
+
+export default function ContentOpsNewRun() {
+  const {
+    data: wireCatalog,
+    loading,
+    error,
+    refresh,
+    refreshing,
+  } = useApiData(() => fetchContentOpsControlSurfaces(), [])
+
+  const catalog = useMemo<ContentOpsCatalog | null>(
+    () => (wireCatalog ? fromWireCatalog(wireCatalog) : null),
+    [wireCatalog],
+  )
+
+  const [request, setRequest] = useState<ContentOpsRequest>(() =>
+    fromWireRequest({}),
+  )
+  const [inputsJson, setInputsJson] = useState<string>(DEFAULT_INPUTS_JSON)
+  const [submitState, setSubmitState] = useState<SubmitState>({ kind: 'idle' })
+
+  if (error) {
+    return <PageError error={error} onRetry={refresh} />
+  }
+  if (loading || !catalog) {
+    return (
+      <div className="flex items-center justify-center py-24 text-slate-400">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+        Loading control surfaces…
+      </div>
+    )
+  }
+
+  const togglePreset = (presetId: string) => {
+    const preset = catalog.presets.find((p) => p.id === presetId)
+    if (!preset) return
+    setRequest((prev) => ({
+      ...prev,
+      preset: prev.preset === presetId ? null : presetId,
+      outputs: prev.preset === presetId ? prev.outputs : [...preset.outputs],
+    }))
+  }
+
+  const toggleOutput = (outputId: string) => {
+    setRequest((prev) => {
+      const has = prev.outputs.includes(outputId)
+      return {
+        ...prev,
+        outputs: has
+          ? prev.outputs.filter((o) => o !== outputId)
+          : [...prev.outputs, outputId],
+      }
+    })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitState({ kind: 'submitting' })
+
+    let parsedInputs: Record<string, unknown>
+    try {
+      const trimmed = inputsJson.trim()
+      parsedInputs = trimmed ? JSON.parse(trimmed) : {}
+      if (typeof parsedInputs !== 'object' || Array.isArray(parsedInputs)) {
+        throw new Error('inputs must be a JSON object')
+      }
+    } catch (err) {
+      setSubmitState({
+        kind: 'invalid_inputs_json',
+        message: err instanceof Error ? err.message : String(err),
+      })
+      return
+    }
+
+    const domainRequest: ContentOpsRequest = { ...request, inputs: parsedInputs }
+    try {
+      const wirePreview = await previewContentOpsRun(toWireRequest(domainRequest))
+      setSubmitState({ kind: 'success', preview: fromWirePreview(wirePreview) })
+    } catch (err) {
+      setSubmitState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-100">Content Ops · New Run</h1>
+          <p className="mt-1 text-sm text-slate-400">
+            Pick a preset or outputs, supply inputs, preview the run before
+            you commit.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={refreshing}
+          className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+        >
+          <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
+          Refresh catalog
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        {/* Preset picker */}
+        <section>
+          <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-slate-400">
+            Preset
+          </h2>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {catalog.presets.map((preset) => {
+              const selected = request.preset === preset.id
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => togglePreset(preset.id)}
+                  className={clsx(
+                    'rounded-lg border px-4 py-3 text-left transition',
+                    selected
+                      ? 'border-cyan-500 bg-cyan-500/10 text-slate-100'
+                      : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500',
+                  )}
+                >
+                  <div className="text-sm font-medium">{preset.label}</div>
+                  <div className="mt-0.5 text-xs text-slate-400">{preset.description}</div>
+                  <div className="mt-2 text-xs text-slate-500">
+                    {preset.outputs.join(' · ')}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Output picker */}
+        <section>
+          <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-slate-400">
+            Outputs
+          </h2>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {catalog.outputs.map((output) => {
+              const checked = request.outputs.includes(output.id)
+              return (
+                <label
+                  key={output.id}
+                  className={clsx(
+                    'flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2 transition',
+                    checked
+                      ? 'border-cyan-500 bg-cyan-500/10'
+                      : 'border-slate-700 bg-slate-900 hover:border-slate-500',
+                    !output.implemented && 'opacity-60',
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleOutput(output.id)}
+                    className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 text-sm font-medium text-slate-100">
+                      {output.label}
+                      {!output.canExecute && output.implemented && (
+                        <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-400">
+                          host service not configured
+                        </span>
+                      )}
+                      {!output.implemented && (
+                        <span className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] text-slate-400">
+                          coming soon
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 text-xs text-slate-400">{output.description}</div>
+                    <div className="mt-1 text-[11px] text-slate-500">
+                      requires:{' '}
+                      {output.requiredInputs.length === 0
+                        ? '(none)'
+                        : output.requiredInputs.join(', ')}{' '}
+                      · est ${output.estimatedRetryAdjustedUnitCostUsd.toFixed(2)}/item
+                    </div>
+                  </div>
+                </label>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Inputs (v0: raw JSON) */}
+        <section>
+          <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-slate-400">
+            Inputs (JSON)
+          </h2>
+          <p className="mb-2 text-xs text-slate-500">
+            Required keys depend on the selected outputs (see chip list
+            above). Type a JSON object; the dynamic per-output form ships
+            in a follow-up slice.
+          </p>
+          <textarea
+            value={inputsJson}
+            onChange={(e) => setInputsJson(e.target.value)}
+            rows={6}
+            spellCheck={false}
+            className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 font-mono text-xs text-slate-200 focus:border-cyan-500 focus:outline-none"
+            placeholder='{"target_account": "Acme", "offer": "Audit"}'
+          />
+        </section>
+
+        {/* Options */}
+        <section>
+          <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-slate-400">
+            Options
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="block text-sm">
+              <span className="text-slate-300">Limit</span>
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                value={request.limit}
+                onChange={(e) =>
+                  setRequest((p) => ({
+                    ...p,
+                    limit: Math.max(1, Math.min(1000, Number(e.target.value) || 1)),
+                  }))
+                }
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Max cost (USD)</span>
+              <input
+                type="number"
+                step={0.01}
+                min={0}
+                value={request.maxCostUsd ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value
+                  setRequest((p) => ({
+                    ...p,
+                    maxCostUsd: v === '' ? null : Math.max(0, Number(v) || 0),
+                  }))
+                }}
+                placeholder="(no cap)"
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Ingestion profile</span>
+              <select
+                value={request.ingestionProfile}
+                onChange={(e) =>
+                  setRequest((p) => ({ ...p, ingestionProfile: e.target.value }))
+                }
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
+              >
+                {catalog.ingestionProfiles.map((profile) => (
+                  <option key={profile} value={profile}>
+                    {profile}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="space-y-2 text-sm">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={request.requireQualityGates}
+                  onChange={(e) =>
+                    setRequest((p) => ({ ...p, requireQualityGates: e.target.checked }))
+                  }
+                  className="h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500"
+                />
+                <span className="text-slate-300">Require quality gates</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={request.allowUnimplementedOutputs}
+                  onChange={(e) =>
+                    setRequest((p) => ({
+                      ...p,
+                      allowUnimplementedOutputs: e.target.checked,
+                    }))
+                  }
+                  className="h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500"
+                />
+                <span className="text-slate-300">Allow unimplemented outputs</span>
+              </label>
+            </div>
+          </div>
+        </section>
+
+        {/* Submit */}
+        <section className="flex items-center justify-between border-t border-slate-800 pt-4">
+          <div className="text-xs text-slate-500">
+            {request.outputs.length === 0
+              ? 'Pick at least one output (or a preset).'
+              : `${request.outputs.length} output(s) selected.`}
+          </div>
+          <button
+            type="submit"
+            disabled={
+              submitState.kind === 'submitting' || request.outputs.length === 0
+            }
+            className="flex items-center gap-2 rounded-md bg-cyan-500 px-4 py-2 text-sm font-medium text-slate-900 hover:bg-cyan-400 disabled:opacity-50"
+          >
+            {submitState.kind === 'submitting' ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4" />
+            )}
+            Preview
+          </button>
+        </section>
+      </form>
+
+      {/* Preview verdict */}
+      {submitState.kind === 'invalid_inputs_json' && (
+        <div className="mt-6 rounded-md border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          Invalid inputs JSON: {submitState.message}
+        </div>
+      )}
+      {submitState.kind === 'error' && (
+        <div className="mt-6 rounded-md border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          Preview failed: {submitState.message}
+        </div>
+      )}
+      {submitState.kind === 'success' && (
+        <PreviewVerdict preview={submitState.preview} />
+      )}
+    </div>
+  )
+}
+
+function PreviewVerdict({ preview }: { preview: ControlSurfacePreview }) {
+  return (
+    <section className="mt-8 rounded-lg border border-slate-800 bg-slate-900/60 p-5">
+      <div className="mb-3 flex items-center gap-3">
+        <span
+          className={clsx(
+            'rounded-full px-3 py-0.5 text-xs font-medium',
+            preview.canRun
+              ? 'bg-emerald-500/20 text-emerald-300'
+              : 'bg-amber-500/20 text-amber-200',
+          )}
+        >
+          {preview.canRun ? 'Can run' : 'Blocked'}
+        </span>
+        <span className="text-sm text-slate-400">
+          Estimated cost: ${preview.estimatedCostUsd.toFixed(2)}
+        </span>
+      </div>
+
+      {preview.outputs.length > 0 && (
+        <Section label="Outputs">
+          <div className="text-sm text-slate-200">
+            {preview.outputs.join(', ')}
+          </div>
+        </Section>
+      )}
+
+      {preview.missingInputs.length > 0 && (
+        <Section label="Missing inputs">
+          <ul className="ml-4 list-disc text-sm text-amber-200">
+            {preview.missingInputs.map((name) => (
+              <li key={name}>{name}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {preview.blockedOutputs.length > 0 && (
+        <Section label="Blocked outputs">
+          <ul className="ml-4 list-disc text-sm text-amber-200">
+            {preview.blockedOutputs.map((name) => (
+              <li key={name}>{name}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {preview.warnings.length > 0 && (
+        <Section label="Warnings">
+          <ul className="ml-4 list-disc text-sm text-slate-300">
+            {preview.warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {preview.normalizedRequest && (
+        <Section label="Normalized request">
+          <pre className="overflow-x-auto rounded-md bg-slate-950/80 p-3 font-mono text-xs text-slate-300">
+            {JSON.stringify(preview.normalizedRequest, null, 2)}
+          </pre>
+        </Section>
+      )}
+    </section>
+  )
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-3 first:mt-0">
+      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+        {label}
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Loader2, Play, RefreshCw } from 'lucide-react'
 import { clsx } from 'clsx'
 import {
@@ -45,6 +45,10 @@ export default function ContentOpsNewRun() {
   )
   const [inputsJson, setInputsJson] = useState<string>(DEFAULT_INPUTS_JSON)
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: 'idle' })
+  // Codex P2 fix: request-id ref so a stale in-flight preview response
+  // can't overwrite a verdict the user has since invalidated by editing
+  // the form. Mirrors the pattern in src/hooks/useApiData.ts.
+  const submitRequestIdRef = useRef(0)
 
   if (error) {
     return <PageError error={error} onRetry={refresh} />
@@ -60,8 +64,10 @@ export default function ContentOpsNewRun() {
 
   // Codex P2 fix: any form mutation invalidates a stale preview verdict so
   // the user never sees a "Can run" badge that doesn't match the current
-  // form state. Re-submit yields a fresh verdict.
+  // form state. Bumping the request id also drops any in-flight preview
+  // response so it can't overwrite the verdict for a newer form state.
   const markStale = () => {
+    submitRequestIdRef.current += 1
     setSubmitState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
   }
 
@@ -91,6 +97,8 @@ export default function ContentOpsNewRun() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    // Bump the id so any prior in-flight request is ignored on resolve.
+    const requestId = ++submitRequestIdRef.current
     setSubmitState({ kind: 'submitting' })
 
     let parsedInputs: Record<string, unknown>
@@ -101,6 +109,7 @@ export default function ContentOpsNewRun() {
         throw new Error('inputs must be a JSON object')
       }
     } catch (err) {
+      if (requestId !== submitRequestIdRef.current) return
       setSubmitState({
         kind: 'invalid_inputs_json',
         message: err instanceof Error ? err.message : String(err),
@@ -111,8 +120,11 @@ export default function ContentOpsNewRun() {
     const domainRequest: ContentOpsRequest = { ...request, inputs: parsedInputs }
     try {
       const wirePreview = await previewContentOpsRun(toWireRequest(domainRequest))
+      // Drop the response if a newer mutation / submission has happened.
+      if (requestId !== submitRequestIdRef.current) return
       setSubmitState({ kind: 'success', preview: fromWirePreview(wirePreview) })
     } catch (err) {
+      if (requestId !== submitRequestIdRef.current) return
       setSubmitState({
         kind: 'error',
         message: err instanceof Error ? err.message : String(err),

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -117,7 +117,20 @@ export default function ContentOpsNewRun() {
       return
     }
 
-    const domainRequest: ContentOpsRequest = { ...request, inputs: parsedInputs }
+    // Submit-time normalization: backend's pydantic validator declares
+    // max_cost_usd with gt=0; collapse 0 / negative to null so we never
+    // round-trip a request the API would reject.
+    const normalizedMaxCost =
+      request.maxCostUsd === null ||
+      !Number.isFinite(request.maxCostUsd) ||
+      request.maxCostUsd <= 0
+        ? null
+        : request.maxCostUsd
+    const domainRequest: ContentOpsRequest = {
+      ...request,
+      inputs: parsedInputs,
+      maxCostUsd: normalizedMaxCost,
+    }
     try {
       const wirePreview = await previewContentOpsRun(toWireRequest(domainRequest))
       // Drop the response if a newer mutation / submission has happened.
@@ -293,18 +306,18 @@ export default function ContentOpsNewRun() {
                 min={0}
                 value={request.maxCostUsd ?? ''}
                 onChange={(e) => {
-                  // Codex P2 fix: backend pydantic validator declares
-                  // max_cost_usd with gt=0 (control_surfaces.py:88), so
-                  // submitting 0 always fails. Treat 0 / negative / blank
-                  // as "no cap" client-side.
+                  // Codex P2 fix v2: keep 0 valid in form state during typing
+                  // so the user can keep keying a sub-dollar value like "0.50"
+                  // (the prior `<= 0 -> null` clobbered the input the moment
+                  // they typed "0"). The submit handler normalizes 0 / negative
+                  // values to null before sending, matching the backend's
+                  // `gt=0` validator (control_surfaces.py:88).
                   const v = e.target.value
                   const parsed = v === '' ? null : Number(v)
                   setRequest((p) => ({
                     ...p,
                     maxCostUsd:
-                      parsed === null || !Number.isFinite(parsed) || parsed <= 0
-                        ? null
-                        : parsed,
+                      parsed === null || !Number.isFinite(parsed) ? null : parsed,
                   }))
                   markStale()
                 }}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -174,6 +174,12 @@ export default function ContentOpsNewRun() {
     // Bump the id so any prior in-flight request is ignored on resolve.
     const requestId = ++submitRequestIdRef.current
     setSubmitState({ kind: 'submitting' })
+    // Codex P2 fix: also reset planState. A previewing-while-planning
+    // sequence would otherwise leave planState stuck at 'submitting'
+    // (its in-flight response is dropped by the requestId guard but
+    // never overwritten), and the Build-plan CTA would stay disabled
+    // indefinitely until the user mutates the form.
+    setPlanState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
 
     const parsed = buildDomainRequest()
     if (!parsed.ok) {

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -60,9 +60,6 @@ from .b2b_evidence import router as b2b_evidence_router
 from .b2b_vendor_claims import router as b2b_vendor_claims_router
 from .b2b_challenger_claims import router as b2b_challenger_claims_router
 from fastapi import Depends
-from extracted_content_pipeline.api.control_surfaces import (
-    create_content_ops_control_surface_router,
-)
 from ..auth.dependencies import require_b2b_plan
 
 logger = logging.getLogger("atlas.api")
@@ -149,7 +146,16 @@ router.include_router(b2b_challenger_claims_router)
 # the same B2B audience. Without this every /api/v1/content-ops/*
 # endpoint would be reachable without a token (the frontend's
 # ProtectedRoute is UI-only gating).
+#
+# The `extracted_content_pipeline` import is inside the try so the
+# host's prod Docker image (which copies only ./atlas_brain) doesn't
+# crash at startup; the image installs the extracted package via the
+# requirements path when present, otherwise the content-ops surface
+# is logged as disabled and existing routes keep serving.
 try:
+    from extracted_content_pipeline.api.control_surfaces import (
+        create_content_ops_control_surface_router,
+    )
     content_ops_router = create_content_ops_control_surface_router(
         dependencies=[Depends(require_b2b_plan("b2b_growth"))],
     )

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -59,6 +59,9 @@ from .b2b_win_loss import router as b2b_win_loss_router
 from .b2b_evidence import router as b2b_evidence_router
 from .b2b_vendor_claims import router as b2b_vendor_claims_router
 from .b2b_challenger_claims import router as b2b_challenger_claims_router
+from extracted_content_pipeline.api.control_surfaces import (
+    create_content_ops_control_surface_router,
+)
 
 logger = logging.getLogger("atlas.api")
 
@@ -132,3 +135,16 @@ router.include_router(b2b_win_loss_router)
 router.include_router(b2b_evidence_router)
 router.include_router(b2b_vendor_claims_router)
 router.include_router(b2b_challenger_claims_router)
+
+# AI Content Ops control-surface routes (preview / plan / execute /
+# control-surfaces). Mounted with no execution_services_provider yet
+# -- preview / plan / GET control-surfaces work; execute correctly
+# returns 503 ("Content Ops execution services are not configured.")
+# until the host wires execution services in a follow-up slice.
+try:
+    content_ops_router = create_content_ops_control_surface_router()
+    router.include_router(content_ops_router)
+except Exception as exc:  # pragma: no cover - defensive at import time
+    logger.warning(
+        "Content Ops router disabled during api package import: %s", exc
+    )

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -59,9 +59,11 @@ from .b2b_win_loss import router as b2b_win_loss_router
 from .b2b_evidence import router as b2b_evidence_router
 from .b2b_vendor_claims import router as b2b_vendor_claims_router
 from .b2b_challenger_claims import router as b2b_challenger_claims_router
+from fastapi import Depends
 from extracted_content_pipeline.api.control_surfaces import (
     create_content_ops_control_surface_router,
 )
+from ..auth.dependencies import require_b2b_plan
 
 logger = logging.getLogger("atlas.api")
 
@@ -141,8 +143,16 @@ router.include_router(b2b_challenger_claims_router)
 # -- preview / plan / GET control-surfaces work; execute correctly
 # returns 503 ("Content Ops execution services are not configured.")
 # until the host wires execution services in a follow-up slice.
+#
+# Auth: gated behind require_b2b_plan("b2b_growth") -- same dependency
+# the existing /api/v1/b2b/campaigns router uses, since Content Ops is
+# the same B2B audience. Without this every /api/v1/content-ops/*
+# endpoint would be reachable without a token (the frontend's
+# ProtectedRoute is UI-only gating).
 try:
-    content_ops_router = create_content_ops_control_surface_router()
+    content_ops_router = create_content_ops_control_surface_router(
+        dependencies=[Depends(require_b2b_plan("b2b_growth"))],
+    )
     router.include_router(content_ops_router)
 except Exception as exc:  # pragma: no cover - defensive at import time
     logger.warning(

--- a/plans/PR-Content-Ops-Screen-1-New-Run.md
+++ b/plans/PR-Content-Ops-Screen-1-New-Run.md
@@ -56,13 +56,16 @@ A new page at `/content-ops/new` that:
    `client.ts` / `b2bClient.ts` convention. ~5 LOC delta.
 4. `atlas_brain/api/__init__.py` -- mount the
    `extracted_content_pipeline` content-ops router into the
-   host's aggregate `api_router`. Without this the screen
-   404s in dev. Added in the fix-up commit after the Codex P1
-   review on round 4. The router is mounted with no
+   host's aggregate `api_router`, gated behind the
+   `require_b2b_plan("b2b_growth")` dependency (same auth gate
+   as `b2b_campaigns_router`; the frontend's `ProtectedRoute`
+   is UI-only and does not protect the API surface). Added
+   across two fix-up commits after Codex P1 reviews on rounds
+   4 and 7. The router is mounted with no
    `execution_services_provider` for v0 -- preview / plan /
    GET control-surfaces work; execute correctly returns 503
    until execution services are wired in a follow-up slice.
-   ~12 LOC delta.
+   ~22 LOC delta.
 5. `plans/PR-Content-Ops-Screen-1-New-Run.md` (this file).
 
 ### What's NOT in this slice

--- a/plans/PR-Content-Ops-Screen-1-New-Run.md
+++ b/plans/PR-Content-Ops-Screen-1-New-Run.md
@@ -45,10 +45,16 @@ A new page at `/content-ops/new` that:
 ### Files touched
 
 1. `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` (new) -- the
-   v0 page component. ~280 LOC.
+   v0 page component. **~497 LOC** (initial estimate ~280 LOC
+   undershot; the form + verdict panel + race-condition guard
+   came in heavier than projected).
 2. `atlas-intel-ui/src/App.tsx` -- register the route at
    `/content-ops/new` and the lazy import. ~3 LOC.
-3. `plans/PR-Content-Ops-Screen-1-New-Run.md` (this file).
+3. `atlas-intel-ui/src/api/contentOps.ts` -- update `BASE` to
+   `${API_BASE}/api/v1/content-ops` so the dev Vite proxy
+   handles the request and the mount aligns with the existing
+   `client.ts` / `b2bClient.ts` convention. ~5 LOC delta.
+4. `plans/PR-Content-Ops-Screen-1-New-Run.md` (this file).
 
 ### What's NOT in this slice
 
@@ -80,11 +86,27 @@ Standard React patterns matching the existing repo:
   loading.
 - Local `useState<ContentOpsRequest>` for the form state, seeded
   with sane defaults from `fromWireRequest({})`.
-- Local `useState<ControlSurfacePreview | null>` for the preview
-  response.
+- Single `SubmitState` discriminated union state for the
+  preview lifecycle:
+  ```ts
+  type SubmitState =
+    | { kind: 'idle' }
+    | { kind: 'submitting' }
+    | { kind: 'invalid_inputs_json'; message: string }
+    | { kind: 'error'; message: string }
+    | { kind: 'success'; preview: ControlSurfacePreview }
+  ```
+  Co-locates loading / parse-error / API-error / success in one
+  variable; the verdict panel switches on `kind`.
+- `submitRequestIdRef` + `markStale()` race-condition guard:
+  any form mutation bumps the request id; `handleSubmit`
+  captures the id at submit time and drops the response if a
+  newer mutation has happened. Mirrors the pattern in
+  `src/hooks/useApiData.ts`.
 - Submit handler: build a domain request, call
   `toWireRequest(domain) → previewContentOpsRun(wire)`, map the
-  response with `fromWirePreview`, store in state.
+  response with `fromWirePreview`, store in state -- but only
+  if the captured request id still matches.
 
 The preset → outputs auto-fill is one-way: selecting a preset
 clones the preset's outputs into the form. Subsequently
@@ -95,6 +117,19 @@ warns about this and falls back to explicit outputs).
 The JSON textarea uses a try/catch parse on submit: parse
 errors surface as a toast-style inline error; valid parses go
 through. No live syntax highlighting -- v0.
+
+`max_cost_usd` is normalized at submit time, not on every
+keystroke, so the user can type sub-dollar values like `0.50`
+without the input clobbering itself when the leading `0` is
+typed. The submit handler maps `0` / negative / blank values to
+`null` (no cap) before sending, matching the backend's pydantic
+`gt=0` validator.
+
+The API mount aligns with the existing repo convention: the
+adapter targets `${API_BASE}/api/v1/content-ops`, matching
+`client.ts` (`/api/v1/consumer/dashboard`) and `b2bClient.ts`
+(`/api/v1/b2b/tenant`). The Vite dev proxy handles `/api/*`
+unchanged.
 
 ## Intentional
 
@@ -142,11 +177,20 @@ through. No live syntax highlighting -- v0.
 
 ## Estimated diff size
 
-- `ContentOpsNewRun.tsx`: ~280 LOC.
-- `App.tsx`: ~3 LOC.
-- Plan doc: ~150 LOC.
+Initial estimate undershot the page component by ~75% -- the
+form + verdict panel + race-condition guard + `SubmitState`
+discriminated union added more than the rough mental model
+projected. Updated for transparency.
 
-Total: ~435 LOC. Marginally over the 400 soft cap. Splitting
-the screen into "page skeleton" vs "form" leaves an unusable
-half-screen; the screen is a structurally indivisible vertical
-slice.
+- `ContentOpsNewRun.tsx`: ~497 LOC actual (initial estimate
+  ~280 LOC).
+- `App.tsx`: ~3 LOC.
+- `api/contentOps.ts`: ~5 LOC delta (BASE path realignment,
+  added in fix-up commit after the Codex P1 review).
+- Plan doc: ~210 LOC actual (post-update).
+
+Total actual: **~715 LOC**. Over the 400 soft cap. The screen
+is a structurally indivisible vertical slice -- splitting at
+"page skeleton" vs "form" leaves an unusable half-screen and
+the race-condition / max-cost / state-machine logic depends on
+the full form being present.

--- a/plans/PR-Content-Ops-Screen-1-New-Run.md
+++ b/plans/PR-Content-Ops-Screen-1-New-Run.md
@@ -188,6 +188,14 @@ unchanged.
 - `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx
   src/App.tsx` -- clean.
 - `cd atlas-intel-ui && npm run build` -- builds.
+- `bash scripts/check_ascii_python.sh` -- clean (the script is
+  scoped to `extracted_content_pipeline`; this slice doesn't
+  touch that package, but running for completeness per AGENTS.md
+  §3b).
+- `python -c "open('atlas_brain/api/__init__.py').read().encode('ascii')"`
+  -- clean (the host change `atlas_brain/api/__init__.py` is
+  outside the package script's scope; verified ASCII-clean
+  separately).
 - Manual: `npm run dev` and exercise the page -- pick a preset,
   select outputs, type inputs, submit, see preview verdict
   render.
@@ -199,14 +207,19 @@ form + verdict panel + race-condition guard + `SubmitState`
 discriminated union added more than the rough mental model
 projected. Updated for transparency.
 
-- `ContentOpsNewRun.tsx`: ~497 LOC actual (initial estimate
-  ~280 LOC).
+- `ContentOpsNewRun.tsx`: ~520 LOC actual (initial estimate
+  ~280 LOC; grew further across the Codex review rounds for the
+  `SubmitState` race guard, `markStale`, max-cost string draft,
+  and `invalid_max_cost` validation state).
 - `App.tsx`: ~3 LOC.
 - `api/contentOps.ts`: ~5 LOC delta (BASE path realignment,
   added in fix-up commit after the Codex P1 review).
-- Plan doc: ~210 LOC actual (post-update).
+- `atlas_brain/api/__init__.py`: ~16 LOC delta (mount the
+  content-ops router into the host's aggregate `api_router`,
+  added in fix-up commit after the Codex P1 round 4 review).
+- Plan doc: ~225 LOC actual (post-update).
 
-Total actual: **~715 LOC**. Over the 400 soft cap. The screen
+Total actual: **~770 LOC**. Over the 400 soft cap. The screen
 is a structurally indivisible vertical slice -- splitting at
 "page skeleton" vs "form" leaves an unusable half-screen and
 the race-condition / max-cost / state-machine logic depends on

--- a/plans/PR-Content-Ops-Screen-1-New-Run.md
+++ b/plans/PR-Content-Ops-Screen-1-New-Run.md
@@ -1,0 +1,152 @@
+# PR: Content Ops Screen 1 — New Run / Control Surface (v0)
+
+## Why this slice exists
+
+PR #403 / #404 / #405 landed the API adapter, contract test
+harness, and domain layer for Content Ops. The v0 frontend
+needs a user-visible entry point: pick a preset, pick outputs,
+provide inputs, see the preview verdict. Without this screen,
+the backend's `/content-ops/*` surface has no UI to drive it.
+
+This PR is the first of three screens defined in the contract
+doc:
+
+> 1. **New Run / Control Surface**
+>    - Loads `GET /content-ops/control-surfaces`.
+>    - Renders preset picker, output picker, required-input
+>      form, options.
+>    - On submit: `POST /content-ops/preview`, render
+>      `ControlSurfacePreview`.
+
+A v0 ships first; per-output dynamic input form, sticky options
+panel, and screen polish are follow-up slices.
+
+## Scope (this PR)
+
+A new page at `/content-ops/new` that:
+
+1. **Loads the catalog** via `fetchContentOpsControlSurfaces` →
+   `fromWireCatalog` → `ContentOpsCatalog` domain type.
+2. **Renders a preset picker** as a radio group (5 options;
+   selecting one auto-fills the output set).
+3. **Renders an output multi-select** as checkboxes (6 outputs;
+   deselects/auto-pops as the user customizes).
+4. **Renders an "inputs" JSON textarea** for v0 -- the user
+   types `{"target_account": "Acme", "offer": "Audit"}` directly.
+   The dynamic per-output input form ships in a follow-up.
+5. **Renders an options panel** with `limit`, `maxCostUsd`,
+   `requireQualityGates`, `allowUnimplementedOutputs`,
+   `ingestionProfile`.
+6. **Submit** posts to `/content-ops/preview` via
+   `previewContentOpsRun` → `fromWirePreview` → renders the
+   verdict (canRun, missing_inputs, blocked_outputs, warnings,
+   estimated_cost_usd, normalized_request).
+
+### Files touched
+
+1. `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` (new) -- the
+   v0 page component. ~280 LOC.
+2. `atlas-intel-ui/src/App.tsx` -- register the route at
+   `/content-ops/new` and the lazy import. ~3 LOC.
+3. `plans/PR-Content-Ops-Screen-1-New-Run.md` (this file).
+
+### What's NOT in this slice
+
+- **Dynamic per-output required-input form.** v0 uses a JSON
+  textarea so the user can type inputs in raw form. The
+  per-output dynamic form lands in a follow-up slice once we
+  see the screen in use.
+- **Plan / Execute screens.** Those are screens 2 and 3 of the
+  contract; their own PRs.
+- **Per-input client-side validation** (length caps, etc.).
+  Screen-1's validation comes from the backend via
+  `missing_inputs` / `warnings`; v0 trusts the backend.
+- **Persisted run state.** No `useReducer` / context / route
+  state preservation -- just local `useState`. Persistence
+  ships when needed.
+- **Selectors in domain layer.** Computed-state derivations
+  like `canSubmit(catalog, request)` live inline in this
+  screen for now. Once a second consumer needs them, they
+  graduate into the domain layer.
+- **Loading / error skeleton components.** v0 uses inline
+  conditional rendering; existing pages (`Brands.tsx`) use
+  the same pattern.
+
+## Mechanism
+
+Standard React patterns matching the existing repo:
+
+- `useApiData` hook from `src/hooks/useApiData.ts` for catalog
+  loading.
+- Local `useState<ContentOpsRequest>` for the form state, seeded
+  with sane defaults from `fromWireRequest({})`.
+- Local `useState<ControlSurfacePreview | null>` for the preview
+  response.
+- Submit handler: build a domain request, call
+  `toWireRequest(domain) → previewContentOpsRun(wire)`, map the
+  response with `fromWirePreview`, store in state.
+
+The preset → outputs auto-fill is one-way: selecting a preset
+clones the preset's outputs into the form. Subsequently
+unchecking an output drops it from the form's outputs without
+clearing the preset selection (the contract notes the backend
+warns about this and falls back to explicit outputs).
+
+The JSON textarea uses a try/catch parse on submit: parse
+errors surface as a toast-style inline error; valid parses go
+through. No live syntax highlighting -- v0.
+
+## Intentional
+
+- **JSON textarea instead of dynamic per-output inputs form.**
+  The dynamic form is the most complex part of the screen and
+  has multiple design questions (which inputs are shared across
+  selected outputs? per-output sub-sections? a flat union with
+  source labels?). Shipping a JSON textarea unblocks the rest
+  of the screen and lets us see the screen in use before
+  committing to a shape. Plan-doc explicitly defers.
+- **Outputs / preset interaction is one-way.** Picking a preset
+  fills outputs; tweaking outputs doesn't clear the preset
+  display. Keeps the UI predictable; matches the backend's
+  behavior of "explicit outputs override preset."
+- **No URL state for the form.** v0 doesn't survive page
+  reload; that's a follow-up. The contract doc doesn't promise
+  URL-state preservation.
+- **No Tailwind-component extraction.** Every existing page
+  inlines Tailwind classes; a `<RadioCard>` extraction is its
+  own slice once we have ≥3 callers.
+- **`Promise<void>` form submit.** No `useTransition` /
+  optimistic state -- v0 keeps the UI honest about loading.
+
+## Deferred
+
+- Dynamic per-output required-input form (follow-up).
+- Inline per-input validation (the backend's `missing_inputs`
+  is the source of truth in v0).
+- Sticky options panel / save-as-template (out of v0 scope).
+- Screen 2 (Plan Preview) and Screen 3 (Execute / Run Result)
+  -- separate PRs.
+- URL-state preservation of the form across reloads.
+- Component extraction (`<RadioCard>`, `<OutputChip>`,
+  `<PreviewVerdictPanel>`) once ≥3 callers exist.
+
+## Verification
+
+- `cd atlas-intel-ui && npx tsc -b --noEmit` -- clean.
+- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx
+  src/App.tsx` -- clean.
+- `cd atlas-intel-ui && npm run build` -- builds.
+- Manual: `npm run dev` and exercise the page -- pick a preset,
+  select outputs, type inputs, submit, see preview verdict
+  render.
+
+## Estimated diff size
+
+- `ContentOpsNewRun.tsx`: ~280 LOC.
+- `App.tsx`: ~3 LOC.
+- Plan doc: ~150 LOC.
+
+Total: ~435 LOC. Marginally over the 400 soft cap. Splitting
+the screen into "page skeleton" vs "form" leaves an unusable
+half-screen; the screen is a structurally indivisible vertical
+slice.

--- a/plans/PR-Content-Ops-Screen-1-New-Run.md
+++ b/plans/PR-Content-Ops-Screen-1-New-Run.md
@@ -54,7 +54,16 @@ A new page at `/content-ops/new` that:
    `${API_BASE}/api/v1/content-ops` so the dev Vite proxy
    handles the request and the mount aligns with the existing
    `client.ts` / `b2bClient.ts` convention. ~5 LOC delta.
-4. `plans/PR-Content-Ops-Screen-1-New-Run.md` (this file).
+4. `atlas_brain/api/__init__.py` -- mount the
+   `extracted_content_pipeline` content-ops router into the
+   host's aggregate `api_router`. Without this the screen
+   404s in dev. Added in the fix-up commit after the Codex P1
+   review on round 4. The router is mounted with no
+   `execution_services_provider` for v0 -- preview / plan /
+   GET control-surfaces work; execute correctly returns 503
+   until execution services are wired in a follow-up slice.
+   ~12 LOC delta.
+5. `plans/PR-Content-Ops-Screen-1-New-Run.md` (this file).
 
 ### What's NOT in this slice
 
@@ -164,6 +173,14 @@ unchanged.
 - URL-state preservation of the form across reloads.
 - Component extraction (`<RadioCard>`, `<OutputChip>`,
   `<PreviewVerdictPanel>`) once ≥3 callers exist.
+- **Wiring `execution_services_provider` into the host mount.**
+  v0 mounts the content-ops router with no provider, so
+  `/execute` returns 503 by design. A follow-up slice wires
+  the host's existing `IntelligenceRepository` /
+  `CampaignRepository` / `BlogPostRepository` / etc. (already
+  present in the host for `/api/v1/b2b/*` routes) into a
+  `ContentOpsExecutionServices` factory and passes it through.
+  Preview and plan work without it.
 
 ## Verification
 

--- a/plans/PR-Content-Ops-Screen-2-Plan-Preview.md
+++ b/plans/PR-Content-Ops-Screen-2-Plan-Preview.md
@@ -1,0 +1,134 @@
+# PR: Content Ops Screen 2 — Plan Preview
+
+## Why this slice exists
+
+Screen 1 (PR #406) lets the user pick a preset / outputs / inputs
+and submit to `/content-ops/preview`. The contract's screen 2
+takes the next step:
+
+> 2. **Plan Preview**
+>    - Triggered when preview `canRun=true`; calls
+>      `POST /content-ops/plan`.
+>    - Renders `GenerationPlan.steps` with config panels.
+>    - "Execute" button enabled when `plan.canExecute=true` and
+>      host execution services are configured.
+
+Without Screen 2, the user can preflight the request but can't
+see the runnable plan (per-output runner names, per-step config
+shapes, blocked-step reasons). Screen 3 (Execute) builds on top
+of this.
+
+## Scope (this PR)
+
+Extends `ContentOpsNewRun.tsx` with a "Build plan" step instead
+of shipping a separate route. After a preview returns
+`canRun=true`, a CTA appears that triggers
+`POST /content-ops/plan` and renders the plan steps panel
+beneath the preview verdict. This avoids duplicating the
+preset / outputs / inputs / options form.
+
+### Files touched
+
+1. `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` -- add
+   a `planState` discriminated union, a `handlePlan()` handler,
+   a `PlanPanel` component that renders
+   `GenerationPlan.steps` + per-step config tables, and a
+   "Build plan" CTA inside the existing `PreviewVerdict`. ~150
+   LOC delta.
+2. `plans/PR-Content-Ops-Screen-2-Plan-Preview.md` (this file).
+
+### What's NOT in this slice
+
+- **A separate `/content-ops/plan` route.** Adding a separate
+  page would duplicate the preset / outputs / inputs / options
+  form (which is ~250 LOC). Better to wait until 3+ pages need
+  the form, then extract a shared `<RequestForm>` component.
+- **Execute submit.** Screen 3's territory. The plan panel
+  shows a disabled "Execute" placeholder with a tooltip
+  ("Screen 3 ships next") -- not a functioning button yet.
+- **Plan refresh / re-plan after edits.** Editing the form
+  invalidates both preview and plan via the same
+  `markStale()` plumbing already in Screen 1.
+- **Per-step config shape adapters** (e.g. render
+  `email_campaign`'s `channels` array as chips, render
+  `signal_extraction`'s `max_text_chars` as a chart-cap badge).
+  v0 renders all per-step config as a generic
+  key-value JSON table -- humanizing is a follow-up slice
+  per the contract doc's view-model layer.
+
+## Mechanism
+
+The state model gains a parallel `planState`:
+
+```ts
+type PlanState =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success'; plan: GenerationPlan }
+```
+
+`handlePlan()` mirrors `handleSubmit()` (parse inputs JSON,
+normalize max cost, build domain request, call
+`planContentOpsRun(toWireRequest(request))`, map response with
+`fromWirePlan`), but writes to `planState`. The same
+`submitRequestIdRef` race guard already in place is reused to
+drop stale plan responses.
+
+The "Build plan" CTA appears inside the existing
+`PreviewVerdict` only when `preview.canRun=true`. Clicking it
+fires `handlePlan()`. The plan panel renders below the preview
+verdict; the user sees both at once.
+
+`markStale()` already invalidates the preview verdict on form
+mutation. Extending it to also reset `planState` keeps the
+two panels in sync with the form.
+
+## Intentional
+
+- **Single route, single form.** The contract's "MVP screens 1 /
+  2 / 3" framing is sequential, not separate-page. The cleanest
+  match is one wizard-style flow on `/content-ops/new`.
+- **Plan panel is read-only.** No "edit step config" affordance
+  in v0; the plan reflects what the backend will run, not
+  what the user can tweak. Editing belongs upstream in the
+  options panel.
+- **Disabled "Execute" placeholder, not a missing button.**
+  Communicates Screen 3's pending arrival without committing
+  to a UX shape. Removed cleanly when Screen 3 lands.
+- **No `useReducer`.** Two parallel states (`submitState` and
+  `planState`) are simple enough that a reducer adds friction.
+  Reducer ships when the lifecycle has 3+ states or screen 3
+  introduces dependent transitions.
+- **Per-step config rendered as JSON.** v0 readability is
+  acceptable; per-output adapters are a clear follow-up slice
+  per the contract's "view-model layer" section.
+
+## Deferred
+
+- Per-output `step.config` view adapters (humanize `channels`,
+  `default_report_type`, etc.). Separate slice per the
+  contract's view-model layer.
+- Screen 3 (Execute / Run Result) -- next PR.
+- Component extraction (`<RequestForm>`, `<StatusBadge>`,
+  `<JsonTable>`) once 3+ callers exist.
+- URL state / shareable plan-preview links.
+
+## Verification
+
+- `cd atlas-intel-ui && npx tsc -b --noEmit` -- clean.
+- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx`
+  -- clean.
+- `cd atlas-intel-ui && npm run build` -- builds.
+- Manual: `npm run dev`; pick `email_only` preset, type
+  `{"target_account": "Acme", "offer": "Audit"}`, submit
+  Preview, click "Build plan", see plan panel render with one
+  step (`email_campaign` runner + config).
+
+## Estimated diff size
+
+- `ContentOpsNewRun.tsx`: ~150 LOC delta (PlanState +
+  handlePlan + PlanPanel + Build-plan CTA).
+- Plan doc: ~140 LOC.
+
+Total: ~290 LOC. Under the 400 LOC soft cap.


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Screen-2-Plan-Preview.md`

Extends the existing `/content-ops/new` screen (PR #406) with a "Build plan" step. After preview returns `canRun=true`, a CTA appears next to the verdict; clicking it calls `POST /content-ops/plan` and renders the `GenerationPlan` steps below the preview verdict. Single route, single form — the contract's "MVP screens 1/2/3" framing is sequential, not separate-page.

> **Note:** stacked on top of PR #406 (`claude/pr-content-ops-screen-1`). Once #406 merges to main, this PR's diff will collapse to just the Screen 2 additions (~379 LOC).

## Changes

- **Parallel `PlanState` discriminated union** alongside `SubmitState`. Form mutations invalidate both via the existing `markStale()` plumbing.
- **`buildDomainRequest()` shared helper** — extracts the inputs-JSON + max-cost validation that `handleSubmit` and `handlePlan` both need. Eliminates duplication.
- **`handlePlan()` handler** — same race-condition guard pattern (`submitRequestIdRef`) as `handleSubmit`.
- **"Build plan" CTA inside `PreviewVerdict`** — shown only when `preview.canRun=true`.
- **`PlanPanel` + `PlanStepCard` components** — render plan-level status badge, step count, per-step cards with output id / status badge / runner / blocked reason / collapsible config JSON.
- **Disabled "Execute" placeholder** with tooltip indicating what's blocking it (plan blocked / host services not configured / Screen 3 pending).

## Intentional

- **Single route, not a new `/content-ops/plan` page.** Avoids ~250 LOC of form duplication. Matches the contract's "Triggered when preview canRun=true" sequencing exactly.
- **Plan panel is read-only.** No edit-step-config affordance in v0.
- **Per-step config rendered as JSON.** Per-output view adapters (humanize `channels`, `default_report_type`, etc.) are a follow-up slice per the contract's view-model layer section.
- **No `useReducer`.** Two parallel states are simple enough that adding a reducer adds friction.

## Deferred

- Screen 3 (Execute / Run Result) — next PR.
- Per-output `step.config` view adapters.
- Component extraction (`<RequestForm>`, `<StatusBadge>`, `<JsonTable>`) once ≥3 callers exist.
- URL state / shareable plan-preview links.

## Verification

- `cd atlas-intel-ui && npx tsc -b --noEmit` — clean.
- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx` — clean.
- `cd atlas-intel-ui && npm run build` — builds.
- Manual: pick `email_only` preset, type valid inputs, Preview, click Build plan, see plan panel with one step.

## Diff size

2 files, +379 / -54 (379 net additions). Under the 400 LOC soft cap. ~140 LOC plan doc; ~240 LOC code. Stack base is `claude/pr-content-ops-screen-1` so the live diff against main currently includes Screen 1's changes too — the visible delta cleans up after #406 merges.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_