### PR TITLE
Surface Content Ops reasoning readiness in UI

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -81,6 +81,7 @@ export default function ContentOpsNewRun() {
       </div>
     )
   }
+  const reasoningConfigured = catalog.reasoning.configured
 
   // Codex P2 fix: any form mutation invalidates a stale preview verdict
   // and plan panel so the user never sees a "Can run" badge or plan
@@ -228,7 +229,7 @@ export default function ContentOpsNewRun() {
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-10">
-      <div className="mb-8 flex items-center justify-between">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-slate-100">Content Ops · New Run</h1>
           <p className="mt-1 text-sm text-slate-400">
@@ -236,15 +237,27 @@ export default function ContentOpsNewRun() {
             you commit.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={refresh}
-          disabled={refreshing}
-          className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-800 disabled:opacity-50"
-        >
-          <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
-          Refresh catalog
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={clsx(
+              'rounded-full border px-3 py-1 text-xs font-medium',
+              reasoningConfigured
+                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'
+                : 'border-slate-700 bg-slate-900 text-slate-400',
+            )}
+          >
+            Reasoning {reasoningConfigured ? 'ready' : 'not configured'}
+          </span>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={refreshing}
+            className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+          >
+            <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
+            Refresh catalog
+          </button>
+        </div>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-8">
@@ -315,6 +328,18 @@ export default function ContentOpsNewRun() {
                       {!output.implemented && (
                         <span className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] text-slate-400">
                           coming soon
+                        </span>
+                      )}
+                      {output.reasoningRequirement !== 'absent' && (
+                        <span
+                          className={clsx(
+                            'rounded px-1.5 py-0.5 text-[10px]',
+                            reasoningConfigured
+                              ? 'bg-emerald-500/10 text-emerald-300'
+                              : 'bg-slate-700 text-slate-400',
+                          )}
+                        >
+                          reasoning {reasoningConfigured ? 'ready' : 'unavailable'}
                         </span>
                       )}
                     </div>

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-catalog-status-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-ui-status
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Surface Content Ops reasoning readiness in UI | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md` | codex-content-ops-reasoning-ui-status | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-ui-status
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-ui-status-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Surface Content Ops reasoning readiness in UI | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md` | codex-content-ops-reasoning-ui-status | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -226,6 +226,11 @@ UI rules:
   injected the runner).
 - `implemented=false` ⇒ show "Coming soon" badge; user can still
   preview if they tick `allowUnimplementedOutputs`.
+- Show catalog-level `reasoning.configured` near the run controls.
+  For outputs whose `reasoningRequirement` is not `"absent"`, show
+  whether host reasoning context is ready or unavailable. This is
+  informational only; optional host reasoning does not block preview
+  or planning.
 
 ### Request
 


### PR DESCRIPTION
## Summary
- display catalog-level Content Ops reasoning readiness on the New Run screen
- show per-output reasoning chips for outputs that can consume host reasoning context
- document the UI rule and claim the coordination row for this slice

## Verification
- `cd atlas-intel-ui && npm ci`
- `cd atlas-intel-ui && npm run build`
- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx src/api/contentOps.ts src/domain/contentOps/types.ts src/domain/contentOps/fromWire.ts src/api/contentOps.contract.ts src/domain/contentOps/contract.ts`
- `git diff --check`
- no non-ASCII added lines