### PR TITLE
Add Content Ops email campaign result summary

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -866,6 +866,7 @@ function ExecutionPanel({ result }: { result: ContentOpsExecutionResult }) {
                 Error: {step.error}
               </div>
             )}
+            <ExecutionStepSummary output={step.output} result={step.result} />
             {Object.keys(step.result).length > 0 && (
               <details className="text-xs text-slate-400">
                 <summary className="cursor-pointer text-slate-500 hover:text-slate-300">
@@ -888,6 +889,42 @@ function ExecutionPanel({ result }: { result: ContentOpsExecutionResult }) {
         </Section>
       )}
     </section>
+  )
+}
+
+function ExecutionStepSummary({
+  output,
+  result,
+}: {
+  output: string
+  result: Record<string, unknown>
+}) {
+  if (output !== 'email_campaign') return null
+
+  const generated = typeof result.generated === 'number' ? result.generated : null
+  const savedIds = Array.isArray(result.saved_ids)
+    ? result.saved_ids.filter((id): id is string => typeof id === 'string')
+    : []
+
+  if (generated === null && savedIds.length === 0) return null
+
+  return (
+    <div className="mb-3 rounded-md border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-slate-300">
+      <div className="flex flex-wrap items-center gap-3">
+        {generated !== null && (
+          <span>
+            Drafts generated:{' '}
+            <span className="font-medium text-slate-100">{generated}</span>
+          </span>
+        )}
+        {savedIds.length > 0 && (
+          <span>
+            Saved:{' '}
+            <span className="font-mono text-slate-100">{savedIds.join(', ')}</span>
+          </span>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-execute-ui-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-result-summary
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add Content Ops email campaign result summary | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md` | codex-content-ops-result-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-result-summary
+Last updated: 2026-05-09T00:00Z by codex-content-ops-result-summary-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops email campaign result summary | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md` | codex-content-ops-result-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -350,6 +350,9 @@ UI rules:
 - The MVP execute view may render `result` as read-only JSON while
   per-output adapters are still landing. It must still surface
   step-level status, runner, and `error` inline.
+- `email_campaign` should summarize `generated` and `saved_ids`
+  before the raw JSON block so users do not need to inspect the
+  result payload for the common draft-generation case.
 
 ### Signal extraction (special case)
 

--- a/plans/PR-Content-Ops-Email-Campaign-Result-Summary.md
+++ b/plans/PR-Content-Ops-Email-Campaign-Result-Summary.md
@@ -1,0 +1,79 @@
+# PR: Content Ops email campaign result summary
+
+## Why This Slice Exists
+
+PR #410 made the Content Ops execute panel functional, but every
+step result still rendered as raw JSON. That is acceptable as a
+fallback, but the first shipped execution shape already has stable,
+user-facing fields for `email_campaign`: `generated` and `saved_ids`.
+
+This slice adds the smallest useful result adapter so users can see
+the common email draft outcome without opening the raw payload.
+
+## Scope
+
+Files touched:
+
+1. `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+   - Add `ExecutionStepSummary`.
+   - Render the summary for `output === "email_campaign"`.
+   - Summarize `generated` and `saved_ids` only when those fields are
+     present with the expected runtime shape.
+   - Keep raw result JSON rendering for every output.
+
+2. `docs/frontend/content_ops_frontend_contract.md`
+   - Document the `email_campaign` summary rule.
+
+3. `docs/extraction/coordination/inflight.md`
+   - Claim the slice while the PR is open.
+
+## Mechanism
+
+`ExecutionPanel` delegates per-step result display to
+`ExecutionStepSummary` before rendering the existing raw JSON block.
+
+`ExecutionStepSummary` is intentionally narrow:
+
+- It returns `null` for every output except `email_campaign`.
+- It reads `generated` only when it is a number.
+- It reads `saved_ids` only when it is an array of strings.
+- It returns `null` when neither field is present.
+
+This keeps malformed or future payload shapes from producing
+misleading UI while preserving the raw payload for inspection.
+
+## Intentional
+
+- No new domain result types yet. This is one small view adapter for
+  one stable result shape.
+- No changes to API adapters, execution behavior, backend routes, or
+  fixtures.
+- No attempt to summarize `report`, `landing_page`, `sales_brief`, or
+  `signal_extraction` in this slice.
+- Raw JSON remains the universal fallback.
+
+## Deferred
+
+- Per-output result adapters for reports, landing pages, sales briefs,
+  and signal extraction.
+- Dedicated component tests for `ContentOpsNewRun`; the repo does not
+  currently have a component-test harness for this page.
+- A richer saved-draft link/display model once the execution payload
+  carries stable URLs or user-facing draft metadata.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci`
+- `cd atlas-intel-ui && npm run build`
+- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx src/api/contentOps.ts src/domain/contentOps/types.ts src/domain/contentOps/fromWire.ts src/api/contentOps.contract.ts src/domain/contentOps/contract.ts`
+- `git diff --check`
+- no non-ASCII added lines
+
+## Diff Size
+
+Expected production delta is small:
+
+- `ContentOpsNewRun.tsx`: about 35 lines.
+- Docs/coordination: about 5 lines plus this plan.
+
+The slice stays under the soft 400-line PR budget.


### PR DESCRIPTION
## Summary
- add a small execute-step summary for email_campaign results
- show generated draft count and saved ids before the raw result JSON
- keep raw JSON rendering for every output and document the email_campaign summary rule

## Verification
- `cd atlas-intel-ui && npm ci`
- `cd atlas-intel-ui && npm run build`
- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx src/api/contentOps.ts src/domain/contentOps/types.ts src/domain/contentOps/fromWire.ts src/api/contentOps.contract.ts src/domain/contentOps/contract.ts`
- `git diff --check`
- no non-ASCII added lines