### PR TITLE
Add Content Ops signal extraction result summary

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -899,6 +899,9 @@ function ExecutionStepSummary({
   output: string
   result: Record<string, unknown>
 }) {
+  if (output === 'signal_extraction') {
+    return <SignalExtractionSummary result={result} />
+  }
   if (output !== 'email_campaign') return null
 
   const generated = typeof result.generated === 'number' ? result.generated : null
@@ -926,6 +929,89 @@ function ExecutionStepSummary({
       </div>
     </div>
   )
+}
+
+function SignalExtractionSummary({ result }: { result: Record<string, unknown> }) {
+  const generated = typeof result.generated === 'number' ? result.generated : null
+  const targetMode =
+    typeof result.target_mode === 'string' ? result.target_mode : null
+  const warningCount = Array.isArray(result.warnings)
+    ? result.warnings.length
+    : null
+  const opportunities = Array.isArray(result.opportunities)
+    ? result.opportunities.filter(isRecord).slice(0, 3)
+    : []
+
+  if (
+    generated === null &&
+    targetMode === null &&
+    warningCount === null &&
+    opportunities.length === 0
+  ) {
+    return null
+  }
+
+  return (
+    <div className="mb-3 space-y-2 rounded-md border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-slate-300">
+      <div className="flex flex-wrap items-center gap-3">
+        {generated !== null && (
+          <span>
+            Opportunities:{' '}
+            <span className="font-medium text-slate-100">{generated}</span>
+          </span>
+        )}
+        {targetMode && (
+          <span>
+            Target mode:{' '}
+            <span className="font-mono text-slate-100">{targetMode}</span>
+          </span>
+        )}
+        {warningCount !== null && (
+          <span>
+            Warnings:{' '}
+            <span className="font-medium text-slate-100">{warningCount}</span>
+          </span>
+        )}
+      </div>
+      {opportunities.length > 0 && (
+        <ul className="space-y-1 text-slate-400">
+          {opportunities.map((opportunity, index) => (
+            <li key={opportunityKey(opportunity, index)}>
+              {opportunityLabel(opportunity)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function opportunityKey(
+  opportunity: Record<string, unknown>,
+  index: number,
+): string {
+  const key = opportunity.target_id ?? opportunity.source_id ?? opportunity.contact_email
+  return typeof key === 'string' && key ? key : String(index)
+}
+
+function opportunityLabel(opportunity: Record<string, unknown>): string {
+  const company = stringField(opportunity, 'company_name') ?? stringField(opportunity, 'company')
+  const vendor = stringField(opportunity, 'vendor')
+  const email = stringField(opportunity, 'contact_email')
+  const id = stringField(opportunity, 'target_id') ?? stringField(opportunity, 'source_id')
+  return [company, vendor, email, id].filter(Boolean).join(' | ') || 'Opportunity'
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | null {
+  const field = value[key]
+  return typeof field === 'string' && field ? field : null
 }
 
 function executionDetailMessage(detail: unknown): string {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -908,11 +908,12 @@ function ExecutionStepSummary({
   const savedIds = Array.isArray(result.saved_ids)
     ? result.saved_ids.filter((id): id is string => typeof id === 'string')
     : []
+  const errorCount = Array.isArray(result.errors) ? result.errors.length : null
 
-  if (generated === null && savedIds.length === 0) return null
+  if (generated === null && savedIds.length === 0 && errorCount === null) return null
 
   return (
-    <div className="mb-3 rounded-md border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-slate-300">
+    <div className="mb-3 space-y-2 rounded-md border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-slate-300">
       <div className="flex flex-wrap items-center gap-3">
         {generated !== null && (
           <span>
@@ -920,13 +921,26 @@ function ExecutionStepSummary({
             <span className="font-medium text-slate-100">{generated}</span>
           </span>
         )}
-        {savedIds.length > 0 && (
+        {errorCount !== null && (
           <span>
-            Saved:{' '}
-            <span className="font-mono text-slate-100">{savedIds.join(', ')}</span>
+            Errors:{' '}
+            <span className="font-medium text-slate-100">{errorCount}</span>
           </span>
         )}
       </div>
+      {savedIds.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span>Saved:</span>
+          {savedIds.map((id) => (
+            <span
+              key={id}
+              className="max-w-full break-all rounded bg-slate-950/60 px-1.5 py-0.5 font-mono text-slate-100"
+            >
+              {id}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1000,7 +1000,7 @@ function opportunityKey(
 
 function opportunityLabel(opportunity: Record<string, unknown>): string {
   const company = stringField(opportunity, 'company_name') ?? stringField(opportunity, 'company')
-  const vendor = stringField(opportunity, 'vendor')
+  const vendor = stringField(opportunity, 'vendor_name') ?? stringField(opportunity, 'vendor')
   const email = stringField(opportunity, 'contact_email')
   const id = stringField(opportunity, 'target_id') ?? stringField(opportunity, 'source_id')
   return [company, vendor, email, id].filter(Boolean).join(' | ') || 'Opportunity'

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-signal-summary
+Last updated: 2026-05-09T00:00Z by codex-content-ops-signal-summary-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops signal extraction result summary | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Signal-Extraction-Result-Summary.md` | codex-content-ops-signal-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-result-summary-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-signal-summary
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add Content Ops signal extraction result summary | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Signal-Extraction-Result-Summary.md` | codex-content-ops-signal-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -353,6 +353,9 @@ UI rules:
 - `email_campaign` should summarize `generated` and `saved_ids`
   before the raw JSON block so users do not need to inspect the
   result payload for the common draft-generation case.
+- `signal_extraction` should summarize `generated`, `target_mode`,
+  `warnings.length`, and a short list of extracted opportunities
+  before the raw JSON block.
 
 ### Signal extraction (special case)
 

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -350,9 +350,9 @@ UI rules:
 - The MVP execute view may render `result` as read-only JSON while
   per-output adapters are still landing. It must still surface
   step-level status, runner, and `error` inline.
-- `email_campaign` should summarize `generated` and `saved_ids`
-  before the raw JSON block so users do not need to inspect the
-  result payload for the common draft-generation case.
+- `email_campaign` should summarize `generated`, `saved_ids`, and
+  `errors.length` before the raw JSON block so users do not need to
+  inspect the result payload for the common draft-generation case.
 - `signal_extraction` should summarize `generated`, `target_mode`,
   `warnings.length`, and a short list of extracted opportunities
   before the raw JSON block.

--- a/plans/PR-Content-Ops-Signal-Extraction-Result-Summary.md
+++ b/plans/PR-Content-Ops-Signal-Extraction-Result-Summary.md
@@ -1,0 +1,70 @@
+# PR: Content Ops signal extraction result summary
+
+## Why This Slice Exists
+
+The execute panel now summarizes `email_campaign`, but
+`signal_extraction` is the other result shape explicitly called out
+in the frontend contract. Its payload is a pipeline artifact rather
+than generated content, so users need the count, target mode, warning
+count, and opportunity identity fields before the raw JSON block.
+
+## Scope
+
+Files touched:
+
+1. `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+   - Extend `ExecutionStepSummary` with a `signal_extraction` branch.
+   - Summarize `generated`, `target_mode`, `warnings.length`, and a
+     short list of extracted opportunities.
+   - Keep raw result JSON rendering for every output.
+
+2. `docs/frontend/content_ops_frontend_contract.md`
+   - Document the `signal_extraction` summary rule.
+
+3. `docs/extraction/coordination/inflight.md`
+   - Claim the slice while the PR is open.
+
+## Mechanism
+
+The summary remains display-only and defensive:
+
+- `generated` renders only when it is a number.
+- `target_mode` renders only when it is a string.
+- `warnings` renders as a count only when it is an array.
+- `opportunities` renders a short list only when it is an array of
+  objects, using best-effort identity fields already documented in the
+  contract.
+
+Unknown payload fields still render under the raw JSON block.
+
+## Intentional
+
+- No new API or domain result types.
+- No backend changes.
+- No attempt to render full opportunity details; this slice only
+  makes the execution result scannable.
+- No changes to `email_campaign` summary behavior.
+
+## Deferred
+
+- Rich opportunity cards with evidence and raw metadata sections.
+- Dedicated component tests for `ContentOpsNewRun`; the repo does not
+  currently have a component-test harness for this page.
+- Result adapters for reports, landing pages, and sales briefs.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci`
+- `cd atlas-intel-ui && npm run build`
+- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx src/api/contentOps.ts src/domain/contentOps/types.ts src/domain/contentOps/fromWire.ts src/api/contentOps.contract.ts src/domain/contentOps/contract.ts`
+- `git diff --check`
+- no non-ASCII added lines
+
+## Diff Size
+
+Expected production delta:
+
+- `ContentOpsNewRun.tsx`: about 70 lines.
+- Docs/coordination: about 5 lines plus this plan.
+
+The slice stays under the soft 400-line PR budget.

--- a/plans/PR-Content-Ops-Signal-Extraction-Result-Summary.md
+++ b/plans/PR-Content-Ops-Signal-Extraction-Result-Summary.md
@@ -16,6 +16,9 @@ Files touched:
    - Extend `ExecutionStepSummary` with a `signal_extraction` branch.
    - Summarize `generated`, `target_mode`, `warnings.length`, and a
      short list of extracted opportunities.
+   - Review follow-up: include `vendor_name` in the opportunity label
+     fallback, surface `email_campaign` `errors.length`, and render
+     saved IDs as wrapping chips instead of one long string.
    - Keep raw result JSON rendering for every output.
 
 2. `docs/frontend/content_ops_frontend_contract.md`
@@ -43,7 +46,9 @@ Unknown payload fields still render under the raw JSON block.
 - No backend changes.
 - No attempt to render full opportunity details; this slice only
   makes the execution result scannable.
-- No changes to `email_campaign` summary behavior.
+- No backend or API changes to `email_campaign` behavior. The UI
+  summary may still surface existing `errors` and wrap existing
+  `saved_ids` more readably.
 
 ## Deferred
 


### PR DESCRIPTION
## Summary
- add a signal_extraction execution summary before raw result JSON
- show generated opportunity count, target mode, warning count, and a short opportunity list
- keep raw JSON fallback intact and add the required plan/contract docs

## Verification
- `cd atlas-intel-ui && npm ci`
- `cd atlas-intel-ui && npm run build`
- `cd atlas-intel-ui && npx eslint src/pages/ContentOpsNewRun.tsx src/api/contentOps.ts src/domain/contentOps/types.ts src/domain/contentOps/fromWire.ts src/api/contentOps.contract.ts src/domain/contentOps/contract.ts`
- `git diff --check`
- no non-ASCII added lines