### PR TITLE
Add Content Ops generated asset result summaries

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -902,23 +902,59 @@ function ExecutionStepSummary({
   if (output === 'signal_extraction') {
     return <SignalExtractionSummary result={result} />
   }
-  if (output !== 'email_campaign') return null
+  if (output === 'email_campaign') {
+    return <GeneratedAssetSummary result={result} generatedLabel="Drafts generated" />
+  }
+  if (['report', 'landing_page', 'sales_brief'].includes(output)) {
+    return <GeneratedAssetSummary result={result} generatedLabel="Assets generated" />
+  }
+  return null
+}
 
+function GeneratedAssetSummary({
+  result,
+  generatedLabel,
+}: {
+  result: Record<string, unknown>
+  generatedLabel: string
+}) {
+  const requested = typeof result.requested === 'number' ? result.requested : null
   const generated = typeof result.generated === 'number' ? result.generated : null
+  const skipped = typeof result.skipped === 'number' ? result.skipped : null
   const savedIds = Array.isArray(result.saved_ids)
     ? result.saved_ids.filter((id): id is string => typeof id === 'string')
     : []
   const errorCount = Array.isArray(result.errors) ? result.errors.length : null
 
-  if (generated === null && savedIds.length === 0 && errorCount === null) return null
+  if (
+    requested === null &&
+    generated === null &&
+    skipped === null &&
+    savedIds.length === 0 &&
+    errorCount === null
+  ) {
+    return null
+  }
 
   return (
     <div className="mb-3 space-y-2 rounded-md border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-slate-300">
       <div className="flex flex-wrap items-center gap-3">
+        {requested !== null && (
+          <span>
+            Requested:{' '}
+            <span className="font-medium text-slate-100">{requested}</span>
+          </span>
+        )}
         {generated !== null && (
           <span>
-            Drafts generated:{' '}
+            {generatedLabel}:{' '}
             <span className="font-medium text-slate-100">{generated}</span>
+          </span>
+        )}
+        {skipped !== null && (
+          <span>
+            Skipped:{' '}
+            <span className="font-medium text-slate-100">{skipped}</span>
           </span>
         )}
         {errorCount !== null && (

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-asset-summaries
+Last updated: 2026-05-09T00:00Z by codex-content-ops-asset-summaries-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops generated asset result summaries | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md` | codex-content-ops-asset-summaries | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-signal-summary-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-asset-summaries
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add Content Ops generated asset result summaries | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md` | codex-content-ops-asset-summaries | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -353,6 +353,9 @@ UI rules:
 - `email_campaign` should summarize `generated`, `saved_ids`, and
   `errors.length` before the raw JSON block so users do not need to
   inspect the result payload for the common draft-generation case.
+- `report`, `landing_page`, and `sales_brief` should summarize their
+  shared generated-asset result shape: `requested`, `generated`,
+  `skipped`, `saved_ids`, and `errors.length`.
 - `signal_extraction` should summarize `generated`, `target_mode`,
   `warnings.length`, and a short list of extracted opportunities
   before the raw JSON block.
@@ -480,6 +483,9 @@ src/domain/
   (`email_campaign | blog_post | report | landing_page | sales_brief
   | signal_extraction`) — each translates `step.result` into a
   presentation
+- Generated-asset result summary for `report`, `landing_page`, and
+  `sales_brief`, all of which currently expose `requested`,
+  `generated`, `skipped`, `saved_ids`, and `errors`
 - Signal extraction table (driven by `SignalExtractionResultView`)
 - Reasoning context drawer (driven by `CampaignReasoningContextView`)
 

--- a/plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md
+++ b/plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md
@@ -1,41 +1,79 @@
-# PR: Content Ops Generated Asset Result Summaries
+# PR: Content Ops generated asset result summaries
 
-Date: 2026-05-09
-Owner: codex-content-ops-asset-summaries
+## Why this slice exists
 
-## Goal
+The execute panel already summarizes `email_campaign` and
+`signal_extraction`, but the implemented generated-asset outputs still
+fall through to raw JSON. That makes successful report, landing-page,
+and sales-brief runs harder to scan even though their backend result
+contracts already share the same small status shape.
 
-Extend the Content Ops execution panel beyond `email_campaign` and
-`signal_extraction` so implemented generated-asset outputs also show a
-useful summary before the raw JSON payload.
+This closes the next frontend-contract gap for Content Ops execution
+results without changing backend behavior.
 
-## Scope
+## Scope (this PR)
 
-- Add a shared result summary for `report`, `landing_page`, and
-  `sales_brief`.
-- Preserve the existing `email_campaign` summary behavior.
-- Keep raw JSON details available for every step.
-- Update the frontend contract doc to name the shared result shape.
+1. Add a shared generated-asset result summary for `report`,
+   `landing_page`, and `sales_brief`.
+2. Preserve the existing `email_campaign` summary behavior while
+   routing it through the same display component.
+3. Keep raw JSON details available for every execution step.
+4. Update the frontend contract doc with the shared result shape.
+5. Claim this slice in the extraction coordination table while the PR
+   is open.
 
-## Verified Contracts
+### Files touched
 
-`ReportGenerationResult`, `LandingPageGenerationResult`, and
-`SalesBriefGenerationResult` all expose:
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md`
 
-- `requested`
-- `generated`
-- `skipped`
-- `saved_ids`
-- `errors`
+## Mechanism
 
-The UI can summarize these fields without changing backend contracts.
+`ExecutionStepSummary` now routes:
 
-## Out Of Scope
+- `signal_extraction` to the existing signal summary.
+- `email_campaign` to `GeneratedAssetSummary` with the label
+  `Drafts generated`.
+- `report`, `landing_page`, and `sales_brief` to
+  `GeneratedAssetSummary` with the label `Assets generated`.
 
-- Blog post summary adapter. Its result contract needs a separate read.
-- Backend result-shape changes.
-- Competitive-intelligence files currently claimed by another session.
+`GeneratedAssetSummary` defensively reads only stable primitive fields:
+`requested`, `generated`, `skipped`, `saved_ids`, and `errors`. Missing
+or malformed fields are ignored, and the raw JSON details remain below
+the summary.
 
-## Validation
+## Intentional
 
-- `npm run build` in `atlas-intel-ui`.
+- No backend changes. The UI consumes the existing `as_dict()` result
+  contracts.
+- No new per-output custom cards for `report`, `landing_page`, or
+  `sales_brief`; their result contracts are identical enough for one
+  shared summary.
+- No blog-post adapter in this slice. Its result shape needs a separate
+  read before adding a summary.
+- No component-test harness added; this page currently validates through
+  the frontend build path.
+
+## Deferred
+
+- Blog-post execution result summary after its backend result contract
+  is read and mapped.
+- Rich generated-asset details, such as titles or preview snippets,
+  once those fields are stable across all asset services.
+- Component-level tests for `ContentOpsNewRun` if the frontend test
+  harness is introduced.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci`
+- `cd atlas-intel-ui && npm run build`
+- `git diff --check`
+- Confirmed no non-ASCII added lines in the TypeScript diff.
+
+## Estimated diff size
+
+- 4 files.
+- About 90 inserted lines and 4 deleted lines.
+- Well below the 400-line soft PR budget.

--- a/plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md
+++ b/plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md
@@ -1,0 +1,41 @@
+# PR: Content Ops Generated Asset Result Summaries
+
+Date: 2026-05-09
+Owner: codex-content-ops-asset-summaries
+
+## Goal
+
+Extend the Content Ops execution panel beyond `email_campaign` and
+`signal_extraction` so implemented generated-asset outputs also show a
+useful summary before the raw JSON payload.
+
+## Scope
+
+- Add a shared result summary for `report`, `landing_page`, and
+  `sales_brief`.
+- Preserve the existing `email_campaign` summary behavior.
+- Keep raw JSON details available for every step.
+- Update the frontend contract doc to name the shared result shape.
+
+## Verified Contracts
+
+`ReportGenerationResult`, `LandingPageGenerationResult`, and
+`SalesBriefGenerationResult` all expose:
+
+- `requested`
+- `generated`
+- `skipped`
+- `saved_ids`
+- `errors`
+
+The UI can summarize these fields without changing backend contracts.
+
+## Out Of Scope
+
+- Blog post summary adapter. Its result contract needs a separate read.
+- Backend result-shape changes.
+- Competitive-intelligence files currently claimed by another session.
+
+## Validation
+
+- `npm run build` in `atlas-intel-ui`.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Generated-Asset-Result-Summaries.md

The execute panel already summarizes `email_campaign` and `signal_extraction`, but implemented generated-asset outputs still fall through to raw JSON. This PR adds a shared summary for `report`, `landing_page`, and `sales_brief` using their existing `requested`, `generated`, `skipped`, `saved_ids`, and `errors` result shape.

## Intentional
- No backend changes. The UI consumes existing `as_dict()` result contracts.
- No separate custom cards for report, landing page, and sales brief because their result contracts are identical enough for one shared display component.
- No blog-post adapter in this slice; its result shape needs a separate read before adding a summary.

## Deferred
- Blog-post execution result summary after its backend result contract is read and mapped.
- Rich generated-asset details, such as titles or preview snippets, once those fields are stable across all asset services.
- Component-level tests for `ContentOpsNewRun` if the frontend test harness is introduced.

## Verification
- `cd atlas-intel-ui && npm ci`
- `cd atlas-intel-ui && npm run build`
- `git diff --check`
- Confirmed no non-ASCII added lines in the TypeScript diff.

## Diff size
4 files, +88 / -4 in the first commit; documentation-only follow-up updates the plan structure and PR body per review.
