### PR TITLE
Add Content Ops blog-post result summary

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -905,7 +905,7 @@ function ExecutionStepSummary({
   if (output === 'email_campaign') {
     return <GeneratedAssetSummary result={result} generatedLabel="Drafts generated" />
   }
-  if (['report', 'landing_page', 'sales_brief'].includes(output)) {
+  if (['blog_post', 'report', 'landing_page', 'sales_brief'].includes(output)) {
     return <GeneratedAssetSummary result={result} generatedLabel="Assets generated" />
   }
   return null

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-summary
+Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-summary-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops blog-post result summary | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Blog-Post-Result-Summary.md` | codex-content-ops-blog-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-asset-summaries-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-summary
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add Content Ops blog-post result summary | EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Blog-Post-Result-Summary.md` | codex-content-ops-blog-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -353,9 +353,9 @@ UI rules:
 - `email_campaign` should summarize `generated`, `saved_ids`, and
   `errors.length` before the raw JSON block so users do not need to
   inspect the result payload for the common draft-generation case.
-- `report`, `landing_page`, and `sales_brief` should summarize their
-  shared generated-asset result shape: `requested`, `generated`,
-  `skipped`, `saved_ids`, and `errors.length`.
+- `blog_post`, `report`, `landing_page`, and `sales_brief` should
+  summarize their shared generated-asset result shape: `requested`,
+  `generated`, `skipped`, `saved_ids`, and `errors.length`.
 - `signal_extraction` should summarize `generated`, `target_mode`,
   `warnings.length`, and a short list of extracted opportunities
   before the raw JSON block.
@@ -483,9 +483,9 @@ src/domain/
   (`email_campaign | blog_post | report | landing_page | sales_brief
   | signal_extraction`) — each translates `step.result` into a
   presentation
-- Generated-asset result summary for `report`, `landing_page`, and
-  `sales_brief`, all of which currently expose `requested`,
-  `generated`, `skipped`, `saved_ids`, and `errors`
+- Generated-asset result summary for `blog_post`, `report`,
+  `landing_page`, and `sales_brief`, all of which currently expose
+  `requested`, `generated`, `skipped`, `saved_ids`, and `errors`
 - Signal extraction table (driven by `SignalExtractionResultView`)
 - Reasoning context drawer (driven by `CampaignReasoningContextView`)
 

--- a/plans/PR-Content-Ops-Blog-Post-Result-Summary.md
+++ b/plans/PR-Content-Ops-Blog-Post-Result-Summary.md
@@ -1,0 +1,63 @@
+# PR: Content Ops blog-post result summary
+
+## Why this slice exists
+
+`blog_post` is the remaining implemented Content Ops output without a
+frontend execution-result summary. A code read confirmed
+`BlogPostGenerationResult.as_dict()` uses the same generated-asset
+shape as reports, landing pages, and sales briefs, so the UI can reuse
+the shared summary added in the prior slice.
+
+## Scope (this PR)
+
+1. Route `blog_post` execution results through the shared generated
+   asset summary.
+2. Update the frontend contract so all generated-asset outputs are
+   listed together.
+3. Claim the slice in the extraction coordination table while the PR
+   is open.
+
+### Files touched
+
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Blog-Post-Result-Summary.md`
+
+## Mechanism
+
+`ExecutionStepSummary` already routes generated-asset outputs to
+`GeneratedAssetSummary`. This PR adds `blog_post` to that output list.
+
+The component defensively reads only `requested`, `generated`,
+`skipped`, `saved_ids`, and `errors`; unknown fields stay available in
+the raw JSON details block.
+
+## Intentional
+
+- No new blog-specific UI component. The backend result contract is the
+  same as the other generated assets.
+- No backend changes.
+- No changes to `blog_generation.py`; it was read only to verify the
+  result contract.
+- No competitive-intelligence files touched.
+
+## Deferred
+
+- Rich blog-post preview details, such as title or excerpt, if the
+  backend later exposes stable preview fields in the execution result.
+- Component-level tests for `ContentOpsNewRun` if the frontend test
+  harness is introduced.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci`
+- `cd atlas-intel-ui && npm run build`
+- `git diff --check`
+- Confirm no non-ASCII added lines in the TypeScript diff.
+
+## Estimated diff size
+
+- 4 files.
+- About 40 inserted lines and 2 deleted lines.
+- Well below the 400-line soft PR budget.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Post-Result-Summary.md

`blog_post` is the remaining implemented Content Ops output without a frontend execution-result summary. A code read confirmed `BlogPostGenerationResult.as_dict()` uses the same generated-asset shape as reports, landing pages, and sales briefs, so this PR routes it through the existing shared summary.

## Intentional
- No new blog-specific UI component. The backend result contract is the same as the other generated assets.
- No backend changes.
- No competitive-intelligence files touched.

## Deferred
- Rich blog-post preview details, such as title or excerpt, if the backend later exposes stable preview fields in the execution result.
- Component-level tests for `ContentOpsNewRun` if the frontend test harness is introduced.

## Verification
- `cd atlas-intel-ui && npm ci`
- `cd atlas-intel-ui && npm run build`
- `git diff --check`
- Confirmed no non-ASCII added lines in the TypeScript diff.

## Diff size
4 files, +72 / -8.
