### PR TITLE
Correct Content Ops reasoning-context frontend contract

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-summary-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-contract
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Correct Content Ops reasoning-context frontend contract | EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `extracted_content_pipeline/STATUS.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Reasoning-Context-Contract-Correction.md` | codex-content-ops-reasoning-contract | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-contract
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-contract-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Correct Content Ops reasoning-context frontend contract | EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `extracted_content_pipeline/STATUS.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Reasoning-Context-Contract-Correction.md` | codex-content-ops-reasoning-contract | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -409,13 +409,19 @@ When an output has `reasoning_requirement="optional_host_context"`
 AND the host has wired `CampaignReasoningContextProvider`
 (`extracted_content_pipeline/campaign_ports.py:171`), the runner
 threads the resulting `CampaignReasoningContext`
-(`campaign_ports.py:53-99`) into the prompt. The execution result
-typically surfaces this context in `step.result` for review.
+(`campaign_ports.py:53-99`) into the prompt.
 
 The catalog-level `reasoning.configured` flag tells the UI whether
 the host mounted a route-level reasoning provider. It is separate
 from each output's `reasoning_requirement`: an output can support
 reasoning even when the current host has not wired a provider.
+
+Important runtime boundary: `ContentOpsStepExecution.result` currently
+contains the per-service summary returned by `as_dict()` (counts,
+saved IDs, warnings, and errors). It does **not** reliably expose the
+consumed reasoning payload. A Reasoning Context Drawer should wait for
+a backend execution-result field that explicitly carries consumed
+reasoning context or a compact reasoning audit summary.
 
 ```ts
 interface CampaignReasoningContextView {
@@ -436,9 +442,9 @@ interface CampaignReasoningContextView {
 UI rules:
 - Show a "Reasoning context" badge next to each output card when
   `reasoningRequirement="optional_host_context"`.
-- Drawer state: `not_applicable` / `not_provided` / `available` /
-  `used`. "Used" appears once an execution completes and the step
-  result contains reasoning context.
+- Treat the badge as configuration readiness only. Do not infer that a
+  specific execution step used reasoning unless the backend returns an
+  explicit per-step reasoning audit field.
 
 ---
 
@@ -487,7 +493,6 @@ src/domain/
   `landing_page`, and `sales_brief`, all of which currently expose
   `requested`, `generated`, `skipped`, `saved_ids`, and `errors`
 - Signal extraction table (driven by `SignalExtractionResultView`)
-- Reasoning context drawer (driven by `CampaignReasoningContextView`)
 
 ### UI layer
 
@@ -521,10 +526,6 @@ Dumb components only. No fetch, no business rules.
    - When `signal_extraction` was in the run, render its result via
      the special-case view.
 
-5. **Reasoning Context Drawer**
-   - Per-step, side panel showing the reasoning context the runner
-     consumed (when surfaced in `step.result`).
-
 ---
 
 ## Out of scope for this contract
@@ -533,6 +534,8 @@ Dumb components only. No fetch, no business rules.
 - Full asset editor UX
 - Visual workflow builder
 - Model-selection UX
+- Reasoning Context Drawer until `/content-ops/execute` exposes an
+  explicit consumed-reasoning context or reasoning-audit result field.
 - Collaboration / role-permission flows
 - CMS export
 - Approval workflow (no backend approval state on the control-surface

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -124,6 +124,9 @@
   UIs do not confuse package implementation status with runtime readiness. The
   output catalog also reports whether each output can consume host-provided
   reasoning context or does not use the reasoning-provider path.
+- Execution result summaries do not currently expose consumed reasoning
+  payloads. Hosts can see whether reasoning is configured in the catalog, but a
+  per-step reasoning drawer needs a future explicit execution-result field.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/plans/PR-Content-Ops-Reasoning-Context-Contract-Correction.md
+++ b/plans/PR-Content-Ops-Reasoning-Context-Contract-Correction.md
@@ -1,0 +1,66 @@
+# PR: Content Ops reasoning-context contract correction
+
+## Why this slice exists
+
+The frontend contract currently says execution results typically expose
+consumed reasoning context in `step.result` and lists a Reasoning
+Context Drawer as an MVP screen. A code read shows that is ahead of the
+backend contract: `ContentOpsStepExecution.result` receives each
+service's summary `as_dict()`, and the generated-asset result summaries
+currently expose counts, saved IDs, and errors, not consumed reasoning
+payloads.
+
+Leaving the contract as-is would push the UI toward a drawer that has
+no reliable runtime data source.
+
+## Scope (this PR)
+
+1. Correct the frontend contract language for host-injected reasoning.
+2. Move the Reasoning Context Drawer from MVP screen to deferred work.
+3. Record the same caveat in `extracted_content_pipeline/STATUS.md`.
+4. Claim this slice in the extraction coordination table while the PR
+   is open.
+
+### Files touched
+
+- `docs/frontend/content_ops_frontend_contract.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Reasoning-Context-Contract-Correction.md`
+
+## Mechanism
+
+The docs now separate three facts:
+
+- The catalog can say whether host reasoning is configured.
+- Output definitions can say whether an output can consume optional
+  host context.
+- Execution summaries do not currently expose consumed reasoning
+  context; a future backend result field is required before a drawer is
+  actionable.
+
+## Intentional
+
+- No UI changes. The output-card reasoning badge already exists and is
+  backed by current catalog data.
+- No backend changes. This slice corrects the contract before adding a
+  new result field.
+- No competitive-intelligence files touched.
+
+## Deferred
+
+- Backend execution-result field for consumed reasoning context or a
+  compact reasoning audit summary.
+- Reasoning Context Drawer UI after that field exists.
+- Component tests for the drawer when it becomes implementable.
+
+## Verification
+
+- `git diff --check`
+- Documentation-only change; no runtime tests required.
+
+## Estimated diff size
+
+- 4 files.
+- About 75 inserted lines and 10 deleted lines.
+- Well below the 400-line soft PR budget.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Context-Contract-Correction.md

The frontend contract said execution results typically expose consumed reasoning context in `step.result`, but the current backend returns per-service summary objects. This PR corrects the contract so future UI work waits for an explicit consumed-reasoning or reasoning-audit field before building a drawer.

## Intentional
- No UI changes. The output-card reasoning badge already exists and is backed by current catalog data.
- No backend changes. This corrects the contract before adding a new result field.
- No competitive-intelligence files touched.

## Deferred
- Backend execution-result field for consumed reasoning context or compact reasoning audit summary.
- Reasoning Context Drawer UI after that field exists.
- Component tests for the drawer when it becomes implementable.

## Verification
- `git diff --check`
- Documentation-only change; no runtime tests required.

## Diff size
4 files, +84 / -11.
