### PR TITLE
Mark blog_post as optional reasoning consumer

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-catalog
+Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-catalog-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Mark blog_post as optional reasoning consumer | EDIT: `extracted_content_pipeline/control_surfaces.py`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `tests/test_extracted_content_control_surface_api.py`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Blog-Reasoning-Catalog.md` | codex-content-ops-blog-reasoning-catalog | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-contract-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-catalog
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Mark blog_post as optional reasoning consumer | EDIT: `extracted_content_pipeline/control_surfaces.py`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `tests/test_extracted_content_control_surface_api.py`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Blog-Reasoning-Catalog.md` | codex-content-ops-blog-reasoning-catalog | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -127,8 +127,8 @@ but the values used in `OUTPUT_CATALOG` are:
   without it
 
 Outputs currently flagged `optional_host_context`: `email_campaign`,
-`report`, `landing_page`, `sales_brief`. Outputs flagged `absent`:
-`blog_post`, `signal_extraction`.
+`blog_post`, `report`, `landing_page`, `sales_brief`. Outputs flagged
+`absent`: `signal_extraction`.
 
 ### Execution status vocabulary
 

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -113,6 +113,7 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         implemented=True,
         estimated_unit_cost_usd=0.45,
         required_inputs=("topic",),
+        reasoning_requirement="optional_host_context",
     ),
     "report": OutputDefinition(
         id="report",

--- a/plans/PR-Content-Ops-Blog-Reasoning-Catalog.md
+++ b/plans/PR-Content-Ops-Blog-Reasoning-Catalog.md
@@ -1,0 +1,60 @@
+# PR: Content Ops blog reasoning catalog
+
+## Why this slice exists
+
+`BlogPostGenerationService` already exposes `with_reasoning_context`
+and threads a host `CampaignReasoningContextProvider` into its prompt
+payload. The control-surface catalog still marks `blog_post` as
+`reasoning_requirement="absent"`, so the frontend cannot show the
+reasoning-readiness badge for a real reasoning-aware output.
+
+## Scope (this PR)
+
+1. Mark `blog_post` as `optional_host_context` in the output catalog.
+2. Update the frontend contract's reasoning vocabulary.
+3. Update the catalog API test that locks output reasoning flags.
+4. Claim this slice in the extraction coordination table while the PR
+   is open.
+
+### Files touched
+
+- `extracted_content_pipeline/control_surfaces.py`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `tests/test_extracted_content_control_surface_api.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Blog-Reasoning-Catalog.md`
+
+## Mechanism
+
+The change is catalog-only. `blog_post` gets the same
+`reasoning_requirement="optional_host_context"` value as the other
+generated assets that can consume `CampaignReasoningContextProvider`.
+
+Execution behavior is already wired through
+`ContentOpsExecutionServices.with_reasoning_context`.
+
+## Intentional
+
+- No changes to `BlogPostGenerationService`; the service already
+  supports the provider.
+- No frontend code changes; the existing badge is catalog-driven.
+- No change to `signal_extraction`, which remains deterministic and
+  reasoning-absent.
+- No competitive-intelligence files touched.
+
+## Deferred
+
+- Explicit per-step consumed-reasoning audit field in execution
+  results.
+- Reasoning Context Drawer UI after that backend field exists.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_control_surface_api.py`
+- `git diff --check`
+
+## Estimated diff size
+
+- 5 files.
+- About 65 inserted lines and 4 deleted lines.
+- Well below the 400-line soft PR budget.

--- a/plans/PR-Content-Ops-Blog-Reasoning-Catalog.md
+++ b/plans/PR-Content-Ops-Blog-Reasoning-Catalog.md
@@ -47,10 +47,17 @@ Execution behavior is already wired through
 - Explicit per-step consumed-reasoning audit field in execution
   results.
 - Reasoning Context Drawer UI after that backend field exists.
+- Optional blog key-parity follow-up: `BlogPostGenerationService`
+  currently writes the normalized provider payload under
+  `reasoning_context`; landing pages also write
+  `campaign_reasoning_context`. Both reach the prompt today, but exact
+  key parity can be added if downstream tooling later inspects the
+  second key directly.
 
 ## Verification
 
 - `python -m pytest tests/test_extracted_content_control_surface_api.py`
+- `python -m pytest tests/test_extracted_content_control_surfaces.py`
 - `git diff --check`
 
 ## Estimated diff size

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -61,7 +61,7 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["email_campaign"]["default_parse_retry_attempts"] == 1
     assert outputs["email_campaign"]["estimated_retry_adjusted_unit_cost_usd"] == 0.36
     assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
-    assert outputs["blog_post"]["reasoning_requirement"] == "absent"
+    assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
     assert payload["execution"] == {"configured": False, "configured_outputs": []}
     assert payload["reasoning"] == {"configured": False}

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -164,7 +164,7 @@ def test_output_catalog_states_reasoning_requirement():
     assert OUTPUT_CATALOG["report"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["landing_page"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["sales_brief"].reasoning_requirement == "optional_host_context"
-    assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "absent"
+    assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["signal_extraction"].reasoning_requirement == "absent"
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Reasoning-Catalog.md

`BlogPostGenerationService` already supports `with_reasoning_context`, but the catalog still marked `blog_post` as reasoning-absent. This PR corrects the output catalog and frontend contract so the existing reasoning-ready badge reflects the real backend capability.

## Intentional
- No changes to `BlogPostGenerationService`; the service already supports the provider.
- No frontend code changes; the existing badge is catalog-driven.
- `signal_extraction` remains reasoning-absent.
- No competitive-intelligence files touched.

## Deferred
- Explicit per-step consumed-reasoning audit field in execution results.
- Reasoning Context Drawer UI after that backend field exists.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py` (23 passed)
- `git diff --check`

## Diff size
5 files, +66 / -4.
