### PR TITLE
Add blog reasoning context key parity

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-key-parity
+Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-key-parity-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add blog reasoning context key parity | EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `tests/test_extracted_blog_generation.py`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Blog-Reasoning-Key-Parity.md` | codex-content-ops-blog-reasoning-key-parity | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-catalog-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-key-parity
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add blog reasoning context key parity | EDIT: `extracted_content_pipeline/blog_generation.py`; EDIT: `tests/test_extracted_blog_generation.py`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Blog-Reasoning-Key-Parity.md` | codex-content-ops-blog-reasoning-key-parity | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -299,10 +299,10 @@ class BlogPostGenerationService:
         if not provided_context.has_content():
             return blueprint
         enriched = dict(blueprint)
-        enriched["reasoning_context"] = campaign_reasoning_context_payload(
-            provided_context
-        )
+        reasoning_payload = campaign_reasoning_context_payload(provided_context)
         enriched.update(campaign_reasoning_context_metadata(provided_context))
+        enriched["reasoning_context"] = reasoning_payload
+        enriched["campaign_reasoning_context"] = reasoning_payload
         return enriched
 
     async def _generate_one(

--- a/plans/PR-Content-Ops-Blog-Reasoning-Key-Parity.md
+++ b/plans/PR-Content-Ops-Blog-Reasoning-Key-Parity.md
@@ -1,0 +1,58 @@
+# PR: Content Ops blog reasoning key parity
+
+## Why this slice exists
+
+PR #416 marked `blog_post` as a reasoning-aware output. Review noted a
+small parity gap: landing pages write both `reasoning_context` and
+`campaign_reasoning_context` into the prompt-visible payload, while
+blog generation only writes `reasoning_context`.
+
+The reasoning payload reaches the prompt today under `reasoning_context`;
+adding the sibling key keeps reasoning-aware generated assets consistent
+for downstream tooling that may inspect `campaign_reasoning_context`
+directly.
+
+## Scope (this PR)
+
+1. Add `campaign_reasoning_context` beside `reasoning_context` in the
+   enriched blog blueprint payload.
+2. Update the existing blog reasoning-provider test to assert both keys
+   reach the prompt JSON.
+3. Claim this slice in the extraction coordination table while the PR
+   is open.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_generation.py`
+- `tests/test_extracted_blog_generation.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Blog-Reasoning-Key-Parity.md`
+
+## Mechanism
+
+`_blueprint_with_reasoning_context()` now computes the normalized
+reasoning payload once, applies existing metadata fields, then writes it
+to both `reasoning_context` and `campaign_reasoning_context`.
+
+## Intentional
+
+- No changes to provider resolution, catalog metadata, or frontend UI.
+- No changes when the provider is absent or returns empty context.
+- No competitive-intelligence files touched.
+
+## Deferred
+
+- Explicit consumed-reasoning audit field in Content Ops execution
+  results.
+- Reasoning Context Drawer UI after that backend field exists.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_blog_generation.py`
+- `git diff --check`
+
+## Estimated diff size
+
+- 4 files.
+- About 60 inserted lines and 2 deleted lines.
+- Well below the 400-line soft PR budget.

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -595,6 +595,7 @@ async def test_generate_no_reasoning_provider_passes_blueprint_unchanged() -> No
 
     system_prompt = llm.calls[0]["messages"][0].content
     assert "reasoning_context" not in system_prompt
+    assert "campaign_reasoning_context" not in system_prompt
 
 
 @pytest.mark.asyncio
@@ -631,6 +632,7 @@ async def test_generate_with_reasoning_provider_merges_context_into_blueprint() 
     # LLM saw the merged blueprint JSON.
     system_prompt = llm.calls[0]["messages"][0].content
     assert "reasoning_context" in system_prompt
+    assert "campaign_reasoning_context" in system_prompt
     assert "Renewal pricing rose 22 percent" in system_prompt
 
     # Draft metadata captured reasoning signal.
@@ -656,6 +658,7 @@ async def test_generate_with_reasoning_provider_returning_empty_is_noop() -> Non
     assert reasoning.calls  # the provider was consulted
     system_prompt = llm.calls[0]["messages"][0].content
     assert "reasoning_context" not in system_prompt
+    assert "campaign_reasoning_context" not in system_prompt
 
     drafts = blog_posts.saved[0]["drafts"]
     assert drafts


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Blog-Reasoning-Key-Parity.md`

After `blog_post` was cataloged as reasoning-aware, this aligns its prompt payload shape with the other generated asset services by writing both `reasoning_context` and `campaign_reasoning_context` when provider context exists.

## Intentional
- Adds the sibling `campaign_reasoning_context` key to the enriched blog blueprint payload.
- Keeps absent-provider and empty-provider behavior unchanged.
- Leaves catalog metadata, frontend UI, provider resolution, and competitive-intelligence files untouched.

## Deferred
- Explicit consumed-reasoning audit field in Content Ops execution results.
- Reasoning Context Drawer UI after that backend field exists.

## Verification
- `python -m py_compile extracted_content_pipeline/blog_generation.py`
- `python -m pytest tests/test_extracted_blog_generation.py`
- `git diff --check`
- ASCII check on touched files

## Diff size
- 4 files changed
- 66 insertions, 4 deletions