### PR TITLE
Add Content Ops reasoning consumption summary

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-consumption-summary
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-consumption-summary-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops reasoning consumption summary | EDIT: `extracted_content_pipeline/content_ops_execution.py`; EDIT: `tests/test_extracted_content_ops_execution.py`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Reasoning-Consumption-Summary.md` | codex-content-ops-reasoning-consumption-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-blog-reasoning-key-parity-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-consumption-summary
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add Content Ops reasoning consumption summary | EDIT: `extracted_content_pipeline/content_ops_execution.py`; EDIT: `tests/test_extracted_content_ops_execution.py`; EDIT: `docs/frontend/content_ops_frontend_contract.md`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Reasoning-Consumption-Summary.md` | codex-content-ops-reasoning-consumption-summary | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -338,6 +338,13 @@ interface ContentOpsStepExecution {
   status: "completed" | "failed" | "skipped";   // step-level
   result: Record<string, unknown>;              // runner-specific result blob
   error: string;                                // populated when status="failed"
+  reasoning?: ContentOpsStepReasoningAudit;     // compact readiness audit only
+}
+
+interface ContentOpsStepReasoningAudit {
+  requirement: "absent" | "optional_host_context" | string;
+  service_supports_reasoning: boolean;
+  provider_configured: boolean;
 }
 ```
 
@@ -416,12 +423,14 @@ the host mounted a route-level reasoning provider. It is separate
 from each output's `reasoning_requirement`: an output can support
 reasoning even when the current host has not wired a provider.
 
-Important runtime boundary: `ContentOpsStepExecution.result` currently
-contains the per-service summary returned by `as_dict()` (counts,
-saved IDs, warnings, and errors). It does **not** reliably expose the
-consumed reasoning payload. A Reasoning Context Drawer should wait for
-a backend execution-result field that explicitly carries consumed
-reasoning context or a compact reasoning audit summary.
+Important runtime boundary: `ContentOpsStepExecution.result` contains
+the per-service summary returned by `as_dict()` (counts, saved IDs,
+warnings, and errors). It does **not** reliably expose the consumed
+reasoning payload. `ContentOpsStepExecution.reasoning` is a compact
+readiness audit only: it tells the UI whether the output can use host
+reasoning, whether the service supports the seam, and whether a
+provider was attached. A Reasoning Context Drawer still requires a
+future field that carries the consumed context itself.
 
 ```ts
 interface CampaignReasoningContextView {
@@ -442,9 +451,10 @@ interface CampaignReasoningContextView {
 UI rules:
 - Show a "Reasoning context" badge next to each output card when
   `reasoningRequirement="optional_host_context"`.
-- Treat the badge as configuration readiness only. Do not infer that a
-  specific execution step used reasoning unless the backend returns an
-  explicit per-step reasoning audit field.
+- Treat catalog badges as configuration readiness only. Use
+  `step.reasoning` for execution-level readiness ("provider attached" /
+  "provider absent") but do not render a context drawer from it; it is
+  not the prompt payload.
 
 ---
 

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .campaign_ports import TenantScope
-from .control_surfaces import ContentOpsRequest, request_from_mapping
+from .control_surfaces import OUTPUT_CATALOG, ContentOpsRequest, request_from_mapping
 from .generation_plan import GenerationPlan, GenerationPlanStep, build_generation_plan
 from .landing_page_ports import MarketingCampaign
 
@@ -106,15 +106,19 @@ class ContentOpsStepExecution:
     status: str
     result: Mapping[str, Any] = field(default_factory=dict)
     error: str = ""
+    reasoning: Mapping[str, Any] = field(default_factory=dict)
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "output": self.output,
             "runner": self.runner,
             "status": self.status,
             "result": dict(self.result),
             "error": self.error,
         }
+        if self.reasoning:
+            data["reasoning"] = dict(self.reasoning)
+        return data
 
 
 @dataclass(frozen=True)
@@ -205,7 +209,7 @@ async def _execute_step(
 ) -> tuple[ContentOpsStepExecution, Mapping[str, Any] | None]:
     if not _has_generate_method(service):
         error = _step_error_dict(step, "service_not_configured")
-        return _failed_step(step, "service_not_configured"), error
+        return _failed_step(step, "service_not_configured", service=service), error
     try:
         result = await _run_step(
             step,
@@ -216,13 +220,14 @@ async def _execute_step(
         )
     except Exception as exc:
         error = _step_error_dict(step, str(exc))
-        return _failed_step(step, str(exc)), error
+        return _failed_step(step, str(exc), service=service), error
     return (
         ContentOpsStepExecution(
             output=step.output,
             runner=step.runner,
             status="completed",
             result=_result_dict(result),
+            reasoning=_step_reasoning_audit(step, service),
         ),
         None,
     )
@@ -622,17 +627,48 @@ def _step_error_dict(step: GenerationPlanStep, error: str) -> dict[str, Any]:
     }
 
 
-def _failed_step(step: GenerationPlanStep, error: str) -> ContentOpsStepExecution:
+def _failed_step(
+    step: GenerationPlanStep,
+    error: str,
+    *,
+    service: Any | None,
+) -> ContentOpsStepExecution:
     return ContentOpsStepExecution(
         output=step.output,
         runner=step.runner,
         status="failed",
         error=error,
+        reasoning=_step_reasoning_audit(step, service),
     )
 
 
 def _has_generate_method(service: Any | None) -> bool:
     return callable(getattr(service, "generate", None))
+
+
+def _step_reasoning_audit(
+    step: GenerationPlanStep,
+    service: Any | None,
+) -> dict[str, Any]:
+    definition = OUTPUT_CATALOG.get(step.output)
+    requirement = (
+        definition.reasoning_requirement
+        if definition is not None
+        else "absent"
+    )
+    service_supports = callable(getattr(service, "with_reasoning_context", None))
+    provider_configured = getattr(service, "_reasoning_context", None) is not None
+    if (
+        requirement == "absent"
+        and not service_supports
+        and not provider_configured
+    ):
+        return {}
+    return {
+        "requirement": requirement,
+        "service_supports_reasoning": service_supports,
+        "provider_configured": provider_configured,
+    }
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -32,6 +32,7 @@ class ContentOpsExecutionServices:
     landing_page: Any | None = None
     sales_brief: Any | None = None
     signal_extraction: Any | None = None
+    reasoning_provider_configured: bool = False
 
     def for_output(self, output: str) -> Any | None:
         if output == "email_campaign":
@@ -85,6 +86,7 @@ class ContentOpsExecutionServices:
             sales_brief=_rebind_reasoning(self.sales_brief, provider),
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
+            reasoning_provider_configured=provider is not None,
         )
 
 
@@ -176,6 +178,7 @@ async def execute_content_ops_request(
             service=services.for_output(step.output),
             scope=resolved_scope,
             filters=filters,
+            reasoning_provider_configured=services.reasoning_provider_configured,
         )
         for step in plan.steps
     ))
@@ -206,10 +209,19 @@ async def _execute_step(
     service: Any | None,
     scope: TenantScope,
     filters: Mapping[str, Any] | None,
+    reasoning_provider_configured: bool,
 ) -> tuple[ContentOpsStepExecution, Mapping[str, Any] | None]:
     if not _has_generate_method(service):
         error = _step_error_dict(step, "service_not_configured")
-        return _failed_step(step, "service_not_configured", service=service), error
+        return (
+            _failed_step(
+                step,
+                "service_not_configured",
+                service=service,
+                reasoning_provider_configured=reasoning_provider_configured,
+            ),
+            error,
+        )
     try:
         result = await _run_step(
             step,
@@ -220,14 +232,26 @@ async def _execute_step(
         )
     except Exception as exc:
         error = _step_error_dict(step, str(exc))
-        return _failed_step(step, str(exc), service=service), error
+        return (
+            _failed_step(
+                step,
+                str(exc),
+                service=service,
+                reasoning_provider_configured=reasoning_provider_configured,
+            ),
+            error,
+        )
     return (
         ContentOpsStepExecution(
             output=step.output,
             runner=step.runner,
             status="completed",
             result=_result_dict(result),
-            reasoning=_step_reasoning_audit(step, service),
+            reasoning=_step_reasoning_audit(
+                step,
+                service,
+                reasoning_provider_configured=reasoning_provider_configured,
+            ),
         ),
         None,
     )
@@ -632,13 +656,18 @@ def _failed_step(
     error: str,
     *,
     service: Any | None,
+    reasoning_provider_configured: bool,
 ) -> ContentOpsStepExecution:
     return ContentOpsStepExecution(
         output=step.output,
         runner=step.runner,
         status="failed",
         error=error,
-        reasoning=_step_reasoning_audit(step, service),
+        reasoning=_step_reasoning_audit(
+            step,
+            service,
+            reasoning_provider_configured=reasoning_provider_configured,
+        ),
     )
 
 
@@ -649,6 +678,8 @@ def _has_generate_method(service: Any | None) -> bool:
 def _step_reasoning_audit(
     step: GenerationPlanStep,
     service: Any | None,
+    *,
+    reasoning_provider_configured: bool,
 ) -> dict[str, Any]:
     definition = OUTPUT_CATALOG.get(step.output)
     requirement = (
@@ -657,17 +688,16 @@ def _step_reasoning_audit(
         else "absent"
     )
     service_supports = callable(getattr(service, "with_reasoning_context", None))
-    provider_configured = getattr(service, "_reasoning_context", None) is not None
     if (
         requirement == "absent"
         and not service_supports
-        and not provider_configured
+        and not reasoning_provider_configured
     ):
         return {}
     return {
         "requirement": requirement,
         "service_supports_reasoning": service_supports,
-        "provider_configured": provider_configured,
+        "provider_configured": reasoning_provider_configured,
     }
 
 

--- a/plans/PR-Content-Ops-Reasoning-Consumption-Summary.md
+++ b/plans/PR-Content-Ops-Reasoning-Consumption-Summary.md
@@ -1,0 +1,65 @@
+# PR: Content Ops reasoning consumption summary
+
+## Why this slice exists
+
+The frontend contract now correctly treats reasoning as optional,
+host-injected context. The remaining backend gap is execution-level
+visibility: a completed step shows its runner result, but there is no
+compact signal telling the UI whether that step was reasoning-capable
+and whether a provider was attached.
+
+## Scope (this PR)
+
+1. Add a compact `reasoning` audit object to `ContentOpsStepExecution`
+   for reasoning-capable outputs.
+2. Keep the audit intentionally small: catalog requirement, service
+   support for `with_reasoning_context`, and provider attachment.
+3. Update the frontend contract to distinguish this audit from the
+   full consumed reasoning payload.
+4. Claim this slice in the coordination table while the PR is open.
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_execution.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Reasoning-Consumption-Summary.md`
+
+## Mechanism
+
+The executor computes the per-step audit from the output catalog and
+the injected service object. Outputs with
+`reasoning_requirement="optional_host_context"` get:
+
+- `requirement`
+- `service_supports_reasoning`
+- `provider_configured`
+
+Outputs whose catalog requirement is `absent` keep the prior payload
+shape unless the service unexpectedly exposes reasoning support.
+
+## Intentional
+
+- No generator behavior changes.
+- No UI drawer.
+- No full reasoning payload exposure.
+- No competitive-intelligence files touched.
+
+## Deferred
+
+- A future drawer-ready field carrying the consumed reasoning context
+  itself.
+- Frontend rendering for the execution-level reasoning audit.
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/content_ops_execution.py`
+- `python -m pytest tests/test_extracted_content_ops_execution.py`
+- `git diff --check`
+
+## Estimated diff size
+
+- 5 files.
+- About 120 inserted lines and 10 deleted lines.
+- Well below the 400-line soft PR budget.

--- a/plans/PR-Content-Ops-Reasoning-Consumption-Summary.md
+++ b/plans/PR-Content-Ops-Reasoning-Consumption-Summary.md
@@ -28,9 +28,10 @@ and whether a provider was attached.
 
 ## Mechanism
 
-The executor computes the per-step audit from the output catalog and
-the injected service object. Outputs with
-`reasoning_requirement="optional_host_context"` get:
+The executor computes the per-step audit from the output catalog, the
+injected service object, and the bundle-level reasoning-provider flag
+set by `ContentOpsExecutionServices.with_reasoning_context(provider)`.
+Outputs with `reasoning_requirement="optional_host_context"` get:
 
 - `requirement`
 - `service_supports_reasoning`

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -74,6 +74,18 @@ class _OpportunityService:
         return _Result()
 
 
+class _ReasoningAwareOpportunityService(_OpportunityService):
+    def __init__(self, reasoning_context: Any | None = None) -> None:
+        super().__init__()
+        self._reasoning_context = reasoning_context
+
+    def with_reasoning_context(
+        self,
+        provider: Any | None,
+    ) -> "_ReasoningAwareOpportunityService":
+        return _ReasoningAwareOpportunityService(reasoning_context=provider)
+
+
 class _LandingPageService:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -872,6 +884,63 @@ async def test_execute_threads_topic_into_blog_post_dispatcher() -> None:
 # -----------------------
 # PR-ControlSurfaces-Reasoning-Provider: bundle-level helper
 # -----------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_step_reports_reasoning_audit_when_provider_attached():
+    """Execution results expose a compact per-step reasoning audit without
+    exposing the full prompt context payload."""
+
+    provider = object()
+    campaign = _ReasoningAwareOpportunityService(reasoning_context=provider)
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["steps"][0]["reasoning"] == {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": True,
+        "provider_configured": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_step_reports_reasoning_audit_when_provider_absent():
+    campaign = _ReasoningAwareOpportunityService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["steps"][0]["reasoning"] == {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": True,
+        "provider_configured": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_step_omits_reasoning_audit_for_absent_requirement():
+    signal = SignalExtractionService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["signal_extraction"],
+            "inputs": {"source_material": "Acme switched from HubSpot."},
+        },
+        services=ContentOpsExecutionServices(signal_extraction=signal),
+    )
+
+    assert "reasoning" not in result["steps"][0]
 
 
 def test_services_with_reasoning_context_derives_new_bundle_with_provider_attached():

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -892,14 +892,17 @@ async def test_execute_step_reports_reasoning_audit_when_provider_attached():
     exposing the full prompt context payload."""
 
     provider = object()
-    campaign = _ReasoningAwareOpportunityService(reasoning_context=provider)
+    campaign = _ReasoningAwareOpportunityService()
+    services = ContentOpsExecutionServices(campaign=campaign).with_reasoning_context(
+        provider
+    )
 
     result = await execute_content_ops_from_mapping(
         {
             "outputs": ["email_campaign"],
             "inputs": {"target_account": "Acme", "offer": "Audit"},
         },
-        services=ContentOpsExecutionServices(campaign=campaign),
+        services=services,
     )
 
     assert result["steps"][0]["reasoning"] == {


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Reasoning-Consumption-Summary.md`

Adds a compact per-step reasoning audit to Content Ops execution results so the frontend can distinguish catalog readiness from execution-level provider attachment.

## Intentional
- Adds optional `step.reasoning` for reasoning-capable outputs.
- Reports `requirement`, `service_supports_reasoning`, and `provider_configured`.
- Keeps full consumed reasoning payload out of the execution result.
- Leaves generator behavior and UI rendering unchanged.

## Deferred
- Drawer-ready field carrying the consumed reasoning context itself.
- Frontend rendering for the execution-level reasoning audit.

## Verification
- `python -m py_compile extracted_content_pipeline/content_ops_execution.py`
- `python -m pytest tests/test_extracted_content_ops_execution.py`
- `python -m pytest tests/test_extracted_content_control_surface_api.py`
- `git diff --check`
- ASCII check on Python/test/plan/coordination files; frontend contract has pre-existing non-ASCII outside this diff.

## Diff size
- 5 files changed
- 196 insertions, 15 deletions