### PR TITLE
Render Content Ops reasoning audit in execution results

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json
@@ -61,7 +61,12 @@
           "draft-2"
         ]
       },
-      "error": ""
+      "error": "",
+      "reasoning": {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": true,
+        "provider_configured": true
+      }
     }
   ],
   "errors": []

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -127,12 +127,19 @@ export type ContentOpsExecutionStatus =
 
 export type ContentOpsStepStatus = 'completed' | 'failed' | 'skipped'
 
+export interface ContentOpsStepReasoningAudit {
+  requirement: 'absent' | 'optional_host_context' | string
+  service_supports_reasoning: boolean
+  provider_configured: boolean
+}
+
 export interface ContentOpsStepExecution {
   output: string
   runner: string
   status: ContentOpsStepStatus
   result: Record<string, unknown>
   error: string                                    // populated when status="failed"
+  reasoning?: ContentOpsStepReasoningAudit
 }
 
 export interface ContentOpsExecutionResult {

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -192,13 +192,21 @@ export function fromWirePlan(wire: GenerationPlanResponse): GenerationPlan {
 export function fromWireStepExecution(
   wire: WireStepExecution,
 ): ContentOpsStepExecution {
-  return {
+  const step: ContentOpsStepExecution = {
     output: wire.output,
     runner: wire.runner,
     status: wire.status,
     result: { ...wire.result },
     error: wire.error,
   }
+  if (wire.reasoning) {
+    step.reasoning = {
+      requirement: wire.reasoning.requirement,
+      serviceSupportsReasoning: wire.reasoning.service_supports_reasoning,
+      providerConfigured: wire.reasoning.provider_configured,
+    }
+  }
+  return step
 }
 
 export function fromWireExecution(

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -12,6 +12,7 @@ export type {
   ContentOpsRequest,
   ContentOpsRun,
   ContentOpsStepExecution,
+  ContentOpsStepReasoningAudit,
   ContentOpsStepStatus,
   ControlSurfacePresetView,
   ControlSurfacePreview,

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -122,12 +122,19 @@ export type ContentOpsExecutionStatus =
 
 export type ContentOpsStepStatus = 'completed' | 'failed' | 'skipped'
 
+export interface ContentOpsStepReasoningAudit {
+  requirement: ReasoningRequirement
+  serviceSupportsReasoning: boolean
+  providerConfigured: boolean
+}
+
 export interface ContentOpsStepExecution {
   output: string
   runner: string
   status: ContentOpsStepStatus
   result: Record<string, unknown>
   error: string
+  reasoning?: ContentOpsStepReasoningAudit
 }
 
 export interface ContentOpsExecutionResult {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -17,6 +17,7 @@ import {
   type ContentOpsCatalog,
   type ContentOpsExecutionResult,
   type ContentOpsRequest,
+  type ContentOpsStepReasoningAudit,
   type ControlSurfacePreview,
   type GenerationPlan,
   type GenerationPlanStep,
@@ -866,6 +867,7 @@ function ExecutionPanel({ result }: { result: ContentOpsExecutionResult }) {
                 Error: {step.error}
               </div>
             )}
+            {step.reasoning && <ReasoningAuditBadge audit={step.reasoning} />}
             <ExecutionStepSummary output={step.output} result={step.result} />
             {Object.keys(step.result).length > 0 && (
               <details className="text-xs text-slate-400">
@@ -977,6 +979,33 @@ function GeneratedAssetSummary({
           ))}
         </div>
       )}
+    </div>
+  )
+}
+
+function ReasoningAuditBadge({ audit }: { audit: ContentOpsStepReasoningAudit }) {
+  if (audit.requirement === 'absent' && !audit.serviceSupportsReasoning) {
+    return null
+  }
+  const ready = audit.providerConfigured && audit.serviceSupportsReasoning
+  const label = ready
+    ? 'Reasoning provider attached'
+    : audit.serviceSupportsReasoning
+      ? 'Reasoning provider absent'
+      : 'Reasoning seam unavailable'
+  return (
+    <div
+      className={clsx(
+        'mb-3 inline-flex max-w-full flex-wrap items-center gap-2 rounded-md border px-2 py-1 text-xs',
+        ready
+          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+          : 'border-slate-700 bg-slate-900/70 text-slate-400',
+      )}
+    >
+      <span>{label}</span>
+      <span className="font-mono text-[11px] opacity-80">
+        {audit.requirement}
+      </span>
     </div>
   )
 }

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-audit-ui
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-audit-ui-cleanup
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Render Content Ops reasoning audit in execution results | EDIT: `atlas-intel-ui/src/api/contentOps.ts`; EDIT: `atlas-intel-ui/src/domain/contentOps/types.ts`; EDIT: `atlas-intel-ui/src/domain/contentOps/fromWire.ts`; EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Reasoning-Audit-UI.md` | codex-content-ops-reasoning-audit-ui | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-consumption-summary-cleanup
+Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-audit-ui
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Render Content Ops reasoning audit in execution results | EDIT: `atlas-intel-ui/src/api/contentOps.ts`; EDIT: `atlas-intel-ui/src/domain/contentOps/types.ts`; EDIT: `atlas-intel-ui/src/domain/contentOps/fromWire.ts`; EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json`; EDIT: `docs/extraction/coordination/inflight.md`; ADD: `plans/PR-Content-Ops-Reasoning-Audit-UI.md` | codex-content-ops-reasoning-audit-ui | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Reasoning-Audit-UI.md
+++ b/plans/PR-Content-Ops-Reasoning-Audit-UI.md
@@ -1,0 +1,57 @@
+# PR: Content Ops reasoning audit UI
+
+## Why this slice exists
+
+PR #418 added a compact `step.reasoning` audit object to Content Ops
+execution results. The UI adapter still drops that field, so the
+execution panel cannot show whether a completed step had a host
+reasoning provider attached.
+
+## Scope (this PR)
+
+1. Add wire and domain types for the optional step reasoning audit.
+2. Map the wire audit into camelCase domain fields.
+3. Render a small execution-step badge when the audit is present.
+4. Update one execution fixture so the TypeScript contract sees the new
+   backend shape.
+5. Claim this slice in the coordination table while the PR is open.
+
+### Files touched
+
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Reasoning-Audit-UI.md`
+
+## Mechanism
+
+The UI treats `step.reasoning` as execution-level readiness only. It
+shows whether the service supports the seam and whether a provider was
+attached. It does not expose or imply access to the full consumed
+reasoning payload.
+
+## Intentional
+
+- No Reasoning Context Drawer.
+- No backend changes.
+- No full prompt payload rendering.
+- No competitive-intelligence files touched.
+
+## Deferred
+
+- Drawer-ready consumed-context field.
+- UI drawer after the backend exposes that field.
+
+## Verification
+
+- `npm run build` from `atlas-intel-ui`
+- `git diff --check`
+
+## Estimated diff size
+
+- 7 files.
+- About 110 inserted lines and 10 deleted lines.
+- Well below the 400-line soft PR budget.


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Reasoning-Audit-UI.md`

Wires the new backend `step.reasoning` audit into the Content Ops frontend adapter and execution result panel.

## Intentional
- Adds optional wire/domain types for per-step reasoning audit.
- Maps snake_case backend audit fields into camelCase domain fields.
- Renders a compact execution-step badge for provider attached / absent / unavailable.
- Keeps the full consumed reasoning payload out of the UI.

## Deferred
- Reasoning Context Drawer.
- Drawer-ready backend field carrying consumed context.

## Verification
- `npm run build` from `atlas-intel-ui` using the main checkout's existing `node_modules` symlinked into the temp worktree for validation only.
- `git diff --check`
- ASCII check on new/typed non-TSX files; `ContentOpsNewRun.tsx` has pre-existing non-ASCII UI punctuation outside this diff.

## Diff size
- 8 files changed
- 118 insertions, 3 deletions