### PR TITLE
PR-Decouple-PoolCompression-1: standalone shim for _b2b_witnesses

### DIFF
--- a/extracted_content_pipeline/autonomous/tasks/_b2b_witnesses.py
+++ b/extracted_content_pipeline/autonomous/tasks/_b2b_witnesses.py
@@ -1,0 +1,25 @@
+"""Standalone substrate for the _b2b_witnesses helper module.
+
+Real implementation lives in atlas_brain; this module exists only so
+that mirrored modules importing build_vendor_witness_artifacts (e.g.,
+``autonomous/tasks/_b2b_pool_compression.py``) can be imported under
+``EXTRACTED_PIPELINE_STANDALONE=1`` without touching atlas_brain.
+
+Runtime behavior is no-op: build_vendor_witness_artifacts returns an
+empty witness pack and empty section packets regardless of inputs.
+Tasks that need real witness extraction should run in atlas_brain
+mode.
+
+See plans/PR-Decouple-PoolCompression-1.md.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_vendor_witness_artifacts(
+    vendor_name: str,
+    reviews: list[dict[str, Any]] | None,
+    **_kwargs: Any,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    return [], {}

--- a/plans/PR-Decouple-PoolCompression-1.md
+++ b/plans/PR-Decouple-PoolCompression-1.md
@@ -1,0 +1,152 @@
+# PR-Decouple-PoolCompression-1: standalone shim for `_b2b_witnesses`
+
+## Why this slice exists
+
+Follow-up to PR-Decouple-CompIntel-1 (#422). After that PR landed, a
+sweep of all 114 manifest-tracked Python files across both extracted
+packages found **exactly one** remaining standalone-import failure:
+
+```
+$ EXTRACTED_PIPELINE_STANDALONE=1 python3 -c \
+    "from extracted_content_pipeline.autonomous.tasks import _b2b_pool_compression"
+ModuleNotFoundError: No module named
+  'extracted_content_pipeline.autonomous.tasks._b2b_witnesses'
+```
+
+`_b2b_pool_compression.py` (a manifest-tracked mirror) imports one
+symbol from a sibling module that is not mirrored:
+
+```python
+from ._b2b_witnesses import build_vendor_witness_artifacts
+```
+
+`atlas_brain/autonomous/tasks/_b2b_witnesses.py` exists (1,325 LOC) but
+is absent from `extracted_content_pipeline/`. Same shape as the
+`brand_registry` failure closed by #422.
+
+## Scope (this PR)
+
+One new file: `extracted_content_pipeline/autonomous/tasks/_b2b_witnesses.py`.
+
+Hand-rolled standalone substrate matching the precedent from #422.
+Exports a single function with the matching signature, returns a
+tuple `([], {})` -- the empty witness pack and section packets.
+
+Plus a regression test pinning that
+`_b2b_pool_compression` imports cleanly under
+`EXTRACTED_PIPELINE_STANDALONE=1`.
+
+## Standalone contract
+
+Same as #422: import-only. The mirror copy is never imported by the
+host -- atlas_brain consumes `atlas_brain.autonomous.tasks._b2b_witnesses`
+directly in production. The substrate here exists so the mirror copy
+of `_b2b_pool_compression` can be loaded in standalone mode without
+reaching into atlas_brain.
+
+`build_vendor_witness_artifacts` returning `([], {})` means downstream
+callers get empty witness data; that is consistent with the rest of
+the standalone surface (`pipelines/llm.py` returning `None`,
+`storage/database.py` returning a fake pool that fails on first
+real call).
+
+## File shape
+
+```python
+# extracted_content_pipeline/autonomous/tasks/_b2b_witnesses.py
+"""Standalone substrate for _b2b_witnesses ...
+
+Real implementation lives in atlas_brain. This module exists so the
+mirrored _b2b_pool_compression can be imported under
+EXTRACTED_PIPELINE_STANDALONE=1 without reaching into atlas_brain.
+"""
+from __future__ import annotations
+from typing import Any
+
+
+def build_vendor_witness_artifacts(
+    vendor_name: str,
+    reviews: list[dict[str, Any]] | None,
+    **_kwargs: Any,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    return [], {}
+```
+
+`**_kwargs` absorbs the eight keyword args atlas_brain's real
+implementation accepts (`max_witnesses`, `min_specificity_score`,
+`fallback_min_witnesses`, `generic_patterns`, `concrete_patterns`,
+`short_excerpt_chars`, `long_excerpt_chars`, `specificity_weights`)
+without re-declaring them. The standalone body ignores all of them
+because it never actually computes witnesses.
+
+## Intentional (looks wrong but is deliberate)
+
+- **`**_kwargs` instead of mirrored signature.** The real function's
+  signature is wide (8 keyword params with defaults). Re-declaring
+  them in the standalone shim duplicates surface area for no
+  behavioral payoff -- under standalone they all get ignored. Match
+  the narrow-export precedent from #422 (`brand_registry` exposed
+  only the 2 symbols the consumer imports).
+- **No env-var gate.** Same rationale as #422: there is no extracted-
+  side real implementation to delegate to in the non-standalone
+  branch, so a gate would be decorative.
+- **Not added to `manifest.json`.** Matches the precedent of the
+  other untracked standalone substrates (`pipelines/llm.py`,
+  `storage/database.py`, `services/brand_registry.py` from #422).
+  Closing the methodology gap (untracked shims belong on the `owned`
+  list) is a separate slice.
+- **`return [], {}` instead of raising or stubbing structured data.**
+  `_b2b_pool_compression` calls
+  `witness_pack, section_packets = build_vendor_witness_artifacts(...)`.
+  Empty list and empty dict cause the downstream code to produce a
+  result with no witness data; no AttributeError or KeyError. Standalone
+  callers that go further than import will get a no-op result rather
+  than a crash.
+
+## Deferred (looks missing but is on purpose)
+
+- **End-to-end standalone runnability for `_b2b_pool_compression`.**
+  Same caveat as #422: the task's database calls remain unserviceable
+  under the fake `_StandalonePool`.
+- **Mirror `_b2b_grounding.py` and `_b2b_phrase_metadata.py`.** Atlas-
+  brain's real `_b2b_witnesses.py` imports from both; the shim here
+  doesn't, so they don't need to be mirrored to satisfy this slice.
+  If a future module mirrored into `extracted_content_pipeline`
+  imports them directly, that's the next slice -- not this one.
+- **Closing the manifest methodology gap.** Same as #422.
+
+## Verification
+
+- New test:
+  `tests/test_extracted_pool_compression_standalone.py` asserting
+  the import succeeds under standalone and that the shim returns
+  `([], {})` regardless of inputs.
+- `EXTRACTED_PIPELINE_STANDALONE=1 python3 -c "from
+  extracted_content_pipeline.autonomous.tasks import
+  _b2b_pool_compression"` -> exits 0, no traceback.
+- `python3 scripts/audit_extracted_standalone.py --fail-on-debt` ->
+  Atlas runtime import findings: 0 (unchanged).
+- `bash scripts/check_ascii_python.sh` -> passed.
+- Repeat sweep across both packages (114 manifest-tracked Python
+  files): 0 standalone-import failures.
+
+## Conflict check
+
+- No file overlap with any open PR. This slice touches a single new
+  file in `extracted_content_pipeline/autonomous/tasks/`; the
+  in-flight `extracted_competitive_intelligence/autonomous/visibility.py`
+  bridge promotion is in a different package.
+
+## Diff size
+
+1 source file (~25 LOC), 1 new test file (~50 LOC), 1 plan doc (this
+file, ~110 LOC). Source-only ~25 LOC -- the smallest possible slice
+that closes the failure.
+
+## After this lands
+
+Sweep across 114 manifest-tracked Python files reports **0 standalone-
+import failures**. The decoupling track for `extracted_content_pipeline`
+and `extracted_competitive_intelligence` is fully green at the
+standalone-toggle level. Whatever next: monolith decomposition,
+manifest methodology cleanup, or product track.

--- a/tests/test_extracted_pool_compression_standalone.py
+++ b/tests/test_extracted_pool_compression_standalone.py
@@ -1,0 +1,102 @@
+"""Standalone-mode regression test for _b2b_pool_compression.
+
+Pins the contract that
+``extracted_content_pipeline.autonomous.tasks._b2b_pool_compression``
+imports cleanly under ``EXTRACTED_PIPELINE_STANDALONE=1``. Pre-PR the
+mirror failed with ``ModuleNotFoundError: No module named
+'extracted_content_pipeline.autonomous.tasks._b2b_witnesses'``; the
+standalone substrate added in PR-Decouple-PoolCompression-1 satisfies
+that import.
+
+Standalone contract is import-only. ``build_vendor_witness_artifacts``
+returns empty witness data (``([], {})``) under the shim -- consistent
+with the rest of the standalone surface. See plans/PR-Decouple-
+PoolCompression-1.md.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Iterator
+
+import pytest
+
+
+_STANDALONE_ENV_VAR = "EXTRACTED_PIPELINE_STANDALONE"
+
+_AFFECTED_MODULES = (
+    "extracted_content_pipeline.autonomous.tasks._b2b_witnesses",
+    "extracted_content_pipeline.autonomous.tasks._b2b_pool_compression",
+)
+
+
+def _evict(*module_names: str) -> None:
+    for name in module_names:
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def standalone_witnesses(monkeypatch) -> Iterator[object]:
+    """Fresh import of the witnesses shim under
+    ``EXTRACTED_PIPELINE_STANDALONE=1``."""
+    monkeypatch.setenv(_STANDALONE_ENV_VAR, "1")
+    _evict(*_AFFECTED_MODULES)
+    try:
+        module = importlib.import_module(
+            "extracted_content_pipeline.autonomous.tasks._b2b_witnesses"
+        )
+        yield module
+    finally:
+        _evict(*_AFFECTED_MODULES)
+
+
+def test_witnesses_shim_exports_required_symbol(standalone_witnesses):
+    assert hasattr(standalone_witnesses, "build_vendor_witness_artifacts")
+
+
+def test_build_vendor_witness_artifacts_returns_empty_pair(standalone_witnesses):
+    build = standalone_witnesses.build_vendor_witness_artifacts
+    pack, packets = build("Acme Corp", [{"text": "ignored"}])
+    assert pack == []
+    assert packets == {}
+
+
+def test_build_vendor_witness_artifacts_accepts_real_signature_kwargs(
+    standalone_witnesses,
+):
+    """The atlas_brain implementation accepts 8 keyword args with defaults.
+    The shim's ``**_kwargs`` should absorb all of them without TypeError."""
+    build = standalone_witnesses.build_vendor_witness_artifacts
+    pack, packets = build(
+        "Acme Corp",
+        [],
+        max_witnesses=12,
+        min_specificity_score=0.5,
+        fallback_min_witnesses=4,
+        generic_patterns=("foo",),
+        concrete_patterns=("bar",),
+        short_excerpt_chars=120,
+        long_excerpt_chars=480,
+        specificity_weights={"a": 1.0},
+    )
+    assert pack == []
+    assert packets == {}
+
+
+def test_pool_compression_mirror_imports_under_standalone(monkeypatch):
+    """The load-bearing assertion for this PR.
+
+    Pre-PR this raised ``ModuleNotFoundError: No module named
+    'extracted_content_pipeline.autonomous.tasks._b2b_witnesses'``.
+    """
+    monkeypatch.setenv(_STANDALONE_ENV_VAR, "1")
+    _evict(*_AFFECTED_MODULES)
+    try:
+        module = importlib.import_module(
+            "extracted_content_pipeline.autonomous.tasks._b2b_pool_compression"
+        )
+        # _b2b_pool_compression is a helper module; just confirm it loaded.
+        assert module is not None
+    finally:
+        _evict(*_AFFECTED_MODULES)


### PR DESCRIPTION
**Plan:** [`plans/PR-Decouple-PoolCompression-1.md`](../blob/claude/decouple-pool-compression-1-witnesses-shim/plans/PR-Decouple-PoolCompression-1.md)

## Summary

Follow-up to PR-Decouple-CompIntel-1 (#422). After that PR landed, a sweep across all 114 manifest-tracked Python files in both extracted packages found **exactly one** remaining standalone-import failure:

```
$ EXTRACTED_PIPELINE_STANDALONE=1 python3 -c \
    "from extracted_content_pipeline.autonomous.tasks import _b2b_pool_compression"
ModuleNotFoundError: No module named
  'extracted_content_pipeline.autonomous.tasks._b2b_witnesses'
```

`_b2b_pool_compression.py` (manifest-tracked mirror) imports one symbol from a sibling module that isn't mirrored: `from ._b2b_witnesses import build_vendor_witness_artifacts`. Same shape as the brand_registry failure closed by #422.

## What changed

One new standalone substrate file matching the precedent from #422:

```python
# extracted_content_pipeline/autonomous/tasks/_b2b_witnesses.py
def build_vendor_witness_artifacts(
    vendor_name: str,
    reviews: list[dict[str, Any]] | None,
    **_kwargs: Any,
) -> tuple[list[dict[str, Any]], dict[str, Any]]:
    return [], {}
```

Plus a regression test (`tests/test_extracted_pool_compression_standalone.py`) pinning that `_b2b_pool_compression` imports cleanly under `EXTRACTED_PIPELINE_STANDALONE=1`, with the load-bearing assertion failing pre-shim with the exact `ModuleNotFoundError` quoted above.

## Intentional (looks wrong but is deliberate)

- **`**_kwargs` instead of mirroring the real signature.** atlas_brain's `build_vendor_witness_artifacts` takes 8 keyword args with defaults; re-declaring them in the standalone shim duplicates surface area for no behavioral payoff. The shim ignores them all (consistent with the no-op contract).
- **`return [], {}` instead of raising.** Downstream code unpacks `witness_pack, section_packets = build_vendor_witness_artifacts(...)`. Empty list and empty dict avoid AttributeError/KeyError; standalone callers get a no-op result rather than a crash.
- **No env-var gate, not added to `manifest.json`.** Same rationale as #422.

## Deferred (looks missing but is on purpose)

- End-to-end standalone runnability for `_b2b_pool_compression` (DB calls remain unserviceable under fake `_StandalonePool`).
- Mirroring `_b2b_grounding.py` and `_b2b_phrase_metadata.py` (atlas_brain's real `_b2b_witnesses.py` imports from both, but the shim doesn't, so they don't need to be mirrored to satisfy this slice).
- Closing the manifest methodology gap.

## Verification

- [x] `pytest tests/test_extracted_pool_compression_standalone.py` -> 4 passed
- [x] `EXTRACTED_PIPELINE_STANDALONE=1 python3 -c "from extracted_content_pipeline.autonomous.tasks import _b2b_pool_compression"` -> exits 0
- [x] `python3 scripts/audit_extracted_standalone.py --fail-on-debt` -> Atlas runtime import findings: 0 (unchanged)
- [x] `bash scripts/check_ascii_python.sh` -> passed
- [x] **Full sweep across both packages (114 manifest-tracked Python files): 0 standalone-import failures**

## After this lands

The decoupling track for `extracted_content_pipeline` and `extracted_competitive_intelligence` is fully green at the standalone-toggle level. Whatever comes next -- monolith decomposition, manifest methodology cleanup, or product track -- decoupling-failure cleanup is closed.

## Conflict check

No file overlap with any open PR. Different package and different file from the in-flight `extracted_competitive_intelligence/autonomous/visibility.py` bridge promotion.

## Diff size

3 files: 25-LOC source shim + 96-LOC regression test + 110-LOC plan doc. Source-only is the smallest possible slice that closes the failure.

## Test plan

- [x] All 4 new tests pass
- [x] Standalone import smoke succeeds
- [x] Audit reports 0 findings
- [x] Repeat full sweep: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)