### PR TITLE
Surface campaign export reasoning summaries

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T00:00Z by codex-content-ops-reasoning-audit-ui-cleanup
+Last updated: 2026-05-09T17:49Z by codex-content-ops-reasoning-usage-export
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Surface campaign draft reasoning and usage summaries in host export | EDIT: `extracted_content_pipeline/campaign_postgres_export.py`; `tests/test_extracted_campaign_postgres_export.py`; export docs only. | codex-content-ops-reasoning-usage-export | Avoid campaign draft export helper/tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T17:49Z by codex-content-ops-reasoning-usage-export
+Last updated: 2026-05-09T17:58Z by codex-content-ops-reasoning-usage-export
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Surface campaign draft reasoning and usage summaries in host export | EDIT: `extracted_content_pipeline/campaign_postgres_export.py`; `tests/test_extracted_campaign_postgres_export.py`; export docs only. | codex-content-ops-reasoning-usage-export | Avoid campaign draft export helper/tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -360,6 +360,11 @@ python scripts/export_extracted_campaign_drafts.py --account-id acct_123 --limit
 python scripts/export_extracted_campaign_drafts.py --account-id acct_123 --format csv --output campaign_drafts.csv
 ```
 
+The draft export keeps the full `metadata` JSON and also exposes scan-friendly
+summary fields: `generation_input_tokens`, `generation_output_tokens`,
+`generation_total_tokens`, `generation_parse_attempts`,
+`reasoning_context_used`, `reasoning_wedge`, and `reasoning_confidence`.
+
 After review, update selected draft rows without writing SQL:
 
 ```bash

--- a/extracted_content_pipeline/campaign_postgres_export.py
+++ b/extracted_content_pipeline/campaign_postgres_export.py
@@ -34,6 +34,13 @@ _EXPORT_COLUMNS = (
     "body",
     "cta",
     "llm_model",
+    "generation_input_tokens",
+    "generation_output_tokens",
+    "generation_total_tokens",
+    "generation_parse_attempts",
+    "reasoning_context_used",
+    "reasoning_wedge",
+    "reasoning_confidence",
     "created_at",
     "metadata",
 )
@@ -146,10 +153,41 @@ def _normalize_limit(value: Any) -> int:
 
 
 def _serializable_row(row: Mapping[str, Any]) -> JsonDict:
-    return {
+    output = {
         key: _json_ready(value)
         for key, value in row.items()
     }
+    output.update(_metadata_summary(output.get("metadata")))
+    return output
+
+
+def _metadata_summary(value: Any) -> JsonDict:
+    metadata = _metadata_mapping(value)
+    usage = _metadata_mapping(metadata.get("generation_usage"))
+    reasoning = _metadata_mapping(metadata.get("reasoning_context"))
+    return {
+        "generation_input_tokens": usage.get("input_tokens"),
+        "generation_output_tokens": usage.get("output_tokens"),
+        "generation_total_tokens": usage.get("total_tokens"),
+        "generation_parse_attempts": metadata.get("generation_parse_attempts"),
+        "reasoning_context_used": bool(reasoning),
+        "reasoning_wedge": reasoning.get("wedge"),
+        "reasoning_confidence": reasoning.get("confidence"),
+    }
+
+
+def _metadata_mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+        return {}
+    return {}
 
 
 def _json_ready(value: Any) -> Any:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -392,6 +392,11 @@ python scripts/export_extracted_campaign_drafts.py \
   --output campaign_drafts.csv
 ```
 
+CSV and JSON exports include `generation_input_tokens`,
+`generation_output_tokens`, `generation_total_tokens`,
+`generation_parse_attempts`, `reasoning_context_used`, `reasoning_wedge`, and
+`reasoning_confidence` as top-level fields derived from saved draft metadata.
+
 Approve or queue selected drafts after review:
 
 ```bash

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -174,7 +174,10 @@ selected account, target mode, and target ids.
 `extracted_content_pipeline/campaign_postgres_export.py` owns the read-only
 review path for generated drafts. It filters saved `b2b_campaigns` rows by
 account, status, target mode, channel, vendor, or company and emits JSON or CSV
-for host review workflows.
+for host review workflows. The export preserves raw `metadata` and derives
+top-level review columns for generation usage and reasoning context status so
+operators can audit token cost and reasoning consumption without unpacking the
+metadata blob.
 
 `extracted_content_pipeline/campaign_postgres_review.py` owns the write side of
 that host review loop. It updates selected `b2b_campaigns` rows by explicit

--- a/plans/PR-Content-Ops-Campaign-Export-Reasoning-Summary.md
+++ b/plans/PR-Content-Ops-Campaign-Export-Reasoning-Summary.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-Campaign-Export-Reasoning-Summary
+
+## Why this slice exists
+
+Recent Content Ops reasoning slices persist reasoning and generation usage
+metadata on saved campaign drafts. The host-facing Postgres export already
+includes the raw `metadata` JSON blob, but operators reviewing CSV/JSON exports
+cannot scan reasoning usage or token totals without opening nested metadata.
+This slice adds read-only summary fields to the export surface.
+
+## Scope (this PR)
+
+1. Derive export-only generation usage fields from each draft row's metadata.
+2. Derive export-only reasoning summary fields from each draft row's metadata.
+3. Cover JSON and CSV export behavior with focused tests.
+4. Document the exported fields in the host-facing docs.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_postgres_export.py`
+- `tests/test_extracted_campaign_postgres_export.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`list_campaign_drafts()` continues to read the same database columns. Before
+rows are returned, `_serializable_row()` now adds derived keys from
+`metadata.generation_usage` and `metadata.reasoning_context`:
+
+- `generation_input_tokens`
+- `generation_output_tokens`
+- `generation_total_tokens`
+- `generation_parse_attempts`
+- `reasoning_context_used`
+- `reasoning_wedge`
+- `reasoning_confidence`
+
+No schema change is needed; CSV output includes the same derived keys as
+columns, and JSON output includes them on each row.
+
+## Intentional
+
+- The raw `metadata` blob remains in the export for hosts that need the full
+  reasoning payload.
+- `reasoning_context_used` is a boolean derived from `metadata.reasoning_context`
+  being a non-empty object. It is not a run-level count; the export works at the
+  draft-row level.
+- Missing metadata yields empty generation fields and
+  `reasoning_context_used=false` instead of filtering rows.
+
+## Deferred
+
+- Asset exports for blog posts, reports, landing pages, and sales briefs are
+  outside this campaign-draft export helper.
+- A richer analytics export over all generated assets can build on these field
+  names later.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_campaign_postgres_export.py` (12 passed)
+- `python -m py_compile extracted_content_pipeline/campaign_postgres_export.py scripts/export_extracted_campaign_drafts.py tests/test_extracted_campaign_postgres_export.py`
+- `bash scripts/run_extracted_pipeline_checks.sh` (1374 passed, 1 existing torch/pynvml warning)
+- `git diff --check`
+- Non-ASCII byte check for edited Python files (clean)
+
+## Estimated diff size
+
+About 6 files, under 200 changed lines.

--- a/tests/test_extracted_campaign_postgres_export.py
+++ b/tests/test_extracted_campaign_postgres_export.py
@@ -58,7 +58,19 @@ def _row(**overrides):
         "cta": "Review plan",
         "llm_model": "offline",
         "created_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
-        "metadata": {"scope": {"account_id": "acct_1"}},
+        "metadata": {
+            "scope": {"account_id": "acct_1"},
+            "generation_usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+            },
+            "generation_parse_attempts": 2,
+            "reasoning_context": {
+                "wedge": "price_squeeze",
+                "confidence": "high",
+            },
+        },
     }
     row.update(overrides)
     return row
@@ -98,6 +110,13 @@ async def test_list_campaign_drafts_filters_review_rows() -> None:
     )
     assert result.rows[0]["created_at"] == "2026-05-04 00:00:00+00:00"
     assert result.filters["account_id"] == "acct_1"
+    assert result.rows[0]["generation_input_tokens"] == 10
+    assert result.rows[0]["generation_output_tokens"] == 5
+    assert result.rows[0]["generation_total_tokens"] == 15
+    assert result.rows[0]["generation_parse_attempts"] == 2
+    assert result.rows[0]["reasoning_context_used"] is True
+    assert result.rows[0]["reasoning_wedge"] == "price_squeeze"
+    assert result.rows[0]["reasoning_confidence"] == "high"
 
 
 @pytest.mark.asyncio
@@ -165,8 +184,50 @@ def test_campaign_draft_export_result_renders_csv() -> None:
     csv_text = result.as_csv()
 
     assert "company_name,vendor_name" in csv_text
+    assert "generation_input_tokens,generation_output_tokens" in csv_text
+    assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in csv_text
     assert "Acme" in csv_text
     assert "{\"\"scope\"\":{\"\"account_id\"\":\"\"acct_1\"\"}" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_list_campaign_drafts_derives_summary_from_json_metadata_string() -> None:
+    metadata = json.dumps(
+        {
+            "generation_usage": {"input_tokens": 8, "output_tokens": 4},
+            "generation_parse_attempts": 1,
+            "reasoning_context": {
+                "wedge": "support_erosion",
+                "confidence": "medium",
+            },
+        }
+    )
+    pool = _Pool(rows=[_row(metadata=metadata)])
+
+    result = await list_campaign_drafts(pool, limit=1)
+
+    assert result.rows[0]["generation_input_tokens"] == 8
+    assert result.rows[0]["generation_output_tokens"] == 4
+    assert result.rows[0]["generation_total_tokens"] is None
+    assert result.rows[0]["generation_parse_attempts"] == 1
+    assert result.rows[0]["reasoning_context_used"] is True
+    assert result.rows[0]["reasoning_wedge"] == "support_erosion"
+    assert result.rows[0]["reasoning_confidence"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_list_campaign_drafts_defaults_summary_fields_without_metadata() -> None:
+    pool = _Pool(rows=[_row(metadata={})])
+
+    result = await list_campaign_drafts(pool, limit=1)
+
+    assert result.rows[0]["generation_input_tokens"] is None
+    assert result.rows[0]["generation_output_tokens"] is None
+    assert result.rows[0]["generation_total_tokens"] is None
+    assert result.rows[0]["generation_parse_attempts"] is None
+    assert result.rows[0]["reasoning_context_used"] is False
+    assert result.rows[0]["reasoning_wedge"] is None
+    assert result.rows[0]["reasoning_confidence"] is None
 
 
 @pytest.mark.asyncio
@@ -204,6 +265,8 @@ async def test_campaign_draft_export_cli_outputs_json(monkeypatch, capsys) -> No
     assert pool.closed is True
     assert output["count"] == 1
     assert output["rows"][0]["company_name"] == "Acme"
+    assert output["rows"][0]["generation_input_tokens"] == 10
+    assert output["rows"][0]["reasoning_context_used"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Campaign-Export-Reasoning-Summary.md

Expose scan-friendly generation usage and reasoning context fields in the host campaign draft export. The database query and saved metadata remain unchanged; JSON/CSV exports derive summary columns from the existing metadata blob.

## Intentional
- The raw metadata blob remains in the export for hosts that need full details.
- Summary fields are derived at export time; no schema or writer changes.
- Missing reasoning metadata returns reasoning_context_used=false rather than filtering drafts.

## Deferred
- Generated asset exports outside campaign drafts remain separate slices.
- A broader analytics export can reuse these field names later.

## Verification
- python -m pytest tests/test_extracted_campaign_postgres_export.py (12 passed)
- python -m py_compile extracted_content_pipeline/campaign_postgres_export.py scripts/export_extracted_campaign_drafts.py tests/test_extracted_campaign_postgres_export.py
- bash scripts/run_extracted_pipeline_checks.sh (1374 passed, 1 existing torch/pynvml warning)
- git diff --check
- Non-ASCII byte check for edited Python files (clean)

## Diff size
7 files, +190 / -4
