### PR TITLE
Align Content Ops reasoning status docs

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:05Z by codex-content-ops-reasoning-status-docs
+Last updated: 2026-05-09T20:14Z by codex-content-ops-reasoning-status-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Align Content Ops reasoning status docs with execution audit shape | EDIT: `extracted_content_pipeline/STATUS.md`; `docs/frontend/content_ops_frontend_contract.md`; docs only. | codex-content-ops-reasoning-status-docs | Avoid Content Ops reasoning status/contract docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T17:58Z by codex-content-ops-reasoning-usage-export
+Last updated: 2026-05-09T20:05Z by codex-content-ops-reasoning-status-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Align Content Ops reasoning status docs with execution audit shape | EDIT: `extracted_content_pipeline/STATUS.md`; `docs/frontend/content_ops_frontend_contract.md`; docs only. | codex-content-ops-reasoning-status-docs | Avoid Content Ops reasoning status/contract docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -1,7 +1,7 @@
 # Content Ops Frontend Contract
 
 Date: 2026-05-09
-Code reference HEAD: `a4020c1` (post PR-Campaign-Config-V2 #398)
+Code reference HEAD: `d66649a9`
 
 This document defines the frontend domain model for the **AI Content Ops**
 product, grounded entirely in the real backend surface that exists today
@@ -100,7 +100,7 @@ top-level `execution.{configured,configured_outputs}` /
 | `GenerationPlan` | `generation_plan.py:48-65` | `can_execute`, `target_mode`, `limit`, `steps`, `preview` |
 | `ContentOpsExecutionServices` | `content_ops_execution.py:16-63` | `campaign`, `blog_post`, `report`, `landing_page`, `sales_brief`, `signal_extraction` (host-port bundle) |
 | `ContentOpsStepExecution` | `content_ops_execution.py:102-123` | `output`, `runner`, `status`, `result`, `error`, optional `reasoning` |
-| `ContentOpsExecutionResult` | `content_ops_execution.py:86-101` | `status`, `plan`, `steps`, `errors` |
+| `ContentOpsExecutionResult` | `content_ops_execution.py:126-141` | `status`, `plan`, `steps`, `errors` |
 | `SignalExtractionConfig` | `signal_extraction.py:19-24` | `limit`, `max_text_chars` |
 | `SignalExtractionResult` | `signal_extraction.py:27-45` | `opportunities`, `warnings`, `target_mode` (+ `generated` property) |
 
@@ -132,7 +132,7 @@ Outputs currently flagged `optional_host_context`: `email_campaign`,
 
 ### Execution status vocabulary
 
-`ContentOpsExecutionResult.status` (`content_ops_execution.py:147-155`):
+`ContentOpsExecutionResult.status` (`content_ops_execution.py:188-197`):
 
 - `"completed"` — every step succeeded
 - `"failed"` — every step failed (distinguished from `partial`
@@ -564,7 +564,7 @@ These can land later; they don't block v0 of the frontend.
 
 ## Code references summary
 
-Every claim in this doc cites a real file:line at HEAD `a4020c1`:
+Every claim in this doc cites a real file:line at HEAD `d66649a9`:
 
 | Topic | Citation |
 | --- | --- |
@@ -584,7 +584,7 @@ Every claim in this doc cites a real file:line at HEAD `a4020c1`:
 | Per-output config builders | `extracted_content_pipeline/generation_plan.py:68-148` |
 | `_step_for_output` per-runner shapes | `extracted_content_pipeline/generation_plan.py:165-266` |
 | `ContentOpsExecutionServices` | `extracted_content_pipeline/content_ops_execution.py:16-63` |
-| `ContentOpsExecutionResult` status logic | `extracted_content_pipeline/content_ops_execution.py:147-155` |
+| `ContentOpsExecutionResult` status logic | `extracted_content_pipeline/content_ops_execution.py:188-197` |
 | `ContentOpsStepExecution` | `extracted_content_pipeline/content_ops_execution.py:102-123` |
 | `SignalExtractionConfig` / `SignalExtractionResult` / `SignalExtractionService` | `extracted_content_pipeline/signal_extraction.py:19-81` |
 | `CampaignReasoningContext` (11 fields) | `extracted_content_pipeline/campaign_ports.py:53-99` |

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -99,7 +99,7 @@ top-level `execution.{configured,configured_outputs}` /
 | `GenerationPlanStep` | `generation_plan.py:28-45` | `output`, `runner`, `status`, `config`, `reason` |
 | `GenerationPlan` | `generation_plan.py:48-65` | `can_execute`, `target_mode`, `limit`, `steps`, `preview` |
 | `ContentOpsExecutionServices` | `content_ops_execution.py:16-63` | `campaign`, `blog_post`, `report`, `landing_page`, `sales_brief`, `signal_extraction` (host-port bundle) |
-| `ContentOpsStepExecution` | `content_ops_execution.py:66-83` | `output`, `runner`, `status`, `result`, `error` |
+| `ContentOpsStepExecution` | `content_ops_execution.py:102-123` | `output`, `runner`, `status`, `result`, `error`, optional `reasoning` |
 | `ContentOpsExecutionResult` | `content_ops_execution.py:86-101` | `status`, `plan`, `steps`, `errors` |
 | `SignalExtractionConfig` | `signal_extraction.py:19-24` | `limit`, `max_text_chars` |
 | `SignalExtractionResult` | `signal_extraction.py:27-45` | `opportunities`, `warnings`, `target_mode` (+ `generated` property) |
@@ -551,7 +551,8 @@ Dumb components only. No fetch, no business rules.
 - Visual workflow builder
 - Model-selection UX
 - Reasoning Context Drawer until `/content-ops/execute` exposes an
-  explicit consumed-reasoning context or reasoning-audit result field.
+  explicit consumed-reasoning payload field. The current `reasoning`
+  audit only exposes readiness and `contexts_used` counts.
 - Collaboration / role-permission flows
 - CMS export
 - Approval workflow (no backend approval state on the control-surface
@@ -584,7 +585,7 @@ Every claim in this doc cites a real file:line at HEAD `a4020c1`:
 | `_step_for_output` per-runner shapes | `extracted_content_pipeline/generation_plan.py:165-266` |
 | `ContentOpsExecutionServices` | `extracted_content_pipeline/content_ops_execution.py:16-63` |
 | `ContentOpsExecutionResult` status logic | `extracted_content_pipeline/content_ops_execution.py:147-155` |
-| `ContentOpsStepExecution` | `extracted_content_pipeline/content_ops_execution.py:66-83` |
+| `ContentOpsStepExecution` | `extracted_content_pipeline/content_ops_execution.py:102-123` |
 | `SignalExtractionConfig` / `SignalExtractionResult` / `SignalExtractionService` | `extracted_content_pipeline/signal_extraction.py:19-81` |
 | `CampaignReasoningContext` (11 fields) | `extracted_content_pipeline/campaign_ports.py:53-99` |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -124,9 +124,12 @@
   UIs do not confuse package implementation status with runtime readiness. The
   output catalog also reports whether each output can consume host-provided
   reasoning context or does not use the reasoning-provider path.
-- Execution result summaries do not currently expose consumed reasoning
-  payloads. Hosts can see whether reasoning is configured in the catalog, but a
-  per-step reasoning drawer needs a future explicit execution-result field.
+- Execution result summaries expose compact reasoning consumption counts when a
+  generated-asset service reports them: runner results can include
+  `reasoning_contexts_used`, and the per-step `reasoning` audit mirrors that
+  count as `contexts_used`. Raw consumed reasoning payloads remain intentionally
+  absent, so a per-step reasoning drawer still needs a future explicit
+  execution-result field.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/plans/PR-Content-Ops-Reasoning-Status-Docs.md
+++ b/plans/PR-Content-Ops-Reasoning-Status-Docs.md
@@ -1,0 +1,51 @@
+# PR-Content-Ops-Reasoning-Status-Docs
+
+## Why this slice exists
+
+Recent Content Ops slices added consumed-reasoning counts to generated asset
+results and surfaced those counts in `ContentOpsStepExecution.reasoning`.
+`extracted_content_pipeline/STATUS.md` and one frontend-contract type table
+still describe the older state, which makes the product status look behind the
+runtime.
+
+## Scope (this PR)
+
+1. Update `STATUS.md` to describe the current execution-result reasoning audit.
+2. Update the frontend contract's frozen-dataclass field table for
+   `ContentOpsStepExecution`.
+3. Keep the Reasoning Context Drawer deferred because raw consumed reasoning
+   payloads are still intentionally not exposed.
+
+### Files touched
+
+- `extracted_content_pipeline/STATUS.md`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+This is a docs-only contract correction. It aligns the docs with the existing
+runtime shape:
+
+- `result.reasoning_contexts_used` is a runner-specific count when services
+  expose it.
+- `reasoning.contexts_used` is the compact per-step audit count.
+- Raw consumed reasoning payloads remain out of the execution response.
+
+## Intentional
+
+- No runtime or API shape changes.
+- No new Reasoning Context Drawer contract; only counts are documented.
+
+## Deferred
+
+- A future drawer-ready response field carrying raw consumed reasoning context.
+
+## Verification
+
+- `rg -n "do not currently expose consumed reasoning|ContentOpsStepExecution" extracted_content_pipeline/STATUS.md docs/frontend/content_ops_frontend_contract.md`
+- `git diff --check`
+
+## Estimated diff size
+
+About 3 files, under 50 changed lines.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Status-Docs.md

Correct the Content Ops status and frontend contract docs now that execution results expose compact reasoning consumption counts through `result.reasoning_contexts_used` and `reasoning.contexts_used`.

## Intentional
- Docs only; no runtime or API shape changes.
- Raw consumed reasoning payload remains out of the execution response.

## Deferred
- Reasoning Context Drawer still needs a future payload-bearing field.

## Verification
- rg -n "do not currently expose consumed reasoning|ContentOpsStepExecution" extracted_content_pipeline/STATUS.md docs/frontend/content_ops_frontend_contract.md
- git diff --check

## Diff size
4 files, +63 / -7
