### PR TITLE
PR-Audit-ManifestDrivenSmokes-2: convert compintel-standalone smoke to manifest-driven

### DIFF
--- a/plans/PR-Audit-ManifestDrivenSmokes-2.md
+++ b/plans/PR-Audit-ManifestDrivenSmokes-2.md
@@ -1,0 +1,163 @@
+# PR-Audit-ManifestDrivenSmokes-2: convert compintel-standalone smoke to manifest-driven
+
+## Why this slice exists
+
+Final smoke in the drift-protection track started by #427 and #428.
+`scripts/smoke_extracted_competitive_intelligence_standalone.py` (209
+LOC) still uses two hardcoded lists:
+
+- A 39-entry MODULES list for the import sweep (Phase 1).
+- A 26-entry `owned_files` tuple for the "still imports atlas_brain"
+  string scan (Phase 4).
+
+Both are drift hazards: when a new file enters the manifest, neither
+list is updated automatically.
+
+A diff between hardcoded and manifest reveals **real coverage gaps**:
+
+| Direction | Count | What |
+|---|---|---|
+| In hardcoded list, NOT in manifest | 14 | Untracked standalone shims (config, storage/database, pipelines/llm, ...). 9 are verified by Phase 2 owner checks; 5-6 only get import-time verification here. |
+| In manifest, NOT in hardcoded list | 6 | `b2b_battle_cards`, `b2b_vendor_briefing`, `autonomous/visibility`, `mcp/b2b/cross_vendor`, `mcp/b2b/displacement`, `services/b2b/product_claim` |
+| In hardcoded `owned_files`, NOT in manifest owned | 1 | `vendor_briefing_delivery` (which is actually a mapping; checking mappings for atlas_brain text is conceptually wrong) |
+| In manifest owned, NOT in hardcoded `owned_files` | 1 | `product_claim.py` |
+
+The manifest-driven refactor closes both drift hazards while preserving
+the substrate-verification concerns (Phases 2 and 3) intact.
+
+## Scope (this PR)
+
+Refactor two of the four phases in
+`smoke_extracted_competitive_intelligence_standalone.py`:
+
+- **Phase 1 (import sweep)**: replace hardcoded MODULES list with
+  manifest walk (mappings + owned), plus a small
+  `_EXTRA_STANDALONE_SHIMS` curated list for untracked standalone
+  substrate modules that should still get import-time verification.
+- **Phase 4 (owned-files atlas_brain scan)**: replace hardcoded
+  `owned_files` tuple with manifest `owned` walk.
+
+Untouched:
+
+- **Phase 2 (owner verification)**: 12 substrate-routing assertions.
+  Each entry is a specific module-attr-substrate triple, not a
+  drift-prone coverage list.
+- **Phase 3 (fallback probes)**: 6 module-level
+  `__atlas_fallback_probe__` checks. Same shape -- substrate
+  behavior, not coverage.
+
+## The `_EXTRA_STANDALONE_SHIMS` curated list
+
+Six standalone substrate modules are imported by the existing smoke
+but are not on the manifest:
+
+```python
+_EXTRA_STANDALONE_SHIMS = (
+    "extracted_competitive_intelligence.autonomous.tasks.campaign_suppression",
+    "extracted_competitive_intelligence.pipelines.llm",
+    "extracted_competitive_intelligence.services.b2b.pdf_renderer",
+    "extracted_competitive_intelligence.services.campaign_sender",
+    "extracted_competitive_intelligence.services.crm_provider",
+    "extracted_competitive_intelligence.services.email_provider",
+)
+```
+
+These are hand-rolled shims that satisfy imports under the standalone
+toggle. They were not added to the manifest's `owned` list when they
+were created (a separate methodology gap; see Deferred). To preserve
+import coverage today, they're listed as a small constant. Adding them
+to the manifest is the better fix; that's a separate slice.
+
+## Why keep Phase 2 hardcoded
+
+The `checks` list of 12 entries asserts that, e.g., `CompIntelSettings`
+resolves to `extracted_competitive_intelligence._standalone.config`,
+not to a fallback. Each entry encodes a substrate-routing decision,
+not a coverage list -- adding a new module-attr to verify requires
+the maintainer to know which substrate it should resolve to. Manifest
+walks can't infer that. Leave hardcoded.
+
+## Why keep Phase 3 hardcoded
+
+The 6-entry tuple of namespace modules that should not have
+`__atlas_fallback_probe__` is similarly non-drift-prone. It's a
+fixed set of namespaces where the substrate must fail closed under
+the toggle. Adding a new namespace requires knowing the fallback
+contract.
+
+## Failure classification
+
+Tighter than #427 / #428: under the standalone toggle, ALL imports
+should succeed (the toggle is meant to enable substrate-only
+operation). This smoke gates on any exception, not just decoupling
+ones. Matches the existing script's tight-gate behavior.
+
+If a 3rd-party env failure surfaces under standalone (which would be
+unusual since the substrate is meant to handle it), that is a real
+substrate gap and should fail the gate.
+
+## Intentional (looks wrong but is deliberate)
+
+- **Tighter gate than #427 / #428.** Different smoke, different
+  contract. Standalone-mode coverage should be hermetic.
+- **`_EXTRA_STANDALONE_SHIMS` is not just merged into the manifest
+  here.** Mixing a methodology change (adding entries to
+  `manifest.owned`) into a refactor PR couples concerns. The 6
+  shims will move to manifest in a follow-up slice.
+- **Phase 4 narrows from 26 to 26 entries** (one swap:
+  `vendor_briefing_delivery` (mapping) out, `product_claim` (owned)
+  in). Net coverage is unchanged in count but conceptually correct.
+  Mappings are byte-synced from atlas_brain and may legitimately
+  contain `atlas_brain.` text -- scanning them is a category error.
+- **Owner-verification (Phase 2) and fallback probes (Phase 3) stay
+  hardcoded.** They're not coverage lists; they're substrate
+  contracts.
+- **No DRY extraction of manifest walk into shared helper.** This
+  is the 4th caller, but the previous 3 share an identical Phase-1-
+  only shape; this script has Phases 1, 2, 3, 4 layered. Premature
+  abstraction. Wait for a 5th caller.
+
+## Deferred (looks missing but is on purpose)
+
+- Add the 6 `_EXTRA_STANDALONE_SHIMS` to `manifest.json:owned`.
+  Methodology change; separate slice.
+- Refactor Phases 2 and 3 to be data-driven (e.g., declarative
+  config files). Different concern from drift hazard.
+- Extract a shared manifest-walk helper (wait for 5th caller).
+- Catch the broader methodology gap (50+ untracked .py files in
+  `extracted_content_pipeline`).
+
+## Verification
+
+- `python3 scripts/smoke_extracted_competitive_intelligence_standalone.py`
+  -> exits 0 with all phases green.
+- New regression test asserts the smoke passes in current state and
+  that `_load_modules` includes both manifest entries and the
+  extra-shims constant.
+- `bash scripts/check_ascii_python.sh` -> passed.
+- Repeat full sweep across both packages: 0 standalone-import
+  failures.
+
+## Conflict check
+
+- No file overlap with any open PR.
+- Independent of #422, #425, #427, #428 (all merged).
+
+## Diff size
+
+- Script refactor: ~50-80 LOC (replace MODULES + owned_files with
+  manifest walk + extras; keep Phases 2, 3 untouched)
+- Regression test: ~80 LOC
+- Plan doc: ~140 LOC
+
+## After this lands
+
+All 4 smokes we control are drift-resistant on their drift-prone
+lists. The class of failures that bit #422 and #425 cannot recur in
+either default-mode or standalone-mode for either package. Remaining
+methodology debt:
+
+- 6 standalone shims still untracked in compintel manifest (queued
+  for follow-up).
+- ~50 untracked .py files in `extracted_content_pipeline`
+  (methodology question -- separate concern).

--- a/scripts/smoke_extracted_competitive_intelligence_standalone.py
+++ b/scripts/smoke_extracted_competitive_intelligence_standalone.py
@@ -1,62 +1,94 @@
 #!/usr/bin/env python3
-"""Smoke-check the competitive-intelligence standalone substrate."""
+"""Standalone-mode smoke-check for extracted_competitive_intelligence.
+
+Four phases:
+
+1. **Import sweep** -- manifest-driven (mappings + owned) plus a small
+   curated list of standalone substrate modules not yet on the
+   manifest. Catches drift when a new mirror is added.
+2. **Owner verification** -- specific module-attr-substrate triples
+   that assert the standalone substrate is being used (not a fallback).
+   Hardcoded by design: each entry encodes a substrate-routing
+   decision.
+3. **Atlas-fallback probes** -- namespaces that must fail closed
+   under the toggle. Hardcoded by design.
+4. **Owned-files atlas_brain scan** -- manifest-driven (owned only).
+   Mappings are byte-synced from atlas_brain and may legitimately
+   contain atlas_brain. text; scanning them is a category error.
+
+Failure gate: any exception or check failure breaks the gate.
+Tighter than the default-mode smokes (#427, #428) -- under the
+standalone toggle, the substrate is meant to handle everything; any
+import failure is a substrate gap.
+
+See plans/PR-Audit-ManifestDrivenSmokes-2.md for rationale.
+"""
 
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "extracted_competitive_intelligence"
+
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 os.environ["EXTRACTED_COMP_INTEL_STANDALONE"] = "1"
 os.environ.setdefault("EXTRACTED_LLM_INFRA_STANDALONE", "1")
 
-MODULES = [
-    "extracted_competitive_intelligence.config",
-    "extracted_competitive_intelligence.storage.database",
-    "extracted_competitive_intelligence.auth.dependencies",
-    "extracted_competitive_intelligence.services.protocols",
-    "extracted_competitive_intelligence.services.llm_router",
-    "extracted_competitive_intelligence.services.vendor_registry",
-    "extracted_competitive_intelligence.services.vendor_target_selection",
+
+# Standalone substrate modules that are imported but not yet listed in
+# the manifest. Adding them to manifest.owned is a separate slice (see
+# Deferred section in plans/PR-Audit-ManifestDrivenSmokes-2.md).
+_EXTRA_STANDALONE_SHIMS = (
+    "extracted_competitive_intelligence.autonomous.tasks.campaign_suppression",
+    "extracted_competitive_intelligence.pipelines.llm",
+    "extracted_competitive_intelligence.services.b2b.pdf_renderer",
     "extracted_competitive_intelligence.services.campaign_sender",
     "extracted_competitive_intelligence.services.crm_provider",
     "extracted_competitive_intelligence.services.email_provider",
-    "extracted_competitive_intelligence.services.scraping.capabilities",
-    "extracted_competitive_intelligence.services.scraping.sources",
-    "extracted_competitive_intelligence.autonomous.tasks.campaign_suppression",
-    "extracted_competitive_intelligence.mcp.b2b.vendor_registry",
-    "extracted_competitive_intelligence.mcp.b2b.write_ports",
-    "extracted_competitive_intelligence.mcp.b2b.write_intelligence",
-    "extracted_competitive_intelligence.pipelines.llm",
-    "extracted_competitive_intelligence.templates.email.vendor_briefing",
-    "extracted_competitive_intelligence.services.b2b.source_impact",
-    "extracted_competitive_intelligence.services.b2b.anthropic_batch",
-    "extracted_competitive_intelligence.services.b2b.challenger_dashboard_claims",
-    "extracted_competitive_intelligence.services.b2b.competitive_set_ports",
-    "extracted_competitive_intelligence.services.b2b.battle_card_ports",
-    "extracted_competitive_intelligence.services.b2b.vendor_briefing_delivery",
-    "extracted_competitive_intelligence.services.b2b.vendor_briefing_repository",
-    "extracted_competitive_intelligence.services.b2b.vendor_briefing_ports",
-    "extracted_competitive_intelligence.services.b2b.vendor_briefing_api_ports",
-    "extracted_competitive_intelligence.services.b2b.llm_exact_cache",
-    "extracted_competitive_intelligence.services.b2b.pdf_renderer",
-    "extracted_competitive_intelligence.services.b2b_competitive_sets",
-    "extracted_competitive_intelligence.autonomous.tasks._b2b_batch_utils",
-    "extracted_competitive_intelligence.autonomous.tasks._b2b_cross_vendor_synthesis",
-    "extracted_competitive_intelligence.reasoning.ecosystem",
-    "extracted_competitive_intelligence.reasoning.cross_vendor_selection",
-    "extracted_competitive_intelligence.reasoning.single_pass_prompts.cross_vendor_battle",
-    "extracted_competitive_intelligence.reasoning.single_pass_prompts.battle_card_reasoning",
-    "extracted_competitive_intelligence.templates.email.vendor_report_delivery",
-    "extracted_competitive_intelligence.templates.email.vendor_checkout_confirmation",
-    "extracted_competitive_intelligence.api.b2b_vendor_briefing",
-]
+)
+
+
+def _target_to_module(target: str) -> str:
+    assert target.endswith(".py"), target
+    base = target[: -len(".py")]
+    if base.endswith("/__init__"):
+        base = base[: -len("/__init__")]
+    return base.replace("/", ".")
+
+
+def _load_manifest() -> dict:
+    return json.loads((ROOT / PACKAGE / "manifest.json").read_text(encoding="utf-8"))
+
+
+def _load_modules(manifest: dict) -> list[str]:
+    """Manifest entries (mappings + owned) plus _EXTRA_STANDALONE_SHIMS."""
+    entries = manifest.get("mappings", []) + manifest.get("owned", [])
+    manifest_modules = {
+        _target_to_module(e["target"])
+        for e in entries
+        if e["target"].endswith(".py")
+        and "/migrations/" not in e["target"]
+        and not e["target"].endswith("/__init__.py")
+    }
+    return sorted(manifest_modules | set(_EXTRA_STANDALONE_SHIMS))
+
+
+def _load_owned_files(manifest: dict) -> list[Path]:
+    """Owned .py files from manifest -- the canonical set for the
+    'still imports atlas_brain' scan."""
+    return sorted(
+        ROOT / e["target"]
+        for e in manifest.get("owned", [])
+        if e["target"].endswith(".py")
+    )
 
 
 def _assert_owner(module_name: str, attr_name: str, expected_prefix: str) -> None:
@@ -71,7 +103,11 @@ def _assert_owner(module_name: str, attr_name: str, expected_prefix: str) -> Non
 
 def main() -> int:
     failed: list[str] = []
-    for module_name in MODULES:
+    manifest = _load_manifest()
+
+    # Phase 1 -- import sweep (manifest-driven + curated shims)
+    modules = _load_modules(manifest)
+    for module_name in modules:
         try:
             importlib.import_module(module_name)
             print(f"OK {module_name}", flush=True)
@@ -79,6 +115,7 @@ def main() -> int:
             print(f"FAIL {module_name}: {type(exc).__name__}: {exc}", flush=True)
             failed.append(module_name)
 
+    # Phase 2 -- owner verification (substrate routing assertions)
     checks = [
         (
             "extracted_competitive_intelligence.config",
@@ -148,6 +185,7 @@ def main() -> int:
             print(f"FAIL {module_name}.{attr_name}: {exc}", flush=True)
             failed.append(f"{module_name}.{attr_name}")
 
+    # Phase 3 -- fallback probes (substrate must fail closed)
     for module_name in (
         "extracted_competitive_intelligence.services",
         "extracted_competitive_intelligence.services.b2b",
@@ -164,36 +202,13 @@ def main() -> int:
         print(f"FAIL {module_name}: Atlas fallback did not fail closed", flush=True)
         failed.append(module_name)
 
-    owned_files = (
-        ROOT / "extracted_competitive_intelligence" / "services" / "vendor_registry.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "vendor_target_selection.py",
-        ROOT / "extracted_competitive_intelligence" / "mcp" / "b2b" / "vendor_registry.py",
-        ROOT / "extracted_competitive_intelligence" / "mcp" / "b2b" / "displacement.py",
-        ROOT / "extracted_competitive_intelligence" / "mcp" / "b2b" / "cross_vendor.py",
-        ROOT / "extracted_competitive_intelligence" / "mcp" / "b2b" / "write_intelligence.py",
-        ROOT / "extracted_competitive_intelligence" / "mcp" / "b2b" / "write_ports.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "scraping" / "capabilities.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "source_impact.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "challenger_dashboard_claims.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "competitive_set_ports.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "battle_card_ports.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "vendor_briefing_delivery.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "vendor_briefing_ports.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b" / "vendor_briefing_api_ports.py",
-        ROOT / "extracted_competitive_intelligence" / "services" / "b2b_competitive_sets.py",
-        ROOT / "extracted_competitive_intelligence" / "autonomous" / "tasks" / "_b2b_batch_utils.py",
-        ROOT / "extracted_competitive_intelligence" / "autonomous" / "tasks" / "_b2b_cross_vendor_synthesis.py",
-        ROOT / "extracted_competitive_intelligence" / "templates" / "email" / "vendor_briefing.py",
-        ROOT / "extracted_competitive_intelligence" / "templates" / "email" / "vendor_report_delivery.py",
-        ROOT / "extracted_competitive_intelligence" / "templates" / "email" / "vendor_checkout_confirmation.py",
-        ROOT / "extracted_competitive_intelligence" / "api" / "b2b_vendor_briefing.py",
-        ROOT / "extracted_competitive_intelligence" / "reasoning" / "ecosystem.py",
-        ROOT / "extracted_competitive_intelligence" / "reasoning" / "cross_vendor_selection.py",
-        ROOT / "extracted_competitive_intelligence" / "reasoning" / "single_pass_prompts" / "cross_vendor_battle.py",
-        ROOT / "extracted_competitive_intelligence" / "reasoning" / "single_pass_prompts" / "battle_card_reasoning.py",
-    )
-    for module_path in owned_files:
-        if "atlas_brain." in module_path.read_text():
+    # Phase 4 -- owned-files atlas_brain scan (manifest-driven)
+    for module_path in _load_owned_files(manifest):
+        if not module_path.exists():
+            print(f"FAIL {module_path.relative_to(ROOT)}: missing owned file", flush=True)
+            failed.append(str(module_path.relative_to(ROOT)))
+            continue
+        if "atlas_brain." in module_path.read_text(encoding="utf-8"):
             print(f"FAIL {module_path.relative_to(ROOT)}: still imports Atlas", flush=True)
             failed.append(str(module_path.relative_to(ROOT)))
 

--- a/tests/test_extracted_compintel_standalone_smoke.py
+++ b/tests/test_extracted_compintel_standalone_smoke.py
@@ -1,0 +1,128 @@
+"""Regression test for the manifest-driven compintel-standalone smoke.
+
+Pins three contracts:
+
+1. ``scripts/smoke_extracted_competitive_intelligence_standalone.py``
+   exits 0 in the current state (all 4 phases green).
+2. ``_load_modules`` returns the union of manifest entries (mappings +
+   owned, filtering migrations + ``__init__.py``) and the
+   ``_EXTRA_STANDALONE_SHIMS`` constant.
+3. ``_load_owned_files`` returns only entries from manifest ``owned``
+   (mappings are byte-synced from atlas_brain and may legitimately
+   contain ``atlas_brain.`` text).
+
+See plans/PR-Audit-ManifestDrivenSmokes-2.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE_SCRIPT = (
+    ROOT / "scripts" / "smoke_extracted_competitive_intelligence_standalone.py"
+)
+
+
+def _load_smoke_module():
+    spec = importlib.util.spec_from_file_location("_compintel_smoke_under_test", SMOKE_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_smoke_script_exists():
+    assert SMOKE_SCRIPT.exists(), f"missing: {SMOKE_SCRIPT}"
+    first_line = SMOKE_SCRIPT.read_text(encoding="utf-8").splitlines()[0]
+    assert first_line.startswith("#!"), "missing shebang"
+
+
+def test_smoke_passes_in_current_state():
+    """All 4 phases (import, owner-verify, fallback-probe, atlas-scan)
+    pass under the standalone toggle."""
+    result = subprocess.run(
+        [sys.executable, str(SMOKE_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=str(ROOT),
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+    assert result.returncode == 0, (
+        f"compintel standalone smoke exited {result.returncode}; "
+        f"see stdout/stderr above for the failing phase."
+    )
+
+
+def test_load_modules_includes_manifest_and_extras():
+    smoke = _load_smoke_module()
+    manifest = smoke._load_manifest()
+    modules = smoke._load_modules(manifest)
+
+    # Every extras entry must show up in the union.
+    for shim in smoke._EXTRA_STANDALONE_SHIMS:
+        assert shim in modules, f"extras shim missing from _load_modules: {shim}"
+
+    # Every manifest .py target (excl migrations + __init__) shows up.
+    expected_manifest_modules = {
+        smoke._target_to_module(e["target"])
+        for e in manifest.get("mappings", []) + manifest.get("owned", [])
+        if e["target"].endswith(".py")
+        and "/migrations/" not in e["target"]
+        and not e["target"].endswith("/__init__.py")
+    }
+    for m in expected_manifest_modules:
+        assert m in modules, f"manifest module missing from _load_modules: {m}"
+
+
+def test_load_owned_files_excludes_mappings():
+    smoke = _load_smoke_module()
+    manifest = smoke._load_manifest()
+    owned_files = smoke._load_owned_files(manifest)
+
+    expected_owned = {
+        ROOT / e["target"]
+        for e in manifest.get("owned", [])
+        if e["target"].endswith(".py")
+    }
+    assert set(owned_files) == expected_owned
+
+    # And concretely: vendor_briefing_delivery is a mapping and must
+    # NOT be in owned-files (this was the conceptual bug in the
+    # pre-PR hardcoded list).
+    mapping_path = ROOT / "extracted_competitive_intelligence/services/b2b/vendor_briefing_delivery.py"
+    assert mapping_path not in set(owned_files), (
+        "owned-files scan must not include manifest mappings"
+    )
+
+
+def test_target_to_module_handles_init_files():
+    smoke = _load_smoke_module()
+    pkg = smoke.PACKAGE
+    assert smoke._target_to_module(f"{pkg}/foo/bar.py") == f"{pkg}.foo.bar"
+    assert smoke._target_to_module(f"{pkg}/foo/__init__.py") == f"{pkg}.foo"
+
+
+def test_extras_constant_is_documented_as_methodology_gap():
+    """The _EXTRA_STANDALONE_SHIMS constant exists because some
+    standalone shims aren't yet on the manifest. This is a known
+    methodology gap. If the constant changes, the plan should
+    reflect the new state."""
+    smoke = _load_smoke_module()
+    # Just assert the constant is non-empty -- any change to its
+    # contents should be deliberate and reviewed.
+    assert len(smoke._EXTRA_STANDALONE_SHIMS) >= 1
+    # And every entry must be a string starting with the package name.
+    for entry in smoke._EXTRA_STANDALONE_SHIMS:
+        assert isinstance(entry, str)
+        assert entry.startswith(smoke.PACKAGE + ".")


### PR DESCRIPTION
**Plan:** [`plans/PR-Audit-ManifestDrivenSmokes-2.md`](../blob/claude/audit-manifest-driven-smokes-2/plans/PR-Audit-ManifestDrivenSmokes-2.md)

## Summary

Final smoke in the drift-protection track started by #427 (pipeline-standalone) and #428 (default-mode for both packages). The compintel-standalone smoke had two hardcoded lists drifting from the manifest:

- 39-entry MODULES list (Phase 1 import sweep)
- 26-entry `owned_files` tuple (Phase 4 atlas_brain scan)

Diff vs. manifest revealed **real coverage gaps**:

| Direction | Count | What |
|---|---|---|
| In hardcoded MODULES, NOT in manifest | 14 | Untracked standalone shims (9 covered by Phase 2 owner-verification; 6 only here) |
| In manifest, NOT in hardcoded MODULES | 6 | `b2b_battle_cards`, `b2b_vendor_briefing`, `autonomous.visibility`, `mcp.b2b.cross_vendor`, `mcp.b2b.displacement`, `services.b2b.product_claim` -- coverage gaps the smoke missed |
| In hardcoded `owned_files`, NOT in manifest owned | 1 | `vendor_briefing_delivery` (a mapping; checking mappings for atlas_brain text is a category error) |
| In manifest owned, NOT in hardcoded `owned_files` | 1 | `product_claim.py` (real coverage gap) |

## What changed

**Phase 1 (import sweep)** -- now: manifest mappings + owned + `_EXTRA_STANDALONE_SHIMS` curated list (6 entries) for untracked standalone substrate modules. 37 imports total (was 39, but 6 manifest gaps closed and 8 redundant-with-Phase-2 entries pruned).

**Phase 4 (owned-files atlas_brain scan)** -- now: manifest owned only. Mappings are byte-synced from atlas_brain and may legitimately contain `atlas_brain.` text; scanning them is a category error.

**Phase 2 (owner verification)** -- untouched. The 12 module-attr-substrate triples encode substrate-routing decisions, not coverage lists.

**Phase 3 (fallback probes)** -- untouched. The 6-entry namespace tuple encodes substrate fail-closed contract, not coverage.

## The `_EXTRA_STANDALONE_SHIMS` constant

6 standalone substrate modules imported but not yet on manifest:

```python
_EXTRA_STANDALONE_SHIMS = (
    "extracted_competitive_intelligence.autonomous.tasks.campaign_suppression",
    "extracted_competitive_intelligence.pipelines.llm",
    "extracted_competitive_intelligence.services.b2b.pdf_renderer",
    "extracted_competitive_intelligence.services.campaign_sender",
    "extracted_competitive_intelligence.services.crm_provider",
    "extracted_competitive_intelligence.services.email_provider",
)
```

Adding them to manifest is a separate slice (mixing methodology change into refactor PR couples concerns).

## Intentional (looks wrong but is deliberate)

- **Tighter gate than #427 / #428.** Under standalone toggle, the substrate handles everything; any import failure is a substrate gap. Matches existing tight-gate behavior.
- **Phase 4 swap** (`vendor_briefing_delivery` out, `product_claim` in) is conceptually correct: only owned files belong in this scan.
- **Phase 2 / Phase 3 stay hardcoded.** They're substrate contracts, not coverage lists.
- **No DRY extraction of manifest walk into shared helper.** This is the 4th caller, but the previous 3 share a Phase-1-only shape; this script has 4 phases layered. Premature abstraction. Wait for a 5th caller.

## Deferred (looks missing but is on purpose)

- Add the 6 `_EXTRA_STANDALONE_SHIMS` to `manifest.json:owned`. Methodology change; separate slice.
- Refactor Phases 2/3 to be data-driven. Different concern.
- Extract a shared manifest-walk helper. Wait for 5th caller.
- Catch broader methodology gap (~50 untracked .py files in `extracted_content_pipeline`).

## Verification

- [x] `python3 scripts/smoke_extracted_competitive_intelligence_standalone.py` -> exits 0, all 4 phases green
- [x] `pytest tests/test_extracted_compintel_standalone_smoke.py -v` -> 6 passed
- [x] `bash scripts/check_ascii_python.sh` -> passed

## Conflict check

- No file overlap with any open PR.
- Independent of #422, #425, #427, #428 (all merged).

## Diff size

- Script refactor: 70 LOC removed, 130 LOC added (net +60 source)
- Regression test: 124 LOC, 6 tests
- Plan doc: 156 LOC

## After this lands

All 4 smokes we control are drift-resistant on their drift-prone lists:

| Smoke | Mode | Coverage | Status |
|---|---|---|---|
| `pipeline_imports` | default | manifest-driven | ✅ #428 |
| `pipeline_standalone` | standalone | manifest-driven | ✅ #427 |
| `compintel_imports` | default | manifest-driven | ✅ #428 |
| `compintel_standalone` | standalone | manifest-driven + extras | **this PR** |

The class of failures that bit #422 and #425 cannot recur in either package's default-mode or standalone-mode CI gates.

Remaining methodology debt (separate slices):
- 6 standalone shims still untracked in compintel manifest (queued)
- ~50 untracked .py files in `extracted_content_pipeline` (separate concern)

## Test plan

- [x] All 4 phases pass in current state
- [x] 6/6 regression tests pass
- [x] `_load_modules` covers both manifest entries and extras
- [x] `_load_owned_files` correctly excludes mappings (only includes owned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)