### PR TITLE
Lock campaign export API reasoning fields

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:18Z by codex-content-ops-export-api-docs
+Last updated: 2026-05-09T20:22Z by codex-content-ops-export-api-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Lock Content Ops API export routes to campaign reasoning summary fields | EDIT: `tests/test_extracted_campaign_api_b2b_campaigns.py`; `tests/test_extracted_campaign_api_seller_campaigns.py`; `extracted_content_pipeline/docs/host_install_runbook.md`; docs/tests only. | codex-content-ops-export-api-docs | Avoid campaign API export route tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:14Z by codex-content-ops-reasoning-status-docs
+Last updated: 2026-05-09T20:18Z by codex-content-ops-export-api-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Lock Content Ops API export routes to campaign reasoning summary fields | EDIT: `tests/test_extracted_campaign_api_b2b_campaigns.py`; `tests/test_extracted_campaign_api_seller_campaigns.py`; `extracted_content_pipeline/docs/host_install_runbook.md`; docs/tests only. | codex-content-ops-export-api-docs | Avoid campaign API export route tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -439,6 +439,10 @@ The router exposes:
 | `GET` | `/b2b/campaigns/drafts/export` | Export scoped drafts as CSV or JSON. |
 | `POST` | `/b2b/campaigns/drafts/review` | Approve, queue, cancel, or expire selected drafts. |
 
+The mounted list/export routes use the same export helper as the CLI, so JSON
+and CSV responses include the generation-usage and reasoning summary fields
+documented above.
+
 Amazon seller installs can mount the seller-specific router:
 
 ```python

--- a/plans/PR-Content-Ops-Export-API-Reasoning-Fields.md
+++ b/plans/PR-Content-Ops-Export-API-Reasoning-Fields.md
@@ -1,0 +1,53 @@
+# PR-Content-Ops-Export-API-Reasoning-Fields
+
+## Why this slice exists
+
+PR #429 added generation-usage and reasoning summary fields to the shared
+campaign draft export helper. The host-mounted B2B and seller FastAPI export
+routes delegate to that helper, but their route tests still only assert generic
+CSV/JSON shape. This slice locks the API surfaces to the same export contract.
+
+## Scope (this PR)
+
+1. Add B2B router assertions that JSON and CSV exports include derived
+   generation/reasoning summary fields.
+2. Add seller router assertions that CSV exports include those same fields.
+3. Clarify host docs that the mounted API export routes expose the same
+   summary fields as the CLI.
+
+### Files touched
+
+- `tests/test_extracted_campaign_api_b2b_campaigns.py`
+- `tests/test_extracted_campaign_api_seller_campaigns.py`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+No production code changes. The existing routers call `list_campaign_drafts()`;
+these tests seed rows with metadata containing `generation_usage`,
+`generation_parse_attempts`, and `reasoning_context`, then assert the router
+responses expose the derived fields added by the shared export helper.
+
+## Intentional
+
+- This is test/docs only because the runtime path already delegates to the
+  shared helper.
+- The seller route is CSV-only in this slice because that route's existing
+  export test covers CSV; JSON behavior is already covered through the shared
+  B2B/export helper path.
+
+## Deferred
+
+- Asset exports outside campaign drafts remain separate work.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_campaign_api_b2b_campaigns.py tests/test_extracted_campaign_api_seller_campaigns.py` (53 passed)
+- `bash scripts/run_extracted_pipeline_checks.sh` (1374 passed, 1 existing torch/pynvml warning)
+- `git diff --check`
+- Non-ASCII byte check for edited Python files (clean)
+
+## Estimated diff size
+
+About 4 files, under 100 changed lines.

--- a/tests/test_extracted_campaign_api_b2b_campaigns.py
+++ b/tests/test_extracted_campaign_api_b2b_campaigns.py
@@ -45,7 +45,19 @@ def _draft_row(**overrides):
         "cta": "Review plan",
         "llm_model": "offline",
         "created_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
-        "metadata": {"scope": {"account_id": "acct_1"}},
+        "metadata": {
+            "scope": {"account_id": "acct_1"},
+            "generation_usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+            },
+            "generation_parse_attempts": 2,
+            "reasoning_context": {
+                "wedge": "price_squeeze",
+                "confidence": "high",
+            },
+        },
     }
     row.update(overrides)
     return row
@@ -147,7 +159,10 @@ def test_b2b_campaign_router_exports_csv() -> None:
         response.headers["content-disposition"]
     )
     assert "company_name,vendor_name" in response.text
+    assert "generation_input_tokens,generation_output_tokens" in response.text
+    assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in response.text
     assert "Acme" in response.text
+    assert "price_squeeze" in response.text
 
 
 def test_b2b_campaign_router_exports_json_when_requested() -> None:
@@ -156,7 +171,15 @@ def test_b2b_campaign_router_exports_json_when_requested() -> None:
     response = _client(pool).get("/b2b/campaigns/drafts/export?format=json")
 
     assert response.status_code == 200
-    assert response.json()["rows"][0]["vendor_name"] == "LegacyCRM"
+    row = response.json()["rows"][0]
+    assert row["vendor_name"] == "LegacyCRM"
+    assert row["generation_input_tokens"] == 10
+    assert row["generation_output_tokens"] == 5
+    assert row["generation_total_tokens"] == 15
+    assert row["generation_parse_attempts"] == 2
+    assert row["reasoning_context_used"] is True
+    assert row["reasoning_wedge"] == "price_squeeze"
+    assert row["reasoning_confidence"] == "high"
 
 
 def test_b2b_campaign_router_rejects_unknown_export_format() -> None:

--- a/tests/test_extracted_campaign_api_seller_campaigns.py
+++ b/tests/test_extracted_campaign_api_seller_campaigns.py
@@ -91,7 +91,19 @@ def _campaign_row(**overrides):
         "cta": "Review category report",
         "llm_model": "offline",
         "created_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
-        "metadata": {"scope": {"account_id": "acct_1"}},
+        "metadata": {
+            "scope": {"account_id": "acct_1"},
+            "generation_usage": {
+                "input_tokens": 8,
+                "output_tokens": 4,
+                "total_tokens": 12,
+            },
+            "generation_parse_attempts": 1,
+            "reasoning_context": {
+                "wedge": "category_shift",
+                "confidence": "medium",
+            },
+        },
     }
     row.update(overrides)
     return row
@@ -993,7 +1005,10 @@ def test_seller_campaign_router_exports_seller_drafts_csv() -> None:
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/csv")
     assert "seller_campaign_drafts.csv" in response.headers["content-disposition"]
+    assert "generation_input_tokens,generation_output_tokens" in response.text
+    assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in response.text
     assert "Acme Seller" in response.text
+    assert "category_shift" in response.text
 
 
 def test_seller_campaign_router_reviews_only_seller_drafts() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Export-API-Reasoning-Fields.md

Lock the host-mounted B2B and seller campaign export API routes to the same generation-usage and reasoning summary fields exposed by the shared campaign draft export helper.

## Intentional
- Tests/docs only; no production code changes.
- The routers already delegate to `list_campaign_drafts()`, so this PR locks behavior at the API boundary.
- Seller route coverage stays CSV-only because its existing export route test is CSV-shaped; B2B covers JSON and CSV.

## Deferred
- Non-campaign generated asset exports remain separate slices.

## Verification
- python -m pytest tests/test_extracted_campaign_api_b2b_campaigns.py tests/test_extracted_campaign_api_seller_campaigns.py (53 passed)
- bash scripts/run_extracted_pipeline_checks.sh (1374 passed, 1 existing torch/pynvml warning)
- git diff --check
- Non-ASCII byte check for edited Python files (clean)

## Diff size
5 files, +100 / -4
