### PR TITLE
PR-D6f: Cache-Control: no-store request header bypass

### DIFF
--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -301,13 +301,36 @@ async def _resolve_byok_or_503(pool, provider: str, account_id: str) -> str:
 # ---- /chat (sync) -------------------------------------------------------
 
 
+def _cache_control_disables_cache(cache_control: str | None) -> bool:
+    """Return True when the request's ``Cache-Control`` header carries
+    a ``no-store`` directive (RFC 7234). Customer-supplied bypass for
+    sensitive prompts they don't want cached. Header is comma-separated
+    directives; presence of ``no-store`` (case-insensitive, with or
+    without a value) disables both lookup and store."""
+    if not cache_control:
+        return False
+    for directive in cache_control.split(","):
+        token = directive.strip().lower()
+        # Some Cache-Control directives take args (e.g. max-age=N);
+        # strip the value suffix before comparing the directive name.
+        token = token.split("=", 1)[0].strip()
+        if token == "no-store":
+            return True
+    return False
+
+
 @router.post("/chat", response_model=ChatResponse)
 async def chat(
     body: ChatRequest,
     user: AuthUser = Depends(require_llm_plan("llm_trial")),
+    cache_control: str | None = Header(default=None, alias="Cache-Control"),
 ) -> ChatResponse:
     """Sync chat completion. Account-scoped via the API key auth path
-    (PR-D1) and plan-gated to llm_trial+ (PR-D2)."""
+    (PR-D1) and plan-gated to llm_trial+ (PR-D2).
+
+    PR-D6f: customer-supplied ``Cache-Control: no-store`` header
+    bypasses both the exact-cache lookup and the post-call store.
+    Useful for sensitive prompts the customer doesn't want cached."""
     _validate_chat_provider(body.provider)
 
     pool = get_db_pool()
@@ -351,8 +374,10 @@ async def chat(
         temperature=body.temperature,
         extra={"system": system_prompt} if system_prompt else None,
     )
+    cache_disabled = _cache_control_disables_cache(cache_control)
+
     cache_hit = None
-    if is_llm_gateway_exact_cache_enabled():
+    if is_llm_gateway_exact_cache_enabled() and not cache_disabled:
         try:
             cache_hit = await lookup_cached_text(
                 _LLM_CHAT_CACHE_NAMESPACE,
@@ -493,9 +518,10 @@ async def chat(
     # PR-D6b: store the response in the exact cache so an identical
     # subsequent call from this account hits. Skipped on empty
     # response (lookup_cached_text would treat it as a non-hit anyway)
-    # and on flag off. Cache write failures must not fail the chat
-    # response -- log and proceed.
-    if text and is_llm_gateway_exact_cache_enabled():
+    # and on flag off. PR-D6f: also skipped when the request carries
+    # ``Cache-Control: no-store``. Cache write failures must not fail
+    # the chat response -- log and proceed.
+    if text and is_llm_gateway_exact_cache_enabled() and not cache_disabled:
         try:
             await store_cached_text(
                 _LLM_CHAT_CACHE_NAMESPACE,

--- a/plans/PR-D6f-cache-control-no-store.md
+++ b/plans/PR-D6f-cache-control-no-store.md
@@ -1,0 +1,138 @@
+# PR-D6f: `Cache-Control: no-store` request header bypass
+
+## Why this slice exists
+
+Item #4 in the post-D6b LLM Gateway follow-up queue (locked
+2026-05-05). Customer-supplied bypass for sensitive prompts they
+don't want cached. Standard HTTP caching convention (RFC 7234).
+
+> **Touches**: `chat` route accepts an optional `Cache-Control`
+> header (FastAPI `Header(default=None)`); when set to `no-store`,
+> skip both lookup and store.
+> **Success criterion**: a request with `Cache-Control: no-store`
+> always calls Anthropic and never writes to the cache, even when
+> the gateway-cache flag is enabled.
+
+PR-D6e (item #1) shipped the `cached: bool` field on `ChatResponse`
+so customers can detect cache hits explicitly. This PR is the
+counterpart: the customer's tool to **suppress** caching when they
+need to.
+
+## Scope (this PR)
+
+Three changes to `atlas_brain/api/llm_gateway.py`:
+
+1. New helper `_cache_control_disables_cache(cache_control)` parses
+   the comma-separated directives and returns True iff `no-store` is
+   present (case-insensitive, with or without a value suffix).
+2. `chat()` accepts an optional `Cache-Control` request header via
+   FastAPI's `Header(default=None, alias="Cache-Control")`.
+3. Both the exact-cache lookup branch and the post-call store branch
+   skip when `cache_disabled` is True. The lookup is gated alongside
+   the existing feature-flag check; the store gets the same guard.
+
+The cache-disabled path falls through to a normal Anthropic call,
+which already returns `cached=False` (PR-D6e). No additional response
+shape change.
+
+## Header parsing
+
+```python
+def _cache_control_disables_cache(cache_control: str | None) -> bool:
+    if not cache_control:
+        return False
+    for directive in cache_control.split(","):
+        token = directive.strip().lower()
+        token = token.split("=", 1)[0].strip()
+        if token == "no-store":
+            return True
+    return False
+```
+
+Handles RFC 7234 reality:
+
+- `Cache-Control: no-store` -> disable.
+- `Cache-Control: no-cache, no-store` -> disable (both directives,
+  one matches).
+- `Cache-Control: NO-STORE` -> disable (case-insensitive).
+- `Cache-Control: max-age=0` -> not disable (different directive).
+- `Cache-Control: maybe-no-store` -> not disable (substring match
+  would be wrong; we tokenize on commas + equals).
+- `Cache-Control: ` (empty/whitespace) -> not disable.
+
+## API contract change
+
+**Additive only.** Optional request header; absent header means
+"caching follows the gateway-cache flag" (existing behavior). No
+existing client breaks.
+
+## Intentional (looks wrong but is deliberate)
+
+- **`no-store` only, not `no-cache`.** RFC 7234 distinguishes them:
+  `no-store` means "don't store this anywhere"; `no-cache` means
+  "always revalidate before using a cached copy." For an LLM API,
+  `no-store` is the right semantic for "don't cache this prompt."
+  `no-cache` is closer to "always re-run" -- a different concept that
+  could be added later if customers ask.
+- **No corresponding response header.** A `Cache-Control` response
+  header (e.g., `max-age`) would tell the customer how long the
+  cached entry is valid. The exact cache today has a fixed TTL
+  managed server-side; no per-call control needed yet.
+- **No analogous gate on `/chat/stream` or `/batch`.** Streaming +
+  cache (queue item #3) and batch + cache (queue item #6) aren't
+  wired yet; bypass headers will be added there when the cache
+  layers are.
+- **Helper function is module-private (underscore prefix).** No
+  reason to export it; the chat route is the only consumer. If a
+  future endpoint needs the same parsing, promote then.
+- **Bypass flips both lookup AND store.** Bypassing only the lookup
+  would still write the customer's "sensitive" prompt to the cache,
+  defeating the purpose. Bypassing only the store would still read
+  from a previous (possibly sensitive) cached entry. Both must skip.
+
+## Deferred (looks missing but is on purpose)
+
+- Items #3, #5, #6 in the post-D6b queue (`/chat/stream` cache,
+  semantic cache, `/batch` cache). Each is its own slice.
+- `no-cache` directive support. Different semantic; add when a
+  customer asks.
+- `private`, `must-revalidate`, etc. Out of scope; this slice is
+  about opt-out for sensitive prompts.
+
+## Verification
+
+- New regression tests
+  `tests/test_llm_gateway_cache_control_no_store.py`:
+  - `_cache_control_disables_cache(None)` -> False
+  - `_cache_control_disables_cache("no-store")` -> True
+  - `_cache_control_disables_cache("no-cache, no-store")` -> True
+  - `_cache_control_disables_cache("NO-STORE")` -> True
+  - `_cache_control_disables_cache("max-age=0")` -> False
+  - `_cache_control_disables_cache("maybe-no-store")` -> False
+  - `_cache_control_disables_cache("")` -> False
+  - File-text assertions: lookup branch + store branch both gate on
+    `not cache_disabled`.
+- `python3 -m py_compile atlas_brain/api/llm_gateway.py` -> clean.
+- `bash scripts/check_ascii_python.sh` -> passed.
+
+## Conflict check
+
+No file overlap with any open PR.
+
+## Diff size
+
+- Source: ~25 LOC additions to `atlas_brain/api/llm_gateway.py`
+  (helper function + header param + 2 guard updates).
+- Tests: ~80 LOC, 8 unit tests + 2 file-text contract assertions.
+- Plan doc: ~110 LOC.
+
+Source-only ~25 LOC. Smallest scope that closes queue item #4 with
+correct RFC-7234 directive parsing.
+
+## After this lands
+
+Customer-supplied cache opt-out works on sync `/chat`. Three queue
+items closed (#1 PR-D6e, #2 PR-D6c, #4 this PR); three remain (#3
+streaming cache, #5 semantic cache, #6 batch cache). Of those, #5
+(semantic cache) is the highest-value next slice -- it's "the second
+cache layer in the 5-layer pitch" and the substrate already exists.

--- a/tests/test_llm_gateway_cache_control_no_store.py
+++ b/tests/test_llm_gateway_cache_control_no_store.py
@@ -1,0 +1,157 @@
+"""Regression tests for PR-D6f: ``Cache-Control: no-store`` bypass.
+
+Pins two contracts:
+
+1. ``_cache_control_disables_cache`` correctly parses the
+   ``Cache-Control`` header per RFC 7234 -- ``no-store`` matches
+   regardless of case, accompanying directives, or value suffix;
+   non-matching tokens (``max-age``, substrings) do not.
+2. The chat() function gates BOTH the lookup branch AND the store
+   branch on ``not cache_disabled`` so a no-store request bypasses
+   both legs of the cache.
+
+Tests for the helper use file-text inspection to extract and
+re-execute its source; tests for the gate use file-text assertions
+on the chat() body. Bypasses the gateway module's full settings
+stack which depends on
+``ATLAS_SAAS_API_KEY_PEPPER`` / ``ATLAS_SAAS_BYOK_ENCRYPTION_KEK``.
+
+See plans/PR-D6f-cache-control-no-store.md.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GATEWAY_PATH = ROOT / "atlas_brain" / "api" / "llm_gateway.py"
+
+
+@pytest.fixture(scope="module")
+def gateway_source() -> str:
+    return GATEWAY_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def helper():
+    """Extract _cache_control_disables_cache from the source and exec
+    it in a sealed namespace. Avoids importing the full gateway
+    module (which requires SAAS env config)."""
+    src = GATEWAY_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"^def _cache_control_disables_cache\(.*?(?=\n(?:\ndef |\nclass |\n@router\.))",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, "Could not locate _cache_control_disables_cache in source"
+    namespace: dict = {}
+    exec(match.group(0), namespace)
+    return namespace["_cache_control_disables_cache"]
+
+
+# ---- Helper parsing -------------------------------------------------------
+
+
+def test_helper_returns_false_for_none(helper):
+    assert helper(None) is False
+
+
+def test_helper_returns_false_for_empty_string(helper):
+    assert helper("") is False
+    assert helper("   ") is False
+
+
+def test_helper_returns_true_for_no_store_alone(helper):
+    assert helper("no-store") is True
+
+
+def test_helper_is_case_insensitive(helper):
+    assert helper("NO-STORE") is True
+    assert helper("No-Store") is True
+
+
+def test_helper_returns_true_when_combined_with_other_directives(helper):
+    assert helper("no-cache, no-store") is True
+    assert helper("no-store, max-age=0") is True
+    assert helper("public, no-store, must-revalidate") is True
+
+
+def test_helper_returns_false_for_unrelated_directives(helper):
+    assert helper("max-age=0") is False
+    assert helper("no-cache") is False
+    assert helper("public") is False
+    assert helper("private, max-age=600") is False
+
+
+def test_helper_does_not_match_substrings(helper):
+    """``maybe-no-store`` and ``no-stored`` are different tokens; the
+    parser tokenizes on commas + equals, not substring."""
+    assert helper("maybe-no-store") is False
+    assert helper("no-stored") is False
+
+
+def test_helper_handles_value_suffix_on_other_directives(helper):
+    """``max-age=N`` has a value suffix; the parser strips before
+    comparing the directive name. ``no-store`` itself doesn't take
+    a value, but be permissive in case some client sends one."""
+    assert helper("max-age=600") is False
+    assert helper("no-store=anything") is True
+
+
+def test_helper_tolerates_leading_trailing_whitespace(helper):
+    assert helper("  no-store  ") is True
+    assert helper("no-cache,  no-store  ,max-age=0") is True
+
+
+# ---- Source-text contract assertions -------------------------------------
+
+
+def test_chat_lookup_branch_is_gated_on_cache_disabled(gateway_source):
+    """The exact-cache lookup must skip when cache_disabled is True."""
+    # The lookup gate combines the feature flag and the header bypass.
+    pattern = "is_llm_gateway_exact_cache_enabled() and not cache_disabled"
+    assert pattern in gateway_source, (
+        "Cache lookup must be gated on (feature_flag AND not cache_disabled)"
+    )
+
+
+def test_chat_store_branch_is_gated_on_cache_disabled(gateway_source):
+    """The post-call store must skip when cache_disabled is True."""
+    # The store gate is the same shape as the lookup gate.
+    pattern = (
+        "if text and is_llm_gateway_exact_cache_enabled() and not cache_disabled:"
+    )
+    assert pattern in gateway_source, (
+        "Cache store must be gated on (text AND feature_flag AND not cache_disabled)"
+    )
+
+
+def test_chat_signature_accepts_cache_control_header(gateway_source):
+    """chat() takes a Cache-Control header param via FastAPI Header."""
+    # The header param uses alias="Cache-Control" (HTTP header name).
+    assert 'cache_control: str | None = Header(default=None, alias="Cache-Control")' in gateway_source, (
+        "chat() must accept Cache-Control header via FastAPI Header param"
+    )
+
+
+def test_cache_disabled_is_computed_once_before_lookup(gateway_source):
+    """``cache_disabled`` is computed from the header at the top of the
+    handler so both lookup and store branches see the same value."""
+    # Source order: cache_disabled assignment must precede both gates.
+    assignment_idx = gateway_source.find(
+        "cache_disabled = _cache_control_disables_cache(cache_control)"
+    )
+    lookup_idx = gateway_source.find("await lookup_cached_text(")
+    store_idx = gateway_source.find("await store_cached_text(")
+
+    assert assignment_idx > 0
+    assert lookup_idx > 0 and assignment_idx < lookup_idx, (
+        "cache_disabled must be computed before the lookup branch"
+    )
+    assert store_idx > 0 and assignment_idx < store_idx, (
+        "cache_disabled must be computed before the store branch"
+    )


### PR DESCRIPTION
**Plan:** [`plans/PR-D6f-cache-control-no-store.md`](../blob/claude/llm-gateway-d6f-cache-control-header/plans/PR-D6f-cache-control-no-store.md)

## Summary

Item #4 in the post-D6b LLM Gateway follow-up queue. Customer-supplied bypass for sensitive prompts they don't want cached. Standard HTTP caching convention (RFC 7234).

PR-D6e shipped the `cached: bool` field so customers can detect cache hits. This PR is the counterpart: the customer's tool to **suppress** caching when they need to.

## What changed

Three changes to `atlas_brain/api/llm_gateway.py`:

1. **New helper `_cache_control_disables_cache(cache_control)`** parses comma-separated directives, returns True iff `no-store` is present (case-insensitive, with or without value suffix). Tokenizes on commas + equals so substrings like `maybe-no-store` don't match.

2. **`chat()` accepts an optional `Cache-Control` header** via FastAPI's `Header(default=None, alias="Cache-Control")`.

3. **Both cache touchpoints gate on `not cache_disabled`** -- the lookup branch and the post-call store. Bypassing only one would defeat the purpose: lookup-only would still write the sensitive prompt; store-only would still read previous cached entries.

## RFC 7234 corner cases handled

| Header | Disabled? |
|---|---|
| `no-store` | ✅ |
| `no-cache, no-store` | ✅ (combined directives) |
| `NO-STORE` | ✅ (case-insensitive) |
| `public, no-store, must-revalidate` | ✅ (mixed list) |
| `max-age=0` | ❌ (different directive) |
| `no-cache` | ❌ (different semantic) |
| `maybe-no-store` | ❌ (substring guard) |
| `no-stored` | ❌ (substring guard) |
| (empty / whitespace / None) | ❌ |
| `no-store=anything` | ✅ (permissive on unexpected value suffix) |

## API contract change

**Additive only.** Optional request header; absent header means "caching follows the gateway-cache flag" (existing behavior). No existing client breaks.

## Intentional (looks wrong but is deliberate)

- **`no-store` only, not `no-cache`.** Different semantics per RFC 7234. `no-store` = "don't store this anywhere"; `no-cache` = "always revalidate." For an LLM API, `no-store` is right for "don't cache this prompt." Adding `no-cache` would be a different concept; do it when a customer asks.
- **Bypass flips both lookup AND store** -- not just one. See above.
- **Helper is module-private** (underscore prefix). Only the chat route consumes it; no point exposing.
- **No analogous gate on `/chat/stream` or `/batch`** -- their cache layers (queue items #3, #6) aren't wired yet; bypass headers will be added there when the cache layers are.

## Tests

13 regression tests in `tests/test_llm_gateway_cache_control_no_store.py`:

- **9 helper-parsing tests** covering all the corner cases in the table above (None, empty, alone, case variations, combined directives, unrelated directives, substring guard, value suffix tolerance, whitespace).
- **4 source-text contract assertions** on the chat() body: lookup branch gates on `not cache_disabled`, store branch gates on `not cache_disabled`, signature accepts the header, ordering is correct (compute once before both branches).

Tests use file-text inspection + helper-source extraction (regex match + `exec` in sealed namespace) to avoid importing the gateway module's full settings stack (which depends on `ATLAS_SAAS_API_KEY_PEPPER` / `ATLAS_SAAS_BYOK_ENCRYPTION_KEK`).

## Verification

- [x] `python3 -m pytest tests/test_llm_gateway_cache_control_no_store.py -v` -> 13 passed
- [x] `python3 -m py_compile atlas_brain/api/llm_gateway.py` -> clean
- [x] `bash scripts/check_ascii_python.sh` -> passed

## Conflict check

No file overlap with any open PR.

## Diff size

- Source: ~25 LOC additions (helper + header param + 2 guard updates)
- Tests: 162 LOC, 13 tests
- Plan doc: 134 LOC

Source-only ~25 LOC.

## After this lands

| # | Item | Status |
|---|---|---|
| 1 | `cached: bool` on ChatResponse | merged in PR-D6e |
| 2 | Cache savings dashboard | merged in PR-D6c |
| 3 | Apply exact cache to `/chat/stream` | queued (open question) |
| 4 | Cache opt-out via `Cache-Control: no-store` | **this PR** |
| 5 | Semantic cache layer | queued (highest-value next) |
| 6 | `/batch` cache | queued |

Customer-supplied cache opt-out works on sync `/chat`. Three queue items closed; three remain. **Item #5 (semantic cache) is the highest-value next slice** -- it's "the second cache layer in the 5-layer pitch" and the substrate (`atlas_brain/reasoning/semantic_cache.py`, account-scoped per PR-D3 migration 315) already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)