### PR TITLE
Add Content Ops sales brief draft export helper

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:50Z by codex-content-ops-sales-export
+Last updated: 2026-05-09T20:55Z by codex-content-ops-sales-export
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add read-only sales brief draft export helper for Content Ops | NEW: `extracted_content_pipeline/sales_brief_export.py`; `tests/test_extracted_sales_brief_export.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; docs/check wiring. | codex-content-ops-sales-export | Avoid sales brief export helper/tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:46Z by codex-content-ops-landing-export
+Last updated: 2026-05-09T20:50Z by codex-content-ops-sales-export
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Add read-only sales brief draft export helper for Content Ops | NEW: `extracted_content_pipeline/sales_brief_export.py`; `tests/test_extracted_sales_brief_export.py`; EDIT: `extracted_content_pipeline/sales_brief_generation.py`; docs/check wiring. | codex-content-ops-sales-export | Avoid sales brief export helper/tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -729,6 +729,7 @@ Several small utility shims provide product-owned local behavior by default so t
 - `campaign_postgres_export.py`: read-only draft export for host review flows
 - `report_export.py`: read-only structured report export for host review flows
 - `landing_page_export.py`: read-only landing page export for host review flows
+- `sales_brief_export.py`: read-only sales brief export for host review flows
 - `campaign_postgres_seller_targets.py`: seller target CRUD/list helpers for
   Amazon seller campaign installs
 - `campaign_postgres_seller_opportunities.py`: prepares Amazon seller

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -50,6 +50,9 @@
 - `landing_page_export` provides a read-only draft export path over generated
   landing pages so hosts can review JSON/CSV outputs without handwritten SQL or
   a mounted landing page API.
+- `sales_brief_export` provides a read-only draft export path over generated
+  sales briefs so hosts can review JSON/CSV outputs without handwritten SQL or
+  a mounted sales brief API.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -192,6 +192,12 @@ hero, section, CTA, SEO meta, and metadata payloads, and derives top-level
 generation and reasoning summary columns for operator review without requiring
 direct SQL access.
 
+`extracted_content_pipeline/sales_brief_export.py` owns the equivalent
+read-only review path for generated sales briefs. It calls the host-injected
+`SalesBriefRepository.list_drafts()` port, emits JSON or CSV rows, preserves
+brief sections and metadata, and derives top-level generation and reasoning
+summary columns for operator review without requiring direct SQL access.
+
 `extracted_content_pipeline/campaign_postgres_review.py` owns the write side of
 that host review loop. It updates selected `b2b_campaigns` rows by explicit
 campaign id, optional account scope, and source-status guard so hosts can move

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -206,6 +206,9 @@
       "target": "extracted_content_pipeline/landing_page_export.py"
     },
     {
+      "target": "extracted_content_pipeline/sales_brief_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_postgres_review.py"
     },
     {

--- a/extracted_content_pipeline/sales_brief_export.py
+++ b/extracted_content_pipeline/sales_brief_export.py
@@ -1,0 +1,165 @@
+"""Read-only sales brief draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+import json
+from typing import Any
+
+from .campaign_ports import TenantScope
+from .sales_brief_ports import SalesBriefDraft, SalesBriefRepository
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "target_id",
+    "target_mode",
+    "brief_type",
+    "title",
+    "headline",
+    "section_count",
+    "reference_count",
+    "generation_input_tokens",
+    "generation_output_tokens",
+    "generation_total_tokens",
+    "generation_parse_attempts",
+    "reasoning_context_used",
+    "reasoning_wedge",
+    "reasoning_confidence",
+    "sections",
+    "reference_ids",
+    "metadata",
+)
+
+
+@dataclass(frozen=True)
+class SalesBriefDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_sales_brief_drafts(
+    repository: SalesBriefRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    target_mode: str | None = None,
+    brief_type: str | None = None,
+    limit: int = 20,
+) -> SalesBriefDraftExportResult:
+    """Return generated sales brief drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if target_mode:
+        filters["target_mode"] = target_mode
+    if brief_type:
+        filters["brief_type"] = brief_type
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        target_mode=target_mode,
+        brief_type=brief_type,
+        limit=normalized_limit,
+    )
+    return SalesBriefDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: SalesBriefDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["section_count"] = len(draft.sections)
+    row["reference_count"] = len(draft.reference_ids)
+    row.update(_metadata_summary(draft.metadata))
+    return row
+
+
+def _metadata_summary(value: Any) -> JsonDict:
+    metadata = _metadata_mapping(value)
+    usage = _metadata_mapping(metadata.get("generation_usage"))
+    reasoning = _metadata_mapping(metadata.get("reasoning_context"))
+    return {
+        "generation_input_tokens": usage.get("input_tokens"),
+        "generation_output_tokens": usage.get("output_tokens"),
+        "generation_total_tokens": usage.get("total_tokens"),
+        "generation_parse_attempts": metadata.get("generation_parse_attempts"),
+        "reasoning_context_used": bool(reasoning),
+        "reasoning_wedge": reasoning.get("wedge"),
+        "reasoning_confidence": reasoning.get("confidence"),
+    }
+
+
+def _metadata_mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+    return {}
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "SalesBriefDraftExportResult",
+    "export_sales_brief_drafts",
+]

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -331,6 +331,7 @@ class SalesBriefGenerationService:
                     target_id=target_id,
                     target_mode=target_mode,
                     default_brief_type=default_brief_type,
+                    opportunity=opportunity,
                 )
             )
 
@@ -479,6 +480,7 @@ class SalesBriefGenerationService:
         target_id: str,
         target_mode: str,
         default_brief_type: str | None = None,
+        opportunity: Mapping[str, Any] | None = None,
     ) -> SalesBriefDraft:
         sections = tuple(
             SalesBriefSection(
@@ -514,6 +516,9 @@ class SalesBriefGenerationService:
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
         }
+        if opportunity is not None:
+            context = normalize_campaign_reasoning_context(opportunity)
+            metadata.update(campaign_reasoning_context_metadata(context))
         if "confidence" in parsed:
             metadata["confidence"] = parsed["confidence"]
         return SalesBriefDraft(

--- a/plans/PR-Content-Ops-Sales-Brief-Export.md
+++ b/plans/PR-Content-Ops-Sales-Brief-Export.md
@@ -1,0 +1,58 @@
+# PR-Content-Ops-Sales-Brief-Export
+
+## Why this slice exists
+
+Campaigns, reports, and landing pages now have read-only JSON/CSV export
+helpers for host review. Sales briefs have a standalone repository and
+`list_drafts()` method, but no matching export seam.
+
+## Scope (this PR)
+
+1. Add a sales-brief-only export helper over `SalesBriefRepository.list_drafts()`.
+2. Support JSON and CSV output from exported sales brief rows.
+3. Preserve brief metadata and expose generation/reasoning summary fields.
+4. Persist compact reasoning metadata from generated sales briefs so export
+   rows reflect real generated drafts.
+5. Document the new helper in package status/productization docs.
+
+### Files touched
+
+- `extracted_content_pipeline/sales_brief_export.py`
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `tests/test_extracted_sales_brief_export.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `extracted_content_pipeline/manifest.json`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`export_sales_brief_drafts(repository, scope=..., ...)` calls the host-provided
+`SalesBriefRepository.list_drafts()` and converts each `SalesBriefDraft` to a
+serializable row. The result mirrors the report and landing page export
+ergonomics:
+
+- `as_dict()` for JSON responses or host scripts.
+- `as_csv()` for review spreadsheets.
+- `filters` and `limit` metadata on the export result.
+
+## Intentional
+
+- No API route or CLI in this first sales brief export slice.
+- No shared generic asset-export abstraction yet.
+
+## Deferred
+
+- Host-mounted API routes / CLIs for generated asset exports.
+
+## Verification
+
+Completed:
+
+- `python -m pytest tests/test_extracted_sales_brief_export.py tests/test_extracted_sales_brief_generation.py`
+- `python -m py_compile extracted_content_pipeline/sales_brief_export.py extracted_content_pipeline/sales_brief_generation.py tests/test_extracted_sales_brief_export.py`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `git diff --check`
+- Non-ASCII byte check for edited Python files.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -46,6 +46,7 @@ pytest \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_report_export.py \
   tests/test_extracted_landing_page_export.py \
+  tests/test_extracted_sales_brief_export.py \
   tests/test_extracted_campaign_postgres_review.py \
   tests/test_extracted_campaign_postgres_seller_targets.py \
   tests/test_extracted_campaign_postgres_seller_opportunities.py \

--- a/tests/test_extracted_sales_brief_export.py
+++ b/tests/test_extracted_sales_brief_export.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import (
+    CampaignReasoningContext,
+    LLMResponse,
+    TenantScope,
+)
+from extracted_content_pipeline.sales_brief_export import (
+    SalesBriefDraftExportResult,
+    export_sales_brief_drafts,
+)
+from extracted_content_pipeline.sales_brief_generation import (
+    SalesBriefGenerationConfig,
+    SalesBriefGenerationService,
+)
+from extracted_content_pipeline.sales_brief_ports import (
+    SalesBriefDraft,
+    SalesBriefSection,
+)
+
+
+class _Repository:
+    def __init__(self, drafts=None) -> None:
+        self.drafts = tuple(drafts or ())
+        self.list_calls: list[dict] = []
+
+    async def save_drafts(self, drafts, *, scope):
+        raise NotImplementedError
+
+    async def list_drafts(
+        self,
+        *,
+        scope,
+        status=None,
+        target_mode=None,
+        brief_type=None,
+        limit=None,
+    ):
+        self.list_calls.append({
+            "scope": scope,
+            "status": status,
+            "target_mode": target_mode,
+            "brief_type": brief_type,
+            "limit": limit,
+        })
+        return self.drafts
+
+    async def update_status(self, brief_id, status, *, scope):
+        raise NotImplementedError
+
+
+class _SavingRepository(_Repository):
+    async def save_drafts(self, drafts, *, scope):
+        self.drafts = tuple(drafts)
+        return tuple(f"sales-brief-{index + 1}" for index, _ in enumerate(drafts))
+
+
+class _Intelligence:
+    async def read_campaign_opportunities(self, *, scope, target_mode, limit, filters=None):
+        return ({
+            "target_id": "vendor-acme",
+            "vendor_name": "Acme",
+            "company_name": "Acme",
+            "evidence": [{"id": "r1", "quote": "Pricing pressure is rising"}],
+        },)
+
+    async def read_vendor_targets(self, *, scope, target_mode, vendor_name=None):  # pragma: no cover
+        raise AssertionError("not used")
+
+
+class _LLM:
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        return LLMResponse(
+            content=(
+                '{"title":"Acme pre-call brief","headline":"Renewal pressure '
+                'opens this week","brief_type":"pre_call","sections":[{'
+                '"id":"context","title":"Context","body_markdown":"Pricing '
+                'pressure is rising","evidence_ids":["r1"]}],'
+                '"reference_ids":["r1"],"confidence":0.82}'
+            ),
+            model="test-model",
+            usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+
+
+class _Skills:
+    def get_prompt(self, name):
+        return "TEMPLATE {target_mode}: {opportunity_json}"
+
+
+class _ReasoningProvider:
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        return CampaignReasoningContext(
+            canonical_reasoning={
+                "wedge": "price_squeeze",
+                "confidence": "high",
+                "summary": "Pricing pressure creates displacement risk.",
+            },
+        )
+
+
+def _draft(**overrides) -> SalesBriefDraft:
+    draft = SalesBriefDraft(
+        target_id="vendor-acme",
+        target_mode="vendor_retention",
+        brief_type="pre_call",
+        title="Acme pre-call brief",
+        headline="Renewal pressure opens this week",
+        sections=(
+            SalesBriefSection(
+                id="context",
+                title="Context",
+                body_markdown="Renewal pricing is the main signal.",
+                claim_ids=("c1",),
+                evidence_ids=("r1",),
+                metadata={"order": 1},
+            ),
+        ),
+        reference_ids=("r1", "r2"),
+        metadata={
+            "generation_usage": {
+                "input_tokens": 12,
+                "output_tokens": 6,
+                "total_tokens": 18,
+            },
+            "generation_parse_attempts": 2,
+            "reasoning_context": {
+                "wedge": "price_squeeze",
+                "confidence": "high",
+            },
+        },
+    )
+    return SalesBriefDraft(
+        target_id=overrides.get("target_id", draft.target_id),
+        target_mode=overrides.get("target_mode", draft.target_mode),
+        brief_type=overrides.get("brief_type", draft.brief_type),
+        title=overrides.get("title", draft.title),
+        headline=overrides.get("headline", draft.headline),
+        sections=overrides.get("sections", draft.sections),
+        reference_ids=overrides.get("reference_ids", draft.reference_ids),
+        metadata=overrides.get("metadata", draft.metadata),
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_sales_brief_drafts_passes_filters_to_repository() -> None:
+    repo = _Repository(drafts=[_draft()])
+
+    result = await export_sales_brief_drafts(
+        repo,
+        scope={"account_id": "acct_1", "user_id": "user_1"},
+        status="approved",
+        target_mode="vendor_retention",
+        brief_type="pre_call",
+        limit=7,
+    )
+
+    call = repo.list_calls[0]
+    assert isinstance(call["scope"], TenantScope)
+    assert call["scope"].account_id == "acct_1"
+    assert call["scope"].user_id == "user_1"
+    assert call["status"] == "approved"
+    assert call["target_mode"] == "vendor_retention"
+    assert call["brief_type"] == "pre_call"
+    assert call["limit"] == 7
+    assert result.limit == 7
+    assert result.filters == {
+        "status": "approved",
+        "account_id": "acct_1",
+        "target_mode": "vendor_retention",
+        "brief_type": "pre_call",
+    }
+
+
+@pytest.mark.asyncio
+async def test_export_sales_brief_drafts_derives_review_summary_fields() -> None:
+    result = await export_sales_brief_drafts(
+        _Repository(drafts=[_draft()]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    row = result.rows[0]
+    assert row["target_id"] == "vendor-acme"
+    assert row["section_count"] == 1
+    assert row["reference_count"] == 2
+    assert row["generation_input_tokens"] == 12
+    assert row["generation_output_tokens"] == 6
+    assert row["generation_total_tokens"] == 18
+    assert row["generation_parse_attempts"] == 2
+    assert row["reasoning_context_used"] is True
+    assert row["reasoning_wedge"] == "price_squeeze"
+    assert row["reasoning_confidence"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_export_sales_brief_drafts_defaults_summary_fields_without_metadata() -> None:
+    result = await export_sales_brief_drafts(
+        _Repository(drafts=[_draft(metadata={})]),
+        limit=1,
+    )
+
+    row = result.rows[0]
+    assert row["generation_input_tokens"] is None
+    assert row["generation_output_tokens"] is None
+    assert row["generation_total_tokens"] is None
+    assert row["generation_parse_attempts"] is None
+    assert row["reasoning_context_used"] is False
+    assert row["reasoning_wedge"] is None
+    assert row["reasoning_confidence"] is None
+
+
+@pytest.mark.asyncio
+async def test_generated_sales_brief_export_includes_reasoning_summary_fields() -> None:
+    repo = _SavingRepository()
+    service = SalesBriefGenerationService(
+        intelligence=_Intelligence(),
+        sales_briefs=repo,
+        llm=_LLM(),
+        skills=_Skills(),
+        reasoning_context=_ReasoningProvider(),
+        config=SalesBriefGenerationConfig(),
+    )
+
+    generated = await service.generate(
+        scope=TenantScope(account_id="acct_1"),
+        target_mode="vendor_retention",
+    )
+    exported = await export_sales_brief_drafts(
+        repo,
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    assert generated.reasoning_contexts_used == 1
+    row = exported.rows[0]
+    assert row["reasoning_context_used"] is True
+    assert row["reasoning_wedge"] == "price_squeeze"
+    assert row["reasoning_confidence"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_export_sales_brief_drafts_rejects_negative_limit() -> None:
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        await export_sales_brief_drafts(_Repository(), limit=-1)
+
+
+def test_sales_brief_draft_export_result_renders_dict_and_csv() -> None:
+    result = SalesBriefDraftExportResult(
+        rows=(
+            {
+                "target_id": "vendor-acme",
+                "target_mode": "vendor_retention",
+                "brief_type": "pre_call",
+                "title": "Acme brief",
+                "headline": "Renewal pressure opens this week",
+                "section_count": 1,
+                "reference_count": 1,
+                "generation_input_tokens": 12,
+                "generation_output_tokens": 6,
+                "generation_total_tokens": 18,
+                "generation_parse_attempts": 1,
+                "reasoning_context_used": True,
+                "reasoning_wedge": "price_squeeze",
+                "reasoning_confidence": "high",
+                "sections": [{"id": "context"}],
+                "reference_ids": ["r1"],
+                "metadata": {"scope": {"account_id": "acct_1"}},
+            },
+        ),
+        limit=1,
+        filters={"status": "draft"},
+    )
+
+    as_dict = result.as_dict()
+    csv_text = result.as_csv()
+
+    assert as_dict["count"] == 1
+    assert as_dict["rows"][0]["reasoning_wedge"] == "price_squeeze"
+    assert "target_id,target_mode,brief_type" in csv_text
+    assert "generation_input_tokens,generation_output_tokens" in csv_text
+    assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in csv_text
+    assert "price_squeeze" in csv_text


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Sales-Brief-Export.md

## Summary
- add sales_brief_export helper over SalesBriefRepository.list_drafts()
- expose JSON/CSV rows with generation usage and reasoning summary fields
- persist compact reasoning metadata on generated sales brief drafts so export rows reflect real generated output
- document the new sales brief review seam and add it to extracted pipeline checks

## Verification
- python -m pytest tests/test_extracted_sales_brief_export.py tests/test_extracted_sales_brief_generation.py
- python -m py_compile extracted_content_pipeline/sales_brief_export.py extracted_content_pipeline/sales_brief_generation.py tests/test_extracted_sales_brief_export.py
- bash scripts/run_extracted_pipeline_checks.sh
- git diff --check
- ASCII clean for edited Python files