### PR TITLE
Add Content Ops generated asset export CLI

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:58Z by codex-content-ops-asset-export-cli
+Last updated: 2026-05-09T21:03Z by codex-content-ops-asset-export-cli
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add host-facing generated asset export CLI for Content Ops | NEW: `scripts/export_extracted_content_assets.py`; `tests/test_extracted_content_asset_export_cli.py`; docs/check wiring. | codex-content-ops-asset-export-cli | Avoid generated asset export CLI/tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T20:55Z by codex-content-ops-sales-export
+Last updated: 2026-05-09T20:58Z by codex-content-ops-asset-export-cli
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Add host-facing generated asset export CLI for Content Ops | NEW: `scripts/export_extracted_content_assets.py`; `tests/test_extracted_content_asset_export_cli.py`; docs/check wiring. | codex-content-ops-asset-export-cli | Avoid generated asset export CLI/tests/docs until PR closes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -730,6 +730,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `report_export.py`: read-only structured report export for host review flows
 - `landing_page_export.py`: read-only landing page export for host review flows
 - `sales_brief_export.py`: read-only sales brief export for host review flows
+- `scripts/export_extracted_content_assets.py`: host-facing report, landing
+  page, and sales brief export CLI
 - `campaign_postgres_seller_targets.py`: seller target CRUD/list helpers for
   Amazon seller campaign installs
 - `campaign_postgres_seller_opportunities.py`: prepares Amazon seller

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -53,6 +53,9 @@
 - `sales_brief_export` provides a read-only draft export path over generated
   sales briefs so hosts can review JSON/CSV outputs without handwritten SQL or
   a mounted sales brief API.
+- `scripts/export_extracted_content_assets.py` exposes the report, landing
+  page, and sales brief export helpers as a host-facing JSON/CSV CLI backed by
+  the product-owned Postgres repositories.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -198,6 +198,12 @@ read-only review path for generated sales briefs. It calls the host-injected
 brief sections and metadata, and derives top-level generation and reasoning
 summary columns for operator review without requiring direct SQL access.
 
+`scripts/export_extracted_content_assets.py` exposes those generated-asset
+export helpers to operators. Hosts choose `--asset report`, `--asset
+landing_page`, or `--asset sales_brief`; the CLI creates the product-owned
+Postgres repository, applies the relevant filters, and writes JSON or CSV
+without requiring ad hoc SQL.
+
 `extracted_content_pipeline/campaign_postgres_review.py` owns the write side of
 that host review loop. It updates selected `b2b_campaigns` rows by explicit
 campaign id, optional account scope, and source-status guard so hosts can move

--- a/plans/PR-Content-Ops-Asset-Export-CLI.md
+++ b/plans/PR-Content-Ops-Asset-Export-CLI.md
@@ -1,0 +1,44 @@
+# PR-Content-Ops-Asset-Export-CLI
+
+## Why this slice exists
+
+Reports, landing pages, and sales briefs now have read-only export helpers, but
+hosts still need to write Python to use them. Campaign drafts already have a
+host-facing export CLI. Generated Content Ops assets should have the same
+operator path.
+
+## Scope (this PR)
+
+1. Add a read-only CLI for generated asset exports:
+   `scripts/export_extracted_content_assets.py`.
+2. Support `--asset report|landing_page|sales_brief`.
+3. Reuse the existing Postgres repository adapters and export helpers.
+4. Support JSON/CSV output, tenant scope, status, limit, and asset-specific
+   filters.
+5. Document the command and add focused tests to extracted pipeline checks.
+
+### Files touched
+
+- `scripts/export_extracted_content_assets.py`
+- `tests/test_extracted_content_asset_export_cli.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Intentional
+
+- No FastAPI route in this slice.
+- No custom SQL in the CLI. It constructs repositories and calls export helpers.
+- One CLI for generated assets rather than three near-identical scripts.
+
+## Verification
+
+Completed:
+
+- `python -m pytest tests/test_extracted_content_asset_export_cli.py`
+- `python -m py_compile scripts/export_extracted_content_assets.py tests/test_extracted_content_asset_export_cli.py`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `git diff --check`
+- Non-ASCII byte check for edited Python files.

--- a/scripts/export_extracted_content_assets.py
+++ b/scripts/export_extracted_content_assets.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Export generated Content Ops assets from the extracted product database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.landing_page_export import (  # noqa: E402
+    export_landing_page_drafts,
+)
+from extracted_content_pipeline.landing_page_postgres import (  # noqa: E402
+    PostgresLandingPageRepository,
+)
+from extracted_content_pipeline.report_export import export_report_drafts  # noqa: E402
+from extracted_content_pipeline.report_postgres import PostgresReportRepository  # noqa: E402
+from extracted_content_pipeline.sales_brief_export import (  # noqa: E402
+    export_sales_brief_drafts,
+)
+from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
+    PostgresSalesBriefRepository,
+)
+
+
+ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export generated AI Content Ops assets from Postgres."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--asset", choices=ASSET_CHOICES, required=True)
+    parser.add_argument("--account-id", default=None, help="Optional tenant/account id.")
+    parser.add_argument(
+        "--status",
+        default="draft",
+        help="Status to export. Use empty string for all statuses.",
+    )
+    parser.add_argument("--target-mode", default=None, help="Report/sales brief target_mode filter.")
+    parser.add_argument("--report-type", default=None, help="Report type filter.")
+    parser.add_argument("--campaign-name", default=None, help="Landing page campaign_name filter.")
+    parser.add_argument("--slug", default=None, help="Landing page slug filter.")
+    parser.add_argument("--brief-type", default=None, help="Sales brief type filter.")
+    parser.add_argument("--limit", type=int, default=20, help="Maximum rows to export.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "csv"),
+        default="json",
+        help="Output format.",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Optional output path.")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to export assets; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        result = await _export_for_asset(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    output = (
+        result.as_csv()
+        if args.format == "csv"
+        else json.dumps(result.as_dict(), indent=2, sort_keys=True)
+    )
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="" if output.endswith("\n") else "\n")
+    return 0
+
+
+async def _export_for_asset(args: argparse.Namespace, pool: Any):
+    scope = TenantScope(account_id=args.account_id)
+    status = _status_arg(args.status)
+    if args.asset == "report":
+        return await export_report_drafts(
+            PostgresReportRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=args.target_mode,
+            report_type=args.report_type,
+            limit=args.limit,
+        )
+    if args.asset == "landing_page":
+        return await export_landing_page_drafts(
+            PostgresLandingPageRepository(pool),
+            scope=scope,
+            status=status,
+            campaign_name=args.campaign_name,
+            slug=args.slug,
+            limit=args.limit,
+        )
+    if args.asset == "sales_brief":
+        return await export_sales_brief_drafts(
+            PostgresSalesBriefRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=args.target_mode,
+            brief_type=args.brief_type,
+            limit=args.limit,
+        )
+    raise ValueError(f"Unsupported asset: {args.asset}")
+
+
+def _status_arg(raw: str | None) -> str | None:
+    status = str(raw or "").strip()
+    return status or None
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -44,6 +44,7 @@ pytest \
   tests/test_extracted_storage_jsonb_helpers.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
+  tests/test_extracted_content_asset_export_cli.py \
   tests/test_extracted_report_export.py \
   tests/test_extracted_landing_page_export.py \
   tests/test_extracted_sales_brief_export.py \

--- a/tests/test_extracted_content_asset_export_cli.py
+++ b/tests/test_extracted_content_asset_export_cli.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/export_extracted_content_assets.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "export_extracted_content_assets",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    def __init__(self, rows=None) -> None:
+        self.rows = list(rows or [])
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.closed = False
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        return self.rows
+
+    async def close(self):
+        self.closed = True
+
+
+def _report_row():
+    return {
+        "target_id": "vendor-acme",
+        "target_mode": "vendor_retention",
+        "report_type": "vendor_pressure",
+        "title": "Acme report",
+        "summary": "Pricing pressure dominates.",
+        "sections": [{"id": "summary", "title": "Summary", "body_markdown": "Body"}],
+        "reference_ids": ["r1"],
+        "metadata": {
+            "generation_usage": {"input_tokens": 10, "output_tokens": 5},
+            "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
+        },
+    }
+
+
+def _landing_page_row():
+    return {
+        "campaign_name": "acme-launch",
+        "persona": "VP Engineering",
+        "value_prop": "Catch pressure early",
+        "title": "Acme landing page",
+        "slug": "acme-launch",
+        "hero": {"headline": "Stop surprises"},
+        "sections": [{"id": "problem", "title": "Problem", "body_markdown": "Body"}],
+        "cta": {"label": "Book a demo"},
+        "meta": {"title_tag": "Acme landing page"},
+        "reference_ids": ["r1"],
+        "metadata": {},
+    }
+
+
+def _sales_brief_row():
+    return {
+        "target_id": "vendor-acme",
+        "target_mode": "vendor_retention",
+        "brief_type": "pre_call",
+        "title": "Acme brief",
+        "headline": "Renewal pressure opens this week",
+        "sections": [{"id": "context", "title": "Context", "body_markdown": "Body"}],
+        "reference_ids": ["r1"],
+        "metadata": {
+            "generation_usage": {"input_tokens": 8, "output_tokens": 4},
+            "reasoning_context": {"wedge": "support_erosion", "confidence": "medium"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_outputs_report_json(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(rows=[_report_row()])
+    created_urls: list[str] = []
+
+    async def create_pool(database_url):
+        created_urls.append(database_url)
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "report",
+            "--account-id",
+            "acct_1",
+            "--target-mode",
+            "vendor_retention",
+            "--report-type",
+            "vendor_pressure",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.fetch_calls[0]
+    assert exit_code == 0
+    assert created_urls == ["postgres://example"]
+    assert pool.closed is True
+    assert "FROM reports" in query
+    assert args == ("acct_1", "draft", "vendor_retention", "vendor_pressure", 20)
+    assert output["count"] == 1
+    assert output["rows"][0]["target_id"] == "vendor-acme"
+    assert output["rows"][0]["reasoning_context_used"] is True
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_writes_landing_page_csv(monkeypatch, tmp_path) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(rows=[_landing_page_row()])
+    output_path = tmp_path / "landing-pages.csv"
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "landing_page",
+            "--campaign-name",
+            "acme-launch",
+            "--slug",
+            "acme-launch",
+            "--format",
+            "csv",
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    assert exit_code == 0
+    query, args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in query
+    assert args == ("", "draft", "acme-launch", "acme-launch", 20)
+    assert "Acme landing page" in output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_outputs_sales_brief_json(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(rows=[_sales_brief_row()])
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "sales_brief",
+            "--status",
+            "",
+            "--target-mode",
+            "vendor_retention",
+            "--brief-type",
+            "pre_call",
+            "--limit",
+            "3",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.fetch_calls[0]
+    assert exit_code == 0
+    assert "FROM sales_briefs" in query
+    assert "status = " not in query
+    assert args == ("", "vendor_retention", "pre_call", 3)
+    assert output["rows"][0]["brief_type"] == "pre_call"
+    assert output["rows"][0]["reasoning_wedge"] == "support_erosion"
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_requires_database_url(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(cli.sys, "argv", ["export", "--asset", "report"])
+
+    with pytest.raises(SystemExit, match="Missing --database-url"):
+        await cli._main()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Asset-Export-CLI.md

## Summary
- add scripts/export_extracted_content_assets.py for report, landing_page, and sales_brief exports
- reuse existing Postgres repositories and export helpers instead of custom SQL
- support JSON/CSV output plus tenant/status/asset-specific filters
- document the host-facing command and add it to extracted pipeline checks

## Verification
- python -m pytest tests/test_extracted_content_asset_export_cli.py
- python -m py_compile scripts/export_extracted_content_assets.py tests/test_extracted_content_asset_export_cli.py
- bash scripts/run_extracted_pipeline_checks.sh
- git diff --check
- ASCII clean for edited Python files