### PR TITLE
PR-D6g-1: schema scaffolding for /batch cache prefilter accounting

### DIFF
--- a/atlas_brain/api/llm_gateway.py
+++ b/atlas_brain/api/llm_gateway.py
@@ -1077,6 +1077,11 @@ class BatchView(BaseModel):
     updated_at: str
     submitted_at: Optional[str] = None
     completed_at: Optional[str] = None
+    # PR-D6g: count of items that were satisfied from the customer's
+    # exact cache at submit time and never sent to Anthropic. The
+    # underlying llm_usage rows (zero tokens, cache_hit=true with
+    # savings metadata) drive cache_savings_usd on /api/v1/llm/usage.
+    cache_prefiltered_items: int = 0
 
 
 def _batch_record_to_view(record) -> BatchView:
@@ -1102,6 +1107,7 @@ def _batch_record_to_view(record) -> BatchView:
         updated_at=_fmt(record.updated_at) or "",
         submitted_at=_fmt(record.submitted_at),
         completed_at=_fmt(record.completed_at),
+        cache_prefiltered_items=record.cache_prefiltered_items,
     )
 
 

--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -121,6 +121,12 @@ class CustomerBatchRecord:
     # retry attempt. The refresh path skips retry when this is
     # within the cooldown window, preventing poll-storms.
     last_usage_retry_at: Optional[datetime] = None
+    # PR-D6g: count of items satisfied from the customer's exact
+    # cache at submit time. These items never reach Anthropic; the
+    # underlying llm_usage rows (zero tokens, cache_hit=true with
+    # savings metadata) drive cache_savings_usd on /usage. Defaults
+    # to 0 -- back-compat with rows from before migration 323.
+    cache_prefiltered_items: int = 0
 
 
 def _row_to_record(row: Any) -> CustomerBatchRecord:
@@ -155,6 +161,13 @@ def _row_to_record(row: Any) -> CustomerBatchRecord:
             row["last_usage_retry_at"]
             if "last_usage_retry_at" in row.keys()
             else None
+        ),
+        # PR-D6g migration 323. Defensive .get pattern so mocks /
+        # rows from before the migration still produce a record.
+        cache_prefiltered_items=(
+            int(row["cache_prefiltered_items"] or 0)
+            if "cache_prefiltered_items" in row.keys()
+            else 0
         ),
     )
 
@@ -205,7 +218,8 @@ async def submit_customer_batch(
                    status, total_items, completed_items, failed_items,
                    error_text, created_at, updated_at, submitted_at,
                    completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
             FROM llm_gateway_batches
             WHERE account_id = $1 AND idempotency_key = $2
             """,
@@ -278,7 +292,8 @@ async def submit_customer_batch(
                           status, total_items, completed_items, failed_items,
                           error_text, created_at, updated_at, submitted_at,
                           completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
                 """,
                 existing["id"],
                 account_id,
@@ -302,7 +317,8 @@ async def submit_customer_batch(
                            status, total_items, completed_items, failed_items,
                            error_text, created_at, updated_at, submitted_at,
                            completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
                     FROM llm_gateway_batches
                     WHERE id = $1 AND account_id = $2
                     """,
@@ -377,7 +393,8 @@ async def submit_customer_batch(
                               status, total_items, completed_items, failed_items,
                               error_text, created_at, updated_at, submitted_at,
                               completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
                     """,
                     account_id,
                     model,
@@ -395,7 +412,8 @@ async def submit_customer_batch(
                        status, total_items, completed_items, failed_items,
                        error_text, created_at, updated_at, submitted_at,
                        completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
                 FROM llm_gateway_batches
                 WHERE account_id = $1 AND idempotency_key = $2
                 """,
@@ -486,7 +504,8 @@ async def submit_customer_batch(
                       status, total_items, completed_items, failed_items,
                       error_text, created_at, updated_at, submitted_at,
                       completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
             """,
             row["id"],
             f"Anthropic batch submit failed: {exc}",
@@ -514,7 +533,8 @@ async def submit_customer_batch(
                   status, total_items, completed_items, failed_items,
                   error_text, created_at, updated_at, submitted_at,
                   completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
         """,
         row["id"],
         str(provider_batch_id) if provider_batch_id else None,
@@ -542,7 +562,8 @@ async def get_customer_batch(
                status, total_items, completed_items, failed_items,
                error_text, created_at, updated_at, submitted_at,
                completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
         FROM llm_gateway_batches
         WHERE id = $1 AND account_id = $2
         """,
@@ -689,7 +710,8 @@ async def refresh_customer_batch_status(
                   status, total_items, completed_items, failed_items,
                   error_text, created_at, updated_at, submitted_at,
                   completed_at, usage_tracked,
-                          anthropic_call_initiated_at, last_usage_retry_at
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
         """,
         batch_id,
         new_status,

--- a/atlas_brain/storage/migrations/323_llm_gateway_batches_cache_prefiltered_items.sql
+++ b/atlas_brain/storage/migrations/323_llm_gateway_batches_cache_prefiltered_items.sql
@@ -1,0 +1,11 @@
+-- PR-D6g: LLM Gateway batch cache prefilter accounting.
+--
+-- Tracks how many items in a customer batch were satisfied from the
+-- exact-text cache and never sent to Anthropic. Customer sees this
+-- on GET /api/v1/llm/batch/{id}; the per-item zero-token llm_usage
+-- rows still drive /api/v1/llm/usage cache_savings_usd.
+--
+-- Defaults to 0 -- back-compat with existing rows.
+
+ALTER TABLE llm_gateway_batches
+    ADD COLUMN IF NOT EXISTS cache_prefiltered_items INTEGER NOT NULL DEFAULT 0;

--- a/plans/PR-D6g-1-batch-cache-prefilter-schema.md
+++ b/plans/PR-D6g-1-batch-cache-prefilter-schema.md
@@ -1,0 +1,129 @@
+# PR-D6g-1: Schema scaffolding for /batch cache prefilter accounting
+
+## Why this slice exists
+
+Item #6 in the post-D6b LLM Gateway follow-up queue: apply the
+existing exact-cache to `/api/v1/llm/batch` so customer batches dedup
+against cached single-call responses.
+
+The full feature has two coupled halves:
+
+1. **Schema scaffolding** -- column, dataclass field, API view field,
+   plumbing through SELECT/INSERT statements. (THIS PR.)
+2. **Prefilter behavior** -- the cache lookup loop, zero-token
+   `llm_usage` row writes, 100%-hit short-circuit (skip Anthropic),
+   partial-hit handling. (PR-D6g-2 follow-up.)
+
+Splitting along the schema/behavior seam keeps each slice reviewable
+and lands the persistence shape first so the behavior PR doesn't
+need to coordinate schema + logic in one diff.
+
+## Scope (this PR)
+
+Schema only. No behavior change today -- `cache_prefiltered_items`
+will always read as `0` until PR-D6g-2 wires the prefilter loop.
+
+Touches:
+
+1. **Migration `323_llm_gateway_batches_cache_prefiltered_items.sql`**
+   -- adds `cache_prefiltered_items INTEGER NOT NULL DEFAULT 0` to
+   `llm_gateway_batches`.
+2. **`atlas_brain/services/llm_gateway_batch.py`**:
+   - New field `cache_prefiltered_items: int = 0` on
+     `CustomerBatchRecord`.
+   - `_row_to_record` reads the new column with the same defensive
+     `.get`-style pattern as `usage_tracked` /
+     `anthropic_call_initiated_at`.
+   - All 6 `SELECT id, account_id, ...` statements updated to
+     include the new column. INSERT statements unchanged because
+     the column has a default.
+3. **`atlas_brain/api/llm_gateway.py`**:
+   - New field `cache_prefiltered_items: int = 0` on `BatchView`.
+   - `_batch_record_to_view` maps the field through.
+
+## Why no behavior change
+
+Wiring the prefilter loop into `submit_customer_batch` requires:
+
+- Lazy imports of `build_request_envelope` /
+  `lookup_cached_text` / `is_llm_gateway_exact_cache_enabled` from
+  `services/b2b/llm_exact_cache`.
+- A 100%-hit short-circuit that bypasses Anthropic entirely and
+  inserts a row with `status='ended'`, `cache_prefiltered_items=N`.
+- A partial-hit path that submits only misses to Anthropic but
+  writes zero-token `llm_usage` rows for the hits and stores the
+  prefilter count on the row.
+- Coordination with the existing idempotency replay path so a
+  retry doesn't double-write the cache-hit usage rows.
+- Coordination with the resume / refresh path
+  (`refresh_customer_batch_status`) so the per-batch
+  `total_items` vs `completed_items` accounting stays consistent
+  when Anthropic completes the misses.
+
+That's its own slice. Landing the schema first means PR-D6g-2 is a
+pure-behavior diff without schema entanglement.
+
+## Intentional (looks wrong but is deliberate)
+
+- **Field defaults to 0.** Back-compat with rows from before the
+  migration; clients that ignore the field are unaffected.
+- **All 6 SELECTs updated, not just one.** Whichever read path
+  serves a `BatchView` needs the column populated; missing it on
+  any one would silently default to 0 even when there should be
+  hits.
+- **No INSERT change.** The column has a default; explicit `0` on
+  INSERT would just match the default. PR-D6g-2 will write the
+  real count.
+- **`_row_to_record` uses defensive `.get`-style** pattern so test
+  mocks with shorter row dicts still work. Matches the precedent
+  set by `usage_tracked` (PR-D4c) and `anthropic_call_initiated_at`
+  (PR-D4e).
+- **No test for the migration itself.** Migration testing is
+  handled separately by the migration runner; this PR's tests
+  pin the dataclass / Pydantic shape.
+
+## Deferred (looks missing but is on purpose)
+
+- **Prefilter loop, zero-token usage rows, 100%-hit short-circuit.**
+  PR-D6g-2.
+- **Partial-hit submission flow.** Likely PR-D6g-3 -- requires
+  coordinated changes to `_persist_batch_usage` and the
+  refresh path.
+- **`Cache-Control: no-store` on /batch.** Symmetric with PR-D6f
+  on /chat; small follow-up.
+
+## Verification
+
+- New regression tests in
+  `tests/test_llm_gateway_batch_cache_prefilter_schema.py`:
+  - Migration file exists and contains the ALTER TABLE.
+  - `BatchView` Pydantic model declares the field with default 0.
+  - `CustomerBatchRecord` dataclass declares the field with default 0.
+  - All SELECT statements in `llm_gateway_batch.py` reference the
+    column.
+  - `_row_to_record` defensively reads the column.
+- `python3 -m py_compile atlas_brain/api/llm_gateway.py atlas_brain/services/llm_gateway_batch.py`
+  -> clean.
+- `bash scripts/check_ascii_python.sh` -> passed.
+
+## Conflict check
+
+No file overlap with any open PR.
+
+## Diff size
+
+- Migration: 12 LOC (one ALTER TABLE).
+- Source: ~30 LOC across 2 files (1 BatchView field + 1
+  CustomerBatchRecord field + _row_to_record reader + 6 SELECT
+  edits + 1 _batch_record_to_view mapping).
+- Tests: ~80 LOC, 5 source-text and structure assertions.
+- Plan doc: ~110 LOC.
+
+Source-only ~30 LOC. Smallest scope that lands the schema
+infrastructure for the prefilter feature.
+
+## After this lands
+
+PR-D6g-2 wires the prefilter behavior on top of this scaffolding.
+Customers see `cache_prefiltered_items > 0` on `/batch/{id}` when
+their batches dedup against the cache.

--- a/tests/test_llm_gateway_batch_cache_prefilter_schema.py
+++ b/tests/test_llm_gateway_batch_cache_prefilter_schema.py
@@ -1,0 +1,132 @@
+"""Regression tests for PR-D6g-1: schema scaffolding for /batch
+cache prefilter accounting.
+
+Pins five contracts:
+
+1. Migration 323 exists and adds the column with the right shape.
+2. ``BatchView`` Pydantic model exposes ``cache_prefiltered_items:
+   int = 0``.
+3. ``CustomerBatchRecord`` dataclass exposes the same field with
+   default 0.
+4. Every SELECT in ``llm_gateway_batch.py`` reads the new column.
+5. ``_row_to_record`` defensively reads the column with the
+   ``.get``-style pattern matching the precedent set by
+   ``usage_tracked`` and ``anthropic_call_initiated_at``.
+
+File-text inspection only -- bypasses the gateway module's full
+settings stack.
+
+See plans/PR-D6g-1-batch-cache-prefilter-schema.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_PATH = (
+    ROOT
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "323_llm_gateway_batches_cache_prefiltered_items.sql"
+)
+GATEWAY_PATH = ROOT / "atlas_brain" / "api" / "llm_gateway.py"
+BATCH_PATH = ROOT / "atlas_brain" / "services" / "llm_gateway_batch.py"
+
+
+@pytest.fixture(scope="module")
+def gateway_source() -> str:
+    return GATEWAY_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def batch_source() -> str:
+    return BATCH_PATH.read_text(encoding="utf-8")
+
+
+def test_migration_323_exists_and_adds_column():
+    """Migration file is present and adds the column with the right
+    type and default."""
+    assert MIGRATION_PATH.exists(), f"missing migration: {MIGRATION_PATH}"
+    text = MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "ALTER TABLE llm_gateway_batches" in text
+    assert "cache_prefiltered_items" in text
+    assert "INTEGER NOT NULL DEFAULT 0" in text
+
+
+def test_batch_view_pydantic_model_has_cache_prefiltered_items(gateway_source):
+    """BatchView model exposes the field with default 0."""
+    assert "class BatchView(BaseModel):" in gateway_source
+    block = gateway_source.split("class BatchView(BaseModel):", 1)[1]
+    block = block.split("\nclass ", 1)[0]
+    assert "cache_prefiltered_items: int = 0" in block, (
+        "BatchView must declare cache_prefiltered_items: int = 0"
+    )
+
+
+def test_batch_record_to_view_maps_cache_prefiltered_items(gateway_source):
+    """The view-mapper threads the field from the record to the view."""
+    assert "def _batch_record_to_view" in gateway_source
+    block = gateway_source.split("def _batch_record_to_view", 1)[1].split(
+        "\ndef ", 1
+    )[0]
+    assert "cache_prefiltered_items=record.cache_prefiltered_items" in block, (
+        "_batch_record_to_view must thread cache_prefiltered_items "
+        "from the record to the view"
+    )
+
+
+def test_customer_batch_record_dataclass_has_cache_prefiltered_items(batch_source):
+    """CustomerBatchRecord dataclass declares the field with default 0."""
+    assert "class CustomerBatchRecord:" in batch_source
+    block = batch_source.split("class CustomerBatchRecord:", 1)[1].split(
+        "\ndef ", 1
+    )[0]
+    assert "cache_prefiltered_items: int = 0" in block, (
+        "CustomerBatchRecord must declare cache_prefiltered_items: int = 0"
+    )
+
+
+def test_row_to_record_defensively_reads_cache_prefiltered_items(batch_source):
+    """The row reader uses the same .get-style pattern as
+    usage_tracked / anthropic_call_initiated_at -- mocks with shorter
+    row dicts still work."""
+    assert "def _row_to_record" in batch_source
+    block = batch_source.split("def _row_to_record", 1)[1].split("\ndef ", 1)[0]
+    assert "cache_prefiltered_items=" in block, (
+        "_row_to_record must read cache_prefiltered_items"
+    )
+    assert '"cache_prefiltered_items" in row.keys()' in block, (
+        "_row_to_record must defensively check the column is present "
+        "(matches the usage_tracked / anthropic_call_initiated_at pattern)"
+    )
+
+
+def test_all_select_statements_include_cache_prefiltered_items(batch_source):
+    """Every SELECT that produces a CustomerBatchRecord row must
+    include the new column. Missing it on any read path would
+    silently default to 0 even when there are real hits."""
+    # Count SELECT statements that reference last_usage_retry_at
+    # (the prior tail-of-list field) -- these are the ones that
+    # need to also include cache_prefiltered_items.
+    select_count = batch_source.count("anthropic_call_initiated_at, last_usage_retry_at,")
+    cache_count = batch_source.count("cache_prefiltered_items")
+
+    # Every SELECT block has cache_prefiltered_items appended.
+    # Plus the dataclass field, plus the _row_to_record reader,
+    # plus the BatchView field (in another file -- not this count).
+    # In this file we expect at least: 6 SELECTs + 1 dataclass +
+    # 2 _row_to_record references = 9+ occurrences.
+    assert cache_count >= 6, (
+        f"expected at least 6 cache_prefiltered_items references in "
+        f"llm_gateway_batch.py; found {cache_count}"
+    )
+    assert select_count >= 5, (
+        f"expected at least 5 SELECT-shaped column lists; found "
+        f"{select_count} -- if this dropped, a SELECT may have been "
+        f"missed by the schema migration"
+    )


### PR DESCRIPTION
**Plan:** [`plans/PR-D6g-1-batch-cache-prefilter-schema.md`](../blob/claude/llm-gateway-d6g-batch-cache-prefilter/plans/PR-D6g-1-batch-cache-prefilter-schema.md)

## Summary

Item #6 in the post-D6b LLM Gateway follow-up queue: apply the existing exact-cache to `/api/v1/llm/batch` so customer batches dedup against cached responses.

The full feature has two coupled halves -- this PR is **schema-only** (PR-D6g-1); behavior wiring is PR-D6g-2 follow-up. Splitting at the schema/behavior seam lands persistence shape first; the behavior PR can then be a pure-behavior diff.

## What changed (schema only)

- **Migration 323** -- adds `cache_prefiltered_items INTEGER NOT NULL DEFAULT 0` to `llm_gateway_batches`.
- **`BatchView` Pydantic model + `CustomerBatchRecord` dataclass** -- both expose `cache_prefiltered_items: int = 0`.
- **`_row_to_record`** -- reads the column with the defensive `.get`-style pattern matching `usage_tracked` (PR-D4c) and `anthropic_call_initiated_at` (PR-D4e).
- **6 SELECT statements** in `services/llm_gateway_batch.py` updated to include the column. INSERTs unchanged because the column has a default.
- **`_batch_record_to_view`** threads the field from record to view.

## No behavior change today

`cache_prefiltered_items` will always read as `0` until PR-D6g-2 wires the prefilter loop, 100%-hit short-circuit, partial-hit handling, and zero-token `llm_usage` row writes.

## Why split?

Wiring the prefilter loop into `submit_customer_batch` requires:

- Lazy imports of the cache helpers from `services/b2b/llm_exact_cache`.
- A 100%-hit short-circuit that bypasses Anthropic and inserts `status='ended'`.
- A partial-hit path that submits only misses, writes zero-token usage rows for hits, stores the prefilter count.
- Coordination with the existing idempotency replay path (don't double-write hits on retry).
- Coordination with the resume / refresh path so `total_items` vs `completed_items` accounting stays consistent when Anthropic completes the misses.

Each is its own decision. Landing the schema first keeps both PRs reviewable.

## Intentional (looks wrong but is deliberate)

- **Field defaults to 0.** Back-compat with rows from before the migration; clients that ignore the field are unaffected.
- **All 6 SELECTs updated, not just one.** Whichever read path serves a `BatchView` needs the column populated; missing it on any one would silently default to 0 even when there should be hits.
- **No INSERT change.** The column has a default; explicit `0` would just match. PR-D6g-2 will write the real count.
- **`_row_to_record` uses defensive `.get`-style** so test mocks with shorter row dicts still work. Matches PR-D4c / PR-D4e precedent.

## Verification

- [x] `pytest tests/test_llm_gateway_batch_cache_prefilter_schema.py -v` -> 6 passed
- [x] `python3 -m py_compile atlas_brain/api/llm_gateway.py atlas_brain/services/llm_gateway_batch.py` -> clean
- [x] `bash scripts/check_ascii_python.sh` -> passed

## Conflict check

No file overlap with any open PR.

## Diff size

- Migration: 12 LOC
- Source: ~30 LOC across 2 files (1 BatchView field + 1 CustomerBatchRecord field + _row_to_record reader + 6 SELECT edits + 1 _batch_record_to_view mapping)
- Tests: 132 LOC, 6 source-text + structure assertions
- Plan doc: 116 LOC

Source-only ~30 LOC.

## After this lands

| # | Item | Status |
|---|---|---|
| 1 | `cached: bool` on ChatResponse | merged in PR-D6e |
| 2 | Cache savings dashboard | merged in PR-D6c |
| 3 | Apply exact cache to `/chat/stream` | queued (open question) |
| 4 | Cache opt-out via `Cache-Control: no-store` on /chat | merged in PR-D6f |
| 5 | Semantic cache layer | queued (open embedding choice) |
| 6 | `/batch` cache schema | **this PR** |
| 6 | `/batch` cache prefilter behavior | PR-D6g-2 follow-up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)