### PR TITLE
PR-D6g-2: 100%-hit short-circuit for /batch cache prefilter

### DIFF
--- a/atlas_brain/services/llm_gateway_batch.py
+++ b/atlas_brain/services/llm_gateway_batch.py
@@ -129,6 +129,189 @@ class CustomerBatchRecord:
     cache_prefiltered_items: int = 0
 
 
+# PR-D6g-2: per-item cache-hit usage row. Mirrors _CACHE_HIT_USAGE_INSERT_SQL
+# in api/llm_gateway.py but tagged for /batch -- direct INSERT (not via
+# trace_llm_call) because the tracer's _store_local short-circuits on
+# all-zero token rows. The cache savings dashboard (/api/v1/llm/usage)
+# reads metadata.cache_savings_usd to dollarize the avoided cost.
+_CACHE_HIT_BATCH_USAGE_INSERT_SQL = """
+INSERT INTO llm_usage (
+    span_name, operation_type, model_name, model_provider,
+    input_tokens, output_tokens, total_tokens,
+    billable_input_tokens, cached_tokens, cache_write_tokens,
+    cost_usd, duration_ms, status, metadata,
+    api_endpoint, account_id
+) VALUES (
+    'llm_gateway.batch', 'llm_call', $1, $2,
+    0, 0, 0,
+    0, 0, 0,
+    0, 0, 'completed', $3::jsonb,
+    'llm_gateway.batch', $4
+)
+"""
+
+_CACHE_SAVINGS_METADATA_KEY = "cache_savings_usd"
+
+
+async def _try_prefilter_batch_through_cache(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    provider: str,
+    model: str,
+    items: Sequence["CustomerBatchItem"],
+) -> Optional[list[dict[str, Any]]]:
+    """Return a list of hit-info dicts iff EVERY item is a cache hit.
+    Otherwise return None and let the caller continue normal submission.
+
+    Lazy-imports the cache helpers so this module's import surface
+    isn't widened for callers who don't trigger the short-circuit.
+
+    PR-D6g-2 handles the 100%-hit case only: a customer re-submits an
+    identical batch (e.g., retry of a deterministic workload), every
+    item hits the exact cache, atlas marks the row ``status='ended'``
+    without calling Anthropic. Partial-hit handling (submit only
+    misses) is PR-D6g-3 -- requires coordinated changes to the
+    refresh / poll path that this slice does not touch.
+    """
+    from .b2b.llm_exact_cache import (
+        build_request_envelope,
+        is_llm_gateway_exact_cache_enabled,
+        lookup_cached_text,
+    )
+
+    if not is_llm_gateway_exact_cache_enabled():
+        return None
+
+    # Same namespace as /chat -- cross-endpoint cache sharing. A
+    # customer's prior /chat call with the same prompt populates
+    # the cache; a later /batch with the same prompt hits.
+    namespace = "llm_gateway.chat"
+    account_id_str = str(account_id)
+
+    hits: list[dict[str, Any]] = []
+    for item in items:
+        envelope = build_request_envelope(
+            provider=provider,
+            model=model,
+            messages=[
+                {"role": str(m.role), "content": str(m.content)}
+                for m in item.messages
+            ],
+            max_tokens=item.max_tokens,
+            temperature=item.temperature,
+        )
+        try:
+            cache_hit = await lookup_cached_text(
+                namespace,
+                envelope,
+                pool=pool,
+                account_id=account_id_str,
+            )
+        except Exception:
+            logger.exception(
+                "submit_customer_batch cache lookup failed account=%s",
+                account_id,
+            )
+            return None  # Fail-open: any error -> normal submission
+
+        if cache_hit is None:
+            return None  # Any miss -> normal submission
+
+        cached_usage = cache_hit.get("usage") or {}
+        try:
+            savings = _estimate_cost_usd(
+                model=cache_hit.get("model") or model,
+                input_tokens=int(cached_usage.get("input_tokens", 0) or 0),
+                output_tokens=int(cached_usage.get("output_tokens", 0) or 0),
+                cached_tokens=int(cached_usage.get("cached_tokens", 0) or 0),
+                cache_write_tokens=int(
+                    cached_usage.get("cache_write_tokens", 0) or 0
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "submit_customer_batch cache-hit savings estimate failed; "
+                "row will record 0.0",
+            )
+            savings = 0.0
+
+        hits.append(
+            {
+                "custom_id": item.custom_id,
+                "response_text": cache_hit["response_text"],
+                "usage": cached_usage,
+                "cache_savings_usd": savings,
+            }
+        )
+    return hits
+
+
+async def _insert_all_cache_hit_batch(
+    pool: Any,
+    *,
+    account_id: _uuid.UUID,
+    model: str,
+    items: Sequence["CustomerBatchItem"],
+    all_hits: list[dict[str, Any]],
+    normalized_key: Optional[str],
+) -> Any:
+    """100%-hit short-circuit: INSERT a terminal batch row and write a
+    zero-token llm_usage row per hit. No Anthropic call.
+
+    Status is ``ended`` at INSERT time -- the batch was already done
+    the moment we looked it up. ``submitted_at`` and ``completed_at``
+    both stamp NOW; ``usage_tracked=TRUE`` because the per-item rows
+    are written below in the same transaction. ``cache_prefiltered_items``
+    equals ``total_items`` (every item was satisfied from cache).
+    """
+    item_count = len(items)
+    async with pool.transaction() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO llm_gateway_batches (
+                account_id, provider, model, status, total_items,
+                completed_items, cache_prefiltered_items, idempotency_key,
+                submitted_at, completed_at, usage_tracked
+            ) VALUES (
+                $1, 'anthropic', $2, 'ended', $3,
+                $3, $3, $4,
+                NOW(), NOW(), TRUE
+            )
+            RETURNING id, account_id, provider, provider_batch_id, model,
+                      status, total_items, completed_items, failed_items,
+                      error_text, created_at, updated_at, submitted_at,
+                      completed_at, usage_tracked,
+                          anthropic_call_initiated_at, last_usage_retry_at,
+                          cache_prefiltered_items
+            """,
+            account_id,
+            model,
+            item_count,
+            normalized_key,
+        )
+        batch_id = row["id"]
+        for hit in all_hits:
+            metadata = json.dumps(
+                {
+                    "account_id": str(account_id),
+                    "endpoint": "llm_gateway.batch",
+                    "cache_hit": True,
+                    _CACHE_SAVINGS_METADATA_KEY: hit["cache_savings_usd"],
+                    "batch_id": str(batch_id),
+                    "custom_id": hit["custom_id"],
+                }
+            )
+            await conn.execute(
+                _CACHE_HIT_BATCH_USAGE_INSERT_SQL,
+                model,
+                "anthropic",
+                metadata,
+                account_id,
+            )
+    return row
+
+
 def _row_to_record(row: Any) -> CustomerBatchRecord:
     return CustomerBatchRecord(
         id=row["id"],
@@ -368,6 +551,40 @@ async def submit_customer_batch(
                 existing["status"],
             )
             row = resumed
+
+    # PR-D6g-2: 100%-hit short-circuit. Before doing the normal
+    # INSERT-then-Anthropic flow, check whether every item in the
+    # batch is already in the customer's exact cache. If yes, skip
+    # the Anthropic call entirely, mark the batch ``status='ended'``
+    # at INSERT time, and write zero-token llm_usage rows for each
+    # cache hit so /api/v1/llm/usage rollups surface the savings.
+    #
+    # Only fires when ``row is None`` (no idempotency replay, no
+    # resume from crash). Lookups happen AFTER the replay/resume
+    # checks above so a retry of the same key always replays the
+    # original record rather than creating a duplicate ``ended`` row.
+    #
+    # Partial-hit handling (some items hit, some miss) is PR-D6g-3 --
+    # requires coordinated changes to the refresh / poll path that
+    # this slice does not touch.
+    if row is None:
+        all_hits = await _try_prefilter_batch_through_cache(
+            pool,
+            account_id=account_id,
+            provider="anthropic",
+            model=model,
+            items=items,
+        )
+        if all_hits is not None:
+            row = await _insert_all_cache_hit_batch(
+                pool,
+                account_id=account_id,
+                model=model,
+                items=items,
+                all_hits=all_hits,
+                normalized_key=normalized_key,
+            )
+            return _row_to_record(row)
 
     # Insert pre-submit so a crash mid-call still leaves a queued row
     # the customer can see. The idempotency_key column is NULL when

--- a/plans/PR-D6g-2-batch-cache-100pct-hit-shortcircuit.md
+++ b/plans/PR-D6g-2-batch-cache-100pct-hit-shortcircuit.md
@@ -1,0 +1,144 @@
+# PR-D6g-2: 100%-hit short-circuit for /batch cache prefilter
+
+## Why this slice exists
+
+Behavior half of the /batch cache prefilter feature scaffolded by
+PR-D6g-1 (#439). When every item in a customer's batch is already
+in their exact cache, atlas marks the batch ``status='ended'`` at
+INSERT time without calling Anthropic. The customer pays nothing
+to Anthropic for that batch; their /api/v1/llm/usage rollup picks
+up the cache savings.
+
+Real workload that benefits: a customer re-submits an identical
+deterministic batch (e.g., retry of a job whose results were
+already produced + cached). Today they pay Anthropic full price
+for the resubmission.
+
+## Scope (this PR)
+
+**100%-hit case only.** Partial-hit handling defers to PR-D6g-3
+because it requires coordinated changes to the refresh / poll
+path that this slice does not touch.
+
+### Touches `services/llm_gateway_batch.py`
+
+- New `_CACHE_HIT_BATCH_USAGE_INSERT_SQL` constant -- direct INSERT
+  (not via `trace_llm_call`) because the tracer's `_store_local`
+  short-circuits on all-zero token rows. Mirrors the chat-side
+  `_CACHE_HIT_USAGE_INSERT_SQL` from PR-D6b but tagged with
+  `'llm_gateway.batch'` span/endpoint.
+- New `_CACHE_SAVINGS_METADATA_KEY` constant -- shared name so the
+  read site (/api/v1/llm/usage rollup) and write site can't drift.
+- New `_try_prefilter_batch_through_cache` helper -- builds an
+  envelope per item using the same `build_request_envelope` shape
+  as /chat, looks each up in the customer's exact cache. Returns
+  the list of hit-info dicts iff EVERY item hits; otherwise None
+  (caller falls through to normal Anthropic submission).
+- New `_insert_all_cache_hit_batch` helper -- INSERTs the batch row
+  with `status='ended'`, `cache_prefiltered_items=N`,
+  `total_items=N`, `completed_items=N`, `usage_tracked=TRUE`,
+  `submitted_at=NOW()`, `completed_at=NOW()`, no
+  `provider_batch_id`. Writes a per-item zero-token `llm_usage`
+  row in the same transaction.
+- `submit_customer_batch` calls the prefilter after the
+  idempotency-replay and resume-from-crash checks but before the
+  normal INSERT-then-Anthropic flow. Short-circuit fires only when
+  `row is None` (no replay, no resume) AND every item hits.
+
+### Cross-endpoint cache sharing
+
+Same namespace as /chat (`"llm_gateway.chat"`). A customer's prior
+/chat call with the same prompt populates the cache; a later
+/batch with the same prompt hits. Same in reverse: a /chat after
+a previously-stored batch item benefits.
+
+The cache key is built from the request envelope (provider, model,
+messages, max_tokens, temperature) -- identical requests share a
+key regardless of which endpoint produced or consumed them.
+
+## Intentional (looks wrong but is deliberate)
+
+- **100%-hit only.** Partial-hit (some items hit, some miss)
+  requires coordinated changes to:
+  - The Anthropic submit shape (send only misses).
+  - `_persist_batch_usage` (already handles per-item rows; need
+    to merge cache-hit accounting alongside Anthropic-completed
+    accounting).
+  - `refresh_customer_batch_status` (the row's `total_items` vs
+    `completed_items` accounting must stay consistent as the
+    Anthropic side reports incremental progress on a smaller
+    actual batch than the customer's logical batch).
+  Each is its own decision. Ship the 100%-hit case first; partial
+  in PR-D6g-3.
+- **Prefilter happens AFTER replay/resume checks.** A retry of an
+  idempotency-keyed batch must always replay the original record,
+  not create a new ``ended`` row even if the cache state would now
+  satisfy every item. Order matters.
+- **Fail-open on lookup error.** If `lookup_cached_text` raises
+  (DB transient, schema drift), the helper returns None and the
+  caller continues normal submission. The customer pays Anthropic
+  rather than seeing a 500 from a cache implementation detail.
+- **`provider_batch_id` is NULL** on the short-circuit row. There
+  is no Anthropic batch -- the customer's GET `/batch/{id}` will
+  show `status='ended'` with `provider_batch_id=null` and
+  `cache_prefiltered_items=N` so they can tell why no Anthropic
+  side exists.
+- **Lazy import of cache helpers** (`build_request_envelope` etc.)
+  inside the prefilter helper. Avoids widening this module's
+  import surface for callers that don't trigger the short-circuit.
+- **All-zero token usage row direct-INSERT** (not via
+  `trace_llm_call`). Same Codex-P1 lesson from PR-D6b: the tracer
+  drops zero-token rows.
+- **`usage_tracked=TRUE` at INSERT time.** All per-item rows are
+  written in the same transaction; there is nothing for the
+  refresh path to reconcile later.
+
+## Deferred (looks missing but is on purpose)
+
+- Partial-hit path (PR-D6g-3).
+- `Cache-Control: no-store` on /batch (symmetric with PR-D6f on
+  /chat).
+- /batch/{id}/results endpoint -- the missing endpoint that would
+  let customers retrieve cache-hit response text. Until it lands,
+  the 100%-hit case is "you saved $X but here are no responses to
+  retrieve" -- accounting-only feature. This PR ships the savings
+  side; retrieval is a separate slice.
+
+## Verification
+
+- New regression tests in
+  `tests/test_llm_gateway_batch_cache_100pct_hit.py`:
+  - Helper / SQL constants exist.
+  - Prefilter helper imports cache helpers lazily.
+  - Submit flow calls prefilter only when `row is None`.
+  - Short-circuit returns early via `_insert_all_cache_hit_batch`.
+  - INSERT shape: `status='ended'`, all three counts equal, no
+    provider_batch_id.
+  - Cache namespace shared with /chat.
+- `python3 -m py_compile atlas_brain/services/llm_gateway_batch.py`
+  -> clean.
+- `bash scripts/check_ascii_python.sh` -> passed.
+
+## Conflict check
+
+No file overlap with any open PR. Builds on the schema landed in
+PR-D6g-1 (#439, merged).
+
+## Diff size
+
+- Source: ~140 LOC added to `services/llm_gateway_batch.py`
+  (prefilter helper + insert helper + short-circuit hook + SQL
+  constants + metadata key constant).
+- Tests: ~110 LOC, source-text contract assertions.
+- Plan doc: ~135 LOC.
+
+## After this lands
+
+Customers re-submitting identical batches (deterministic retry
+workloads) get a free batch -- Anthropic isn't called and the
+customer's bill doesn't move. The savings show up in
+`/api/v1/llm/usage` `total_cache_savings_usd` (PR-D6c surface).
+The batch row's `cache_prefiltered_items` shows the count.
+
+Partial-hit (PR-D6g-3) is the next slice -- bigger lift because
+it requires the refresh path to know about the cache-hit subset.

--- a/tests/test_llm_gateway_batch_cache_100pct_hit.py
+++ b/tests/test_llm_gateway_batch_cache_100pct_hit.py
@@ -1,0 +1,160 @@
+"""Regression tests for PR-D6g-2: 100%-hit short-circuit for /batch
+cache prefilter.
+
+Pins six contracts:
+
+1. The cache-hit usage INSERT SQL exists with the right shape (zero
+   tokens, ``llm_gateway.batch`` span/endpoint).
+2. The prefilter helper imports cache primitives lazily and uses
+   the same namespace as /chat (cross-endpoint sharing).
+3. The prefilter returns ``None`` on any miss and on lookup error
+   (fail-open contract).
+4. The short-circuit hook fires AFTER the idempotency replay /
+   resume checks (only when ``row is None``).
+5. The 100%-hit insert sets ``status='ended'``, all three count
+   fields equal to ``len(items)``, and the row has no
+   ``provider_batch_id``.
+6. Cache savings metadata key is shared between write and read
+   sites (no drift).
+
+File-text inspection only -- bypasses the gateway module's full
+settings stack.
+
+See plans/PR-D6g-2-batch-cache-100pct-hit-shortcircuit.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BATCH_PATH = ROOT / "atlas_brain" / "services" / "llm_gateway_batch.py"
+
+
+@pytest.fixture(scope="module")
+def batch_source() -> str:
+    return BATCH_PATH.read_text(encoding="utf-8")
+
+
+def test_cache_hit_usage_insert_sql_exists_with_zero_token_shape(batch_source):
+    """The INSERT writes all-zero token counts and tags the row with
+    'llm_gateway.batch' so /usage rollups can attribute savings."""
+    assert "_CACHE_HIT_BATCH_USAGE_INSERT_SQL" in batch_source
+    sql_block = batch_source.split("_CACHE_HIT_BATCH_USAGE_INSERT_SQL = ", 1)[1].split(
+        '"""', 2
+    )[1]
+    assert "INSERT INTO llm_usage" in sql_block
+    assert "'llm_gateway.batch'" in sql_block
+    assert "0, 0, 0" in sql_block, "must write zero token counts"
+    assert "'completed'" in sql_block
+    assert "$3::jsonb" in sql_block, "metadata must be jsonb"
+
+
+def test_cache_savings_metadata_key_constant_exists(batch_source):
+    """A module-level constant pins the savings metadata key so write
+    and read sites can't drift (matches PR-D6c on /chat)."""
+    assert '_CACHE_SAVINGS_METADATA_KEY = "cache_savings_usd"' in batch_source
+
+
+def test_prefilter_helper_lazy_imports_cache_primitives(batch_source):
+    """The cache helpers are lazy-imported inside the prefilter
+    function -- avoids widening this module's import surface."""
+    assert "async def _try_prefilter_batch_through_cache" in batch_source
+    helper_block = batch_source.split(
+        "async def _try_prefilter_batch_through_cache", 1
+    )[1].split("\nasync def ", 1)[0]
+    # Lazy import is INSIDE the function body, not at module top.
+    assert "from .b2b.llm_exact_cache import" in helper_block
+    assert "build_request_envelope" in helper_block
+    assert "is_llm_gateway_exact_cache_enabled" in helper_block
+    assert "lookup_cached_text" in helper_block
+
+
+def test_prefilter_returns_none_on_any_miss(batch_source):
+    """Any miss -> caller falls through to normal submission (no
+    short-circuit). Pin the contract via source assertion."""
+    helper_block = batch_source.split(
+        "async def _try_prefilter_batch_through_cache", 1
+    )[1].split("\nasync def ", 1)[0]
+    assert "if cache_hit is None:" in helper_block
+    assert "return None  # Any miss" in helper_block
+
+
+def test_prefilter_fails_open_on_lookup_error(batch_source):
+    """Cache lookup exception -> return None (fall through to
+    normal submission). Customer pays Anthropic instead of seeing a
+    500 from a cache implementation detail."""
+    helper_block = batch_source.split(
+        "async def _try_prefilter_batch_through_cache", 1
+    )[1].split("\nasync def ", 1)[0]
+    assert "except Exception:" in helper_block
+    assert "return None  # Fail-open" in helper_block
+
+
+def test_prefilter_uses_chat_cache_namespace(batch_source):
+    """Cross-endpoint cache sharing: /batch and /chat share the
+    'llm_gateway.chat' namespace so they hit each other's stored
+    responses for identical prompts."""
+    helper_block = batch_source.split(
+        "async def _try_prefilter_batch_through_cache", 1
+    )[1].split("\nasync def ", 1)[0]
+    assert 'namespace = "llm_gateway.chat"' in helper_block
+
+
+def test_short_circuit_only_fires_when_row_is_none(batch_source):
+    """The prefilter hook lives inside ``if row is None:`` so a
+    replay or resume always wins over the cache short-circuit."""
+    submit_block = batch_source.split("async def submit_customer_batch", 1)[1].split(
+        "\nasync def ", 1
+    )[0]
+    # The hook is a NEW ``if row is None`` block (the second one;
+    # the first is the existing INSERT path that follows it).
+    assert "if row is None:" in submit_block
+    assert "_try_prefilter_batch_through_cache" in submit_block
+    # Hook calls _insert_all_cache_hit_batch on 100% hits.
+    assert "_insert_all_cache_hit_batch" in submit_block
+
+
+def test_insert_all_cache_hit_batch_marks_status_ended(batch_source):
+    """The 100%-hit INSERT writes status='ended', all three counts
+    equal to total_items, no provider_batch_id, both timestamps NOW,
+    usage_tracked=TRUE."""
+    insert_block = batch_source.split("async def _insert_all_cache_hit_batch", 1)[
+        1
+    ].split("\nasync def ", 1)[0]
+    assert "'ended'" in insert_block
+    assert "cache_prefiltered_items" in insert_block
+    assert "completed_items" in insert_block
+    # All three counts (total_items, completed_items, cache_prefiltered_items)
+    # use the same $3 placeholder (item_count). The SQL spans multiple
+    # lines so we count occurrences in the VALUES clause.
+    insert_sql = insert_block.split("INSERT INTO", 1)[1].split("RETURNING", 1)[0]
+    values_clause = insert_sql.split("VALUES", 1)[1]
+    assert values_clause.count("$3") == 3, (
+        "total_items, completed_items, cache_prefiltered_items must all "
+        f"use $3 placeholder; found {values_clause.count('$3')}"
+    )
+    # Timestamps marked NOW; usage_tracked TRUE; no provider_batch_id
+    # column in the INSERT (defaults to NULL).
+    assert "NOW(), NOW(), TRUE" in insert_block
+    assert "provider_batch_id" not in insert_block.split("INSERT", 1)[1].split(
+        "RETURNING", 1
+    )[0], "provider_batch_id should not be in the INSERT column list (defaults to NULL)"
+
+
+def test_insert_writes_per_item_zero_token_usage_row(batch_source):
+    """Each cache hit gets a zero-token llm_usage row in the same
+    transaction so /usage rollups attribute the savings."""
+    insert_block = batch_source.split("async def _insert_all_cache_hit_batch", 1)[
+        1
+    ].split("\nasync def ", 1)[0]
+    assert "for hit in all_hits:" in insert_block
+    assert "_CACHE_HIT_BATCH_USAGE_INSERT_SQL" in insert_block
+    # Metadata includes cache_hit, savings, batch_id, custom_id.
+    assert '"cache_hit": True' in insert_block
+    assert "_CACHE_SAVINGS_METADATA_KEY" in insert_block
+    assert '"batch_id"' in insert_block
+    assert '"custom_id"' in insert_block


### PR DESCRIPTION
**Plan:** [`plans/PR-D6g-2-batch-cache-100pct-hit-shortcircuit.md`](../blob/claude/llm-gateway-d6g2-100pct-hit-shortcircuit/plans/PR-D6g-2-batch-cache-100pct-hit-shortcircuit.md)

## Summary

Behavior half of the /batch cache prefilter feature scaffolded by PR-D6g-1 (#439). When every item in a customer's batch is already in their exact cache, atlas marks the batch `status='ended'` at INSERT time without calling Anthropic.

**Real workload that benefits:** deterministic batch retries (same prompts, customer's response set already cached). Today they pay Anthropic full price for the resubmission.

## What changed

### `services/llm_gateway_batch.py`

- **`_CACHE_HIT_BATCH_USAGE_INSERT_SQL`** -- mirrors the chat-side cache-hit INSERT from PR-D6b but tagged `'llm_gateway.batch'`. Direct INSERT because the tracer drops zero-token rows.
- **`_CACHE_SAVINGS_METADATA_KEY`** -- shared constant so the write site (this PR) and read site (`/api/v1/llm/usage` rollup, PR-D6c) can't drift.
- **`_try_prefilter_batch_through_cache`** -- builds an envelope per item using `build_request_envelope` (same shape as /chat); looks each up via `lookup_cached_text`. Returns list of hit-info dicts iff EVERY item hits; otherwise None. Lazy-imports cache primitives.
- **`_insert_all_cache_hit_batch`** -- INSERTs the batch row with `status='ended'`, `cache_prefiltered_items=N`, `total_items=N`, `completed_items=N`, no `provider_batch_id`, both timestamps NOW, `usage_tracked=TRUE`. Writes per-item zero-token `llm_usage` rows in the same transaction.
- **`submit_customer_batch`** calls the prefilter AFTER replay/resume but BEFORE the normal Anthropic submission. Short-circuit only fires when `row is None` (no replay, no resume) AND every item hits.

## Cross-endpoint cache sharing

Same namespace as /chat (`"llm_gateway.chat"`). Customer's prior /chat call populates the cache; later /batch with the same prompt hits. Same in reverse.

## Intentional (looks wrong but is deliberate)

- **100%-hit only.** Partial-hit defers to PR-D6g-3 because it needs coordinated changes to:
  - Anthropic submit shape (send only misses)
  - `_persist_batch_usage` (merge cache-hit accounting alongside Anthropic-completed)
  - `refresh_customer_batch_status` (total_items vs completed_items consistency as Anthropic reports incremental progress on a smaller-than-logical batch)
- **Prefilter happens AFTER replay/resume.** A retry of an idempotency-keyed batch must always replay the original record, not create a new `ended` row even if cache would now satisfy every item.
- **Fail-open on lookup error.** Cache lookup raises -> return None -> fall through to normal submission. Customer pays Anthropic instead of seeing a 500 from a cache implementation detail.
- **`provider_batch_id` is NULL** on the short-circuit row -- there is no Anthropic batch. Customer's `GET /batch/{id}` shows `status='ended'`, `provider_batch_id=null`, `cache_prefiltered_items=N` so they can tell why.
- **Lazy-imports** cache helpers inside the prefilter function -- avoids widening this module's import surface.
- **All-zero token usage row direct-INSERT** (not via `trace_llm_call`) -- same Codex-P1 lesson as PR-D6b.
- **`usage_tracked=TRUE` at INSERT time** -- all per-item rows in the same transaction; nothing for the refresh path to reconcile.

## Deferred (looks missing but is on purpose)

- Partial-hit path (PR-D6g-3).
- `Cache-Control: no-store` on /batch (symmetric with PR-D6f on /chat).
- `/batch/{id}/results` endpoint -- the missing endpoint that would let customers retrieve cache-hit response text. Until it lands, the 100%-hit case is "you saved $X but here are no responses to retrieve" -- accounting-only feature. This PR ships the savings side; retrieval is a separate slice.

## Verification

- [x] `pytest tests/test_llm_gateway_batch_cache_100pct_hit.py -v` -> 9 passed
- [x] `python3 -m py_compile atlas_brain/services/llm_gateway_batch.py` -> clean
- [x] `bash scripts/check_ascii_python.sh` -> passed

## Conflict check

No file overlap with any open PR. Builds on schema landed in PR-D6g-1 (#439, merged).

## Diff size

- Source: ~140 LOC added to `services/llm_gateway_batch.py`
- Tests: 168 LOC, 9 source-text contract assertions
- Plan doc: 156 LOC

## After this lands

Customers re-submitting identical batches (deterministic retry workloads) get a free batch -- Anthropic isn't called, customer's bill doesn't move. Savings show up in `/api/v1/llm/usage` `total_cache_savings_usd` (PR-D6c surface). The batch row's `cache_prefiltered_items` shows the count.

## Stack so far in this conversation

| PR | Track | What | Status |
|---|---|---|---|
| #422 | drift-protection | brand_registry shim | merged |
| #425 | drift-protection | _b2b_witnesses shim | merged |
| #427 | drift-protection | manifest-driven pipeline standalone smoke | merged |
| #428 | drift-protection | manifest-driven default-mode smokes | merged |
| #431 | drift-protection | manifest-driven compintel-standalone smoke | merged |
| #434 | LLM Gateway D6e | ChatResponse.cached field | merged |
| #435 | LLM Gateway D6f | Cache-Control: no-store | merged |
| #439 | LLM Gateway D6g-1 | /batch cache prefilter schema | merged |
| **this** | LLM Gateway D6g-2 | /batch 100%-hit short-circuit | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)