### PR TITLE
Add Content Ops generated asset review CLI

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:05Z by codex-content-ops-asset-review-cli
+Last updated: 2026-05-09T21:13Z by codex-content-ops-asset-review-cli
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add generated asset review status CLI for Content Ops | NEW: `scripts/review_extracted_content_assets.py`; NEW: `tests/test_extracted_content_asset_review_cli.py`; NEW: `plans/PR-Content-Ops-Asset-Review-CLI.md`; EDIT: `scripts/run_extracted_pipeline_checks.sh`; EDIT: `extracted_content_pipeline/README.md`; EDIT: `extracted_content_pipeline/STATUS.md`; EDIT: `extracted_content_pipeline/docs/standalone_productization.md`. | codex-content-ops-asset-review-cli | Generated asset review CLI/tests/docs until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:03Z by codex-content-ops-asset-export-cli
+Last updated: 2026-05-09T21:05Z by codex-content-ops-asset-review-cli
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add generated asset review status CLI for Content Ops | NEW: `scripts/review_extracted_content_assets.py`; NEW: `tests/test_extracted_content_asset_review_cli.py`; NEW: `plans/PR-Content-Ops-Asset-Review-CLI.md`; EDIT: `scripts/run_extracted_pipeline_checks.sh`; EDIT: `extracted_content_pipeline/README.md`; EDIT: `extracted_content_pipeline/STATUS.md`; EDIT: `extracted_content_pipeline/docs/standalone_productization.md`. | codex-content-ops-asset-review-cli | Generated asset review CLI/tests/docs until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -373,6 +373,15 @@ python scripts/review_extracted_campaign_drafts.py <campaign-id> --account-id ac
 python scripts/review_extracted_campaign_drafts.py <campaign-id> --account-id acct_123 --status cancelled --reason "customer rejected"
 ```
 
+Generated reports, landing pages, and sales briefs use the matching asset
+review CLI:
+
+```bash
+python scripts/review_extracted_content_assets.py --asset report --id <report-id> --account-id acct_123 --status approved
+python scripts/review_extracted_content_assets.py --asset landing_page --id <landing-page-id> --account-id acct_123 --status queued
+python scripts/review_extracted_content_assets.py --asset sales_brief --id <brief-id> --account-id acct_123 --status rejected
+```
+
 Hosts with FastAPI apps can mount the same draft review/export loop through a
 router factory. The host injects its database pool, tenant scope, and auth
 dependencies:
@@ -732,6 +741,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `sales_brief_export.py`: read-only sales brief export for host review flows
 - `scripts/export_extracted_content_assets.py`: host-facing report, landing
   page, and sales brief export CLI
+- `scripts/review_extracted_content_assets.py`: host-facing report, landing
+  page, and sales brief status-update CLI
 - `campaign_postgres_seller_targets.py`: seller target CRUD/list helpers for
   Amazon seller campaign installs
 - `campaign_postgres_seller_opportunities.py`: prepares Amazon seller

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -56,6 +56,9 @@
 - `scripts/export_extracted_content_assets.py` exposes the report, landing
   page, and sales brief export helpers as a host-facing JSON/CSV CLI backed by
   the product-owned Postgres repositories.
+- `scripts/review_extracted_content_assets.py` exposes scoped status updates
+  for exported report, landing page, and sales brief drafts without handwritten
+  SQL.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -204,6 +204,11 @@ landing_page`, or `--asset sales_brief`; the CLI creates the product-owned
 Postgres repository, applies the relevant filters, and writes JSON or CSV
 without requiring ad hoc SQL.
 
+`scripts/review_extracted_content_assets.py` owns the matching status-update
+loop for generated assets. Hosts pass `--asset`, `--id`, `--status`, and an
+optional `--account-id`; the CLI calls the matching product-owned Postgres
+repository and emits a JSON hit/miss result without requiring ad hoc SQL.
+
 `extracted_content_pipeline/campaign_postgres_review.py` owns the write side of
 that host review loop. It updates selected `b2b_campaigns` rows by explicit
 campaign id, optional account scope, and source-status guard so hosts can move

--- a/plans/PR-Content-Ops-Asset-Review-CLI.md
+++ b/plans/PR-Content-Ops-Asset-Review-CLI.md
@@ -1,0 +1,45 @@
+# PR-Content-Ops-Asset-Review-CLI
+
+## Why this slice exists
+
+Reports, landing pages, and sales briefs now have export helpers and a shared
+export CLI. Hosts can review generated assets without SQL, but they still need
+to write Python or SQL to move an exported asset to `approved`, `queued`,
+`rejected`, or another lifecycle status.
+
+## Scope (this PR)
+
+1. Add `scripts/review_extracted_content_assets.py`.
+2. Support `--asset report|landing_page|sales_brief`.
+3. Reuse the existing Postgres repository adapters and their scoped
+   `update_status()` methods.
+4. Emit JSON for both hit and miss cases so operator automation can consume the
+   result.
+5. Document the command and add focused tests to extracted pipeline checks.
+
+### Files touched
+
+- `scripts/review_extracted_content_assets.py`
+- `tests/test_extracted_content_asset_review_cli.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Intentional
+
+- No batch update helper in this slice. Generated asset repositories expose a
+  simple single-row hit/miss contract today.
+- No FastAPI route in this slice.
+- One CLI for generated assets rather than three near-identical scripts.
+
+## Verification
+
+Planned:
+
+- `python -m pytest tests/test_extracted_content_asset_review_cli.py`
+- `python -m py_compile scripts/review_extracted_content_assets.py tests/test_extracted_content_asset_review_cli.py`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `git diff --check`
+- Non-ASCII byte check for edited Python files.

--- a/plans/PR-Content-Ops-Asset-Review-CLI.md
+++ b/plans/PR-Content-Ops-Asset-Review-CLI.md
@@ -1,0 +1,58 @@
+# PR-Content-Ops-Asset-Review-CLI
+
+## Why this slice exists
+
+Reports, landing pages, and sales briefs now have export helpers and a shared
+export CLI. Hosts can review generated assets without SQL, but they still need
+to write Python or SQL to move an exported asset to `approved`, `queued`,
+`rejected`, or another lifecycle status.
+
+## Scope (this PR)
+
+1. Add `scripts/review_extracted_content_assets.py`.
+2. Support `--asset report|landing_page|sales_brief`.
+3. Reuse the existing Postgres repository adapters and their scoped
+   `update_status()` methods.
+4. Emit JSON for both hit and miss cases so operator automation can consume the
+   result.
+5. Document the command and add focused tests to extracted pipeline checks.
+
+### Files touched
+
+- `scripts/review_extracted_content_assets.py`
+- `tests/test_extracted_content_asset_review_cli.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Intentional
+
+- No batch update helper in this slice. Generated asset repositories expose a
+  simple single-row hit/miss contract today.
+- No FastAPI route in this slice.
+- One CLI for generated assets rather than three near-identical scripts.
+
+## Deferred
+
+- Batch asset review/status updates.
+- FastAPI routes for generated asset review workflows.
+- Per-host status vocabulary enforcement. Generated asset tables intentionally
+  allow host-defined lifecycle values.
+
+## Verification
+
+Planned:
+
+- `python -m pytest tests/test_extracted_content_asset_review_cli.py`
+- `python -m py_compile scripts/review_extracted_content_assets.py tests/test_extracted_content_asset_review_cli.py`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `git diff --check`
+- Non-ASCII byte check for edited Python files.
+
+## Estimated diff size
+
+- Production: ~115 LOC.
+- Tests: ~180 LOC.
+- Docs/check wiring: ~70 LOC.

--- a/scripts/review_extracted_content_assets.py
+++ b/scripts/review_extracted_content_assets.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Update generated Content Ops asset statuses in the extracted database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.landing_page_postgres import (  # noqa: E402
+    PostgresLandingPageRepository,
+)
+from extracted_content_pipeline.report_postgres import PostgresReportRepository  # noqa: E402
+from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
+    PostgresSalesBriefRepository,
+)
+
+
+ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Review generated AI Content Ops assets in Postgres."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--asset", choices=ASSET_CHOICES, required=True)
+    parser.add_argument("--id", dest="asset_id", required=True, help="Asset UUID to update.")
+    parser.add_argument(
+        "--status",
+        required=True,
+        help="Status to apply. Host-defined lifecycle statuses are accepted.",
+    )
+    parser.add_argument("--account-id", default=None, help="Optional tenant/account id.")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to review assets; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    args.status = _status_arg(args.status)
+    pool = await _create_pool(args.database_url)
+    try:
+        updated = await _review_asset(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    print(json.dumps(_result_payload(args, updated), indent=2, sort_keys=True))
+    return 0 if updated else 1
+
+
+async def _review_asset(args: argparse.Namespace, pool: Any) -> bool:
+    scope = TenantScope(account_id=args.account_id)
+    if args.asset == "report":
+        return await PostgresReportRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    if args.asset == "landing_page":
+        return await PostgresLandingPageRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    if args.asset == "sales_brief":
+        return await PostgresSalesBriefRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    raise ValueError(f"Unsupported asset: {args.asset}")
+
+
+def _result_payload(args: argparse.Namespace, updated: bool) -> dict[str, Any]:
+    return {
+        "account_id": args.account_id,
+        "asset": args.asset,
+        "id": args.asset_id,
+        "status": args.status,
+        "updated": bool(updated),
+    }
+
+
+def _status_arg(raw: str | None) -> str:
+    status = str(raw or "").strip()
+    if not status:
+        raise SystemExit("--status must be a non-empty string")
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/review_extracted_content_assets.py
+++ b/scripts/review_extracted_content_assets.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Update generated Content Ops asset statuses in the extracted database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.landing_page_postgres import (  # noqa: E402
+    PostgresLandingPageRepository,
+)
+from extracted_content_pipeline.report_postgres import PostgresReportRepository  # noqa: E402
+from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
+    PostgresSalesBriefRepository,
+)
+
+
+ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+STATUS_CHOICES = ("draft", "approved", "queued", "rejected", "expired")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Review generated AI Content Ops assets in Postgres."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--asset", choices=ASSET_CHOICES, required=True)
+    parser.add_argument("--id", dest="asset_id", required=True, help="Asset UUID to update.")
+    parser.add_argument(
+        "--status",
+        choices=STATUS_CHOICES,
+        required=True,
+        help="Status to apply.",
+    )
+    parser.add_argument("--account-id", default=None, help="Optional tenant/account id.")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to review assets; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        updated = await _review_asset(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    print(json.dumps(_result_payload(args, updated), indent=2, sort_keys=True))
+    return 0 if updated else 1
+
+
+async def _review_asset(args: argparse.Namespace, pool: Any) -> bool:
+    scope = TenantScope(account_id=args.account_id)
+    if args.asset == "report":
+        return await PostgresReportRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    if args.asset == "landing_page":
+        return await PostgresLandingPageRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    if args.asset == "sales_brief":
+        return await PostgresSalesBriefRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    raise ValueError(f"Unsupported asset: {args.asset}")
+
+
+def _result_payload(args: argparse.Namespace, updated: bool) -> dict[str, Any]:
+    return {
+        "account_id": args.account_id,
+        "asset": args.asset,
+        "id": args.asset_id,
+        "status": args.status,
+        "updated": bool(updated),
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -45,6 +45,7 @@ pytest \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
   tests/test_extracted_content_asset_export_cli.py \
+  tests/test_extracted_content_asset_review_cli.py \
   tests/test_extracted_report_export.py \
   tests/test_extracted_landing_page_export.py \
   tests/test_extracted_sales_brief_export.py \

--- a/tests/test_extracted_content_asset_review_cli.py
+++ b/tests/test_extracted_content_asset_review_cli.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/review_extracted_content_assets.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "review_extracted_content_assets",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    def __init__(self, result: str = "UPDATE 1") -> None:
+        self.result = result
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.closed = False
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        return self.result
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_updates_report_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+    created_urls: list[str] = []
+
+    async def create_pool(database_url):
+        created_urls.append(database_url)
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "report",
+            "--id",
+            "report-uuid-1",
+            "--status",
+            "approved",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert created_urls == ["postgres://example"]
+    assert pool.closed is True
+    assert "UPDATE reports" in query
+    assert args == ("report-uuid-1", "approved", "acct_1")
+    assert output == {
+        "account_id": "acct_1",
+        "asset": "report",
+        "id": "report-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_returns_nonzero_on_landing_page_miss(
+    monkeypatch,
+    capsys,
+) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(result="UPDATE 0")
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "landing_page",
+            "--id",
+            "landing-page-uuid-1",
+            "--status",
+            "rejected",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 1
+    assert pool.closed is True
+    assert "UPDATE landing_pages" in query
+    assert args == ("landing-page-uuid-1", "rejected", "acct_1")
+    assert output["updated"] is False
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_updates_sales_brief_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "sales_brief",
+            "--id",
+            "sales-brief-uuid-1",
+            "--status",
+            "queued",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert "UPDATE sales_briefs" in query
+    assert args == ("sales-brief-uuid-1", "queued", "")
+    assert output["account_id"] is None
+    assert output["updated"] is True
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_allows_host_defined_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "report",
+            "--id",
+            "report-uuid-1",
+            "--status",
+            "published",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert "UPDATE reports" in query
+    assert args == ("report-uuid-1", "published", "acct_1")
+    assert output["status"] == "published"
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_rejects_empty_status(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "report",
+            "--id",
+            "report-uuid-1",
+            "--status",
+            "",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="--status must be a non-empty string"):
+        await cli._main()
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_requires_database_url(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--asset",
+            "report",
+            "--id",
+            "report-uuid-1",
+            "--status",
+            "approved",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="Missing --database-url"):
+        await cli._main()

--- a/tests/test_extracted_content_asset_review_cli.py
+++ b/tests/test_extracted_content_asset_review_cli.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/review_extracted_content_assets.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "review_extracted_content_assets",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    def __init__(self, result: str = "UPDATE 1") -> None:
+        self.result = result
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.closed = False
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        return self.result
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_updates_report_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+    created_urls: list[str] = []
+
+    async def create_pool(database_url):
+        created_urls.append(database_url)
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "report",
+            "--id",
+            "report-uuid-1",
+            "--status",
+            "approved",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert created_urls == ["postgres://example"]
+    assert pool.closed is True
+    assert "UPDATE reports" in query
+    assert args == ("report-uuid-1", "approved", "acct_1")
+    assert output == {
+        "account_id": "acct_1",
+        "asset": "report",
+        "id": "report-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_returns_nonzero_on_landing_page_miss(
+    monkeypatch,
+    capsys,
+) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(result="UPDATE 0")
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "landing_page",
+            "--id",
+            "landing-page-uuid-1",
+            "--status",
+            "rejected",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 1
+    assert pool.closed is True
+    assert "UPDATE landing_pages" in query
+    assert args == ("landing-page-uuid-1", "rejected", "acct_1")
+    assert output["updated"] is False
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_updates_sales_brief_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "sales_brief",
+            "--id",
+            "sales-brief-uuid-1",
+            "--status",
+            "queued",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert "UPDATE sales_briefs" in query
+    assert args == ("sales-brief-uuid-1", "queued", "")
+    assert output["account_id"] is None
+    assert output["updated"] is True
+
+
+@pytest.mark.asyncio
+async def test_asset_review_cli_requires_database_url(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--asset",
+            "report",
+            "--id",
+            "report-uuid-1",
+            "--status",
+            "approved",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="Missing --database-url"):
+        await cli._main()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Asset-Review-CLI.md

## Summary
- add `scripts/review_extracted_content_assets.py` for scoped report, landing page, and sales brief status updates
- add focused CLI tests and wire them into extracted pipeline checks
- document the generated-asset review/status command next to the export flow

## Verification
- `python -m pytest tests/test_extracted_content_asset_review_cli.py`
- `python -m py_compile scripts/review_extracted_content_assets.py tests/test_extracted_content_asset_review_cli.py`
- `bash scripts/run_extracted_pipeline_checks.sh`
- `git diff --check`
- non-ASCII byte check for edited Python files