### PR TITLE
Add Content Ops generated asset API router

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:13Z by codex-content-ops-asset-review-cli
+Last updated: 2026-05-09T21:16Z by codex-content-ops-asset-api
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add generated asset FastAPI review/export router for Content Ops | NEW: `extracted_content_pipeline/api/generated_assets.py`; NEW: `tests/test_extracted_content_asset_api.py`; NEW: `plans/PR-Content-Ops-Generated-Asset-API.md`; EDIT: `scripts/run_extracted_pipeline_checks.sh`; EDIT: `extracted_content_pipeline/README.md`; EDIT: `extracted_content_pipeline/STATUS.md`; EDIT: `extracted_content_pipeline/docs/standalone_productization.md`. | codex-content-ops-asset-api | Generated asset API router/tests/docs until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:16Z by codex-content-ops-asset-api
+Last updated: 2026-05-09T21:25Z by codex-content-ops-asset-api
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add generated asset FastAPI review/export router for Content Ops | NEW: `extracted_content_pipeline/api/generated_assets.py`; NEW: `tests/test_extracted_content_asset_api.py`; NEW: `plans/PR-Content-Ops-Generated-Asset-API.md`; EDIT: `scripts/run_extracted_pipeline_checks.sh`; EDIT: `extracted_content_pipeline/README.md`; EDIT: `extracted_content_pipeline/STATUS.md`; EDIT: `extracted_content_pipeline/docs/standalone_productization.md`. | codex-content-ops-asset-api | Generated asset API router/tests/docs until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -382,6 +382,27 @@ python scripts/review_extracted_content_assets.py --asset landing_page --id <lan
 python scripts/review_extracted_content_assets.py --asset sales_brief --id <brief-id> --account-id acct_123 --status rejected
 ```
 
+FastAPI hosts can mount the generated asset router for the same report, landing
+page, and sales brief review loop:
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.generated_assets import create_generated_asset_router
+
+
+app.include_router(
+    create_generated_asset_router(
+        pool_provider=get_pool,
+        scope_provider=current_tenant_scope,
+        dependencies=[Depends(require_content_ops_user)],
+    )
+)
+```
+
+This adds JSON draft listing, CSV/JSON export, and scoped status-update routes
+for generated assets without importing Atlas API globals.
+
 Hosts with FastAPI apps can mount the same draft review/export loop through a
 router factory. The host injects its database pool, tenant scope, and auth
 dependencies:
@@ -764,6 +785,8 @@ Several small utility shims provide product-owned local behavior by default so t
   operation triggers with optional `VisibilitySink` telemetry
 - `api/b2b_campaigns.py`: optional FastAPI router factory for host-mounted
   B2B draft list/export/review routes
+- `api/generated_assets.py`: optional FastAPI router factory for host-mounted
+  report, landing page, and sales brief list/export/review routes
 - `api/seller_campaigns.py`: optional FastAPI router factory for host-mounted
   seller target management, category refresh, opportunity preparation, and
   seller draft review routes

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -59,6 +59,9 @@
 - `scripts/review_extracted_content_assets.py` exposes scoped status updates
   for exported report, landing page, and sales brief drafts without handwritten
   SQL.
+- `api.generated_assets` provides a FastAPI router factory around generated
+  report, landing page, and sales brief list/export/review workflows. Hosts
+  inject pool providers, tenant scope, and auth dependencies.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -1,0 +1,315 @@
+"""FastAPI router factory for generated Content Ops asset review."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Body, HTTPException, Query, Response
+except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
+    APIRouter = None
+    Body = None
+    HTTPException = None
+    Query = None
+    Response = Any
+    _FASTAPI_IMPORT_ERROR: ImportError | None = exc
+else:
+    _FASTAPI_IMPORT_ERROR = None
+
+from ..campaign_ports import TenantScope
+from ..landing_page_export import export_landing_page_drafts
+from ..landing_page_postgres import PostgresLandingPageRepository
+from ..report_export import export_report_drafts
+from ..report_postgres import PostgresReportRepository
+from ..sales_brief_export import export_sales_brief_drafts
+from ..sales_brief_postgres import PostgresSalesBriefRepository
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
+
+ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+
+
+def _require_fastapi() -> None:
+    if _FASTAPI_IMPORT_ERROR is None:
+        return
+    raise RuntimeError(
+        "FastAPI is required to create generated asset API routes. "
+        "Install fastapi in the host application environment."
+    ) from _FASTAPI_IMPORT_ERROR
+
+
+@dataclass(frozen=True)
+class GeneratedAssetApiConfig:
+    """Host-owned API defaults for generated asset review routes."""
+
+    prefix: str = "/content-assets"
+    tags: tuple[str, ...] = ("content-assets",)
+    default_status: str | None = "draft"
+    default_limit: int = 20
+    max_limit: int = 200
+    export_filename_prefix: str = "content_assets"
+
+    def __post_init__(self) -> None:
+        if self.default_limit < 0:
+            raise ValueError("default_limit must be non-negative")
+        if self.max_limit <= 0:
+            raise ValueError("max_limit must be positive")
+        if self.default_limit > self.max_limit:
+            raise ValueError("default_limit must be less than or equal to max_limit")
+        if not _clean(self.export_filename_prefix):
+            raise ValueError("export_filename_prefix is required")
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+async def _resolve_pool(pool_provider: PoolProvider) -> Any:
+    pool = await _maybe_await(pool_provider())
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    if getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    return pool
+
+
+async def _resolve_scope(
+    scope_provider: ScopeProvider | None,
+) -> TenantScope | Mapping[str, Any] | None:
+    if scope_provider is None:
+        return None
+    scope = await _maybe_await(scope_provider())
+    if scope is None or isinstance(scope, (TenantScope, Mapping)):
+        return scope
+    raise HTTPException(status_code=500, detail="Invalid tenant scope")
+
+
+def _api_limit(value: int | None, config: GeneratedAssetApiConfig) -> int:
+    limit = config.default_limit if value is None else int(value)
+    if limit < 0:
+        raise HTTPException(status_code=400, detail="limit must be non-negative")
+    return min(limit, config.max_limit)
+
+
+def _status_filter(value: str | None, config: GeneratedAssetApiConfig) -> str | None:
+    if value is None:
+        return config.default_status
+    status = _clean(value)
+    return status or None
+
+
+def _review_status(value: Any) -> str:
+    status = _clean(value)
+    if not status:
+        raise HTTPException(status_code=400, detail="status is required")
+    return status
+
+
+def _asset_arg(value: str) -> str:
+    asset = _clean(value)
+    if asset not in ASSET_CHOICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"asset must be one of {', '.join(ASSET_CHOICES)}",
+        )
+    return asset
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def create_generated_asset_router(
+    *,
+    pool_provider: PoolProvider,
+    scope_provider: ScopeProvider | None = None,
+    config: GeneratedAssetApiConfig | None = None,
+    dependencies: Sequence[Any] | None = None,
+) -> APIRouter:
+    """Create host-mounted generated asset review routes."""
+    _require_fastapi()
+    resolved_config = config or GeneratedAssetApiConfig()
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+        dependencies=list(dependencies or ()),
+    )
+
+    @router.get("/{asset}/drafts")
+    async def list_drafts(
+        asset: str,
+        status: str | None = Query(None, description="Status filter. Empty string means all statuses."),
+        target_mode: str | None = Query(None),
+        report_type: str | None = Query(None),
+        campaign_name: str | None = Query(None),
+        slug: str | None = Query(None),
+        brief_type: str | None = Query(None),
+        limit: int | None = Query(None, ge=0),
+    ) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        result = await _export_for_asset(
+            _asset_arg(asset),
+            pool,
+            scope=scope,
+            status=_status_filter(status, resolved_config),
+            target_mode=target_mode,
+            report_type=report_type,
+            campaign_name=campaign_name,
+            slug=slug,
+            brief_type=brief_type,
+            limit=_api_limit(limit, resolved_config),
+        )
+        return result.as_dict()
+
+    @router.get("/{asset}/drafts/export", response_model=None)
+    async def export_drafts(
+        asset: str,
+        status: str | None = Query(None, description="Status filter. Empty string means all statuses."),
+        target_mode: str | None = Query(None),
+        report_type: str | None = Query(None),
+        campaign_name: str | None = Query(None),
+        slug: str | None = Query(None),
+        brief_type: str | None = Query(None),
+        limit: int | None = Query(None, ge=0),
+        format: str = Query("csv", description="csv or json"),
+    ) -> Any:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        asset_name = _asset_arg(asset)
+        result = await _export_for_asset(
+            asset_name,
+            pool,
+            scope=scope,
+            status=_status_filter(status, resolved_config),
+            target_mode=target_mode,
+            report_type=report_type,
+            campaign_name=campaign_name,
+            slug=slug,
+            brief_type=brief_type,
+            limit=_api_limit(limit, resolved_config),
+        )
+        format_name = _clean(format).lower()
+        if format_name == "json":
+            return result.as_dict()
+        if format_name != "csv":
+            raise HTTPException(status_code=400, detail="format must be csv or json")
+        filename = f"{_clean(resolved_config.export_filename_prefix)}_{asset_name}.csv"
+        return Response(
+            content=result.as_csv(),
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    @router.post("/{asset}/drafts/review")
+    async def review_draft(
+        asset: str,
+        payload: dict[str, Any] = Body(...),
+    ) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        tenant = _tenant_scope(scope)
+        asset_name = _asset_arg(asset)
+        asset_id = _clean(payload.get("id") or payload.get("asset_id"))
+        if not asset_id:
+            raise HTTPException(status_code=400, detail="id is required")
+        status = _review_status(payload.get("status"))
+        updated = await _update_asset_status(
+            asset_name,
+            pool,
+            asset_id=asset_id,
+            status=status,
+            scope=tenant,
+        )
+        return {
+            "account_id": tenant.account_id,
+            "asset": asset_name,
+            "id": asset_id,
+            "status": status,
+            "updated": bool(updated),
+        }
+
+    return router
+
+
+async def _export_for_asset(
+    asset: str,
+    pool: Any,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None,
+    status: str | None,
+    target_mode: str | None,
+    report_type: str | None,
+    campaign_name: str | None,
+    slug: str | None,
+    brief_type: str | None,
+    limit: int,
+) -> Any:
+    if asset == "report":
+        return await export_report_drafts(
+            PostgresReportRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            report_type=report_type,
+            limit=limit,
+        )
+    if asset == "landing_page":
+        return await export_landing_page_drafts(
+            PostgresLandingPageRepository(pool),
+            scope=scope,
+            status=status,
+            campaign_name=campaign_name,
+            slug=slug,
+            limit=limit,
+        )
+    if asset == "sales_brief":
+        return await export_sales_brief_drafts(
+            PostgresSalesBriefRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            brief_type=brief_type,
+            limit=limit,
+        )
+    raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
+
+
+async def _update_asset_status(
+    asset: str,
+    pool: Any,
+    *,
+    asset_id: str,
+    status: str,
+    scope: TenantScope,
+) -> bool:
+    if asset == "report":
+        return await PostgresReportRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "landing_page":
+        return await PostgresLandingPageRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "sales_brief":
+        return await PostgresSalesBriefRepository(pool).update_status(asset_id, status, scope=scope)
+    raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "GeneratedAssetApiConfig",
+    "create_generated_asset_router",
+]

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -152,10 +152,11 @@ def create_generated_asset_router(
         brief_type: str | None = Query(None),
         limit: int | None = Query(None, ge=0),
     ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
         pool = await _resolve_pool(pool_provider)
         scope = await _resolve_scope(scope_provider)
         result = await _export_for_asset(
-            _asset_arg(asset),
+            asset_name,
             pool,
             scope=scope,
             status=_status_filter(status, resolved_config),
@@ -180,9 +181,9 @@ def create_generated_asset_router(
         limit: int | None = Query(None, ge=0),
         format: str = Query("csv", description="csv or json"),
     ) -> Any:
+        asset_name = _asset_arg(asset)
         pool = await _resolve_pool(pool_provider)
         scope = await _resolve_scope(scope_provider)
-        asset_name = _asset_arg(asset)
         result = await _export_for_asset(
             asset_name,
             pool,
@@ -212,10 +213,10 @@ def create_generated_asset_router(
         asset: str,
         payload: dict[str, Any] = Body(...),
     ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
         pool = await _resolve_pool(pool_provider)
         scope = await _resolve_scope(scope_provider)
         tenant = _tenant_scope(scope)
-        asset_name = _asset_arg(asset)
         asset_id = _clean(payload.get("id") or payload.get("asset_id"))
         if not asset_id:
             raise HTTPException(status_code=400, detail="id is required")

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -209,6 +209,11 @@ loop for generated assets. Hosts pass `--asset`, `--id`, `--status`, and an
 optional `--account-id`; the CLI calls the matching product-owned Postgres
 repository and emits a JSON hit/miss result without requiring ad hoc SQL.
 
+`extracted_content_pipeline/api/generated_assets.py` owns the host-mounted
+FastAPI surface for generated asset review workflows. It exposes list, CSV/JSON
+export, and status-update routes for reports, landing pages, and sales briefs
+while requiring the host to inject database, tenant scope, and auth providers.
+
 `extracted_content_pipeline/campaign_postgres_review.py` owns the write side of
 that host review loop. It updates selected `b2b_campaigns` rows by explicit
 campaign id, optional account scope, and source-status guard so hosts can move

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -290,6 +290,9 @@
       "target": "extracted_content_pipeline/api/b2b_campaigns.py"
     },
     {
+      "target": "extracted_content_pipeline/api/generated_assets.py"
+    },
+    {
       "target": "extracted_content_pipeline/api/seller_campaigns.py"
     },
     {

--- a/plans/PR-Content-Ops-Generated-Asset-API.md
+++ b/plans/PR-Content-Ops-Generated-Asset-API.md
@@ -1,0 +1,57 @@
+# PR-Content-Ops-Generated-Asset-API
+
+## Why this slice exists
+
+Campaign drafts have a host-mounted FastAPI review/export router. Generated
+reports, landing pages, and sales briefs now have Postgres repositories plus
+export and review CLIs, but host FastAPI installs still need custom route code
+to expose the same workflow.
+
+## Scope (this PR)
+
+1. Add `extracted_content_pipeline/api/generated_assets.py`.
+2. Support generated asset list/export/review routes for `report`,
+   `landing_page`, and `sales_brief`.
+3. Reuse existing Postgres repositories, export helpers, and scoped
+   `update_status()` methods.
+4. Preserve host-defined status strings for review updates.
+5. Add focused FastAPI tests and wire them into extracted pipeline checks.
+
+### Files touched
+
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Intentional
+
+- No new generation or persistence path.
+- No batch review endpoint in this slice.
+- No Atlas API globals. Hosts inject pool and tenant scope providers.
+
+## Deferred
+
+- Batch review/status updates for generated assets.
+- Generated asset execution routes. This router only exposes post-generation
+  review/export workflows.
+- Per-host status vocabulary enforcement.
+
+## Verification
+
+Planned:
+
+- `python -m pytest tests/test_extracted_content_asset_api.py`
+- `python -m py_compile extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `git diff --check`
+- Non-ASCII byte check for edited Python files.
+
+## Estimated diff size
+
+- Production: ~250 LOC.
+- Tests: ~250 LOC.
+- Docs/check wiring: ~40 LOC.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -59,6 +59,7 @@ pytest \
   tests/test_extracted_campaign_api_webhooks.py \
   tests/test_extracted_campaign_api_operations.py \
   tests/test_extracted_campaign_api_hosted_workflow.py \
+  tests/test_extracted_content_asset_api.py \
   tests/test_extracted_campaign_api_b2b_campaigns.py \
   tests/test_extracted_campaign_api_seller_campaigns.py \
   tests/test_extracted_campaign_postgres_sequence_progression.py \

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -216,6 +216,24 @@ def test_generated_asset_router_rejects_unknown_asset() -> None:
     assert "asset must be one of" in response.json()["detail"]
 
 
+def test_generated_asset_router_rejects_unknown_asset_before_pool_resolution() -> None:
+    app = FastAPI()
+    calls = 0
+
+    async def pool_provider():
+        nonlocal calls
+        calls += 1
+        raise AssertionError("pool provider should not be touched")
+
+    app.include_router(create_generated_asset_router(pool_provider=pool_provider))
+
+    response = TestClient(app).get("/content-assets/blog_post/drafts")
+
+    assert response.status_code == 400
+    assert "asset must be one of" in response.json()["detail"]
+    assert calls == 0
+
+
 def test_generated_asset_router_rejects_empty_review_status() -> None:
     response = _client(_Pool()).post(
         "/content-assets/report/drafts/review",

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from extracted_content_pipeline.api.generated_assets import (
+    GeneratedAssetApiConfig,
+    create_generated_asset_router,
+)
+import extracted_content_pipeline.api.generated_assets as asset_api
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Pool:
+    def __init__(
+        self,
+        rows=None,
+        *,
+        execute_result: str = "UPDATE 1",
+        initialized: bool = True,
+    ) -> None:
+        self.rows = list(rows or [])
+        self.execute_result = execute_result
+        self.is_initialized = initialized
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        return self.rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        return self.execute_result
+
+
+def _report_row():
+    return {
+        "target_id": "vendor-acme",
+        "target_mode": "vendor_retention",
+        "report_type": "vendor_pressure",
+        "title": "Acme report",
+        "summary": "Pricing pressure dominates.",
+        "sections": [{"id": "summary", "title": "Summary", "body_markdown": "Body"}],
+        "reference_ids": ["r1"],
+        "metadata": {
+            "generation_usage": {"input_tokens": 10, "output_tokens": 5},
+            "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
+        },
+    }
+
+
+def _landing_page_row():
+    return {
+        "campaign_name": "acme-launch",
+        "persona": "VP Engineering",
+        "value_prop": "Catch pressure early",
+        "title": "Acme landing page",
+        "slug": "acme-launch",
+        "hero": {"headline": "Stop surprises"},
+        "sections": [{"id": "problem", "title": "Problem", "body_markdown": "Body"}],
+        "cta": {"label": "Book a demo"},
+        "meta": {"title_tag": "Acme landing page"},
+        "reference_ids": ["r1"],
+        "metadata": {},
+    }
+
+
+def _sales_brief_row():
+    return {
+        "target_id": "vendor-acme",
+        "target_mode": "vendor_retention",
+        "brief_type": "pre_call",
+        "title": "Acme brief",
+        "headline": "Renewal pressure opens this week",
+        "sections": [{"id": "context", "title": "Context", "body_markdown": "Body"}],
+        "reference_ids": ["r1"],
+        "metadata": {
+            "generation_usage": {"input_tokens": 8, "output_tokens": 4},
+            "reasoning_context": {"wedge": "support_erosion", "confidence": "medium"},
+        },
+    }
+
+
+def _client(
+    pool,
+    *,
+    scope=None,
+    config: GeneratedAssetApiConfig | None = None,
+    dependencies=None,
+) -> TestClient:
+    app = FastAPI()
+
+    async def pool_provider():
+        return pool
+
+    async def scope_provider():
+        return scope
+
+    app.include_router(
+        create_generated_asset_router(
+            pool_provider=pool_provider,
+            scope_provider=scope_provider if scope is not None else None,
+            config=config,
+            dependencies=dependencies,
+        )
+    )
+    return TestClient(app)
+
+
+def test_generated_asset_router_lists_report_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_report_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/report/drafts"
+        "?target_mode=vendor_retention&report_type=vendor_pressure&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["rows"][0]["title"] == "Acme report"
+    assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
+    query, args = pool.fetch_calls[0]
+    assert "FROM reports" in query
+    assert args == ("acct_1", "draft", "vendor_retention", "vendor_pressure", 5)
+
+
+def test_generated_asset_router_exports_landing_page_csv() -> None:
+    pool = _Pool(rows=[_landing_page_row()])
+
+    response = _client(pool).get(
+        "/content-assets/landing_page/drafts/export"
+        "?format=csv&campaign_name=acme-launch&slug=acme-launch"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "content_assets_landing_page.csv" in response.headers["content-disposition"]
+    assert "campaign_name,persona,value_prop" in response.text
+    assert "Acme landing page" in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in query
+    assert args == ("", "draft", "acme-launch", "acme-launch", 20)
+
+
+def test_generated_asset_router_exports_sales_brief_json_without_status_filter() -> None:
+    pool = _Pool(rows=[_sales_brief_row()])
+
+    response = _client(pool).get(
+        "/content-assets/sales_brief/drafts/export"
+        "?format=json&status=&target_mode=vendor_retention&brief_type=pre_call"
+    )
+
+    assert response.status_code == 200
+    row = response.json()["rows"][0]
+    assert row["brief_type"] == "pre_call"
+    assert row["reasoning_wedge"] == "support_erosion"
+    query, args = pool.fetch_calls[0]
+    assert "FROM sales_briefs" in query
+    assert "status = " not in query
+    assert args == ("", "vendor_retention", "pre_call", 20)
+
+
+def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
+    pool = _Pool()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/report/drafts/review",
+        json={"id": "report-uuid-1", "status": "published"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "account_id": "acct_1",
+        "asset": "report",
+        "id": "report-uuid-1",
+        "status": "published",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE reports" in query
+    assert args == ("report-uuid-1", "published", "acct_1")
+
+
+def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
+    pool = _Pool(execute_result="UPDATE 0")
+
+    response = _client(pool).post(
+        "/content-assets/sales_brief/drafts/review",
+        json={"asset_id": "brief-uuid-1", "status": "ready_for_call"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["updated"] is False
+    query, args = pool.execute_calls[0]
+    assert "UPDATE sales_briefs" in query
+    assert args == ("brief-uuid-1", "ready_for_call", "")
+
+
+def test_generated_asset_router_rejects_unknown_asset() -> None:
+    response = _client(_Pool()).get("/content-assets/blog_post/drafts")
+
+    assert response.status_code == 400
+    assert "asset must be one of" in response.json()["detail"]
+
+
+def test_generated_asset_router_rejects_empty_review_status() -> None:
+    response = _client(_Pool()).post(
+        "/content-assets/report/drafts/review",
+        json={"id": "report-uuid-1", "status": ""},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "status is required"
+
+
+def test_generated_asset_router_rejects_unknown_export_format() -> None:
+    response = _client(_Pool(rows=[_report_row()])).get(
+        "/content-assets/report/drafts/export?format=xlsx"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "format must be csv or json"
+
+
+def test_generated_asset_router_requires_database() -> None:
+    response = _client(_Pool(initialized=False)).get("/content-assets/report/drafts")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database unavailable"
+
+
+def test_generated_asset_router_honors_host_dependencies() -> None:
+    pool = _Pool(rows=[_report_row()])
+
+    def require_auth():
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    response = _client(pool, dependencies=[Depends(require_auth)]).get(
+        "/content-assets/report/drafts"
+    )
+
+    assert response.status_code == 403
+    assert pool.fetch_calls == []
+
+
+def test_generated_asset_api_config_rejects_invalid_limits() -> None:
+    with pytest.raises(ValueError, match="max_limit must be positive"):
+        GeneratedAssetApiConfig(max_limit=0)
+
+    with pytest.raises(ValueError, match="default_limit must be less"):
+        GeneratedAssetApiConfig(default_limit=5, max_limit=4)
+
+
+def test_generated_asset_router_requires_fastapi(monkeypatch) -> None:
+    monkeypatch.setattr(asset_api, "_FASTAPI_IMPORT_ERROR", ImportError("missing"))
+
+    with pytest.raises(RuntimeError, match="FastAPI is required"):
+        create_generated_asset_router(pool_provider=lambda: None)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Generated-Asset-API.md

## Summary
- add `api.generated_assets` router for report, landing page, and sales brief list/export/review workflows
- reuse existing Postgres repositories, export helpers, and scoped status-update contracts
- add focused FastAPI coverage and wire it into extracted pipeline checks

## Verification
- `python -m pytest tests/test_extracted_content_asset_api.py`
- `python -m py_compile extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
- `python scripts/check_extracted_imports.py && python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `bash scripts/run_extracted_pipeline_checks.sh`
- `git diff --check`
- non-ASCII byte check for edited Python files