### PR TITLE
Document Content Ops generated asset review paths

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:27Z by codex-content-ops-asset-runbook
+Last updated: 2026-05-09T21:32Z by codex-content-ops-asset-runbook
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Document generated asset export/review/API paths in the Content Ops host runbook | EDIT: `extracted_content_pipeline/docs/host_install_runbook.md`; NEW: `plans/PR-Content-Ops-Generated-Asset-Runbook.md`. | codex-content-ops-asset-runbook | Content Ops generated asset runbook section until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:25Z by codex-content-ops-asset-api
+Last updated: 2026-05-09T21:27Z by codex-content-ops-asset-runbook
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Document generated asset export/review/API paths in the Content Ops host runbook | EDIT: `extracted_content_pipeline/docs/host_install_runbook.md`; NEW: `plans/PR-Content-Ops-Generated-Asset-Runbook.md`. | codex-content-ops-asset-runbook | Content Ops generated asset runbook section until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -443,6 +443,84 @@ The mounted list/export routes use the same export helper as the CLI, so JSON
 and CSV responses include the generation-usage and reasoning summary fields
 documented above.
 
+Export generated reports, landing pages, or sales briefs through the generated
+asset CLI when the host needs the same review loop for non-campaign outputs:
+
+```bash
+python scripts/export_extracted_content_assets.py \
+  --asset report \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --report-type vendor_pressure \
+  --format csv \
+  --output report_drafts.csv
+
+python scripts/export_extracted_content_assets.py \
+  --asset landing_page \
+  --account-id acct_123 \
+  --campaign-name renewal-play \
+  --format json
+
+python scripts/export_extracted_content_assets.py \
+  --asset sales_brief \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --brief-type pre_call \
+  --limit 20
+```
+
+Move reviewed generated assets through host-defined lifecycle statuses without
+writing SQL:
+
+```bash
+python scripts/review_extracted_content_assets.py \
+  --asset report \
+  --id <report-id> \
+  --account-id acct_123 \
+  --status approved
+
+python scripts/review_extracted_content_assets.py \
+  --asset landing_page \
+  --id <landing-page-id> \
+  --account-id acct_123 \
+  --status published
+
+python scripts/review_extracted_content_assets.py \
+  --asset sales_brief \
+  --id <brief-id> \
+  --account-id acct_123 \
+  --status ready_for_call
+```
+
+Or mount the generated asset API router beside the campaign draft router:
+
+```python
+from fastapi import Depends
+
+from extracted_content_pipeline.api.generated_assets import create_generated_asset_router
+
+
+app.include_router(
+    create_generated_asset_router(
+        pool_provider=get_pool,
+        scope_provider=current_tenant_scope,
+        dependencies=[Depends(require_content_ops_user)],
+    )
+)
+```
+
+The generated asset router exposes:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/content-assets/{asset}/drafts` | List generated asset drafts as JSON. |
+| `GET` | `/content-assets/{asset}/drafts/export` | Export generated asset drafts as CSV or JSON. |
+| `POST` | `/content-assets/{asset}/drafts/review` | Update one generated asset status by id. |
+
+Supported `{asset}` values are `report`, `landing_page`, and `sales_brief`.
+Review statuses are host-defined strings; the product does not impose a fixed
+status vocabulary for these generated asset tables.
+
 Amazon seller installs can mount the seller-specific router:
 
 ```python

--- a/plans/PR-Content-Ops-Generated-Asset-Runbook.md
+++ b/plans/PR-Content-Ops-Generated-Asset-Runbook.md
@@ -1,0 +1,44 @@
+# PR-Content-Ops-Generated-Asset-Runbook
+
+## Why this slice exists
+
+Generated reports, landing pages, and sales briefs now have export/review CLIs
+and a host-mounted FastAPI router, but the host install runbook still documents
+only the campaign draft review loop. Operators following the runbook would miss
+the generated asset review path unless they found the README.
+
+## Scope (this PR)
+
+1. Document generated asset export CLI examples.
+2. Document generated asset review/status CLI examples.
+3. Document the generated asset FastAPI router mount.
+4. List the generated asset list/export/review routes.
+
+### Files touched
+
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Generated-Asset-Runbook.md`
+
+## Intentional
+
+- Documentation only.
+- No runtime changes.
+- No changes to campaign, seller, webhook, or operations router docs beyond the
+  generated-asset insertion point.
+
+## Deferred
+
+- Batch generated asset review/status examples.
+- UI screenshots or frontend operator walkthroughs.
+
+## Verification
+
+Planned:
+
+- `git diff --check`
+- `rg -n "create_generated_asset_router|review_extracted_content_assets|export_extracted_content_assets" extracted_content_pipeline/docs/host_install_runbook.md`
+
+## Estimated diff size
+
+- Docs/plans/coordination: ~80 LOC.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Generated-Asset-Runbook.md

## Summary
- add generated report, landing page, and sales brief export CLI examples to the host install runbook
- add generated asset review/status CLI examples using host-defined statuses
- document the generated asset FastAPI router mount and route table

## Verification
- `rg -n "create_generated_asset_router|review_extracted_content_assets|export_extracted_content_assets|/content-assets/\{asset\}/drafts" extracted_content_pipeline/docs/host_install_runbook.md`
- `git diff --check`