### PR TITLE
Cover hosted Content Ops generated asset workflow

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:35Z by codex-content-ops-hosted-asset-workflow
+Last updated: 2026-05-09T21:49Z by codex-content-ops-hosted-asset-workflow
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add hosted workflow coverage for generated asset router mounting | EDIT: `tests/test_extracted_campaign_api_hosted_workflow.py`; NEW: `plans/PR-Content-Ops-Hosted-Asset-Workflow.md`. | codex-content-ops-hosted-asset-workflow | Hosted workflow generated asset router test coverage until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:32Z by codex-content-ops-asset-runbook
+Last updated: 2026-05-09T21:35Z by codex-content-ops-hosted-asset-workflow
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add hosted workflow coverage for generated asset router mounting | EDIT: `tests/test_extracted_campaign_api_hosted_workflow.py`; NEW: `plans/PR-Content-Ops-Hosted-Asset-Workflow.md`. | codex-content-ops-hosted-asset-workflow | Hosted workflow generated asset router test coverage until this PR closes. |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Hosted-Asset-Workflow.md
+++ b/plans/PR-Content-Ops-Hosted-Asset-Workflow.md
@@ -1,0 +1,43 @@
+# PR-Content-Ops-Hosted-Asset-Workflow
+
+## Why this slice exists
+
+The host install runbook now tells customers to mount the generated asset
+router beside the existing campaign operations and B2B campaign review routers.
+The standalone router has focused tests, but the hosted workflow regression
+still only mounts the campaign routers. We should lock the combined host shape
+before adding more surfaces.
+
+## Scope (this PR)
+
+1. Mount `create_generated_asset_router` in the hosted workflow test fixture.
+2. Add one regression proving generated asset list/review routes share the host
+   auth, tenant scope, and database pool providers.
+
+### Files touched
+
+- `tests/test_extracted_campaign_api_hosted_workflow.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Hosted-Asset-Workflow.md`
+
+## Intentional
+
+- Test-only product contract coverage.
+- No runtime implementation changes.
+- No docs changes beyond the plan and coordination row.
+
+## Deferred
+
+- Seller + generated asset combined workflow coverage.
+- Frontend/UI tests that call the generated asset router.
+
+## Verification
+
+Planned:
+
+- `python -m pytest tests/test_extracted_campaign_api_hosted_workflow.py tests/test_extracted_content_asset_api.py`
+- `git diff --check`
+
+## Estimated diff size
+
+- Tests/plan/coordination: ~90 LOC.

--- a/tests/test_extracted_campaign_api_hosted_workflow.py
+++ b/tests/test_extracted_campaign_api_hosted_workflow.py
@@ -16,6 +16,7 @@ from extracted_content_pipeline.api.campaign_operations import (
     CampaignOperationsApiConfig,
     create_campaign_operations_router,
 )
+from extracted_content_pipeline.api.generated_assets import create_generated_asset_router
 from extracted_content_pipeline.campaign_ports import TenantScope
 
 
@@ -23,7 +24,25 @@ CAMPAIGN_ID = "00000000-0000-0000-0000-000000000011"
 
 
 class _Pool:
-    is_initialized = True
+    def __init__(
+        self,
+        rows: list[dict[str, Any]] | None = None,
+        *,
+        execute_result: str = "UPDATE 1",
+    ) -> None:
+        self.is_initialized = True
+        self.rows = list(rows or [])
+        self.execute_result = execute_result
+        self.fetch_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        return self.rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        return self.execute_result
 
 
 class _Result:
@@ -110,6 +129,13 @@ def _host_client(
     )
     app.include_router(
         create_b2b_campaign_router(
+            pool_provider=pool_provider,
+            scope_provider=scope_provider,
+            dependencies=dependencies,
+        )
+    )
+    app.include_router(
+        create_generated_asset_router(
             pool_provider=pool_provider,
             scope_provider=scope_provider,
             dependencies=dependencies,
@@ -288,3 +314,72 @@ def test_hosted_campaign_api_workflow_keeps_host_auth_before_product_calls(
     assert response.status_code == 403
     assert response.json()["detail"] == "forbidden"
     assert calls == []
+
+
+def test_hosted_workflow_mounts_generated_asset_router_with_shared_ports() -> None:
+    pool = _Pool(rows=[{
+        "target_id": "vendor-acme",
+        "target_mode": "vendor_retention",
+        "report_type": "vendor_pressure",
+        "title": "Acme report",
+        "summary": "Pricing pressure dominates.",
+        "sections": [
+            {
+                "id": "summary",
+                "title": "Summary",
+                "body_markdown": "Body",
+            }
+        ],
+        "reference_ids": ["r1"],
+        "metadata": {"reasoning_context": {"wedge": "price_squeeze"}},
+    }])
+    scope = TenantScope(account_id="acct_1", user_id="user_1")
+    counters: dict[str, int] = {}
+
+    client = _host_client(
+        pool=pool,
+        sender=_Sender(),
+        llm=_LLM(),
+        skills=_Skills(),
+        reasoning=_Reasoning(),
+        scope=scope,
+        counters=counters,
+    )
+
+    list_response = client.get(
+        "/content-assets/report/drafts"
+        "?target_mode=vendor_retention&report_type=vendor_pressure&limit=5"
+    )
+    review_response = client.post(
+        "/content-assets/report/drafts/review",
+        json={"id": "report-uuid-1", "status": "approved"},
+    )
+
+    assert list_response.status_code == 200
+    assert review_response.status_code == 200
+    assert list_response.json()["rows"][0]["reasoning_wedge"] == "price_squeeze"
+    assert review_response.json() == {
+        "account_id": "acct_1",
+        "asset": "report",
+        "id": "report-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+
+    fetch_query, fetch_args = pool.fetch_calls[0]
+    execute_query, execute_args = pool.execute_calls[0]
+    assert "FROM reports" in fetch_query
+    assert fetch_args == (
+        "acct_1",
+        "draft",
+        "vendor_retention",
+        "vendor_pressure",
+        5,
+    )
+    assert "UPDATE reports" in execute_query
+    assert execute_args == ("report-uuid-1", "approved", "acct_1")
+    assert counters == {
+        "auth": 2,
+        "scope": 2,
+        "pool": 2,
+    }


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Hosted-Asset-Workflow.md

## Summary
- mount `create_generated_asset_router` in the hosted workflow regression fixture beside campaign operation/review routers
- add coverage proving generated report list/review routes share host auth, tenant scope, and DB pool providers
- keep the slice test-only; no runtime implementation changes

## Verification
- `python -m pytest tests/test_extracted_campaign_api_hosted_workflow.py tests/test_extracted_content_asset_api.py`
- `python -m py_compile tests/test_extracted_campaign_api_hosted_workflow.py`
- `bash scripts/run_extracted_pipeline_checks.sh`
- `git diff --check`