### PR TITLE
Add blog post generated-asset review path

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:49Z by codex-content-ops-hosted-asset-workflow
+Last updated: 2026-05-09T21:53Z by codex-content-ops-blog-post-review
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add blog_post to generated Content Ops asset review/export/API path | NEW: `extracted_content_pipeline/blog_post_postgres.py`, `extracted_content_pipeline/blog_post_export.py`, `extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql`; EDIT: `extracted_content_pipeline/api/generated_assets.py`, generated asset CLIs/tests/docs/manifest/status/check script | codex-content-ops-blog-post-review | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -53,15 +53,18 @@
 - `sales_brief_export` provides a read-only draft export path over generated
   sales briefs so hosts can review JSON/CSV outputs without handwritten SQL or
   a mounted sales brief API.
+- `blog_post_export` provides the same read-only draft export path over
+  generated blog posts, backed by `PostgresBlogPostRepository` and the existing
+  `blog_posts` table.
 - `scripts/export_extracted_content_assets.py` exposes the report, landing
-  page, and sales brief export helpers as a host-facing JSON/CSV CLI backed by
-  the product-owned Postgres repositories.
+  page, sales brief, and blog post export helpers as a host-facing JSON/CSV CLI
+  backed by the product-owned Postgres repositories.
 - `scripts/review_extracted_content_assets.py` exposes scoped status updates
-  for exported report, landing page, and sales brief drafts without handwritten
-  SQL.
+  for exported report, landing page, sales brief, and blog post drafts without
+  handwritten SQL.
 - `api.generated_assets` provides a FastAPI router factory around generated
-  report, landing page, and sales brief list/export/review workflows. Hosts
-  inject pool providers, tenant scope, and auth dependencies.
+  report, landing page, sales brief, and blog post list/export/review workflows.
+  Hosts inject pool providers, tenant scope, and auth dependencies.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -19,6 +19,8 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import TenantScope
+from ..blog_post_export import export_blog_post_drafts
+from ..blog_post_postgres import PostgresBlogPostRepository
 from ..landing_page_export import export_landing_page_drafts
 from ..landing_page_postgres import PostgresLandingPageRepository
 from ..report_export import export_report_drafts
@@ -30,7 +32,7 @@ from ..sales_brief_postgres import PostgresSalesBriefRepository
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
 
-ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
 
 
 def _require_fastapi() -> None:
@@ -149,6 +151,7 @@ def create_generated_asset_router(
         report_type: str | None = Query(None),
         campaign_name: str | None = Query(None),
         slug: str | None = Query(None),
+        topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
         limit: int | None = Query(None, ge=0),
     ) -> dict[str, Any]:
@@ -164,6 +167,7 @@ def create_generated_asset_router(
             report_type=report_type,
             campaign_name=campaign_name,
             slug=slug,
+            topic_type=topic_type,
             brief_type=brief_type,
             limit=_api_limit(limit, resolved_config),
         )
@@ -177,6 +181,7 @@ def create_generated_asset_router(
         report_type: str | None = Query(None),
         campaign_name: str | None = Query(None),
         slug: str | None = Query(None),
+        topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
         limit: int | None = Query(None, ge=0),
         format: str = Query("csv", description="csv or json"),
@@ -193,6 +198,7 @@ def create_generated_asset_router(
             report_type=report_type,
             campaign_name=campaign_name,
             slug=slug,
+            topic_type=topic_type,
             brief_type=brief_type,
             limit=_api_limit(limit, resolved_config),
         )
@@ -249,9 +255,18 @@ async def _export_for_asset(
     report_type: str | None,
     campaign_name: str | None,
     slug: str | None,
+    topic_type: str | None,
     brief_type: str | None,
     limit: int,
 ) -> Any:
+    if asset == "blog_post":
+        return await export_blog_post_drafts(
+            PostgresBlogPostRepository(pool),
+            scope=scope,
+            status=status,
+            topic_type=topic_type,
+            limit=limit,
+        )
     if asset == "report":
         return await export_report_drafts(
             PostgresReportRepository(pool),
@@ -290,6 +305,8 @@ async def _update_asset_status(
     status: str,
     scope: TenantScope,
 ) -> bool:
+    if asset == "blog_post":
+        return await PostgresBlogPostRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "report":
         return await PostgresReportRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "landing_page":

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -1,0 +1,162 @@
+"""Read-only blog-post draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+import json
+from typing import Any
+
+from .blog_ports import BlogPostDraft, BlogPostRepository
+from .campaign_ports import TenantScope
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "slug",
+    "title",
+    "description",
+    "topic_type",
+    "tag_count",
+    "chart_count",
+    "generation_input_tokens",
+    "generation_output_tokens",
+    "generation_total_tokens",
+    "generation_parse_attempts",
+    "reasoning_context_used",
+    "reasoning_wedge",
+    "reasoning_confidence",
+    "tags",
+    "content",
+    "charts",
+    "data_context",
+    "metadata",
+)
+
+
+@dataclass(frozen=True)
+class BlogPostDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_blog_post_drafts(
+    repository: BlogPostRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    topic_type: str | None = None,
+    limit: int = 20,
+) -> BlogPostDraftExportResult:
+    """Return generated blog-post drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if topic_type:
+        filters["topic_type"] = topic_type
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        topic_type=topic_type,
+        limit=normalized_limit,
+    )
+    return BlogPostDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: BlogPostDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["tag_count"] = len(draft.tags)
+    row["chart_count"] = len(draft.charts)
+    row.update(_metadata_summary(draft.metadata))
+    return row
+
+
+def _metadata_summary(value: Any) -> JsonDict:
+    metadata = _metadata_mapping(value)
+    usage = _metadata_mapping(metadata.get("generation_usage"))
+    reasoning = _metadata_mapping(metadata.get("reasoning_context"))
+    return {
+        "generation_input_tokens": usage.get("input_tokens"),
+        "generation_output_tokens": usage.get("output_tokens"),
+        "generation_total_tokens": usage.get("total_tokens"),
+        "generation_parse_attempts": metadata.get("generation_parse_attempts"),
+        "reasoning_context_used": bool(reasoning),
+        "reasoning_wedge": reasoning.get("wedge"),
+        "reasoning_confidence": reasoning.get("confidence"),
+    }
+
+
+def _metadata_mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+    return {}
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "BlogPostDraftExportResult",
+    "export_blog_post_drafts",
+]

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -1,0 +1,189 @@
+"""Postgres repository adapter for AI Content Ops blog posts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Mapping, Sequence
+
+from .blog_ports import BlogPostDraft
+from .campaign_ports import JsonDict, TenantScope
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+_METADATA_KEY = "_metadata"
+
+
+def _draft_data_context(draft: BlogPostDraft, scope: TenantScope) -> JsonDict:
+    data_context = dict(draft.data_context or {})
+    data_context[_METADATA_KEY] = dict(draft.metadata or {})
+    data_context["scope"] = {
+        "account_id": scope.account_id,
+        "user_id": scope.user_id,
+    }
+    return data_context
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> BlogPostDraft:
+    tags_raw = decode_jsonb_field(row.get("tags"), default=[])
+    if not isinstance(tags_raw, Sequence) or isinstance(tags_raw, (str, bytes)):
+        tags_raw = []
+
+    charts_raw = decode_jsonb_field(row.get("charts"), default=[])
+    if not isinstance(charts_raw, Sequence) or isinstance(charts_raw, (str, bytes)):
+        charts_raw = []
+
+    data_context_raw = decode_jsonb_field(row.get("data_context"), default={})
+    if not isinstance(data_context_raw, Mapping):
+        data_context_raw = {}
+
+    data_context = dict(data_context_raw)
+    metadata_raw = data_context.pop(_METADATA_KEY, {})
+    metadata = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+    if row.get("llm_model") and "generation_model" not in metadata:
+        metadata["generation_model"] = str(row.get("llm_model"))
+
+    return BlogPostDraft(
+        slug=str(row.get("slug") or ""),
+        title=str(row.get("title") or ""),
+        description=str(row.get("description") or ""),
+        topic_type=str(row.get("topic_type") or ""),
+        tags=tuple(str(tag) for tag in tags_raw if str(tag).strip()),
+        content=str(row.get("content") or ""),
+        charts=tuple(dict(chart) for chart in charts_raw if isinstance(chart, Mapping)),
+        data_context=data_context,
+        metadata=metadata,
+    )
+
+
+def _source_report_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return date.fromisoformat(value.strip()[:10])
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass(frozen=True)
+class PostgresBlogPostRepository:
+    """Async Postgres adapter for generated blog-post drafts."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[BlogPostDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            data_context = _draft_data_context(draft, scope)
+            blog_post_id = await self.pool.fetchval(
+                """
+                INSERT INTO blog_posts (
+                    account_id, slug, title, description, topic_type,
+                    tags, content, charts, data_context, status,
+                    llm_model, source_report_date
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6::jsonb, $7, $8::jsonb, $9::jsonb, 'draft',
+                    $10, $11
+                )
+                ON CONFLICT (slug) DO UPDATE SET
+                    account_id = EXCLUDED.account_id,
+                    title = EXCLUDED.title,
+                    description = EXCLUDED.description,
+                    topic_type = EXCLUDED.topic_type,
+                    tags = EXCLUDED.tags,
+                    content = EXCLUDED.content,
+                    charts = EXCLUDED.charts,
+                    data_context = EXCLUDED.data_context,
+                    status = EXCLUDED.status,
+                    llm_model = EXCLUDED.llm_model,
+                    source_report_date = EXCLUDED.source_report_date
+                WHERE blog_posts.status != 'published'
+                RETURNING id
+                """,
+                account_id,
+                draft.slug,
+                draft.title,
+                draft.description,
+                draft.topic_type,
+                json_dump_jsonb(list(draft.tags or ())),
+                draft.content,
+                json_dump_jsonb([dict(chart) for chart in draft.charts or ()]),
+                json_dump_jsonb(data_context),
+                str(draft.metadata.get("generation_model") or "") or None,
+                _source_report_date(data_context.get("source_report_date")),
+            )
+            if blog_post_id:
+                saved.append(str(blog_post_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        topic_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[BlogPostDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if topic_type is not None:
+            params.append(topic_type)
+            clauses.append(f"topic_type = ${len(params)}")
+        sql = (
+            "SELECT slug, title, description, topic_type, tags, content, "
+            "charts, data_context, llm_model "
+            "FROM blog_posts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        blog_post_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE blog_posts
+               SET status = $2,
+                   published_at = CASE
+                       WHEN $2 = 'published' THEN COALESCE(published_at, NOW())
+                       ELSE published_at
+                   END
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            blog_post_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+
+__all__ = [
+    "PostgresBlogPostRepository",
+]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -443,10 +443,18 @@ The mounted list/export routes use the same export helper as the CLI, so JSON
 and CSV responses include the generation-usage and reasoning summary fields
 documented above.
 
-Export generated reports, landing pages, or sales briefs through the generated
-asset CLI when the host needs the same review loop for non-campaign outputs:
+Export generated blog posts, reports, landing pages, or sales briefs through
+the generated asset CLI when the host needs the same review loop for
+non-campaign outputs:
 
 ```bash
+python scripts/export_extracted_content_assets.py \
+  --asset blog_post \
+  --account-id acct_123 \
+  --topic-type vendor_alternative \
+  --format csv \
+  --output blog_post_drafts.csv
+
 python scripts/export_extracted_content_assets.py \
   --asset report \
   --account-id acct_123 \
@@ -473,6 +481,12 @@ Move reviewed generated assets through host-defined lifecycle statuses without
 writing SQL:
 
 ```bash
+python scripts/review_extracted_content_assets.py \
+  --asset blog_post \
+  --id <blog-post-id> \
+  --account-id acct_123 \
+  --status approved
+
 python scripts/review_extracted_content_assets.py \
   --asset report \
   --id <report-id> \
@@ -517,9 +531,9 @@ The generated asset router exposes:
 | `GET` | `/content-assets/{asset}/drafts/export` | Export generated asset drafts as CSV or JSON. |
 | `POST` | `/content-assets/{asset}/drafts/review` | Update one generated asset status by id. |
 
-Supported `{asset}` values are `report`, `landing_page`, and `sales_brief`.
-Review statuses are host-defined strings; the product does not impose a fixed
-status vocabulary for these generated asset tables.
+Supported `{asset}` values are `blog_post`, `report`, `landing_page`, and
+`sales_brief`. Review statuses are host-defined strings; the product does not
+impose a fixed status vocabulary for these generated asset tables.
 
 Amazon seller installs can mount the seller-specific router:
 

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -203,6 +203,9 @@
       "target": "extracted_content_pipeline/report_export.py"
     },
     {
+      "target": "extracted_content_pipeline/blog_post_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/landing_page_export.py"
     },
     {
@@ -257,6 +260,9 @@
       "target": "extracted_content_pipeline/blog_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/blog_post_postgres.py"
+    },
+    {
       "target": "extracted_content_pipeline/content_ops_execution.py"
     },
     {
@@ -300,6 +306,9 @@
     },
     {
       "target": "extracted_content_pipeline/storage/migrations/152_campaign_draft_export_indexes.sql"
+    },
+    {
+      "target": "extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql"
     },
     {
       "target": "extracted_content_pipeline/storage/migrations/092_subcategory_intelligence.sql"

--- a/extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql
+++ b/extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql
@@ -1,0 +1,12 @@
+-- Add host-account scope for extracted AI Content Ops blog-post review paths.
+-- Keep the legacy slug uniqueness intact because copied blog writers still
+-- use ON CONFLICT (slug).
+
+ALTER TABLE blog_posts
+ADD COLUMN IF NOT EXISTS account_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_blog_posts_account_status
+    ON blog_posts (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_blog_posts_account_topic
+    ON blog_posts (account_id, topic_type, created_at DESC);

--- a/plans/PR-Content-Ops-Blog-Post-Asset-Review.md
+++ b/plans/PR-Content-Ops-Blog-Post-Asset-Review.md
@@ -1,0 +1,99 @@
+# PR-Content-Ops-Blog-Post-Asset-Review
+
+## Why this slice exists
+
+`blog_post` is an implemented AI Content Ops output with `BlogPostRepository`
+list/review methods, but the host-facing generated-asset review path only
+supports reports, landing pages, and sales briefs. Hosts can generate blog
+drafts through the extracted service, but cannot use the same packaged
+Postgres adapter, export CLI, review CLI, or generated-asset API to inspect and
+approve them.
+
+## Scope (this PR)
+
+1. Add a Postgres `BlogPostRepository` adapter for the existing `blog_posts`
+   table.
+2. Add a read-only blog-post export helper parallel to report/landing/sales
+   export helpers.
+3. Add `blog_post` to the generated-asset CLI and API switchboards.
+4. Add the minimal blog-post account-scope migration needed by the host review
+   path.
+5. Add focused tests and wire them into the extracted pipeline check script.
+
+Files touched:
+
+- `extracted_content_pipeline/blog_post_postgres.py`
+- `extracted_content_pipeline/blog_post_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `scripts/export_extracted_content_assets.py`
+- `scripts/review_extracted_content_assets.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `tests/test_extracted_blog_post_postgres.py`
+- `tests/test_extracted_blog_post_export.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_extracted_content_asset_export_cli.py`
+- `tests/test_extracted_content_asset_review_cli.py`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The new adapter stores generated blog drafts in `blog_posts`, preserving
+generation metadata inside `data_context["_metadata"]` because the legacy table
+does not have a standalone metadata JSONB column. A new `account_id` column
+gives hosted installs the same scope filter shape as the other generated assets
+without changing the legacy `slug` uniqueness or autonomous task conflict path.
+
+The export helper flattens blog drafts into JSON/CSV review rows with generation
+usage, parse-attempt, and reasoning-context summary fields. Existing generated
+asset CLIs and API routes route `asset=blog_post` to the new adapter/helper.
+
+## Intentional
+
+- The migration adds `account_id` but does not remove the legacy unique slug
+  constraint. Removing it would break existing `ON CONFLICT (slug)` writers.
+- Blog metadata is stored under `data_context["_metadata"]` rather than adding a
+  second metadata column in this slice. This keeps the adapter compatible with
+  the existing `BlogPostDraft` shape and current `blog_posts` schema.
+- Existing legacy blog rows default to `account_id=''`, so unscoped host review
+  paths can still see them.
+
+## Deferred
+
+- Per-tenant duplicate slugs remain a schema limitation until legacy blog writers
+  migrate away from `ON CONFLICT (slug)`.
+- The generated-asset frontend can add a blog-post tab after the API exposes the
+  asset path; this PR only ships backend/CLI review surfaces.
+
+## Verification
+
+Local checks run:
+
+- `pytest tests/test_extracted_blog_post_postgres.py tests/test_extracted_blog_post_export.py tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py`
+  - 38 passed
+- `bash scripts/check_ascii_python.sh`
+  - passed
+- `python -m py_compile extracted_content_pipeline/blog_post_postgres.py extracted_content_pipeline/blog_post_export.py scripts/export_extracted_content_assets.py scripts/review_extracted_content_assets.py`
+  - passed
+- `python scripts/check_extracted_imports.py`
+  - passed for 89 modules
+- `bash scripts/validate_extracted_content_pipeline.sh`
+  - passed
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - passed
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - passed with 0 findings
+- `pytest tests/test_extracted_campaign_manifest.py tests/test_extracted_storage_jsonb_helpers.py`
+  - 24 passed
+- `bash scripts/run_extracted_pipeline_checks.sh`
+  - 1431 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+17 files, +1055/-17. This is above the soft target because the slice needs one
+adapter, one export helper, three switchboard updates, migration/docs/manifest
+wiring, and parity tests at repository/export/API/CLI boundaries. The runtime
+change is still one logical asset-review seam.

--- a/scripts/export_extracted_content_assets.py
+++ b/scripts/export_extracted_content_assets.py
@@ -17,6 +17,10 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.blog_post_export import export_blog_post_drafts  # noqa: E402
+from extracted_content_pipeline.blog_post_postgres import (  # noqa: E402
+    PostgresBlogPostRepository,
+)
 from extracted_content_pipeline.landing_page_export import (  # noqa: E402
     export_landing_page_drafts,
 )
@@ -33,7 +37,7 @@ from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
 )
 
 
-ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -54,6 +58,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--target-mode", default=None, help="Report/sales brief target_mode filter.")
     parser.add_argument("--report-type", default=None, help="Report type filter.")
+    parser.add_argument("--topic-type", default=None, help="Blog post topic_type filter.")
     parser.add_argument("--campaign-name", default=None, help="Landing page campaign_name filter.")
     parser.add_argument("--slug", default=None, help="Landing page slug filter.")
     parser.add_argument("--brief-type", default=None, help="Sales brief type filter.")
@@ -106,6 +111,14 @@ async def _main() -> int:
 async def _export_for_asset(args: argparse.Namespace, pool: Any):
     scope = TenantScope(account_id=args.account_id)
     status = _status_arg(args.status)
+    if args.asset == "blog_post":
+        return await export_blog_post_drafts(
+            PostgresBlogPostRepository(pool),
+            scope=scope,
+            status=status,
+            topic_type=args.topic_type,
+            limit=args.limit,
+        )
     if args.asset == "report":
         return await export_report_drafts(
             PostgresReportRepository(pool),

--- a/scripts/review_extracted_content_assets.py
+++ b/scripts/review_extracted_content_assets.py
@@ -17,6 +17,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.blog_post_postgres import (  # noqa: E402
+    PostgresBlogPostRepository,
+)
 from extracted_content_pipeline.landing_page_postgres import (  # noqa: E402
     PostgresLandingPageRepository,
 )
@@ -26,7 +29,7 @@ from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
 )
 
 
-ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -79,6 +82,12 @@ async def _main() -> int:
 
 async def _review_asset(args: argparse.Namespace, pool: Any) -> bool:
     scope = TenantScope(account_id=args.account_id)
+    if args.asset == "blog_post":
+        return await PostgresBlogPostRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
     if args.asset == "report":
         return await PostgresReportRepository(pool).update_status(
             args.asset_id,

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -32,6 +32,8 @@ pytest \
   tests/test_extracted_content_ops_execution.py \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_extracted_parse_retry_helpers.py \
+  tests/test_extracted_blog_post_postgres.py \
+  tests/test_extracted_blog_post_export.py \
   tests/test_extracted_report_postgres.py \
   tests/test_extracted_report_generation.py \
   tests/test_extracted_quality_gate_report_pack.py \

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.blog_ports import BlogPostDraft
+from extracted_content_pipeline.blog_post_export import (
+    BlogPostDraftExportResult,
+    export_blog_post_drafts,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Repository:
+    def __init__(self, drafts=None) -> None:
+        self.drafts = tuple(drafts or ())
+        self.list_calls: list[dict] = []
+
+    async def save_drafts(self, drafts, *, scope):
+        raise NotImplementedError
+
+    async def list_drafts(
+        self,
+        *,
+        scope,
+        status=None,
+        topic_type=None,
+        limit=None,
+    ):
+        self.list_calls.append({
+            "scope": scope,
+            "status": status,
+            "topic_type": topic_type,
+            "limit": limit,
+        })
+        return self.drafts
+
+    async def update_status(self, blog_post_id, status, *, scope):
+        raise NotImplementedError
+
+
+def _draft(**overrides) -> BlogPostDraft:
+    draft = BlogPostDraft(
+        slug="acme-pricing-pressure",
+        title="Acme Pricing Pressure",
+        description="Pricing pressure dominates.",
+        topic_type="vendor_alternative",
+        tags=("pricing", "retention"),
+        content="body",
+        charts=({"id": "chart-1"},),
+        data_context={"vendor": "Acme"},
+        metadata={
+            "generation_usage": {
+                "input_tokens": 12,
+                "output_tokens": 6,
+                "total_tokens": 18,
+            },
+            "generation_parse_attempts": 2,
+            "reasoning_context": {
+                "wedge": "price_squeeze",
+                "confidence": "high",
+            },
+        },
+    )
+    return BlogPostDraft(
+        slug=overrides.get("slug", draft.slug),
+        title=overrides.get("title", draft.title),
+        description=overrides.get("description", draft.description),
+        topic_type=overrides.get("topic_type", draft.topic_type),
+        tags=overrides.get("tags", draft.tags),
+        content=overrides.get("content", draft.content),
+        charts=overrides.get("charts", draft.charts),
+        data_context=overrides.get("data_context", draft.data_context),
+        metadata=overrides.get("metadata", draft.metadata),
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_passes_filters_to_repository() -> None:
+    repo = _Repository(drafts=[_draft()])
+
+    result = await export_blog_post_drafts(
+        repo,
+        scope={"account_id": "acct_1", "user_id": "user_1"},
+        status="approved",
+        topic_type="vendor_alternative",
+        limit=7,
+    )
+
+    call = repo.list_calls[0]
+    assert isinstance(call["scope"], TenantScope)
+    assert call["scope"].account_id == "acct_1"
+    assert call["scope"].user_id == "user_1"
+    assert call["status"] == "approved"
+    assert call["topic_type"] == "vendor_alternative"
+    assert call["limit"] == 7
+    assert result.filters == {
+        "status": "approved",
+        "account_id": "acct_1",
+        "topic_type": "vendor_alternative",
+    }
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_derives_review_summary_fields() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[_draft()]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    row = result.rows[0]
+    assert row["slug"] == "acme-pricing-pressure"
+    assert row["tag_count"] == 2
+    assert row["chart_count"] == 1
+    assert row["generation_input_tokens"] == 12
+    assert row["generation_output_tokens"] == 6
+    assert row["generation_total_tokens"] == 18
+    assert row["generation_parse_attempts"] == 2
+    assert row["reasoning_context_used"] is True
+    assert row["reasoning_wedge"] == "price_squeeze"
+    assert row["reasoning_confidence"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_defaults_summary_fields_without_metadata() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[_draft(metadata={})]),
+        limit=1,
+    )
+
+    row = result.rows[0]
+    assert row["generation_input_tokens"] is None
+    assert row["generation_output_tokens"] is None
+    assert row["generation_total_tokens"] is None
+    assert row["generation_parse_attempts"] is None
+    assert row["reasoning_context_used"] is False
+    assert row["reasoning_wedge"] is None
+    assert row["reasoning_confidence"] is None
+
+
+def test_blog_post_export_result_renders_csv() -> None:
+    result = BlogPostDraftExportResult(
+        rows=(
+            {
+                "slug": "acme-pricing-pressure",
+                "title": "Acme Pricing Pressure",
+                "topic_type": "vendor_alternative",
+                "tags": ["pricing"],
+                "metadata": {"generation_parse_attempts": 2},
+            },
+        ),
+        limit=20,
+        filters={"status": "draft"},
+    )
+
+    csv_text = result.as_csv()
+
+    assert csv_text.startswith("slug,title,description,topic_type")
+    assert "acme-pricing-pressure" in csv_text
+    assert "{\"\"generation_parse_attempts\"\":2}" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_rejects_negative_limit() -> None:
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        await export_blog_post_drafts(_Repository(), limit=-1)

--- a/tests/test_extracted_blog_post_postgres.py
+++ b/tests/test_extracted_blog_post_postgres.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from extracted_content_pipeline.blog_ports import BlogPostDraft
+from extracted_content_pipeline.blog_post_postgres import PostgresBlogPostRepository
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
+
+
+def _draft() -> BlogPostDraft:
+    return BlogPostDraft(
+        slug="acme-pricing-pressure",
+        title="Acme Pricing Pressure",
+        description="Pricing pressure dominates the latest review sample.",
+        topic_type="vendor_alternative",
+        tags=("pricing", "retention"),
+        content="Pricing pressure is rising.",
+        charts=({"id": "pricing_mentions", "type": "bar"},),
+        data_context={"source_report_date": "2026-05-09", "vendor": "Acme"},
+        metadata={
+            "generation_model": "fake-llm",
+            "generation_usage": {"input_tokens": 12, "output_tokens": 6},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_scope_metadata_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["blog-post-uuid-1"]
+    repo = PostgresBlogPostRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("blog-post-uuid-1",)
+    args = pool.fetchval_calls[0]["args"]
+    assert args[0] == "acct-1"
+    assert args[1] == "acme-pricing-pressure"
+    assert json.loads(args[5]) == ["pricing", "retention"]
+    assert json.loads(args[7]) == [{"id": "pricing_mentions", "type": "bar"}]
+    data_context = json.loads(args[8])
+    assert data_context["scope"]["account_id"] == "acct-1"
+    assert data_context["_metadata"]["generation_model"] == "fake-llm"
+    assert args[9] == "fake-llm"
+    assert args[10] == date(2026, 5, 9)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_topic_and_scope() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "slug": "acme-pricing-pressure",
+            "title": "Acme Pricing Pressure",
+            "description": "Pricing pressure dominates.",
+            "topic_type": "vendor_alternative",
+            "tags": json.dumps(["pricing"]),
+            "content": "body",
+            "charts": json.dumps([{"id": "chart-1"}]),
+            "data_context": json.dumps({
+                "vendor": "Acme",
+                "_metadata": {"generation_model": "fake-llm"},
+            }),
+            "llm_model": "fake-llm",
+        }
+    ]
+    repo = PostgresBlogPostRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        topic_type="vendor_alternative",
+        limit=10,
+    )
+
+    assert len(drafts) == 1
+    assert drafts[0].slug == "acme-pricing-pressure"
+    assert drafts[0].tags == ("pricing",)
+    assert drafts[0].charts == ({"id": "chart-1"},)
+    assert drafts[0].data_context == {"vendor": "Acme"}
+    assert drafts[0].metadata["generation_model"] == "fake-llm"
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "account_id = $1" in sql
+    assert "status = $2" in sql
+    assert "topic_type = $3" in sql
+    assert "LIMIT $4" in sql
+    assert args == ("acct-1", "draft", "vendor_alternative", 10)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "slug": "decoded",
+            "title": "Decoded",
+            "description": "",
+            "topic_type": "market_landscape",
+            "tags": ["market"],
+            "content": "body",
+            "charts": [{"id": "chart"}],
+            "data_context": {"_metadata": {"generation_parse_attempts": 2}},
+            "llm_model": None,
+        }
+    ]
+    repo = PostgresBlogPostRepository(pool)
+
+    drafts = await repo.list_drafts(scope=TenantScope())
+
+    assert drafts[0].tags == ("market",)
+    assert drafts[0].charts == ({"id": "chart"},)
+    assert drafts[0].metadata["generation_parse_attempts"] == 2
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_true_on_hit_and_runs_scoped_update() -> None:
+    pool = _Pool()
+    repo = PostgresBlogPostRepository(pool)
+
+    hit = await repo.update_status(
+        "blog-post-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is True
+    query = pool.execute_calls[0]["query"]
+    args = pool.execute_calls[0]["args"]
+    assert "UPDATE blog_posts" in query
+    assert "account_id = $3" in query
+    assert args == ("blog-post-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_false_on_miss() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresBlogPostRepository(pool)
+
+    hit = await repo.update_status("missing-id", "approved", scope=TenantScope())
+
+    assert hit is False
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_returns_empty_tuple_for_empty_input() -> None:
+    pool = _Pool()
+    repo = PostgresBlogPostRepository(pool)
+
+    saved = await repo.save_drafts([], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ()
+    assert pool.fetchval_calls == []

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -54,6 +54,25 @@ def _report_row():
     }
 
 
+def _blog_post_row():
+    return {
+        "slug": "acme-pricing-pressure",
+        "title": "Acme Pricing Pressure",
+        "description": "Pricing pressure dominates.",
+        "topic_type": "vendor_alternative",
+        "tags": ["pricing", "retention"],
+        "content": "Pricing pressure is rising.",
+        "charts": [{"id": "pricing_mentions"}],
+        "data_context": {
+            "_metadata": {
+                "generation_usage": {"input_tokens": 9, "output_tokens": 4},
+                "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
+            }
+        },
+        "llm_model": "fake-llm",
+    }
+
+
 def _landing_page_row():
     return {
         "campaign_name": "acme-launch",
@@ -133,6 +152,27 @@ def test_generated_asset_router_lists_report_drafts_with_filters() -> None:
     assert args == ("acct_1", "draft", "vendor_retention", "vendor_pressure", 5)
 
 
+def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_blog_post_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/blog_post/drafts"
+        "?topic_type=vendor_alternative&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["rows"][0]["slug"] == "acme-pricing-pressure"
+    assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
+    query, args = pool.fetch_calls[0]
+    assert "FROM blog_posts" in query
+    assert args == ("acct_1", "draft", "vendor_alternative", 5)
+
+
 def test_generated_asset_router_exports_landing_page_csv() -> None:
     pool = _Pool(rows=[_landing_page_row()])
 
@@ -194,6 +234,31 @@ def test_generated_asset_router_reviews_report_with_host_defined_status() -> Non
     assert args == ("report-uuid-1", "published", "acct_1")
 
 
+def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:
+    pool = _Pool()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/blog_post/drafts/review",
+        json={"id": "blog-post-uuid-1", "status": "published"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "account_id": "acct_1",
+        "asset": "blog_post",
+        "id": "blog-post-uuid-1",
+        "status": "published",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE blog_posts" in query
+    assert args == ("blog-post-uuid-1", "published", "acct_1")
+
+
 def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
     pool = _Pool(execute_result="UPDATE 0")
 
@@ -210,7 +275,7 @@ def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
 
 
 def test_generated_asset_router_rejects_unknown_asset() -> None:
-    response = _client(_Pool()).get("/content-assets/blog_post/drafts")
+    response = _client(_Pool()).get("/content-assets/podcast_episode/drafts")
 
     assert response.status_code == 400
     assert "asset must be one of" in response.json()["detail"]
@@ -227,7 +292,7 @@ def test_generated_asset_router_rejects_unknown_asset_before_pool_resolution() -
 
     app.include_router(create_generated_asset_router(pool_provider=pool_provider))
 
-    response = TestClient(app).get("/content-assets/blog_post/drafts")
+    response = TestClient(app).get("/content-assets/podcast_episode/drafts")
 
     assert response.status_code == 400
     assert "asset must be one of" in response.json()["detail"]

--- a/tests/test_extracted_content_asset_export_cli.py
+++ b/tests/test_extracted_content_asset_export_cli.py
@@ -53,6 +53,25 @@ def _report_row():
     }
 
 
+def _blog_post_row():
+    return {
+        "slug": "acme-pricing-pressure",
+        "title": "Acme Pricing Pressure",
+        "description": "Pricing pressure dominates.",
+        "topic_type": "vendor_alternative",
+        "tags": ["pricing"],
+        "content": "body",
+        "charts": [],
+        "data_context": {
+            "_metadata": {
+                "generation_usage": {"input_tokens": 9, "output_tokens": 4},
+                "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
+            }
+        },
+        "llm_model": "fake-llm",
+    }
+
+
 def _landing_page_row():
     return {
         "campaign_name": "acme-launch",
@@ -126,6 +145,44 @@ async def test_asset_export_cli_outputs_report_json(monkeypatch, capsys) -> None
     assert output["count"] == 1
     assert output["rows"][0]["target_id"] == "vendor-acme"
     assert output["rows"][0]["reasoning_context_used"] is True
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_outputs_blog_post_json(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(rows=[_blog_post_row()])
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "blog_post",
+            "--account-id",
+            "acct_1",
+            "--topic-type",
+            "vendor_alternative",
+            "--limit",
+            "4",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.fetch_calls[0]
+    assert exit_code == 0
+    assert "FROM blog_posts" in query
+    assert args == ("acct_1", "draft", "vendor_alternative", 4)
+    assert output["rows"][0]["slug"] == "acme-pricing-pressure"
+    assert output["rows"][0]["reasoning_wedge"] == "price_squeeze"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_asset_review_cli.py
+++ b/tests/test_extracted_content_asset_review_cli.py
@@ -85,6 +85,49 @@ async def test_asset_review_cli_updates_report_status(monkeypatch, capsys) -> No
 
 
 @pytest.mark.asyncio
+async def test_asset_review_cli_updates_blog_post_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "blog_post",
+            "--id",
+            "blog-post-uuid-1",
+            "--status",
+            "approved",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert "UPDATE blog_posts" in query
+    assert args == ("blog-post-uuid-1", "approved", "acct_1")
+    assert output == {
+        "account_id": "acct_1",
+        "asset": "blog_post",
+        "id": "blog-post-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_asset_review_cli_returns_nonzero_on_landing_page_miss(
     monkeypatch,
     capsys,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Post-Asset-Review.md

Add blog_post to the generated Content Ops asset review/export/API path. Blog generation was already an implemented output with a BlogPostRepository contract, but hosts could not use the same packaged Postgres adapter, export CLI, review CLI, or generated-asset API used by reports, landing pages, and sales briefs.

## Intentional
- Preserve the legacy blog_posts slug uniqueness because copied blog writers still use ON CONFLICT (slug).
- Store BlogPostDraft metadata inside data_context[_metadata] rather than adding a parallel metadata column.
- Existing legacy blog rows default to account_id='' so unscoped host review paths can still see them.

## Deferred
- Per-tenant duplicate blog slugs need a later schema/writer migration.
- Frontend blog-post review tab can consume this API in a separate UI slice.

## Verification
- pytest tests/test_extracted_blog_post_postgres.py tests/test_extracted_blog_post_export.py tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py -- 38 passed
- python -m py_compile extracted_content_pipeline/blog_post_postgres.py extracted_content_pipeline/blog_post_export.py extracted_content_pipeline/api/generated_assets.py scripts/export_extracted_content_assets.py scripts/review_extracted_content_assets.py -- passed
- bash scripts/check_ascii_python.sh -- passed
- python scripts/check_extracted_imports.py -- passed for 89 modules
- bash scripts/validate_extracted_content_pipeline.sh -- passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -- 0 findings
- pytest tests/test_extracted_campaign_manifest.py tests/test_extracted_storage_jsonb_helpers.py -- 24 passed
- bash scripts/run_extracted_pipeline_checks.sh -- 1431 passed, 1 existing torch/pynvml warning

## Diff size
17 files, +1056 / -17