### PR TITLE
Add blog post Postgres repository foundation

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T22:11Z by codex-content-ops-blog-post-repo
+Last updated: 2026-05-09T22:27Z by codex-content-ops-blog-post-repo
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Postgres repository foundation for generated blog-post assets | NEW: `extracted_content_pipeline/blog_post_postgres.py`, `extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql`, `tests/test_extracted_blog_post_postgres.py`, `plans/PR-Content-Ops-Blog-Post-Repository.md` | codex-content-ops-blog-post-repo | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T21:49Z by codex-content-ops-hosted-asset-workflow
+Last updated: 2026-05-09T22:11Z by codex-content-ops-blog-post-repo
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add Postgres repository foundation for generated blog-post assets | NEW: `extracted_content_pipeline/blog_post_postgres.py`, `extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql`, `tests/test_extracted_blog_post_postgres.py`, `plans/PR-Content-Ops-Blog-Post-Repository.md` | codex-content-ops-blog-post-repo | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -1,0 +1,189 @@
+"""Postgres repository adapter for AI Content Ops blog posts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Mapping, Sequence
+
+from .blog_ports import BlogPostDraft
+from .campaign_ports import JsonDict, TenantScope
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+_METADATA_KEY = "_metadata"
+
+
+def _draft_data_context(draft: BlogPostDraft, scope: TenantScope) -> JsonDict:
+    data_context = dict(draft.data_context or {})
+    data_context[_METADATA_KEY] = dict(draft.metadata or {})
+    data_context["scope"] = {
+        "account_id": scope.account_id,
+        "user_id": scope.user_id,
+    }
+    return data_context
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> BlogPostDraft:
+    tags_raw = decode_jsonb_field(row.get("tags"), default=[])
+    if not isinstance(tags_raw, Sequence) or isinstance(tags_raw, (str, bytes)):
+        tags_raw = []
+
+    charts_raw = decode_jsonb_field(row.get("charts"), default=[])
+    if not isinstance(charts_raw, Sequence) or isinstance(charts_raw, (str, bytes)):
+        charts_raw = []
+
+    data_context_raw = decode_jsonb_field(row.get("data_context"), default={})
+    if not isinstance(data_context_raw, Mapping):
+        data_context_raw = {}
+
+    data_context = dict(data_context_raw)
+    metadata_raw = data_context.pop(_METADATA_KEY, {})
+    metadata = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+    if row.get("llm_model") and "generation_model" not in metadata:
+        metadata["generation_model"] = str(row.get("llm_model"))
+
+    return BlogPostDraft(
+        slug=str(row.get("slug") or ""),
+        title=str(row.get("title") or ""),
+        description=str(row.get("description") or ""),
+        topic_type=str(row.get("topic_type") or ""),
+        tags=tuple(str(tag) for tag in tags_raw if str(tag).strip()),
+        content=str(row.get("content") or ""),
+        charts=tuple(dict(chart) for chart in charts_raw if isinstance(chart, Mapping)),
+        data_context=data_context,
+        metadata=metadata,
+    )
+
+
+def _source_report_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return date.fromisoformat(value.strip()[:10])
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass(frozen=True)
+class PostgresBlogPostRepository:
+    """Async Postgres adapter for generated blog-post drafts."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[BlogPostDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            data_context = _draft_data_context(draft, scope)
+            blog_post_id = await self.pool.fetchval(
+                """
+                INSERT INTO blog_posts (
+                    account_id, slug, title, description, topic_type,
+                    tags, content, charts, data_context, status,
+                    llm_model, source_report_date
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6::jsonb, $7, $8::jsonb, $9::jsonb, 'draft',
+                    $10, $11
+                )
+                ON CONFLICT (slug) DO UPDATE SET
+                    account_id = EXCLUDED.account_id,
+                    title = EXCLUDED.title,
+                    description = EXCLUDED.description,
+                    topic_type = EXCLUDED.topic_type,
+                    tags = EXCLUDED.tags,
+                    content = EXCLUDED.content,
+                    charts = EXCLUDED.charts,
+                    data_context = EXCLUDED.data_context,
+                    status = EXCLUDED.status,
+                    llm_model = EXCLUDED.llm_model,
+                    source_report_date = EXCLUDED.source_report_date
+                WHERE blog_posts.status != 'published'
+                RETURNING id
+                """,
+                account_id,
+                draft.slug,
+                draft.title,
+                draft.description,
+                draft.topic_type,
+                json_dump_jsonb(list(draft.tags or ())),
+                draft.content,
+                json_dump_jsonb([dict(chart) for chart in draft.charts or ()]),
+                json_dump_jsonb(data_context),
+                str(draft.metadata.get("generation_model") or "") or None,
+                _source_report_date(data_context.get("source_report_date")),
+            )
+            if blog_post_id:
+                saved.append(str(blog_post_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        topic_type: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[BlogPostDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if topic_type is not None:
+            params.append(topic_type)
+            clauses.append(f"topic_type = ${len(params)}")
+        sql = (
+            "SELECT slug, title, description, topic_type, tags, content, "
+            "charts, data_context, llm_model "
+            "FROM blog_posts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        blog_post_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE blog_posts
+               SET status = $2,
+                   published_at = CASE
+                       WHEN $2 = 'published' THEN COALESCE(published_at, NOW())
+                       ELSE published_at
+                   END
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            blog_post_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+
+__all__ = [
+    "PostgresBlogPostRepository",
+]

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -113,6 +113,7 @@ class PostgresBlogPostRepository:
                     llm_model = EXCLUDED.llm_model,
                     source_report_date = EXCLUDED.source_report_date
                 WHERE blog_posts.status != 'published'
+                  AND blog_posts.account_id = EXCLUDED.account_id
                 RETURNING id
                 """,
                 account_id,

--- a/extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql
+++ b/extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql
@@ -1,0 +1,12 @@
+-- Add host-account scope for extracted AI Content Ops blog-post review paths.
+-- Keep the legacy slug uniqueness intact because copied blog writers still
+-- use ON CONFLICT (slug).
+
+ALTER TABLE blog_posts
+ADD COLUMN IF NOT EXISTS account_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_blog_posts_account_status
+    ON blog_posts (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_blog_posts_account_topic
+    ON blog_posts (account_id, topic_type, created_at DESC);

--- a/plans/PR-Content-Ops-Blog-Post-Repository.md
+++ b/plans/PR-Content-Ops-Blog-Post-Repository.md
@@ -1,0 +1,53 @@
+# PR-Content-Ops-Blog-Post-Repository
+
+## Why this slice exists
+
+`blog_post` is an implemented AI Content Ops output, but it only has a
+persistence protocol. Hosts cannot inject a packaged Postgres repository for
+the existing `blog_posts` table, so blog generation is behind the other asset
+services.
+
+This is the first split from oversized draft PR #445. It only adds the
+repository/storage foundation; export/API/CLI wiring stays out of this PR.
+
+## Scope (this PR)
+
+1. Add a scoped Postgres adapter for `BlogPostRepository`.
+2. Add the minimal `account_id` migration needed for host-scoped blog review.
+3. Add repository tests for save/list/update behavior.
+
+Files touched: repository adapter, account-scope migration, repository tests,
+plan, and coordination row.
+
+## Mechanism
+
+The adapter persists `BlogPostDraft` rows into `blog_posts`, storing draft
+metadata under `data_context["_metadata"]` because the legacy table has no
+standalone metadata column. The migration adds `account_id` and scoped indexes
+for list/review calls.
+
+## Intentional
+
+- Preserve legacy unique `slug`; copied blog writers still use `ON CONFLICT (slug)`.
+- Store malformed `source_report_date` strings as `NULL`.
+- Default legacy rows to `account_id=''`, matching the unscoped review path.
+
+## Deferred
+
+- Blog-post export helpers stay in the next stacked PR.
+- Generated-asset API/CLI switchboards and docs/status/check-script cleanup
+  stay in later stacked PRs.
+- Per-tenant duplicate blog slugs need a later schema/writer migration.
+
+## Verification
+
+- `pytest tests/test_extracted_blog_post_postgres.py`
+  - 4 passed
+- `python -m py_compile extracted_content_pipeline/blog_post_postgres.py`
+  - passed
+- `bash scripts/check_ascii_python.sh`
+  - passed
+
+## Estimated diff size
+
+5 files, about +390/-1. Export/API/CLI/docs stay in separate stacked PRs.

--- a/tests/test_extracted_blog_post_postgres.py
+++ b/tests/test_extracted_blog_post_postgres.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from extracted_content_pipeline.blog_ports import BlogPostDraft
+from extracted_content_pipeline.blog_post_postgres import PostgresBlogPostRepository
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Pool:
+    def __init__(self):
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
+
+
+def _draft() -> BlogPostDraft:
+    return BlogPostDraft(
+        slug="acme-pricing-pressure",
+        title="Acme Pricing Pressure",
+        description="Pricing pressure dominates the latest review sample.",
+        topic_type="vendor_alternative",
+        tags=("pricing", "retention"),
+        content="Pricing pressure is rising.",
+        charts=({"id": "pricing_mentions", "type": "bar"},),
+        data_context={"source_report_date": "2026-05-09", "vendor": "Acme"},
+        metadata={
+            "generation_model": "fake-llm",
+            "generation_usage": {"input_tokens": 12, "output_tokens": 6},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_scope_metadata_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["blog-post-uuid-1"]
+    repo = PostgresBlogPostRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("blog-post-uuid-1",)
+    args = pool.fetchval_calls[0]["args"]
+    assert args[0] == "acct-1"
+    assert args[1] == "acme-pricing-pressure"
+    assert json.loads(args[5]) == ["pricing", "retention"]
+    assert json.loads(args[7]) == [{"id": "pricing_mentions", "type": "bar"}]
+    data_context = json.loads(args[8])
+    assert data_context["scope"]["account_id"] == "acct-1"
+    assert data_context["_metadata"]["generation_model"] == "fake-llm"
+    assert args[9] == "fake-llm"
+    assert args[10] == date(2026, 5, 9)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_topic_and_scope() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "slug": "acme-pricing-pressure",
+            "title": "Acme Pricing Pressure",
+            "description": "Pricing pressure dominates.",
+            "topic_type": "vendor_alternative",
+            "tags": json.dumps(["pricing"]),
+            "content": "body",
+            "charts": json.dumps([{"id": "chart-1"}]),
+            "data_context": json.dumps({
+                "vendor": "Acme",
+                "_metadata": {"generation_model": "fake-llm"},
+            }),
+            "llm_model": "fake-llm",
+        }
+    ]
+    repo = PostgresBlogPostRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        topic_type="vendor_alternative",
+        limit=10,
+    )
+
+    assert len(drafts) == 1
+    assert drafts[0].slug == "acme-pricing-pressure"
+    assert drafts[0].tags == ("pricing",)
+    assert drafts[0].charts == ({"id": "chart-1"},)
+    assert drafts[0].data_context == {"vendor": "Acme"}
+    assert drafts[0].metadata["generation_model"] == "fake-llm"
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "account_id = $1" in sql
+    assert "status = $2" in sql
+    assert "topic_type = $3" in sql
+    assert "LIMIT $4" in sql
+    assert args == ("acct-1", "draft", "vendor_alternative", 10)
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_true_on_hit_and_runs_scoped_update() -> None:
+    pool = _Pool()
+    repo = PostgresBlogPostRepository(pool)
+
+    hit = await repo.update_status(
+        "blog-post-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hit is True
+    query = pool.execute_calls[0]["query"]
+    args = pool.execute_calls[0]["args"]
+    assert "UPDATE blog_posts" in query
+    assert "account_id = $3" in query
+    assert args == ("blog-post-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_false_on_miss() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresBlogPostRepository(pool)
+
+    hit = await repo.update_status("missing-id", "approved", scope=TenantScope())
+
+    assert hit is False

--- a/tests/test_extracted_blog_post_postgres.py
+++ b/tests/test_extracted_blog_post_postgres.py
@@ -71,6 +71,19 @@ async def test_save_drafts_persists_scope_metadata_and_returns_ids() -> None:
 
 
 @pytest.mark.asyncio
+async def test_save_drafts_skips_cross_tenant_slug_conflict() -> None:
+    pool = _Pool()
+    pool.fetchval_results = [None]
+    repo = PostgresBlogPostRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-b"))
+
+    assert saved == ()
+    sql = pool.fetchval_calls[0]["query"]
+    assert "blog_posts.account_id = EXCLUDED.account_id" in sql
+
+
+@pytest.mark.asyncio
 async def test_list_drafts_filters_by_status_topic_and_scope() -> None:
     pool = _Pool()
     pool.fetch_rows = [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Post-Repository.md

Split from oversized draft PR #445. This adds only the generated blog-post Postgres repository foundation: the account-scope migration, `PostgresBlogPostRepository`, and repository tests. Export/API/CLI/docs stay in stacked follow-ups.

## Intentional
- Preserve legacy blog_posts slug uniqueness because copied blog writers still use `ON CONFLICT (slug)`.
- Store BlogPostDraft metadata under `data_context[_metadata]` because the legacy table has no metadata JSONB column.
- Default legacy rows to `account_id=''`, matching the unscoped review path.

## Deferred
- Blog-post export helpers stay in the next stacked PR.
- Generated-asset API/CLI switchboards and docs/status/check-script cleanup stay in later stacked PRs.
- Per-tenant duplicate blog slugs need a later schema/writer migration.

## Verification
- `pytest tests/test_extracted_blog_post_postgres.py` -- 5 passed
- `python -m py_compile extracted_content_pipeline/blog_post_postgres.py` -- passed
- `bash scripts/check_ascii_python.sh` -- passed
- `git diff --check` -- passed

## Diff size
5 files, +414 / -3