### PR TITLE
Add blog post draft export helper

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-09T22:27Z by codex-content-ops-blog-post-repo
+Last updated: 2026-05-10T00:09Z by codex-content-ops-blog-post-export
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Add read-only export helper for generated blog-post drafts | NEW: `extracted_content_pipeline/blog_post_export.py`, `tests/test_extracted_blog_post_export.py`, `plans/PR-Content-Ops-Blog-Post-Export.md` | codex-content-ops-blog-post-export | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:09Z by codex-content-ops-blog-post-export
+Last updated: 2026-05-10T00:19Z by codex-content-ops-blog-post-export
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add read-only export helper for generated blog-post drafts | NEW: `extracted_content_pipeline/blog_post_export.py`, `tests/test_extracted_blog_post_export.py`, `plans/PR-Content-Ops-Blog-Post-Export.md` | codex-content-ops-blog-post-export | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -1,0 +1,162 @@
+"""Read-only blog-post draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+import json
+from typing import Any
+
+from .blog_ports import BlogPostDraft, BlogPostRepository
+from .campaign_ports import TenantScope
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "slug",
+    "title",
+    "description",
+    "topic_type",
+    "tag_count",
+    "chart_count",
+    "generation_input_tokens",
+    "generation_output_tokens",
+    "generation_total_tokens",
+    "generation_parse_attempts",
+    "reasoning_context_used",
+    "reasoning_wedge",
+    "reasoning_confidence",
+    "tags",
+    "content",
+    "charts",
+    "data_context",
+    "metadata",
+)
+
+
+@dataclass(frozen=True)
+class BlogPostDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_blog_post_drafts(
+    repository: BlogPostRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    topic_type: str | None = None,
+    limit: int = 20,
+) -> BlogPostDraftExportResult:
+    """Return generated blog-post drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if topic_type:
+        filters["topic_type"] = topic_type
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        topic_type=topic_type,
+        limit=normalized_limit,
+    )
+    return BlogPostDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: BlogPostDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["tag_count"] = len(draft.tags)
+    row["chart_count"] = len(draft.charts)
+    row.update(_metadata_summary(draft.metadata))
+    return row
+
+
+def _metadata_summary(value: Any) -> JsonDict:
+    metadata = _metadata_mapping(value)
+    usage = _metadata_mapping(metadata.get("generation_usage"))
+    reasoning = _metadata_mapping(metadata.get("reasoning_context"))
+    return {
+        "generation_input_tokens": usage.get("input_tokens"),
+        "generation_output_tokens": usage.get("output_tokens"),
+        "generation_total_tokens": usage.get("total_tokens"),
+        "generation_parse_attempts": metadata.get("generation_parse_attempts"),
+        "reasoning_context_used": bool(reasoning),
+        "reasoning_wedge": reasoning.get("wedge"),
+        "reasoning_confidence": reasoning.get("confidence"),
+    }
+
+
+def _metadata_mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+    return {}
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "BlogPostDraftExportResult",
+    "export_blog_post_drafts",
+]

--- a/plans/PR-Content-Ops-Blog-Post-Export.md
+++ b/plans/PR-Content-Ops-Blog-Post-Export.md
@@ -1,0 +1,52 @@
+# PR-Content-Ops-Blog-Post-Export
+
+## Why this slice exists
+
+PR #447 added the generated blog-post Postgres repository foundation. Hosts
+still need a read-only export helper before the generated-asset API/CLI
+switchboards can route `blog_post` alongside reports, landing pages, and sales
+briefs.
+
+## Scope (this PR)
+
+1. Add `export_blog_post_drafts(...)` for JSON/CSV review rows.
+2. Add focused export-helper tests.
+3. Claim this split in coordination.
+
+Files touched: export helper, export tests, plan, and coordination row.
+
+## Mechanism
+
+The helper calls `BlogPostRepository.list_drafts(...)` with tenant scope,
+status, topic type, and limit filters. It converts `BlogPostDraft` rows into
+flat review/export dictionaries with generation usage, parse-attempt, and
+reasoning-context summary fields. CSV rendering mirrors the existing report,
+landing-page, and sales-brief export helpers.
+
+## Intentional
+
+- This PR does not wire the helper into any CLI or API. That stays in the next
+  stacked PR so the export semantics can be reviewed separately.
+- `content`, `charts`, `data_context`, and `metadata` are included in the export
+  row because blog drafts are long-form assets and reviewers need the full draft
+  body.
+
+## Deferred
+
+- Generated-asset API/CLI switchboards stay in the next stacked PR.
+- Docs/status/manifest/check-script cleanup stays in the final coordination PR.
+
+## Verification
+
+- `pytest tests/test_extracted_blog_post_export.py`
+  - 5 passed
+- `python -m py_compile extracted_content_pipeline/blog_post_export.py`
+  - passed
+- `bash scripts/check_ascii_python.sh`
+  - passed
+- `git diff --check`
+  - passed
+
+## Estimated diff size
+
+4 files, about +240/-1.

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.blog_ports import BlogPostDraft
+from extracted_content_pipeline.blog_post_export import (
+    BlogPostDraftExportResult,
+    export_blog_post_drafts,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Repository:
+    def __init__(self, drafts=None) -> None:
+        self.drafts = tuple(drafts or ())
+        self.list_calls: list[dict] = []
+
+    async def save_drafts(self, drafts, *, scope):
+        raise NotImplementedError
+
+    async def list_drafts(
+        self,
+        *,
+        scope,
+        status=None,
+        topic_type=None,
+        limit=None,
+    ):
+        self.list_calls.append({
+            "scope": scope,
+            "status": status,
+            "topic_type": topic_type,
+            "limit": limit,
+        })
+        return self.drafts
+
+    async def update_status(self, blog_post_id, status, *, scope):
+        raise NotImplementedError
+
+
+def _draft(**overrides) -> BlogPostDraft:
+    draft = BlogPostDraft(
+        slug="acme-pricing-pressure",
+        title="Acme Pricing Pressure",
+        description="Pricing pressure dominates.",
+        topic_type="vendor_alternative",
+        tags=("pricing", "retention"),
+        content="body",
+        charts=({"id": "chart-1"},),
+        data_context={"vendor": "Acme"},
+        metadata={
+            "generation_usage": {
+                "input_tokens": 12,
+                "output_tokens": 6,
+                "total_tokens": 18,
+            },
+            "generation_parse_attempts": 2,
+            "reasoning_context": {
+                "wedge": "price_squeeze",
+                "confidence": "high",
+            },
+        },
+    )
+    return BlogPostDraft(
+        slug=overrides.get("slug", draft.slug),
+        title=overrides.get("title", draft.title),
+        description=overrides.get("description", draft.description),
+        topic_type=overrides.get("topic_type", draft.topic_type),
+        tags=overrides.get("tags", draft.tags),
+        content=overrides.get("content", draft.content),
+        charts=overrides.get("charts", draft.charts),
+        data_context=overrides.get("data_context", draft.data_context),
+        metadata=overrides.get("metadata", draft.metadata),
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_passes_filters_to_repository() -> None:
+    repo = _Repository(drafts=[_draft()])
+
+    result = await export_blog_post_drafts(
+        repo,
+        scope={"account_id": "acct_1", "user_id": "user_1"},
+        status="approved",
+        topic_type="vendor_alternative",
+        limit=7,
+    )
+
+    call = repo.list_calls[0]
+    assert isinstance(call["scope"], TenantScope)
+    assert call["scope"].account_id == "acct_1"
+    assert call["scope"].user_id == "user_1"
+    assert call["status"] == "approved"
+    assert call["topic_type"] == "vendor_alternative"
+    assert call["limit"] == 7
+    assert result.filters == {
+        "status": "approved",
+        "account_id": "acct_1",
+        "topic_type": "vendor_alternative",
+    }
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_derives_review_summary_fields() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[_draft()]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    row = result.rows[0]
+    assert row["slug"] == "acme-pricing-pressure"
+    assert row["tag_count"] == 2
+    assert row["chart_count"] == 1
+    assert row["generation_input_tokens"] == 12
+    assert row["generation_output_tokens"] == 6
+    assert row["generation_total_tokens"] == 18
+    assert row["generation_parse_attempts"] == 2
+    assert row["reasoning_context_used"] is True
+    assert row["reasoning_wedge"] == "price_squeeze"
+    assert row["reasoning_confidence"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_defaults_summary_fields_without_metadata() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[_draft(metadata={})]),
+        limit=1,
+    )
+
+    row = result.rows[0]
+    assert row["generation_input_tokens"] is None
+    assert row["generation_output_tokens"] is None
+    assert row["generation_total_tokens"] is None
+    assert row["generation_parse_attempts"] is None
+    assert row["reasoning_context_used"] is False
+    assert row["reasoning_wedge"] is None
+    assert row["reasoning_confidence"] is None
+
+
+def test_blog_post_export_result_renders_csv() -> None:
+    result = BlogPostDraftExportResult(
+        rows=(
+            {
+                "slug": "acme-pricing-pressure",
+                "title": "Acme Pricing Pressure",
+                "topic_type": "vendor_alternative",
+                "tags": ["pricing"],
+                "metadata": {"generation_parse_attempts": 2},
+            },
+        ),
+        limit=20,
+        filters={"status": "draft"},
+    )
+
+    csv_text = result.as_csv()
+
+    assert csv_text.startswith("slug,title,description,topic_type")
+    assert "acme-pricing-pressure" in csv_text
+    assert "{\"\"generation_parse_attempts\"\":2}" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_rejects_negative_limit() -> None:
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        await export_blog_post_drafts(_Repository(), limit=-1)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Post-Export.md

Second stacked slice after #447. This adds only the read-only `blog_post` export helper and focused tests. API/CLI switchboards and docs/status/check-script wiring stay in follow-up PRs.

## Intentional
- Keep this slice limited to export semantics; API and CLI switchboards follow separately.
- Include full blog content in export rows because reviewers need the long-form body.

## Deferred
- Generated-asset API/CLI switchboards stay in the next stacked PR.
- Docs/status/manifest/check-script cleanup stays in the final coordination PR.

## Verification
- `pytest tests/test_extracted_blog_post_export.py` -- 5 passed
- `python -m py_compile extracted_content_pipeline/blog_post_export.py` -- passed
- `bash scripts/check_ascii_python.sh` -- passed
- `git diff --check` -- passed

## Diff size
4 files, +381 / -1