### PR TITLE
Wire blog post into generated asset API and CLIs

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:19Z by codex-content-ops-blog-post-export
+Last updated: 2026-05-10T00:13Z by codex-content-ops-blog-post-api-cli
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| (in flight) | Wire blog_post into generated asset API and CLI switchboards | EDIT: `extracted_content_pipeline/api/generated_assets.py`, `scripts/export_extracted_content_assets.py`, `scripts/review_extracted_content_assets.py`, generated asset API/CLI tests; NEW: `plans/PR-Content-Ops-Blog-Post-Api-Cli.md` | codex-content-ops-blog-post-api-cli | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:13Z by codex-content-ops-blog-post-api-cli
+Last updated: 2026-05-10T00:31Z by codex-content-ops-blog-post-api-cli
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Wire blog_post into generated asset API and CLI switchboards | EDIT: `extracted_content_pipeline/api/generated_assets.py`, `scripts/export_extracted_content_assets.py`, `scripts/review_extracted_content_assets.py`, generated asset API/CLI tests; NEW: `plans/PR-Content-Ops-Blog-Post-Api-Cli.md` | codex-content-ops-blog-post-api-cli | Existing competitive-intelligence row; avoid `extracted_competitive_intelligence/*` |
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -19,6 +19,8 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import TenantScope
+from ..blog_post_export import export_blog_post_drafts
+from ..blog_post_postgres import PostgresBlogPostRepository
 from ..landing_page_export import export_landing_page_drafts
 from ..landing_page_postgres import PostgresLandingPageRepository
 from ..report_export import export_report_drafts
@@ -30,7 +32,7 @@ from ..sales_brief_postgres import PostgresSalesBriefRepository
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
 
-ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
 
 
 def _require_fastapi() -> None:
@@ -149,6 +151,7 @@ def create_generated_asset_router(
         report_type: str | None = Query(None),
         campaign_name: str | None = Query(None),
         slug: str | None = Query(None),
+        topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
         limit: int | None = Query(None, ge=0),
     ) -> dict[str, Any]:
@@ -164,6 +167,7 @@ def create_generated_asset_router(
             report_type=report_type,
             campaign_name=campaign_name,
             slug=slug,
+            topic_type=topic_type,
             brief_type=brief_type,
             limit=_api_limit(limit, resolved_config),
         )
@@ -177,6 +181,7 @@ def create_generated_asset_router(
         report_type: str | None = Query(None),
         campaign_name: str | None = Query(None),
         slug: str | None = Query(None),
+        topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
         limit: int | None = Query(None, ge=0),
         format: str = Query("csv", description="csv or json"),
@@ -193,6 +198,7 @@ def create_generated_asset_router(
             report_type=report_type,
             campaign_name=campaign_name,
             slug=slug,
+            topic_type=topic_type,
             brief_type=brief_type,
             limit=_api_limit(limit, resolved_config),
         )
@@ -249,9 +255,18 @@ async def _export_for_asset(
     report_type: str | None,
     campaign_name: str | None,
     slug: str | None,
+    topic_type: str | None,
     brief_type: str | None,
     limit: int,
 ) -> Any:
+    if asset == "blog_post":
+        return await export_blog_post_drafts(
+            PostgresBlogPostRepository(pool),
+            scope=scope,
+            status=status,
+            topic_type=topic_type,
+            limit=limit,
+        )
     if asset == "report":
         return await export_report_drafts(
             PostgresReportRepository(pool),
@@ -290,6 +305,8 @@ async def _update_asset_status(
     status: str,
     scope: TenantScope,
 ) -> bool:
+    if asset == "blog_post":
+        return await PostgresBlogPostRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "report":
         return await PostgresReportRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "landing_page":

--- a/plans/PR-Content-Ops-Blog-Post-Api-Cli.md
+++ b/plans/PR-Content-Ops-Blog-Post-Api-Cli.md
@@ -1,0 +1,50 @@
+# PR-Content-Ops-Blog-Post-Api-Cli
+
+## Why this slice exists
+
+PR #447 added the blog-post Postgres repository and PR #448 added the read-only
+export helper. The existing generated-asset API and CLIs still only route
+reports, landing pages, and sales briefs. Hosts need `blog_post` to use the
+same review/export surface.
+
+## Scope (this PR)
+
+1. Add `blog_post` to generated-asset API list/export/review routing.
+2. Add `blog_post` to the generated-asset export and review CLIs.
+3. Add focused API/CLI routing tests.
+
+Files touched: generated asset router, generated asset CLIs, focused routing
+tests, plan, and coordination row.
+
+## Mechanism
+
+The switchboards route `asset=blog_post` to `PostgresBlogPostRepository` and
+`export_blog_post_drafts(...)`. `topic_type` is the blog-specific filter,
+parallel to `report_type`, `campaign_name`, and `brief_type` on the other asset
+types.
+
+## Intentional
+
+- This PR does not update runbooks/status/manifest/check-script. Those are
+  coordination/docs wiring and stay in the final stacked PR.
+- Unknown-asset tests now use `podcast_episode` because `blog_post` becomes a
+  valid generated asset.
+
+## Deferred
+
+- Docs/status/manifest/check-script cleanup stays in the final coordination PR.
+
+## Verification
+
+- `pytest tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py`
+  - 27 passed
+- `python -m py_compile extracted_content_pipeline/api/generated_assets.py scripts/export_extracted_content_assets.py scripts/review_extracted_content_assets.py`
+  - passed
+- `bash scripts/check_ascii_python.sh`
+  - passed
+- `git diff --check`
+  - passed
+
+## Estimated diff size
+
+6 files, about +220/-5.

--- a/scripts/export_extracted_content_assets.py
+++ b/scripts/export_extracted_content_assets.py
@@ -17,6 +17,10 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.blog_post_export import export_blog_post_drafts  # noqa: E402
+from extracted_content_pipeline.blog_post_postgres import (  # noqa: E402
+    PostgresBlogPostRepository,
+)
 from extracted_content_pipeline.landing_page_export import (  # noqa: E402
     export_landing_page_drafts,
 )
@@ -33,7 +37,7 @@ from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
 )
 
 
-ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -54,6 +58,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--target-mode", default=None, help="Report/sales brief target_mode filter.")
     parser.add_argument("--report-type", default=None, help="Report type filter.")
+    parser.add_argument("--topic-type", default=None, help="Blog post topic_type filter.")
     parser.add_argument("--campaign-name", default=None, help="Landing page campaign_name filter.")
     parser.add_argument("--slug", default=None, help="Landing page slug filter.")
     parser.add_argument("--brief-type", default=None, help="Sales brief type filter.")
@@ -106,6 +111,14 @@ async def _main() -> int:
 async def _export_for_asset(args: argparse.Namespace, pool: Any):
     scope = TenantScope(account_id=args.account_id)
     status = _status_arg(args.status)
+    if args.asset == "blog_post":
+        return await export_blog_post_drafts(
+            PostgresBlogPostRepository(pool),
+            scope=scope,
+            status=status,
+            topic_type=args.topic_type,
+            limit=args.limit,
+        )
     if args.asset == "report":
         return await export_report_drafts(
             PostgresReportRepository(pool),

--- a/scripts/review_extracted_content_assets.py
+++ b/scripts/review_extracted_content_assets.py
@@ -17,6 +17,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.blog_post_postgres import (  # noqa: E402
+    PostgresBlogPostRepository,
+)
 from extracted_content_pipeline.landing_page_postgres import (  # noqa: E402
     PostgresLandingPageRepository,
 )
@@ -26,7 +29,7 @@ from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
 )
 
 
-ASSET_CHOICES = ("report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -79,6 +82,12 @@ async def _main() -> int:
 
 async def _review_asset(args: argparse.Namespace, pool: Any) -> bool:
     scope = TenantScope(account_id=args.account_id)
+    if args.asset == "blog_post":
+        return await PostgresBlogPostRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
     if args.asset == "report":
         return await PostgresReportRepository(pool).update_status(
             args.asset_id,

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -54,6 +54,25 @@ def _report_row():
     }
 
 
+def _blog_post_row():
+    return {
+        "slug": "acme-pricing-pressure",
+        "title": "Acme Pricing Pressure",
+        "description": "Pricing pressure dominates.",
+        "topic_type": "vendor_alternative",
+        "tags": ["pricing"],
+        "content": "body",
+        "charts": [],
+        "data_context": {
+            "_metadata": {
+                "generation_usage": {"input_tokens": 9, "output_tokens": 4},
+                "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
+            }
+        },
+        "llm_model": "fake-llm",
+    }
+
+
 def _landing_page_row():
     return {
         "campaign_name": "acme-launch",
@@ -133,6 +152,27 @@ def test_generated_asset_router_lists_report_drafts_with_filters() -> None:
     assert args == ("acct_1", "draft", "vendor_retention", "vendor_pressure", 5)
 
 
+def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_blog_post_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/blog_post/drafts"
+        "?topic_type=vendor_alternative&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["rows"][0]["slug"] == "acme-pricing-pressure"
+    assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
+    query, args = pool.fetch_calls[0]
+    assert "FROM blog_posts" in query
+    assert args == ("acct_1", "draft", "vendor_alternative", 5)
+
+
 def test_generated_asset_router_exports_landing_page_csv() -> None:
     pool = _Pool(rows=[_landing_page_row()])
 
@@ -194,6 +234,31 @@ def test_generated_asset_router_reviews_report_with_host_defined_status() -> Non
     assert args == ("report-uuid-1", "published", "acct_1")
 
 
+def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:
+    pool = _Pool()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/blog_post/drafts/review",
+        json={"id": "blog-post-uuid-1", "status": "published"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "account_id": "acct_1",
+        "asset": "blog_post",
+        "id": "blog-post-uuid-1",
+        "status": "published",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE blog_posts" in query
+    assert args == ("blog-post-uuid-1", "published", "acct_1")
+
+
 def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
     pool = _Pool(execute_result="UPDATE 0")
 
@@ -210,7 +275,7 @@ def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
 
 
 def test_generated_asset_router_rejects_unknown_asset() -> None:
-    response = _client(_Pool()).get("/content-assets/blog_post/drafts")
+    response = _client(_Pool()).get("/content-assets/podcast_episode/drafts")
 
     assert response.status_code == 400
     assert "asset must be one of" in response.json()["detail"]
@@ -227,7 +292,7 @@ def test_generated_asset_router_rejects_unknown_asset_before_pool_resolution() -
 
     app.include_router(create_generated_asset_router(pool_provider=pool_provider))
 
-    response = TestClient(app).get("/content-assets/blog_post/drafts")
+    response = TestClient(app).get("/content-assets/podcast_episode/drafts")
 
     assert response.status_code == 400
     assert "asset must be one of" in response.json()["detail"]

--- a/tests/test_extracted_content_asset_export_cli.py
+++ b/tests/test_extracted_content_asset_export_cli.py
@@ -53,6 +53,25 @@ def _report_row():
     }
 
 
+def _blog_post_row():
+    return {
+        "slug": "acme-pricing-pressure",
+        "title": "Acme Pricing Pressure",
+        "description": "Pricing pressure dominates.",
+        "topic_type": "vendor_alternative",
+        "tags": ["pricing"],
+        "content": "body",
+        "charts": [],
+        "data_context": {
+            "_metadata": {
+                "generation_usage": {"input_tokens": 9, "output_tokens": 4},
+                "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
+            }
+        },
+        "llm_model": "fake-llm",
+    }
+
+
 def _landing_page_row():
     return {
         "campaign_name": "acme-launch",
@@ -126,6 +145,44 @@ async def test_asset_export_cli_outputs_report_json(monkeypatch, capsys) -> None
     assert output["count"] == 1
     assert output["rows"][0]["target_id"] == "vendor-acme"
     assert output["rows"][0]["reasoning_context_used"] is True
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_outputs_blog_post_json(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(rows=[_blog_post_row()])
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "blog_post",
+            "--account-id",
+            "acct_1",
+            "--topic-type",
+            "vendor_alternative",
+            "--limit",
+            "4",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.fetch_calls[0]
+    assert exit_code == 0
+    assert "FROM blog_posts" in query
+    assert args == ("acct_1", "draft", "vendor_alternative", 4)
+    assert output["rows"][0]["slug"] == "acme-pricing-pressure"
+    assert output["rows"][0]["reasoning_wedge"] == "price_squeeze"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_asset_review_cli.py
+++ b/tests/test_extracted_content_asset_review_cli.py
@@ -85,6 +85,49 @@ async def test_asset_review_cli_updates_report_status(monkeypatch, capsys) -> No
 
 
 @pytest.mark.asyncio
+async def test_asset_review_cli_updates_blog_post_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "blog_post",
+            "--id",
+            "blog-post-uuid-1",
+            "--status",
+            "approved",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert "UPDATE blog_posts" in query
+    assert args == ("blog-post-uuid-1", "approved", "acct_1")
+    assert output == {
+        "account_id": "acct_1",
+        "asset": "blog_post",
+        "id": "blog-post-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_asset_review_cli_returns_nonzero_on_landing_page_miss(
     monkeypatch,
     capsys,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Post-Api-Cli.md

Third stacked slice after #447 and #448. This wires `blog_post` into the existing generated-asset API and export/review CLIs. Docs/status/manifest/check-script wiring stays in the final coordination PR.

## Intentional
- Keep docs/status/manifest/check-script cleanup out of this switchboard slice.
- Use `topic_type` as the blog-specific filter.
- Unknown-asset tests now use `podcast_episode` because `blog_post` is valid.

## Deferred
- Final docs/status/manifest/check-script wiring follows in a separate coordination PR.

## Verification
- `pytest tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py` -- 27 passed
- `python -m py_compile extracted_content_pipeline/api/generated_assets.py scripts/export_extracted_content_assets.py scripts/review_extracted_content_assets.py` -- passed
- `bash scripts/check_ascii_python.sh` -- passed
- `git diff --check` -- passed

## Diff size
8 files, +262 / -8