### PR TITLE
Document blog post generated asset review wiring

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:32Z by codex-content-ops-blog-post-review-docs
+Last updated: 2026-05-10T00:41Z by codex-content-ops-blog-post-review-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Document blog post generated-asset review wiring | EDIT: `extracted_content_pipeline/manifest.json`; `scripts/run_extracted_pipeline_checks.sh`; `tests/test_extracted_campaign_manifest.py`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/host_install_runbook.md`. NEW: `plans/PR-Content-Ops-Blog-Post-Review-Docs.md`. | codex-content-ops-blog-post-review-docs | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:31Z by codex-content-ops-blog-post-api-cli
+Last updated: 2026-05-10T00:32Z by codex-content-ops-blog-post-review-docs
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Document blog post generated-asset review wiring | EDIT: `extracted_content_pipeline/manifest.json`; `scripts/run_extracted_pipeline_checks.sh`; `tests/test_extracted_campaign_manifest.py`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/host_install_runbook.md`. NEW: `plans/PR-Content-Ops-Blog-Post-Review-Docs.md`. | codex-content-ops-blog-post-review-docs | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -47,21 +47,24 @@
 - `report_export` provides a read-only draft export path over generated
   structured reports so hosts can review JSON/CSV outputs without handwritten
   SQL or a mounted report API.
+- `blog_post_export` provides a read-only draft export path over generated
+  blog posts so hosts can review JSON/CSV outputs without handwritten SQL or a
+  mounted blog post API.
 - `landing_page_export` provides a read-only draft export path over generated
   landing pages so hosts can review JSON/CSV outputs without handwritten SQL or
   a mounted landing page API.
 - `sales_brief_export` provides a read-only draft export path over generated
   sales briefs so hosts can review JSON/CSV outputs without handwritten SQL or
   a mounted sales brief API.
-- `scripts/export_extracted_content_assets.py` exposes the report, landing
-  page, and sales brief export helpers as a host-facing JSON/CSV CLI backed by
-  the product-owned Postgres repositories.
+- `scripts/export_extracted_content_assets.py` exposes the report, blog post,
+  landing page, and sales brief export helpers as a host-facing JSON/CSV CLI
+  backed by the product-owned Postgres repositories.
 - `scripts/review_extracted_content_assets.py` exposes scoped status updates
-  for exported report, landing page, and sales brief drafts without handwritten
-  SQL.
+  for exported report, blog post, landing page, and sales brief drafts without
+  handwritten SQL.
 - `api.generated_assets` provides a FastAPI router factory around generated
-  report, landing page, and sales brief list/export/review workflows. Hosts
-  inject pool providers, tenant scope, and auth dependencies.
+  report, blog post, landing page, and sales brief list/export/review
+  workflows. Hosts inject pool providers, tenant scope, and auth dependencies.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -459,7 +459,6 @@ python scripts/export_extracted_content_assets.py \
 python scripts/export_extracted_content_assets.py \
   --asset blog_post \
   --account-id acct_123 \
-  --target-mode vendor_retention \
   --topic-type vendor_showdown \
   --format csv \
   --output blog_post_drafts.csv

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -443,8 +443,9 @@ The mounted list/export routes use the same export helper as the CLI, so JSON
 and CSV responses include the generation-usage and reasoning summary fields
 documented above.
 
-Export generated reports, landing pages, or sales briefs through the generated
-asset CLI when the host needs the same review loop for non-campaign outputs:
+Export generated reports, blog posts, landing pages, or sales briefs through
+the generated asset CLI when the host needs the same review loop for
+non-campaign outputs:
 
 ```bash
 python scripts/export_extracted_content_assets.py \
@@ -454,6 +455,14 @@ python scripts/export_extracted_content_assets.py \
   --report-type vendor_pressure \
   --format csv \
   --output report_drafts.csv
+
+python scripts/export_extracted_content_assets.py \
+  --asset blog_post \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --topic-type vendor_showdown \
+  --format csv \
+  --output blog_post_drafts.csv
 
 python scripts/export_extracted_content_assets.py \
   --asset landing_page \
@@ -476,6 +485,12 @@ writing SQL:
 python scripts/review_extracted_content_assets.py \
   --asset report \
   --id <report-id> \
+  --account-id acct_123 \
+  --status approved
+
+python scripts/review_extracted_content_assets.py \
+  --asset blog_post \
+  --id <blog-post-id> \
   --account-id acct_123 \
   --status approved
 
@@ -517,9 +532,9 @@ The generated asset router exposes:
 | `GET` | `/content-assets/{asset}/drafts/export` | Export generated asset drafts as CSV or JSON. |
 | `POST` | `/content-assets/{asset}/drafts/review` | Update one generated asset status by id. |
 
-Supported `{asset}` values are `report`, `landing_page`, and `sales_brief`.
-Review statuses are host-defined strings; the product does not impose a fixed
-status vocabulary for these generated asset tables.
+Supported `{asset}` values are `report`, `blog_post`, `landing_page`, and
+`sales_brief`. Review statuses are host-defined strings; the product does not
+impose a fixed status vocabulary for these generated asset tables.
 
 Amazon seller installs can mount the seller-specific router:
 

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -203,6 +203,9 @@
       "target": "extracted_content_pipeline/report_export.py"
     },
     {
+      "target": "extracted_content_pipeline/blog_post_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/landing_page_export.py"
     },
     {
@@ -257,6 +260,9 @@
       "target": "extracted_content_pipeline/blog_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/blog_post_postgres.py"
+    },
+    {
       "target": "extracted_content_pipeline/content_ops_execution.py"
     },
     {
@@ -303,6 +309,9 @@
     },
     {
       "target": "extracted_content_pipeline/storage/migrations/092_subcategory_intelligence.sql"
+    },
+    {
+      "target": "extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql"
     },
     {
       "target": "extracted_content_pipeline/pipelines/notify.py"

--- a/plans/PR-Content-Ops-Blog-Post-Review-Docs.md
+++ b/plans/PR-Content-Ops-Blog-Post-Review-Docs.md
@@ -1,0 +1,31 @@
+# PR-Content-Ops-Blog-Post-Review-Docs
+
+## Goal
+
+Close the documentation, manifest, and extracted-check wiring for the
+`blog_post` generated-asset review path after the repository, export helper, API,
+and CLI slices merged.
+
+## Plan
+
+1. Mark the blog post Postgres/export modules and account-scope migration as
+   product-owned in `extracted_content_pipeline/manifest.json`.
+2. Add the blog post Postgres/export suites to
+   `scripts/run_extracted_pipeline_checks.sh`.
+3. Update manifest tests so the new product-owned files and migration stay
+   tracked.
+4. Update status and host runbook docs so generated-asset export/review/API
+   guidance lists `blog_post` beside report, landing page, and sales brief.
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No new generated-asset routes or CLI flags.
+- No competitive-intelligence files.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_manifest.py`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `bash scripts/check_ascii_python.sh`
+- `git diff --check`

--- a/plans/PR-Content-Ops-Blog-Post-Review-Docs.md
+++ b/plans/PR-Content-Ops-Blog-Post-Review-Docs.md
@@ -1,31 +1,63 @@
 # PR-Content-Ops-Blog-Post-Review-Docs
 
-## Goal
+## Why this slice exists
 
-Close the documentation, manifest, and extracted-check wiring for the
-`blog_post` generated-asset review path after the repository, export helper, API,
-and CLI slices merged.
+The blog post generated-asset repository, export helper, API, and CLIs are now
+merged. The remaining gap is metadata and host-facing documentation: the
+manifest, extracted check runner, status notes, and install runbook still need
+to advertise and pin the `blog_post` review/export path alongside report,
+landing page, and sales brief.
 
-## Plan
+## Scope (this PR)
 
 1. Mark the blog post Postgres/export modules and account-scope migration as
-   product-owned in `extracted_content_pipeline/manifest.json`.
-2. Add the blog post Postgres/export suites to
-   `scripts/run_extracted_pipeline_checks.sh`.
+   product-owned.
+2. Add the blog post Postgres/export suites to the extracted pipeline runner.
 3. Update manifest tests so the new product-owned files and migration stay
    tracked.
 4. Update status and host runbook docs so generated-asset export/review/API
-   guidance lists `blog_post` beside report, landing page, and sales brief.
+   guidance includes `blog_post`.
 
-## Non-Goals
+### Files touched
 
-- No runtime behavior changes.
-- No new generated-asset routes or CLI flags.
-- No competitive-intelligence files.
+- `extracted_content_pipeline/manifest.json`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_campaign_manifest.py`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Blog-Post-Review-Docs.md`
+
+## Mechanism
+
+The manifest adds the product-owned blog post export/repository modules and the
+blog post account-scope migration under `owned`. The extracted pipeline runner
+adds the two already-merged blog post suites to the default check list. The host
+runbook documents `blog_post` as a supported generated asset and shows a
+`topic_type`-scoped export example.
+
+## Intentional
+
+- No runtime behavior changes; the API and CLI routing already landed in the
+  prior slice.
+- The blog post export example does not include `--target-mode` because the
+  blog post export path filters by `topic_type`, not target mode.
+- The coordination row stays in `inflight.md` until the PR merges, per the
+  multi-session protocol.
+
+## Deferred
+
+- None for the blog post generated-asset review/export wiring. Follow-on work
+  should move to the next AI Content Ops asset or reasoning slice.
 
 ## Verification
 
-- `pytest tests/test_extracted_campaign_manifest.py`
-- `bash scripts/run_extracted_pipeline_checks.sh`
-- `bash scripts/check_ascii_python.sh`
-- `git diff --check`
+- `pytest tests/test_extracted_campaign_manifest.py` -> 7 passed
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1430 passed, 1 existing
+  torch/pynvml warning
+- `bash scripts/check_ascii_python.sh` -> passed
+- `git diff --check` -> passed
+
+## Estimated diff size
+
+7 files, roughly +90 / -13. Under the 400 LOC review budget.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -26,6 +26,7 @@ pytest \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_extracted_blog_generation.py \
+  tests/test_extracted_blog_post_postgres.py \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \
   tests/test_extracted_content_control_surface_api.py \
@@ -47,6 +48,7 @@ pytest \
   tests/test_extracted_content_asset_export_cli.py \
   tests/test_extracted_content_asset_review_cli.py \
   tests/test_extracted_report_export.py \
+  tests/test_extracted_blog_post_export.py \
   tests/test_extracted_landing_page_export.py \
   tests/test_extracted_sales_brief_export.py \
   tests/test_extracted_campaign_postgres_review.py \

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -24,6 +24,7 @@ PRODUCT_OWNED_CAMPAIGN_MIGRATIONS = {
     "151_campaign_opportunities.sql",
     "152_campaign_draft_export_indexes.sql",
     "092_subcategory_intelligence.sql",
+    "276_blog_post_account_scope.sql",
 }
 
 DEFERRED_CROSS_PRODUCT_MIGRATIONS = {
@@ -103,6 +104,9 @@ def test_product_owned_campaign_migrations_define_product_tables() -> None:
     subcategory_schema = (
         migrations_dir / "092_subcategory_intelligence.sql"
     ).read_text()
+    blog_post_scope_schema = (
+        migrations_dir / "276_blog_post_account_scope.sql"
+    ).read_text()
 
     assert "CREATE TABLE IF NOT EXISTS campaign_opportunities" in opportunity_schema
     assert "idx_campaign_opportunities_account_mode" in opportunity_schema
@@ -110,6 +114,12 @@ def test_product_owned_campaign_migrations_define_product_tables() -> None:
     assert "idx_b2b_campaigns_vendor_created" in export_indexes_schema
     assert "ADD COLUMN IF NOT EXISTS subcategory TEXT" in subcategory_schema
     assert "product_metadata" not in subcategory_schema
+    assert (
+        "ADD COLUMN IF NOT EXISTS account_id TEXT NOT NULL DEFAULT ''"
+        in blog_post_scope_schema
+    )
+    assert "idx_blog_posts_account_status" in blog_post_scope_schema
+    assert "idx_blog_posts_account_topic" in blog_post_scope_schema
 
 
 def test_manifest_tracks_product_owned_adapter_files() -> None:
@@ -125,6 +135,8 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/campaign_postgres_generation.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_analytics.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_webhooks.py" in owned
+    assert "extracted_content_pipeline/blog_post_export.py" in owned
+    assert "extracted_content_pipeline/blog_post_postgres.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_review.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_seller_targets.py" in owned
     assert "extracted_content_pipeline/campaign_postgres_seller_opportunities.py" in owned
@@ -143,6 +155,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/storage/migrations/151_campaign_opportunities.sql" in owned
     assert "extracted_content_pipeline/storage/migrations/152_campaign_draft_export_indexes.sql" in owned
     assert "extracted_content_pipeline/storage/migrations/092_subcategory_intelligence.sql" in owned
+    assert "extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
     assert "extracted_content_pipeline/reasoning/evidence_engine.py" in owned
@@ -179,6 +192,8 @@ def test_product_owned_utility_helpers_are_not_manifest_synced() -> None:
     assert "extracted_content_pipeline/campaign_postgres_generation.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_analytics.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_webhooks.py" not in mapped
+    assert "extracted_content_pipeline/blog_post_export.py" not in mapped
+    assert "extracted_content_pipeline/blog_post_postgres.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_seller_targets.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_seller_opportunities.py" not in mapped
     assert "extracted_content_pipeline/campaign_postgres_seller_category_intelligence.py" not in mapped


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Post-Review-Docs.md

## Summary
- mark blog post generated-asset repository/export/migration files as product-owned in the manifest
- add blog post repository/export suites to the extracted pipeline check runner
- update status and host runbook docs so generated-asset export/review/API guidance includes blog_post

## Verification
- pytest tests/test_extracted_campaign_manifest.py
- bash scripts/run_extracted_pipeline_checks.sh
- bash scripts/check_ascii_python.sh
- git diff --check