### PR TITLE
Add consumed reasoning context to Content Ops execution

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:41Z by codex-content-ops-blog-post-review-docs
+Last updated: 2026-05-10T00:48Z by codex-content-ops-reasoning-execution
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Add consumed reasoning payload field to Content Ops execution | EDIT: `extracted_content_pipeline/content_ops_execution.py`; `tests/test_extracted_content_ops_execution.py`; `docs/frontend/content_ops_frontend_contract.md`; `extracted_content_pipeline/STATUS.md`. NEW: `plans/PR-Content-Ops-Consumed-Reasoning-Execution.md`. | codex-content-ops-reasoning-execution | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -338,7 +338,7 @@ interface ContentOpsStepExecution {
   status: "completed" | "failed" | "skipped";   // step-level
   result: Record<string, unknown>;              // runner-specific result blob
   error: string;                                // populated when status="failed"
-  reasoning?: ContentOpsStepReasoningAudit;     // compact readiness audit only
+  reasoning?: ContentOpsStepReasoningAudit;     // readiness + optional consumed context
 }
 
 interface ContentOpsStepReasoningAudit {
@@ -346,6 +346,7 @@ interface ContentOpsStepReasoningAudit {
   service_supports_reasoning: boolean;
   provider_configured: boolean;
   contexts_used?: number;
+  consumed_contexts?: CampaignReasoningContextView[];
 }
 ```
 
@@ -428,15 +429,14 @@ reasoning even when the current host has not wired a provider.
 
 Important runtime boundary: `ContentOpsStepExecution.result` contains
 the per-service summary returned by `as_dict()` (counts, saved IDs,
-warnings, and errors). It does **not** reliably expose the consumed
-reasoning payload. `ContentOpsStepExecution.reasoning` is a compact
-readiness audit only: it tells the UI whether the output can use host
-reasoning, whether the service supports the seam, and whether a
-provider was attached. When the service result includes
-`reasoning_contexts_used`, the audit also exposes `contexts_used` as
+warnings, and errors). `ContentOpsStepExecution.reasoning` tells the UI
+whether the output can use host reasoning, whether the service supports
+the seam, and whether a provider was attached. When the service result
+includes `reasoning_contexts_used`, the audit exposes `contexts_used` as
 the count of generated assets that actually consumed reasoning context.
-A Reasoning Context Drawer still requires a future field that carries
-the consumed context itself.
+When the service result also includes `consumed_reasoning_contexts`, the
+audit exposes `consumed_contexts` as the drawer-ready context payload.
+Services that do not opt into this payload keep the count-only response.
 
 ```ts
 interface CampaignReasoningContextView {
@@ -459,8 +459,8 @@ UI rules:
   `reasoningRequirement="optional_host_context"`.
 - Treat catalog badges as configuration readiness only. Use
   `step.reasoning` for execution-level readiness ("provider attached" /
-  "provider absent") but do not render a context drawer from it; it is
-  not the prompt payload.
+  "provider absent"). Render a context drawer only when
+  `step.reasoning.consumed_contexts` is present.
 
 ---
 
@@ -550,9 +550,9 @@ Dumb components only. No fetch, no business rules.
 - Full asset editor UX
 - Visual workflow builder
 - Model-selection UX
-- Reasoning Context Drawer until `/content-ops/execute` exposes an
-  explicit consumed-reasoning payload field. The current `reasoning`
-  audit only exposes readiness and `contexts_used` counts.
+- Full Reasoning Context Drawer UX. `/content-ops/execute` now exposes
+  `reasoning.consumed_contexts` when services opt in, but the actual
+  drawer component and per-output service adoption land separately.
 - Collaboration / role-permission flows
 - CMS export
 - Approval workflow (no backend approval state on the control-surface

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -148,9 +148,9 @@
 - Execution result summaries expose compact reasoning consumption counts when a
   generated-asset service reports them: runner results can include
   `reasoning_contexts_used`, and the per-step `reasoning` audit mirrors that
-  count as `contexts_used`. Raw consumed reasoning payloads remain intentionally
-  absent, so a per-step reasoning drawer still needs a future explicit
-  execution-result field.
+  count as `contexts_used`. Services can also opt into
+  `consumed_reasoning_contexts`; the per-step `reasoning` audit surfaces those
+  rows as `consumed_contexts` for future reasoning-drawer UIs.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -705,6 +705,9 @@ def _step_reasoning_audit(
     contexts_used = _reasoning_contexts_used(result)
     if contexts_used is not None:
         audit["contexts_used"] = contexts_used
+    consumed_contexts = _consumed_reasoning_contexts(result)
+    if consumed_contexts:
+        audit["consumed_contexts"] = consumed_contexts
     return audit
 
 
@@ -717,6 +720,23 @@ def _reasoning_contexts_used(result: Mapping[str, Any] | None) -> int | None:
     if isinstance(raw, int) and raw >= 0:
         return raw
     return None
+
+
+def _consumed_reasoning_contexts(
+    result: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if result is None:
+        return []
+    raw = result.get("consumed_reasoning_contexts")
+    if isinstance(raw, Mapping):
+        return [dict(raw)] if raw else []
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        return []
+    contexts: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, Mapping) and item:
+            contexts.append(dict(item))
+    return contexts
 
 
 def _clean(value: Any) -> str:

--- a/plans/PR-Content-Ops-Consumed-Reasoning-Execution.md
+++ b/plans/PR-Content-Ops-Consumed-Reasoning-Execution.md
@@ -1,0 +1,64 @@
+# PR-Content-Ops-Consumed-Reasoning-Execution
+
+## Why this slice exists
+
+AI Content Ops execution already reports whether a reasoning provider is wired
+and how many contexts a service says it consumed. The frontend contract still
+calls the reasoning drawer blocked because `/content-ops/execute` has no stable
+field for a service to return the consumed reasoning payload itself.
+
+## Scope (this PR)
+
+1. Add an optional `consumed_contexts` field to the per-step execution reasoning
+   audit when a service result returns `consumed_reasoning_contexts`.
+2. Keep existing `contexts_used` behavior unchanged for services that only
+   report counts.
+3. Update the Content Ops frontend contract and package status to describe the
+   new optional field.
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_execution.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Consumed-Reasoning-Execution.md`
+
+## Mechanism
+
+`_step_reasoning_audit(...)` now looks for `result["consumed_reasoning_contexts"]`
+after it mirrors `reasoning_contexts_used`. If the value is a mapping or a list
+of mappings, it is copied into `reasoning.consumed_contexts`. Missing or
+malformed values are ignored so older services keep their current response
+shape.
+
+## Intentional
+
+- This does not force every generator to expose raw consumed context yet. It
+  creates the execution contract first so service-level opt-in slices can land
+  without changing the API shape again.
+- `contexts_used` remains the compact count; `consumed_contexts` is the
+  optional drawer-ready payload.
+- `signal_extraction` still omits reasoning audit because its catalog
+  requirement is `absent`.
+
+## Deferred
+
+- Service-level opt-in for campaign, blog post, report, landing page, and sales
+  brief results to populate `consumed_reasoning_contexts` from their prompt
+  payloads.
+- Frontend drawer UI that renders `reasoning.consumed_contexts`.
+
+## Verification
+
+- `pytest tests/test_extracted_content_ops_execution.py` -> 34 passed
+- `python -m py_compile extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_ops_execution.py` -> passed
+- `bash scripts/check_ascii_python.sh` -> passed
+- `git diff --check` -> passed
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1432 passed, 1 existing
+  torch/pynvml warning
+
+## Estimated diff size
+
+6 files, roughly +120 / -20. Under the 400 LOC review budget.

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -18,13 +18,19 @@ from extracted_content_pipeline.signal_extraction import SignalExtractionService
 class _Result:
     generated: int = 1
     reasoning_contexts_used: int = 0
+    consumed_reasoning_contexts: tuple[dict[str, Any], ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "generated": self.generated,
             "reasoning_contexts_used": self.reasoning_contexts_used,
             "saved_ids": ["draft-1"],
         }
+        if self.consumed_reasoning_contexts:
+            data["consumed_reasoning_contexts"] = [
+                dict(item) for item in self.consumed_reasoning_contexts
+            ]
+        return data
 
 
 class _OpportunityService:
@@ -963,6 +969,77 @@ async def test_execute_step_reports_actual_reasoning_contexts_used():
         "service_supports_reasoning": True,
         "provider_configured": True,
         "contexts_used": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_step_reports_consumed_reasoning_contexts_when_result_includes_them():
+    consumed = {
+        "wedge": "pricing_pressure",
+        "confidence": 0.82,
+        "proof_points": [{"label": "Renewal spike", "value": "34%"}],
+    }
+
+    class _ReasoningPayloadService(_ReasoningAwareOpportunityService):
+        async def generate(self, **kwargs: Any) -> _Result:
+            self.calls.append(dict(kwargs))
+            return _Result(
+                generated=1,
+                reasoning_contexts_used=1,
+                consumed_reasoning_contexts=(consumed,),
+            )
+
+    services = ContentOpsExecutionServices(
+        campaign=_ReasoningPayloadService(),
+        reasoning_provider_configured=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        },
+        services=services,
+    )
+
+    assert result["steps"][0]["reasoning"] == {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": True,
+        "provider_configured": True,
+        "contexts_used": 1,
+        "consumed_contexts": [consumed],
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_step_ignores_malformed_consumed_reasoning_contexts():
+    class _MalformedReasoningPayloadService(_ReasoningAwareOpportunityService):
+        async def generate(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(dict(kwargs))
+            return {
+                "generated": 1,
+                "reasoning_contexts_used": 1,
+                "consumed_reasoning_contexts": ["not-a-context", {}, 3],
+            }
+
+    services = ContentOpsExecutionServices(
+        campaign=_MalformedReasoningPayloadService(),
+        reasoning_provider_configured=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        },
+        services=services,
+    )
+
+    assert result["steps"][0]["reasoning"] == {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": True,
+        "provider_configured": True,
+        "contexts_used": 1,
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Consumed-Reasoning-Execution.md

AI Content Ops execution already reported reasoning readiness and `contexts_used` counts, but there was no stable execution-response field for consumed reasoning payloads. This adds an opt-in `reasoning.consumed_contexts` field when services return `consumed_reasoning_contexts`, without changing current generator behavior.

## Intentional
- Existing services remain count-only until their own opt-in slices.
- `contexts_used` stays the compact count; `consumed_contexts` is the optional drawer-ready payload.
- `signal_extraction` still omits reasoning audit because its requirement is absent.

## Deferred
- Service-level adoption for campaign, blog post, report, landing page, and sales brief results.
- Frontend drawer UI rendering for `reasoning.consumed_contexts`.

## Verification
- `pytest tests/test_extracted_content_ops_execution.py` -> 34 passed
- `python -m py_compile extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_ops_execution.py` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `git diff --check` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1432 passed, 1 existing torch/pynvml warning

## Diff size
6 files, +181 / -19