### PR TITLE
PR-Content-Ops-Execution-Services-Wire-1: wire signal_extraction service

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -1,0 +1,50 @@
+"""Factory for the Content Ops execution-services bundle.
+
+Builds a `ContentOpsExecutionServices` populated with the
+generators the host has fully wired. This v0 slot wires
+`signal_extraction` only -- a deterministic generator with no
+external dependencies (no `IntelligenceRepository`, no
+`LLMClient`, no `SkillStore`). Other slots stay `None`; the
+executor's per-step dispatcher returns `service_not_configured`
+for unset slots, which the route layer maps to a per-step error
+the UI can render.
+
+Follow-up slices will plug the remaining 5 generators
+(`campaign`, `blog_post`, `report`, `landing_page`,
+`sales_brief`) into the same bundle once their host-side
+repository factories land.
+
+See `plans/PR-Content-Ops-Execution-Services-Wire-1.md` for the
+slice contract.
+"""
+
+from __future__ import annotations
+
+from extracted_content_pipeline.content_ops_execution import (
+    ContentOpsExecutionServices,
+)
+from extracted_content_pipeline.signal_extraction import (
+    SignalExtractionService,
+)
+
+
+# Module-level singleton: SignalExtractionService is stateless, so
+# re-creating it per request would just churn allocations.
+_SIGNAL_EXTRACTION_SERVICE: SignalExtractionService = SignalExtractionService()
+
+
+def build_content_ops_execution_services() -> ContentOpsExecutionServices:
+    """Return the host's Content Ops execution-services bundle.
+
+    Slots not yet populated remain `None`; the executor returns
+    `service_not_configured` per output for unset slots. As host
+    repositories / LLM / skills factories arrive, follow-up
+    slices populate the remaining slots in this same bundle.
+    """
+
+    return ContentOpsExecutionServices(
+        signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
+    )
+
+
+__all__ = ["build_content_ops_execution_services"]

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -156,8 +156,10 @@ try:
     from extracted_content_pipeline.api.control_surfaces import (
         create_content_ops_control_surface_router,
     )
+    from .._content_ops_services import build_content_ops_execution_services
     content_ops_router = create_content_ops_control_surface_router(
         dependencies=[Depends(require_b2b_plan("b2b_growth"))],
+        execution_services_provider=build_content_ops_execution_services,
     )
     router.include_router(content_ops_router)
 except Exception as exc:  # pragma: no cover - defensive at import time

--- a/plans/PR-Content-Ops-Execution-Services-Wire-1.md
+++ b/plans/PR-Content-Ops-Execution-Services-Wire-1.md
@@ -55,9 +55,13 @@ Tightly bounded:
    provider into the existing
    `create_content_ops_control_surface_router(...)` call.
 3. `tests/test_atlas_content_ops_execution_services.py` (new)
-   -- ~100 LOC. Two tests: `signal_extraction` runs through the
-   executor; the other 5 outputs still return
-   `service_not_configured`.
+   -- ~100 LOC. Three tests:
+   - `signal_extraction` runs through the executor.
+   - The other 5 outputs still return
+     `service_not_configured`.
+   - `test_bundle_only_advertises_wired_outputs`: pins that
+     `configured_outputs()` advertises only the wired output
+     (canary for future slot population).
 4. `plans/PR-Content-Ops-Execution-Services-Wire-1.md` (this
    file).
 
@@ -85,7 +89,7 @@ Tightly bounded:
 The factory returns a singleton-shaped bundle:
 
 ```python
-# atlas_brain/api/_content_ops_services.py
+# atlas_brain/_content_ops_services.py
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
 )
@@ -112,13 +116,17 @@ The router-construction call gains `execution_services_provider`:
 
 ```python
 # atlas_brain/api/__init__.py
-from ._content_ops_services import build_content_ops_execution_services
+from .._content_ops_services import build_content_ops_execution_services
 
 content_ops_router = create_content_ops_control_surface_router(
     dependencies=[Depends(require_b2b_plan("b2b_growth"))],
     execution_services_provider=build_content_ops_execution_services,
 )
 ```
+
+The factory is passed as a bare function reference (not wrapped
+in a lambda) -- `_resolve_execution_services` accepts any
+`Callable[[], ContentOpsExecutionServices]` shape.
 
 The provider is a plain `Callable[[], ContentOpsExecutionServices]`;
 the route's `_resolve_execution_services` handles both sync and
@@ -164,9 +172,9 @@ async returns.
 ## Verification
 
 - `python -m pytest tests/test_atlas_content_ops_execution_services.py`
-  -- 2 passed.
+  -- 3 passed.
 - `bash scripts/check_ascii_python.sh` -- clean.
-- `python -c "from atlas_brain.api._content_ops_services import
+- `python -c "from atlas_brain._content_ops_services import
    build_content_ops_execution_services as f; b = f(); print(
    b.configured_outputs())"` -- `('signal_extraction',)`.
 - AST-parse + ASCII-clean spot-check on

--- a/plans/PR-Content-Ops-Execution-Services-Wire-1.md
+++ b/plans/PR-Content-Ops-Execution-Services-Wire-1.md
@@ -40,7 +40,8 @@ Tightly bounded:
 2. **Modify `atlas_brain/api/__init__.py`** to import the
    factory and pass it to
    `create_content_ops_control_surface_router(
-   execution_services_provider=lambda: build_content_ops_execution_services())`.
+   execution_services_provider=build_content_ops_execution_services)`
+   as a bare function reference.
 3. **One regression test** in
    `tests/test_atlas_content_ops_execution_services.py` pinning
    that the bundle round-trips through the executor for

--- a/plans/PR-Content-Ops-Execution-Services-Wire-1.md
+++ b/plans/PR-Content-Ops-Execution-Services-Wire-1.md
@@ -1,0 +1,183 @@
+# PR: wire `execution_services_provider` for `signal_extraction` (E1 of N)
+
+## Why this slice exists
+
+PR #406 mounted the `extracted_content_pipeline` content-ops
+router into the host's aggregate `api_router` with **no**
+`execution_services_provider`. That correctly returned `503
+"Content Ops execution services are not configured."` for
+`POST /content-ops/execute`, with the explicit Deferred:
+
+> **Wiring `execution_services_provider` into the host mount.**
+> v0 mounts the content-ops router with no provider, so
+> `/execute` returns 503 by design. A follow-up slice wires the
+> host's existing repositories (...) into a
+> `ContentOpsExecutionServices` factory and passes it through.
+
+Now that Screens 1 / 2 / 3 have all landed (PRs #408-#424 across
+parallel sessions), the Execute button is the last functional
+gap: it submits, but the backend always 503s.
+
+This PR closes the gap for **`signal_extraction` only** -- the
+deterministic generator with **zero dependencies** (no
+`IntelligenceRepository`, no `LLMClient`, no `SkillStore`). It
+proves the provider-wiring pattern; the remaining 5 generators
+(campaign / blog / report / landing_page / sales_brief) ship
+in follow-up slices once their host-side repository factories
+are in place.
+
+## Scope (this PR)
+
+Tightly bounded:
+
+1. **New module `atlas_brain/_content_ops_services.py`**
+   that builds a `ContentOpsExecutionServices` bundle with
+   `signal_extraction` populated. Exposes a single function
+   `build_content_ops_execution_services()` returning the
+   bundle. Other slots in the bundle stay `None`; the executor
+   falls back to `service_not_configured` for them, which the
+   route layer already maps to a clean per-step error.
+2. **Modify `atlas_brain/api/__init__.py`** to import the
+   factory and pass it to
+   `create_content_ops_control_surface_router(
+   execution_services_provider=lambda: build_content_ops_execution_services())`.
+3. **One regression test** in
+   `tests/test_atlas_content_ops_execution_services.py` pinning
+   that the bundle round-trips through the executor for
+   `signal_extraction` and continues to return
+   `service_not_configured` for the other outputs.
+
+### Files touched
+
+1. `atlas_brain/_content_ops_services.py` (new) -- ~30 LOC
+   factory + module-level singleton + docstring.
+2. `atlas_brain/api/__init__.py` -- ~5 LOC delta to thread the
+   provider into the existing
+   `create_content_ops_control_surface_router(...)` call.
+3. `tests/test_atlas_content_ops_execution_services.py` (new)
+   -- ~100 LOC. Two tests: `signal_extraction` runs through the
+   executor; the other 5 outputs still return
+   `service_not_configured`.
+4. `plans/PR-Content-Ops-Execution-Services-Wire-1.md` (this
+   file).
+
+### What's NOT in this slice
+
+- **Wiring `campaign` / `blog_post` / `report` /
+  `landing_page` / `sales_brief`.** Each needs a
+  Postgres-backed repository, an `LLMClient`, and a
+  `SkillStore` -- those host-side factories are themselves
+  follow-up work. Once any one of them lands, an E2 / E3 slice
+  plugs it into the bundle in the same shape.
+- **Tenant scope plumbing.** The route already accepts a
+  `scope_provider`; that is a separate slice and explicitly
+  not introduced here.
+- **Reasoning context provider.** Already wired via PR
+  #ControlSurfaces-Reasoning-Provider (PR #402). This slice
+  doesn't touch it.
+- **Frontend changes.** None. The Execute button on Screen 3
+  is already implemented; it currently 503s. After this slice,
+  hitting Execute with `signal_extraction` selected returns a
+  real result.
+
+## Mechanism
+
+The factory returns a singleton-shaped bundle:
+
+```python
+# atlas_brain/api/_content_ops_services.py
+from extracted_content_pipeline.content_ops_execution import (
+    ContentOpsExecutionServices,
+)
+from extracted_content_pipeline.signal_extraction import (
+    SignalExtractionService,
+)
+
+_SIGNAL_EXTRACTION_SERVICE = SignalExtractionService()
+
+def build_content_ops_execution_services() -> ContentOpsExecutionServices:
+    return ContentOpsExecutionServices(
+        signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
+    )
+```
+
+`SignalExtractionService` is stateless (no DB, no LLM, no
+skills) so a module-level singleton is safe. The other slots
+stay `None`; the executor's per-step dispatcher already returns
+`service_not_configured` for unset slots, and the route layer's
+`_sanitize_execution_result` keeps that error legible to the
+UI.
+
+The router-construction call gains `execution_services_provider`:
+
+```python
+# atlas_brain/api/__init__.py
+from ._content_ops_services import build_content_ops_execution_services
+
+content_ops_router = create_content_ops_control_surface_router(
+    dependencies=[Depends(require_b2b_plan("b2b_growth"))],
+    execution_services_provider=build_content_ops_execution_services,
+)
+```
+
+The provider is a plain `Callable[[], ContentOpsExecutionServices]`;
+the route's `_resolve_execution_services` handles both sync and
+async returns.
+
+## Intentional
+
+- **Module-level singleton, not per-request factory.**
+  `SignalExtractionService` has no per-request state; recreating
+  it every call would just churn allocations. When future
+  services need per-request state (DB sessions, etc.) the
+  factory becomes per-request without touching this signature.
+- **Bundle leaves other slots `None`.** The executor handles
+  unset slots cleanly; populating them with stubs would mask
+  legitimate "not configured" signals from the UI's "Execute"
+  button enable-state.
+- **No env-var gate.** The factory always builds the bundle.
+  Hosts that want to disable Content Ops execution can omit the
+  router mount itself (the existing try/except already handles
+  the disabled case).
+- **Factory lives in `atlas_brain/_content_ops_services.py`,
+  not directly in `__init__.py`.** Keeps `__init__.py`'s router
+  aggregation lean; lets the factory grow as more services
+  arrive without bloating the package init.
+
+## Deferred
+
+- **`campaign` service**: needs `IntelligenceRepository`
+  (Postgres), `CampaignRepository` (Postgres), `LLMClient`,
+  `SkillStore`. Host has these primitives; wiring is a separate
+  slice.
+- **`blog_post` service**: needs `BlogBlueprintRepository`
+  (Postgres), `BlogPostRepository` (Postgres), `LLMClient`,
+  `SkillStore`.
+- **`report` / `landing_page` / `sales_brief`**: same shape as
+  campaign / blog (intelligence + repo + LLM + skills).
+- **`scope_provider` wiring** to thread tenant scope from auth
+  into the executor.
+- **Per-output e2e smoke tests** that POST to /execute and
+  confirm a real draft lands. Today's tests stop at the bundle
+  layer.
+
+## Verification
+
+- `python -m pytest tests/test_atlas_content_ops_execution_services.py`
+  -- 2 passed.
+- `bash scripts/check_ascii_python.sh` -- clean.
+- `python -c "from atlas_brain.api._content_ops_services import
+   build_content_ops_execution_services as f; b = f(); print(
+   b.configured_outputs())"` -- `('signal_extraction',)`.
+- AST-parse + ASCII-clean spot-check on
+  `atlas_brain/api/__init__.py` and
+  `atlas_brain/_content_ops_services.py`.
+
+## Estimated diff size
+
+- `_content_ops_services.py`: ~30 LOC.
+- `__init__.py`: ~5 LOC delta.
+- Test: ~100 LOC.
+- Plan doc: ~140 LOC.
+
+Total: ~275 LOC. Within the 400 LOC PR target. Tightly scoped.

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -1,0 +1,91 @@
+"""Pin the host's Content Ops execution-services bundle.
+
+`atlas_brain/api/_content_ops_services.py` builds a
+`ContentOpsExecutionServices` with `signal_extraction` populated
+and the other 5 slots left `None`. Two regression tests:
+
+1. `signal_extraction` runs through the full executor with the
+   bundle attached -- proves the wiring closes the prior 503
+   "execution services not configured" gap.
+
+2. The other 5 outputs still fall through with
+   `service_not_configured` -- confirms the bundle doesn't
+   silently mask outputs we haven't wired yet.
+
+When follow-up slices add `campaign` / `blog_post` / etc.,
+test 2 needs an updated expected-set; treat it as the canary
+that the bundle's slot population matches the plan.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atlas_brain._content_ops_services import (
+    build_content_ops_execution_services,
+)
+from extracted_content_pipeline.content_ops_execution import (
+    execute_content_ops_from_mapping,
+)
+
+
+@pytest.mark.asyncio
+async def test_signal_extraction_runs_through_host_bundle() -> None:
+    """`/execute` with `outputs=["signal_extraction"]` returns a
+    completed step using the host's wired
+    `SignalExtractionService`."""
+
+    services = build_content_ops_execution_services()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["signal_extraction"],
+            "inputs": {"source_material": "Acme review export"},
+        },
+        services=services,
+    )
+
+    assert result["status"] == "completed", result
+    assert len(result["steps"]) == 1
+    step = result["steps"][0]
+    assert step["output"] == "signal_extraction"
+    assert step["status"] == "completed"
+    # SignalExtractionResult.as_dict() shape:
+    #   {"opportunities": [...], "warnings": [...], "target_mode": ...}
+    assert "opportunities" in step["result"]
+    assert step["result"]["target_mode"] == "vendor_retention"
+
+
+@pytest.mark.asyncio
+async def test_unwired_outputs_still_return_service_not_configured() -> None:
+    """The bundle leaves `campaign` / `blog_post` / `report` /
+    `landing_page` / `sales_brief` slots `None`. The executor's
+    per-step dispatcher must surface that as
+    `service_not_configured` rather than silently succeeding."""
+
+    services = build_content_ops_execution_services()
+
+    # Pick an output the bundle does NOT wire, ensure the request
+    # gets through preview / plan and lands on the executor's
+    # per-step service-resolution path.
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["report"],
+            "inputs": {"opportunity_id": "opp-1"},
+        },
+        services=services,
+    )
+
+    assert result["status"] == "failed", result
+    assert len(result["errors"]) == 1
+    assert result["errors"][0]["reason"] == "service_not_configured"
+
+
+def test_bundle_only_advertises_wired_outputs() -> None:
+    """The bundle's `configured_outputs()` is the source of truth
+    the catalog endpoint surfaces in
+    `execution.configured_outputs`. Today only
+    `signal_extraction` is wired."""
+
+    services = build_content_ops_execution_services()
+    assert services.configured_outputs() == ("signal_extraction",)

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -1,8 +1,8 @@
 """Pin the host's Content Ops execution-services bundle.
 
-`atlas_brain/api/_content_ops_services.py` builds a
+`atlas_brain/_content_ops_services.py` builds a
 `ContentOpsExecutionServices` with `signal_extraction` populated
-and the other 5 slots left `None`. Two regression tests:
+and the other 5 slots left `None`. Three regression tests:
 
 1. `signal_extraction` runs through the full executor with the
    bundle attached -- proves the wiring closes the prior 503
@@ -12,9 +12,13 @@ and the other 5 slots left `None`. Two regression tests:
    `service_not_configured` -- confirms the bundle doesn't
    silently mask outputs we haven't wired yet.
 
+3. `configured_outputs()` advertises only the wired output --
+   pins the source-of-truth the catalog endpoint exposes in
+   `execution.configured_outputs`.
+
 When follow-up slices add `campaign` / `blog_post` / etc.,
-test 2 needs an updated expected-set; treat it as the canary
-that the bundle's slot population matches the plan.
+tests 2 and 3 need updated expected-sets; treat them as the
+canary that the bundle's slot population matches the plan.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Execution-Services-Wire-1.md`

Wires `execution_services_provider` for `signal_extraction` — closes the deferred 503 ("Content Ops execution services are not configured.") gap from PR #406's host mount, scoped to the deterministic generator with zero external dependencies.

The Execute button on Screen 3 currently always 503s because the host mounted the content-ops router with `execution_services_provider=None`. After this PR, an Execute call with `outputs=["signal_extraction"]` returns a real result. The remaining 5 generators (campaign / blog_post / report / landing_page / sales_brief) need host-side repository / LLM / skills factories — those ship in E2 / E3+ follow-up slices.

## Files

- **`atlas_brain/_content_ops_services.py`** (new) — module-level singleton factory `build_content_ops_execution_services()` returning a `ContentOpsExecutionServices` bundle with `signal_extraction` populated, other 5 slots `None`. Lives at `atlas_brain/` root (not inside `api/`) so the test harness can import it without triggering the heavy router init chain (numpy / torch / asyncpg).
- **`atlas_brain/api/__init__.py`** — thread the factory into the existing `create_content_ops_control_surface_router(...)` call. ~2 LOC delta.
- **`tests/test_atlas_content_ops_execution_services.py`** (new) — 3 regression tests:
  - `signal_extraction` runs through the executor with the bundle attached.
  - The other 5 outputs still return `service_not_configured` (canary for future slot population).
  - `configured_outputs()` advertises only the wired output.

## Intentional

- **`signal_extraction` only.** It's stateless (no LLM, no skills, no repo). Other generators need host-side factories that are themselves follow-up work.
- **Module-level singleton** — `SignalExtractionService` is stateless; per-request construction would churn allocations.
- **Other slots stay `None`** — executor returns `service_not_configured` for unset slots; populating stubs would mask the catalog's `Execute` enable-state.
- **Factory at `atlas_brain/_content_ops_services.py`, not inside `api/`** — keeps test harness import light (the heavy `api/__init__.py` chain isn't loaded).

## Deferred

- `campaign` / `blog_post` / `report` / `landing_page` / `sales_brief` service wiring (E2 / E3+ slices).
- `scope_provider` plumbing for tenant scope.
- Per-output e2e smoke tests posting to `/execute`.

## Verification

- `pytest tests/test_atlas_content_ops_execution_services.py` — 3 passed.
- `bash scripts/check_ascii_python.sh` — clean.
- AST parse + ASCII checks on new/modified Python files — clean.
- `python -c "from atlas_brain._content_ops_services import build_content_ops_execution_services as f; print(f().configured_outputs())"` → `('signal_extraction',)`.

## Diff size

4 files, +326 / -0. Within the 400 LOC PR target. ~140 LOC plan doc; ~50 LOC factory + 91 LOC test + 2 LOC __init__.py edit.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_