### PR TITLE
PR-Content-Ops-LLM-Skills-Infra-1: host LLM + Skill adapters for Content Ops

### DIFF
--- a/atlas_brain/_content_ops_infrastructure.py
+++ b/atlas_brain/_content_ops_infrastructure.py
@@ -1,0 +1,197 @@
+"""Adapters bridging host LLM + Skill infrastructure into Content Ops.
+
+The extracted Content Ops package declares two ports
+(`extracted_content_pipeline.campaign_ports`):
+
+- `LLMClient.complete(messages, *, max_tokens, temperature, metadata)
+  -> LLMResponse` (async)
+- `SkillStore.get_prompt(name) -> str | None` (sync)
+
+The host already has equivalent infrastructure:
+
+- `atlas_brain.services.LLMService.chat(messages, max_tokens, temperature)
+  -> dict` (sync), accessed via `llm_registry.get_active()`.
+- `atlas_brain.skills.SkillRegistry.get(name) -> Optional[Skill]`,
+  via `get_skill_registry()`.
+
+This module provides thin adapters and factories so the next
+slices (E2 / E3+) can wire LLM-needing generators
+(`landing_page`, `campaign`, etc.) into the Content Ops bundle
+without re-deriving the bridge each time.
+
+This module is deliberately at `atlas_brain/_content_ops_infrastructure.py`
+(not inside `atlas_brain/api/`) so the test harness can import
+it without triggering the heavy router init chain (numpy /
+torch / asyncpg).
+
+See `plans/PR-Content-Ops-LLM-Skills-Infra-1.md` for the slice
+contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from extracted_content_pipeline.campaign_ports import (
+    LLMClient,
+    LLMMessage,
+    LLMResponse,
+    SkillStore,
+)
+
+
+class _HostLLMClient:
+    """Adapter implementing `LLMClient` over a host `LLMService`.
+
+    Host `chat()` is synchronous and returns a `dict` carrying a
+    `response` (or `content`) field plus optional `usage`. The
+    extracted port is async and returns a structured
+    `LLMResponse`. The bridge: run `chat()` in a worker thread
+    via `asyncio.to_thread` and wrap the dict.
+
+    `metadata` is dropped on the host side because the host's
+    `chat()` doesn't accept arbitrary metadata today; the
+    extracted package only uses the field for informational
+    `asset_type` tags, so generation behavior is unaffected. If
+    a future host LLM revision adds a metadata passthrough, this
+    adapter is the single place to plumb it.
+    """
+
+    def __init__(self, host_llm: Any) -> None:
+        self._host = host_llm
+
+    async def complete(
+        self,
+        messages: Sequence[LLMMessage],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LLMResponse:
+        del metadata  # host chat() doesn't accept arbitrary metadata today.
+        # The host's `chat()` reads only `.role` and `.content` from each
+        # message; we pass `SimpleNamespace` rather than importing the
+        # host's `Message` dataclass because importing
+        # `atlas_brain.services.protocols` triggers the full
+        # `atlas_brain.services.__init__` chain (torch / ollama / etc.).
+        # Keeping the duck-typed shape lets this adapter test cleanly
+        # in dependency-light environments.
+        from types import SimpleNamespace
+
+        host_messages = [
+            SimpleNamespace(role=str(m.role or ""), content=str(m.content or ""))
+            for m in messages
+        ]
+        result = await asyncio.to_thread(
+            self._host.chat,
+            host_messages,
+            max_tokens=int(max_tokens),
+            temperature=float(temperature),
+        )
+        if not isinstance(result, Mapping):
+            # Host returned a non-mapping (defensive); wrap as empty body.
+            return LLMResponse(content=str(result or ""))
+
+        content = str(result.get("response") or result.get("content") or "")
+        model_name: str | None = None
+        try:
+            info = self._host.model_info
+            if info is not None:
+                model_name = str(getattr(info, "name", None) or info)
+        except Exception:  # pragma: no cover - defensive
+            model_name = None
+
+        usage_value = result.get("usage")
+        usage: dict[str, Any]
+        if isinstance(usage_value, Mapping):
+            usage = dict(usage_value)
+        else:
+            usage = {}
+
+        return LLMResponse(
+            content=content,
+            model=model_name,
+            usage=usage,
+            raw=dict(result),
+        )
+
+
+class _HostSkillStore:
+    """Adapter implementing `SkillStore` over a host `SkillRegistry`."""
+
+    def __init__(self, registry: Any) -> None:
+        self._registry = registry
+
+    def get_prompt(self, name: str) -> str | None:
+        skill = self._registry.get(name)
+        if skill is None:
+            return None
+        content = getattr(skill, "content", None)
+        if not isinstance(content, str):
+            return None
+        return content
+
+
+def build_content_ops_llm_client(
+    *,
+    llm_registry: Any = None,
+) -> LLMClient | None:
+    """Return a Content-Ops-shaped LLM client, or ``None`` if no
+    host LLM is currently active.
+
+    Returning `None` (rather than raising) lets the
+    services-bundle factory skip wiring LLM-needing generators
+    when the host hasn't activated a model yet -- those slots
+    stay `None` on the bundle and the executor surfaces
+    `service_not_configured` per output, which the catalog
+    endpoint exposes to the UI's Execute enable-state.
+
+    The registry argument is dependency-injection for tests:
+    callers in dev environments without the host's full
+    `atlas_brain.services` init chain (torch / ollama
+    implementations) can pass a stub. Production callers omit
+    the kwarg and the factory imports the canonical singleton
+    on demand.
+    """
+
+    if llm_registry is None:
+        # Lazy import: only production callers reach here. Tests
+        # always inject a stub.
+        from atlas_brain.services.registry import (
+            llm_registry as default_registry,
+        )
+
+        llm_registry = default_registry
+
+    host_llm = llm_registry.get_active()
+    if host_llm is None:
+        return None
+    return _HostLLMClient(host_llm)
+
+
+def build_content_ops_skill_store(
+    *,
+    registry: Any = None,
+) -> SkillStore:
+    """Return a Content-Ops-shaped skill store backed by the host
+    `SkillRegistry`.
+
+    Always available -- the host registry loads skills lazily
+    from disk on first access. The registry argument is
+    dependency-injection for tests; production callers omit it
+    and get the canonical singleton.
+    """
+
+    if registry is None:
+        from atlas_brain.skills.registry import get_skill_registry
+
+        registry = get_skill_registry()
+    return _HostSkillStore(registry)
+
+
+__all__ = [
+    "build_content_ops_llm_client",
+    "build_content_ops_skill_store",
+]

--- a/atlas_brain/_content_ops_infrastructure.py
+++ b/atlas_brain/_content_ops_infrastructure.py
@@ -71,17 +71,26 @@ class _HostLLMClient:
         metadata: Mapping[str, Any] | None = None,
     ) -> LLMResponse:
         del metadata  # host chat() doesn't accept arbitrary metadata today.
-        # The host's `chat()` reads only `.role` and `.content` from each
-        # message; we pass `SimpleNamespace` rather than importing the
-        # host's `Message` dataclass because importing
+        # The host's `chat()` reads `.role` / `.content`, and the cloud
+        # backends (OpenRouter / Groq / Together / Ollama) additionally
+        # read `.tool_calls` and `.tool_call_id` while building their
+        # provider payloads. We pass a `SimpleNamespace` rather than
+        # importing the host's `Message` dataclass because importing
         # `atlas_brain.services.protocols` triggers the full
-        # `atlas_brain.services.__init__` chain (torch / ollama / etc.).
-        # Keeping the duck-typed shape lets this adapter test cleanly
-        # in dependency-light environments.
+        # `atlas_brain.services.__init__` chain (torch / ollama / etc.)
+        # in dependency-light test envs. Including the optional
+        # tool-call fields with `None` defaults keeps the duck-typed
+        # shape compatible with all live backends without re-exposing
+        # the heavy import.
         from types import SimpleNamespace
 
         host_messages = [
-            SimpleNamespace(role=str(m.role or ""), content=str(m.content or ""))
+            SimpleNamespace(
+                role=str(m.role or ""),
+                content=str(m.content or ""),
+                tool_calls=None,
+                tool_call_id=None,
+            )
             for m in messages
         ]
         result = await asyncio.to_thread(
@@ -119,7 +128,16 @@ class _HostLLMClient:
 
 
 class _HostSkillStore:
-    """Adapter implementing `SkillStore` over a host `SkillRegistry`."""
+    """Adapter implementing `SkillStore` over a host-style `SkillRegistry`.
+
+    Used as the fallback when the extracted-package registry isn't
+    desired (e.g. tests that inject a stub registry with `.get(name)`
+    returning a `Skill`-like object). Production callers get the
+    extracted package's `LocalSkillRegistry` directly via
+    ``build_content_ops_skill_store()``, which already implements
+    ``get_prompt()`` and merges host overrides with the packaged
+    skill defaults.
+    """
 
     def __init__(self, registry: Any) -> None:
         self._registry = registry
@@ -171,24 +189,46 @@ def build_content_ops_llm_client(
     return _HostLLMClient(host_llm)
 
 
+_HOST_SKILLS_DIR = (
+    __import__("pathlib").Path(__file__).resolve().parent / "skills"
+)
+
+
 def build_content_ops_skill_store(
     *,
     registry: Any = None,
 ) -> SkillStore:
-    """Return a Content-Ops-shaped skill store backed by the host
-    `SkillRegistry`.
+    """Return a Content-Ops-shaped skill store.
 
-    Always available -- the host registry loads skills lazily
-    from disk on first access. The registry argument is
-    dependency-injection for tests; production callers omit it
-    and get the canonical singleton.
+    Production: returns the extracted package's
+    `LocalSkillRegistry` via ``get_skill_registry`` with the
+    host's `atlas_brain/skills/` tree as the override root.
+    The extracted factory already implements host-first /
+    packaged-fallback semantics, so:
+    - Host-customized prompts (e.g. a host-specific
+      `digest/blog_post_generation`) override the packaged
+      default.
+    - Packaged-only prompts (e.g. `digest/landing_page_generation`,
+      `digest/report_generation`, `digest/sales_brief_generation`,
+      `digest/b2b_campaign_reasoning_context`) resolve through
+      the bundled defaults that ship inside the extracted
+      package.
+
+    Tests: pass a stub registry via the ``registry=`` kwarg.
+    The stub must expose ``get(name)`` returning either a
+    `Skill`-like object with `.content` or `None`. The factory
+    wraps it in `_HostSkillStore` so tests can verify the
+    adapter wiring without touching real markdown files.
     """
 
-    if registry is None:
-        from atlas_brain.skills.registry import get_skill_registry
+    if registry is not None:
+        return _HostSkillStore(registry)
 
-        registry = get_skill_registry()
-    return _HostSkillStore(registry)
+    from extracted_content_pipeline.skills.registry import (
+        get_skill_registry as get_extracted_skill_registry,
+    )
+
+    return get_extracted_skill_registry(root=_HOST_SKILLS_DIR)
 
 
 __all__ = [

--- a/atlas_brain/_content_ops_infrastructure.py
+++ b/atlas_brain/_content_ops_infrastructure.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 from extracted_content_pipeline.campaign_ports import (
@@ -189,9 +190,7 @@ def build_content_ops_llm_client(
     return _HostLLMClient(host_llm)
 
 
-_HOST_SKILLS_DIR = (
-    __import__("pathlib").Path(__file__).resolve().parent / "skills"
-)
+_HOST_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 
 
 def build_content_ops_skill_store(

--- a/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
+++ b/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
@@ -57,12 +57,23 @@ LLM-needing service ships).
      the markdown body. Pins that the skill name space the
      extracted services expect resolves correctly through the
      host registry.
+   - `test_host_skill_store_falls_back_to_packaged_skills`
+     -- pins the four packaged-only skill names
+     (`digest/landing_page_generation`,
+     `digest/report_generation`,
+     `digest/sales_brief_generation`,
+     `digest/b2b_campaign_reasoning_context`) resolve
+     through the extracted-package fallback. Codex P2 canary.
    - `test_host_skill_store_returns_none_for_missing_skill`
      -- canary for the "skill not found" branch.
    - `test_host_llm_client_translates_messages_and_response`
      -- a fake host LLMService receives the translated messages
      and returns a dict; the adapter wraps it into an
      LLMResponse with the right shape.
+   - `test_host_llm_client_messages_carry_tool_call_attributes`
+     -- pins `.tool_calls` / `.tool_call_id` on each
+     SimpleNamespace so cloud backends that read them during
+     payload conversion don't AttributeError. Codex P1 canary.
    - `test_host_llm_client_handles_content_field_alias` --
      adapter accepts `{"content": ...}` aliases for backends
      that return the field under that key instead of
@@ -78,7 +89,7 @@ LLM-needing service ships).
      -- factory accepts an injected registry stub for tests
      and delegates lookups through it.
 
-   Total: 7 tests.
+   Total: 9 tests.
 
 3. `plans/PR-Content-Ops-LLM-Skills-Infra-1.md` (this file).
 
@@ -266,17 +277,18 @@ typing + extracted-fallback wiring + the response-shape
 unwrap added more than the rough mental model. Updated for
 transparency.
 
-- `_content_ops_infrastructure.py`: ~205 LOC actual (initial
+- `_content_ops_infrastructure.py`: ~237 LOC actual (initial
   estimate ~110; the SimpleNamespace duck-type, the cloud
   backend `tool_calls` / `tool_call_id` fix-up, the
   defensive `Mapping` checks on the response, and the
   extracted-skill-fallback factory all came in heavier).
-- Test: ~205 LOC actual (initial estimate ~150; 9 tests
+- Test: ~236 LOC actual (initial estimate ~150; 9 tests
   rather than 4).
-- Plan doc: ~265 LOC actual (post-update, includes Updates
-  section and SimpleNamespace bullet).
+- Plan doc: ~290 LOC actual (post-update, includes Updates
+  section, SimpleNamespace bullet, and the expanded test
+  inventory).
 
-Total actual: **~675 LOC**. Over the 400 LOC soft cap. The
+Total actual: **~755 LOC**. Over the 400 LOC soft cap. The
 adapters and tests are structurally indivisible (the LLM and
 Skill adapters share the docstring framing; splitting them
 would leave one half unusable). Plan doc and tests dominate.

--- a/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
+++ b/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
@@ -201,11 +201,37 @@ omit the kwarg and get the canonical singleton.
 ## Verification
 
 - `pytest tests/test_atlas_content_ops_infrastructure.py` --
-  7 passed.
+  9 passed.
 - AST-parse of the new module + the test file.
 - ASCII-clean check on the new module + test file (the
   package-scoped `check_ascii_python.sh` script doesn't cover
   `atlas_brain/`; we run `read().encode('ascii')` separately).
+
+## Updates from review
+
+After Codex review of the initial commit:
+
+- **Codex P1 fix**: cloud backends (OpenRouter / Groq /
+  Together / Ollama) read `msg.tool_calls` and
+  `msg.tool_call_id` during payload conversion. The
+  `SimpleNamespace` host-message shape now includes both
+  fields with `None` defaults so payload conversion
+  succeeds without re-introducing the heavy
+  `services.protocols` import. New regression test
+  `test_host_llm_client_messages_carry_tool_call_attributes`
+  pins the contract.
+- **Codex P2 fix**: skills the next-slice services depend on
+  by default (`digest/landing_page_generation`,
+  `digest/report_generation`,
+  `digest/sales_brief_generation`,
+  `digest/b2b_campaign_reasoning_context`) live only in the
+  extracted package. The skill-store factory now uses the
+  extracted package's `get_skill_registry(root=
+  atlas_brain/skills/)`, which already does host-first /
+  packaged-fallback. Host overrides win; missing host skills
+  resolve through the packaged defaults. New regression test
+  `test_host_skill_store_falls_back_to_packaged_skills` pins
+  this for all four packaged-only skill names.
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
+++ b/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
@@ -105,7 +105,7 @@ The LLM adapter bridges sync host -> async extracted via
 
 ```python
 class _HostLLMClient:
-    def __init__(self, host_llm: LLMService) -> None:
+    def __init__(self, host_llm: Any) -> None:
         self._host = host_llm
 
     async def complete(
@@ -117,19 +117,33 @@ class _HostLLMClient:
         metadata: Mapping[str, Any] | None = None,
     ) -> LLMResponse:
         del metadata  # host's chat() doesn't accept arbitrary metadata
-        host_messages = [Message(role=m.role, content=m.content) for m in messages]
+        # SimpleNamespace duck-typing: importing
+        # `atlas_brain.services.protocols` would trigger
+        # `services/__init__.py` which eagerly loads ollama / torch.
+        # The host's `chat()` reads only `.role` / `.content`
+        # (and the cloud backends additionally read
+        # `.tool_calls` / `.tool_call_id`); a SimpleNamespace
+        # with those four attributes is structurally sufficient
+        # without re-introducing the heavy import.
+        host_messages = [
+            SimpleNamespace(
+                role=str(m.role or ""),
+                content=str(m.content or ""),
+                tool_calls=None,
+                tool_call_id=None,
+            )
+            for m in messages
+        ]
         result = await asyncio.to_thread(
             self._host.chat,
             host_messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
+            max_tokens=int(max_tokens),
+            temperature=float(temperature),
         )
-        return LLMResponse(
-            content=str(result.get("response") or result.get("content") or ""),
-            model=str(self._host.model_info.name) if self._host.model_info else None,
-            usage=dict(result.get("usage") or {}),
-            raw=result,
-        )
+        # Response wrap: accept "response" or "content" aliases,
+        # `model` from `host.model_info.name` (defensive), `usage`
+        # only when Mapping-shaped, `raw` is the full dict.
+        ...
 ```
 
 The skill adapter is a thin delegator:
@@ -164,6 +178,18 @@ omit the kwarg and get the canonical singleton.
   `_content_ops_services.py`: imports under `atlas_brain.api.*`
   trigger the heavy router init chain (numpy / torch / asyncpg).
   Tests can pull these adapters in cleanly without that.
+- **`SimpleNamespace` duck-typing for the host `Message`
+  shape.** Importing `atlas_brain.services.protocols` would
+  trigger `services/__init__.py` which eagerly loads ollama /
+  torch. The host's `chat()` reads only `.role` / `.content`
+  from each message (and the cloud backends additionally read
+  `.tool_calls` / `.tool_call_id`); a `SimpleNamespace` with
+  those four attributes is structurally sufficient without
+  re-introducing the heavy import. Codex P1 review on the
+  initial commit confirmed the cloud-backend touchpoints
+  (`atlas_brain/services/llm/openrouter.py:147`,
+  `groq.py:105`, etc.); fields added with `None` defaults so
+  the duck-typed shape stays compatible.
 - **`metadata` kwarg on `complete()` is dropped.** The host's
   `chat()` doesn't accept arbitrary metadata. The extracted
   package's `metadata` is informational (asset_type tags etc.);
@@ -235,12 +261,22 @@ After Codex review of the initial commit:
 
 ## Estimated diff size
 
-- `_content_ops_infrastructure.py`: ~110 LOC (LLM adapter +
-  Skill adapter + 2 factories + module docstring).
-- Test: ~150 LOC.
-- Plan doc: ~190 LOC.
+Initial estimate undershot the implementation; defensive
+typing + extracted-fallback wiring + the response-shape
+unwrap added more than the rough mental model. Updated for
+transparency.
 
-Total: ~450 LOC. Marginally over the 400 LOC soft cap; the
-plan doc is most of it. Splitting LLM adapter from Skill
-adapter would leave neither slice useful on its own (the
-generators need both). Indivisible.
+- `_content_ops_infrastructure.py`: ~205 LOC actual (initial
+  estimate ~110; the SimpleNamespace duck-type, the cloud
+  backend `tool_calls` / `tool_call_id` fix-up, the
+  defensive `Mapping` checks on the response, and the
+  extracted-skill-fallback factory all came in heavier).
+- Test: ~205 LOC actual (initial estimate ~150; 9 tests
+  rather than 4).
+- Plan doc: ~265 LOC actual (post-update, includes Updates
+  section and SimpleNamespace bullet).
+
+Total actual: **~675 LOC**. Over the 400 LOC soft cap. The
+adapters and tests are structurally indivisible (the LLM and
+Skill adapters share the docstring framing; splitting them
+would leave one half unusable). Plan doc and tests dominate.

--- a/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
+++ b/plans/PR-Content-Ops-LLM-Skills-Infra-1.md
@@ -1,0 +1,220 @@
+# PR: host-side LLMClient + SkillStore infrastructure for Content Ops
+
+## Why this slice exists
+
+PR #452 wired `signal_extraction` into the Execute route's
+`execution_services_provider`. That generator has zero
+dependencies. The remaining 5 generators (`campaign`,
+`blog_post`, `report`, `landing_page`, `sales_brief`) all need
+two shared infrastructure ports:
+
+- `LLMClient` -- async `complete(messages, *, max_tokens,
+  temperature, metadata=None) -> LLMResponse`
+  (`extracted_content_pipeline/campaign_ports.py`).
+- `SkillStore` -- sync `get_prompt(name) -> str | None`
+  (same module).
+
+The host already has equivalent infrastructure:
+
+- `atlas_brain.services.LLMService` -- sync `chat(messages,
+  max_tokens, temperature) -> dict` accessed through
+  `llm_registry.get_active()`.
+- `atlas_brain.skills.SkillRegistry` -- `get(name) ->
+  Optional[Skill]` via `get_skill_registry()`.
+
+Without an adapter, none of the 5 remaining generators can land.
+With one, they each become a small follow-up slice that just
+plugs the LLM + skills factory output into a service constructor.
+
+This PR is the shared infrastructure. No service wired here.
+
+## Scope (this PR)
+
+One new module and a test file. The host's `__init__.py` is
+NOT touched -- that's the next slice's job (when an actual
+LLM-needing service ships).
+
+### Files touched
+
+1. `atlas_brain/_content_ops_infrastructure.py` (new):
+   - `_HostLLMClient` adapter that wraps a host `LLMService`
+     and implements the extracted package's `LLMClient`
+     protocol (async `complete()`).
+   - `_HostSkillStore` adapter that wraps `SkillRegistry` and
+     implements `SkillStore.get_prompt()`.
+   - `build_content_ops_llm_client()` -- returns an adapter
+     wrapping `llm_registry.get_active()`, or `None` if no
+     LLM is active. Callers (the next slice's services-bundle
+     factory) decide whether to skip wiring LLM-needing
+     generators.
+   - `build_content_ops_skill_store()` -- returns an adapter
+     wrapping `get_skill_registry()`. Always available (skills
+     load lazily from disk on first access).
+
+2. `tests/test_atlas_content_ops_infrastructure.py` (new):
+   - `test_host_skill_store_returns_existing_skill_content`
+     -- `get_prompt("digest/blog_post_generation")` returns
+     the markdown body. Pins that the skill name space the
+     extracted services expect resolves correctly through the
+     host registry.
+   - `test_host_skill_store_returns_none_for_missing_skill`
+     -- canary for the "skill not found" branch.
+   - `test_host_llm_client_translates_messages_and_response`
+     -- a fake host LLMService receives the translated messages
+     and returns a dict; the adapter wraps it into an
+     LLMResponse with the right shape.
+   - `test_host_llm_client_handles_content_field_alias` --
+     adapter accepts `{"content": ...}` aliases for backends
+     that return the field under that key instead of
+     `"response"`.
+   - `test_build_content_ops_llm_client_returns_none_when_no_active`
+     -- factory short-circuits cleanly when `llm_registry`
+     has no active service. Uses the dependency-injection
+     kwarg to avoid importing the host's full services chain.
+   - `test_build_content_ops_llm_client_wraps_active_service`
+     -- factory returns a `_HostLLMClient` adapter when the
+     registry has an active service.
+   - `test_build_content_ops_skill_store_uses_injected_registry`
+     -- factory accepts an injected registry stub for tests
+     and delegates lookups through it.
+
+   Total: 7 tests.
+
+3. `plans/PR-Content-Ops-LLM-Skills-Infra-1.md` (this file).
+
+### What's NOT in this slice
+
+- Any service wired into `execution_services_provider`. The
+  bundle factory in `atlas_brain/_content_ops_services.py`
+  stays unchanged. Next slice (E2) wires `landing_page` (which
+  has the smallest dependency footprint among LLM-needing
+  services -- no `IntelligenceRepository`).
+- Postgres-backed repositories
+  (`PostgresLandingPageRepository`, etc.). Those are extracted
+  package responsibilities; the bundle factory imports them
+  from there when needed.
+- A reasoning-context provider. PR #402 wired the route-level
+  seam; the bundle's `with_reasoning_context()` derivation
+  handles per-request rebinding. This slice doesn't touch
+  reasoning.
+
+## Mechanism
+
+The LLM adapter bridges sync host -> async extracted via
+`asyncio.to_thread`:
+
+```python
+class _HostLLMClient:
+    def __init__(self, host_llm: LLMService) -> None:
+        self._host = host_llm
+
+    async def complete(
+        self,
+        messages: Sequence[LLMMessage],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LLMResponse:
+        del metadata  # host's chat() doesn't accept arbitrary metadata
+        host_messages = [Message(role=m.role, content=m.content) for m in messages]
+        result = await asyncio.to_thread(
+            self._host.chat,
+            host_messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return LLMResponse(
+            content=str(result.get("response") or result.get("content") or ""),
+            model=str(self._host.model_info.name) if self._host.model_info else None,
+            usage=dict(result.get("usage") or {}),
+            raw=result,
+        )
+```
+
+The skill adapter is a thin delegator:
+
+```python
+class _HostSkillStore:
+    def __init__(self, registry: SkillRegistry) -> None:
+        self._registry = registry
+
+    def get_prompt(self, name: str) -> str | None:
+        skill = self._registry.get(name)
+        return skill.content if skill is not None else None
+```
+
+Factories return adapter instances on demand (no module-level
+singletons -- the host's `llm_registry.get_active()` can change
+when the operator hot-swaps models, so the factory always reads
+the current active instance).
+
+Both factories accept an optional registry kwarg
+(`llm_registry=` / `registry=`) for dependency injection. When
+omitted, the factory imports the canonical singleton lazily on
+first call. Tests pass stubs to verify the wiring without
+triggering the host's full `atlas_brain.services.__init__`
+chain (torch / ollama implementations); production callers
+omit the kwarg and get the canonical singleton.
+
+## Intentional
+
+- **Adapters live in `atlas_brain/_content_ops_infrastructure.py`,
+  not inside `api/`.** Same reason as
+  `_content_ops_services.py`: imports under `atlas_brain.api.*`
+  trigger the heavy router init chain (numpy / torch / asyncpg).
+  Tests can pull these adapters in cleanly without that.
+- **`metadata` kwarg on `complete()` is dropped.** The host's
+  `chat()` doesn't accept arbitrary metadata. The extracted
+  package's `metadata` is informational (asset_type tags etc.);
+  losing it on the host adapter doesn't change generation
+  behavior. Future host LLM versions may add a `metadata`
+  passthrough; the adapter can plumb it then.
+- **`build_content_ops_llm_client()` returns `None` when no
+  LLM is active.** Cleaner than raising: the next slice's
+  services-bundle factory can just skip wiring LLM-needing
+  services and let them remain `service_not_configured`. The
+  catalog endpoint already surfaces that to the UI.
+- **No metaclass / abstract registration.** The adapter
+  classes don't inherit from the extracted Protocols (they
+  satisfy them structurally). Keeping them concrete classes
+  with explicit method bodies makes the wire shape easy to
+  audit.
+- **`asyncio.to_thread` rather than spinning the host LLM in
+  an async wrapper.** The host's `chat()` is sync today; if it
+  ever goes async natively, the adapter changes one line.
+
+## Deferred
+
+- `landing_page` service wiring (next slice E2). Plugs LLM +
+  Skill factories into the bundle.
+- `campaign` / `blog_post` / `report` / `sales_brief` service
+  wiring. Each adds a Postgres repo + plugs the same LLM/Skill
+  adapters in.
+- Streaming LLM responses. Extracted package's `LLMClient`
+  Protocol is non-streaming today.
+- `metadata` kwarg pass-through (host LLM doesn't accept it
+  yet).
+- Per-request LLM model selection. Today's adapter uses the
+  globally active model.
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_infrastructure.py` --
+  7 passed.
+- AST-parse of the new module + the test file.
+- ASCII-clean check on the new module + test file (the
+  package-scoped `check_ascii_python.sh` script doesn't cover
+  `atlas_brain/`; we run `read().encode('ascii')` separately).
+
+## Estimated diff size
+
+- `_content_ops_infrastructure.py`: ~110 LOC (LLM adapter +
+  Skill adapter + 2 factories + module docstring).
+- Test: ~150 LOC.
+- Plan doc: ~190 LOC.
+
+Total: ~450 LOC. Marginally over the 400 LOC soft cap; the
+plan doc is most of it. Splitting LLM adapter from Skill
+adapter would leave neither slice useful on its own (the
+generators need both). Indivisible.

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -34,18 +34,38 @@ from extracted_content_pipeline.campaign_ports import LLMMessage
 
 
 def test_host_skill_store_returns_existing_skill_content() -> None:
-    """Skill adapter resolves a real host skill via `get_skill_registry()`."""
+    """Skill store resolves a host-shipped skill via the host
+    overrides root."""
 
     store = build_content_ops_skill_store()
-    # The blog-post skill ships with the repo at
-    # atlas_brain/skills/digest/blog_post_generation.md.
     prompt = store.get_prompt("digest/blog_post_generation")
     assert isinstance(prompt, str)
     assert len(prompt) > 0
 
 
+def test_host_skill_store_falls_back_to_packaged_skills() -> None:
+    """Codex P2 fix: skills that the extracted services depend on
+    by default (e.g. `digest/landing_page_generation`,
+    `digest/report_generation`, `digest/sales_brief_generation`,
+    `digest/b2b_campaign_reasoning_context`) live in the
+    extracted package, not in `atlas_brain/skills/`. The factory
+    must fall back to the packaged copies so the next slice's
+    services don't immediately fail with "skill not found"."""
+
+    store = build_content_ops_skill_store()
+    for name in (
+        "digest/landing_page_generation",
+        "digest/report_generation",
+        "digest/sales_brief_generation",
+        "digest/b2b_campaign_reasoning_context",
+    ):
+        prompt = store.get_prompt(name)
+        assert isinstance(prompt, str), name
+        assert len(prompt) > 0, name
+
+
 def test_host_skill_store_returns_none_for_missing_skill() -> None:
-    """Skill adapter doesn't raise on lookup miss."""
+    """Skill store doesn't raise on lookup miss."""
 
     store = build_content_ops_skill_store()
     assert store.get_prompt("digest/__definitely_not_a_real_skill__") is None
@@ -105,6 +125,42 @@ async def test_host_llm_client_translates_messages_and_response() -> None:
         "response": "Hello, world.",
         "usage": {"input_tokens": 5, "output_tokens": 3},
     }
+
+
+@pytest.mark.asyncio
+async def test_host_llm_client_messages_carry_tool_call_attributes() -> None:
+    """Codex P1 fix: cloud backends (OpenRouter / Groq / Together /
+    Ollama) read `msg.tool_calls` and `msg.tool_call_id` while
+    converting messages to provider payloads. Without these
+    attributes the adapter would AttributeError before any
+    Content Ops generation request reached the backend. Pin the
+    duck-typed shape includes them with `None` defaults."""
+
+    captured: dict[str, Any] = {}
+
+    class _ToolReadingFakeLLM:
+        model_info = None
+
+        def chat(self, messages, *, max_tokens, temperature):
+            del max_tokens, temperature
+            # Simulates how OpenRouter / Groq / Ollama backends
+            # touch every message during payload conversion.
+            for msg in messages:
+                _ = msg.role
+                _ = msg.content
+                _ = msg.tool_calls
+                _ = msg.tool_call_id
+            captured["read_succeeded"] = True
+            return {"response": "ok"}
+
+    client = _HostLLMClient(_ToolReadingFakeLLM())
+    response = await client.complete(
+        [LLMMessage(role="user", content="hi")],
+        max_tokens=8,
+        temperature=0.0,
+    )
+    assert captured["read_succeeded"] is True
+    assert response.content == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -1,20 +1,36 @@
 """Pin the host's Content Ops LLM + Skill adapters.
 
 `atlas_brain/_content_ops_infrastructure.py` bridges the host's
-sync `LLMService` and `SkillRegistry` to the extracted package's
-async `LLMClient` / sync `SkillStore` ports. Four regression
-tests:
+sync `LLMService` and packaged `LocalSkillRegistry` to the
+extracted package's async `LLMClient` / sync `SkillStore`
+ports. Nine regression tests covering both adapters and both
+factories:
 
-1. Skill adapter resolves an existing skill name to its markdown
-   body.
-2. Skill adapter returns `None` for missing skill names (canary
-   for the "not loaded yet" branch).
-3. LLM adapter translates `LLMMessage` -> host `Message`,
-   bridges sync host `chat()` to async via `asyncio.to_thread`,
-   and wraps the dict response into an `LLMResponse`.
-4. `build_content_ops_llm_client()` returns `None` when no host
-   LLM is active -- the bundle factory's signal to skip wiring
-   LLM-needing services.
+Skill side:
+1. Real-disk lookup of a host-shipped skill (`digest/blog_post_generation`).
+2. Codex P2 fallback canary: skills that live only in the
+   extracted package (`digest/landing_page_generation` etc.)
+   resolve through the packaged-fallback root.
+3. Missing-skill name returns None.
+
+LLM side:
+4. Full happy-path message translation + response wrap.
+5. Codex P1 canary: each duck-typed message exposes
+   `.tool_calls` / `.tool_call_id` so cloud backends that read
+   them during payload conversion don't AttributeError.
+6. Response-shape `content` field alias.
+
+Factories:
+7. `build_content_ops_llm_client()` returns `None` when no
+   host LLM is active.
+8. `build_content_ops_llm_client()` wraps an active service.
+9. `build_content_ops_skill_store(registry=stub)` delegates
+   through the injected stub.
+
+Tests use the dependency-injection kwargs on both factories so
+the test harness doesn't trigger
+`atlas_brain.services.__init__`'s torch / ollama eager-load
+chain.
 """
 
 from __future__ import annotations

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -1,0 +1,164 @@
+"""Pin the host's Content Ops LLM + Skill adapters.
+
+`atlas_brain/_content_ops_infrastructure.py` bridges the host's
+sync `LLMService` and `SkillRegistry` to the extracted package's
+async `LLMClient` / sync `SkillStore` ports. Four regression
+tests:
+
+1. Skill adapter resolves an existing skill name to its markdown
+   body.
+2. Skill adapter returns `None` for missing skill names (canary
+   for the "not loaded yet" branch).
+3. LLM adapter translates `LLMMessage` -> host `Message`,
+   bridges sync host `chat()` to async via `asyncio.to_thread`,
+   and wraps the dict response into an `LLMResponse`.
+4. `build_content_ops_llm_client()` returns `None` when no host
+   LLM is active -- the bundle factory's signal to skip wiring
+   LLM-needing services.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from atlas_brain._content_ops_infrastructure import (
+    _HostLLMClient,
+    _HostSkillStore,
+    build_content_ops_llm_client,
+    build_content_ops_skill_store,
+)
+from extracted_content_pipeline.campaign_ports import LLMMessage
+
+
+def test_host_skill_store_returns_existing_skill_content() -> None:
+    """Skill adapter resolves a real host skill via `get_skill_registry()`."""
+
+    store = build_content_ops_skill_store()
+    # The blog-post skill ships with the repo at
+    # atlas_brain/skills/digest/blog_post_generation.md.
+    prompt = store.get_prompt("digest/blog_post_generation")
+    assert isinstance(prompt, str)
+    assert len(prompt) > 0
+
+
+def test_host_skill_store_returns_none_for_missing_skill() -> None:
+    """Skill adapter doesn't raise on lookup miss."""
+
+    store = build_content_ops_skill_store()
+    assert store.get_prompt("digest/__definitely_not_a_real_skill__") is None
+
+
+@pytest.mark.asyncio
+async def test_host_llm_client_translates_messages_and_response() -> None:
+    """LLM adapter bridges sync host -> async extracted with the
+    right message + response shape."""
+
+    received: dict[str, Any] = {}
+
+    class _FakeHostLLM:
+        def __init__(self) -> None:
+            self.model_info = SimpleNamespace(name="test-model")
+
+        def chat(
+            self,
+            messages: list[Any],
+            *,
+            max_tokens: int,
+            temperature: float,
+        ) -> dict[str, Any]:
+            received["messages"] = messages
+            received["max_tokens"] = max_tokens
+            received["temperature"] = temperature
+            return {
+                "response": "Hello, world.",
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+            }
+
+    client = _HostLLMClient(_FakeHostLLM())
+    response = await client.complete(
+        [
+            LLMMessage(role="system", content="You are helpful."),
+            LLMMessage(role="user", content="Say hello."),
+        ],
+        max_tokens=64,
+        temperature=0.5,
+        metadata={"asset_type": "blog_post"},  # silently dropped
+    )
+
+    # Translation: the host saw two `Message`-shaped objects.
+    assert len(received["messages"]) == 2
+    assert received["messages"][0].role == "system"
+    assert received["messages"][0].content == "You are helpful."
+    assert received["messages"][1].role == "user"
+    assert received["messages"][1].content == "Say hello."
+    assert received["max_tokens"] == 64
+    assert received["temperature"] == 0.5
+
+    # Response wrap.
+    assert response.content == "Hello, world."
+    assert response.model == "test-model"
+    assert response.usage == {"input_tokens": 5, "output_tokens": 3}
+    assert response.raw == {
+        "response": "Hello, world.",
+        "usage": {"input_tokens": 5, "output_tokens": 3},
+    }
+
+
+@pytest.mark.asyncio
+async def test_host_llm_client_handles_content_field_alias() -> None:
+    """Some host backends return `{"content": ...}` instead of
+    `{"response": ...}`. The adapter accepts either."""
+
+    class _FakeHostLLM:
+        model_info = None
+
+        def chat(self, messages, *, max_tokens, temperature):
+            del messages, max_tokens, temperature
+            return {"content": "Body via content field."}
+
+    client = _HostLLMClient(_FakeHostLLM())
+    response = await client.complete(
+        [LLMMessage(role="user", content="hi")],
+        max_tokens=8,
+        temperature=0.0,
+    )
+    assert response.content == "Body via content field."
+    assert response.model is None
+
+
+def test_build_content_ops_llm_client_returns_none_when_no_active() -> None:
+    """Factory short-circuits when `llm_registry.get_active()`
+    returns None -- the bundle factory's signal to leave LLM-
+    needing slots `None`."""
+
+    stub_registry = SimpleNamespace(get_active=lambda: None)
+    assert build_content_ops_llm_client(llm_registry=stub_registry) is None
+
+
+def test_build_content_ops_llm_client_wraps_active_service() -> None:
+    """Factory returns a `_HostLLMClient` adapter wrapping the
+    currently active host service."""
+
+    fake_service = SimpleNamespace(model_info=None, chat=lambda *a, **k: {})
+    stub_registry = SimpleNamespace(get_active=lambda: fake_service)
+    client = build_content_ops_llm_client(llm_registry=stub_registry)
+    assert isinstance(client, _HostLLMClient)
+    # The wrapped service is the one we patched.
+    assert client._host is fake_service  # type: ignore[attr-defined]
+
+
+def test_build_content_ops_skill_store_uses_injected_registry() -> None:
+    """Skill-store factory accepts an injected registry so tests
+    can verify the wiring without depending on the host's
+    on-disk skills directory."""
+
+    sentinel_skill = SimpleNamespace(content="injected body")
+    stub_registry = SimpleNamespace(
+        get=lambda name: sentinel_skill if name == "x/y" else None,
+    )
+    store = build_content_ops_skill_store(registry=stub_registry)
+    assert store.get_prompt("x/y") == "injected body"
+    assert store.get_prompt("missing") is None


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-LLM-Skills-Infra-1.md`

Host-side LLM + Skill adapters bridging the host's existing infrastructure (`LLMService.chat()` sync, `SkillRegistry.get()`) to the extracted Content Ops package's `LLMClient` (async `complete()`) + `SkillStore` (`get_prompt()`) ports. Foundation for E2 (`landing_page`) and beyond — each remaining generator just plugs these factories into a service constructor.

No service wired in this PR. The bundle factory in `atlas_brain/_content_ops_services.py` stays unchanged; only `signal_extraction` is currently in the bundle (PR #452).

## Files

- **`atlas_brain/_content_ops_infrastructure.py`** (new):
  - `_HostLLMClient`: async `complete()` over the host's sync `LLMService.chat()` via `asyncio.to_thread`; translates `LLMMessage` → `SimpleNamespace` (duck-typed; avoids importing the host's `services/protocols.py` and its torch/ollama chain) and wraps the dict response into `LLMResponse`.
  - `_HostSkillStore`: `get_prompt()` delegates to `SkillRegistry.get(name).content`.
  - `build_content_ops_llm_client(llm_registry=None)`: returns adapter wrapping the active host service, or `None` if no active. `None` signals the bundle factory to skip wiring LLM-needing slots.
  - `build_content_ops_skill_store(registry=None)`: always returns an adapter.
  - Both factories accept optional registry kwargs for dependency injection — tests pass stubs without triggering `atlas_brain.services.__init__`'s torch/ollama eager-load chain.

- **`tests/test_atlas_content_ops_infrastructure.py`** (new): 7 tests covering both adapters' translation logic, factory short-circuits, content-field alias, and the injected-registry path.

## Intentional

- **Adapters at `atlas_brain/` root, not `api/`** — same reason as `_content_ops_services.py`: imports under `atlas_brain.api.*` trigger the heavy router init chain (numpy / torch / asyncpg).
- **`SimpleNamespace` duck-typing** for the host `Message` shape — importing `atlas_brain.services.protocols` would trigger `services/__init__.py` which eagerly loads ollama / torch.
- **Dependency-injection kwargs** on both factories — tests verify the wiring without the host's full env.
- **`metadata` dropped on the host side** — host `chat()` doesn't accept it; extracted only uses it for informational `asset_type` tags so generation behavior is unaffected.

## Deferred

- **E2 (landing_page) service wiring** — next slice plugs these factories + a Postgres landing_page repo into the bundle. Smallest LLM-dependent service (no `IntelligenceRepository`).
- **`campaign` / `blog_post` / `report` / `sales_brief`** — each adds a Postgres repo + plugs the same LLM/Skill adapters in.
- **Streaming responses** (extracted port is non-streaming today).
- **`metadata` passthrough** (host LLM doesn't accept it yet).
- **Per-request model selection** (today's adapter uses the globally active model).

## Verification

- `python -m pytest tests/test_atlas_content_ops_infrastructure.py` — **7 passed**.
- AST parse + ASCII checks on new files — clean.

## Diff size

3 files, +581 / -0. Marginally over the 400 LOC soft cap; ~220 LOC plan doc + ~197 LOC adapter + ~164 LOC test. Adapters and tests are structurally indivisible (the LLM and Skill adapters share the docstring framing and the test setup).

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_