### PR TITLE
PR-Content-Ops-Scope-Wire-1: ContextVar bridge for AuthUser → TenantScope

### DIFF
--- a/atlas_brain/_content_ops_scope.py
+++ b/atlas_brain/_content_ops_scope.py
@@ -1,0 +1,106 @@
+"""Per-request scope bridge for Content Ops.
+
+The route's `scope_provider` is a plain
+``Callable[[], TenantScope | Mapping | None | Awaitable[...]]``
+declared by the extracted package's
+`create_content_ops_control_surface_router(...)`. It can't
+receive FastAPI dependency-injected objects (the route
+handler invokes it as `provider()` with no arguments). To
+bridge the per-request `AuthUser` produced by the host's
+auth chain into that plain-callable shape, we use an
+asyncio-aware `ContextVar`:
+
+1. The route's `dependencies=[Depends(capture_content_ops_auth_user)]`
+   (defined in `atlas_brain/api/__init__.py` -- the FastAPI
+   dep wiring lives there because importing it in this
+   module would pull in the host's heavy auth chain via
+   `atlas_brain.auth.dependencies` -> `cryptography` etc.)
+   runs the existing `require_b2b_plan("b2b_growth")` gate
+   and calls `set_current_auth_user(user)` on this module.
+
+2. When the route handler invokes
+   `scope_provider() -> build_content_ops_scope()`, the
+   factory reads the `ContextVar` and converts the user to
+   a typed `TenantScope`.
+
+`ContextVar` is asyncio-aware: each request runs in its own
+task and gets its own ContextVar context, so concurrent
+requests don't see each other's users.
+
+See `plans/PR-Content-Ops-Scope-Wire-1.md` for the slice
+contract. Closes the Codex P1 deferred from PR #454 (E2):
+landing_page drafts now persist under the authenticated
+tenant's `account_id` instead of an empty string.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any, Callable
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+# Module-level per-request ContextVar. asyncio.Task-local: each
+# inbound request gets its own copy. Default `None` so any code
+# path that runs outside a request (background tasks, test harness
+# without a fake user) sees the same "scope not configured" signal
+# the existing route path already handles.
+_CURRENT_AUTH_USER: ContextVar[Any | None] = ContextVar(
+    "content_ops_auth_user", default=None,
+)
+
+
+def set_current_auth_user(user: Any | None) -> None:
+    """Set the per-request `AuthUser` captured by the host's
+    FastAPI dep. Called from `atlas_brain/api/__init__.py`'s
+    `capture_content_ops_auth_user` dependency.
+
+    Lives here (rather than inside the FastAPI dep itself) so
+    tests can populate the ContextVar without going through
+    the auth chain.
+    """
+
+    _CURRENT_AUTH_USER.set(user)
+
+
+def get_current_auth_user() -> Any | None:
+    """Test seam + read accessor for the captured user."""
+
+    return _CURRENT_AUTH_USER.get()
+
+
+def build_content_ops_scope(
+    *,
+    user_factory: Callable[[], Any | None] | None = None,
+) -> TenantScope | None:
+    """Resolve the per-request `AuthUser` into a `TenantScope`.
+
+    Production: reads the `ContextVar` populated by
+    `capture_content_ops_auth_user` upstream in the request's
+    dep chain.
+
+    Tests: pass `user_factory=` to inject a stub. When the
+    factory returns `None`, the scope is `None` -- matches the
+    existing route's "scope not configured" path so background
+    tasks and test runs without a fake user behave predictably.
+    """
+
+    if user_factory is not None:
+        user = user_factory()
+    else:
+        user = get_current_auth_user()
+
+    if user is None:
+        return None
+    return TenantScope(
+        account_id=getattr(user, "account_id", None),
+        user_id=getattr(user, "user_id", None),
+    )
+
+
+__all__ = [
+    "build_content_ops_scope",
+    "get_current_auth_user",
+    "set_current_auth_user",
+]

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -157,9 +157,35 @@ try:
         create_content_ops_control_surface_router,
     )
     from .._content_ops_services import build_content_ops_execution_services
+    from .._content_ops_scope import (
+        build_content_ops_scope,
+        set_current_auth_user,
+    )
+    from ..auth.dependencies import AuthUser
+
+    async def _capture_content_ops_auth_user(
+        user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
+    ) -> AuthUser:
+        """Bridge the per-request AuthUser to the
+        `_content_ops_scope` ContextVar so the route's
+        `scope_provider` can read it. Composing on top of
+        `require_b2b_plan` keeps the existing auth gate (paying
+        tier check, B2B product check, past-due guard) intact.
+        Closes the Codex P1 cross-tenant safety issue from
+        PR #454 (E2): drafts now persist under the
+        authenticated tenant's account_id rather than empty
+        string.
+        """
+
+        set_current_auth_user(user)
+        return user
+
     content_ops_router = create_content_ops_control_surface_router(
-        dependencies=[Depends(require_b2b_plan("b2b_growth"))],
-        execution_services_provider=build_content_ops_execution_services,
+        dependencies=[Depends(_capture_content_ops_auth_user)],
+        execution_services_provider=lambda: (
+            build_content_ops_execution_services(enable_db_services=True)
+        ),
+        scope_provider=build_content_ops_scope,
     )
     router.include_router(content_ops_router)
 except Exception as exc:  # pragma: no cover - defensive at import time

--- a/plans/PR-Content-Ops-Scope-Wire-1.md
+++ b/plans/PR-Content-Ops-Scope-Wire-1.md
@@ -1,0 +1,200 @@
+# PR: wire `scope_provider` from authenticated `AuthUser` (E2.5 of N)
+
+## Why this slice exists
+
+PR #454 (E2) added the landing_page wiring helper and tests
+but gated it behind `enable_db_services=False` in production
+because Codex flagged a P1 cross-tenant safety issue:
+without a `scope_provider`, the executor falls back to an
+empty `TenantScope` and `PostgresLandingPageRepository.save_drafts`
+persists drafts under `account_id=""`. All tenants' drafts
+would land in the same empty-account bucket.
+
+This slice wires the missing piece -- a `scope_provider` that
+resolves the per-request `AuthUser` from the existing
+`require_b2b_plan` auth gate and converts it to a typed
+`TenantScope` -- and then flips `enable_db_services=True` in
+production so the bundle's `landing_page` slot lights up.
+
+After this lands, `POST /api/v1/content-ops/execute` with
+`outputs=["landing_page"]` writes drafts under the correct
+authenticated tenant.
+
+## Scope (this PR)
+
+Three files, tightly bounded:
+
+1. **`atlas_brain/_content_ops_scope.py`** (new): a
+   `ContextVar`-based bridge from FastAPI's per-request
+   dependency injection to the route's plain
+   `Callable[[], TenantScope]` `scope_provider` shape.
+   - `_CURRENT_AUTH_USER: ContextVar[AuthUser | None]`
+     captures the per-request user.
+   - `capture_content_ops_auth_user(user: AuthUser =
+     Depends(require_b2b_plan("b2b_growth")))` -- FastAPI
+     dependency that runs the existing auth gate AND sets
+     the ContextVar. Used as `dependencies=[Depends(...)]`
+     on the content-ops router so it runs on every
+     content-ops request.
+   - `build_content_ops_scope() -> TenantScope | None`
+     reads the ContextVar and converts to `TenantScope`.
+     Returns `None` when no user is captured (matches the
+     existing route's "scope-not-configured" path).
+   - Both factories accept dependency-injection kwargs for
+     tests so the test harness doesn't need to construct
+     real `AuthUser` instances through the host's auth chain.
+
+2. **`atlas_brain/api/__init__.py`** -- swap the existing
+   `dependencies=[Depends(require_b2b_plan("b2b_growth"))]`
+   for `dependencies=[Depends(capture_content_ops_auth_user)]`
+   (which itself depends on `require_b2b_plan`, so the auth
+   gate is preserved). Pass `scope_provider=build_content_ops_scope`.
+   Flip the `execution_services_provider` to call
+   `build_content_ops_execution_services(enable_db_services=True)`.
+
+3. **`tests/test_atlas_content_ops_scope.py`** (new): pin the
+   ContextVar / scope round-trip:
+   - `capture_content_ops_auth_user` sets the user;
+     `build_content_ops_scope()` reads it back as a
+     `TenantScope` with `account_id` + `user_id`.
+   - `build_content_ops_scope()` returns `None` when no
+     user is captured (e.g. background task path).
+   - `_CURRENT_AUTH_USER` is request-local: setting it in
+     one async task doesn't leak to a sibling task.
+
+### What's NOT in this slice
+
+- **`scope_provider` shape changes** in
+  `extracted_content_pipeline/api/control_surfaces.py`. The
+  existing `Callable[[], TenantScope | Mapping | None |
+  Awaitable[...]]` shape is fine; the host bridges its
+  per-request `AuthUser` to that shape via a `ContextVar`.
+- **Wiring the remaining 4 LLM-needing services**
+  (`campaign`, `blog_post`, `report`, `sales_brief`). All
+  4 still need an `IntelligenceRepository` host factory --
+  E3+. This slice just unblocks `landing_page`.
+- **Per-request reasoning provider wiring.** PR #402 already
+  wired the route-level seam; the bundle's
+  `with_reasoning_context()` derivation handles per-request
+  rebinding when a host wants multi-pass reasoning. Out of
+  scope here.
+
+## Mechanism
+
+The `ContextVar` bridge lets the host expose the per-request
+`AuthUser` to a plain callable `scope_provider`:
+
+```python
+# atlas_brain/_content_ops_scope.py
+from contextvars import ContextVar
+from fastapi import Depends
+from .auth.dependencies import AuthUser, require_b2b_plan
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+_CURRENT_AUTH_USER: ContextVar[AuthUser | None] = ContextVar(
+    "content_ops_auth_user", default=None,
+)
+
+
+async def capture_content_ops_auth_user(
+    user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
+) -> AuthUser:
+    _CURRENT_AUTH_USER.set(user)
+    return user
+
+
+def build_content_ops_scope() -> TenantScope | None:
+    user = _CURRENT_AUTH_USER.get()
+    if user is None:
+        return None
+    return TenantScope(
+        account_id=user.account_id,
+        user_id=user.user_id,
+    )
+```
+
+`ContextVar` is asyncio-aware: each request runs in its own
+task and gets its own ContextVar context, so concurrent
+requests don't see each other's users.
+
+The route mount in `atlas_brain/api/__init__.py` plugs the
+two together:
+
+```python
+content_ops_router = create_content_ops_control_surface_router(
+    dependencies=[Depends(capture_content_ops_auth_user)],
+    execution_services_provider=(
+        lambda: build_content_ops_execution_services(
+            enable_db_services=True,
+        )
+    ),
+    scope_provider=build_content_ops_scope,
+)
+```
+
+`capture_content_ops_auth_user` is itself a `Depends` of
+`require_b2b_plan("b2b_growth")`, so the auth gate is
+preserved (paying tier check, B2B product check, past-due
+guard); we just thread the resulting user into a
+ContextVar before the route handler runs.
+
+## Intentional
+
+- **`ContextVar` rather than extending the route's
+  `scope_provider` signature.** The route's existing
+  `Callable[[], ...]` shape lives in the extracted package
+  and serves multiple hosts; widening it to accept
+  FastAPI-shaped `Depends` objects would couple the
+  extracted package to FastAPI specifically. The
+  `ContextVar` keeps the FastAPI coupling on the host side.
+- **Both factories accept DI kwargs.** Same pattern as PRs
+  #453 and #454; tests pass stubs without triggering the
+  host's auth init chain.
+- **`enable_db_services=True` flipped on AT THE SAME
+  TIME** as the scope wiring. Splitting into two more PRs
+  ("wire scope" then "flip flag") would leave the gate
+  closed on a flag-only PR with nothing to gate -- not a
+  meaningful slice. The Codex P1 was about the unsafe
+  combination; closing both ends together is the right
+  unit.
+- **`build_content_ops_scope()` returns `None` when no
+  user is captured.** Matches the existing route's
+  "scope-not-configured" path. Background tasks or test
+  harnesses that don't go through the auth gate get a
+  `None` scope, which the executor handles cleanly.
+- **No env-var gate.** Production always wires scope and
+  enables DB services; tests always inject stubs.
+  Operators that want to disable DB services can swap
+  the bundle factory.
+
+## Deferred
+
+- `IntelligenceRepository` host factory + the 4 remaining
+  generators (E3+).
+- `allowed_vendors` / `roles` on `TenantScope` -- the
+  existing `AuthUser` dataclass doesn't carry those today;
+  if a future feature needs them, the host's auth layer
+  surfaces them and `build_content_ops_scope` plumbs them
+  through.
+- Multi-pass reasoning provider host wiring.
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_scope.py
+   tests/test_atlas_content_ops_execution_services.py`
+  -- new + existing tests pass.
+- AST + ASCII checks on new module + test + modified
+  `__init__.py`.
+- Smoke: `python -c "from atlas_brain._content_ops_scope
+   import build_content_ops_scope; print(
+   build_content_ops_scope())"` -> `None` (no user
+  captured outside a request).
+
+## Estimated diff size
+
+- `_content_ops_scope.py`: ~80 LOC.
+- `api/__init__.py`: ~6 LOC delta.
+- Test: ~120 LOC.
+- Plan doc: ~190 LOC.
+
+Total: ~395 LOC. Right at the budget.

--- a/plans/PR-Content-Ops-Scope-Wire-1.md
+++ b/plans/PR-Content-Ops-Scope-Wire-1.md
@@ -52,15 +52,23 @@ Three files, tightly bounded:
    Flip the `execution_services_provider` to call
    `build_content_ops_execution_services(enable_db_services=True)`.
 
-3. **`tests/test_atlas_content_ops_scope.py`** (new): pin the
-   ContextVar / scope round-trip:
-   - `capture_content_ops_auth_user` sets the user;
-     `build_content_ops_scope()` reads it back as a
-     `TenantScope` with `account_id` + `user_id`.
-   - `build_content_ops_scope()` returns `None` when no
-     user is captured (e.g. background task path).
-   - `_CURRENT_AUTH_USER` is request-local: setting it in
-     one async task doesn't leak to a sibling task.
+3. **`tests/test_atlas_content_ops_scope.py`** (new): six
+   regression tests pinning the ContextVar / scope bridge:
+   - `test_build_content_ops_scope_round_trips_user_via_context_var`
+     -- set the user via `set_current_auth_user`,
+     `build_content_ops_scope()` returns the matching
+     `TenantScope`.
+   - `test_build_content_ops_scope_returns_none_when_no_user_captured`
+     -- background-task / unauthenticated path.
+   - `test_build_content_ops_scope_uses_injected_user_factory`
+     -- DI kwarg short-circuits the ContextVar read.
+   - `test_build_content_ops_scope_returns_none_when_factory_returns_none`
+     -- factory returning None -> scope None.
+   - `test_context_var_is_task_local` -- asyncio.Task-local
+     isolation; sibling tasks don't see each other's users.
+   - `test_codex_p1_contract_account_id_is_non_empty_for_authenticated_user`
+     -- explicit pin on the cross-tenant safety contract from
+     PR #454's Codex P1 review.
 
 ### What's NOT in this slice
 
@@ -86,43 +94,57 @@ The `ContextVar` bridge lets the host expose the per-request
 
 ```python
 # atlas_brain/_content_ops_scope.py
+# Test-clean: NO fastapi or .auth.dependencies imports here.
+# The capturing FastAPI dep lives in api/__init__.py because
+# importing atlas_brain.auth.dependencies pulls cryptography
+# which panics in dependency-light dev envs.
 from contextvars import ContextVar
-from fastapi import Depends
-from .auth.dependencies import AuthUser, require_b2b_plan
 from extracted_content_pipeline.campaign_ports import TenantScope
 
-_CURRENT_AUTH_USER: ContextVar[AuthUser | None] = ContextVar(
+_CURRENT_AUTH_USER: ContextVar[Any | None] = ContextVar(
     "content_ops_auth_user", default=None,
 )
 
 
-async def capture_content_ops_auth_user(
-    user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
-) -> AuthUser:
+def set_current_auth_user(user: Any | None) -> None:
     _CURRENT_AUTH_USER.set(user)
-    return user
 
 
-def build_content_ops_scope() -> TenantScope | None:
-    user = _CURRENT_AUTH_USER.get()
+def build_content_ops_scope(
+    *, user_factory: Callable[[], Any | None] | None = None,
+) -> TenantScope | None:
+    user = (user_factory or _CURRENT_AUTH_USER.get)()
     if user is None:
         return None
     return TenantScope(
-        account_id=user.account_id,
-        user_id=user.user_id,
+        account_id=getattr(user, "account_id", None),
+        user_id=getattr(user, "user_id", None),
     )
 ```
 
-`ContextVar` is asyncio-aware: each request runs in its own
-task and gets its own ContextVar context, so concurrent
-requests don't see each other's users.
-
-The route mount in `atlas_brain/api/__init__.py` plugs the
-two together:
+The FastAPI dep + the route mount live in
+`atlas_brain/api/__init__.py` (which already pays the
+auth-chain import cost):
 
 ```python
+# atlas_brain/api/__init__.py
+from fastapi import Depends
+from .._content_ops_scope import (
+    build_content_ops_scope,
+    set_current_auth_user,
+)
+from ..auth.dependencies import AuthUser, require_b2b_plan
+
+
+async def _capture_content_ops_auth_user(
+    user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
+) -> AuthUser:
+    set_current_auth_user(user)
+    return user
+
+
 content_ops_router = create_content_ops_control_surface_router(
-    dependencies=[Depends(capture_content_ops_auth_user)],
+    dependencies=[Depends(_capture_content_ops_auth_user)],
     execution_services_provider=(
         lambda: build_content_ops_execution_services(
             enable_db_services=True,
@@ -147,6 +169,16 @@ ContextVar before the route handler runs.
   FastAPI-shaped `Depends` objects would couple the
   extracted package to FastAPI specifically. The
   `ContextVar` keeps the FastAPI coupling on the host side.
+- **The FastAPI capturing dep lives in `api/__init__.py`,
+  not inside `_content_ops_scope.py`.** Importing
+  `atlas_brain.auth.dependencies` pulls in `cryptography`,
+  which panics in dependency-light dev envs (the same
+  reason the LLM/Skill adapters in PR #453 use
+  `SimpleNamespace` rather than the host's `Message`
+  dataclass). `api/__init__.py` already pays the auth-chain
+  import cost, so the dep belongs there. The scope module
+  exposes `set_current_auth_user` / `get_current_auth_user`
+  so the dep can plumb the user across the boundary.
 - **Both factories accept DI kwargs.** Same pattern as PRs
   #453 and #454; tests pass stubs without triggering the
   host's auth init chain.
@@ -192,9 +224,24 @@ ContextVar before the route handler runs.
 
 ## Estimated diff size
 
-- `_content_ops_scope.py`: ~80 LOC.
-- `api/__init__.py`: ~6 LOC delta.
-- Test: ~120 LOC.
-- Plan doc: ~190 LOC.
+Initial estimate undershot api/__init__.py (5x) and the test
+file. Updated for transparency.
 
-Total: ~395 LOC. Right at the budget.
+- `_content_ops_scope.py`: ~106 LOC actual (initial ~80;
+  added defensive `getattr` reads + module docstring more
+  detail than projected).
+- `api/__init__.py`: ~30 LOC delta actual (initial ~6;
+  the new FastAPI dep + its docstring + the
+  set_current_auth_user wiring + the lambda wrapping
+  enable_db_services=True together exceed the rough
+  mental model).
+- Test: ~150 LOC actual (initial ~120; 6 tests rather
+  than 3).
+- Plan doc: ~225 LOC actual (post-update with split
+  Mechanism blocks + new Intentional bullet + expanded
+  test inventory).
+
+Total actual: ~510 LOC. Over the 400 LOC soft cap.
+Indivisible -- the ContextVar setter, reader, FastAPI dep,
+and route mount must ship together for the bridge to
+function. Plan doc and tests dominate.

--- a/tests/test_atlas_content_ops_scope.py
+++ b/tests/test_atlas_content_ops_scope.py
@@ -1,0 +1,150 @@
+"""Pin the ContextVar -> TenantScope bridge for Content Ops.
+
+`atlas_brain/_content_ops_scope.py` exposes:
+- `set_current_auth_user(user)` -- the host's FastAPI dep
+  (defined in `atlas_brain/api/__init__.py`) calls this from
+  inside the auth gate so the per-request `AuthUser` lands in
+  a `ContextVar`.
+- `get_current_auth_user()` -- read accessor for tests.
+- `build_content_ops_scope(user_factory=None)` -- the route's
+  `scope_provider`. Reads the ContextVar (or an injected
+  factory in tests) and returns a typed `TenantScope`.
+
+Five regression tests:
+
+1. Round-trip: set a fake user, build_content_ops_scope()
+   returns a TenantScope with matching account_id / user_id.
+2. Returns None when no user is captured (background-task
+   path; matches the route's "scope not configured" branch).
+3. user_factory DI kwarg short-circuits the ContextVar read
+   so tests don't need to populate it.
+4. ContextVar is asyncio-task-local: setting in one task
+   doesn't leak into a sibling task.
+5. Closes the Codex P1 contract from PR #454: the scope's
+   account_id is non-empty when an authenticated user is
+   present, so PostgresLandingPageRepository.save_drafts no
+   longer falls back to account_id="".
+
+The ContextVar lives at module scope, so tests that mutate
+it must reset (a `setUp`/`tearDown` pattern via pytest
+fixtures keeps tests independent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from atlas_brain._content_ops_scope import (
+    build_content_ops_scope,
+    get_current_auth_user,
+    set_current_auth_user,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+@pytest.fixture(autouse=True)
+def _reset_context_var() -> Any:
+    """Reset the ContextVar between tests so leaks don't
+    cascade. autouse so every test gets a clean slate."""
+
+    set_current_auth_user(None)
+    yield
+    set_current_auth_user(None)
+
+
+def _fake_user(*, account_id: str = "acct-1", user_id: str = "user-1") -> Any:
+    return SimpleNamespace(account_id=account_id, user_id=user_id)
+
+
+def test_build_content_ops_scope_round_trips_user_via_context_var() -> None:
+    """Set the ContextVar; build_content_ops_scope() returns a
+    TenantScope carrying the same identifiers."""
+
+    user = _fake_user(account_id="acct-42", user_id="user-99")
+    set_current_auth_user(user)
+
+    scope = build_content_ops_scope()
+
+    assert isinstance(scope, TenantScope)
+    assert scope.account_id == "acct-42"
+    assert scope.user_id == "user-99"
+
+
+def test_build_content_ops_scope_returns_none_when_no_user_captured() -> None:
+    """Background tasks / test runs without a fake user see the
+    same `None` scope the existing route's
+    "scope-not-configured" path handles."""
+
+    # Fixture already reset; no user captured.
+    assert get_current_auth_user() is None
+    assert build_content_ops_scope() is None
+
+
+def test_build_content_ops_scope_uses_injected_user_factory() -> None:
+    """Tests can pass `user_factory=` to inject a stub without
+    populating the ContextVar."""
+
+    fake = _fake_user(account_id="dep-acct", user_id="dep-user")
+    scope = build_content_ops_scope(user_factory=lambda: fake)
+
+    assert isinstance(scope, TenantScope)
+    assert scope.account_id == "dep-acct"
+    assert scope.user_id == "dep-user"
+
+
+def test_build_content_ops_scope_returns_none_when_factory_returns_none() -> None:
+    """Even with the kwarg present, returning None -> None."""
+
+    assert build_content_ops_scope(user_factory=lambda: None) is None
+
+
+@pytest.mark.asyncio
+async def test_context_var_is_task_local() -> None:
+    """asyncio.Task-local: setting the user in one task doesn't
+    leak into a sibling task. Concurrent requests must not see
+    each other's tenants."""
+
+    seen_in_sibling: dict[str, Any] = {}
+
+    async def _set_in_task() -> None:
+        set_current_auth_user(_fake_user(account_id="task-A"))
+        # Yield control so the sibling can run before we
+        # re-check.
+        await asyncio.sleep(0)
+        seen_in_sibling["after_yield"] = get_current_auth_user()
+
+    async def _sibling_task() -> None:
+        # Sibling hasn't set anything; should see None even if
+        # the other task set its own.
+        await asyncio.sleep(0)
+        seen_in_sibling["sibling"] = get_current_auth_user()
+
+    await asyncio.gather(_set_in_task(), _sibling_task())
+
+    # Sibling never set -- must be None despite the other task
+    # writing to its own copy.
+    assert seen_in_sibling["sibling"] is None
+    # The setter task still sees its own user after yielding.
+    assert getattr(seen_in_sibling["after_yield"], "account_id", None) == "task-A"
+
+
+def test_codex_p1_contract_account_id_is_non_empty_for_authenticated_user() -> None:
+    """Codex P1 from PR #454 review: without scope wiring,
+    PostgresLandingPageRepository.save_drafts persists drafts
+    under account_id="" -- cross-tenant leakage. With this
+    slice, an authenticated AuthUser flows through the bridge
+    and the resulting TenantScope.account_id is the user's
+    real account id. Pin the contract."""
+
+    user = _fake_user(account_id="real-tenant-id", user_id="user-x")
+    set_current_auth_user(user)
+
+    scope = build_content_ops_scope()
+
+    assert scope is not None
+    assert scope.account_id == "real-tenant-id"
+    assert scope.account_id != ""

--- a/tests/test_atlas_content_ops_scope.py
+++ b/tests/test_atlas_content_ops_scope.py
@@ -10,7 +10,7 @@
   `scope_provider`. Reads the ContextVar (or an injected
   factory in tests) and returns a typed `TenantScope`.
 
-Five regression tests:
+Six regression tests:
 
 1. Round-trip: set a fake user, build_content_ops_scope()
    returns a TenantScope with matching account_id / user_id.
@@ -18,9 +18,11 @@ Five regression tests:
    path; matches the route's "scope not configured" branch).
 3. user_factory DI kwarg short-circuits the ContextVar read
    so tests don't need to populate it.
-4. ContextVar is asyncio-task-local: setting in one task
+4. user_factory returning None still produces None scope
+   (canary for the explicit-None branch).
+5. ContextVar is asyncio-task-local: setting in one task
    doesn't leak into a sibling task.
-5. Closes the Codex P1 contract from PR #454: the scope's
+6. Closes the Codex P1 contract from PR #454: the scope's
    account_id is non-empty when an authenticated user is
    present, so PostgresLandingPageRepository.save_drafts no
    longer falls back to account_id="".


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Scope-Wire-1.md`

Wires `scope_provider` from the authenticated `AuthUser` and flips `enable_db_services=True` in production. **Closes the Codex P1 deferred from PR #454 (E2)**: `landing_page` drafts now persist under the authenticated tenant's `account_id` rather than `account_id=""`.

After this lands, `POST /api/v1/content-ops/execute` with `outputs=["landing_page"]` writes drafts under the correct authenticated tenant; the bundle's `configured_outputs()` advertises `(landing_page, signal_extraction)`.

## Mechanism

`ContextVar`-based bridge from FastAPI's per-request dependency injection to the route's plain `Callable[[], TenantScope]` `scope_provider` shape. `ContextVar` is asyncio-aware so concurrent requests don't see each other's tenants.

```python
# atlas_brain/_content_ops_scope.py
_CURRENT_AUTH_USER: ContextVar[Any | None] = ContextVar("content_ops_auth_user", default=None)

def build_content_ops_scope(*, user_factory=None) -> TenantScope | None:
    user = (user_factory or get_current_auth_user)()
    if user is None: return None
    return TenantScope(account_id=user.account_id, user_id=user.user_id)

# atlas_brain/api/__init__.py
async def _capture_content_ops_auth_user(
    user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
) -> AuthUser:
    set_current_auth_user(user)
    return user

content_ops_router = create_content_ops_control_surface_router(
    dependencies=[Depends(_capture_content_ops_auth_user)],
    execution_services_provider=lambda: build_content_ops_execution_services(enable_db_services=True),
    scope_provider=build_content_ops_scope,
)
```

The capturing dep is itself a `Depends` on `require_b2b_plan("b2b_growth")`, so the existing auth gate (paying tier check, B2B product check, past-due guard) is preserved.

## Intentional

- **ContextVar rather than extending the route's `scope_provider` signature.** The extracted package's `Callable[[], ...]` shape lives across multiple hosts; widening to accept FastAPI `Depends` would couple the package to FastAPI. ContextVar keeps the FastAPI coupling on the host side.
- **The FastAPI capturing dep lives in `api/__init__.py`** rather than `_content_ops_scope.py` because importing `atlas_brain.auth.dependencies` pulls in cryptography (which panics in dependency-light dev envs). `api/__init__.py` already pays that cost.
- **`enable_db_services=True` flipped on at the same time as scope wiring.** Splitting would leave a flag-only PR with nothing to gate — not a meaningful slice. The Codex P1 was about the unsafe combination; closing both ends together is the right unit.
- **`build_content_ops_scope()` returns `None` when no user is captured** — matches the existing route's "scope-not-configured" path so background tasks behave predictably.

## Deferred

- `IntelligenceRepository` host factory + the 4 remaining generators (E3+).
- `allowed_vendors` / `roles` on `TenantScope` (`AuthUser` doesn't carry those today).
- Multi-pass reasoning provider host wiring.

## Verification

- `pytest tests/test_atlas_content_ops_scope.py tests/test_atlas_content_ops_execution_services.py` — **14 passed** (6 new + 8 existing).
- AST + ASCII checks clean.

## Diff size

4 files, +484 / -2. Marginally over the 400 LOC soft cap; ~200 LOC plan doc + ~150 LOC test + ~106 LOC scope module + ~30 LOC api `__init__.py` delta. Indivisible — the ContextVar setter and reader must ship together for the bridge to work.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_