### PR TITLE
PR-Content-Ops-Execution-Services-Wire-3: campaign / report / sales_brief

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -9,24 +9,39 @@ route layer maps to a per-step error the UI can render.
 Currently wired:
 - `signal_extraction` (E1, PR #452): deterministic generator
   with no external dependencies.
-- `landing_page` (E2, this slice): plugs the host LLM + Skill
-  adapters from PR #453 + `PostgresLandingPageRepository`
-  backed by the host's `DatabasePool`. Slot stays `None` when
-  no LLM is active.
+- `landing_page` (E2, PR #454 + E2.5, PR #455): plugs the
+  host LLM + Skill adapters from PR #453 +
+  `PostgresLandingPageRepository` backed by the host's
+  `DatabasePool`. `scope_provider` (PR #455) ensures drafts
+  persist under the authenticated tenant.
+- `campaign` / `report` / `sales_brief` (E3, this slice):
+  share an identical wiring shape -- a single
+  `PostgresIntelligenceRepository` (campaign opportunities)
+  plus the per-output Postgres repo + LLM/Skill adapters.
+  All three slots stay `None` when LLM or pool is absent.
 
-Follow-up slices (E3+) will plug the remaining 4 generators
-(`campaign`, `blog_post`, `report`, `sales_brief`) into the
-same bundle once an `IntelligenceRepository` host factory
-lands.
+Follow-up slice (E4) wires `blog_post` -- different repo
+shape (`BlogBlueprintRepository`).
 
-See `plans/PR-Content-Ops-Execution-Services-Wire-2.md`.
+See `plans/PR-Content-Ops-Execution-Services-Wire-3.md`.
 """
 
 from __future__ import annotations
 
 from typing import Any, Callable
 
-from extracted_content_pipeline.campaign_ports import LLMClient, SkillStore
+from extracted_content_pipeline.campaign_generation import (
+    CampaignGenerationService,
+)
+from extracted_content_pipeline.campaign_ports import (
+    IntelligenceRepository,
+    LLMClient,
+    SkillStore,
+)
+from extracted_content_pipeline.campaign_postgres import (
+    PostgresCampaignRepository,
+    PostgresIntelligenceRepository,
+)
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
 )
@@ -35,6 +50,18 @@ from extracted_content_pipeline.landing_page_generation import (
 )
 from extracted_content_pipeline.landing_page_postgres import (
     PostgresLandingPageRepository,
+)
+from extracted_content_pipeline.report_generation import (
+    ReportGenerationService,
+)
+from extracted_content_pipeline.report_postgres import (
+    PostgresReportRepository,
+)
+from extracted_content_pipeline.sales_brief_generation import (
+    SalesBriefGenerationService,
+)
+from extracted_content_pipeline.sales_brief_postgres import (
+    PostgresSalesBriefRepository,
 )
 from extracted_content_pipeline.signal_extraction import (
     SignalExtractionService,
@@ -70,6 +97,64 @@ def _build_landing_page_service(
         return None
     return LandingPageGenerationService(
         landing_pages=PostgresLandingPageRepository(pool=pool),
+        llm=llm,
+        skills=skills,
+    )
+
+
+def _build_campaign_service(
+    *,
+    intelligence: IntelligenceRepository | None,
+    llm: LLMClient | None,
+    skills: SkillStore,
+    pool: Any,
+) -> CampaignGenerationService | None:
+    """E3: campaign drafts. Same short-circuit shape as
+    `_build_landing_page_service`."""
+
+    if llm is None or pool is None or intelligence is None:
+        return None
+    return CampaignGenerationService(
+        intelligence=intelligence,
+        campaigns=PostgresCampaignRepository(pool=pool),
+        llm=llm,
+        skills=skills,
+    )
+
+
+def _build_report_service(
+    *,
+    intelligence: IntelligenceRepository | None,
+    llm: LLMClient | None,
+    skills: SkillStore,
+    pool: Any,
+) -> ReportGenerationService | None:
+    """E3: structured report drafts."""
+
+    if llm is None or pool is None or intelligence is None:
+        return None
+    return ReportGenerationService(
+        intelligence=intelligence,
+        reports=PostgresReportRepository(pool=pool),
+        llm=llm,
+        skills=skills,
+    )
+
+
+def _build_sales_brief_service(
+    *,
+    intelligence: IntelligenceRepository | None,
+    llm: LLMClient | None,
+    skills: SkillStore,
+    pool: Any,
+) -> SalesBriefGenerationService | None:
+    """E3: sales-brief drafts."""
+
+    if llm is None or pool is None or intelligence is None:
+        return None
+    return SalesBriefGenerationService(
+        intelligence=intelligence,
+        sales_briefs=PostgresSalesBriefRepository(pool=pool),
         llm=llm,
         skills=skills,
     )
@@ -127,11 +212,38 @@ def build_content_ops_execution_services(
         pool_factory = get_db_pool
 
     landing_page = None
+    campaign = None
+    report = None
+    sales_brief = None
     if enable_db_services:
         llm = llm_factory()
         skills = skills_factory()
         pool = pool_factory()
+        # Shared across the three IntelligenceRepository-dependent
+        # services -- the dataclass is immutable, the underlying
+        # pool is shared anyway, no per-call state.
+        intelligence: IntelligenceRepository | None = (
+            PostgresIntelligenceRepository(pool=pool) if pool is not None else None
+        )
         landing_page = _build_landing_page_service(
+            llm=llm,
+            skills=skills,
+            pool=pool,
+        )
+        campaign = _build_campaign_service(
+            intelligence=intelligence,
+            llm=llm,
+            skills=skills,
+            pool=pool,
+        )
+        report = _build_report_service(
+            intelligence=intelligence,
+            llm=llm,
+            skills=skills,
+            pool=pool,
+        )
+        sales_brief = _build_sales_brief_service(
+            intelligence=intelligence,
             llm=llm,
             skills=skills,
             pool=pool,
@@ -140,6 +252,9 @@ def build_content_ops_execution_services(
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
         landing_page=landing_page,
+        campaign=campaign,
+        report=report,
+        sales_brief=sales_brief,
     )
 
 

--- a/plans/PR-Content-Ops-Execution-Services-Wire-3.md
+++ b/plans/PR-Content-Ops-Execution-Services-Wire-3.md
@@ -159,7 +159,14 @@ exercise the wiring path.
 ## Estimated diff size
 
 - `_content_ops_services.py`: ~80 LOC delta.
-- Test: ~150 LOC delta.
-- Plan doc: ~150 LOC.
+- Test: ~190 LOC delta (13 tests rather than the projected
+  ~10; docstring inventory expanded).
+- Plan doc: ~165 LOC.
 
-Total: ~380 LOC. Within the 400 LOC PR target.
+Total actual: +414 / -44 = 458 changes. Marginally over the
+400-LOC soft cap. Indivisible -- the Intentional bullet
+about combining the 3 IntelligenceRepository-dependent
+services in one PR is the justification: each helper is
+~10 LOC, three near-duplicate slices would be process
+overhead with no review value. Tests dominate the line
+count; the production-code delta itself is well under cap.

--- a/plans/PR-Content-Ops-Execution-Services-Wire-3.md
+++ b/plans/PR-Content-Ops-Execution-Services-Wire-3.md
@@ -1,0 +1,165 @@
+# PR: wire `campaign`, `report`, and `sales_brief` services (E3 of N)
+
+## Why this slice exists
+
+After PR #455 (E2.5), the host's `execution_services_provider`
+bundle wires 2 of 6 outputs: `signal_extraction` + `landing_page`.
+The remaining 4 outputs are:
+
+- `campaign`, `report`, `sales_brief` -- all share an identical
+  dependency shape: `IntelligenceRepository` (read campaign
+  opportunities) + the per-output `*Repository` (persist drafts) +
+  `LLMClient` + `SkillStore`.
+- `blog_post` -- different shape: `BlogBlueprintRepository` +
+  `BlogPostRepository` + `LLMClient` + `SkillStore`. No
+  `IntelligenceRepository`. Separate slice (E4).
+
+This slice wires all 3 IntelligenceRepository-dependent
+generators in a single PR -- the wiring is mechanical and
+identical across the three, so combining them avoids
+shipping three near-duplicate slices. After E3 lands, the
+bundle advertises 5 of 6 outputs; only `blog_post` remains.
+
+## Scope (this PR)
+
+The bundle factory and the test file. No frontend or route
+changes.
+
+### Files touched
+
+1. `atlas_brain/_content_ops_services.py`:
+   - Add `_build_campaign_service`, `_build_report_service`,
+     `_build_sales_brief_service` helpers. Each follows the
+     same shape as `_build_landing_page_service` (PR #454):
+     short-circuit to `None` when LLM or pool is absent;
+     otherwise construct the service from
+     `PostgresIntelligenceRepository` + the per-output Postgres
+     repo + the LLM/Skill adapters.
+   - Update `build_content_ops_execution_services()` to call
+     all three helpers when `enable_db_services=True`. Single
+     `PostgresIntelligenceRepository(pool=pool)` instance is
+     shared across the three services (Postgres pool is the
+     real connection budget; the dataclass wrapper is
+     lightweight).
+   - ~80 LOC delta.
+
+2. `tests/test_atlas_content_ops_execution_services.py`:
+   - 3 new "wired-when-LLM-active-and-db-enabled" tests (one
+     per output) + 3 new "slot stays None when no LLM" tests
+     + update the existing `configured_outputs` tests to
+     reflect the new tuple `(campaign, landing_page, report,
+     sales_brief, signal_extraction)`.
+   - Rewrite the unwired-output canary to pick `blog_post`
+     since it's the only output left in the unwired set.
+   - ~150 LOC delta.
+
+3. `plans/PR-Content-Ops-Execution-Services-Wire-3.md`
+   (this file).
+
+### What's NOT in this slice
+
+- **`blog_post` service.** Different repo shape
+  (`BlogBlueprintRepository` -- not Postgres-backed by the
+  same pool). Separate slice (E4).
+- **Per-service config tuning.** Each
+  `*GenerationConfig` has defaults (skill_name,
+  default_brief_type, etc.); the host accepts the defaults.
+  Operator-level tuning (e.g. `b2b_growth` plan caps a
+  different temperature) is out of scope.
+- **Reasoning context provider host wiring.** Route seam
+  shipped in PR #402; the bundle's
+  `with_reasoning_context()` derivation handles per-request
+  rebinding when the host wires a provider. Not part of E3.
+- **End-to-end smoke test posting to `/api/v1/content-ops/execute`**
+  with each new output. Today's tests stop at the
+  bundle/service layer.
+
+## Mechanism
+
+Each helper follows the established `_build_landing_page_service`
+template -- short-circuit on missing dependency, otherwise
+construct the service:
+
+```python
+def _build_report_service(
+    *,
+    intelligence: IntelligenceRepository | None,
+    llm: LLMClient | None,
+    skills: SkillStore,
+    pool: Any,
+) -> ReportGenerationService | None:
+    if llm is None or pool is None or intelligence is None:
+        return None
+    return ReportGenerationService(
+        intelligence=intelligence,
+        reports=PostgresReportRepository(pool=pool),
+        llm=llm,
+        skills=skills,
+    )
+```
+
+`build_content_ops_execution_services()` resolves the shared
+`PostgresIntelligenceRepository(pool=pool)` once and passes
+it to all three service builders -- same pool, same wrapper
+instance. The repository is a frozen dataclass with no
+per-call state, so sharing is safe.
+
+The `enable_db_services` flag still gates all DB-backed
+generators behind the production scope-wiring contract from
+PR #455. Tests pass `enable_db_services=True` explicitly to
+exercise the wiring path.
+
+## Intentional
+
+- **All 3 IntelligenceRepository-dependent services in one
+  PR.** The wiring is identical across the three; shipping
+  three near-duplicate slices would be process overhead with
+  no review value. Each helper is ~10 LOC; the only delta is
+  the per-output Postgres repo class.
+- **Shared `PostgresIntelligenceRepository` instance.** The
+  dataclass is immutable and the underlying pool is shared
+  anyway; constructing three copies adds no isolation and
+  one-extra-allocation per request churn.
+- **Defensive `intelligence is None` guard** matches the
+  existing LLM/pool guards from PR #454. Today the
+  intelligence repo is always built when the pool is
+  available, but the guard keeps the slot-skipping shape
+  uniform across all four DB-backed generators (landing_page
+  + the three this PR adds).
+- **Pool-only `PostgresIntelligenceRepository(pool=pool)`
+  construction**, omitting `opportunity_table` -- accepts
+  the package's `"campaign_opportunities"` default. Operator
+  override would be a separate slice if needed.
+- **`blog_post` deliberately deferred.** Different repo
+  shape (`BlogBlueprintRepository`); plugging it in alongside
+  the IntelligenceRepository services would conflate two
+  unrelated wiring patterns. Each gets its own slice.
+
+## Deferred
+
+- `blog_post` service wiring (E4) -- needs
+  `BlogBlueprintRepository` + `BlogPostRepository` + LLM +
+  Skills.
+- Multi-pass reasoning provider host wiring -- separate
+  follow-up; the bundle's per-request `with_reasoning_context`
+  derivation is already in place (PR #402).
+- End-to-end smoke test posting to
+  `/api/v1/content-ops/execute` with each generator and
+  asserting real drafts persist under the authenticated
+  tenant. Today's tests stop at the bundle layer.
+- Per-service config tuning (e.g. operator-level
+  temperature, max_tokens overrides).
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_execution_services.py`
+  -- updated tests pass.
+- AST + ASCII checks on the modified module + test file.
+
+## Estimated diff size
+
+- `_content_ops_services.py`: ~80 LOC delta.
+- Test: ~150 LOC delta.
+- Plan doc: ~150 LOC.
+
+Total: ~380 LOC. Within the 400 LOC PR target.

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -5,8 +5,12 @@
 the host has wired. Currently:
 
 - `signal_extraction` (E1, PR #452): always wired (stateless).
-- `landing_page` (E2, this slice): wired when an LLM is
-  active; slot stays `None` otherwise.
+- `landing_page` (E2 + E2.5, PRs #454/#455): wired when an
+  LLM + pool are active; slot stays `None` otherwise.
+- `campaign` / `report` / `sales_brief` (E3, this slice):
+  same shape as landing_page but each also takes a
+  shared `PostgresIntelligenceRepository`. Skip together
+  when LLM or pool is absent.
 
 Tests use the factory's dependency-injection kwargs (`llm_factory`
 / `skills_factory` / `pool_factory`) to stub host
@@ -14,29 +18,31 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (8 tests):
+Test inventory (12 tests):
 
-1. `signal_extraction` runs through the full executor with the
-   bundle attached.
-2. `landing_page` is populated when an LLM is wired AND
-   `enable_db_services=True` (E2 canary).
-3. `landing_page` slot stays `None` when no LLM is active
-   (E2 fallback behavior).
-4. `landing_page` slot stays `None` when pool is None
-   (defensive early-startup guard).
-5. `landing_page` slot stays `None` in production default
-   (Codex P1 safety: `enable_db_services=False` until E2.5
-   wires `scope_provider`).
-6. Unwired outputs still return `service_not_configured` --
-   confirms the bundle doesn't silently mask the remaining 4
-   slots (`campaign`, `blog_post`, `report`, `sales_brief`).
-7. `configured_outputs()` advertises landing_page +
-   signal_extraction with LLM + `enable_db_services=True`.
-8. `configured_outputs()` advertises only signal_extraction
-   without an LLM (or in default production mode).
+1. `signal_extraction` runs through the full executor.
+2. `landing_page` populated when LLM + db enabled (E2 canary).
+3. `landing_page` skips when no LLM (E2 fallback).
+4. `landing_page` skips when pool is None.
+5. `landing_page` skips in production default
+   (Codex P1 safety pin).
+6. `campaign` populated when LLM + db enabled (E3 canary).
+7. `report` populated when LLM + db enabled (E3 canary).
+8. `sales_brief` populated when LLM + db enabled (E3 canary).
+9. campaign / report / sales_brief skip together when no LLM.
+10. campaign / report / sales_brief skip together when pool
+    is None.
+11. `blog_post` (the only remaining unwired output after E3)
+    still returns `service_not_configured`.
+12. `configured_outputs()` with LLM + db enabled advertises
+    `(email_campaign, report, landing_page, sales_brief,
+    signal_extraction)` -- order follows the upstream
+    `ContentOpsExecutionServices.configured_outputs` iteration
+    (not alphabetical). Without LLM or in production default,
+    only `signal_extraction`.
 
-When follow-up slices add `campaign` / `blog_post` / etc.,
-tests 6 and 7 need updated expected-sets.
+When E4 wires `blog_post`, tests 11 and 12 need updated
+expected-sets.
 """
 
 from __future__ import annotations
@@ -129,7 +135,10 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
 
     assert services.landing_page is not None
     assert services.configured_outputs() == (
+        "email_campaign",
+        "report",
         "landing_page",
+        "sales_brief",
         "signal_extraction",
     )
 
@@ -191,14 +200,92 @@ def test_landing_page_slot_stays_none_in_production_default() -> None:
     assert services.configured_outputs() == ("signal_extraction",)
 
 
+def test_campaign_wired_when_llm_active_and_db_enabled() -> None:
+    """E3 canary: campaign service slot is populated with the
+    full LLM + Skill + Postgres + IntelligenceRepository chain.
+    Bundle's `for_output("email_campaign")` returns the
+    service."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_make_llm_stub,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=True,
+    )
+    assert services.campaign is not None
+    assert services.for_output("email_campaign") is services.campaign
+
+
+def test_report_wired_when_llm_active_and_db_enabled() -> None:
+    """E3 canary: report service slot populated."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_make_llm_stub,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=True,
+    )
+    assert services.report is not None
+    assert services.for_output("report") is services.report
+
+
+def test_sales_brief_wired_when_llm_active_and_db_enabled() -> None:
+    """E3 canary: sales_brief service slot populated."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_make_llm_stub,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=True,
+    )
+    assert services.sales_brief is not None
+    assert services.for_output("sales_brief") is services.sales_brief
+
+
+def test_e3_services_skip_together_when_no_active_llm() -> None:
+    """E3 fallback: campaign / report / sales_brief slots all
+    stay `None` when no LLM is active. Same short-circuit shape
+    as landing_page (PR #454). Only signal_extraction remains
+    advertised."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=True,
+    )
+    assert services.campaign is None
+    assert services.report is None
+    assert services.sales_brief is None
+    assert services.configured_outputs() == ("signal_extraction",)
+
+
+def test_e3_services_skip_together_when_pool_is_none() -> None:
+    """E3 fallback: campaign / report / sales_brief slots all
+    skip when pool is None during early host startup."""
+
+    def _no_pool() -> Any:
+        return None
+
+    services = build_content_ops_execution_services(
+        llm_factory=_make_llm_stub,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_no_pool,
+        enable_db_services=True,
+    )
+    assert services.campaign is None
+    assert services.report is None
+    assert services.sales_brief is None
+    assert services.configured_outputs() == ("signal_extraction",)
+
+
 @pytest.mark.asyncio
-async def test_unwired_outputs_still_return_service_not_configured() -> None:
-    """The bundle leaves `campaign` / `blog_post` / `report` /
-    `sales_brief` slots `None`. The executor's per-step
-    dispatcher must surface that as `service_not_configured`
-    rather than silently succeeding. Picking `report` since
-    `landing_page` is no longer in the unwired set when
-    `enable_db_services=True`."""
+async def test_unwired_blog_post_still_returns_service_not_configured() -> None:
+    """After E3 wires campaign / report / sales_brief, the only
+    output left in the unwired set is `blog_post` (different
+    repo shape -- BlogBlueprintRepository -- E4). The
+    executor's per-step dispatcher must surface that as
+    `service_not_configured`."""
 
     services = build_content_ops_execution_services(
         llm_factory=_make_llm_stub,
@@ -209,8 +296,8 @@ async def test_unwired_outputs_still_return_service_not_configured() -> None:
 
     result = await execute_content_ops_from_mapping(
         {
-            "outputs": ["report"],
-            "inputs": {"opportunity_id": "opp-1"},
+            "outputs": ["blog_post"],
+            "inputs": {"topic": "Q3 churn signals"},
         },
         services=services,
     )
@@ -233,7 +320,10 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
         enable_db_services=True,
     )
     assert services.configured_outputs() == (
+        "email_campaign",
+        "report",
         "landing_page",
+        "sales_brief",
         "signal_extraction",
     )
 

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -18,7 +18,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (12 tests):
+Test inventory (13 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -38,8 +38,10 @@ Test inventory (12 tests):
     `(email_campaign, report, landing_page, sales_brief,
     signal_extraction)` -- order follows the upstream
     `ContentOpsExecutionServices.configured_outputs` iteration
-    (not alphabetical). Without LLM or in production default,
-    only `signal_extraction`.
+    (not alphabetical).
+13. `configured_outputs()` without an active LLM (even with
+    `enable_db_services=True`) advertises only
+    `signal_extraction`.
 
 When E4 wires `blog_post`, tests 11 and 12 need updated
 expected-sets.


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Execution-Services-Wire-3.md`

## Summary

E3 of the host execution-services wiring. After PR #455 (E2.5),
the bundle wired 2 of 6 outputs (`signal_extraction` +
`landing_page`). This PR wires the three remaining
`IntelligenceRepository`-dependent outputs in a single slice
because the wiring shape is identical across all three:

- `campaign` (output id `email_campaign`)
- `report`
- `sales_brief`

Each follows the established `_build_landing_page_service`
template -- short-circuit to `None` when LLM, pool, or the
shared `IntelligenceRepository` is absent; otherwise construct
the service with the per-output Postgres repo + the shared
`PostgresIntelligenceRepository(pool=pool)` + LLM/Skill
adapters.

After E3, `configured_outputs()` advertises 5 of 6 outputs
when LLM and DB services are both wired:
`(email_campaign, report, landing_page, sales_brief,
signal_extraction)`. Only `blog_post` remains for E4 (different
repo shape -- `BlogBlueprintRepository`, no
`IntelligenceRepository`).

## Files touched

1. `atlas_brain/_content_ops_services.py`:
   - 3 new helpers (~30 LOC each), shared
     `PostgresIntelligenceRepository(pool=pool)` instance.
2. `tests/test_atlas_content_ops_execution_services.py`:
   - Extended from 8 to 13 tests: 3 new "wired-when-LLM-active"
     canaries (one per output) + 2 combined "skip together"
     fallbacks (no LLM, no pool) + replaced the old `report`
     unwired canary with `blog_post` (the only output left in
     the unwired set).
   - Updated `configured_outputs()` expected tuples to the
     5-output shape (order follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration, not alphabetical).
3. `plans/PR-Content-Ops-Execution-Services-Wire-3.md` (new).

## Intentional

- **All 3 IntelligenceRepository-dependent services in one
  PR.** The wiring is identical across the three; each helper
  is ~10 LOC. Three near-duplicate slices would be process
  overhead with no review value.
- **Shared `PostgresIntelligenceRepository` instance.** The
  dataclass is immutable and the underlying pool is shared
  anyway; constructing three copies adds no isolation.
- **Defensive `intelligence is None` guard** matches the
  existing LLM/pool guards from PR #454. Today the
  intelligence repo is always built when the pool is
  available, but the guard keeps the slot-skipping shape
  uniform across all four DB-backed generators.
- **`blog_post` deliberately deferred.** Different repo shape
  (`BlogBlueprintRepository`); plugging it in alongside the
  IntelligenceRepository services would conflate two
  unrelated wiring patterns. Each gets its own slice.
- **`enable_db_services=False` production default preserved.**
  Same Codex P1 safety pin from PR #454; PR #455 already
  flipped it on for the production mount.

## Deferred

- `blog_post` service wiring (E4) -- needs
  `BlogBlueprintRepository` + `BlogPostRepository` + LLM +
  Skills.
- Multi-pass reasoning provider host wiring -- separate
  follow-up; the bundle's per-request
  `with_reasoning_context` derivation is already in place
  (PR #402).
- End-to-end smoke test posting to
  `/api/v1/content-ops/execute` with each generator and
  asserting real drafts persist under the authenticated
  tenant. Today's tests stop at the bundle layer.
- Per-service config tuning (operator-level temperature /
  max_tokens overrides).

## Verification

- `pytest tests/test_atlas_content_ops_execution_services.py`
  -- 13 passed, 0 failed locally.
- AST parse + ASCII gates clean on the modified module +
  test file.
- `bash scripts/check_ascii_python.sh` -- pass.

## Test plan

- [ ] CI runs `pytest tests/test_atlas_content_ops_execution_services.py`
- [ ] Codex per-line review
- [ ] Claude reviewer pass

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_