### PR TITLE
PR-Blog-Blueprint-Storage-1: blog blueprint table + Postgres adapter

### DIFF
--- a/extracted_content_pipeline/blog_blueprint_postgres.py
+++ b/extracted_content_pipeline/blog_blueprint_postgres.py
@@ -27,7 +27,6 @@ from .campaign_ports import JsonDict, TenantScope
 from .storage._jsonb_helpers import (
     decode_jsonb_field,
     json_dump_jsonb,
-    parse_command_tag,
     row_to_dict,
 )
 
@@ -171,9 +170,14 @@ class PostgresBlogBlueprintRepository:
     ) -> int:
         """Flag blueprints as consumed so they drop out of reads.
 
-        Returns the count of rows actually updated -- mismatched
-        ids (already-consumed, wrong tenant) are silently
-        skipped. ``consumed_at`` defaults to ``NOW()`` server-side.
+        Returns the count of rows actually updated, parsed from
+        asyncpg's ``"UPDATE N"`` command tag. Mismatched ids
+        (already-consumed, wrong tenant) are silently skipped --
+        callers can compare the return to ``len(blueprint_ids)``
+        to detect partial-batch failures. Test fakes that return
+        a non-string command tag fall back to
+        ``len(blueprint_ids)``. ``consumed_at`` defaults to
+        ``NOW()`` server-side.
         """
 
         if not blueprint_ids:
@@ -191,7 +195,12 @@ class PostgresBlogBlueprintRepository:
             list(blueprint_ids),
             consumed_at,
         )
-        return 1 if parse_command_tag(result) else 0
+        if isinstance(result, str):
+            try:
+                return int(result.rsplit(" ", 1)[-1])
+            except (ValueError, IndexError):
+                return len(blueprint_ids)
+        return len(blueprint_ids)
 
 
 __all__ = [

--- a/extracted_content_pipeline/blog_blueprint_postgres.py
+++ b/extracted_content_pipeline/blog_blueprint_postgres.py
@@ -1,0 +1,200 @@
+"""Postgres adapter for AI Content Ops blog blueprints.
+
+Backs the package's ``BlogBlueprintRepository`` Protocol
+(``extracted_content_pipeline/blog_ports.py``) with a concrete
+table implementation. Hosts that maintain blueprints in their
+own storage can implement the Protocol against that store
+instead; this adapter is the default for hosts using the
+extracted package's own migrations.
+
+Read path (the Protocol method): returns blueprints filtered
+by ``(account_id, target_mode)`` with ``consumed_at IS NULL``,
+ordered by recency, payload merged with row metadata so the
+generator sees a single self-contained dict.
+
+Write path (concrete extension): ``save_blueprints`` for hosts
+landing blueprints in this table; ``mark_consumed`` to flag
+already-generated blueprints so duplicate runs skip them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+@dataclass(frozen=True)
+class BlogBlueprint:
+    """In-memory representation of a stored blog blueprint row.
+
+    Only used by the ``save_blueprints`` writer; the read path
+    returns plain ``Mapping`` rows for the generator to consume.
+    """
+
+    target_mode: str
+    topic_type: str
+    slug: str
+    suggested_title: str = ""
+    payload: Mapping[str, Any] = ()  # type: ignore[assignment]
+
+
+def _row_to_blueprint(row: Mapping[str, Any]) -> JsonDict:
+    """Decode a row into the dict shape the generator consumes.
+
+    The ``payload`` JSONB carries the rich blueprint dict
+    (sections / charts / tags / data_context / etc.). Row-level
+    metadata (``id``, ``target_mode``, ``topic_type``, ``slug``,
+    ``suggested_title``) is merged in so callers see a single
+    self-contained dict regardless of which fields lived in
+    typed columns vs. the JSONB blob.
+    """
+
+    payload_raw = decode_jsonb_field(row.get("payload"), default={})
+    if not isinstance(payload_raw, Mapping):
+        payload_raw = {}
+    merged: JsonDict = dict(payload_raw)
+    merged.setdefault("id", str(row.get("id") or ""))
+    merged.setdefault("target_mode", str(row.get("target_mode") or ""))
+    merged.setdefault("topic_type", str(row.get("topic_type") or ""))
+    merged.setdefault("slug", str(row.get("slug") or ""))
+    merged.setdefault("suggested_title", str(row.get("suggested_title") or ""))
+    return merged
+
+
+@dataclass(frozen=True)
+class PostgresBlogBlueprintRepository:
+    """Async Postgres adapter for blog blueprints."""
+
+    pool: Any
+    table: str = "blog_blueprints"
+
+    async def read_blog_blueprints(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return unconsumed blueprints for the tenant + target_mode.
+
+        ``filters`` is accepted for protocol parity but currently
+        only honored for ``topic_type`` -- additional facets can
+        be added without a breaking change.
+        """
+
+        topic_type = None
+        if filters:
+            raw = filters.get("topic_type")
+            if isinstance(raw, str) and raw.strip():
+                topic_type = raw.strip()
+
+        query = f"""
+            SELECT id, target_mode, topic_type, slug, suggested_title, payload
+            FROM {self.table}
+            WHERE account_id = $1
+              AND target_mode = $2
+              AND consumed_at IS NULL
+        """
+        args: list[Any] = [scope.account_id or "", target_mode]
+        if topic_type is not None:
+            query += " AND topic_type = $3"
+            args.append(topic_type)
+        query += f" ORDER BY created_at DESC LIMIT ${len(args) + 1}"
+        args.append(int(limit))
+
+        rows = await self.pool.fetch(query, *args)
+        return tuple(_row_to_blueprint(row_to_dict(row)) for row in rows)
+
+    async def save_blueprints(
+        self,
+        blueprints: Sequence[BlogBlueprint],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist blueprints and return assigned ids.
+
+        Outside the upstream Protocol -- hosts with their own
+        blueprint store don't need this. Hosts using the
+        extracted package's table call this from their blueprint
+        ETL path (or extend the autonomous task to write
+        through here).
+
+        Conflicts on the unique ``(account_id, target_mode, slug)``
+        index resolve to UPDATE: payload + suggested_title are
+        refreshed and ``consumed_at`` is cleared so the blueprint
+        is eligible for regeneration. Returns the resulting id.
+        """
+
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for blueprint in blueprints:
+            blueprint_id = await self.pool.fetchval(
+                f"""
+                INSERT INTO {self.table} (
+                    account_id, target_mode, topic_type, slug,
+                    suggested_title, payload
+                )
+                VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                ON CONFLICT (account_id, target_mode, slug) DO UPDATE
+                SET topic_type = EXCLUDED.topic_type,
+                    suggested_title = EXCLUDED.suggested_title,
+                    payload = EXCLUDED.payload,
+                    consumed_at = NULL
+                RETURNING id
+                """,
+                account_id,
+                blueprint.target_mode,
+                blueprint.topic_type,
+                blueprint.slug,
+                blueprint.suggested_title,
+                json_dump_jsonb(dict(blueprint.payload or {})),
+            )
+            saved.append(str(blueprint_id))
+        return tuple(saved)
+
+    async def mark_consumed(
+        self,
+        blueprint_ids: Sequence[str],
+        *,
+        scope: TenantScope,
+        consumed_at: datetime | None = None,
+    ) -> int:
+        """Flag blueprints as consumed so they drop out of reads.
+
+        Returns the count of rows actually updated -- mismatched
+        ids (already-consumed, wrong tenant) are silently
+        skipped. ``consumed_at`` defaults to ``NOW()`` server-side.
+        """
+
+        if not blueprint_ids:
+            return 0
+        account_id = scope.account_id or ""
+        result = await self.pool.execute(
+            f"""
+            UPDATE {self.table}
+            SET consumed_at = COALESCE($3, NOW())
+            WHERE account_id = $1
+              AND id = ANY($2::uuid[])
+              AND consumed_at IS NULL
+            """,
+            account_id,
+            list(blueprint_ids),
+            consumed_at,
+        )
+        return 1 if parse_command_tag(result) else 0
+
+
+__all__ = [
+    "BlogBlueprint",
+    "PostgresBlogBlueprintRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/274_blog_blueprints.sql
+++ b/extracted_content_pipeline/storage/migrations/274_blog_blueprints.sql
@@ -1,0 +1,37 @@
+-- Blog blueprints: pre-generated structural plans the AI Content Ops blog
+-- post generator consumes when producing prose. The package's
+-- BlogBlueprintRepository Protocol (extracted_content_pipeline/blog_ports.py)
+-- previously had no implementation; this table backs the new
+-- PostgresBlogBlueprintRepository so the bundle factory can wire blog_post.
+--
+-- The payload JSONB carries the rich blueprint dict (sections / charts /
+-- tags / data_context / etc.) the LLM prompt consumes. Flattening into
+-- typed columns would force a migration on every blueprint-shape tweak;
+-- JSONB also lets multiple topic_types coexist without sparse columns.
+--
+-- consumed_at tracks single-use semantics: once the generator emits a
+-- draft from a blueprint, the row is marked consumed and the default
+-- read path filters it out. Hosts can clear consumed_at to re-run a
+-- blueprint for regeneration / experimentation.
+
+CREATE TABLE IF NOT EXISTS blog_blueprints (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    topic_type TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    suggested_title TEXT NOT NULL DEFAULT '',
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    consumed_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blog_blueprints_slug
+    ON blog_blueprints (account_id, target_mode, slug);
+
+CREATE INDEX IF NOT EXISTS idx_blog_blueprints_unconsumed
+    ON blog_blueprints (account_id, target_mode, created_at DESC)
+    WHERE consumed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_blog_blueprints_topic
+    ON blog_blueprints (account_id, target_mode, topic_type, created_at DESC);

--- a/plans/PR-Blog-Blueprint-Storage-1.md
+++ b/plans/PR-Blog-Blueprint-Storage-1.md
@@ -1,0 +1,194 @@
+# PR: blog blueprint storage layer (Storage-1 of 2)
+
+## Why this slice exists
+
+After PR #456 (E3), the host's Content Ops execution-services
+bundle wires 5 of 6 outputs (`signal_extraction`,
+`landing_page`, `email_campaign`, `report`, `sales_brief`).
+The last unwired slot is `blog_post`.
+
+Unlike the four already-wired DB-backed outputs, the package's
+`BlogBlueprintRepository` (`extracted_content_pipeline/blog_ports.py:39`)
+is a Protocol with no implementation. The host generates
+blueprints in-memory inside
+`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+(deterministic `PostBlueprint` dataclasses) and consumes them
+immediately -- no persistence layer connects the two halves.
+Without a `PostgresBlogBlueprintRepository`, the bundle factory
+has nothing concrete to wire into the `BlogPostGenerationService`
+constructor.
+
+This slice adds the storage layer only -- migration + repository
++ tests. A follow-up slice (PR-Content-Ops-Execution-Services-Wire-4)
+plugs the new repo into the bundle factory once it lands.
+
+## Scope (this PR)
+
+Three files plus the plan doc:
+
+1. **`extracted_content_pipeline/storage/migrations/274_blog_blueprints.sql`** (new):
+   Creates the `blog_blueprints` table -- structurally similar
+   to `273_reports.sql` (the most recent migration). Fields:
+   `id`, `account_id`, `target_mode`, `topic_type`, `slug`,
+   `suggested_title`, `payload` (JSONB -- the full blueprint
+   dict the LLM consumes), `status`, `created_at`, `consumed_at`.
+   Indexes on `(account_id, target_mode, status, created_at)`
+   for the read path, plus a unique index on
+   `(account_id, target_mode, slug)` to prevent duplicates from
+   the host's idempotent generators.
+
+2. **`extracted_content_pipeline/blog_blueprint_postgres.py`** (new):
+   `PostgresBlogBlueprintRepository(pool=...)` -- frozen
+   dataclass following `PostgresLandingPageRepository` /
+   `PostgresReportRepository` pattern.
+   - `read_blog_blueprints(*, scope, target_mode, limit,
+     filters=None)` -- the protocol method consumed by
+     `BlogPostGenerationService.generate()` at
+     `extracted_content_pipeline/blog_generation.py:221`.
+     Returns `Sequence[Mapping[str, Any]]` -- decodes each
+     row's `payload` JSONB and merges in the row-level metadata
+     (`id`, `target_mode`, `topic_type`, `slug`,
+     `suggested_title`) so the generator sees a self-contained
+     blueprint dict.
+   - `save_blueprints(blueprints, *, scope)` -- write helper.
+     Not part of the upstream Protocol but needed so a host-side
+     adapter (the autonomous task, or a separate ETL) can land
+     blueprints in the table. Returns assigned ids.
+   - `mark_consumed(blueprint_ids, *, scope)` -- sets
+     `consumed_at` so duplicate generation runs skip already-used
+     blueprints. Optional path; the read path filters
+     `consumed_at IS NULL` by default.
+
+3. **`tests/test_extracted_blog_blueprint_postgres.py`** (new):
+   ~6 tests pinning the round-trip + scope-isolation contract,
+   following `test_extracted_blog_post_postgres.py` shape (fake
+   pool with `fetch` / `fetchval` / `execute` recorders).
+   - `save_blueprints` round-trips payload through JSONB
+     round-trip
+   - `read_blog_blueprints` filters by `account_id` +
+     `target_mode` + `consumed_at IS NULL`
+   - `read_blog_blueprints` honors `limit`
+   - `read_blog_blueprints` returns merged payload + row metadata
+   - `mark_consumed` sets the `consumed_at` timestamp
+   - `read_blog_blueprints` with no rows returns `()`
+     (defensive empty-table canary)
+
+### What's NOT in this slice
+
+- **Bundle factory wiring of `blog_post`.** Separate slice
+  (PR-Content-Ops-Execution-Services-Wire-4); requires this
+  storage layer to land first.
+- **Host autonomous task changes** to persist `PostBlueprint`s
+  into the new table. The host's existing in-memory pipeline
+  keeps working; a future slice extends it (or adds an ETL
+  step) to populate `blog_blueprints` so the wired generator
+  has data to read.
+- **`BlogBlueprintRepository` Protocol changes.** The upstream
+  contract stays as-is; this slice only adds an implementation.
+
+## Mechanism
+
+The repository is a thin asyncpg adapter following the
+established frozen-dataclass shape:
+
+```python
+@dataclass(frozen=True)
+class PostgresBlogBlueprintRepository:
+    pool: Any
+    table: str = "blog_blueprints"
+
+    async def read_blog_blueprints(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        rows = await self.pool.fetch(
+            f"""
+            SELECT id, target_mode, topic_type, slug, suggested_title, payload
+            FROM {self.table}
+            WHERE account_id = $1
+              AND target_mode = $2
+              AND consumed_at IS NULL
+            ORDER BY created_at DESC
+            LIMIT $3
+            """,
+            scope.account_id or "",
+            target_mode,
+            int(limit),
+        )
+        return tuple(_row_to_blueprint(row) for row in rows)
+```
+
+Each row's `payload` JSONB carries the rich blueprint dict
+(sections / charts / tags / data_context / etc.) that the
+LLM prompt consumes; `_row_to_blueprint` decodes it and
+merges row metadata so the generator sees a single dict.
+
+## Intentional
+
+- **Migration number 274.** Continues the existing sequence
+  (273_reports.sql is most recent in
+  `extracted_content_pipeline/storage/migrations/`). No
+  conflict with host-side migrations -- the package's
+  numbering namespace is independent.
+- **`payload` JSONB rather than per-field columns.** Blueprint
+  shape evolves with the generators; flattening into typed
+  columns would force a migration on every blueprint-shape
+  tweak. JSONB also lets multiple `topic_type`s coexist
+  without sparse columns.
+- **Unique `(account_id, target_mode, slug)` constraint.** The
+  host's blueprint generators are idempotent on
+  `(target, topic_type)`; the slug derives from those. Without
+  the constraint, repeat runs would multiply rows and the
+  LIMIT-N read would surface duplicates.
+- **`consumed_at` rather than DELETE-on-read.** Audit trail +
+  ability to re-run a blueprint by clearing the timestamp.
+  Default WHERE filter keeps the consumed rows out of normal
+  reads.
+- **`save_blueprints` outside the Protocol.** The upstream
+  `BlogBlueprintRepository` Protocol is read-only by design
+  (different writers per host). The package's repo concrete
+  adds the writer for hosts that want blueprints in this
+  table; hosts with their own blueprint store can implement
+  the Protocol against it instead.
+- **Frozen dataclass shape, pool-only construction.** Matches
+  PR #455 / PR #456 wiring shape -- the repo's only state
+  is the pool + a configurable table name (test override).
+
+## Deferred
+
+- Bundle wiring of `blog_post` (next slice).
+- Host autonomous task changes to persist `PostBlueprint`s
+  into the new table (separate slice -- the in-memory pipeline
+  keeps working; the new path is opt-in).
+- Per-blueprint quality-gate or expiry policy.
+- Read-side filters beyond `target_mode` (e.g. `topic_type`,
+  `vendor`) -- can be folded into the existing `filters`
+  arg as needed; not exercised today.
+
+## Verification
+
+- `pytest tests/test_extracted_blog_blueprint_postgres.py`
+  -- new tests pass.
+- `bash scripts/check_ascii_python.sh` -- ASCII clean.
+- AST parse of new module + test file.
+- Existing extracted-pipeline gates (validate +
+  forbid_atlas_reasoning_imports + audit_extracted_standalone)
+  stay clean.
+
+## Estimated diff size
+
+- Migration: ~30 LOC.
+- Repository: ~150 LOC.
+- Tests: ~200 LOC.
+- Plan doc: ~150 LOC.
+
+Total: ~530 LOC. Slightly over the 400 LOC soft cap. The
+storage layer is indivisible -- the migration, repo
+implementation, and tests must ship together for the schema
+to be useful. A test-only PR with no implementation has no
+review value, and an implementation-only PR with no migration
+has no schema to bind to.

--- a/plans/PR-Blog-Blueprint-Storage-1.md
+++ b/plans/PR-Blog-Blueprint-Storage-1.md
@@ -176,9 +176,9 @@ merges row metadata so the generator sees a single dict.
   into the new table (separate slice -- the in-memory pipeline
   keeps working; the new path is opt-in).
 - Per-blueprint quality-gate or expiry policy.
-- Read-side filters beyond `target_mode` (e.g. `topic_type`,
-  `vendor`) -- can be folded into the existing `filters`
-  arg as needed; not exercised today.
+- Read-side filters beyond `topic_type` (e.g. `vendor`,
+  `created_after`) -- already routed through the existing
+  `filters` arg; not exercised today.
 
 ## Verification
 

--- a/plans/PR-Blog-Blueprint-Storage-1.md
+++ b/plans/PR-Blog-Blueprint-Storage-1.md
@@ -31,11 +31,15 @@ Three files plus the plan doc:
    to `273_reports.sql` (the most recent migration). Fields:
    `id`, `account_id`, `target_mode`, `topic_type`, `slug`,
    `suggested_title`, `payload` (JSONB -- the full blueprint
-   dict the LLM consumes), `status`, `created_at`, `consumed_at`.
-   Indexes on `(account_id, target_mode, status, created_at)`
-   for the read path, plus a unique index on
-   `(account_id, target_mode, slug)` to prevent duplicates from
-   the host's idempotent generators.
+   dict the LLM consumes), `created_at`, `consumed_at`. Soft-
+   delete is the `consumed_at` timestamp (NULL = unconsumed);
+   no separate `status` column. Indexes:
+   - Unique on `(account_id, target_mode, slug)` to prevent
+     duplicates from the host's idempotent generators.
+   - Partial on `(account_id, target_mode, created_at DESC)
+     WHERE consumed_at IS NULL` for the default read path.
+   - On `(account_id, target_mode, topic_type, created_at
+     DESC)` for the topic_type-filtered read.
 
 2. **`extracted_content_pipeline/blog_blueprint_postgres.py`** (new):
    `PostgresBlogBlueprintRepository(pool=...)` -- frozen
@@ -60,18 +64,25 @@ Three files plus the plan doc:
      `consumed_at IS NULL` by default.
 
 3. **`tests/test_extracted_blog_blueprint_postgres.py`** (new):
-   ~6 tests pinning the round-trip + scope-isolation contract,
+   8 tests pinning the round-trip + scope-isolation contract,
    following `test_extracted_blog_post_postgres.py` shape (fake
    pool with `fetch` / `fetchval` / `execute` recorders).
-   - `save_blueprints` round-trips payload through JSONB
-     round-trip
+   - `save_blueprints` round-trips payload through JSONB.
+   - `save_blueprints` upsert clears `consumed_at` so re-saved
+     blueprints are eligible for re-generation.
    - `read_blog_blueprints` filters by `account_id` +
-     `target_mode` + `consumed_at IS NULL`
-   - `read_blog_blueprints` honors `limit`
-   - `read_blog_blueprints` returns merged payload + row metadata
-   - `mark_consumed` sets the `consumed_at` timestamp
+     `target_mode` + `consumed_at IS NULL` and applies the
+     LIMIT.
+   - `read_blog_blueprints` honors the `topic_type` filter.
+   - `read_blog_blueprints` returns merged payload + row
+     metadata so the generator sees a self-contained dict.
    - `read_blog_blueprints` with no rows returns `()`
-     (defensive empty-table canary)
+     (defensive empty-table canary).
+   - `mark_consumed` issues the tenant-scoped UPDATE AND
+     returns the integer count parsed from the
+     `"UPDATE N"` command tag.
+   - `mark_consumed` with empty ids short-circuits (no DB
+     roundtrip).
 
 ### What's NOT in this slice
 
@@ -181,14 +192,16 @@ merges row metadata so the generator sees a single dict.
 
 ## Estimated diff size
 
-- Migration: ~30 LOC.
-- Repository: ~150 LOC.
-- Tests: ~200 LOC.
-- Plan doc: ~150 LOC.
+- Migration: ~37 LOC.
+- Repository: ~210 LOC (slightly above the original ~150
+  estimate after the inline `mark_consumed` integer-count
+  parse + expanded docstrings).
+- Tests: ~265 LOC (8 tests rather than the projected 6).
+- Plan doc: ~205 LOC.
 
-Total: ~530 LOC. Slightly over the 400 LOC soft cap. The
-storage layer is indivisible -- the migration, repo
-implementation, and tests must ship together for the schema
-to be useful. A test-only PR with no implementation has no
-review value, and an implementation-only PR with no migration
-has no schema to bind to.
+Total actual: ~717 LOC. ~75% over the 400 LOC soft cap.
+Indivisible -- the migration, repo implementation, and tests
+must ship together for the schema to be useful. A test-only
+PR with no implementation has no review value, and an
+implementation-only PR with no migration has no schema to
+bind to.

--- a/tests/test_extracted_blog_blueprint_postgres.py
+++ b/tests/test_extracted_blog_blueprint_postgres.py
@@ -6,7 +6,7 @@ the missing concrete implementation of the package's
 last unwired Content Ops slot). The bundle factory's blog_post
 wiring slice depends on this storage layer landing first.
 
-Test inventory (7 tests):
+Test inventory (8 tests):
 
 1. `save_blueprints` round-trips payload through JSONB.
 2. `save_blueprints` upsert resets `consumed_at` so the row
@@ -19,7 +19,10 @@ Test inventory (7 tests):
 6. `read_blog_blueprints` with no rows returns `()`
    (empty-table canary).
 7. `mark_consumed` issues the UPDATE with the expected
-   tenant-scoped predicate.
+   tenant-scoped predicate AND returns the integer count
+   parsed from the "UPDATE N" command tag.
+8. `mark_consumed` with empty ids short-circuits (no DB
+   roundtrip, returns 0).
 
 Test harness uses an asyncpg-shaped fake pool (matches
 `tests/test_extracted_blog_post_postgres.py`).
@@ -225,6 +228,11 @@ async def test_read_blog_blueprints_empty_table_returns_empty_tuple() -> None:
 
 @pytest.mark.asyncio
 async def test_mark_consumed_issues_tenant_scoped_update() -> None:
+    """Pin the actual integer count parse from asyncpg's
+    "UPDATE N" command tag -- callers compare the return to
+    `len(blueprint_ids)` to detect partial-batch failures, so
+    coercing to a 0/1 bool would silently mis-report."""
+
     pool = _Pool()
     pool.execute_result = "UPDATE 2"
     repo = PostgresBlogBlueprintRepository(pool=pool)
@@ -234,7 +242,7 @@ async def test_mark_consumed_issues_tenant_scoped_update() -> None:
         scope=TenantScope(account_id="acct-1"),
     )
 
-    assert hits == 1  # parse_command_tag returns True -> 1 here
+    assert hits == 2
     query = pool.execute_calls[0]["query"]
     assert "account_id = $1" in query
     assert "id = ANY($2::uuid[])" in query
@@ -242,3 +250,18 @@ async def test_mark_consumed_issues_tenant_scoped_update() -> None:
     args = pool.execute_calls[0]["args"]
     assert args[0] == "acct-1"
     assert args[1] == ["bp-uuid-1", "bp-uuid-2"]
+
+
+@pytest.mark.asyncio
+async def test_mark_consumed_with_empty_ids_short_circuits() -> None:
+    """Empty input must skip the DB roundtrip -- otherwise an
+    `id = ANY('{}'::uuid[])` predicate would still execute
+    once per call. Returns 0."""
+
+    pool = _Pool()
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    hits = await repo.mark_consumed([], scope=TenantScope(account_id="acct-1"))
+
+    assert hits == 0
+    assert pool.execute_calls == []

--- a/tests/test_extracted_blog_blueprint_postgres.py
+++ b/tests/test_extracted_blog_blueprint_postgres.py
@@ -1,0 +1,244 @@
+"""Pin the Postgres adapter for blog blueprints.
+
+`extracted_content_pipeline/blog_blueprint_postgres.py` adds
+the missing concrete implementation of the package's
+`BlogBlueprintRepository` Protocol (PR #456 left this as the
+last unwired Content Ops slot). The bundle factory's blog_post
+wiring slice depends on this storage layer landing first.
+
+Test inventory (7 tests):
+
+1. `save_blueprints` round-trips payload through JSONB.
+2. `save_blueprints` upsert resets `consumed_at` so the row
+   is eligible for re-generation.
+3. `read_blog_blueprints` filters by account_id + target_mode
+   + `consumed_at IS NULL` and applies the LIMIT.
+4. `read_blog_blueprints` honors the `topic_type` filter.
+5. `read_blog_blueprints` returns merged payload + row metadata
+   so the generator sees a self-contained dict.
+6. `read_blog_blueprints` with no rows returns `()`
+   (empty-table canary).
+7. `mark_consumed` issues the UPDATE with the expected
+   tenant-scoped predicate.
+
+Test harness uses an asyncpg-shaped fake pool (matches
+`tests/test_extracted_blog_post_postgres.py`).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from extracted_content_pipeline.blog_blueprint_postgres import (
+    BlogBlueprint,
+    PostgresBlogBlueprintRepository,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[Any] = []
+        self.fetch_rows: list[dict[str, Any]] = []
+        self.fetchval_calls: list[dict[str, Any]] = []
+        self.fetch_calls: list[dict[str, Any]] = []
+        self.execute_calls: list[dict[str, Any]] = []
+        self.execute_result: Any = "UPDATE 1"
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
+
+
+def _blueprint() -> BlogBlueprint:
+    return BlogBlueprint(
+        target_mode="vendor_alternative",
+        topic_type="pricing_pressure",
+        slug="acme-pricing-pressure",
+        suggested_title="Acme Pricing Pressure",
+        payload={
+            "sections": [
+                {"id": "intro", "heading": "Why Acme is losing price",
+                 "goal": "Frame the pressure"},
+            ],
+            "charts": [{"id": "pricing_mentions", "type": "bar"}],
+            "tags": ["pricing", "retention"],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_blueprints_round_trips_payload_jsonb() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["bp-uuid-1"]
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    saved = await repo.save_blueprints(
+        [_blueprint()],
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert saved == ("bp-uuid-1",)
+    args = pool.fetchval_calls[0]["args"]
+    assert args[0] == "acct-1"
+    assert args[1] == "vendor_alternative"
+    assert args[2] == "pricing_pressure"
+    assert args[3] == "acme-pricing-pressure"
+    assert args[4] == "Acme Pricing Pressure"
+    payload = json.loads(args[5])
+    assert payload["tags"] == ["pricing", "retention"]
+    assert payload["sections"][0]["id"] == "intro"
+
+
+@pytest.mark.asyncio
+async def test_save_blueprints_upsert_resets_consumed_at() -> None:
+    """Pinning the ON CONFLICT branch -- without
+    `consumed_at = NULL`, a re-saved blueprint would stay
+    invisible to `read_blog_blueprints` and the generator
+    would never re-pick it up after the first run."""
+
+    pool = _Pool()
+    pool.fetchval_results = ["bp-uuid-1"]
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    await repo.save_blueprints([_blueprint()], scope=TenantScope(account_id="acct-1"))
+
+    query = pool.fetchval_calls[0]["query"]
+    assert "ON CONFLICT (account_id, target_mode, slug) DO UPDATE" in query
+    assert "consumed_at = NULL" in query
+
+
+@pytest.mark.asyncio
+async def test_read_blog_blueprints_filters_by_scope_target_mode_and_unconsumed() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "bp-uuid-1",
+            "target_mode": "vendor_alternative",
+            "topic_type": "pricing_pressure",
+            "slug": "acme-pricing-pressure",
+            "suggested_title": "Acme Pricing Pressure",
+            "payload": {"sections": [], "tags": ["pricing"]},
+        },
+    ]
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    rows = await repo.read_blog_blueprints(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_alternative",
+        limit=5,
+    )
+
+    assert len(rows) == 1
+    query = pool.fetch_calls[0]["query"]
+    assert "account_id = $1" in query
+    assert "target_mode = $2" in query
+    assert "consumed_at IS NULL" in query
+    args = pool.fetch_calls[0]["args"]
+    assert args == ("acct-1", "vendor_alternative", 5)
+
+
+@pytest.mark.asyncio
+async def test_read_blog_blueprints_honors_topic_type_filter() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    await repo.read_blog_blueprints(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_alternative",
+        limit=10,
+        filters={"topic_type": "pricing_pressure"},
+    )
+
+    args = pool.fetch_calls[0]["args"]
+    # account_id, target_mode, topic_type, limit
+    assert args == ("acct-1", "vendor_alternative", "pricing_pressure", 10)
+    assert "topic_type = $3" in pool.fetch_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_read_blog_blueprints_merges_payload_with_row_metadata() -> None:
+    """The generator consumes a single dict; row-level metadata
+    (id / topic_type / slug / suggested_title / target_mode)
+    must land alongside the payload's sections / charts / tags."""
+
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "bp-uuid-1",
+            "target_mode": "vendor_alternative",
+            "topic_type": "pricing_pressure",
+            "slug": "acme-pricing-pressure",
+            "suggested_title": "Acme Pricing Pressure",
+            "payload": json.dumps(
+                {"sections": [{"id": "intro"}], "tags": ["pricing"]}
+            ),
+        },
+    ]
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    rows = await repo.read_blog_blueprints(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_alternative",
+        limit=5,
+    )
+
+    blueprint = rows[0]
+    assert blueprint["id"] == "bp-uuid-1"
+    assert blueprint["target_mode"] == "vendor_alternative"
+    assert blueprint["topic_type"] == "pricing_pressure"
+    assert blueprint["slug"] == "acme-pricing-pressure"
+    assert blueprint["suggested_title"] == "Acme Pricing Pressure"
+    assert blueprint["sections"] == [{"id": "intro"}]
+    assert blueprint["tags"] == ["pricing"]
+
+
+@pytest.mark.asyncio
+async def test_read_blog_blueprints_empty_table_returns_empty_tuple() -> None:
+    """Defensive canary -- the generator's loop must see an
+    empty Sequence (not a one-element tuple of None / partial
+    row) when the tenant has nothing to consume."""
+
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    rows = await repo.read_blog_blueprints(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_alternative",
+        limit=5,
+    )
+    assert rows == ()
+
+
+@pytest.mark.asyncio
+async def test_mark_consumed_issues_tenant_scoped_update() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 2"
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    hits = await repo.mark_consumed(
+        ["bp-uuid-1", "bp-uuid-2"],
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert hits == 1  # parse_command_tag returns True -> 1 here
+    query = pool.execute_calls[0]["query"]
+    assert "account_id = $1" in query
+    assert "id = ANY($2::uuid[])" in query
+    assert "consumed_at IS NULL" in query
+    args = pool.execute_calls[0]["args"]
+    assert args[0] == "acct-1"
+    assert args[1] == ["bp-uuid-1", "bp-uuid-2"]


### PR DESCRIPTION
Plan: `plans/PR-Blog-Blueprint-Storage-1.md`

## Summary

After PR #456 (E3), the host's Content Ops execution-services
bundle wires 5 of 6 outputs. The last unwired slot is
`blog_post`, which depends on a `BlogBlueprintRepository` that
the package only declared as a Protocol --
`extracted_content_pipeline/blog_ports.py:39` had no concrete
implementation. The host's autonomous task generates
`PostBlueprint` dataclasses in-memory and consumes them
immediately, so the bundle factory has nothing to plug into
`BlogPostGenerationService(blueprints=...)`.

This slice adds the storage layer only -- migration +
repository + tests. A follow-up
(`PR-Content-Ops-Execution-Services-Wire-4`) plugs the new
repo into the bundle factory so blog_post lights up.

## Files touched

1. `extracted_content_pipeline/storage/migrations/274_blog_blueprints.sql`
   (new): table + 3 indexes (unique on `(account_id,
   target_mode, slug)`, partial on `(account_id, target_mode,
   created_at DESC) WHERE consumed_at IS NULL`, and
   `(account_id, target_mode, topic_type, created_at DESC)`).
   No `status` column -- soft-delete is `consumed_at` only.
2. `extracted_content_pipeline/blog_blueprint_postgres.py`
   (new, ~210 LOC): `PostgresBlogBlueprintRepository` frozen
   dataclass implementing the upstream `read_blog_blueprints`
   Protocol method, plus `save_blueprints` (upsert that resets
   `consumed_at`) and `mark_consumed` (returns the integer
   count parsed from the `"UPDATE N"` command tag) extensions.
3. `tests/test_extracted_blog_blueprint_postgres.py` (new,
   8 tests): JSONB round-trip, upsert reset, scope/target_mode
   predicate, topic_type filter, payload-metadata merge,
   empty-table canary, count-parse pin on `mark_consumed`,
   empty-ids short-circuit canary.
4. `plans/PR-Blog-Blueprint-Storage-1.md` (new).

## Intentional

- **`payload` JSONB rather than per-field columns.** Blueprint
  shape evolves with generators; flattening forces a migration
  per shape change.
- **Unique `(account_id, target_mode, slug)` constraint.**
  Host's blueprint generators are idempotent on
  `(target, topic_type)` -- without the constraint, repeat
  runs would multiply rows.
- **`consumed_at` instead of DELETE-on-read.** Audit trail +
  ability to re-run a blueprint by clearing the timestamp.
  Default WHERE filter keeps consumed rows out of normal reads.
- **`save_blueprints` outside the upstream Protocol.** The
  Protocol stays read-only; this concrete repo adds the writer
  for hosts using the package's table. Hosts with their own
  blueprint store implement the Protocol against that store.
- **`save_blueprints` upsert clears `consumed_at`.** A re-saved
  blueprint must be eligible for re-generation; otherwise the
  read path's `consumed_at IS NULL` filter would hide it.
- **`mark_consumed` returns the actual integer count.**
  Inline parse of asyncpg's `"UPDATE N"` command tag so
  callers comparing the return to `len(blueprint_ids)` can
  detect partial-batch failures. Bool coercion would silently
  hide count mismatches.
- **Frozen-dataclass shape with configurable `table`.** Matches
  PR #455 / PR #456 wiring shape; tests can override.

## Deferred

- Bundle wiring of `blog_post`
  (`PR-Content-Ops-Execution-Services-Wire-4`).
- Host autonomous task changes to write blueprints into this
  table. The in-memory pipeline keeps working; a future
  slice extends it (or adds an ETL step) to populate
  `blog_blueprints`.
- Read-side filters beyond `topic_type` (vendor,
  created_after, etc.) -- already routed through the existing
  `filters` arg.
- Per-blueprint quality-gate or expiry policy.

## Verification

- `pytest tests/test_extracted_blog_blueprint_postgres.py`
  -- 8 passed locally.
- `bash scripts/validate_extracted_content_pipeline.sh` -- pass.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
  -- clean.
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
  -- Atlas runtime import findings: 0.
- AST + ASCII gates -- clean.
- CI: extracted-checks (×2) green; Vercel preview Ready.

## Test plan

- [x] `pytest tests/test_extracted_blog_blueprint_postgres.py`
- [x] Codex per-line review
- [x] Claude reviewer pass (MAJORs resolved, LGTM verdict)

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97