### PR TITLE
PR-Content-Ops-Execution-Services-Wire-4: wire blog_post

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -14,22 +14,33 @@ Currently wired:
   `PostgresLandingPageRepository` backed by the host's
   `DatabasePool`. `scope_provider` (PR #455) ensures drafts
   persist under the authenticated tenant.
-- `campaign` / `report` / `sales_brief` (E3, this slice):
+- `campaign` / `report` / `sales_brief` (E3, PR #456):
   share an identical wiring shape -- a single
   `PostgresIntelligenceRepository` (campaign opportunities)
   plus the per-output Postgres repo + LLM/Skill adapters.
   All three slots stay `None` when LLM or pool is absent.
+- `blog_post` (E4, this slice): plugs the
+  `PostgresBlogBlueprintRepository` (PR #458) +
+  `PostgresBlogPostRepository` + LLM/Skill adapters. Slot
+  stays `None` when LLM or pool is absent. After E4 the
+  bundle advertises 6 of 6 outputs.
 
-Follow-up slice (E4) wires `blog_post` -- different repo
-shape (`BlogBlueprintRepository`).
-
-See `plans/PR-Content-Ops-Execution-Services-Wire-3.md`.
+See `plans/PR-Content-Ops-Execution-Services-Wire-4.md`.
 """
 
 from __future__ import annotations
 
 from typing import Any, Callable
 
+from extracted_content_pipeline.blog_blueprint_postgres import (
+    PostgresBlogBlueprintRepository,
+)
+from extracted_content_pipeline.blog_generation import (
+    BlogPostGenerationService,
+)
+from extracted_content_pipeline.blog_post_postgres import (
+    PostgresBlogPostRepository,
+)
 from extracted_content_pipeline.campaign_generation import (
     CampaignGenerationService,
 )
@@ -160,6 +171,33 @@ def _build_sales_brief_service(
     )
 
 
+def _build_blog_post_service(
+    *,
+    llm: LLMClient | None,
+    skills: SkillStore,
+    pool: Any,
+) -> BlogPostGenerationService | None:
+    """E4: blog-post drafts.
+
+    Same short-circuit shape as `_build_landing_page_service`
+    (no `IntelligenceRepository` -- blog_post's data source is
+    the blueprint store, not campaign opportunities). An
+    empty `blog_blueprints` table just means
+    `BlogPostGenerationService.generate()` returns zero
+    drafts; the slot is still wired so the catalog endpoint
+    advertises `blog_post`.
+    """
+
+    if llm is None or pool is None:
+        return None
+    return BlogPostGenerationService(
+        blueprints=PostgresBlogBlueprintRepository(pool=pool),
+        blog_posts=PostgresBlogPostRepository(pool=pool),
+        llm=llm,
+        skills=skills,
+    )
+
+
 def build_content_ops_execution_services(
     *,
     llm_factory: Callable[[], LLMClient | None] | None = None,
@@ -215,6 +253,7 @@ def build_content_ops_execution_services(
     campaign = None
     report = None
     sales_brief = None
+    blog_post = None
     if enable_db_services:
         llm = llm_factory()
         skills = skills_factory()
@@ -248,6 +287,11 @@ def build_content_ops_execution_services(
             skills=skills,
             pool=pool,
         )
+        blog_post = _build_blog_post_service(
+            llm=llm,
+            skills=skills,
+            pool=pool,
+        )
 
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
@@ -255,6 +299,7 @@ def build_content_ops_execution_services(
         campaign=campaign,
         report=report,
         sales_brief=sales_brief,
+        blog_post=blog_post,
     )
 
 

--- a/plans/PR-Content-Ops-Execution-Services-Wire-4.md
+++ b/plans/PR-Content-Ops-Execution-Services-Wire-4.md
@@ -1,0 +1,175 @@
+# PR: wire `blog_post` service into bundle (E4 of N)
+
+## Why this slice exists
+
+After PR #456 (E3, IntelligenceRepository-dependent
+generators) and PR #458 (`PostgresBlogBlueprintRepository`
+storage layer), every dependency required to wire
+`blog_post` is now in place:
+
+- `BlogPostGenerationService` (extracted package, already
+  written).
+- `PostgresBlogPostRepository` (extracted package, already
+  written).
+- `PostgresBlogBlueprintRepository` (PR #458, just landed).
+- `LLMClient` + `SkillStore` adapters (PR #453).
+- Pool factory + scope_provider wiring (PRs #455 / #456).
+
+This slice plugs the last unwired Content Ops slot into the
+host bundle factory. After E4, `configured_outputs()`
+advertises 6 of 6 outputs when LLM and DB services are both
+enabled.
+
+## Scope (this PR)
+
+The bundle factory and the test file. No frontend or route
+changes; the production mount from PR #455 already passes
+`enable_db_services=True`.
+
+### Files touched
+
+1. `atlas_brain/_content_ops_services.py`:
+   - Add `_build_blog_post_service` helper following the
+     established `_build_landing_page_service` template --
+     short-circuit to `None` when LLM or pool is absent;
+     otherwise construct `BlogPostGenerationService` with
+     `PostgresBlogBlueprintRepository(pool=pool)` +
+     `PostgresBlogPostRepository(pool=pool)` + LLM/Skill
+     adapters.
+   - Update `build_content_ops_execution_services()` to call
+     the new helper when `enable_db_services=True` and pass
+     the result through to the `ContentOpsExecutionServices`
+     constructor's `blog_post` slot.
+   - Update the module docstring's "currently wired" inventory
+     so it lists `blog_post` alongside the other 5 outputs;
+     drop the "follow-up slice (E4)" note since this is E4.
+   - ~30 LOC delta.
+
+2. `tests/test_atlas_content_ops_execution_services.py`:
+   - Add 2 new "wired-when-LLM-active" canaries:
+     - `test_blog_post_wired_when_llm_active_and_db_enabled`
+       -- verifies `services.blog_post is not None` and
+       `services.for_output("blog_post") is services.blog_post`.
+     - `test_blog_post_slot_stays_none_when_no_active_llm`
+       -- mirror of the existing landing_page / campaign
+       fallback canaries. Pool-None canary is already
+       covered by `test_e3_services_skip_together_when_pool_is_none`
+       extended to assert the blog_post slot too.
+   - Replace the now-obsolete
+     `test_unwired_blog_post_still_returns_service_not_configured`
+     -- with all 6 outputs wired, the unwired set is empty.
+     Replace it with a canary that pins the new bundle shape
+     (`for_output("blog_post")` returns the service).
+   - Update the existing `configured_outputs()` expected
+     tuples to include `blog_post`. The upstream iteration
+     order is `(email_campaign, blog_post, report,
+     landing_page, sales_brief, signal_extraction)` --
+     verified at `extracted_content_pipeline/content_ops_execution.py:54-61`.
+   - Update the docstring inventory from 13 to 14 tests
+     (one swapped, two added).
+   - ~80 LOC delta.
+
+3. `plans/PR-Content-Ops-Execution-Services-Wire-4.md`
+   (this file).
+
+### What's NOT in this slice
+
+- **Host autonomous task changes to populate
+  `blog_blueprints`.** PR #458's storage layer adds the
+  table; a separate slice (or operator-driven ETL) lands
+  blueprints in it. The wired `blog_post` generator reads
+  whatever's there; an empty table just means
+  `BlogPostGenerationService.generate()` returns zero
+  drafts -- not an error.
+- **Reasoning context provider host wiring.** The bundle's
+  `with_reasoning_context()` derivation (PR #402) handles
+  per-request rebinding when the host wires a provider. Out
+  of scope.
+- **End-to-end smoke test posting to
+  `/api/v1/content-ops/execute`** with `outputs=["blog_post"]`
+  and asserting a real draft persists. Today's tests stop at
+  the bundle/service layer.
+
+## Mechanism
+
+The helper follows the established
+`_build_landing_page_service` template -- short-circuit on
+missing dependency, otherwise construct the service:
+
+```python
+def _build_blog_post_service(
+    *,
+    llm: LLMClient | None,
+    skills: SkillStore,
+    pool: Any,
+) -> BlogPostGenerationService | None:
+    """E4: blog-post drafts. Same short-circuit shape as
+    `_build_landing_page_service`."""
+
+    if llm is None or pool is None:
+        return None
+    return BlogPostGenerationService(
+        blueprints=PostgresBlogBlueprintRepository(pool=pool),
+        blog_posts=PostgresBlogPostRepository(pool=pool),
+        llm=llm,
+        skills=skills,
+    )
+```
+
+`build_content_ops_execution_services()` calls the helper in
+the same `if enable_db_services:` block as the other
+DB-backed generators, then passes the result to the
+`ContentOpsExecutionServices(blog_post=...)` constructor.
+
+## Intentional
+
+- **Same helper shape as `_build_landing_page_service`.**
+  Two repo args (blueprints + blog_posts) instead of one,
+  but otherwise identical -- short-circuit on
+  `llm is None or pool is None`, no IntelligenceRepository
+  needed (blog_post takes blueprints, not opportunities).
+- **No `intelligence is None` guard.** Unlike campaign /
+  report / sales_brief, `BlogPostGenerationService` does not
+  take an `IntelligenceRepository` -- its data source is the
+  blueprint store, not the campaign-opportunity table.
+- **`PostgresBlogBlueprintRepository` constructed with default
+  `table="blog_blueprints"`.** The dataclass exposes a
+  `table` override for tests; production accepts the default.
+- **Bundle advertises `blog_post` even with an empty
+  `blog_blueprints` table.** The slot wiring is independent
+  of data presence -- an empty table just means the
+  generator returns zero drafts. Surfacing
+  `service_not_configured` for "no blueprints yet" would
+  conflate "wiring missing" with "no data" and break the
+  catalog endpoint's `execution.configured_outputs` contract.
+- **`enable_db_services=False` production default
+  preserved.** Same Codex P1 safety pin from PR #454; PR
+  #455 flipped it on for the production mount. No change.
+
+## Deferred
+
+- Host autonomous task changes to populate
+  `blog_blueprints` (separate slice or operator ETL).
+- End-to-end smoke test posting to
+  `/api/v1/content-ops/execute` with each generator and
+  asserting real drafts persist.
+- Multi-pass reasoning provider host wiring.
+- Per-service config tuning.
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_execution_services.py`
+  -- updated tests pass.
+- AST + ASCII checks on the modified module + test file.
+
+## Estimated diff size
+
+- `_content_ops_services.py`: ~30 LOC delta.
+- Test: ~80 LOC delta.
+- Plan doc: ~155 LOC.
+
+Total: ~265 LOC. Comfortably within the 400 LOC PR target.
+The wiring is the smallest of the four execution-services
+slices because the helper is single-shape (no shared
+IntelligenceRepository instance) and the test extensions
+are minimal -- the existing fixtures cover the new slot.

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -7,10 +7,14 @@ the host has wired. Currently:
 - `signal_extraction` (E1, PR #452): always wired (stateless).
 - `landing_page` (E2 + E2.5, PRs #454/#455): wired when an
   LLM + pool are active; slot stays `None` otherwise.
-- `campaign` / `report` / `sales_brief` (E3, this slice):
+- `campaign` / `report` / `sales_brief` (E3, PR #456):
   same shape as landing_page but each also takes a
   shared `PostgresIntelligenceRepository`. Skip together
   when LLM or pool is absent.
+- `blog_post` (E4, this slice): same shape as
+  landing_page (no IntelligenceRepository); plugs the
+  `PostgresBlogBlueprintRepository` (PR #458) +
+  `PostgresBlogPostRepository`.
 
 Tests use the factory's dependency-injection kwargs (`llm_factory`
 / `skills_factory` / `pool_factory`) to stub host
@@ -18,7 +22,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (13 tests):
+Test inventory (14 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -32,19 +36,18 @@ Test inventory (13 tests):
 9. campaign / report / sales_brief skip together when no LLM.
 10. campaign / report / sales_brief skip together when pool
     is None.
-11. `blog_post` (the only remaining unwired output after E3)
-    still returns `service_not_configured`.
-12. `configured_outputs()` with LLM + db enabled advertises
-    `(email_campaign, report, landing_page, sales_brief,
-    signal_extraction)` -- order follows the upstream
-    `ContentOpsExecutionServices.configured_outputs` iteration
-    (not alphabetical).
-13. `configured_outputs()` without an active LLM (even with
+11. `blog_post` populated when LLM + db enabled (E4 canary)
+    and `for_output("blog_post")` returns the service.
+12. `blog_post` skips when no LLM (E4 fallback).
+13. `configured_outputs()` with LLM + db enabled advertises
+    all 6 outputs: `(email_campaign, blog_post, report,
+    landing_page, sales_brief, signal_extraction)` -- order
+    follows the upstream
+    `ContentOpsExecutionServices.configured_outputs`
+    iteration (not alphabetical).
+14. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     `signal_extraction`.
-
-When E4 wires `blog_post`, tests 11 and 12 need updated
-expected-sets.
 """
 
 from __future__ import annotations
@@ -138,6 +141,7 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
     assert services.landing_page is not None
     assert services.configured_outputs() == (
         "email_campaign",
+        "blog_post",
         "report",
         "landing_page",
         "sales_brief",
@@ -263,8 +267,9 @@ def test_e3_services_skip_together_when_no_active_llm() -> None:
 
 
 def test_e3_services_skip_together_when_pool_is_none() -> None:
-    """E3 fallback: campaign / report / sales_brief slots all
-    skip when pool is None during early host startup."""
+    """E3 + E4 fallback: campaign / report / sales_brief +
+    blog_post slots all skip when pool is None during early
+    host startup."""
 
     def _no_pool() -> Any:
         return None
@@ -278,16 +283,15 @@ def test_e3_services_skip_together_when_pool_is_none() -> None:
     assert services.campaign is None
     assert services.report is None
     assert services.sales_brief is None
+    assert services.blog_post is None
     assert services.configured_outputs() == ("signal_extraction",)
 
 
-@pytest.mark.asyncio
-async def test_unwired_blog_post_still_returns_service_not_configured() -> None:
-    """After E3 wires campaign / report / sales_brief, the only
-    output left in the unwired set is `blog_post` (different
-    repo shape -- BlogBlueprintRepository -- E4). The
-    executor's per-step dispatcher must surface that as
-    `service_not_configured`."""
+def test_blog_post_wired_when_llm_active_and_db_enabled() -> None:
+    """E4 canary: blog_post slot populated with the
+    `PostgresBlogBlueprintRepository` (PR #458) +
+    `PostgresBlogPostRepository` + LLM/Skill chain. Bundle's
+    `for_output("blog_post")` returns the service."""
 
     services = build_content_ops_execution_services(
         llm_factory=_make_llm_stub,
@@ -295,18 +299,24 @@ async def test_unwired_blog_post_still_returns_service_not_configured() -> None:
         pool_factory=_make_pool_stub,
         enable_db_services=True,
     )
+    assert services.blog_post is not None
+    assert services.for_output("blog_post") is services.blog_post
 
-    result = await execute_content_ops_from_mapping(
-        {
-            "outputs": ["blog_post"],
-            "inputs": {"topic": "Q3 churn signals"},
-        },
-        services=services,
+
+def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
+    """E4 fallback: blog_post slot stays `None` when no LLM
+    is active. Same short-circuit shape as landing_page
+    (PR #454). With no LLM only signal_extraction remains
+    advertised."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=True,
     )
-
-    assert result["status"] == "failed", result
-    assert len(result["errors"]) == 1
-    assert result["errors"][0]["reason"] == "service_not_configured"
+    assert services.blog_post is None
+    assert services.configured_outputs() == ("signal_extraction",)
 
 
 def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
@@ -323,6 +333,7 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
     )
     assert services.configured_outputs() == (
         "email_campaign",
+        "blog_post",
         "report",
         "landing_page",
         "sales_brief",


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Execution-Services-Wire-4.md`

## Summary

E4 of N. After PR #456 (E3) and PR #458 (blog blueprint
Postgres storage layer), every dependency required to wire
the last unwired Content Ops slot is now in place.

Adds `_build_blog_post_service` helper following the
established `_build_landing_page_service` template --
short-circuit to `None` when LLM or pool is absent;
otherwise construct
`BlogPostGenerationService(blueprints=PostgresBlogBlueprintRepository(pool=pool), blog_posts=PostgresBlogPostRepository(pool=pool), llm, skills)`.
No `IntelligenceRepository` -- blog_post's data source is
the blueprint store, not campaign opportunities.

After E4, `configured_outputs()` advertises **6 of 6** outputs
when LLM and DB services are both wired:
`(email_campaign, blog_post, report, landing_page,
sales_brief, signal_extraction)`.

## Files touched

1. `atlas_brain/_content_ops_services.py`:
   - Add `_build_blog_post_service` helper (~25 LOC).
   - Update `build_content_ops_execution_services()` to call
     the helper inside the existing
     `if enable_db_services:` block.
   - Module docstring: list `blog_post` (E4) under "Currently
     wired"; drop the "follow-up slice (E4)" note.
2. `tests/test_atlas_content_ops_execution_services.py`:
   - Extended from 13 to 14 tests:
     - New `test_blog_post_wired_when_llm_active_and_db_enabled`
       canary.
     - New `test_blog_post_slot_stays_none_when_no_active_llm`
       fallback.
     - Replaced obsolete
       `test_unwired_blog_post_still_returns_service_not_configured`
       (no unwired outputs left).
     - Extended `test_e3_services_skip_together_when_pool_is_none`
       to also pin `blog_post is None`.
   - All `configured_outputs()` expected tuples updated to
     the 6-output shape.
3. `plans/PR-Content-Ops-Execution-Services-Wire-4.md` (new).

## Intentional

- **Same helper shape as `_build_landing_page_service`.** Two
  repo args (blueprints + blog_posts) instead of one, no
  `IntelligenceRepository` -- blog_post takes blueprints,
  not opportunities.
- **No `intelligence is None` guard.**
  `BlogPostGenerationService` does not take an
  `IntelligenceRepository`.
- **`PostgresBlogBlueprintRepository` constructed with default
  `table="blog_blueprints"`.** The dataclass exposes a
  `table` override for tests; production accepts the default.
- **Bundle advertises `blog_post` even with an empty
  `blog_blueprints` table.** An empty table means
  `BlogPostGenerationService.generate()` returns zero
  drafts; the slot is still wired so the catalog endpoint
  advertises it. Surfacing `service_not_configured` for "no
  blueprints yet" would conflate "wiring missing" with "no
  data".
- **`enable_db_services=False` production default
  preserved.** Same Codex P1 safety pin from PR #454.

## Deferred

- Host autonomous task changes to populate
  `blog_blueprints` (separate slice or operator ETL).
- End-to-end smoke test posting to
  `/api/v1/content-ops/execute` with each generator and
  asserting real drafts persist.
- Multi-pass reasoning provider host wiring.
- Per-service config tuning.

## Verification

- `pytest tests/test_atlas_content_ops_execution_services.py`
  -- 14 passed locally.
- AST + ASCII gates -- clean.
- Smoke: imported the bundle factory with
  `enable_db_services=True` + LLM + pool stubs; verified
  `services.blog_post is not None`,
  `services.for_output("blog_post") is services.blog_post`,
  and `configured_outputs()` returns the 6-output tuple.

## Test plan

- [ ] CI runs `pytest tests/test_atlas_content_ops_execution_services.py`
- [ ] Codex per-line review
- [ ] Claude reviewer pass

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_