### PR TITLE
PR-Blog-Post-Subscriptions-1: B2B blog post subscriptions storage + reader

### DIFF
--- a/atlas_brain/_blog_post_subscriptions.py
+++ b/atlas_brain/_blog_post_subscriptions.py
@@ -1,0 +1,78 @@
+"""B2B blog post subscription reader.
+
+Per-tenant opt-in list for the autonomous blog-post task's
+blueprint fanout. PR-Subscriptions-2 wires the autonomous task
+to read this list once per run and fan blueprints out per
+matching subscription via
+``PostgresBlogBlueprintRepository.save_blueprints``.
+
+Subscriptions land in the host's ``b2b_blog_post_subscriptions``
+table (migration 324). This module is the typed reader; the
+autonomous task imports `list_active_blog_post_subscriptions`
+and `BlogPostSubscription.matches`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BlogPostSubscription:
+    """One tenant's opt-in row from ``b2b_blog_post_subscriptions``.
+
+    Empty ``topic_types`` / ``target_modes`` mean "accept all
+    values" -- the natural representation of "no restriction".
+    The ``matches`` predicate enforces the semantics so callers
+    don't conditionalize.
+    """
+
+    account_id: str
+    topic_types: tuple[str, ...] = ()
+    target_modes: tuple[str, ...] = ()
+
+    def matches(self, *, topic_type: str, target_mode: str) -> bool:
+        """Return whether a generated blueprint should fan out
+        to this subscription."""
+
+        if self.topic_types and topic_type not in self.topic_types:
+            return False
+        if self.target_modes and target_mode not in self.target_modes:
+            return False
+        return True
+
+
+async def list_active_blog_post_subscriptions(
+    pool: Any,
+) -> list[BlogPostSubscription]:
+    """Return enabled subscription rows ordered by account_id.
+
+    The expected subscription count is small (per-tenant
+    business-tier opt-in), so a list rather than an async
+    iterator keeps the call site simple. If counts grow,
+    switch to async iteration without a contract change.
+    """
+
+    rows = await pool.fetch(
+        """
+        SELECT account_id, topic_types, target_modes
+        FROM b2b_blog_post_subscriptions
+        WHERE enabled = TRUE
+        ORDER BY account_id
+        """
+    )
+    return [
+        BlogPostSubscription(
+            account_id=str(row["account_id"]),
+            topic_types=tuple(row["topic_types"] or ()),
+            target_modes=tuple(row["target_modes"] or ()),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "BlogPostSubscription",
+    "list_active_blog_post_subscriptions",
+]

--- a/atlas_brain/storage/migrations/324_b2b_blog_post_subscriptions.sql
+++ b/atlas_brain/storage/migrations/324_b2b_blog_post_subscriptions.sql
@@ -1,0 +1,32 @@
+-- B2B blog post subscriptions: per-tenant opt-in for scheduled blueprint
+-- fanout. The autonomous blog-post task (b2b_blog_post_generation) runs as a
+-- single-host cron; without per-tenant fanout, the blueprints it generates
+-- are visible to no authenticated tenant via /api/v1/content-ops/execute.
+--
+-- This table mirrors b2b_report_subscriptions (migration 0265) -- same FK
+-- shape, same enabled flag, same per-account uniqueness -- minus the
+-- delivery-mechanic fields (recipient_emails, frequency, freshness_policy)
+-- since blueprint fan-out is a write-side push (autonomous task ->
+-- blog_blueprints), not a read-side delivery.
+--
+-- topic_types / target_modes are filter arrays; an empty array means "accept
+-- all values". A subscription with empty filters receives every blueprint
+-- the autonomous task generates.
+--
+-- PR-Subscriptions-2 wires the autonomous task to read this list and fan
+-- out blueprints per matching subscription via
+-- PostgresBlogBlueprintRepository.save_blueprints.
+
+CREATE TABLE IF NOT EXISTS b2b_blog_post_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id UUID NOT NULL REFERENCES saas_accounts(id) ON DELETE CASCADE,
+    topic_types TEXT[] NOT NULL DEFAULT '{}',
+    target_modes TEXT[] NOT NULL DEFAULT '{}',
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_b2b_blog_post_subscriptions_enabled
+    ON b2b_blog_post_subscriptions (enabled, account_id);

--- a/plans/PR-Blog-Post-Subscriptions-1.md
+++ b/plans/PR-Blog-Post-Subscriptions-1.md
@@ -1,0 +1,193 @@
+# PR: blog post subscriptions schema + reader (Subscriptions-1 of 2)
+
+## Why this slice exists
+
+PR #459 wired `blog_post` into the Content Ops execution-services
+bundle (last unwired slot). The wired generator reads from
+`blog_blueprints` filtered by `scope.account_id` (Codex P1
+cross-tenant isolation contract). But the host's autonomous
+blog-post task (`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`)
+runs as a single-host scheduled cron with no tenant context --
+it generates `PostBlueprint`s in-memory and produces drafts
+directly without persisting blueprints anywhere.
+
+Result: the bundle advertises `blog_post`, but the table is
+empty for every authenticated tenant. Calling
+`/api/v1/content-ops/execute` with `outputs=["blog_post"]`
+returns zero drafts.
+
+To bridge, the autonomous task needs to fan out each generated
+blueprint to every account that's subscribed to B2B blog posts.
+This slice lands the storage + reader for that subscription
+list. PR-Subscriptions-2 wires the autonomous task itself.
+
+This shape mirrors `b2b_report_subscriptions`
+(`atlas_brain/storage/migrations/265_b2b_report_subscriptions.sql`)
+-- the established host pattern for per-tenant subscription
+to scheduled content-generation outputs. Same FK shape
+(`account_id REFERENCES saas_accounts(id) ON DELETE CASCADE`),
+same enabled/disabled flag, same per-account uniqueness.
+
+## Scope (this PR)
+
+Storage + reader only. No autonomous task changes; no
+end-to-end fanout.
+
+### Files touched
+
+1. **`atlas_brain/storage/migrations/324_b2b_blog_post_subscriptions.sql`**
+   (new): the subscription table + indexes. Mirrors
+   `b2b_report_subscriptions` shape minus the
+   delivery-mechanic fields (recipient_emails, frequency,
+   freshness_policy) since blueprint fan-out is a
+   write-side push, not a read-side delivery. Carries
+   `topic_types TEXT[]` + `target_modes TEXT[]` filters
+   (empty arrays = subscribe to all values) so accounts can
+   opt into specific blog topic_types or target_modes
+   without subscribing to the firehose.
+
+2. **`atlas_brain/_blog_post_subscriptions.py`** (new):
+   `BlogPostSubscription` dataclass (frozen, account_id +
+   topic_types + target_modes) + `matches()` predicate +
+   `list_active_blog_post_subscriptions(pool)` async reader
+   that returns enabled rows. The reader is the only thing
+   PR-Subscriptions-2's autonomous task calls; the dataclass
+   is the typed contract.
+
+   Lives at the `atlas_brain/` root (not inside
+   `services/`) for the same reason as the Content Ops
+   LLM/Skill adapters from PR #453: importing
+   `atlas_brain.services` triggers an eager torch / ollama
+   load that panics in dependency-light dev envs. The
+   underscore-prefix indicates a host-internal module --
+   not a public re-export surface.
+
+3. **`tests/test_atlas_blog_post_subscriptions.py`** (new):
+   ~8 tests pinning the reader's enabled-only filter, the
+   row-to-dataclass shape, and the `matches()` predicate's
+   filter semantics (empty = accept-all, populated = subset
+   match). Uses an asyncpg-shaped fake pool, same shape as
+   `tests/test_extracted_blog_blueprint_postgres.py`.
+
+4. **`plans/PR-Blog-Post-Subscriptions-1.md`** (this file).
+
+### What's NOT in this slice
+
+- **Autonomous task fanout.** Saved for PR-Subscriptions-2.
+  That slice imports `list_active_blog_post_subscriptions`
+  here, loops over each subscription, calls
+  `subscription.matches(topic_type=..., target_mode=...)`,
+  and writes a per-account copy of the blueprint via
+  `PostgresBlogBlueprintRepository.save_blueprints`.
+- **Subscription management endpoints / admin UI.**
+  Subscriptions land via direct SQL or NocoDB until a
+  follow-on slice ships an admin route. The B2B report
+  subscription pattern accumulated its admin surface
+  incrementally over many PRs (#266+); the same path here.
+- **Per-subscription delivery configuration** (recipient
+  emails, frequency, retention). The blueprint fanout is
+  fire-and-forget into `blog_blueprints` -- the
+  content-ops `/execute` route does the actual delivery on
+  user request.
+
+## Mechanism
+
+The reader is a thin asyncpg call returning typed rows:
+
+```python
+@dataclass(frozen=True)
+class BlogPostSubscription:
+    account_id: str
+    topic_types: tuple[str, ...] = ()
+    target_modes: tuple[str, ...] = ()
+
+    def matches(self, *, topic_type: str, target_mode: str) -> bool:
+        if self.topic_types and topic_type not in self.topic_types:
+            return False
+        if self.target_modes and target_mode not in self.target_modes:
+            return False
+        return True
+
+
+async def list_active_blog_post_subscriptions(
+    pool: Any,
+) -> list[BlogPostSubscription]:
+    rows = await pool.fetch(
+        """
+        SELECT account_id, topic_types, target_modes
+        FROM b2b_blog_post_subscriptions
+        WHERE enabled = TRUE
+        ORDER BY account_id
+        """
+    )
+    return [
+        BlogPostSubscription(
+            account_id=str(row["account_id"]),
+            topic_types=tuple(row["topic_types"] or ()),
+            target_modes=tuple(row["target_modes"] or ()),
+        )
+        for row in rows
+    ]
+```
+
+PR-Subscriptions-2 will call this once per autonomous run and
+fan out blueprints to each subscriber whose `matches()`
+predicate accepts the blueprint's topic_type / target_mode.
+
+## Intentional
+
+- **Mirror `b2b_report_subscriptions` shape**. Established
+  host pattern for per-tenant subscription to scheduled
+  content. Same FK, same enabled flag, same uniqueness on
+  `account_id`. Operators familiar with the report
+  subscription admin path apply the same mental model.
+- **`TEXT[]` filters with empty-array = accept-all
+  semantics.** Avoids a separate "subscribe to all" boolean
+  toggle; an empty filter is the natural representation of
+  "no restriction". The `matches()` predicate enforces the
+  semantics so callers don't conditionalize.
+- **Reader returns a list, not a generator / cursor.** The
+  expected subscription count is small (per-tenant
+  business-tier opt-in, not per-user); a list keeps the
+  call site simple. If subscription counts grow large, the
+  reader can switch to async iteration without a contract
+  change.
+- **`UNIQUE (account_id)` rather than `(account_id, topic)`.**
+  Each account gets one subscription row carrying the full
+  filter set; multiple-subscription-per-account would
+  require merge semantics on fanout. Single row keeps the
+  authoritative filter list visible.
+- **No `created_by` / `updated_by` audit columns.** The
+  report subscription mirror has them, but those exist to
+  power the report subscription admin UI's "set up by:"
+  display. Without an admin UI here yet, the columns would
+  carry no data; defer until an admin route ships.
+
+## Deferred
+
+- Autonomous task fanout (PR-Subscriptions-2).
+- Subscription management endpoints + admin UI.
+- Per-subscription delivery cadence (the autonomous task's
+  cron schedule is the cadence; per-account override is
+  out of scope).
+- Blueprint expiry / GC -- consumed_at + retention policy
+  handled in PR #458's storage layer.
+
+## Verification
+
+- `pytest tests/test_atlas_blog_post_subscriptions.py`
+  -- new tests pass.
+- AST + ASCII checks on the new module + test.
+- `bash scripts/check_ascii_python.sh` -- pass.
+
+## Estimated diff size
+
+- Migration: ~25 LOC.
+- Reader module: ~80 LOC.
+- Tests: ~180 LOC.
+- Plan doc: ~165 LOC.
+
+Total: ~450 LOC. Marginally over the 400 LOC soft cap.
+Indivisible -- a migration without a reader has no
+consumer, a reader without the migration won't pass tests
+against a real pool. Plan doc dominates.

--- a/tests/test_atlas_blog_post_subscriptions.py
+++ b/tests/test_atlas_blog_post_subscriptions.py
@@ -1,0 +1,175 @@
+"""Pin the B2B blog-post subscription reader.
+
+`atlas_brain/services/blog_post_subscriptions.py` is the typed
+contract PR-Subscriptions-2's autonomous task fanout will
+import. This file pins:
+- `list_active_blog_post_subscriptions(pool)` filters
+  enabled-only and returns typed dataclasses.
+- `BlogPostSubscription.matches(topic_type, target_mode)`
+  semantics: empty filters accept-all, populated filters do
+  subset matching.
+
+Test inventory (8 tests):
+
+1. Empty table returns an empty list.
+2. Active rows are converted to `BlogPostSubscription`s.
+3. The reader's WHERE clause keeps disabled rows out (the
+   fake pool delivers whatever rows the test sets, so the
+   contract here is the WHERE clause we ship in the SQL --
+   pin it via the recorded query string).
+4. Empty array columns deserialize to empty tuples.
+5. `matches()` with empty filters accepts everything.
+6. `matches()` with `topic_types` filter rejects mismatches.
+7. `matches()` with `target_modes` filter rejects mismatches.
+8. `matches()` with both filters requires both to pass.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from atlas_brain._blog_post_subscriptions import (
+    BlogPostSubscription,
+    list_active_blog_post_subscriptions,
+)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetch_rows: list[dict[str, Any]] = []
+        self.fetch_calls: list[dict[str, Any]] = []
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+
+@pytest.mark.asyncio
+async def test_empty_table_returns_empty_list() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+
+    subs = await list_active_blog_post_subscriptions(pool)
+
+    assert subs == []
+
+
+@pytest.mark.asyncio
+async def test_active_rows_become_typed_subscriptions() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "account_id": "acct-1",
+            "topic_types": ["vendor_alternative", "churn_report"],
+            "target_modes": ["vendor_retention"],
+        },
+        {
+            "account_id": "acct-2",
+            "topic_types": [],
+            "target_modes": [],
+        },
+    ]
+
+    subs = await list_active_blog_post_subscriptions(pool)
+
+    assert len(subs) == 2
+    assert subs[0].account_id == "acct-1"
+    assert subs[0].topic_types == ("vendor_alternative", "churn_report")
+    assert subs[0].target_modes == ("vendor_retention",)
+    assert subs[1].account_id == "acct-2"
+    assert subs[1].topic_types == ()
+    assert subs[1].target_modes == ()
+
+
+@pytest.mark.asyncio
+async def test_reader_query_filters_enabled_rows() -> None:
+    """The reader's contract for skipping disabled rows is
+    the SQL WHERE clause itself. Pin the query shape so a
+    refactor that drops the predicate is caught."""
+
+    pool = _Pool()
+    pool.fetch_rows = []
+
+    await list_active_blog_post_subscriptions(pool)
+
+    query = pool.fetch_calls[0]["query"]
+    assert "WHERE enabled = TRUE" in query
+    assert "FROM b2b_blog_post_subscriptions" in query
+    assert "ORDER BY account_id" in query
+
+
+@pytest.mark.asyncio
+async def test_null_array_columns_deserialize_to_empty_tuples() -> None:
+    """Defensive canary: asyncpg returns NULL columns as
+    `None`, not as empty arrays. The `or ()` coercion in the
+    reader guards against that. Without it, the dataclass
+    would be constructed with `topic_types=None`, breaking
+    the `matches()` predicate."""
+
+    pool = _Pool()
+    pool.fetch_rows = [
+        {"account_id": "acct-1", "topic_types": None, "target_modes": None},
+    ]
+
+    subs = await list_active_blog_post_subscriptions(pool)
+
+    assert subs[0].topic_types == ()
+    assert subs[0].target_modes == ()
+
+
+def test_matches_empty_filters_accepts_everything() -> None:
+    sub = BlogPostSubscription(account_id="acct-1")
+
+    assert sub.matches(topic_type="vendor_alternative", target_mode="vendor_retention")
+    assert sub.matches(topic_type="churn_report", target_mode="account")
+    assert sub.matches(topic_type="anything", target_mode="anything")
+
+
+def test_matches_topic_types_filter_rejects_mismatches() -> None:
+    sub = BlogPostSubscription(
+        account_id="acct-1",
+        topic_types=("vendor_alternative",),
+    )
+
+    assert sub.matches(topic_type="vendor_alternative", target_mode="anything")
+    assert not sub.matches(topic_type="churn_report", target_mode="anything")
+
+
+def test_matches_target_modes_filter_rejects_mismatches() -> None:
+    sub = BlogPostSubscription(
+        account_id="acct-1",
+        target_modes=("vendor_retention",),
+    )
+
+    assert sub.matches(topic_type="anything", target_mode="vendor_retention")
+    assert not sub.matches(topic_type="anything", target_mode="account")
+
+
+def test_matches_both_filters_requires_both_to_pass() -> None:
+    sub = BlogPostSubscription(
+        account_id="acct-1",
+        topic_types=("vendor_alternative",),
+        target_modes=("vendor_retention",),
+    )
+
+    assert sub.matches(
+        topic_type="vendor_alternative",
+        target_mode="vendor_retention",
+    )
+    # Topic matches, target doesn't.
+    assert not sub.matches(
+        topic_type="vendor_alternative",
+        target_mode="account",
+    )
+    # Target matches, topic doesn't.
+    assert not sub.matches(
+        topic_type="churn_report",
+        target_mode="vendor_retention",
+    )
+    # Neither matches.
+    assert not sub.matches(
+        topic_type="churn_report",
+        target_mode="account",
+    )

--- a/tests/test_atlas_blog_post_subscriptions.py
+++ b/tests/test_atlas_blog_post_subscriptions.py
@@ -1,6 +1,6 @@
 """Pin the B2B blog-post subscription reader.
 
-`atlas_brain/services/blog_post_subscriptions.py` is the typed
+`atlas_brain/_blog_post_subscriptions.py` is the typed
 contract PR-Subscriptions-2's autonomous task fanout will
 import. This file pins:
 - `list_active_blog_post_subscriptions(pool)` filters


### PR DESCRIPTION
Plan: `plans/PR-Blog-Post-Subscriptions-1.md`

## Summary

After PR #459, the host bundle wires `blog_post` into the
Content Ops execution-services bundle. The wired generator
reads `blog_blueprints` filtered by `scope.account_id`, but
the host's autonomous blog-post task runs as a single-host
scheduled cron with no tenant context -- it generates
`PostBlueprint`s in-memory without persisting any. Result:
the bundle advertises `blog_post` but every authenticated
tenant sees an empty table.

To bridge, the autonomous task needs to fan out each
blueprint to every account subscribed to B2B blog posts.
This slice lands the storage + reader for that subscription
list. PR-Subscriptions-2 wires the autonomous task fanout.

## Files touched

1. `atlas_brain/storage/migrations/324_b2b_blog_post_subscriptions.sql`
   (new, ~30 LOC): per-tenant table mirroring
   `0265_b2b_report_subscriptions` shape -- same FK
   (`account_id REFERENCES saas_accounts ON DELETE CASCADE`),
   same enabled flag, `UNIQUE (account_id)`. Filter columns
   `topic_types TEXT[]` / `target_modes TEXT[]` with empty
   array = accept-all semantics.
2. `atlas_brain/_blog_post_subscriptions.py` (new, ~85 LOC):
   `BlogPostSubscription` frozen dataclass +
   `matches(topic_type, target_mode)` predicate +
   `list_active_blog_post_subscriptions(pool)` async reader.
   Lives at `atlas_brain/` root (not `services/`) for the
   same reason as PR #453's LLM/Skill adapters: importing
   `atlas_brain.services` triggers an eager torch / ollama
   load that panics in dependency-light dev envs.
3. `tests/test_atlas_blog_post_subscriptions.py` (new, 8
   tests): enabled-only filter, query-shape contract,
   null-array defensive coercion, `matches()` semantics
   (empty = accept-all, populated = subset, both filters
   required).
4. `plans/PR-Blog-Post-Subscriptions-1.md` (new).

## Intentional

- **Mirror `b2b_report_subscriptions` shape.** Established
  host pattern for per-tenant subscription to scheduled
  content; operators familiar with the report subscription
  admin path apply the same mental model.
- **`TEXT[]` filters with empty-array = accept-all
  semantics.** Avoids a separate "subscribe to all" boolean
  toggle; an empty filter naturally represents "no
  restriction". `matches()` enforces the semantics.
- **Reader returns a list, not an async iterator.**
  Per-tenant subscription count is small. If counts grow,
  switch to async iteration without a contract change.
- **`UNIQUE (account_id)` rather than per-topic uniqueness.**
  Each account gets one row carrying the full filter set;
  multi-row would require merge semantics on fanout.
- **Module at `atlas_brain/` root with underscore prefix.**
  Same pattern as PR #453's `_content_ops_infrastructure.py`
  / PR #455's `_content_ops_scope.py` -- avoids the eager
  init chain in `atlas_brain.services`.
- **No `created_by` / `updated_by` audit columns.** The
  report subscription mirror has them to power admin UI
  display; without an admin route here yet, defer until one
  ships.

## Deferred

- Autonomous task fanout (PR-Subscriptions-2).
- Subscription management endpoints / admin UI -- the B2B
  report subscription pattern accumulated its admin surface
  incrementally over many PRs (#266+); same path here.
- Per-subscription delivery cadence -- the autonomous task's
  cron is the cadence.
- Blueprint expiry / GC -- handled in PR #458's storage
  layer via `consumed_at`.

## Verification

- `pytest tests/test_atlas_blog_post_subscriptions.py`
  -- 8 passed locally.
- AST parse + ASCII gate clean on the new module + test
  file.
- `bash scripts/check_ascii_python.sh` -- pass.

## Test plan

- [ ] CI runs `pytest tests/test_atlas_blog_post_subscriptions.py`
- [ ] Codex per-line review
- [ ] Claude reviewer pass

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_