### PR TITLE
PR-Blog-Post-Subscriptions-2: autonomous task tenant fanout

### DIFF
--- a/atlas_brain/_blog_blueprint_fanout.py
+++ b/atlas_brain/_blog_blueprint_fanout.py
@@ -1,0 +1,171 @@
+"""Fan an autonomous-task blueprint out to per-tenant subscribers.
+
+After the autonomous blog-post task generates and stores a
+finished blog draft, this helper looks up active
+``BlogPostSubscription`` rows (PR #460) and writes a per-account
+copy of the blueprint into ``blog_blueprints`` (PR #458) so the
+Content Ops ``/api/v1/content-ops/execute`` route (PR #459) can
+read them under each tenant's authenticated scope.
+
+Per-account ``save_blueprints`` failures are logged but don't
+abort the remaining fanout: the autonomous task's draft has
+already been stored, so partial fanout is strictly better than
+no fanout.
+
+Lives at ``atlas_brain/`` root for the same reason as
+``_blog_post_subscriptions.py`` and
+``_content_ops_infrastructure.py`` -- importing
+``atlas_brain.services`` triggers an eager torch / ollama load
+that panics in dependency-light dev envs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, is_dataclass
+from typing import Any, Awaitable, Callable, Sequence
+
+from extracted_content_pipeline.blog_blueprint_postgres import (
+    BlogBlueprint,
+    PostgresBlogBlueprintRepository,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+from ._blog_post_subscriptions import (
+    BlogPostSubscription,
+    list_active_blog_post_subscriptions,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Fixed target_mode for autonomous-task blueprints. The
+# autonomous task generates one shape of B2B retention blog
+# post regardless of topic_type; subscriptions filter by
+# topic_type for variety. target_mode is the top-level
+# grouping for future fan-in (e.g. an "executive brief"
+# generator emitting target_mode="executive_brief").
+DEFAULT_TARGET_MODE = "b2b_blog_post"
+
+
+SubscriptionsFactory = Callable[[], Awaitable[Sequence[BlogPostSubscription]]]
+RepoFactory = Callable[[Any], Any]
+
+
+async def fanout_blueprint(
+    pool: Any,
+    blueprint: Any,
+    *,
+    target_mode: str = DEFAULT_TARGET_MODE,
+    subscriptions_factory: SubscriptionsFactory | None = None,
+    repo_factory: RepoFactory | None = None,
+) -> int:
+    """Save a per-account copy of ``blueprint`` for every
+    matching subscription. Returns the count of fanout writes.
+
+    ``blueprint`` is duck-typed: any object exposing
+    ``topic_type`` / ``slug`` / ``suggested_title`` / ``sections``
+    / ``charts`` / ``tags`` / ``data_context`` /
+    ``quotable_phrases`` / ``cta`` is acceptable. The autonomous
+    task passes a ``PostBlueprint`` dataclass.
+
+    DI kwargs let tests stub the subscription reader and repo
+    constructor without populating the host's full init chain
+    (asyncpg / saas_accounts / blog_blueprints migration).
+    """
+
+    subs = await _read_subscriptions(pool, subscriptions_factory)
+    if not subs:
+        return 0
+
+    matching = [
+        sub
+        for sub in subs
+        if sub.matches(
+            topic_type=getattr(blueprint, "topic_type", ""),
+            target_mode=target_mode,
+        )
+    ]
+    if not matching:
+        return 0
+
+    repo = (
+        repo_factory(pool)
+        if repo_factory is not None
+        else PostgresBlogBlueprintRepository(pool=pool)
+    )
+
+    payload = _serialize_payload(blueprint)
+    saved = 0
+    for sub in matching:
+        record = BlogBlueprint(
+            target_mode=target_mode,
+            topic_type=str(getattr(blueprint, "topic_type", "")),
+            slug=str(getattr(blueprint, "slug", "")),
+            suggested_title=str(getattr(blueprint, "suggested_title", "")),
+            payload=payload,
+        )
+        try:
+            await repo.save_blueprints(
+                [record],
+                scope=TenantScope(account_id=sub.account_id),
+            )
+            saved += 1
+        except Exception as exc:
+            logger.warning(
+                "Blog blueprint fanout failed for account_id=%s slug=%s: %s",
+                sub.account_id,
+                getattr(blueprint, "slug", "?"),
+                exc,
+            )
+    return saved
+
+
+async def _read_subscriptions(
+    pool: Any,
+    factory: SubscriptionsFactory | None,
+) -> Sequence[BlogPostSubscription]:
+    if factory is not None:
+        return await factory()
+    return await list_active_blog_post_subscriptions(pool)
+
+
+def _serialize_payload(blueprint: Any) -> dict[str, Any]:
+    """Convert a PostBlueprint (or duck-typed analog) into a
+    JSONB-safe dict. Nested dataclasses (SectionSpec /
+    ChartSpec) round-trip through ``asdict``."""
+
+    return {
+        "sections": [
+            _to_dict(item) for item in (getattr(blueprint, "sections", None) or [])
+        ],
+        "charts": [
+            _to_dict(item) for item in (getattr(blueprint, "charts", None) or [])
+        ],
+        "tags": list(getattr(blueprint, "tags", None) or []),
+        "data_context": dict(getattr(blueprint, "data_context", None) or {}),
+        "quotable_phrases": [
+            _to_dict(item)
+            for item in (getattr(blueprint, "quotable_phrases", None) or [])
+        ],
+        "cta": _to_dict(getattr(blueprint, "cta", None))
+        if getattr(blueprint, "cta", None)
+        else None,
+    }
+
+
+def _to_dict(value: Any) -> Any:
+    """Coerce a dataclass / mapping into a plain dict."""
+
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, dict):
+        return dict(value)
+    return value
+
+
+__all__ = [
+    "DEFAULT_TARGET_MODE",
+    "fanout_blueprint",
+]

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -28,6 +28,7 @@ from typing import Any
 from ...config import settings
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
+from ..._blog_blueprint_fanout import fanout_blueprint as _fanout_blog_blueprint
 from ...services.scraping.sources import (
     VERIFIED_SOURCES,
     ReviewSource,
@@ -3237,6 +3238,16 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 )
                 continue
 
+            try:
+                fanout_count = await _fanout_blog_blueprint(pool, blueprint)
+                if fanout_count:
+                    logger.info(
+                        "Blog blueprint fanned out: slug=%s subscribers=%d",
+                        blueprint.slug, fanout_count,
+                    )
+            except Exception as exc:
+                logger.warning("Blog blueprint fanout exception: %s", exc)
+
             from ..visibility import record_attempt
             await record_attempt(
                 pool, artifact_type="blog_post", artifact_id=blueprint.slug,
@@ -3468,6 +3479,15 @@ async def _regenerate_existing_posts(
                 attempt_no=1,
             )
             if post_id:
+                try:
+                    fanout_count = await _fanout_blog_blueprint(pool, blueprint)
+                    if fanout_count:
+                        logger.info(
+                            "Blog blueprint fanned out: slug=%s subscribers=%d",
+                            slug, fanout_count,
+                        )
+                except Exception as exc:
+                    logger.warning("Blog blueprint fanout exception: %s", exc)
                 results.append({
                     "post_id": str(post_id),
                     "topic_type": topic_type,

--- a/plans/PR-Blog-Post-Subscriptions-2.md
+++ b/plans/PR-Blog-Post-Subscriptions-2.md
@@ -1,0 +1,238 @@
+# PR: autonomous task tenant fanout (Subscriptions-2 of 2)
+
+## Why this slice exists
+
+PR-Subscriptions-1 (PR #460) landed the
+`b2b_blog_post_subscriptions` table and the typed reader.
+This slice closes the loop: when the autonomous blog-post
+task (`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`)
+generates a `PostBlueprint`, fan it out to every active
+subscriber by writing a per-account copy into
+`blog_blueprints` (PR #458's table). The Content Ops
+`/api/v1/content-ops/execute` route then reads those
+blueprints under each tenant's authenticated scope and
+generates drafts on demand.
+
+After this lands, the wired `blog_post` slot from PR #459
+becomes functionally end-to-end: autonomous task ->
+subscriber fanout -> `/execute` route -> draft.
+
+## Scope (this PR)
+
+Fanout helper + autonomous task hook + tests. No subscription
+admin endpoints; no schema changes.
+
+### Files touched
+
+1. **`atlas_brain/_blog_blueprint_fanout.py`** (new, ~110
+   LOC): the fanout helper. Pure async function
+   `fanout_blueprint(pool, blueprint)` that:
+   - Calls `list_active_blog_post_subscriptions(pool)` (PR
+     #460's reader).
+   - Filters to subscriptions whose
+     `matches(topic_type, target_mode)` accepts the
+     blueprint.
+   - Builds a JSONB-safe payload from the host's
+     `PostBlueprint` (sections + charts + tags +
+     data_context + quotable_phrases + cta).
+   - For each matching subscription, calls
+     `PostgresBlogBlueprintRepository.save_blueprints` with
+     `TenantScope(account_id=subscription.account_id)`.
+   - Per-account `save` failures are logged but don't abort
+     the remaining fanout -- the autonomous task's draft
+     has already been generated and stored; partial fanout
+     is strictly better than no fanout.
+   - DI kwargs (`subscriptions_factory`, `repo_factory`)
+     so tests stub host infrastructure without triggering
+     asyncpg / heavy host init.
+   - Lives at `atlas_brain/` root (not `services/`) for the
+     same reason as PR #460's `_blog_post_subscriptions.py`
+     and PR #453's `_content_ops_infrastructure.py`:
+     importing `atlas_brain.services` triggers an eager
+     torch / ollama load.
+
+2. **`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`**
+   (modified, ~15 LOC delta): import the fanout helper and
+   call it at the two existing `_assemble_and_store`
+   callsites (lines 3222 and 3462) AFTER the draft is
+   stored. Wrapped in try/except so a fanout failure never
+   regresses the existing autonomous flow; logged at WARN
+   level.
+
+3. **`tests/test_atlas_blog_blueprint_fanout.py`** (new,
+   8 tests, ~225 LOC): pin the helper's empty-list
+   short-circuit, no-matching-subscribers short-circuit,
+   payload serialization, multi-subscriber count return,
+   per-account save isolation (one failure doesn't abort
+   the rest), `target_mode` default, and the matches()
+   filter integration with both topic_types and
+   target_modes constraints.
+
+4. **`plans/PR-Blog-Post-Subscriptions-2.md`** (this file).
+
+### What's NOT in this slice
+
+- **Subscription management endpoints / admin UI.** Same as
+  PR #460's deferred list -- subscriptions land via direct
+  SQL or NocoDB until a follow-on slice ships an admin
+  route.
+- **Backfilling existing blog_posts into blog_blueprints.**
+  The autonomous task's prior runs produced finished blog
+  drafts in `blog_posts`; this slice only fans out
+  blueprints generated AFTER it lands. Operators wanting
+  retroactive fanout run a one-shot ETL.
+- **Per-subscription cadence override.** Cadence is the
+  autonomous task's existing cron; per-account override is
+  out of scope.
+
+## Mechanism
+
+The helper is a pure async function with three tunable
+seams (DI kwargs):
+
+```python
+async def fanout_blueprint(
+    pool: Any,
+    blueprint: Any,  # PostBlueprint duck-typed
+    *,
+    target_mode: str = DEFAULT_TARGET_MODE,
+    subscriptions_factory: Callable | None = None,
+    repo_factory: Callable | None = None,
+) -> int:
+    if subscriptions_factory is not None:
+        subs = await subscriptions_factory()
+    else:
+        subs = await list_active_blog_post_subscriptions(pool)
+    if not subs:
+        return 0
+
+    matching = [
+        s for s in subs
+        if s.matches(topic_type=blueprint.topic_type,
+                     target_mode=target_mode)
+    ]
+    if not matching:
+        return 0
+
+    repo = (repo_factory or PostgresBlogBlueprintRepository)(pool=pool)
+    payload = _serialize_payload(blueprint)
+
+    saved = 0
+    for sub in matching:
+        record = BlogBlueprint(
+            target_mode=target_mode,
+            topic_type=blueprint.topic_type,
+            slug=blueprint.slug,
+            suggested_title=blueprint.suggested_title,
+            payload=payload,
+        )
+        try:
+            await repo.save_blueprints(
+                [record],
+                scope=TenantScope(account_id=sub.account_id),
+            )
+            saved += 1
+        except Exception as exc:
+            logger.warning(
+                "Blog blueprint fanout failed for account_id=%s slug=%s: %s",
+                sub.account_id, blueprint.slug, exc,
+            )
+    return saved
+```
+
+The autonomous task hook is a single new line at each of the
+two `_assemble_and_store` callsites (in a try/except so a
+fanout exception can't regress the existing flow):
+
+```python
+post_id = await _assemble_and_store(...)
+if post_id:
+    try:
+        fanout_count = await _fanout_blog_blueprint(pool, blueprint)
+        if fanout_count:
+            logger.info(
+                "Blog blueprint fanned out: slug=%s subscribers=%d",
+                blueprint.slug, fanout_count,
+            )
+    except Exception as exc:
+        logger.warning("Blog blueprint fanout exception: %s", exc)
+```
+
+## Intentional
+
+- **Fixed `DEFAULT_TARGET_MODE = "b2b_blog_post"`.** The
+  autonomous task generates one shape of B2B retention
+  blog post regardless of topic_type; subscriptions filter
+  by topic_type for variety. `target_mode` is the
+  top-level grouping for future fan-in (e.g. a separate
+  "executive brief" generator emitting
+  `target_mode="executive_brief"`). Operators that want
+  finer per-target-mode subscription control populate
+  `b2b_blog_post_subscriptions.target_modes[]` accordingly.
+- **Per-account `save` failures don't abort the fanout.**
+  The autonomous task's draft has already been stored
+  (post_id is non-empty); partial fanout is strictly better
+  than no fanout. Errors logged at WARN.
+- **Fanout happens AFTER `_assemble_and_store`** rather than
+  before. If the draft generation fails mid-way, we don't
+  want to land a blueprint in subscribers' `blog_blueprints`
+  that the host's blog_posts table never produced anything
+  from -- that would surface in `/execute` as a draft
+  attempt that may then fail differently.
+- **DI kwargs (`subscriptions_factory`, `repo_factory`) on
+  the helper.** Same pattern as PRs #453 / #455 / #460 --
+  tests pass stubs without triggering the host's full init
+  chain.
+- **Helper lives at `atlas_brain/` root with underscore
+  prefix.** Matches `_blog_post_subscriptions.py` /
+  `_content_ops_infrastructure.py` / `_content_ops_scope.py`
+  -- avoids the heavy `atlas_brain.services` import chain
+  in dev environments.
+- **Two callsites patched, not one.** The autonomous task
+  has two `_assemble_and_store` callsites (different topic
+  generation phases); both produce blueprints that should
+  fan out. Refactoring them into a single funnel is a
+  separate refactor; the surgical insert keeps this slice
+  focused.
+
+## Deferred
+
+- Subscription management admin UI / API endpoints.
+- Backfilling pre-existing `blog_posts` rows into
+  `blog_blueprints` for new subscribers.
+- Per-subscription cadence overrides.
+- `b2b_blog_post_subscriptions` audit columns
+  (`created_by`, `updated_by`) -- carry no data without an
+  admin route.
+- Multi-pass reasoning provider host wiring.
+
+## Verification
+
+- `pytest tests/test_atlas_blog_blueprint_fanout.py`
+  -- new tests pass.
+- `pytest tests/test_atlas_blog_post_subscriptions.py`
+  -- existing PR #460 tests stay green.
+- AST + ASCII checks on the new module + test +
+  modified autonomous task file.
+- Smoke: `python -c "from atlas_brain._blog_blueprint_fanout
+  import fanout_blueprint; print(fanout_blueprint)"` -> the
+  function imports cleanly without triggering the heavy
+  host init chain.
+
+## Estimated diff size
+
+- `_blog_blueprint_fanout.py`: ~115 LOC.
+- Autonomous task patch: ~15 LOC delta (1 import + 2
+  callsite hooks of ~7 LOC each).
+- Tests: ~225 LOC (8 tests).
+- Plan doc: ~190 LOC.
+
+Total: ~545 LOC. Marginally over the 400 LOC soft cap.
+Indivisible at the helper-plus-callsite seam: the helper
+without callsites is dead code, the callsites without the
+helper would inline the logic into the 9000-line
+autonomous task file. Splitting into separate "helper PR"
++ "callsites PR" buys nothing -- the helper's tests
+exercise the full contract. The autonomous task
+modifications are mechanical and don't change behavior on
+empty-subscription deployments.

--- a/tests/test_atlas_blog_blueprint_fanout.py
+++ b/tests/test_atlas_blog_blueprint_fanout.py
@@ -1,0 +1,286 @@
+"""Pin the blog-blueprint fanout helper.
+
+`atlas_brain/_blog_blueprint_fanout.py` is the bridge between
+the autonomous task's in-memory `PostBlueprint` and the
+per-tenant `blog_blueprints` table. PR-Subscriptions-2 hooks
+this into the autonomous task's two `_assemble_and_store`
+callsites; the tests here pin the helper's contract:
+
+1. Empty subscription list short-circuits to 0 (no repo
+   construction, no save).
+2. No-matching-subscriber short-circuits (subs exist but
+   all reject the blueprint's topic_type / target_mode).
+3. Multi-subscriber fanout returns the count of saves.
+4. Per-account save failure is logged but doesn't abort the
+   remaining fanout (partial fanout is better than none).
+5. Payload serialization handles SectionSpec / ChartSpec
+   nested dataclasses.
+6. `target_mode` default is the package-level constant.
+7. `target_mode` override is honored.
+8. `topic_types` / `target_modes` filters integrate
+   correctly via `matches()`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from types import SimpleNamespace
+
+import pytest
+
+from atlas_brain._blog_blueprint_fanout import (
+    DEFAULT_TARGET_MODE,
+    fanout_blueprint,
+)
+from atlas_brain._blog_post_subscriptions import BlogPostSubscription
+
+
+@dataclass
+class _ChartStub:
+    chart_id: str
+    chart_type: str
+    title: str
+    data: list[dict[str, Any]] = field(default_factory=list)
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _SectionStub:
+    id: str
+    heading: str
+    goal: str
+    key_stats: dict[str, Any] = field(default_factory=dict)
+
+
+def _blueprint(
+    *,
+    topic_type: str = "vendor_alternative",
+    slug: str = "acme-pricing",
+) -> Any:
+    """Duck-type the host's PostBlueprint without importing
+    the 9000-line autonomous task."""
+
+    return SimpleNamespace(
+        topic_type=topic_type,
+        slug=slug,
+        suggested_title="Acme Pricing Pressure",
+        tags=["pricing", "retention"],
+        data_context={"vendor": "Acme", "report_date": "2026-05-09"},
+        sections=[_SectionStub(id="intro", heading="Why Acme", goal="Frame")],
+        charts=[_ChartStub(chart_id="px", chart_type="bar", title="Mentions")],
+        quotable_phrases=[{"text": "moving away from Acme", "vendor": "Acme"}],
+        cta={"label": "See alternatives", "href": "/alts"},
+    )
+
+
+class _RecordingRepo:
+    def __init__(self, *, fail_for_account: str | None = None) -> None:
+        self.saved: list[tuple[str, str]] = []
+        self.fail_for_account = fail_for_account
+
+    async def save_blueprints(self, blueprints, *, scope):
+        if self.fail_for_account and scope.account_id == self.fail_for_account:
+            raise RuntimeError("simulated DB failure")
+        for bp in blueprints:
+            self.saved.append((scope.account_id, bp.slug))
+
+
+@pytest.mark.asyncio
+async def test_empty_subscription_list_short_circuits() -> None:
+    repo = _RecordingRepo()
+
+    async def _no_subs() -> list[BlogPostSubscription]:
+        return []
+
+    saved = await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(),
+        subscriptions_factory=_no_subs,
+        repo_factory=lambda _pool: repo,
+    )
+
+    assert saved == 0
+    assert repo.saved == []
+
+
+@pytest.mark.asyncio
+async def test_no_matching_subscriber_short_circuits() -> None:
+    """All subs reject the blueprint's topic_type so the
+    fanout writes nothing -- distinct from the empty-list
+    canary because subs exist; just none match."""
+
+    repo = _RecordingRepo()
+
+    async def _subs() -> list[BlogPostSubscription]:
+        return [
+            BlogPostSubscription(
+                account_id="acct-1",
+                topic_types=("churn_report",),
+            ),
+        ]
+
+    saved = await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(topic_type="vendor_alternative"),
+        subscriptions_factory=_subs,
+        repo_factory=lambda _pool: repo,
+    )
+    assert saved == 0
+    assert repo.saved == []
+
+
+@pytest.mark.asyncio
+async def test_multi_subscriber_fanout_returns_count() -> None:
+    repo = _RecordingRepo()
+
+    async def _subs() -> list[BlogPostSubscription]:
+        return [
+            BlogPostSubscription(account_id="acct-1"),
+            BlogPostSubscription(account_id="acct-2"),
+            BlogPostSubscription(account_id="acct-3"),
+        ]
+
+    saved = await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(slug="acme-pricing"),
+        subscriptions_factory=_subs,
+        repo_factory=lambda _pool: repo,
+    )
+    assert saved == 3
+    assert sorted(repo.saved) == [
+        ("acct-1", "acme-pricing"),
+        ("acct-2", "acme-pricing"),
+        ("acct-3", "acme-pricing"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_per_account_save_failure_does_not_abort_others() -> None:
+    """The autonomous task's draft is already stored when
+    fanout runs; one bad subscription must not lose the
+    remaining writes."""
+
+    repo = _RecordingRepo(fail_for_account="acct-2")
+
+    async def _subs() -> list[BlogPostSubscription]:
+        return [
+            BlogPostSubscription(account_id="acct-1"),
+            BlogPostSubscription(account_id="acct-2"),  # fails
+            BlogPostSubscription(account_id="acct-3"),
+        ]
+
+    saved = await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(),
+        subscriptions_factory=_subs,
+        repo_factory=lambda _pool: repo,
+    )
+    assert saved == 2
+    assert sorted(repo.saved) == [
+        ("acct-1", "acme-pricing"),
+        ("acct-3", "acme-pricing"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_payload_serializes_nested_dataclasses() -> None:
+    """SectionSpec / ChartSpec are dataclasses; the helper
+    converts them via asdict so JSONB serialization in the
+    Postgres adapter (PR #458) sees plain dicts."""
+
+    captured: dict[str, Any] = {}
+
+    class _PayloadCapturingRepo:
+        async def save_blueprints(self, blueprints, *, scope):
+            captured["payload"] = blueprints[0].payload
+
+    async def _subs() -> list[BlogPostSubscription]:
+        return [BlogPostSubscription(account_id="acct-1")]
+
+    await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(),
+        subscriptions_factory=_subs,
+        repo_factory=lambda _pool: _PayloadCapturingRepo(),
+    )
+
+    payload = captured["payload"]
+    assert payload["sections"] == [
+        {"id": "intro", "heading": "Why Acme", "goal": "Frame", "key_stats": {}},
+    ]
+    assert payload["charts"] == [
+        {
+            "chart_id": "px",
+            "chart_type": "bar",
+            "title": "Mentions",
+            "data": [],
+            "config": {},
+        },
+    ]
+    assert payload["tags"] == ["pricing", "retention"]
+    assert payload["data_context"]["vendor"] == "Acme"
+    assert payload["quotable_phrases"][0]["vendor"] == "Acme"
+    assert payload["cta"]["label"] == "See alternatives"
+
+
+def test_default_target_mode_constant_is_b2b_blog_post() -> None:
+    """The autonomous task fans out under a single target_mode
+    so subscriptions can fan in by topic_type alone. Pin the
+    constant so a renaming refactor surfaces here."""
+
+    assert DEFAULT_TARGET_MODE == "b2b_blog_post"
+
+
+@pytest.mark.asyncio
+async def test_target_mode_override_is_honored() -> None:
+    captured: dict[str, Any] = {}
+
+    class _Repo:
+        async def save_blueprints(self, blueprints, *, scope):
+            captured["target_mode"] = blueprints[0].target_mode
+
+    async def _subs() -> list[BlogPostSubscription]:
+        return [BlogPostSubscription(account_id="acct-1")]
+
+    await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(),
+        target_mode="executive_brief",
+        subscriptions_factory=_subs,
+        repo_factory=lambda _pool: _Repo(),
+    )
+    assert captured["target_mode"] == "executive_brief"
+
+
+@pytest.mark.asyncio
+async def test_target_modes_filter_rejects_default_target_mode() -> None:
+    """A subscription with target_modes=("executive_brief",)
+    rejects the default b2b_blog_post target_mode and the
+    fanout writes nothing for that account. Confirms the
+    helper passes target_mode through matches() correctly."""
+
+    repo = _RecordingRepo()
+
+    async def _subs() -> list[BlogPostSubscription]:
+        return [
+            BlogPostSubscription(
+                account_id="acct-only-exec",
+                target_modes=("executive_brief",),
+            ),
+            BlogPostSubscription(
+                account_id="acct-firehose",
+            ),
+        ]
+
+    saved = await fanout_blueprint(
+        pool=SimpleNamespace(),
+        blueprint=_blueprint(),
+        subscriptions_factory=_subs,
+        repo_factory=lambda _pool: repo,
+    )
+    # Only the firehose subscription matches the default
+    # target_mode; the exec-brief-only subscription is
+    # filtered out.
+    assert saved == 1
+    assert repo.saved == [("acct-firehose", "acme-pricing")]


### PR DESCRIPTION
Plan: `plans/PR-Blog-Post-Subscriptions-2.md`

## Summary

Closes the Content Ops `blog_post` functional loop.
PR-Subscriptions-1 (PR #460) landed the
`b2b_blog_post_subscriptions` table and the typed reader.
This slice adds the fanout helper and hooks it into the
autonomous blog-post task at the two `_assemble_and_store`
callsites (main daily run + regeneration path).

After this:
1. Autonomous task generates a `PostBlueprint`.
2. Stores the finished blog draft in `blog_posts` (existing
   flow, unchanged).
3. Calls `fanout_blueprint(pool, blueprint)` -> reads
   active subscriptions, filters via `matches()`, writes a
   per-account copy of the blueprint into `blog_blueprints`
   (PR #458's table) for every matching subscriber.
4. Content Ops `/api/v1/content-ops/execute` reads those
   blueprints under the authenticated tenant scope and
   generates additional drafts on demand.

## Files touched

1. `atlas_brain/_blog_blueprint_fanout.py` (new, ~165 LOC):
   `fanout_blueprint` async helper with DI seams
   (`subscriptions_factory`, `repo_factory`). Per-account
   save failures logged but don't abort remaining fanout.
   `DEFAULT_TARGET_MODE = "b2b_blog_post"` pins the
   host's blog flavor. Lives at `atlas_brain/` root for the
   same reason as PR #460's
   `_blog_post_subscriptions.py` and PR #453's
   `_content_ops_infrastructure.py` (avoids heavy
   `atlas_brain.services` import chain).
2. `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
   (modified, ~25 LOC delta): one new top-level import + two
   surgical try/except hooks after each `_assemble_and_store`
   callsite. Fanout exceptions log at WARN level; never
   regress the existing autonomous flow.
3. `tests/test_atlas_blog_blueprint_fanout.py` (new, 8
   tests, ~300 LOC): empty-list short-circuit,
   no-matching-subscriber short-circuit, multi-subscriber
   count return, per-account failure isolation, payload
   serialization of nested `SectionSpec` / `ChartSpec`
   dataclasses, `target_mode` default + override,
   `target_modes` filter integration via `matches()`.
4. `plans/PR-Blog-Post-Subscriptions-2.md` (new).

## Intentional

- **Fixed `DEFAULT_TARGET_MODE = "b2b_blog_post"`.** The
  autonomous task generates one shape of B2B retention blog
  post; subscriptions filter by `topic_type` for variety.
  `target_mode` is the top-level grouping for future fan-in
  (e.g. an "executive brief" generator emitting
  `target_mode="executive_brief"`). Operators wanting finer
  per-target-mode control populate
  `b2b_blog_post_subscriptions.target_modes[]`.
- **Per-account `save` failures don't abort the fanout.**
  The autonomous task's draft has already been stored
  (post_id is non-empty when fanout runs); partial fanout
  is strictly better than no fanout.
- **Fanout happens AFTER `_assemble_and_store` succeeds.**
  Guards against landing blueprints in subscribers' tables
  when the autonomous flow itself failed mid-run.
- **DI kwargs on the helper.** Same pattern as PRs #453 /
  #455 / #460 -- tests stub host infrastructure without
  triggering the full init chain.
- **Two surgical callsite hooks, not a refactor.** The
  autonomous task has two `_assemble_and_store` callsites
  (main run + regeneration path); both produce blueprints
  that should fan out. Refactoring them into a single funnel
  is a separate slice.
- **Helper at `atlas_brain/` root with underscore prefix.**
  Avoids the heavy `services/__init__.py` torch/ollama
  load.

## Deferred

- Subscription management admin UI / API endpoints.
- Backfilling pre-existing `blog_posts` rows into
  `blog_blueprints` for new subscribers.
- Per-subscription cadence overrides.
- `b2b_blog_post_subscriptions` audit columns
  (`created_by` / `updated_by`).
- Multi-pass reasoning provider host wiring.

## Verification

- `pytest tests/test_atlas_blog_blueprint_fanout.py`
  -- 8 passed locally.
- `pytest tests/test_atlas_blog_post_subscriptions.py`
  -- 8 passed (PR #460 unchanged).
- AST + ASCII gates clean on all 3 changed files (helper +
  autonomous task + new test).
- Smoke: helper module imports cleanly without triggering
  the heavy host init chain.

## Test plan

- [ ] CI runs `pytest tests/test_atlas_blog_blueprint_fanout.py`
- [ ] Codex per-line review
- [ ] Claude reviewer pass

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_