### PR TITLE
PR-Content-Ops-Reasoning-Provider-Host-Wire-1: file-backed provider

### DIFF
--- a/atlas_brain/_content_ops_reasoning.py
+++ b/atlas_brain/_content_ops_reasoning.py
@@ -1,0 +1,104 @@
+"""Host factory for the Content Ops reasoning context provider.
+
+PR #402 shipped the route-level ``reasoning_context_provider``
+seam in ``extracted_content_pipeline/api/control_surfaces.py``
+plus the bundle's per-request ``with_reasoning_context()``
+derivation. This module is the host adapter the route mount
+calls to obtain a configured provider (or ``None``).
+
+Operators opt in by setting
+``ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH`` to a JSON file
+readable by the package's ``FileCampaignReasoningContextProvider``.
+When unset the factory returns ``None`` -- no behavior change
+for hosts that haven't opted in.
+
+Loader exceptions resolve to ``None`` with a WARN log so a
+malformed file never crashes the route mount.
+
+Lives at ``atlas_brain/`` root with underscore prefix to dodge
+the heavy ``atlas_brain.services`` import chain (same pattern as
+``_content_ops_infrastructure.py`` / ``_content_ops_scope.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+
+logger = logging.getLogger(__name__)
+
+
+_ENV_VAR = "ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH"
+
+
+def build_content_ops_reasoning_context_provider(
+    *,
+    path_factory: Callable[[], str | None] | None = None,
+    loader_factory: Callable[[str], Any] | None = None,
+) -> Any | None:
+    """Return the configured reasoning context provider, or
+    ``None`` when the host hasn't opted in.
+
+    Hosts opt in by setting
+    ``ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH`` to a JSON file
+    readable by ``FileCampaignReasoningContextProvider``. Failures
+    (missing file, parse errors) resolve to ``None`` with a
+    warning logged -- the reasoning provider is enrichment, a
+    bad file must not block the entire Content Ops surface for
+    all tenants.
+
+    DI kwargs let tests stub the env-var read and the loader
+    without touching the filesystem or the heavy
+    ``extracted_content_pipeline.campaign_reasoning_data`` module.
+    """
+
+    path = (path_factory or _read_env_path)()
+    if not path:
+        return None
+    if not Path(path).is_file():
+        logger.warning(
+            "Content Ops reasoning context path %s does not exist; "
+            "provider stays unwired.",
+            path,
+        )
+        return None
+
+    loader = loader_factory or _default_loader
+    try:
+        return loader(path)
+    except Exception as exc:
+        logger.warning(
+            "Failed to load Content Ops reasoning context from %s: %s",
+            path,
+            exc,
+        )
+        return None
+
+
+def _read_env_path() -> str | None:
+    """Read the env var; return ``None`` for unset / empty."""
+
+    value = os.environ.get(_ENV_VAR)
+    return value or None
+
+
+def _default_loader(path: str) -> Any:
+    """Lazy import the package's file-backed loader.
+
+    Keeps this module light enough to import in dependency-light
+    dev envs; the heavier
+    ``extracted_content_pipeline.campaign_reasoning_data`` only
+    loads when the env var is actually set.
+    """
+
+    from extracted_content_pipeline.campaign_reasoning_data import (
+        load_campaign_reasoning_context_provider,
+    )
+
+    return load_campaign_reasoning_context_provider(path)
+
+
+__all__ = ["build_content_ops_reasoning_context_provider"]

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -161,6 +161,9 @@ try:
         build_content_ops_scope,
         set_current_auth_user,
     )
+    from .._content_ops_reasoning import (
+        build_content_ops_reasoning_context_provider,
+    )
     from ..auth.dependencies import AuthUser
 
     async def _capture_content_ops_auth_user(
@@ -186,6 +189,7 @@ try:
             build_content_ops_execution_services(enable_db_services=True)
         ),
         scope_provider=build_content_ops_scope,
+        reasoning_context_provider=build_content_ops_reasoning_context_provider,
     )
     router.include_router(content_ops_router)
 except Exception as exc:  # pragma: no cover - defensive at import time

--- a/plans/PR-Content-Ops-Reasoning-Provider-Host-Wire-1.md
+++ b/plans/PR-Content-Ops-Reasoning-Provider-Host-Wire-1.md
@@ -1,0 +1,222 @@
+# PR: wire reasoning context provider into host route mount (Host-Wire-1 of N)
+
+## Why this slice exists
+
+PR #402 shipped the route-level `reasoning_context_provider`
+seam in `extracted_content_pipeline/api/control_surfaces.py`
+plus the bundle's per-request `with_reasoning_context()`
+derivation, but the host's content-ops route mount in
+`atlas_brain/api/__init__.py` doesn't pass that kwarg yet.
+Result: every `/api/v1/content-ops/execute` request runs
+through the bundle without enriched reasoning context.
+
+The extracted package ships `FileCampaignReasoningContextProvider`
+(`extracted_content_pipeline/campaign_reasoning_data.py`) as
+a reference implementation: read pre-computed contexts from a
+JSON file and serve them per-call. Operators that already
+have offline reasoning pipelines can populate that file and
+get reasoning enrichment immediately for all 5 LLM-using
+outputs (`landing_page`, `email_campaign`, `report`,
+`sales_brief`, `blog_post`).
+
+This slice wires the missing seam. It does NOT introduce a
+new live reasoning chain (separate slice if desired) -- it
+unblocks the file-backed path and establishes the wiring
+pattern any future provider (database-backed, host
+intervention-pipeline-backed) plugs into without touching
+the route mount again.
+
+## Scope (this PR)
+
+Three files plus the plan doc; tightly bounded:
+
+1. **`atlas_brain/_content_ops_reasoning.py`** (new): the
+   factory.
+   - `build_content_ops_reasoning_context_provider()` reads
+     `ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH` from the
+     environment.
+   - When set + the file exists, returns
+     `load_campaign_reasoning_context_provider(path)` (the
+     file-backed adapter from
+     `extracted_content_pipeline.campaign_reasoning_data`).
+   - When unset OR the file is missing, returns `None` --
+     same behavior as today, no regression for hosts that
+     haven't opted in.
+   - Loader exceptions are logged at WARN and resolve to
+     `None` so a malformed file doesn't kill the route
+     mount during host startup.
+   - DI kwargs (`path_factory`, `loader_factory`) for
+     test isolation -- same pattern as PRs #453 / #455 /
+     #460 / #461.
+   - Lives at `atlas_brain/` root with underscore prefix
+     (matches the established host-internal pattern).
+
+2. **`atlas_brain/api/__init__.py`** (modified, ~5 LOC
+   delta): pass
+   `reasoning_context_provider=build_content_ops_reasoning_context_provider`
+   to `create_content_ops_control_surface_router(...)`.
+   The route layer's existing
+   `with_reasoning_context` derivation handles per-request
+   rebinding from there.
+
+3. **`tests/test_atlas_content_ops_reasoning.py`** (new):
+   ~6 tests pinning env-var-unset path returns `None`,
+   missing-file path returns `None`, malformed-file path
+   logs + returns `None`, valid-file path returns the
+   loaded provider, DI kwargs short-circuit env-var
+   resolution, and provider-loaded round-trip via the
+   exposed reader method.
+
+4. **`plans/PR-Content-Ops-Reasoning-Provider-Host-Wire-1.md`**
+   (this file).
+
+### What's NOT in this slice
+
+- **A live reasoning chain.** The file-backed provider is the
+  reference adapter; richer providers (database-backed,
+  intervention-pipeline-backed) are separate slices.
+- **Per-tenant reasoning context isolation.** The
+  file-backed provider is host-wide -- all authenticated
+  tenants see the same contexts. A tenant-scoped provider
+  is a follow-up; the file-backed one is a meaningful
+  unblock for single-tenant deployments / staging.
+- **Pydantic settings nesting.** Reading the env var
+  directly via `os.environ.get` keeps this slice from
+  touching the 5000+ line `config.py`. A future settings
+  refactor can fold the env var into a
+  `ContentOpsSettings` block.
+- **Operator UI for managing context contents.** Operators
+  edit the file directly today; admin tooling is a follow-up.
+
+## Mechanism
+
+```python
+# atlas_brain/_content_ops_reasoning.py
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_VAR = "ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH"
+
+
+def build_content_ops_reasoning_context_provider(
+    *,
+    path_factory: Callable[[], str | None] | None = None,
+    loader_factory: Callable[[str], Any] | None = None,
+) -> Any | None:
+    """Return the configured reasoning context provider, or
+    None when the host hasn't opted in.
+
+    Hosts opt in by setting ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH
+    to a JSON file readable by FileCampaignReasoningContextProvider.
+    Failures (missing file, parse errors) resolve to None with
+    a warning logged -- a bad file must not crash the route mount.
+    """
+
+    path = (path_factory or _read_env_path)()
+    if not path:
+        return None
+    if not Path(path).is_file():
+        logger.warning(
+            "Content Ops reasoning context path %s does not exist; "
+            "provider stays unwired.",
+            path,
+        )
+        return None
+
+    loader = loader_factory or _default_loader
+    try:
+        return loader(path)
+    except Exception as exc:
+        logger.warning(
+            "Failed to load Content Ops reasoning context from %s: %s",
+            path, exc,
+        )
+        return None
+
+
+def _read_env_path() -> str | None:
+    return os.environ.get(_ENV_VAR) or None
+
+
+def _default_loader(path: str) -> Any:
+    from extracted_content_pipeline.campaign_reasoning_data import (
+        load_campaign_reasoning_context_provider,
+    )
+    return load_campaign_reasoning_context_provider(path)
+```
+
+`atlas_brain/api/__init__.py` adds one kwarg:
+
+```python
+content_ops_router = create_content_ops_control_surface_router(
+    dependencies=[Depends(_capture_content_ops_auth_user)],
+    execution_services_provider=lambda: (
+        build_content_ops_execution_services(enable_db_services=True)
+    ),
+    scope_provider=build_content_ops_scope,
+    reasoning_context_provider=build_content_ops_reasoning_context_provider,
+)
+```
+
+## Intentional
+
+- **Default unwired (`None`).** Matches today's behavior;
+  hosts that haven't set the env var see no change.
+- **Lazy import of the file-backed provider.** Keeps the
+  factory module light enough to import in dependency-light
+  dev envs; the heavy `extracted_content_pipeline.campaign_reasoning_data`
+  module loads only when the env var is set.
+- **WARN-and-fall-back on errors rather than raise.** The
+  reasoning provider is enrichment; a malformed JSON file
+  must not crash the route mount or block the entire
+  Content Ops surface for all tenants.
+- **Env var rather than Pydantic settings.** The host's
+  `config.py` is 5000+ LOC and folding into it would
+  balloon this slice. The env-var pattern is symmetric
+  with PR #453's `_content_ops_infrastructure.py`. A
+  future settings refactor can fold the var in.
+- **DI kwargs (`path_factory`, `loader_factory`).** Same
+  testability pattern as the rest of the Content Ops
+  wiring slices.
+- **Module at `atlas_brain/` root with underscore prefix.**
+  Matches `_content_ops_infrastructure.py` (PR #453),
+  `_content_ops_scope.py` (PR #455), etc. -- avoids the
+  heavy `atlas_brain.services` import chain.
+
+## Deferred
+
+- Database-backed reasoning provider (per-tenant contexts).
+- Intervention-pipeline-backed provider that surfaces
+  `intelligence/autonomous_narrative_architect` outputs as
+  per-opportunity reasoning contexts.
+- Pydantic settings integration.
+- Admin tooling for editing the context file.
+- Per-output reasoning policies (e.g. blog_post requires
+  reasoning, email_campaign optional).
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_reasoning.py`
+  -- new tests pass.
+- AST + ASCII gates clean.
+- Smoke: `python -c "from atlas_brain._content_ops_reasoning
+  import build_content_ops_reasoning_context_provider; print(
+  build_content_ops_reasoning_context_provider())"` -> `None`
+  (no env var set).
+
+## Estimated diff size
+
+- `_content_ops_reasoning.py`: ~95 LOC.
+- `api/__init__.py` delta: ~5 LOC.
+- Tests: ~180 LOC.
+- Plan doc: ~165 LOC.
+
+Total: ~445 LOC. Marginally over the 400 LOC soft cap.
+Indivisible -- the factory needs the route-mount kwarg to
+have an effect; tests need both. The ~80 LOC overage is
+all plan doc and test scaffolding; production code is
+~100 LOC total.

--- a/tests/test_atlas_content_ops_reasoning.py
+++ b/tests/test_atlas_content_ops_reasoning.py
@@ -1,0 +1,153 @@
+"""Pin the host's Content Ops reasoning context provider factory.
+
+`atlas_brain/_content_ops_reasoning.py` is the host adapter the
+route mount calls to obtain a configured
+`CampaignReasoningContextProvider` (or `None`).
+
+Test inventory (7 tests):
+
+1. Env var unset returns `None` (default unwired path).
+2. Env var set but file missing returns `None` and logs WARN
+   (defensive against typo'd paths or unmounted volumes).
+3. Loader exception (malformed file) returns `None` and logs
+   WARN (must not crash route mount).
+4. Valid path returns whatever the loader produces.
+5. `path_factory` DI kwarg short-circuits the env-var read.
+6. `path_factory` returning empty string equals returning
+   `None` (the env-var coercion treats both as unset).
+7. `loader_factory` DI kwarg short-circuits the lazy import
+   of the package's file-backed loader.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from atlas_brain._content_ops_reasoning import (
+    build_content_ops_reasoning_context_provider,
+)
+
+
+def test_env_var_unset_returns_none() -> None:
+    """Default behavior when the host hasn't opted in -- no
+    factory call should reach the loader."""
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: None,
+    )
+    assert provider is None
+
+
+def test_missing_file_returns_none_and_logs_warn(
+    tmp_path: Any, caplog: Any,
+) -> None:
+    """If an operator typos the path or mounts the wrong
+    volume, we must not crash the route mount."""
+
+    missing = tmp_path / "nope.json"
+    caplog.set_level(logging.WARNING, logger="atlas_brain._content_ops_reasoning")
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: str(missing),
+    )
+
+    assert provider is None
+    assert any("does not exist" in rec.message for rec in caplog.records)
+
+
+def test_loader_exception_returns_none_and_logs_warn(
+    tmp_path: Any, caplog: Any,
+) -> None:
+    """Malformed JSON / loader-internal exceptions resolve to
+    None with WARN, never propagate."""
+
+    real_file = tmp_path / "bad.json"
+    real_file.write_text("not valid json", encoding="utf-8")
+    caplog.set_level(logging.WARNING, logger="atlas_brain._content_ops_reasoning")
+
+    def _raising_loader(_path: str) -> Any:
+        raise RuntimeError("simulated parse failure")
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: str(real_file),
+        loader_factory=_raising_loader,
+    )
+
+    assert provider is None
+    assert any("Failed to load" in rec.message for rec in caplog.records)
+
+
+def test_valid_path_returns_loaded_provider(tmp_path: Any) -> None:
+    """The factory returns whatever the loader hands back when
+    the path exists and the loader succeeds."""
+
+    real_file = tmp_path / "ok.json"
+    real_file.write_text("[]", encoding="utf-8")
+
+    sentinel = object()
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: str(real_file),
+        loader_factory=lambda _path: sentinel,
+    )
+
+    assert provider is sentinel
+
+
+def test_path_factory_short_circuits_env_var_read(
+    tmp_path: Any, monkeypatch: Any,
+) -> None:
+    """A test-supplied path_factory must take precedence over
+    the env var so tests don't need to set environment state."""
+
+    real_file = tmp_path / "ok.json"
+    real_file.write_text("[]", encoding="utf-8")
+    sentinel = object()
+
+    monkeypatch.setenv(
+        "ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH",
+        "/should/never/be/read.json",
+    )
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: str(real_file),
+        loader_factory=lambda _path: sentinel,
+    )
+    assert provider is sentinel
+
+
+def test_path_factory_empty_string_equals_unset() -> None:
+    """The env-var read coerces empty -> None; the explicit
+    factory mirror must do the same."""
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: "",
+    )
+    assert provider is None
+
+
+def test_loader_factory_short_circuits_default_loader(
+    tmp_path: Any,
+) -> None:
+    """The DI loader_factory replaces the lazy import of
+    `extracted_content_pipeline.campaign_reasoning_data` so
+    tests don't trigger the module load chain."""
+
+    real_file = tmp_path / "ok.json"
+    real_file.write_text("[]", encoding="utf-8")
+    captured: dict[str, str] = {}
+
+    def _capturing_loader(path: str) -> Any:
+        captured["path"] = path
+        return "loader-result"
+
+    provider = build_content_ops_reasoning_context_provider(
+        path_factory=lambda: str(real_file),
+        loader_factory=_capturing_loader,
+    )
+
+    assert provider == "loader-result"
+    assert captured["path"] == str(real_file)


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Reasoning-Provider-Host-Wire-1.md`

## Summary

PR #402 shipped the route-level
`reasoning_context_provider` seam in
`extracted_content_pipeline/api/control_surfaces.py` plus
the bundle's per-request `with_reasoning_context()`
derivation, but the host's content-ops route mount in
`atlas_brain/api/__init__.py` didn't pass that kwarg yet.
Result: every `/api/v1/content-ops/execute` request ran
through the bundle without enriched reasoning context.

This slice wires the missing seam using the package's
`FileCampaignReasoningContextProvider` as the reference
adapter. Operators with offline reasoning pipelines populate
a JSON file, set `ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH`,
and reasoning enrichment lights up for **all 5 LLM-using
outputs** (`landing_page`, `email_campaign`, `report`,
`sales_brief`, `blog_post`).

Default behavior unchanged: hosts that don't set the env var
see no behavior change.

## Files touched

1. `atlas_brain/_content_ops_reasoning.py` (new, ~105 LOC):
   `build_content_ops_reasoning_context_provider()` reads
   the env var, validates the file exists, lazily imports
   the package loader, returns the provider. Loader
   exceptions resolve to `None` with WARN log -- a malformed
   file must not crash the route mount. DI kwargs
   (`path_factory`, `loader_factory`) keep tests off the
   filesystem and off the heavy package import. Lives at
   `atlas_brain/` root with underscore prefix (matches PRs
   #453 / #455 / #460 / #461 pattern).
2. `atlas_brain/api/__init__.py` (modified, ~6 LOC delta):
   import the new factory, pass it as
   `reasoning_context_provider=` to the router mount.
3. `tests/test_atlas_content_ops_reasoning.py` (new, 7
   tests): env-var unset, missing file, loader exception
   handling, valid-path round-trip, `path_factory` DI
   short-circuit, empty-string = unset coercion,
   `loader_factory` DI short-circuit.
4. `plans/PR-Content-Ops-Reasoning-Provider-Host-Wire-1.md`
   (new).

## Intentional

- **Default unwired (`None`).** Matches today's behavior;
  hosts that haven't set the env var see no change.
- **Lazy import of the file-backed provider.** Keeps the
  factory module light enough to import in dependency-light
  dev envs.
- **WARN-and-fall-back on errors.** The reasoning provider
  is enrichment; a malformed JSON file must not block the
  entire Content Ops surface for all tenants.
- **Env var rather than Pydantic settings.** The host's
  `config.py` is 5000+ LOC; folding into it would balloon
  this slice. The env-var pattern is symmetric with PR
  #453's `_content_ops_infrastructure.py`.
- **DI kwargs (`path_factory`, `loader_factory`).** Same
  testability pattern as PRs #453 / #455 / #460 / #461.
- **Module at `atlas_brain/` root with underscore prefix.**
  Matches `_content_ops_infrastructure.py`,
  `_content_ops_scope.py`, `_blog_post_subscriptions.py`,
  `_blog_blueprint_fanout.py`.

## Deferred

- Database-backed reasoning provider (per-tenant contexts).
- Intervention-pipeline-backed provider that surfaces
  `intelligence/autonomous_narrative_architect` outputs.
- Pydantic settings integration.
- Admin tooling for editing the context file.
- Per-output reasoning policies (e.g. `blog_post` requires
  reasoning, `email_campaign` optional).

## Verification

- `pytest tests/test_atlas_content_ops_reasoning.py`
  -- 7 passed locally.
- AST + ASCII gates clean on all 3 changed files.

## Test plan

- [ ] CI runs `pytest tests/test_atlas_content_ops_reasoning.py`
- [ ] Codex per-line review
- [ ] Claude reviewer pass

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97

---
_Generated by [Claude Code](https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97)_