### PR TITLE
fix: lift blog blueprint fanout into host-only wrapper

### DIFF
--- a/atlas_brain/autonomous/tasks/__init__.py
+++ b/atlas_brain/autonomous/tasks/__init__.py
@@ -39,7 +39,7 @@ _BUILTIN_TASKS = [
     ("campaign_analytics_refresh", "run", "campaign_analytics_refresh"),
     ("amazon_seller_campaign_generation", "run", "amazon_seller_campaign_generation"),
     ("b2b_churn_alert", "run", "b2b_churn_alert"),
-    ("b2b_blog_post_generation", "run", "b2b_blog_post_generation"),
+    ("_b2b_blog_post_generation_host", "run", "b2b_blog_post_generation"),
     ("b2b_tenant_report", "run", "b2b_tenant_report"),
     ("b2b_report_subscription_delivery", "run", "b2b_report_subscription_delivery"),
     ("b2b_watchlist_alert_delivery", "run", "b2b_watchlist_alert_delivery"),

--- a/atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py
+++ b/atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py
@@ -1,0 +1,83 @@
+"""Host wrapper for the B2B blog-post autonomous task.
+
+Wires the per-blueprint fanout (PR #461,
+``atlas_brain/_blog_blueprint_fanout.py``) into the autonomous
+task's ``set_blueprint_published_hook`` injection seam, then
+re-exports ``run`` so the task registry
+(``atlas_brain/autonomous/tasks/__init__.py``) can register it
+under the existing ``b2b_blog_post_generation`` task name.
+
+This module is host-only -- it lives at
+``atlas_brain/autonomous/tasks/`` and is NOT mirrored into
+``extracted_content_pipeline/``. The autonomous task itself
+(``b2b_blog_post_generation.py``) stays portable: it imports
+no host-only fanout chain, only invokes the optional
+``_blueprint_published_hook`` callback when one is installed.
+
+Dual-resident discipline:
+
+* ``b2b_blog_post_generation.py`` is mapped in
+  ``extracted_content_pipeline/manifest.json``; both copies
+  must stay byte-identical (the validate gauntlet enforces it).
+* ``_b2b_blog_post_generation_host.py`` (this file) and
+  ``_blog_blueprint_fanout.py`` are NOT mapped -- they live
+  only in atlas_brain. The extracted package's standalone
+  smoke runs without them and the autonomous task remains
+  importable in the dependency-light extracted env.
+
+Background: PR #461 originally placed the fanout calls
+inline inside ``b2b_blog_post_generation.py`` and added a
+``from ..._blog_blueprint_fanout import fanout_blueprint``
+to that file. That broke standalone import because the
+fanout module + its ``_blog_post_subscriptions`` dependency
+exist only in atlas_brain. The validate gauntlet didn't catch
+the drift on PR #461 because no PR between #461 and PR #463
+touched ``extracted_content_pipeline/`` so the workflow's
+``paths:`` filter never fired. PR #464 lifts the host-only
+chain into this wrapper so the source-of-truth file is
+extraction-safe again.
+"""
+
+from __future__ import annotations
+
+from .b2b_blog_post_generation import (
+    run,
+    set_blueprint_published_hook,
+)
+from .._blog_blueprint_fanout import fanout_blueprint as _fanout_blog_blueprint
+
+
+async def _publish_hook(pool, blueprint) -> None:
+    """Per-blueprint fanout adapter wired into the autonomous task.
+
+    The autonomous task swallows hook exceptions (``logger.warning``
+    on any raise) so this adapter intentionally lets exceptions
+    bubble up -- the task layer is the one that decides whether a
+    fanout failure should be logged or escalated.
+    """
+
+    fanout_count = await _fanout_blog_blueprint(pool, blueprint)
+    if fanout_count:
+        # The task-side log already records "Blog blueprint published
+        # hook" outcomes; surface the count here for observability
+        # without duplicating the warning-on-exception path.
+        import logging
+
+        logging.getLogger(
+            "atlas.autonomous.tasks._b2b_blog_post_generation_host"
+        ).info(
+            "Blog blueprint fanned out: slug=%s subscribers=%d",
+            getattr(blueprint, "slug", "?"),
+            fanout_count,
+        )
+
+
+# Install the hook at module import time. The autonomous tasks
+# registry (``atlas_brain/autonomous/tasks/__init__.py``) imports
+# this module, which side-effect-binds the hook before the
+# registry calls ``register_builtin``. Idempotent: re-imports
+# overwrite the same callable.
+set_blueprint_published_hook(_publish_hook)
+
+
+__all__ = ["run"]

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -23,12 +23,11 @@ import logging
 import re
 from dataclasses import dataclass, field, asdict
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Any, Awaitable, Callable, Optional
 
 from ...config import settings
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
-from ..._blog_blueprint_fanout import fanout_blueprint as _fanout_blog_blueprint
 from ...services.scraping.sources import (
     VERIFIED_SOURCES,
     ReviewSource,
@@ -55,6 +54,31 @@ from ._b2b_specificity import (
 )
 
 logger = logging.getLogger("atlas.autonomous.tasks.b2b_blog_post_generation")
+
+
+# Per-blueprint published hook. Hosts that want to react to each
+# stored blueprint (e.g. fan it out to per-tenant subscribers in
+# atlas_brain) install a callback via ``set_blueprint_published_hook``.
+# Default ``None`` keeps the autonomous task standalone-portable --
+# this module must remain importable inside ``extracted_content_pipeline``
+# without the host's per-tenant fanout chain.
+BlueprintPublishedHook = Callable[[Any, Any], Awaitable[None]]
+_blueprint_published_hook: Optional[BlueprintPublishedHook] = None
+
+
+def set_blueprint_published_hook(
+    hook: Optional[BlueprintPublishedHook],
+) -> None:
+    """Install / clear the per-blueprint published callback.
+
+    Called once at host wiring time (see
+    ``atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py``).
+    Passing ``None`` clears the hook -- useful for tests that want
+    the standalone path.
+    """
+
+    global _blueprint_published_hook
+    _blueprint_published_hook = hook
 
 
 async def _fetch_latest_evidence_vault(
@@ -3238,15 +3262,13 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 )
                 continue
 
-            try:
-                fanout_count = await _fanout_blog_blueprint(pool, blueprint)
-                if fanout_count:
-                    logger.info(
-                        "Blog blueprint fanned out: slug=%s subscribers=%d",
-                        blueprint.slug, fanout_count,
+            if _blueprint_published_hook is not None:
+                try:
+                    await _blueprint_published_hook(pool, blueprint)
+                except Exception as exc:
+                    logger.warning(
+                        "Blog blueprint published hook exception: %s", exc,
                     )
-            except Exception as exc:
-                logger.warning("Blog blueprint fanout exception: %s", exc)
 
             from ..visibility import record_attempt
             await record_attempt(
@@ -3479,15 +3501,14 @@ async def _regenerate_existing_posts(
                 attempt_no=1,
             )
             if post_id:
-                try:
-                    fanout_count = await _fanout_blog_blueprint(pool, blueprint)
-                    if fanout_count:
-                        logger.info(
-                            "Blog blueprint fanned out: slug=%s subscribers=%d",
-                            slug, fanout_count,
+                if _blueprint_published_hook is not None:
+                    try:
+                        await _blueprint_published_hook(pool, blueprint)
+                    except Exception as exc:
+                        logger.warning(
+                            "Blog blueprint published hook exception: %s",
+                            exc,
                         )
-                except Exception as exc:
-                    logger.warning("Blog blueprint fanout exception: %s", exc)
                 results.append({
                     "post_id": str(post_id),
                     "topic_type": topic_type,

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -23,12 +23,11 @@ import logging
 import re
 from dataclasses import dataclass, field, asdict
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Any, Awaitable, Callable, Optional
 
 from ...config import settings
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
-from ..._blog_blueprint_fanout import fanout_blueprint as _fanout_blog_blueprint
 from ...services.scraping.sources import (
     VERIFIED_SOURCES,
     ReviewSource,
@@ -55,6 +54,31 @@ from ._b2b_specificity import (
 )
 
 logger = logging.getLogger("atlas.autonomous.tasks.b2b_blog_post_generation")
+
+
+# Per-blueprint published hook. Hosts that want to react to each
+# stored blueprint (e.g. fan it out to per-tenant subscribers in
+# atlas_brain) install a callback via ``set_blueprint_published_hook``.
+# Default ``None`` keeps the autonomous task standalone-portable --
+# this module must remain importable inside ``extracted_content_pipeline``
+# without the host's per-tenant fanout chain.
+BlueprintPublishedHook = Callable[[Any, Any], Awaitable[None]]
+_blueprint_published_hook: Optional[BlueprintPublishedHook] = None
+
+
+def set_blueprint_published_hook(
+    hook: Optional[BlueprintPublishedHook],
+) -> None:
+    """Install / clear the per-blueprint published callback.
+
+    Called once at host wiring time (see
+    ``atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py``).
+    Passing ``None`` clears the hook -- useful for tests that want
+    the standalone path.
+    """
+
+    global _blueprint_published_hook
+    _blueprint_published_hook = hook
 
 
 async def _fetch_latest_evidence_vault(
@@ -3238,15 +3262,13 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 )
                 continue
 
-            try:
-                fanout_count = await _fanout_blog_blueprint(pool, blueprint)
-                if fanout_count:
-                    logger.info(
-                        "Blog blueprint fanned out: slug=%s subscribers=%d",
-                        blueprint.slug, fanout_count,
+            if _blueprint_published_hook is not None:
+                try:
+                    await _blueprint_published_hook(pool, blueprint)
+                except Exception as exc:
+                    logger.warning(
+                        "Blog blueprint published hook exception: %s", exc,
                     )
-            except Exception as exc:
-                logger.warning("Blog blueprint fanout exception: %s", exc)
 
             from ..visibility import record_attempt
             await record_attempt(
@@ -3479,15 +3501,14 @@ async def _regenerate_existing_posts(
                 attempt_no=1,
             )
             if post_id:
-                try:
-                    fanout_count = await _fanout_blog_blueprint(pool, blueprint)
-                    if fanout_count:
-                        logger.info(
-                            "Blog blueprint fanned out: slug=%s subscribers=%d",
-                            slug, fanout_count,
+                if _blueprint_published_hook is not None:
+                    try:
+                        await _blueprint_published_hook(pool, blueprint)
+                    except Exception as exc:
+                        logger.warning(
+                            "Blog blueprint published hook exception: %s",
+                            exc,
                         )
-                except Exception as exc:
-                    logger.warning("Blog blueprint fanout exception: %s", exc)
                 results.append({
                     "post_id": str(post_id),
                     "topic_type": topic_type,

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -28,6 +28,7 @@ from typing import Any
 from ...config import settings
 from ...storage.database import get_db_pool
 from ...storage.models import ScheduledTask
+from ..._blog_blueprint_fanout import fanout_blueprint as _fanout_blog_blueprint
 from ...services.scraping.sources import (
     VERIFIED_SOURCES,
     ReviewSource,
@@ -3237,6 +3238,16 @@ async def run(task: ScheduledTask) -> dict[str, Any]:
                 )
                 continue
 
+            try:
+                fanout_count = await _fanout_blog_blueprint(pool, blueprint)
+                if fanout_count:
+                    logger.info(
+                        "Blog blueprint fanned out: slug=%s subscribers=%d",
+                        blueprint.slug, fanout_count,
+                    )
+            except Exception as exc:
+                logger.warning("Blog blueprint fanout exception: %s", exc)
+
             from ..visibility import record_attempt
             await record_attempt(
                 pool, artifact_type="blog_post", artifact_id=blueprint.slug,
@@ -3468,6 +3479,15 @@ async def _regenerate_existing_posts(
                 attempt_no=1,
             )
             if post_id:
+                try:
+                    fanout_count = await _fanout_blog_blueprint(pool, blueprint)
+                    if fanout_count:
+                        logger.info(
+                            "Blog blueprint fanned out: slug=%s subscribers=%d",
+                            slug, fanout_count,
+                        )
+                except Exception as exc:
+                    logger.warning("Blog blueprint fanout exception: %s", exc)
                 results.append({
                     "post_id": str(post_id),
                     "topic_type": topic_type,


### PR DESCRIPTION
## Why

PR #463 was the first PR after PR #461 to touch `extracted_content_pipeline/`, so the **Extracted Pipeline Checks** workflow's `paths:` filter fired for the first time and surfaced two related failures:

1. **OUT OF SYNC drift**: `validate_extracted_content_pipeline.sh` reported `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` had diverged from the extracted copy. PR #461 added blueprint fanout inline (~20 LOC) without re-running the sync.
2. **Broken import chain on extracted**: simply running the sync (the obvious "fix") doesn't work — PR #461's added `from ..._blog_blueprint_fanout import fanout_blueprint` points at a **host-only** module. Neither `_blog_blueprint_fanout.py` nor its dependency `_blog_post_subscriptions.py` was ever copied to `extracted_content_pipeline/`, so the synced extracted file would fail `smoke_extracted_pipeline_imports.py` on the missing module.

The previous commit on this branch (`e7294b88`) ran the sync and surfaced exactly that secondary failure on PR #464's CI. This commit (`ef456928`) lifts the host-only fanout chain out of the source-of-truth file so a clean sync can land.

## Mechanism

- **Source-of-truth `b2b_blog_post_generation.py`**: removed the `from ..._blog_blueprint_fanout import` line and replaced the two inline `try/except: await _fanout_blog_blueprint(pool, blueprint)` blocks with `if _blueprint_published_hook is not None: await _blueprint_published_hook(pool, blueprint)` guards. Added a module-level `set_blueprint_published_hook(hook)` setter so hosts can install a callback without changing the task signature. Default hook is `None`, keeping the autonomous task standalone-portable inside `extracted_content_pipeline`.
- **New host-only wrapper `atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py`**: imports `fanout_blueprint` from `atlas_brain/_blog_blueprint_fanout.py`, installs it via `set_blueprint_published_hook` at module load, and re-exports `run`. Lives in `atlas_brain/autonomous/tasks/` and is **NOT** mirrored into the extracted package (no manifest entry).
- **Registry `atlas_brain/autonomous/tasks/__init__.py`**: changed the `_BUILTIN_TASKS` tuple from `("b2b_blog_post_generation", "run", "b2b_blog_post_generation")` to `("_b2b_blog_post_generation_host", "run", "b2b_blog_post_generation")`. Same task name from the scheduler's perspective; the wrapper is loaded, hook installed, then `run` registered.
- **Sync re-run**: `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py` now matches the cleaned source-of-truth byte-for-byte.

## After this PR

- `atlas_brain` and `extracted_content_pipeline` source-of-truth copies are byte-identical -> `validate_extracted_content_pipeline.sh` passes.
- Extracted copy imports cleanly with no host-only chain -> `smoke_extracted_pipeline_imports.py` passes.
- atlas_brain still runs fanout exactly as PR #461 intended -> behavior unchanged on the host side.

## Verification

```
$ bash scripts/validate_extracted_content_pipeline.sh
Validation passed: mapped files for extracted_content_pipeline match atlas_brain sources
forbid_hard_atlas_imports: clean (extracted_content_pipeline)

$ python scripts/check_extracted_imports.py
Import check passed for 89 extracted_content_pipeline module(s)

$ bash scripts/check_ascii_python.sh
ASCII check passed for extracted_content_pipeline Python files

$ python -c "import ast; ast.parse(open('atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py').read())"
# (silent, parses cleanly)
```

## Test plan

- [ ] CI green on this PR (extracted-checks passes both validate + smoke + import + audit + pytest gauntlet)
- [ ] Once merged, rebase PR #463 onto main; its CI should go green
- [ ] Audit follow-up: should the sync gauntlet (or a new gating test) catch host-only-import drift earlier? PR #461 should have caught this if extracted-checks had run on it. The workflow's `paths:` filter excludes `_blog_blueprint_fanout.py`-style additions because they're not under any of the watched paths.

## Files changed

- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` (modified): hook seam (+~20 LOC, -fanout calls).
- `atlas_brain/autonomous/tasks/_b2b_blog_post_generation_host.py` (new, ~80 LOC): host wrapper.
- `atlas_brain/autonomous/tasks/__init__.py` (modified, 1 LOC): registry.
- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py` (modified, synced from source-of-truth).

## Background

PR #461 (PR-Blog-Post-Subscriptions-2) added per-tenant blog post subscription fanout. It was correct mechanism but reached for the source-of-truth file directly. The extracted-checks gauntlet didn't catch the drift because no PR between #461 and PR #463 touched `extracted_content_pipeline/`, so the workflow's `paths:` filter never fired and the latent failure stayed dormant for ~2 PRs.

https://claude.ai/code/session_013vD2xcxZG1cJEEwPYUvH97