### PR TITLE
Add build-time pre-rendering for public SEO routes

### DIFF
--- a/atlas-intel-ui/vercel.json
+++ b/atlas-intel-ui/vercel.json
@@ -3,6 +3,9 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/landing",    "destination": "/landing/index.html" },
+    { "source": "/blog",       "destination": "/blog/index.html" },
+    { "source": "/blog/(.*)", "destination": "/blog/$1/index.html" },
+    { "source": "/(.*)",       "destination": "/index.html" }
   ]
 }

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -1,13 +1,24 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
 import { resolve, join } from 'node:path'
 
+const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
+const DEFAULT_OG_IMAGE = `${BASE_URL}/og-default.png`
+
+// ---------------------------------------------------------------------------
+// Sitemap plugin
+// ---------------------------------------------------------------------------
 function sitemapPlugin() {
   return {
     name: 'generate-sitemap',
     closeBundle() {
-      // Read blog index to extract slugs
       const indexPath = resolve(import.meta.dirname, 'src/content/blog/index.ts')
       if (!existsSync(indexPath)) return
 
@@ -19,7 +30,6 @@ function sitemapPlugin() {
         slugs.push(match[1])
       }
 
-      // Also extract from individual .ts files in the blog directory
       const blogDir = resolve(import.meta.dirname, 'src/content/blog')
       for (const file of readdirSync(blogDir)) {
         if (file.endsWith('.ts') && file !== 'index.ts') {
@@ -31,14 +41,14 @@ function sitemapPlugin() {
 
       const today = new Date().toISOString().split('T')[0]
       const urls = [
-        { loc: 'https://atlas-intel-ui-two.vercel.app/landing', priority: '1.0', changefreq: 'weekly' },
-        { loc: 'https://atlas-intel-ui-two.vercel.app/blog', priority: '0.9', changefreq: 'daily' },
+        { loc: `${BASE_URL}/landing`, priority: '1.0', changefreq: 'weekly' },
+        { loc: `${BASE_URL}/blog`, priority: '0.9', changefreq: 'daily' },
         ...slugs.map(slug => ({
-          loc: `https://atlas-intel-ui-two.vercel.app/blog/${slug}`,
+          loc: `${BASE_URL}/blog/${slug}`,
           priority: '0.7',
           changefreq: 'monthly',
         })),
-        { loc: 'https://atlas-intel-ui-two.vercel.app/', priority: '0.3', changefreq: 'monthly' },
+        { loc: `${BASE_URL}/`, priority: '0.3', changefreq: 'monthly' },
       ]
 
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -60,8 +70,180 @@ ${urls.map(u => `  <url>
   }
 }
 
+// ---------------------------------------------------------------------------
+// Pre-render plugin
+//
+// Strategy: at build time, clone dist/index.html into per-route directories
+// with the correct static <head> meta baked in. Crawlers (Googlebot, GPTBot,
+// PerplexityBot, ClaudeBot) fetch the HTML file directly and see proper title,
+// description, canonical, og:image, og:type, and JSON-LD without executing JS.
+//
+// Authenticated routes stay as the regular SPA (index.html fallback).
+// Only public routes are pre-rendered: /landing, /blog, /blog/:slug.
+// ---------------------------------------------------------------------------
+
+interface PrerenderedRoute {
+  path: string        // URL path, e.g. /blog/my-slug
+  title: string
+  description: string
+  canonical: string
+  ogType: string
+  jsonLd?: object
+}
+
+function buildHeadHtml(route: PrerenderedRoute): string {
+  const { title, description, canonical, ogType, jsonLd } = route
+  const lines = [
+    `<title>${title}</title>`,
+    `<meta name="description" content="${description}" />`,
+    `<link rel="canonical" href="${canonical}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:url" content="${canonical}" />`,
+    `<meta property="og:type" content="${ogType}" />`,
+    `<meta property="og:site_name" content="Atlas Intelligence" />`,
+    `<meta property="og:image" content="${DEFAULT_OG_IMAGE}" />`,
+    `<meta property="og:image:width" content="1200" />`,
+    `<meta property="og:image:height" content="630" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:image" content="${DEFAULT_OG_IMAGE}" />`,
+  ]
+  if (jsonLd) {
+    lines.push(
+      `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`,
+    )
+  }
+  return lines.map(l => `    ${l}`).join('\n')
+}
+
+function prerenderPlugin() {
+  return {
+    name: 'prerender-public-routes',
+    closeBundle() {
+      const distDir = resolve(import.meta.dirname, 'dist')
+      const indexHtmlPath = join(distDir, 'index.html')
+      if (!existsSync(indexHtmlPath)) return
+
+      const baseHtml = readFileSync(indexHtmlPath, 'utf-8')
+
+      // Collect blog post metadata from content files
+      const blogDir = resolve(import.meta.dirname, 'src/content/blog')
+      const blogRoutes: PrerenderedRoute[] = []
+
+      for (const file of readdirSync(blogDir)) {
+        if (!file.endsWith('.ts') || file === 'index.ts') continue
+        const content = readFileSync(join(blogDir, file), 'utf-8')
+        const slug = (content.match(/slug:\s*'([^']+)'/) || [])[1]
+        if (!slug) continue
+
+        const seoTitle =
+          (content.match(/seo_title:\s*'([^']+)'/) || [])[1] ||
+          (content.match(/title:\s*'([^']+)'/) || [])[1] ||
+          'Atlas Intelligence Blog'
+        const seoDesc =
+          (content.match(/seo_description:\s*'([^']+)'/) || [])[1] ||
+          (content.match(/description:\s*'([^']+)'/) || [])[1] ||
+          'Amazon seller intelligence and competitive analysis insights.'
+
+        blogRoutes.push({
+          path: `/blog/${slug}`,
+          title: `${seoTitle} | Atlas Intelligence`,
+          description: seoDesc,
+          canonical: `${BASE_URL}/blog/${slug}`,
+          ogType: 'article',
+          jsonLd: {
+            '@context': 'https://schema.org',
+            '@type': 'BlogPosting',
+            headline: seoTitle,
+            description: seoDesc,
+            image: DEFAULT_OG_IMAGE,
+            author: {
+              '@type': 'Organization',
+              name: 'Atlas Intelligence',
+            },
+            publisher: {
+              '@type': 'Organization',
+              name: 'Atlas Intelligence',
+              url: BASE_URL,
+            },
+            mainEntityOfPage: {
+              '@type': 'WebPage',
+              '@id': `${BASE_URL}/blog/${slug}`,
+            },
+          },
+        })
+      }
+
+      const LANDING_JSON_LD = {
+        '@context': 'https://schema.org',
+        '@graph': [
+          { '@type': 'WebSite', name: 'Atlas Intelligence', url: BASE_URL },
+          {
+            '@type': 'SoftwareApplication',
+            name: 'Atlas Intelligence',
+            applicationCategory: 'BusinessApplication',
+            operatingSystem: 'Web',
+            description:
+              'Amazon review intelligence platform for tracking competitor complaints, safety signals, and customer migration patterns.',
+            offers: {
+              '@type': 'AggregateOffer',
+              lowPrice: '49',
+              highPrice: '399',
+              priceCurrency: 'USD',
+            },
+            url: `${BASE_URL}/landing`,
+          },
+        ],
+      }
+
+      const routes: PrerenderedRoute[] = [
+        {
+          path: '/landing',
+          title: 'Atlas Intelligence — Amazon Review Monitoring & Competitor Signals',
+          description:
+            'Track competitor complaints, safety signals, and customer migration patterns across your Amazon product category. Start free for 14 days.',
+          canonical: `${BASE_URL}/landing`,
+          ogType: 'website',
+          jsonLd: LANDING_JSON_LD,
+        },
+        {
+          path: '/blog',
+          title: 'Blog | Atlas Intelligence',
+          description:
+            'Amazon seller intelligence, review monitoring strategies, and competitive analysis insights.',
+          canonical: `${BASE_URL}/blog`,
+          ogType: 'website',
+        },
+        ...blogRoutes,
+      ]
+
+      let count = 0
+      for (const route of routes) {
+        const headHtml = buildHeadHtml(route)
+        // Replace the fallback <title> in index.html and inject all meta before </head>
+        const rendered = baseHtml
+          .replace(
+            /<title>[^<]*<\/title>/,
+            `<title>${route.title}</title>`,
+          )
+          .replace('</head>', `${headHtml}\n  </head>`)
+
+        // Write to dist/<path>/index.html
+        const outDir = join(distDir, ...route.path.split('/').filter(Boolean))
+        if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true })
+        writeFileSync(join(outDir, 'index.html'), rendered)
+        count++
+      }
+
+      console.log(`  Pre-rendered ${count} public routes`)
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), sitemapPlugin()],
+  plugins: [react(), sitemapPlugin(), prerenderPlugin()],
   server: {
     host: true,
     port: 5175,

--- a/plans/PR-SEO-Prerender.md
+++ b/plans/PR-SEO-Prerender.md
@@ -1,0 +1,117 @@
+# PR: SEO Pre-render Public Routes
+
+Date: 2026-05-10
+Owner: antigravity
+Depends on: PR #446 (PR-SEO-Foundation-Fixes) — merged
+
+## Why this slice exists
+
+PR #446 fixed the meta tag *content* in React components, but none of it was
+visible to crawlers because the app is a client-side SPA. Googlebot and all AI
+crawler agents (GPTBot, PerplexityBot, ClaudeBot) receive a blank
+`<div id="root"></div>` when they fetch any URL. This slice adds a zero-
+dependency Vite build plugin that bakes correct `<head>` HTML into static
+files for every public route at build time, making all SEO/GEO/AEO signals
+immediately readable without JavaScript execution.
+
+## Scope (this PR)
+
+1. Add `prerenderPlugin()` to `vite.config.ts` — a build-time plugin that
+   generates `dist/<route>/index.html` for each public route with full static
+   `<head>` meta baked in.
+2. Update `vercel.json` to serve pre-rendered `.html` files for public routes
+   before falling back to `index.html` for authenticated SPA routes.
+3. No third-party SSR dependency added — pure Node.js `fs` + string
+   manipulation in the Vite config.
+
+### Files touched
+
+- `atlas-intel-ui/vite.config.ts`
+- `atlas-intel-ui/vercel.json`
+- `plans/PR-SEO-Prerender.md` (this file)
+
+## Mechanism
+
+**`prerenderPlugin()`** runs in `closeBundle()` (after Vite finishes emitting
+assets). It:
+
+1. Reads `dist/index.html` as a base template.
+2. Reads each `src/content/blog/*.ts` file and extracts `slug`, `seo_title`,
+   and `seo_description` via regex (no TS transpilation needed at build time —
+   these are plain string literals).
+3. Builds a static `<head>` block per route using `buildHeadHtml()`:
+   - `<title>`, `<meta name="description">`, `<link rel="canonical">`
+   - Full OG tag set (`og:title`, `og:description`, `og:url`, `og:type`,
+     `og:site_name`, `og:image`, `og:image:width`, `og:image:height`)
+   - Twitter card set
+   - `<script type="application/ld+json">` with route-appropriate schema
+4. Replaces the fallback `<title>` in `index.html` and injects meta before
+   `</head>`.
+5. Writes the result to `dist/<path>/index.html`.
+
+**`vercel.json` rewrites:** The new rewrite rules check for a pre-rendered
+file first (`/landing` → `/landing/index.html`, `/blog/(.*)`→
+`/blog/$1/index.html`) before falling through to the SPA catch-all. Vercel
+evaluates rewrites in order, so authenticated routes (`/b2b/*`, `/reviews`,
+etc.) correctly fall through to `/index.html`.
+
+**Build output:**
+```
+dist/landing/index.html          ← pre-rendered, full meta
+dist/blog/index.html             ← pre-rendered, full meta
+dist/blog/<slug>/index.html      ← pre-rendered, per-post title/desc/JSON-LD
+dist/index.html                  ← unchanged SPA shell (auth routes)
+```
+
+## Intentional
+
+- **No third-party SSR library.** `vite-plugin-ssg` (v0.1.0, installed
+  during investigation) requires exporting `ssgOptions` from each page file
+  and uses `StaticRouter` — too invasive for what is effectively a one-time
+  meta injection. The custom plugin is ~120 lines, has no dependencies beyond
+  Node.js builtins, and is trivially auditable.
+- **String-regex extraction of blog meta**, not TS import. Importing TS at
+  Vite build plugin time requires a transpilation step; regex on known literal
+  patterns is faster and has zero failure modes at build time.
+- **Only public routes pre-rendered.** Authenticated routes stay SPA —
+  crawlers cannot access them and `robots.txt` disallows them anyway.
+- **`dist/index.html` is not modified.** The base SPA shell is left intact
+  so authenticated routes continue working normally.
+
+## Deferred
+
+- Per-post `og:image` (custom image per blog post) → future content tooling PR
+- `BreadcrumbList` schema on blog posts → future NIT PR
+- `robots.txt` domain → after custom domain is set
+- Incremental static regeneration → not available on Vercel without Next.js;
+  acceptable since blog content is updated at build time
+
+## Verification
+
+```bash
+cd atlas-intel-ui && npm run build
+# Should print: "Pre-rendered 16 public routes"
+
+# Confirm static files exist
+ls dist/landing/index.html
+ls dist/blog/index.html
+ls dist/blog/amazon-review-monitoring-tools-2026-03/index.html
+
+# Confirm meta is baked in (no JS needed)
+grep 'og:title' dist/landing/index.html
+grep 'og:title' dist/blog/index.html
+grep 'og:title' dist/blog/amazon-review-monitoring-tools-2026-03/index.html
+grep 'application/ld+json' dist/landing/index.html
+
+# Build exit code
+echo "Exit: $?"
+```
+
+Expected output:
+- `og:title` present in all three files with correct values
+- `application/ld+json` count = 1 in landing
+- Exit: 0
+
+## Estimated diff size
+
+~200 LOC (vite.config.ts rewrite + vercel.json). Within 400 LOC budget.


### PR DESCRIPTION
Plan: plans/PR-SEO-Prerender.md

Depends on #446 (merged). Bakes static `<head>` meta into per-route HTML files at build time so crawlers see correct title/description/og:image/JSON-LD without executing JavaScript.

## Intentional
- No third-party SSR library — custom zero-dependency Vite plugin (~120 LOC)
- String-regex blog meta extraction avoids TS transpilation at build time
- Only public routes pre-rendered; authenticated routes stay SPA
- `dist/index.html` unchanged; SPA shell intact for auth routes

## Deferred
- Per-post og:image → future content tooling PR
- BreadcrumbList schema → future NIT PR
- robots.txt domain → after custom domain is set

## Verification
- `npm run build`: exit 0, 'Pre-rendered 16 public routes'
- `grep 'og:title' dist/landing/index.html` → correct title baked in
- `grep 'og:title' dist/blog/amazon-review-monitoring-tools-2026-03/index.html` → correct per-post title
- `grep 'application/ld+json' dist/landing/index.html` → 1 JSON-LD block

## Diff size
~200 LOC, 3 files