### PR TITLE
Add consumed reasoning payloads to campaign and blog results

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T00:48Z by codex-content-ops-reasoning-execution
+Last updated: 2026-05-10T18:05Z by codex-content-ops-consumed-campaign-blog
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add consumed reasoning payload field to Content Ops execution | EDIT: `extracted_content_pipeline/content_ops_execution.py`; `tests/test_extracted_content_ops_execution.py`; `docs/frontend/content_ops_frontend_contract.md`; `extracted_content_pipeline/STATUS.md`. NEW: `plans/PR-Content-Ops-Consumed-Reasoning-Execution.md`. | codex-content-ops-reasoning-execution | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Add consumed reasoning payloads to campaign/blog generation results | EDIT: `extracted_content_pipeline/services/campaign_reasoning_context.py`; `extracted_content_pipeline/campaign_generation.py`; `extracted_content_pipeline/blog_generation.py`; `tests/test_extracted_campaign_generation.py`; `tests/test_extracted_blog_generation.py`. NEW: `plans/PR-Content-Ops-Consumed-Reasoning-Campaign-Blog.md`. | codex-content-ops-consumed-campaign-blog | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -25,6 +25,7 @@ from .services._parse_retry_helpers import (
 from .services.campaign_reasoning_context import (
     campaign_reasoning_context_metadata,
     campaign_reasoning_context_payload,
+    consumed_campaign_reasoning_contexts,
     normalize_campaign_reasoning_context,
 )
 from extracted_quality_gate.blog_pack import evaluate_blog_post
@@ -58,11 +59,12 @@ class BlogPostGenerationResult:
     generated: int
     skipped: int
     reasoning_contexts_used: int = 0
+    consumed_reasoning_contexts: tuple[Mapping[str, Any], ...] = ()
     saved_ids: tuple[str, ...] = ()
     errors: tuple[Mapping[str, Any], ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "requested": self.requested,
             "generated": self.generated,
             "skipped": self.skipped,
@@ -70,6 +72,11 @@ class BlogPostGenerationResult:
             "saved_ids": list(self.saved_ids),
             "errors": list(self.errors),
         }
+        if self.consumed_reasoning_contexts:
+            data["consumed_reasoning_contexts"] = [
+                dict(item) for item in self.consumed_reasoning_contexts
+            ]
+        return data
 
 
 def parse_blog_post_response(text: str) -> dict[str, Any] | None:
@@ -229,6 +236,7 @@ class BlogPostGenerationService:
         errors: list[dict[str, Any]] = []
         skipped = 0
         reasoning_contexts_used = 0
+        consumed_reasoning_contexts: list[dict[str, Any]] = []
         for row in rows:
             blueprint = await self._blueprint_with_reasoning_context(
                 scope=scope,
@@ -269,6 +277,9 @@ class BlogPostGenerationService:
                 continue
             if _has_prompt_reasoning_context(blueprint):
                 reasoning_contexts_used += 1
+                consumed_reasoning_contexts.extend(
+                    consumed_campaign_reasoning_contexts(blueprint)
+                )
             drafts.append(self._build_draft(parsed, blueprint=blueprint))
 
         saved_ids: tuple[str, ...] = ()
@@ -282,6 +293,7 @@ class BlogPostGenerationService:
             generated=len(drafts),
             skipped=skipped,
             reasoning_contexts_used=reasoning_contexts_used,
+            consumed_reasoning_contexts=tuple(consumed_reasoning_contexts),
             saved_ids=saved_ids,
             errors=tuple(errors),
         )

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -25,6 +25,7 @@ from .campaign_ports import (
 from .services.campaign_reasoning_context import (
     campaign_reasoning_context_metadata,
     campaign_reasoning_context_payload,
+    consumed_campaign_reasoning_contexts,
     normalize_campaign_reasoning_context,
 )
 from .services.campaign_quality import campaign_quality_revalidation
@@ -155,11 +156,12 @@ class CampaignGenerationResult:
     generated: int = 0
     skipped: int = 0
     reasoning_contexts_used: int = 0
+    consumed_reasoning_contexts: tuple[Mapping[str, Any], ...] = ()
     saved_ids: tuple[str, ...] = ()
     errors: tuple[dict[str, Any], ...] = field(default_factory=tuple)
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "requested": self.requested,
             "generated": self.generated,
             "skipped": self.skipped,
@@ -167,6 +169,11 @@ class CampaignGenerationResult:
             "saved_ids": list(self.saved_ids),
             "errors": list(self.errors),
         }
+        if self.consumed_reasoning_contexts:
+            data["consumed_reasoning_contexts"] = [
+                dict(item) for item in self.consumed_reasoning_contexts
+            ]
+        return data
 
 
 def parse_campaign_draft_response(text: str) -> dict[str, Any] | None:
@@ -320,6 +327,7 @@ class CampaignGenerationService:
         errors: list[dict[str, Any]] = []
         skipped = 0
         reasoning_contexts_used = 0
+        consumed_reasoning_contexts: list[dict[str, Any]] = []
         resolved_channels = self._channels(override=channels)
         for opportunity in opportunities:
             target_id = opportunity_target_id(opportunity)
@@ -400,6 +408,9 @@ class CampaignGenerationService:
                     }
                 if _has_prompt_reasoning_context(channel_opportunity):
                     reasoning_contexts_used += 1
+                    consumed_reasoning_contexts.extend(
+                        consumed_campaign_reasoning_contexts(channel_opportunity)
+                    )
                 drafts.append(
                     CampaignDraft(
                         target_id=target_id,
@@ -422,6 +433,7 @@ class CampaignGenerationService:
             generated=len(drafts),
             skipped=skipped,
             reasoning_contexts_used=reasoning_contexts_used,
+            consumed_reasoning_contexts=tuple(consumed_reasoning_contexts),
             saved_ids=saved_ids,
             errors=tuple(errors),
         )

--- a/extracted_content_pipeline/services/campaign_reasoning_context.py
+++ b/extracted_content_pipeline/services/campaign_reasoning_context.py
@@ -341,6 +341,25 @@ def campaign_reasoning_context_payload(
     return context.as_dict()
 
 
+def consumed_campaign_reasoning_contexts(value: Any) -> tuple[dict[str, Any], ...]:
+    """Return bounded prompt-visible reasoning contexts from an enriched payload."""
+
+    payload = _copy_dict(value)
+    nested = _copy_dict(payload.get("reasoning_context"))
+    raw_context = _first_dict(
+        payload.get("campaign_reasoning_context"),
+        nested.get("campaign_reasoning_context"),
+    )
+    if not raw_context:
+        return ()
+    context = normalize_campaign_reasoning_context({
+        "campaign_reasoning_context": raw_context,
+    })
+    if not context.has_content():
+        return ()
+    return (campaign_reasoning_context_payload(context),)
+
+
 def campaign_reasoning_context_metadata(
     context: CampaignReasoningContext,
 ) -> dict[str, Any]:
@@ -478,6 +497,7 @@ def campaign_reasoning_delta_summary(
 __all__ = [
     "campaign_reasoning_context_metadata",
     "campaign_reasoning_context_payload",
+    "consumed_campaign_reasoning_contexts",
     "campaign_reasoning_atom_context",
     "campaign_reasoning_delta_summary",
     "campaign_reasoning_scope_summary",

--- a/plans/PR-Content-Ops-Consumed-Reasoning-Campaign-Blog.md
+++ b/plans/PR-Content-Ops-Consumed-Reasoning-Campaign-Blog.md
@@ -1,0 +1,68 @@
+# PR-Content-Ops-Consumed-Reasoning-Campaign-Blog
+
+## Why this slice exists
+
+PR #451 added the execution response contract for
+`reasoning.consumed_contexts`, but the generated-asset services still
+mostly return only `reasoning_contexts_used`. The first attempt to close
+all services in one PR crossed the review-size gate, so this smaller
+slice ships the shared helper and two generator adoptions first.
+
+## Scope (this PR)
+
+1. Add a shared helper that extracts bounded prompt-visible consumed
+   reasoning payloads from an enriched generation payload.
+2. Adopt that helper in campaign generation.
+3. Adopt that helper in blog post generation.
+4. Keep `reasoning_contexts_used`, prompt construction, persistence
+   metadata, provider lookup, and public method signatures unchanged.
+
+### Files touched
+
+- `extracted_content_pipeline/services/campaign_reasoning_context.py`
+- `extracted_content_pipeline/campaign_generation.py`
+- `extracted_content_pipeline/blog_generation.py`
+- `tests/test_extracted_campaign_generation.py`
+- `tests/test_extracted_blog_generation.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Consumed-Reasoning-Campaign-Blog.md`
+
+## Mechanism
+
+`consumed_campaign_reasoning_contexts(payload)` extracts only the
+prompt-visible `campaign_reasoning_context` sibling, or the same key
+nested under `reasoning_context`. It normalizes through the existing
+bounded `CampaignReasoningContext` contract and returns a tuple of
+drawer-ready dictionaries.
+
+Campaign and blog generation append those dictionaries at the same
+point they already increment `reasoning_contexts_used`: after parse and
+quality gates pass, immediately before a draft is accepted.
+
+## Intentional
+
+- No raw provider rows are exposed.
+- No behavior changes when reasoning is absent; `as_dict()` omits
+  `consumed_reasoning_contexts` when empty.
+- Campaign follow-up channels may report the same context more than
+  once because existing usage is per generated draft/channel.
+- Report, landing page, sales brief, smoke, and docs move to the next
+  PR to keep this under the review-size gate.
+
+## Deferred
+
+- Report, landing page, and sales brief service adoption.
+- Offline execution smoke validation for `reasoning.consumed_contexts`.
+- Frontend Reasoning Context Drawer rendering.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_generation.py tests/test_extracted_blog_generation.py` -> 59 passed
+- `python -m py_compile extracted_content_pipeline/services/campaign_reasoning_context.py extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/blog_generation.py` -> passed
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1432 passed, 1 existing torch/pynvml warning
+- `git diff --check` -> passed
+- ASCII byte check on edited Python files -> passed
+
+## Estimated diff size
+
+7 files, roughly +145 / -7. Under the 400 LOC soft review budget.

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -635,7 +635,11 @@ async def test_generate_with_reasoning_provider_merges_context_into_blueprint() 
     assert "reasoning_context" in system_prompt
     assert "campaign_reasoning_context" in system_prompt
     assert "Renewal pricing rose 22 percent" in system_prompt
-    assert result.as_dict()["reasoning_contexts_used"] == 1
+    result_dict = result.as_dict()
+    assert result_dict["reasoning_contexts_used"] == 1
+    assert result_dict["consumed_reasoning_contexts"][0]["top_theses"][0]["claim"] == (
+        "Renewal pricing rose 22 percent"
+    )
 
     # Draft metadata captured reasoning signal.
     drafts = blog_posts.saved[0]["drafts"]

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -411,7 +411,11 @@ async def test_generate_uses_host_reasoning_context_without_pool_compression_imp
     result = await service.generate(scope=scope, target_mode="vendor_retention")
 
     assert result.generated == 1
-    assert result.as_dict()["reasoning_contexts_used"] == 1
+    result_dict = result.as_dict()
+    assert result_dict["reasoning_contexts_used"] == 1
+    assert result_dict["consumed_reasoning_contexts"][0]["proof_points"][0]["label"] == (
+        "pricing_mentions"
+    )
     assert provider.calls[0]["scope"] == scope
     assert provider.calls[0]["target_id"] == "opp-1"
     assert provider.calls[0]["target_mode"] == "vendor_retention"
@@ -1234,4 +1238,3 @@ async def test_generate_per_call_quality_prompt_proof_term_limit_override():
     assert len(found_terms) <= 2, (
         f"override should cap proof terms at 2; saw {len(found_terms)}: {found_terms}"
     )
-


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Consumed-Reasoning-Campaign-Blog.md

Split replacement for closed draft #466. This smaller PR adds the shared consumed-reasoning helper and adopts it only in campaign + blog generation results.

## Intentional
- Exposes only the bounded prompt-visible `campaign_reasoning_context` payload, not raw provider rows.
- Keeps `reasoning_contexts_used`, prompt construction, persistence metadata, provider lookup, and public generation method signatures unchanged.
- Omits `consumed_reasoning_contexts` from result dicts when no reasoning reached the prompt.
- Defers report, landing page, sales brief, smoke, and docs to the next split PR to stay under the review-size gate.

## Deferred
- Report, landing page, and sales brief service adoption.
- Offline execution smoke validation for `reasoning.consumed_contexts`.
- Frontend Reasoning Context Drawer rendering.

## Verification
- `pytest tests/test_extracted_campaign_generation.py tests/test_extracted_blog_generation.py` -> 59 passed
- `python -m py_compile extracted_content_pipeline/services/campaign_reasoning_context.py extracted_content_pipeline/campaign_generation.py extracted_content_pipeline/blog_generation.py` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1432 passed, 1 existing torch/pynvml warning
- `git diff --check` -> passed
- ASCII byte check on edited Python files -> passed

## Diff size
7 files, +126 / -7.
