### PR TITLE
Add live DB reasoning context check for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-10T23:29Z by codex-cleanup-pr469-coordination
+Last updated: 2026-05-10T23:33Z by codex-content-ops-reasoning-db-check
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Add live-DSN DB reasoning context check CLI | NEW: `scripts/check_extracted_campaign_reasoning_postgres.py`; `tests/test_extracted_campaign_reasoning_postgres_check.py`; `plans/PR-Content-Ops-Reasoning-DB-Check.md`. EDIT: `scripts/run_extracted_pipeline_checks.sh`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/host_install_runbook.md`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-reasoning-db-check | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -195,6 +195,16 @@ python scripts/run_extracted_campaign_generation_example.py \
 rows by target id, company, email, or vendor and feeds the normalized
 `CampaignReasoningContextProvider` port documented in
 `docs/reasoning_handoff_contract.md`.
+For DB-backed installs, validate a loaded `campaign_reasoning_contexts` row
+without running generation:
+
+```bash
+python scripts/check_extracted_campaign_reasoning_postgres.py \
+  --account-id acct_123 \
+  --target-id opp_123 \
+  --company-name "Acme" \
+  --json
+```
 
 For lightweight installs that do not already have reasoning JSON, use
 `services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -300,6 +300,19 @@ Use `--multi-pass-pack-name`, `--multi-pass-max-continuations`, and
 See `reasoning_handoff_contract.md` for the accepted shape and the no-direct-
 import rule. AI Content Ops consumes compressed reasoning through a provider;
 the provider may be file-backed, single-pass, multi-pass, or host-owned.
+After applying migration 277 and loading DB-backed reasoning rows, verify a
+target can resolve through the same Postgres adapter used by hosted execution:
+
+```bash
+python scripts/check_extracted_campaign_reasoning_postgres.py \
+  --account-id acct_123 \
+  --target-id opp_123 \
+  --company-name "Acme" \
+  --json
+```
+
+The check exits non-zero when no matching context is found, making it suitable
+for deployment smoke tests after a reasoning ETL or migration run.
 
 ## Step 6: Add Optional Prompt Overrides
 

--- a/plans/PR-Content-Ops-Reasoning-DB-Check.md
+++ b/plans/PR-Content-Ops-Reasoning-DB-Check.md
@@ -1,0 +1,63 @@
+# PR-Content-Ops-Reasoning-DB-Check
+
+## Why this slice exists
+
+PR #463 added the DB-backed reasoning provider and PR #469 proved the provider
+contract through an offline fixture. Operators still need a small live-DSN
+check after applying migration 277 and loading `campaign_reasoning_contexts`
+rows, without running a full generation job.
+
+## Scope (this PR)
+
+1. Add `scripts/check_extracted_campaign_reasoning_postgres.py`.
+2. Use the existing `PostgresCampaignReasoningContextRepository` read path.
+3. Return JSON or concise text and exit non-zero when no context matches.
+4. Add focused unit tests and include them in the extracted gauntlet.
+5. Document the check in README and the host install runbook.
+
+### Files touched
+
+- `scripts/check_extracted_campaign_reasoning_postgres.py`
+- `tests/test_extracted_campaign_reasoning_postgres_check.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The script accepts the same DSN convention as other extracted DB CLIs:
+`--database-url`, `EXTRACTED_DATABASE_URL`, or `DATABASE_URL`. It builds a
+`TenantScope`, passes target selectors to
+`PostgresCampaignReasoningContextRepository.read_campaign_reasoning_context`,
+and emits:
+
+- `status="ok"` plus the normalized context payload when found.
+- `status="missing"` with exit code 1 when no context matches.
+
+The check is read-only and does not create, mutate, or seed rows.
+
+## Intentional
+
+- No generation, sender, LLM, or network-provider handles are opened.
+- No production API behavior changes.
+- No new table shape; the script only uses migration 277's table through the
+  existing repository.
+
+## Deferred
+
+- Full end-to-end live generation smoke from DB reasoning row to persisted
+  generated asset.
+- Admin UI surfacing for provider health.
+
+## Verification
+
+- Focused test file.
+- `python -m py_compile` on the new script.
+- Full extracted pipeline check.
+- `git diff --check`.
+- ASCII byte check on edited Python/test files.
+
+## Estimated diff size
+
+7 files, roughly +190 / -0. Under the 400 LOC soft review budget.

--- a/scripts/check_extracted_campaign_reasoning_postgres.py
+++ b/scripts/check_extracted_campaign_reasoning_postgres.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Check DB-backed Content Ops reasoning context lookup."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_reasoning_postgres import (  # noqa: E402
+    PostgresCampaignReasoningContextRepository,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a campaign_reasoning_contexts row can be read for a "
+            "target through the DB-backed Content Ops reasoning provider."
+        )
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--account-id", default="", help="Tenant/account id.")
+    parser.add_argument("--target-id", required=True, help="Primary target id.")
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--company-name", default="")
+    parser.add_argument("--company", default="")
+    parser.add_argument("--contact-email", default="")
+    parser.add_argument("--email", default="")
+    parser.add_argument("--vendor-name", default="")
+    parser.add_argument("--vendor", default="")
+    parser.add_argument(
+        "--table",
+        default="campaign_reasoning_contexts",
+        help="Reasoning context table name.",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to check campaign reasoning context; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _check_reasoning_context(
+    repository: Any,
+    *,
+    account_id: str,
+    target_id: str,
+    target_mode: str,
+    opportunity: Mapping[str, Any],
+) -> dict[str, Any]:
+    context = await repository.read_campaign_reasoning_context(
+        scope=TenantScope(account_id=account_id),
+        target_id=target_id,
+        target_mode=target_mode,
+        opportunity=opportunity,
+    )
+    if context is None:
+        return {
+            "status": "missing",
+            "target_id": target_id,
+            "target_mode": target_mode,
+        }
+    payload = context.as_dict() if hasattr(context, "as_dict") else dict(context)
+    return {
+        "status": "ok",
+        "target_id": target_id,
+        "target_mode": target_mode,
+        "context": payload,
+    }
+
+
+def _opportunity_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    pairs = {
+        "company_name": args.company_name,
+        "company": args.company,
+        "contact_email": args.contact_email,
+        "email": args.email,
+        "vendor_name": args.vendor_name,
+        "vendor": args.vendor,
+    }
+    return {
+        key: str(value).strip()
+        for key, value in pairs.items()
+        if str(value or "").strip()
+    }
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        repository = PostgresCampaignReasoningContextRepository(
+            pool=pool,
+            table=args.table,
+        )
+        result = await _check_reasoning_context(
+            repository,
+            account_id=str(args.account_id or ""),
+            target_id=str(args.target_id or ""),
+            target_mode=str(args.target_mode or ""),
+            opportunity=_opportunity_from_args(args),
+        )
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif result["status"] == "ok":
+        print(
+            "found reasoning context for "
+            f"target_id={result['target_id']} target_mode={result['target_mode']}"
+        )
+    else:
+        print(
+            "missing reasoning context for "
+            f"target_id={result['target_id']} target_mode={result['target_mode']}",
+            file=sys.stderr,
+        )
+    return 0 if result["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -28,6 +28,7 @@ pytest \
   tests/test_extracted_blog_generation.py \
   tests/test_extracted_blog_post_postgres.py \
   tests/test_extracted_campaign_reasoning_postgres.py \
+  tests/test_extracted_campaign_reasoning_postgres_check.py \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \
   tests/test_extracted_content_control_surface_api.py \

--- a/tests/test_extracted_campaign_reasoning_postgres_check.py
+++ b/tests/test_extracted_campaign_reasoning_postgres_check.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import CampaignReasoningContext
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_extracted_campaign_reasoning_postgres.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_extracted_campaign_reasoning_postgres",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Repository:
+    def __init__(self, context: CampaignReasoningContext | None) -> None:
+        self.context = context
+        self.calls: list[dict[str, Any]] = []
+
+    async def read_campaign_reasoning_context(self, **kwargs: Any) -> Any:
+        self.calls.append(dict(kwargs))
+        return self.context
+
+
+def test_opportunity_from_args_drops_blank_values() -> None:
+    module = _load_script_module()
+    args = argparse.Namespace(
+        company_name=" Acme ",
+        company="",
+        contact_email=" buyer@example.com ",
+        email=None,
+        vendor_name="HubSpot",
+        vendor=" ",
+    )
+
+    assert module._opportunity_from_args(args) == {
+        "company_name": "Acme",
+        "contact_email": "buyer@example.com",
+        "vendor_name": "HubSpot",
+    }
+
+
+@pytest.mark.asyncio
+async def test_check_reasoning_context_returns_ok_payload() -> None:
+    module = _load_script_module()
+    repo = _Repository(
+        CampaignReasoningContext(
+            top_theses=({"claim": "Renewal pricing"},),
+            proof_points=({"label": "source_material", "value": "pricing"},),
+        )
+    )
+
+    result = await module._check_reasoning_context(
+        repo,
+        account_id="acct-1",
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={"company_name": "Acme"},
+    )
+
+    assert result["status"] == "ok"
+    assert result["context"]["top_theses"][0]["claim"] == "Renewal pricing"
+    assert repo.calls[0]["scope"].account_id == "acct-1"
+    assert repo.calls[0]["target_id"] == "opp-1"
+    assert repo.calls[0]["opportunity"] == {"company_name": "Acme"}
+
+
+@pytest.mark.asyncio
+async def test_check_reasoning_context_returns_missing_payload() -> None:
+    module = _load_script_module()
+
+    result = await module._check_reasoning_context(
+        _Repository(None),
+        account_id="acct-1",
+        target_id="opp-404",
+        target_mode="vendor_retention",
+        opportunity={},
+    )
+
+    assert result == {
+        "status": "missing",
+        "target_id": "opp-404",
+        "target_mode": "vendor_retention",
+    }

--- a/tests/test_extracted_campaign_reasoning_postgres_check.py
+++ b/tests/test_extracted_campaign_reasoning_postgres_check.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 from pathlib import Path
+import sys
 from typing import Any
 
 import pytest
@@ -95,3 +96,48 @@ async def test_check_reasoning_context_returns_missing_payload() -> None:
         "target_id": "opp-404",
         "target_mode": "vendor_retention",
     }
+
+
+@pytest.mark.asyncio
+async def test_cli_boundary_returns_one_when_no_context_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+
+    class _Pool:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    pool = _Pool()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_extracted_campaign_reasoning_postgres.py",
+            "--database-url",
+            "postgres://example",
+            "--account-id",
+            "acct-1",
+            "--target-id",
+            "opp-404",
+        ],
+    )
+    async def _pool_factory(_dsn: str) -> _Pool:
+        return pool
+
+    monkeypatch.setattr(module, "_create_pool", _pool_factory)
+    monkeypatch.setattr(
+        module,
+        "PostgresCampaignReasoningContextRepository",
+        lambda **_kwargs: _Repository(None),
+    )
+
+    assert await module._main() == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "missing reasoning context for target_id=opp-404" in captured.err
+    assert pool.closed is True


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-DB-Check.md

## Summary
- add a read-only live-DSN check for campaign_reasoning_contexts lookup through the DB-backed reasoning provider
- return JSON/text and exit non-zero when no matching context is found
- document the check in README/runbook and include its tests in the extracted gauntlet

## Verification
- pytest tests/test_extracted_campaign_reasoning_postgres_check.py -> 3 passed
- python -m py_compile scripts/check_extracted_campaign_reasoning_postgres.py -> passed
- python scripts/check_extracted_campaign_reasoning_postgres.py --target-id opp-1 --json -> expected missing-DSN exit
- bash scripts/run_extracted_pipeline_checks.sh -> 1446 passed, 1 existing torch/pynvml warning
- git diff --check -> passed
- ASCII byte check on edited Python/test files -> passed

## Coordination
- Follows #463 and #469
- Opened as draft for review before merge