### PR TITLE
Lock route-level Content Ops consumed reasoning payloads

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T00:34Z by codex-content-ops-reasoning-ui-parity
+Last updated: 2026-05-11T00:42Z by codex-content-ops-route-reasoning-payload
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Render Content Ops reasoning provider source and consumed contexts in Atlas Intel UI | NEW: `plans/PR-Content-Ops-Reasoning-UI-Parity.md`. EDIT: `atlas-intel-ui/src/api/contentOps.ts`; `atlas-intel-ui/src/domain/contentOps/types.ts`; `atlas-intel-ui/src/domain/contentOps/fromWire.ts`; `atlas-intel-ui/src/domain/contentOps/index.ts`; `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `atlas-intel-ui/src/api/__fixtures__/contentOps/execution-completed.json`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-reasoning-ui-parity | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md
+++ b/plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md
@@ -1,0 +1,52 @@
+# Content Ops Route Reasoning Payload Regression
+
+## Why this slice exists
+
+Recent slices added route-level reasoning provider wiring, executor-level
+`reasoning.consumed_contexts`, and UI rendering for consumed contexts. Coverage
+still had one boundary gap: no test proved that `POST /content-ops/execute`
+returns consumed context payloads after resolving a route-level provider and
+rebinding the host service bundle.
+
+## Scope (this PR)
+
+1. Add a route-boundary regression test for provider resolution ->
+   `with_reasoning_context()` -> execution response `reasoning.consumed_contexts`.
+2. Remove the merged #473 coordination row and claim this slice.
+
+### Files touched
+
+- `tests/test_extracted_content_control_surface_api.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`
+
+## Mechanism
+
+The test uses the existing control-surface router directly. A fake campaign
+service returns `reasoning_contexts_used=1` and a
+`consumed_reasoning_contexts` row only when the route-level provider has been
+attached through `with_reasoning_context()`. The assertion checks the endpoint
+payload, not the lower-level executor helper.
+
+## Intentional
+
+- No production code change. This is a regression lock for behavior already
+  shipped across prior slices.
+- The fake service does not call a real provider. Provider lookup is already
+  covered by the file/DB provider tests and the live-DSN check CLI.
+
+## Deferred
+
+- No frontend screenshot or browser test. PR #473 already covered the UI build.
+- No live database setup. PR #471 owns live provider lookup.
+
+## Verification
+
+- `pytest tests/test_extracted_content_control_surface_api.py` -> 26 passed
+- `python -m py_compile tests/test_extracted_content_control_surface_api.py` -> passed
+- `git diff --check` -> passed
+- ASCII byte check on edited Python file -> passed
+
+## Estimated diff size
+
+3 files, about +90 / -2 including this plan.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -582,6 +582,30 @@ class _ReasoningCapturingService:
         return {"generated": 1, "saved_ids": ["draft-1"]}
 
 
+class _ReasoningPayloadService(_ReasoningCapturingService):
+    def with_reasoning_context(self, provider):
+        return _ReasoningPayloadService(reasoning_context=provider)
+
+    async def generate(self, *, scope, target_mode, limit=None, filters=None, **kwargs):
+        self.calls.append({
+            "reasoning_context": self._reasoning_context,
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "kwargs": dict(kwargs),
+        })
+        payload = {"generated": 1, "saved_ids": ["draft-1"]}
+        if self._reasoning_context is not None:
+            payload["reasoning_contexts_used"] = 1
+            payload["consumed_reasoning_contexts"] = [
+                {
+                    "summary": "Acme renewal pricing pressure",
+                    "proof_points": [{"label": "source_material", "value": "pricing"}],
+                }
+            ]
+        return payload
+
+
 @pytest.mark.asyncio
 async def test_execute_route_threads_reasoning_provider_into_services():
     """A configured ``reasoning_context_provider`` reaches the service
@@ -614,6 +638,45 @@ async def test_execute_route_threads_reasoning_provider_into_services():
     # route's behavior already implies the wiring; the unit-level
     # bundle test in test_extracted_content_ops_execution.py asserts
     # the mechanical detail.
+
+
+@pytest.mark.asyncio
+async def test_execute_route_returns_consumed_reasoning_payloads_from_rebound_service():
+    """Route-level provider resolution must compose with the executor's
+    consumed-context audit. This locks the HTTP payload shape that the
+    UI consumes, not just the lower-level executor helper."""
+
+    base = _ReasoningPayloadService()
+    sentinel = object()
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            campaign=base
+        ),
+        reasoning_context_provider=lambda: sentinel,
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        }
+    )
+
+    assert base.calls == []
+    assert payload["steps"][0]["reasoning"] == {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": True,
+        "provider_configured": True,
+        "contexts_used": 1,
+        "consumed_contexts": [
+            {
+                "summary": "Acme renewal pricing pressure",
+                "proof_points": [{"label": "source_material", "value": "pricing"}],
+            }
+        ],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md

Route tests covered provider rebinding and executor tests covered consumed context copying, but no route-boundary regression proved both compose in `POST /content-ops/execute`.

## Intentional
- Test-only production behavior lock; no runtime code change.
- Fake service returns consumed payloads only after route-level provider rebinding.
- No real provider or DB lookup in this test; those are covered elsewhere.

## Deferred
- No browser/UI test; PR #473 covered UI build parity.
- No live DB setup; PR #471 covers live provider lookup.

## Verification
- `pytest tests/test_extracted_content_control_surface_api.py` -> 26 passed
- `python -m py_compile tests/test_extracted_content_control_surface_api.py` -> passed
- `git diff --check` -> passed
- ASCII byte check on edited Python file -> passed

## Diff size
3 files, +117 / -2