### PR TITLE
Refresh Content Ops reasoning docs after UI parity

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T00:42Z by codex-content-ops-route-reasoning-payload
+Last updated: 2026-05-11T00:47Z by codex-content-ops-reasoning-docs-current
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Refresh Content Ops reasoning docs after compact consumed-context UI shipped | NEW: `plans/PR-Content-Ops-Reasoning-Docs-Current.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/frontend/content_ops_frontend_contract.md`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-reasoning-docs-current | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -463,8 +463,9 @@ UI rules:
   `reasoningRequirement="optional_host_context"`.
 - Treat catalog badges as configuration readiness only. Use
   `step.reasoning` for execution-level readiness ("provider attached" /
-  "provider absent"). Render a context drawer only when
-  `step.reasoning.consumed_contexts` is present.
+  "provider absent"). Render compact consumed-context summaries when
+  `step.reasoning.consumed_contexts` is present; reserve richer
+  drawer/detail inspection for a follow-up.
 
 ---
 
@@ -555,9 +556,8 @@ Dumb components only. No fetch, no business rules.
 - Visual workflow builder
 - Model-selection UX
 - Full Reasoning Context Drawer UX. `/content-ops/execute` now exposes
-  `reasoning.consumed_contexts` for LLM-backed generated assets when
-  reasoning reaches the prompt, but the actual drawer component lands
-  separately.
+  `reasoning.consumed_contexts`, and Atlas Intel renders compact summaries,
+  but the richer drawer/detail inspector lands separately.
 - Collaboration / role-permission flows
 - CMS export
 - Approval workflow (no backend approval state on the control-surface

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -150,7 +150,8 @@
   services. Runner results include `reasoning_contexts_used` and, when
   reasoning reached the prompt, `consumed_reasoning_contexts`; the per-step
   `reasoning` audit mirrors those as `contexts_used` and `consumed_contexts`
-  for future reasoning-drawer UIs.
+  for UI inspection. Atlas Intel renders compact consumed-context summaries;
+  a fuller drawer/detail UX remains a frontend follow-up.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/plans/PR-Content-Ops-Reasoning-Docs-Current.md
+++ b/plans/PR-Content-Ops-Reasoning-Docs-Current.md
@@ -1,0 +1,50 @@
+# Content Ops Reasoning Docs Current
+
+## Why this slice exists
+
+PRs #472-#474 closed the reasoning-source and consumed-context path through the
+backend, route boundary, and Atlas Intel UI. A few docs still described the
+Reasoning Context Drawer as wholly future work even though the UI now renders
+compact consumed-context summaries.
+
+## Scope (this PR)
+
+1. Update status/frontend docs to reflect that compact consumed-context
+   rendering has shipped.
+2. Keep full drawer/detail UX explicitly deferred.
+3. Remove the merged #474 coordination row and claim this slice.
+
+### Files touched
+
+- `extracted_content_pipeline/STATUS.md`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Reasoning-Docs-Current.md`
+
+## Mechanism
+
+This is documentation-only. It changes stale future-tense language to current
+state:
+
+- `reasoning.consumed_contexts` exists in execution responses.
+- Atlas Intel UI renders compact summaries for consumed contexts.
+- A richer drawer/detail inspector remains deferred.
+
+## Intentional
+
+- No production code or tests change.
+- Older plan docs are not rewritten; they are historical records of the PRs
+  they described.
+
+## Deferred
+
+- Full consumed-context drawer/detail UX.
+- Any additional frontend screenshots or browser automation.
+
+## Verification
+
+- `git diff --check` -> passed
+
+## Estimated diff size
+
+4 files, about +70 / -10 including this plan.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Docs-Current.md

The backend and Atlas Intel UI now expose and render compact consumed-context summaries, but some docs still described that entire surface as future work.

## Intentional
- Documentation-only; no production code or tests change.
- Keep full drawer/detail inspection explicitly deferred.
- Do not rewrite historical plan docs.

## Deferred
- Full consumed-context drawer/detail UX.
- Browser screenshot automation.

## Verification
- `git diff --check` -> passed

## Diff size
4 files, +59 / -8