### PR TITLE
Fix blog_post reasoning fixture and docs

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -29,7 +29,7 @@
         "topic"
       ],
       "default_max_items": 1,
-      "reasoning_requirement": "absent",
+      "reasoning_requirement": "optional_host_context",
       "execution_configured": false,
       "can_execute": false
     },

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T00:47Z by codex-content-ops-reasoning-docs-current
+Last updated: 2026-05-11T00:53Z by codex-content-blog-reasoning-fixture-doc
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Refresh Content Ops reasoning docs after compact consumed-context UI shipped | NEW: `plans/PR-Content-Ops-Reasoning-Docs-Current.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/frontend/content_ops_frontend_contract.md`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-reasoning-docs-current | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -64,7 +64,7 @@ Current output ids:
 | Output | Status | Reasoning | Notes |
 |---|---|---|---|
 | `email_campaign` | Implemented | `optional_host_context` | Existing campaign draft path. |
-| `blog_post` | Implemented | `absent` | Blog-post generation service path. |
+| `blog_post` | Implemented | `optional_host_context` | Blog-post generation service path. |
 | `report` | Implemented | `optional_host_context` | Structured report draft path. |
 | `landing_page` | Implemented | `optional_host_context` | Landing page generation service path. |
 | `sales_brief` | Implemented | `optional_host_context` | Sales brief generation service path. |

--- a/plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md
+++ b/plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md
@@ -1,0 +1,54 @@
+# PR-Content-Ops-Blog-Reasoning-Fixture-Doc
+
+## Why this slice exists
+
+The Content Ops backend catalog and tests now classify `blog_post` as
+`reasoning_requirement="optional_host_context"`, but the frontend catalog
+fixture and preview API documentation still say `absent`. That stale value can
+mislead future UI work and review even though the runtime catalog is correct.
+
+This slice also replaces the stale in-flight row left by PR 475 with the active
+coordination row for this corrective PR.
+
+## Scope (this PR)
+
+1. Update the static Content Ops frontend catalog fixture so `blog_post`
+   matches the backend catalog.
+2. Update the preview API output-catalog table to match the backend catalog.
+3. Refresh the coordination in-flight row for this PR.
+
+### Files touched
+
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`
+
+## Mechanism
+
+The backend source of truth is `extracted_content_pipeline/control_surfaces.py`.
+Its `OUTPUT_CATALOG["blog_post"].reasoning_requirement` is already
+`optional_host_context`, and backend tests assert that value. This PR updates
+the static fixture and documentation to the same value; no runtime code changes.
+
+## Intentional
+
+- No backend or UI component logic changes. The runtime contract is already
+  correct; only static contract material was stale.
+- No fixture regeneration. The only stale field found in this slice is the
+  `blog_post` reasoning requirement.
+
+## Deferred
+
+- None. This closes the discovered fixture/doc drift for `blog_post`.
+
+## Verification
+
+- `npm ci` in `atlas-intel-ui`
+- `npm run build` in `atlas-intel-ui`
+- `rg -n "blog_post.*absent|absent.*blog_post|\\| `blog_post` \\| Implemented \\| `absent`" atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json extracted_content_pipeline/docs/control_surface_preview_api.md docs/frontend/content_ops_frontend_contract.md tests extracted_content_pipeline/control_surfaces.py`
+- `git diff --check`
+
+## Estimated diff size
+
+4 files, under 120 LOC total.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md

The backend Content Ops catalog and tests classify `blog_post` as `optional_host_context`, but the static UI catalog fixture and preview API doc still said `absent`. This aligns the static contract material with the runtime source of truth.

## Intentional
- Docs and fixture only; no backend or UI runtime change.
- Replaces the stale PR 475 in-flight row with this active slice.

## Deferred
- None.

## Verification
- `npm ci` in `atlas-intel-ui` (completed; existing audit findings only)
- `npm run build` in `atlas-intel-ui` (passed)
- `rg -n 'blog_post.*absent|absent.*blog_post|\\| `blog_post` \\| Implemented \\| `absent`' atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json extracted_content_pipeline/docs/control_surface_preview_api.md docs/frontend/content_ops_frontend_contract.md tests extracted_content_pipeline/control_surfaces.py` (only unrelated churn test name remains)
- `git diff --check` (passed)

## Diff size
4 files, +58 / -4