### PR TITLE
Log ordered AI Content Ops deferred backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -1,0 +1,120 @@
+# AI Content Ops Deferred Backlog
+
+Date: 2026-05-11
+
+## Purpose
+
+This is the current ordered backlog for AI Content Ops deferrals surfaced by
+older PR plans and post-merge audits. It is not a full product roadmap; it is
+the short list of follow-up work that still matters after the execution,
+reasoning, export, and compact UI parity work already merged.
+
+## Retired Historical Deferrals
+
+The following items appear in older plan docs but are no longer active backlog:
+
+- Execution service wiring for `email_campaign`, `blog_post`, `report`,
+  `landing_page`, `sales_brief`, and `signal_extraction`.
+- Host LLM and skill adapters for the Content Ops execution bundle.
+- File-backed and DB-backed reasoning provider wiring.
+- Catalog-level reasoning provider status.
+- Consumed reasoning payloads and compact consumed-context summaries for the
+  five LLM-backed generated assets.
+- Atlas Intel compact rendering for reasoning source and consumed contexts.
+- Parse-retry parity and retry-adjusted usage/cost reporting across generated
+  assets.
+- Generated asset export and review paths for report, blog post, landing page,
+  and sales brief drafts.
+- `blog_post` reasoning catalog/fixture parity.
+
+## Active Backlog
+
+### 1. Live execute persistence smoke for all generated assets
+
+**Priority:** P0
+
+**Why:** This is the strongest operational proof that AI Content Ops is usable
+outside Atlas. Existing tests cover bundles, route boundaries, offline smokes,
+and provider contracts, but there is still no single live smoke proving:
+
+1. `POST /content-ops/execute` enters the hosted route.
+2. Tenant scope is applied.
+3. Host adapters are used.
+4. Each LLM-backed output persists a real draft.
+5. The response reports generated ids, reasoning usage, and failures correctly.
+
+**Likely slice:** one PR with a focused route-level smoke for the smallest
+fixture set, then expand asset-by-asset if the first version gets too large.
+
+### 2. Blog blueprint population path
+
+**Priority:** P1
+
+**Why:** Blog execution is wired, but the sellable blog path needs a reliable
+way to populate `blog_blueprints`. Older storage work intentionally deferred
+the host autonomous task or ETL that writes blueprints. Without this, blog
+generation can be technically wired while still depending on pre-seeded rows.
+
+**Likely slice:** define the host-side blueprint ingestion/population seam and
+add one CLI or task adapter that writes `PostBlueprint` rows through the
+product-owned repository.
+
+### 3. Intervention or autonomous reasoning provider
+
+**Priority:** P1
+
+**Why:** File and DB providers are enough for handoff, but they do not yet turn
+Atlas reasoning/intervention outputs into Content Ops context automatically.
+This is the bridge to the higher-value product story: reasoning as a separate
+layer that content products can consume.
+
+**Likely slice:** add a provider that reads
+`intelligence/autonomous_narrative_architect` or equivalent intervention output
+and normalizes it into the existing `CampaignReasoningContextProvider` port.
+
+### 4. DB reasoning provider hardening
+
+**Priority:** P2
+
+**Why:** The DB provider is functional, but older plans deferred operational
+polish:
+
+- Per-target-mode read filtering.
+- Settings integration for provider selection/config.
+- Upsert semantics for saved contexts.
+- Stale-context sweeper.
+- Admin editing workflow for context rows.
+
+**Likely slice:** start with per-target-mode filtering and settings integration;
+defer admin UI until the storage semantics are stable.
+
+### 5. Full reasoning context drawer/detail UX
+
+**Priority:** P2
+
+**Why:** Atlas Intel now renders compact consumed-context summaries. The richer
+drawer/detail UI remains deferred. This is useful for trust and debugging, but
+it should follow the live smoke/provider hardening work because the runtime
+contract is already inspectable at a compact level.
+
+**Likely slice:** add a drawer over the existing `reasoning.consumed_contexts`
+payload first. Do not add a new backend shape unless the current bounded
+payload is insufficient.
+
+### 6. Operator review UX and richer result previews
+
+**Priority:** P3
+
+**Why:** Older frontend/result-summary plans deferred batch review/status
+updates, richer generated-asset previews, and component-level tests. These are
+product polish, not core readiness blockers.
+
+**Likely slice:** batch review/status updates before richer preview cards,
+because batch review improves operator throughput across all asset types.
+
+## Current Pick Recommendation
+
+Take item 1 next: live execute persistence smoke. It proves the standalone
+product works end-to-end through the same route and adapter seams customers
+would use. If that smoke exposes setup friction, fix the friction before adding
+more UI surface.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T00:53Z by codex-content-blog-reasoning-fixture-doc
+Last updated: 2026-05-11T01:04Z by codex-content-ops-deferred-backlog-log
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-deferred-backlog-log | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,12 +1,12 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T01:04Z by codex-content-ops-deferred-backlog-log
+Last updated: 2026-05-11T01:10Z by codex-2026-05-11
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
 | (in flight) | Promote `autonomous/visibility.py` from Phase 1 bridge to manifest-synced mirror (Phase 3 progress, 1/7 active bridges) | EDIT: `extracted_competitive_intelligence/manifest.json` (+ source/target mapping for `autonomous/visibility.py` AND `storage/migrations/246_pipeline_visibility.sql` per Codex P2). REPLACE: `extracted_competitive_intelligence/autonomous/visibility.py` (23-LOC bridge -> 344-LOC mirror copy of atlas_brain peer via `sync_extracted.sh`). NEW: `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` (mirror of atlas migration creating `artifact_attempts` / `enrichment_quarantines` / `pipeline_visibility_events` / `pipeline_visibility_reviews` so standalone deployments don't silently drop visibility writes). atlas_brain count 12->11. | claude-2026-05-03 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-deferred-backlog-log | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -2,6 +2,11 @@
 
 ## Current state
 
+Current ordered AI Content Ops deferrals are tracked in
+`docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. Older plan docs
+still contain historical `Deferred` sections; use the backlog doc as the active
+source of truth for what remains.
+
 - Scaffold root exists at `extracted_content_pipeline/`.
 - Primary task modules are copied and import-smokeable:
   - `blog_post_generation.py`

--- a/plans/PR-Content-Ops-Deferred-Backlog-Log.md
+++ b/plans/PR-Content-Ops-Deferred-Backlog-Log.md
@@ -1,0 +1,49 @@
+# PR-Content-Ops-Deferred-Backlog-Log
+
+## Why this slice exists
+
+The Content Ops extraction has accumulated many `Deferred` sections across
+older PR plans. Most of the high-impact items have since landed, but the old
+plan docs still make it hard to tell what is active backlog versus closed
+history.
+
+This docs-only slice records the remaining AI Content Ops deferrals in priority
+order so the next implementation slices can be picked deliberately.
+
+## Scope (this PR)
+
+1. Add a current AI Content Ops deferred backlog doc.
+2. Link the backlog from `extracted_content_pipeline/STATUS.md`.
+3. Update the coordination in-flight table for this docs slice.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Deferred-Backlog-Log.md`
+
+## Mechanism
+
+The backlog separates retired historical deferrals from active follow-up work.
+Active items are ordered by production value: operational proof first, then
+data-feed readiness, then advanced reasoning provider work, then operator UX.
+
+## Intentional
+
+- Documentation only. No runtime behavior changes.
+- The backlog is intentionally ordered, not exhaustive grep output.
+- Old plan docs are left intact as historical records.
+
+## Deferred
+
+- Implementing the backlog items themselves.
+
+## Verification
+
+- `rg -n "Active Backlog|Retired Historical Deferrals|Deferred Backlog" docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md extracted_content_pipeline/STATUS.md docs/extraction/coordination/inflight.md`
+- `git diff --check`
+
+## Estimated diff size
+
+4 files, under 160 LOC.

--- a/plans/PR-Content-Ops-Deferred-Backlog-Log.md
+++ b/plans/PR-Content-Ops-Deferred-Backlog-Log.md
@@ -46,4 +46,4 @@ data-feed readiness, then advanced reasoning provider work, then operator UX.
 
 ## Estimated diff size
 
-4 files, under 160 LOC.
+4 files; docs-only plus coordination.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Deferred-Backlog-Log.md

Older Content Ops plan docs contain many `Deferred` sections, but most of the major items have since landed. This PR records the active remaining backlog in priority order and links STATUS.md to that current source of truth.

## Intentional
- Documentation only; no runtime behavior changes.
- Older plan docs remain historical records instead of being rewritten.
- The backlog is ordered by production value, not raw grep frequency.

## Deferred
- Implementing the listed backlog items.

## Verification
- `rg -n "Active Backlog|Retired Historical Deferrals|Deferred Backlog|Current ordered AI Content Ops deferrals|Log ordered AI Content Ops deferred backlog" docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md extracted_content_pipeline/STATUS.md docs/extraction/coordination/inflight.md` (passed)
- `git diff --check` (passed)

## Diff size
4 files, +176 / -2