### PR TITLE
Pre-push audit scripts: CLAUDE.md MCP counts + plan doc shape

### DIFF
--- a/plans/PR-Pre-Push-Audit-Scripts.md
+++ b/plans/PR-Pre-Push-Audit-Scripts.md
@@ -1,0 +1,185 @@
+# PR-Pre-Push-Audit-Scripts
+
+## Why this slice exists
+
+PR #457 (the CLAUDE.md / AGENTS.md refresh) was caught three times
+by the Codex bot for stale numeric claims in `CLAUDE.md`:
+
+1. `email_server` listed as 8 tools; actual is 9.
+2. `invoicing_server` listed as 15 tools; actual is 18.
+3. `intelligence_server` listed as 17 tools; actual is 33.
+4. `b2b_churn_server` headline listed as "60+" / "66"; actual sum
+   across `mcp/b2b/*.py` is 83.
+5. `MCP Servers` section intro still said "Seven MCP servers" after
+   nine were documented above it.
+6. Invoicing tool inventory listed 15 names below an "18 tools"
+   header.
+
+Each catch cost a Codex review round-trip, a CLAUDE.md edit, a
+commit, and a push. The drift would never have shipped if a
+mechanical pre-push check had grep-counted `@mcp.tool` decorators
+and diffed against CLAUDE.md's claims.
+
+Companion analysis in PR #457's discussion concluded: *bash scripts
+beat subagents for mechanical audits*. Subagents save parent-context
+tokens but cost system-prompt overhead per invocation; bash scripts
+cost zero LLM tokens. The biggest absolute-token savings on the
+table for our PR workflow are the mechanical audits we don't yet
+have.
+
+This slice ships those audits.
+
+## Scope (this PR)
+
+1. `scripts/audit_claude_md_claims.py` — parse `CLAUDE.md` for
+   numeric MCP tool-count claims, count actual `@mcp.tool`
+   decorators in `atlas_brain/mcp/*_server.py` (and the
+   `atlas_brain/mcp/b2b/` sub-module split for `b2b_churn_server`),
+   report drift, exit 1 if any.
+2. `scripts/audit_plan_doc.py` — given a path to a plan doc,
+   verify it has the 7 required AGENTS.md sections in order
+   (Why / Scope / Mechanism / Intentional / Deferred /
+   Verification / Estimated diff size). Exit 1 if any missing or
+   out of order.
+3. `scripts/pre_push_audit.sh` — convenience wrapper that runs
+   both above + existing `scripts/check_ascii_python.sh`. One
+   command for the builder to run before opening a PR.
+
+### Files touched
+
+- `scripts/audit_claude_md_claims.py` (new)
+- `scripts/audit_plan_doc.py` (new)
+- `scripts/pre_push_audit.sh` (new)
+- `plans/PR-Pre-Push-Audit-Scripts.md` (this file, new)
+
+No edits to existing files. No wiring into git hooks, CI, or
+`AGENTS.md` (all deferred — see *Deferred*).
+
+## Mechanism
+
+### `audit_claude_md_claims.py`
+
+Two functions:
+
+```
+actual_counts() -> dict[str, int]
+    For each atlas_brain/mcp/*_server.py, count grep -c "@mcp.tool".
+    For atlas_brain/mcp/b2b/, sum @mcp.tool across all *.py files
+    and report as "b2b_churn".
+
+claimed_counts() -> dict[str, int]
+    Parse the MCP servers table in CLAUDE.md (the "### atlas_brain/mcp/"
+    table). Match rows shaped like "| Email | 8057 | 9 | ..." and
+    extract (server name, tool count).
+```
+
+Report per-server: claimed, actual, status (OK or DRIFT). Exit 1
+if any DRIFT.
+
+### `audit_plan_doc.py`
+
+Reads the plan doc; for each of the 7 required section titles,
+scan for a line starting with `## ` containing that title (case
+insensitive). Track order. Report each section as `OK <heading>`
+or `MISSING ## <title>`. Exit 1 if any missing or out of order.
+
+### `pre_push_audit.sh`
+
+Bash wrapper that runs the above two + the existing ASCII check.
+Reports a summary line per check. Exit 1 if any check failed.
+
+## Intentional
+
+- **Python, not pure bash, for the parsers.** `audit_claude_md_claims`
+  needs regex matching across markdown tables; `audit_plan_doc`
+  needs ordered-section validation. Both stay simple in Python
+  (~80 LOC each) vs gnarly in bash. The wrapper is bash for the
+  "run everything" entry point.
+- **ASCII output only** — matches `scripts/check_ascii_python.sh`
+  policy for `.py` files; using OK / DRIFT / MISSING text labels
+  instead of ✓ / ✗ unicode.
+- **No new dependencies.** Pure stdlib (`pathlib`, `re`, `sys`).
+  Runs in any venv that has Python 3.10+.
+- **Auditors report drift; they don't enforce a specific CLAUDE.md
+  state.** On `main` today, `audit_claude_md_claims.py` will
+  report drift because PR #457 hasn't merged. When #457 merges,
+  drift goes to zero. The auditor's job is to *tell you*, not to
+  presume which side is correct.
+- **No git hook installation.** Wiring `pre_push_audit.sh` into
+  `.git/hooks/pre-push` is a per-developer choice; some prefer to
+  run it manually. Scripted as a runnable file under `scripts/`,
+  not as a hook.
+- **`audit_plan_doc.py` does not yet check "Files touched"
+  matches `git diff --name-only`.** That requires a `--base-ref`
+  argument and git plumbing; punted to a follow-up so this slice
+  stays small and reviewable.
+
+## Deferred
+
+- **`scripts/audit_pr_claims.py`** — a broader claim verifier that
+  parses arbitrary PR body / CLAUDE.md claims (file paths exist,
+  "wired into X" claims, package LOC claims) and verifies each.
+  Would have caught the `.mcp.json` claim Codex flagged in PR #457.
+  Follow-up slice: `PR-Audit-PR-Claims`.
+- **`audit_plan_doc.py --base-ref` flag** to verify the
+  *Files touched* subsection matches `git diff --name-only
+  <base-ref>...HEAD`. Follow-up slice once the base auditor is in
+  use.
+- **Git pre-push hook wiring.** A `scripts/install_pre_push_hook.sh`
+  installer that creates `.git/hooks/pre-push` calling
+  `scripts/pre_push_audit.sh`. Follow-up if/when we want enforcement.
+- **CI integration.** Adding the auditors to the GitHub Actions
+  pipeline. Follow-up: `PR-CI-Wire-Audit-Scripts`.
+- **AGENTS.md reference to the auditors.** A bullet under
+  "Builder workflow" that says "run `bash scripts/pre_push_audit.sh`
+  before pushing." Follow-up so this slice can land without
+  AGENTS.md churn.
+- **`pre_push_audit.sh` running per-`extracted_*` validators.**
+  The existing `extracted/_shared/scripts/validate_extracted.sh`
+  is one call away; could be wrapped. Follow-up to keep this PR's
+  surface narrow.
+
+## Verification
+
+Local commands the builder ran (reviewer should reproduce):
+
+```bash
+# 1. The MCP claim auditor reports the drift that PR #457 fixes,
+#    on main today. (Expected: non-zero exit with 4+ DRIFT lines.)
+python scripts/audit_claude_md_claims.py
+echo "exit: $?"
+# Expected lines include:
+#   email             8       9   DRIFT
+#   invoicing        15      18   DRIFT
+#   intelligence     17      33   DRIFT
+#   b2b_churn        60+     83   DRIFT (or similar; depends on how
+#                                  CLAUDE.md is parsed)
+
+# 2. The plan-doc auditor accepts this slice's own plan doc.
+python scripts/audit_plan_doc.py plans/PR-Pre-Push-Audit-Scripts.md
+echo "exit: $?"
+# Expected: all 7 sections OK, exit 0.
+
+# 3. The plan-doc auditor rejects a deliberately incomplete plan.
+echo "# bad plan\n\n## Why this slice exists\n\nfoo" > /tmp/bad-plan.md
+python scripts/audit_plan_doc.py /tmp/bad-plan.md
+echo "exit: $?"
+# Expected: 6 MISSING lines, exit 1.
+
+# 4. The wrapper runs all three checks.
+bash scripts/pre_push_audit.sh
+echo "exit: $?"
+# Expected (on main, today): exit 1 due to CLAUDE.md drift.
+```
+
+## Estimated diff size
+
+| File | LOC (approx) |
+|---|---|
+| `scripts/audit_claude_md_claims.py` | ~80 |
+| `scripts/audit_plan_doc.py` | ~50 |
+| `scripts/pre_push_audit.sh` | ~30 |
+| `plans/PR-Pre-Push-Audit-Scripts.md` | ~150 |
+| **Total** | **~310** |
+
+Well under the 400 LOC soft cap.

--- a/plans/PR-Pre-Push-Audit-Scripts.md
+++ b/plans/PR-Pre-Push-Audit-Scripts.md
@@ -59,21 +59,32 @@ No edits to existing files. No wiring into git hooks, CI, or
 
 ### `audit_claude_md_claims.py`
 
-Two functions:
+Parses CLAUDE.md for per-server section headers shaped like
+`### <Name> MCP Server (N tools)` (or `(60+ tools)` soft counts),
+then counts `@mcp.tool` decorators in each matching
+`atlas_brain/mcp/*_server.py`. For `b2b_churn` -- whose server is
+split across modules -- sums decorators across
+`atlas_brain/mcp/b2b/*.py`.
+
+Public functions:
 
 ```
-actual_counts() -> dict[str, int]
-    For each atlas_brain/mcp/*_server.py, count grep -c "@mcp.tool".
-    For atlas_brain/mcp/b2b/, sum @mcp.tool across all *.py files
-    and report as "b2b_churn".
+count_decorators(path) -> int
+    Count "@mcp.tool" prefix lines in a Python source file.
 
-claimed_counts() -> dict[str, int]
-    Parse the MCP servers table in CLAUDE.md (the "### atlas_brain/mcp/"
-    table). Match rows shaped like "| Email | 8057 | 9 | ..." and
-    extract (server name, tool count).
+actual_count_for(file_key) -> int
+    Dispatch on a HEADER_TO_FILE value: either count a single
+    server file, or sum the b2b sub-module split (sentinel
+    "_b2b_sum").
+
+HEADER_PATTERN: regex matching the section headers.
+HEADER_TO_FILE: maps the human-readable doc name (e.g. "Email")
+    to either a server filename ("email_server.py") or the
+    sentinel "_b2b_sum".
 ```
 
-Report per-server: claimed, actual, status (OK or DRIFT). Exit 1
+Report shape per server: claimed (from doc), actual (from code),
+status (OK / DRIFT / DRIFT (soft count) for "N+" claims). Exit 1
 if any DRIFT.
 
 ### `audit_plan_doc.py`
@@ -174,12 +185,23 @@ echo "exit: $?"
 
 ## Estimated diff size
 
-| File | LOC (approx) |
-|---|---|
-| `scripts/audit_claude_md_claims.py` | ~80 |
-| `scripts/audit_plan_doc.py` | ~50 |
-| `scripts/pre_push_audit.sh` | ~30 |
-| `plans/PR-Pre-Push-Audit-Scripts.md` | ~150 |
-| **Total** | **~310** |
+Original estimate at plan time: ~310 LOC. Actual shipping diff after
+review feedback applied: ~452 LOC.
 
-Well under the 400 LOC soft cap.
+| File | LOC (approx, post-review) |
+|---|---|
+| `scripts/audit_claude_md_claims.py` | ~105 |
+| `scripts/audit_plan_doc.py` | ~80 |
+| `scripts/pre_push_audit.sh` | ~75 |
+| `plans/PR-Pre-Push-Audit-Scripts.md` | ~192 |
+| **Total** | **~452** |
+
+**~52 LOC over the 400 soft cap.** The slice is genuinely
+indivisible: plan-doc and scripts ship together per AGENTS.md
+anti-pattern about plan-doc-arriving-in-a-follow-up. The plan
+doc is ~42% of the total; splitting any single script into its
+own PR would force two more ~150-LOC plan docs, net worse for
+reviewer effort. Per AGENTS.md section 1d, soft-cap overage on
+an indivisible slice is acceptable when justified in *Why*; the
+*Why* section above explains that this slice closes drift Codex
+caught 3+ times on PR #457 and ships with its own self-test.

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -45,7 +45,7 @@ def count_decorators(path: Path) -> int:
         return -1
     return sum(
         1
-        for line in path.read_text().splitlines()
+        for line in path.read_text(encoding="utf-8").splitlines()
         if line.lstrip().startswith("@mcp.tool")
     )
 
@@ -64,7 +64,7 @@ def main() -> int:
         print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
         return 2
 
-    text = CLAUDE_MD.read_text()
+    text = CLAUDE_MD.read_text(encoding="utf-8")
     rows = []
     for m in HEADER_PATTERN.finditer(text):
         name = m.group("name").strip()

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -35,14 +35,22 @@ HEADER_TO_FILE = {
 }
 
 HEADER_PATTERN = re.compile(
-    r"^###\s+(?P<name>.+?)\s+MCP Server\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?",
+    # Tight match for "### <Name> MCP Server (<N>[+] [tools])":
+    # require the trailing ")" and accept either bare digits "(83)" or
+    # the "N tools" form, with optional "+" suffix. Anchored to start
+    # of line; allows arbitrary whitespace inside the parens.
+    r"^###\s+(?P<name>.+?)\s+MCP Server"
+    r"\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?\s*(?:,[^)]*)?\)",
     re.MULTILINE,
 )
 
+MISSING_FILE = "MISSING_FILE"
+MISSING_DIR = "MISSING_DIR"
 
-def count_decorators(path: Path) -> int:
+
+def count_decorators(path: Path) -> int | str:
     if not path.exists():
-        return -1
+        return MISSING_FILE
     return sum(
         1
         for line in path.read_text(encoding="utf-8").splitlines()
@@ -50,12 +58,19 @@ def count_decorators(path: Path) -> int:
     )
 
 
-def actual_count_for(file_key: str) -> int:
+def actual_count_for(file_key: str) -> int | str:
     if file_key == "_b2b_sum":
         b2b = MCP_DIR / "b2b"
         if not b2b.is_dir():
-            return -1
-        return sum(count_decorators(p) for p in sorted(b2b.glob("*.py")))
+            return MISSING_DIR
+        total = 0
+        for p in sorted(b2b.glob("*.py")):
+            n = count_decorators(p)
+            if isinstance(n, str):
+                # A b2b sub-module went missing mid-walk; surface it.
+                return n
+            total += n
+        return total
     return count_decorators(MCP_DIR / file_key)
 
 
@@ -75,12 +90,15 @@ def main() -> int:
             rows.append((name, claimed, "?", "UNKNOWN"))
             continue
         actual = actual_count_for(file_key)
-        if claimed.endswith("+"):
+        if isinstance(actual, str):
+            # MISSING_FILE / MISSING_DIR sentinel -- show explicitly.
+            rows.append((name, claimed, "N/A", actual))
+        elif claimed.endswith("+"):
             # Soft / loose claim -- always drift since we have an exact count.
-            status = "DRIFT (soft count)"
+            rows.append((name, claimed, str(actual), "DRIFT (soft count)"))
         else:
             status = "OK" if int(claimed) == actual else "DRIFT"
-        rows.append((name, claimed, str(actual), status))
+            rows.append((name, claimed, str(actual), status))
 
     if not rows:
         print("No '### ... MCP Server (N tools)' headers found in CLAUDE.md.")

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Verify MCP tool counts claimed in CLAUDE.md match @mcp.tool decorators.
+
+Parses the per-server section headers in CLAUDE.md
+(e.g. "### Email MCP Server (9 tools)") and compares each claim
+against the actual count of @mcp.tool() decorators in the matching
+atlas_brain/mcp/*_server.py file. For b2b_churn_server, sums across
+atlas_brain/mcp/b2b/*.py because the server is split into modules.
+
+Exits 0 if all claims match the code. Exits 1 if any drift.
+
+Usage:
+    python scripts/audit_claude_md_claims.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+MCP_DIR = REPO_ROOT / "atlas_brain" / "mcp"
+
+HEADER_TO_FILE = {
+    "CRM": "crm_server.py",
+    "Email": "email_server.py",
+    "Twilio": "twilio_server.py",
+    "Calendar": "calendar_server.py",
+    "Invoicing": "invoicing_server.py",
+    "Intelligence": "intelligence_server.py",
+    "Universal Scraper": "scraper_server.py",
+    "Memory": "memory_server.py",
+    "B2B Churn Intelligence": "_b2b_sum",
+}
+
+HEADER_PATTERN = re.compile(
+    r"^###\s+(?P<name>.+?)\s+MCP Server\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?",
+    re.MULTILINE,
+)
+
+
+def count_decorators(path: Path) -> int:
+    if not path.exists():
+        return -1
+    return sum(
+        1
+        for line in path.read_text().splitlines()
+        if line.lstrip().startswith("@mcp.tool")
+    )
+
+
+def actual_count_for(file_key: str) -> int:
+    if file_key == "_b2b_sum":
+        b2b = MCP_DIR / "b2b"
+        if not b2b.is_dir():
+            return -1
+        return sum(count_decorators(p) for p in sorted(b2b.glob("*.py")))
+    return count_decorators(MCP_DIR / file_key)
+
+
+def main() -> int:
+    if not CLAUDE_MD.exists():
+        print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
+        return 2
+
+    text = CLAUDE_MD.read_text()
+    rows = []
+    for m in HEADER_PATTERN.finditer(text):
+        name = m.group("name").strip()
+        claimed = m.group("count")
+        file_key = HEADER_TO_FILE.get(name)
+        if file_key is None:
+            # Unknown server name in a header -- flag it rather than ignore.
+            rows.append((name, claimed, "?", "UNKNOWN"))
+            continue
+        actual = actual_count_for(file_key)
+        if claimed.endswith("+"):
+            # Soft / loose claim -- always drift since we have an exact count.
+            status = "DRIFT (soft count)"
+        else:
+            status = "OK" if int(claimed) == actual else "DRIFT"
+        rows.append((name, claimed, str(actual), status))
+
+    if not rows:
+        print("No '### ... MCP Server (N tools)' headers found in CLAUDE.md.")
+        return 1
+
+    name_w = max(len(r[0]) for r in rows)
+    print(f"{'server'.ljust(name_w)}  claimed  actual  status")
+    print("-" * (name_w + 28))
+    drift = False
+    for name, claimed, actual, status in rows:
+        if status != "OK":
+            drift = True
+        print(f"{name.ljust(name_w)}  {claimed:>7}  {actual:>6}  {status}")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_plan_doc.py
+++ b/scripts/audit_plan_doc.py
@@ -45,7 +45,7 @@ def main() -> int:
         return 2
 
     headings = []  # list of (line_no, heading_text) for "## ..." lines
-    for i, line in enumerate(path.read_text().splitlines(), start=1):
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if line.startswith("## "):
             headings.append((i, line[3:].strip()))
 

--- a/scripts/audit_plan_doc.py
+++ b/scripts/audit_plan_doc.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Verify a plan doc has the 7 AGENTS.md sections, in order.
+
+Required sections per AGENTS.md section 1a:
+    Why this slice exists
+    Scope                 (matches "Scope" or "Scope (this PR)")
+    Mechanism
+    Intentional
+    Deferred
+    Verification
+    Estimated diff size
+
+Scans for "## <title>" headings (case-insensitive substring match) and
+checks each required title appears at least once, in the order above.
+
+Exits 0 if all present and ordered. Exits 1 otherwise.
+
+Usage:
+    python scripts/audit_plan_doc.py plans/PR-Some-Slice.md
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REQUIRED = [
+    "Why this slice exists",
+    "Scope",
+    "Mechanism",
+    "Intentional",
+    "Deferred",
+    "Verification",
+    "Estimated diff size",
+]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: audit_plan_doc.py PATH", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"plan doc not found: {path}", file=sys.stderr)
+        return 2
+
+    headings = []  # list of (line_no, heading_text) for "## ..." lines
+    for i, line in enumerate(path.read_text().splitlines(), start=1):
+        if line.startswith("## "):
+            headings.append((i, line[3:].strip()))
+
+    print(f"plan doc: {path}")
+    print("-" * 60)
+
+    last_index = -1
+    drift = False
+    for required in REQUIRED:
+        match = None
+        for idx, (line_no, heading) in enumerate(headings):
+            if required.lower() in heading.lower():
+                match = (idx, line_no, heading)
+                break
+        if match is None:
+            print(f"MISSING        ## {required}")
+            drift = True
+            continue
+        idx, line_no, heading = match
+        if idx <= last_index:
+            print(f"OUT OF ORDER   line {line_no}: ## {heading}")
+            drift = True
+        else:
+            print(f"OK  line {line_no:>4}  ## {heading}")
+            last_index = idx
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_plan_doc.py
+++ b/scripts/audit_plan_doc.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 """Verify a plan doc has the 7 AGENTS.md sections, in order.
 
-Required sections per AGENTS.md section 1a:
-    Why this slice exists
-    Scope                 (matches "Scope" or "Scope (this PR)")
-    Mechanism
-    Intentional
-    Deferred
-    Verification
-    Estimated diff size
+Required sections per AGENTS.md section 1a (with allowed variants):
+    Why this slice exists       ("Why this slice exists" only)
+    Scope                       ("Scope" or "Scope (this PR)")
+    Mechanism                   ("Mechanism")
+    Intentional                 ("Intentional")
+    Deferred                    ("Deferred")
+    Verification                ("Verification")
+    Estimated diff size         ("Estimated diff size")
 
-Scans for "## <title>" headings (case-insensitive substring match) and
-checks each required title appears at least once, in the order above.
+Scans for "## <title>" headings and checks each required slot is filled
+by a heading whose normalized text (lowercased, whitespace-collapsed) is
+in the slot's explicit allowlist. Substring matching is intentionally
+avoided so that headings like "## Out of scope" cannot pass the "Scope"
+requirement.
 
 Exits 0 if all present and ordered. Exits 1 otherwise.
 
@@ -20,18 +23,30 @@ Usage:
 """
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
-REQUIRED = [
-    "Why this slice exists",
-    "Scope",
-    "Mechanism",
-    "Intentional",
-    "Deferred",
-    "Verification",
-    "Estimated diff size",
+# Each tuple is (canonical_title, allowlist_of_acceptable_variants).
+# Variants are matched on a normalized form (lowercased, whitespace
+# collapsed) so reviewers can use small wording tweaks without breaking
+# the audit, but unrelated headings like "Out of scope" cannot satisfy
+# the "Scope" slot.
+REQUIRED: list[tuple[str, tuple[str, ...]]] = [
+    ("Why this slice exists", ("why this slice exists",)),
+    ("Scope", ("scope", "scope (this pr)")),
+    ("Mechanism", ("mechanism",)),
+    ("Intentional", ("intentional",)),
+    ("Deferred", ("deferred",)),
+    ("Verification", ("verification",)),
+    ("Estimated diff size", ("estimated diff size",)),
 ]
+
+_WS = re.compile(r"\s+")
+
+
+def _normalize(heading: str) -> str:
+    return _WS.sub(" ", heading.strip().lower())
 
 
 def main() -> int:
@@ -54,14 +69,14 @@ def main() -> int:
 
     last_index = -1
     drift = False
-    for required in REQUIRED:
+    for canonical, variants in REQUIRED:
         match = None
         for idx, (line_no, heading) in enumerate(headings):
-            if required.lower() in heading.lower():
+            if _normalize(heading) in variants:
                 match = (idx, line_no, heading)
                 break
         if match is None:
-            print(f"MISSING        ## {required}")
+            print(f"MISSING        ## {canonical}")
             drift = True
             continue
         idx, line_no, heading = match

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# pre_push_audit.sh - run mechanical pre-push checks.
+#
+# Runs (in order):
+#   1. scripts/audit_claude_md_claims.py
+#       MCP tool counts in CLAUDE.md vs @mcp.tool decorators.
+#   2. scripts/audit_plan_doc.py <path>  (for each plans/PR-*.md
+#       modified vs origin/main on this branch -- if any).
+#   3. scripts/check_ascii_python.sh
+#       ASCII-only .py policy.
+#
+# Exits 0 if all checks pass. Exits 1 if any failed.
+#
+# Usage:
+#   bash scripts/pre_push_audit.sh
+#
+# Intended to be run manually before opening a PR. Wiring into a
+# git pre-push hook is deferred to a follow-up slice.
+
+set -u
+cd "$(git rev-parse --show-toplevel)"
+
+failures=0
+
+run_check() {
+    local label="$1"
+    shift
+    echo
+    echo "==> $label"
+    if "$@"; then
+        echo "    PASS"
+    else
+        echo "    FAIL"
+        failures=$((failures + 1))
+    fi
+}
+
+run_check "CLAUDE.md MCP tool counts" \
+    python scripts/audit_claude_md_claims.py
+
+# Find plan docs touched on this branch: committed vs origin/main +
+# uncommitted in the working tree (untracked or modified).
+base="$(git merge-base HEAD origin/main 2>/dev/null || echo HEAD~1)"
+committed=$(git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null || true)
+uncommitted=$(git status --porcelain -- 'plans/PR-*.md' 2>/dev/null | awk '{print $NF}' || true)
+plan_docs=$(printf '%s\n%s\n' "$committed" "$uncommitted" | sort -u | grep -v '^$' || true)
+
+if [ -n "$plan_docs" ]; then
+    while IFS= read -r doc; do
+        [ -z "$doc" ] && continue
+        run_check "Plan doc: $doc" \
+            python scripts/audit_plan_doc.py "$doc"
+    done <<< "$plan_docs"
+else
+    echo
+    echo "==> Plan docs"
+    echo "    SKIP (no plans/PR-*.md added or modified vs $base or in working tree)"
+fi
+
+if [ -x scripts/check_ascii_python.sh ]; then
+    run_check "ASCII Python policy" bash scripts/check_ascii_python.sh
+else
+    echo
+    echo "==> ASCII Python policy"
+    echo "    SKIP (scripts/check_ascii_python.sh not executable)"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "all checks passed"
+    exit 0
+else
+    echo "$failures check(s) failed"
+    exit 1
+fi

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -17,7 +17,7 @@
 # Intended to be run manually before opening a PR. Wiring into a
 # git pre-push hook is deferred to a follow-up slice.
 
-set -u
+set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 failures=0
@@ -57,12 +57,12 @@ else
     echo "    SKIP (no plans/PR-*.md added or modified vs $base or in working tree)"
 fi
 
-if [ -x scripts/check_ascii_python.sh ]; then
+if [ -f scripts/check_ascii_python.sh ]; then
     run_check "ASCII Python policy" bash scripts/check_ascii_python.sh
 else
     echo
     echo "==> ASCII Python policy"
-    echo "    SKIP (scripts/check_ascii_python.sh not executable)"
+    echo "    SKIP (scripts/check_ascii_python.sh not found)"
 fi
 
 echo

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -38,9 +38,42 @@ run_check() {
 run_check "CLAUDE.md MCP tool counts" \
     python scripts/audit_claude_md_claims.py
 
-# Find plan docs touched on this branch: committed vs origin/main +
-# uncommitted in the working tree (untracked or modified).
-base="$(git merge-base HEAD origin/main 2>/dev/null || echo HEAD~1)"
+# Find plan docs touched on this branch: committed vs the resolved
+# trunk base + uncommitted in the working tree (untracked or modified).
+#
+# Trunk base resolution priority:
+#   1. refs/remotes/origin/HEAD (the canonical default branch pointer,
+#      typically origin/main but survives a rename).
+#   2. origin/main literally, if it exists.
+#
+# Note: we intentionally do NOT use @{upstream} here. For a feature
+# branch that pushes to its own name (e.g. claude/pr-foo ->
+# origin/claude/pr-foo), @{upstream} is the branch's own remote
+# tracker, not the trunk -- which makes the diff empty and the
+# plan-doc audit SKIP silently.
+#
+# If neither tier resolves, fail with a clear message rather than
+# silently falling back to HEAD~1 (which would skip plan-doc audits
+# for any branch with more than one commit ahead).
+resolve_base() {
+    local ref
+    if ref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+        echo "$ref"; return 0
+    fi
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+        echo "origin/main"; return 0
+    fi
+    return 1
+}
+
+if ! base_ref=$(resolve_base); then
+    echo "pre_push_audit.sh: could not resolve a trunk base ref." >&2
+    echo "  tried: refs/remotes/origin/HEAD, origin/main" >&2
+    echo "  fix: 'git remote set-head origin -a' OR ensure origin/main exists" >&2
+    exit 2
+fi
+
+base="$(git merge-base HEAD "$base_ref")"
 committed=$(git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null || true)
 uncommitted=$(git status --porcelain -- 'plans/PR-*.md' 2>/dev/null | awk '{print $NF}' || true)
 plan_docs=$(printf '%s\n%s\n' "$committed" "$uncommitted" | sort -u | grep -v '^$' || true)
@@ -54,7 +87,7 @@ if [ -n "$plan_docs" ]; then
 else
     echo
     echo "==> Plan docs"
-    echo "    SKIP (no plans/PR-*.md added or modified vs $base or in working tree)"
+    echo "    SKIP (no plans/PR-*.md added or modified vs $base_ref or in working tree)"
 fi
 
 if [ -f scripts/check_ascii_python.sh ]; then


### PR DESCRIPTION
Plan: plans/PR-Pre-Push-Audit-Scripts.md

PR #457 was caught three times by the Codex bot for stale MCP tool counts in `CLAUDE.md` (email 8→9, invoicing 15→18, intelligence 17→33, b2b_churn 60+ →83). Each catch cost a review round-trip and a fix-PR-and-push cycle. A 10-line bash auditor that grep-counts `@mcp.tool` decorators would have caught all four on the first push, with zero LLM token cost.

This slice ships three mechanical pre-push audits.

## Scope
- `scripts/audit_claude_md_claims.py` — parses `### <Name> MCP Server (N tools)` headers in `CLAUDE.md`, counts `@mcp.tool` decorators in matching `atlas_brain/mcp/*_server.py` (sums `atlas_brain/mcp/b2b/*.py` for `b2b_churn`), reports drift per server, exits 1 on any DRIFT. Handles "60+" soft counts.
- `scripts/audit_plan_doc.py PATH` — verifies a plan doc has all 7 AGENTS.md sections in order (Why / Scope / Mechanism / Intentional / Deferred / Verification / Estimated diff size). Reports `MISSING` / `OUT OF ORDER` / `OK` per section, exits 1 on any miss.
- `scripts/pre_push_audit.sh` — runs both above + existing `scripts/check_ascii_python.sh`. Picks up plan docs from `git diff <merge-base>...HEAD` AND from `git status --porcelain` (so uncommitted new plan docs are checked too, which is the common pre-push state).

## Intentional
- Auditors report drift, not enforce a specific state. On `main` today the `CLAUDE.md` auditor exits 1 because PR #457 hasn't merged. When #457 merges it exits 0.
- Python for the parsers (regex + ordered-section check), bash for the wrapper. Pure stdlib; no new deps.
- ASCII-only `.py` (matches `scripts/check_ascii_python.sh` policy); uses `OK / DRIFT / MISSING / OUT OF ORDER` labels, not unicode.
- No git hook installation. Wrapping into `.git/hooks/pre-push` is a per-developer choice; punted to a follow-up.
- `audit_plan_doc.py` does not yet verify "Files touched" matches `git diff --name-only` — punted to keep this slice small.

## Deferred
- `scripts/audit_pr_claims.py` — broader claim verifier (file paths, "wired into X", LOC claims).
- `audit_plan_doc.py --base-ref` flag to diff Files-touched against `git diff --name-only`.
- Git pre-push hook installer.
- CI wiring (GitHub Actions).
- AGENTS.md reference to the auditors (follow-up so this slice can land without AGENTS.md churn).
- Per-`extracted_*/` validator integration in `pre_push_audit.sh`.

## Verification
All four documented commands run and produce the documented output:

```
python scripts/audit_claude_md_claims.py
  -> 4 DRIFT lines on main (email/invoicing/intelligence/b2b_churn); exit 1.

python scripts/audit_plan_doc.py plans/PR-Pre-Push-Audit-Scripts.md
  -> all 7 sections OK; exit 0.

python scripts/audit_plan_doc.py <known-bad-plan>
  -> 6 MISSING lines; exit 1.
   + out-of-order variant -> 1 OUT OF ORDER line; exit 1.

bash scripts/pre_push_audit.sh
  -> CLAUDE.md FAIL, plan doc PASS, ASCII PASS; exit 1.
```

## Diff size
4 files, 441 LOC added (0 removed):
- `scripts/audit_claude_md_claims.py`: 102 LOC
- `scripts/audit_plan_doc.py`: 79 LOC
- `scripts/pre_push_audit.sh`: 75 LOC
- `plans/PR-Pre-Push-Audit-Scripts.md`: 185 LOC

**41 LOC over the 400 soft cap.** The slice is genuinely indivisible — plan doc + scripts ship together per AGENTS.md anti-pattern about plan-doc-arriving-in-a-follow-up. Plan doc is 185 of the 441 LOC; splitting docs from code would create a half-state PR.

https://claude.ai/code/session_0195vGeXxDvdt63kEWknb4Hf

---
_Generated by [Claude Code](https://claude.ai/code/session_0195vGeXxDvdt63kEWknb4Hf)_