### PR TITLE
Tier-1 mechanical audits: tool-name inventory, manifests, review sources

### DIFF
--- a/plans/PR-Tier-1-Audits.md
+++ b/plans/PR-Tier-1-Audits.md
@@ -73,12 +73,17 @@ that lands after PR #483 merges (see *Deferred*).
 ### `audit_mcp_tool_names_match_docs.py`
 
 ```
-parse_doc_claims(claude_md_text) -> dict[server, set[tool_name]]
+doc_claims(claude_md_text) -> (dict[server, set[tool_name]], list[str])
     For each "### <Name> MCP Server" header in CLAUDE.md:
         Slice the section text up to the next "### " or "## ".
-        Within the slice, find all backticked snake_case
-        identifiers via re.findall(r"`([a-z][a-z0-9_]+)`").
-        Store the set under HEADER_TO_KEY[name].
+        Within the slice, find backticked snake_case identifiers
+        via re.findall(r"`([a-z][a-z0-9_]{3,})`")
+        (minimum length 4 to drop noise like `id` / `url`).
+        Store the set under known-server name. Headers whose
+        name is NOT in HEADER_TO_FILE go into a separate
+        `unknown_headers` list which is reported as DRIFT --
+        a renamed or newly added server should surface, not
+        be silently dropped.
 
 actual_tool_names() -> dict[server, set[tool_name]]
     For each atlas_brain/mcp/*_server.py:
@@ -152,9 +157,18 @@ or DRIFT.
 - **`audit_extracted_manifests.py` walks `extracted_*/manifest.json`
   globs, not a hardcoded package list.** Survives future
   package additions or removals. Note: `extracted_reasoning_core/`
-  does not have a manifest today; CLAUDE.md claims it does. That
-  is a real drift the auditor surfaces, but fixing CLAUDE.md is
-  Deferred.
+  does not have a manifest today; CLAUDE.md claims it does. The
+  auditor does NOT report missing manifests (only per-manifest
+  consistency), so this drift surfaces only when someone reads
+  the audit output and notices the absence. A follow-up could
+  extend the auditor with an expected-packages list; deferred.
+- **Path validation in `audit_extracted_manifests.py`.** Rejects
+  absolute paths and `..` traversal in `source`/`target` values
+  before any disk I/O; requires `source` to start with
+  `atlas_brain/` and `target` to start with the manifest's own
+  package directory (`extracted_<name>/`). Catches malformed
+  manifests that would otherwise pass the existence check by
+  resolving to unrelated repo files.
 - **`audit_mcp_tool_names_match_docs.py` uses backtick-snake_case
   heuristic, not "lines starting with `Tools:`".** The actual
   inventory in CLAUDE.md spans multiple continuation lines and

--- a/plans/PR-Tier-1-Audits.md
+++ b/plans/PR-Tier-1-Audits.md
@@ -1,0 +1,229 @@
+# PR-Tier-1-Audits
+
+## Why this slice exists
+
+PR #483 shipped the first three mechanical pre-push audits
+(CLAUDE.md MCP tool counts, plan-doc shape, wrapper). The
+remaining Tier-1 audits identified during PR #457's review pass --
+the ones that would have caught real drift Codex caught me on --
+are not yet in the repo. This slice closes that.
+
+Three audits, each catching a different shape of drift seen this
+session:
+
+1. **Tool-name inventory drift.** Codex caught me when the
+   `### Invoicing MCP Server (18 tools)` header was correct but
+   the `Tools: ...` inventory list immediately below it still
+   named only 15. PR #483's count auditor would not catch this
+   -- it only verifies the header count.
+
+2. **Manifest sync drift.** `sync_extracted.sh` blindly trusts
+   `<pkg>/manifest.json`. Today nothing audits that every
+   `source` path actually exists in `atlas_brain/`, every
+   `target` exists in the package, or that synced pairs are
+   byte-identical. Drift here is silent until a sync fails.
+
+3. **Enum-count drift.** Codex caught me on "16 review sources"
+   when the `ReviewSource` enum has 19 members. Same shape as
+   the MCP tool count audit but for a different enum claim.
+   Generalizable pattern.
+
+This is recommendation #2 from the PR #457 token-savings analysis
+(*"bash scripts for mechanical audits, zero LLM, biggest absolute
+saver"*), Tier 1.
+
+## Scope (this PR)
+
+1. `scripts/audit_mcp_tool_names_match_docs.py` -- for each
+   `### <Name> MCP Server` section in CLAUDE.md, gather all
+   backticked snake_case identifiers (the claimed tool
+   inventory), compare to actual `@mcp.tool` function names in
+   the matching `atlas_brain/mcp/*_server.py` (sum
+   `atlas_brain/mcp/b2b/*.py` for `b2b_churn`). Report names
+   missing-from-doc and extra-in-doc per server.
+
+2. `scripts/audit_extracted_manifests.py` -- for each
+   `extracted_*/manifest.json`:
+   - Every `mappings[i].source` exists in `atlas_brain/`.
+   - Every `mappings[i].target` exists in the package.
+   - Every `owned[i].target` exists in the package.
+   - Synced pairs (mappings entries) are byte-identical between
+     source and target.
+   Report per-package drift; exit 1 on any fail.
+
+3. `scripts/audit_review_source_count.py` -- parse
+   `atlas_brain/services/scraping/sources.py` via `ast`, count
+   `ReviewSource` enum members. Scan CLAUDE.md for "N review
+   sources" / "N review sites" claims. Compare; exit 1 on
+   drift.
+
+### Files touched
+
+- `scripts/audit_mcp_tool_names_match_docs.py` (new)
+- `scripts/audit_extracted_manifests.py` (new)
+- `scripts/audit_review_source_count.py` (new)
+- `plans/PR-Tier-1-Audits.md` (this file, new)
+
+No edits to existing files. `scripts/pre_push_audit.sh` does NOT
+get updated in this slice -- that wiring is deferred to a follow-up
+that lands after PR #483 merges (see *Deferred*).
+
+## Mechanism
+
+### `audit_mcp_tool_names_match_docs.py`
+
+```
+parse_doc_claims(claude_md_text) -> dict[server, set[tool_name]]
+    For each "### <Name> MCP Server" header in CLAUDE.md:
+        Slice the section text up to the next "### " or "## ".
+        Within the slice, find all backticked snake_case
+        identifiers via re.findall(r"`([a-z][a-z0-9_]+)`").
+        Store the set under HEADER_TO_KEY[name].
+
+actual_tool_names() -> dict[server, set[tool_name]]
+    For each atlas_brain/mcp/*_server.py:
+        Walk the file via `ast`; for each FunctionDef preceded by
+        an @mcp.tool decorator, collect the function name.
+    For b2b: do the same across atlas_brain/mcp/b2b/*.py.
+
+Compare per server: missing (in code but not doc) and extra (in
+doc but not code). Report; exit 1 on any drift.
+```
+
+False-positive risk: a section might mention a non-tool
+snake_case identifier in backticks (e.g., a generic helper name
+inside a code block). Acceptable because (a) the actual MCP
+inventory uses this exact shape consistently and (b) noise shows
+up as "extra in doc" which is easy to interpret and fix.
+
+### `audit_extracted_manifests.py`
+
+```
+for each <pkg>/manifest.json:
+    parse manifest
+    for entry in manifest["mappings"]:
+        check (REPO_ROOT / entry["source"]).exists()
+        check (REPO_ROOT / entry["target"]).exists()
+        check files are byte-identical
+            (using pathlib.Path.read_bytes())
+    for entry in manifest["owned"]:
+        check (REPO_ROOT / entry["target"]).exists()
+
+Report a single line per failure with package + reason.
+Exit 1 on any fail.
+```
+
+### `audit_review_source_count.py`
+
+```
+# Truth side: parse the enum
+import ast
+tree = ast.parse(sources_py_text)
+for node in ast.walk(tree):
+    if isinstance(node, ast.ClassDef) and node.name == "ReviewSource":
+        member_count = sum(
+            1 for n in node.body if isinstance(n, ast.Assign)
+        )
+
+# Claim side: scan CLAUDE.md
+pattern = r"(\d+)\s+review\s+(?:source[s]?|site[s]?)"
+claims = re.findall(pattern, claude_md_text, re.IGNORECASE)
+# Each claim should equal member_count.
+```
+
+Report each claim with its line number, expected vs actual, OK
+or DRIFT.
+
+## Intentional
+
+- **Off `main`, NOT stacked on `claude/pr-pre-push-audit-scripts`
+  (PR #483).** Each audit script is independently useful;
+  wrapper integration is a 5-line follow-up after #483 lands.
+  Stacking would couple this PR's mergeability to #483's review
+  cycle.
+- **No update to `scripts/pre_push_audit.sh` in this slice.** The
+  wrapper lives on the PR #483 branch and on main once #483
+  merges. Updating it now means either (a) duplicating PR #483's
+  wrapper here or (b) basing this off #483's branch (stacked).
+  Both add coupling. The clean shape is: ship the three scripts
+  here, ship the wrapper update + AGENTS.md workflow doc in a
+  follow-up `PR-Pre-Merge-Workflow-And-Wrapper` after #483
+  merges.
+- **`audit_extracted_manifests.py` walks `extracted_*/manifest.json`
+  globs, not a hardcoded package list.** Survives future
+  package additions or removals. Note: `extracted_reasoning_core/`
+  does not have a manifest today; CLAUDE.md claims it does. That
+  is a real drift the auditor surfaces, but fixing CLAUDE.md is
+  Deferred.
+- **`audit_mcp_tool_names_match_docs.py` uses backtick-snake_case
+  heuristic, not "lines starting with `Tools:`".** The actual
+  inventory in CLAUDE.md spans multiple continuation lines and
+  has multiple `Tools (Group, N): ...` rows per server. A
+  line-prefix heuristic misses the continuation lines; the
+  whole-section heuristic does not.
+- **`audit_review_source_count.py` uses `ast` to count enum
+  members, not regex.** Regex is brittle for Python source;
+  `ast` survives multi-line members, comments, and decorators.
+- **All three scripts ASCII-only.** Matches the
+  `scripts/check_ascii_python.sh` policy.
+
+## Deferred
+
+- **`scripts/pre_push_audit.sh` wiring.** Follow-up:
+  `PR-Pre-Merge-Workflow-And-Wrapper` (after PR #483 merges).
+  That PR also adds the AGENTS.md pre-merge gate workflow section
+  (mechanical-then-model order) the user asked for.
+- **AGENTS.md reference to the new auditors.** Same follow-up.
+- **Fix CLAUDE.md's claim that `extracted_reasoning_core` has a
+  manifest.** The auditor will surface this when run; the actual
+  CLAUDE.md edit is a doc fix outside this slice's scope.
+- **`audit_pr_claims.py`** -- the Tier-3 broader claim verifier.
+  Still useful but lower ROI; deferred to a later slice if a
+  specific claim drift recurs.
+- **CI integration (GitHub Actions).** Eventual goal: mechanical
+  audits run automatically on every push so a Claude session
+  isn't needed for the deterministic part. Phase 2 of the
+  pre-merge gate plan.
+- **`audit_mcp_tool_names_match_docs.py` per-tool grouping.**
+  Currently treats the inventory as a set; doesn't verify the
+  `Tools (Strategic, 8): ...` group-count sub-claims. Follow-up.
+
+## Verification
+
+Local commands the builder ran (reviewer should reproduce):
+
+```bash
+# 1. Tool-name inventory auditor on current main (CLAUDE.md is
+#    stale on main; PR #457 is the fix). Expected: drift across
+#    several servers because PR #457 hasn't merged.
+python scripts/audit_mcp_tool_names_match_docs.py
+echo "exit: $?"
+
+# 2. Manifest auditor on current main. Expected: pass for all 5
+#    extracted_* packages OR surface real drift (any non-existent
+#    source path, any drift in synced pairs).
+python scripts/audit_extracted_manifests.py
+echo "exit: $?"
+
+# 3. Review-source-count auditor on current main. Expected:
+#    DRIFT because CLAUDE.md on main says "16 review sites" but
+#    actual enum has 19 members. (PR #457 fixes this.)
+python scripts/audit_review_source_count.py
+echo "exit: $?"
+```
+
+## Estimated diff size
+
+| File | LOC (est) |
+|---|---|
+| `scripts/audit_mcp_tool_names_match_docs.py` | ~110 |
+| `scripts/audit_extracted_manifests.py` | ~90 |
+| `scripts/audit_review_source_count.py` | ~75 |
+| `plans/PR-Tier-1-Audits.md` | ~175 |
+| **Total** | **~450** |
+
+50 LOC over the 400 soft cap; same shape as PR #483 (plan doc
+~40% of the total). Slice is genuinely indivisible (three audit
+scripts + plan ship together); splitting one audit into its own
+PR would three plan docs each ~150 LOC, net worse for the
+reviewer.

--- a/scripts/audit_extracted_manifests.py
+++ b/scripts/audit_extracted_manifests.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -29,11 +29,13 @@ def _validate_path(
     """Return an error string if rel is unsafe or misplaced, else None.
 
     Rejects:
-      - absolute paths
+      - absolute paths (POSIX, Windows drive-letter, UNC) via
+        PurePath checks on both flavors -- not just startswith("/"),
+        so e.g. "C:\\foo" and "\\\\srv\\share" are caught too.
       - paths containing '..' segments (parent-dir traversal)
       - paths not anchored under `must_start_with`
     """
-    if rel.startswith("/"):
+    if PurePosixPath(rel).is_absolute() or PureWindowsPath(rel).is_absolute():
         return f"{kind}[{idx}]: absolute path rejected ({rel!r})"
     parts = Path(rel).parts
     if ".." in parts:

--- a/scripts/audit_extracted_manifests.py
+++ b/scripts/audit_extracted_manifests.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify every extracted_*/manifest.json is consistent with the filesystem.
+
+For each manifest:
+  - Every mappings[i].source path exists under atlas_brain/.
+  - Every mappings[i].target path exists in the package.
+  - Every owned[i].target path exists in the package.
+  - Synced pairs (mappings entries) are byte-identical between
+    source and target. Drift here means sync_extracted.sh has not
+    been run since the source was edited.
+
+Exits 0 if all manifests are consistent. Exits 1 on any drift.
+
+Usage:
+    python scripts/audit_extracted_manifests.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def check_manifest(manifest_path: Path) -> list[str]:
+    """Return a list of failure descriptions for this manifest."""
+    failures: list[str] = []
+    try:
+        data = json.loads(manifest_path.read_text())
+    except Exception as exc:  # noqa: BLE001
+        return [f"{manifest_path}: failed to parse JSON ({exc})"]
+
+    mappings = data.get("mappings", [])
+    owned = data.get("owned", [])
+
+    for i, entry in enumerate(mappings):
+        src_rel = entry.get("source")
+        tgt_rel = entry.get("target")
+        if not src_rel or not tgt_rel:
+            failures.append(
+                f"mappings[{i}]: missing source or target ({entry!r})"
+            )
+            continue
+        src = REPO_ROOT / src_rel
+        tgt = REPO_ROOT / tgt_rel
+        if not src.exists():
+            failures.append(f"mappings[{i}].source missing: {src_rel}")
+        if not tgt.exists():
+            failures.append(f"mappings[{i}].target missing: {tgt_rel}")
+        if src.exists() and tgt.exists():
+            try:
+                if src.read_bytes() != tgt.read_bytes():
+                    failures.append(
+                        f"sync drift: {src_rel} != {tgt_rel} "
+                        "(run extracted/_shared/scripts/sync_extracted.sh)"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    f"mappings[{i}]: could not compare ({exc})"
+                )
+
+    for i, entry in enumerate(owned):
+        tgt_rel = entry.get("target")
+        if not tgt_rel:
+            failures.append(f"owned[{i}]: missing target ({entry!r})")
+            continue
+        tgt = REPO_ROOT / tgt_rel
+        if not tgt.exists():
+            failures.append(f"owned[{i}].target missing: {tgt_rel}")
+
+    return failures
+
+
+def main() -> int:
+    manifests = sorted(REPO_ROOT.glob("extracted_*/manifest.json"))
+    if not manifests:
+        print("No extracted_*/manifest.json files found.")
+        return 1
+
+    drift = False
+    for mf in manifests:
+        rel = mf.relative_to(REPO_ROOT)
+        failures = check_manifest(mf)
+        if not failures:
+            data = json.loads(mf.read_text())
+            n_map = len(data.get("mappings", []))
+            n_own = len(data.get("owned", []))
+            print(f"OK     {rel}  (mappings={n_map}, owned={n_own})")
+        else:
+            drift = True
+            print(f"DRIFT  {rel}")
+            for f in failures:
+                print(f"  - {f}")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_extracted_manifests.py
+++ b/scripts/audit_extracted_manifests.py
@@ -23,14 +23,38 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+def _validate_path(
+    rel: str, must_start_with: str, kind: str, idx: int
+) -> str | None:
+    """Return an error string if rel is unsafe or misplaced, else None.
+
+    Rejects:
+      - absolute paths
+      - paths containing '..' segments (parent-dir traversal)
+      - paths not anchored under `must_start_with`
+    """
+    if rel.startswith("/"):
+        return f"{kind}[{idx}]: absolute path rejected ({rel!r})"
+    parts = Path(rel).parts
+    if ".." in parts:
+        return f"{kind}[{idx}]: parent-dir traversal rejected ({rel!r})"
+    if not rel.startswith(must_start_with):
+        return (
+            f"{kind}[{idx}]: path not under expected tree "
+            f"(expected to start with {must_start_with!r}, got {rel!r})"
+        )
+    return None
+
+
 def check_manifest(manifest_path: Path) -> list[str]:
     """Return a list of failure descriptions for this manifest."""
     failures: list[str] = []
     try:
-        data = json.loads(manifest_path.read_text())
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
         return [f"{manifest_path}: failed to parse JSON ({exc})"]
 
+    package_dir = manifest_path.parent.name + "/"
     mappings = data.get("mappings", [])
     owned = data.get("owned", [])
 
@@ -41,6 +65,15 @@ def check_manifest(manifest_path: Path) -> list[str]:
             failures.append(
                 f"mappings[{i}]: missing source or target ({entry!r})"
             )
+            continue
+        # Reject malformed / unsafe paths before any disk I/O.
+        src_err = _validate_path(src_rel, "atlas_brain/", "mappings.source", i)
+        tgt_err = _validate_path(tgt_rel, package_dir, "mappings.target", i)
+        if src_err:
+            failures.append(src_err)
+        if tgt_err:
+            failures.append(tgt_err)
+        if src_err or tgt_err:
             continue
         src = REPO_ROOT / src_rel
         tgt = REPO_ROOT / tgt_rel
@@ -65,6 +98,10 @@ def check_manifest(manifest_path: Path) -> list[str]:
         if not tgt_rel:
             failures.append(f"owned[{i}]: missing target ({entry!r})")
             continue
+        tgt_err = _validate_path(tgt_rel, package_dir, "owned.target", i)
+        if tgt_err:
+            failures.append(tgt_err)
+            continue
         tgt = REPO_ROOT / tgt_rel
         if not tgt.exists():
             failures.append(f"owned[{i}].target missing: {tgt_rel}")
@@ -83,7 +120,7 @@ def main() -> int:
         rel = mf.relative_to(REPO_ROOT)
         failures = check_manifest(mf)
         if not failures:
-            data = json.loads(mf.read_text())
+            data = json.loads(mf.read_text(encoding="utf-8"))
             n_map = len(data.get("mappings", []))
             n_own = len(data.get("owned", []))
             print(f"OK     {rel}  (mappings={n_map}, owned={n_own})")

--- a/scripts/audit_mcp_tool_names_match_docs.py
+++ b/scripts/audit_mcp_tool_names_match_docs.py
@@ -52,22 +52,30 @@ def section_slice(text: str, start: int) -> str:
     return rest if m is None else rest[: m.start()]
 
 
-def doc_claims(text: str) -> dict[str, set[str]]:
+def doc_claims(text: str) -> tuple[dict[str, set[str]], list[str]]:
+    """Return (known_claims, unknown_headers).
+
+    `unknown_headers` collects MCP Server section names that are not in
+    HEADER_TO_FILE -- a renamed or newly added server should surface
+    as drift rather than being silently dropped.
+    """
     claims: dict[str, set[str]] = {}
+    unknown: list[str] = []
     for m in HEADER_PATTERN.finditer(text):
         name = m.group("name").strip()
         if name not in HEADER_TO_FILE:
+            unknown.append(name)
             continue
         section = section_slice(text, m.end())
         idents = set(BACKTICK_IDENT.findall(section))
         claims[name] = idents
-    return claims
+    return claims, unknown
 
 
 def tool_names_in_file(path: Path) -> set[str]:
     if not path.exists():
         return set()
-    tree = ast.parse(path.read_text())
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     names: set[str] = set()
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -102,12 +110,18 @@ def main() -> int:
         print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
         return 2
 
-    claims = doc_claims(CLAUDE_MD.read_text())
-    if not claims:
-        print("No '### ... MCP Server' headers matched the known set.")
+    claims, unknown_headers = doc_claims(CLAUDE_MD.read_text(encoding="utf-8"))
+    if not claims and not unknown_headers:
+        print("No '### ... MCP Server' headers found in CLAUDE.md.")
         return 1
 
     drift = False
+    if unknown_headers:
+        drift = True
+        print("DRIFT: unknown MCP Server header(s) in CLAUDE.md:")
+        for n in unknown_headers:
+            print(f"  - {n!r} not in HEADER_TO_FILE (rename or new server?)")
+
     for name in sorted(claims):
         file_key = HEADER_TO_FILE[name]
         actual = actual_for(file_key)

--- a/scripts/audit_mcp_tool_names_match_docs.py
+++ b/scripts/audit_mcp_tool_names_match_docs.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Verify MCP tool-name inventories in CLAUDE.md match @mcp.tool functions.
+
+For each "### <Name> MCP Server" section in CLAUDE.md, gather every
+backticked snake_case identifier (the claimed tool inventory). Compare
+to actual @mcp.tool function names in the matching
+atlas_brain/mcp/*_server.py (or sum atlas_brain/mcp/b2b/*.py for
+b2b_churn).
+
+Reports per server:
+    missing-in-doc  -> in code but not named in CLAUDE.md
+    extra-in-doc    -> named in CLAUDE.md but no @mcp.tool in code
+
+Exits 0 if every server's inventory matches the code. Exits 1 on drift.
+
+Usage:
+    python scripts/audit_mcp_tool_names_match_docs.py
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+MCP_DIR = REPO_ROOT / "atlas_brain" / "mcp"
+
+HEADER_TO_FILE = {
+    "CRM": "crm_server.py",
+    "Email": "email_server.py",
+    "Twilio": "twilio_server.py",
+    "Calendar": "calendar_server.py",
+    "Invoicing": "invoicing_server.py",
+    "Intelligence": "intelligence_server.py",
+    "Universal Scraper": "scraper_server.py",
+    "Memory": "memory_server.py",
+    "B2B Churn Intelligence": "_b2b_sum",
+}
+
+HEADER_PATTERN = re.compile(
+    r"^###\s+(?P<name>.+?)\s+MCP Server", re.MULTILINE
+)
+BACKTICK_IDENT = re.compile(r"`([a-z][a-z0-9_]{3,})`")
+
+
+def section_slice(text: str, start: int) -> str:
+    """Return the substring from `start` up to the next "### " or "## "."""
+    rest = text[start:]
+    m = re.search(r"\n(?:## |### )", rest)
+    return rest if m is None else rest[: m.start()]
+
+
+def doc_claims(text: str) -> dict[str, set[str]]:
+    claims: dict[str, set[str]] = {}
+    for m in HEADER_PATTERN.finditer(text):
+        name = m.group("name").strip()
+        if name not in HEADER_TO_FILE:
+            continue
+        section = section_slice(text, m.end())
+        idents = set(BACKTICK_IDENT.findall(section))
+        claims[name] = idents
+    return claims
+
+
+def tool_names_in_file(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            # Match @mcp.tool or @mcp.tool(...)
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "tool"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "mcp"
+            ):
+                names.add(node.name)
+                break
+    return names
+
+
+def actual_for(file_key: str) -> set[str]:
+    if file_key == "_b2b_sum":
+        out: set[str] = set()
+        b2b = MCP_DIR / "b2b"
+        if b2b.is_dir():
+            for p in sorted(b2b.glob("*.py")):
+                out |= tool_names_in_file(p)
+        return out
+    return tool_names_in_file(MCP_DIR / file_key)
+
+
+def main() -> int:
+    if not CLAUDE_MD.exists():
+        print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
+        return 2
+
+    claims = doc_claims(CLAUDE_MD.read_text())
+    if not claims:
+        print("No '### ... MCP Server' headers matched the known set.")
+        return 1
+
+    drift = False
+    for name in sorted(claims):
+        file_key = HEADER_TO_FILE[name]
+        actual = actual_for(file_key)
+        claimed = claims[name]
+        missing_in_doc = actual - claimed
+        extra_in_doc = claimed - actual
+        status = "OK" if not (missing_in_doc or extra_in_doc) else "DRIFT"
+        print(
+            f"\n{name} ({file_key})  claimed={len(claimed)}  actual={len(actual)}  {status}"
+        )
+        if missing_in_doc:
+            drift = True
+            print("  missing in doc (in code, not in CLAUDE.md):")
+            for n in sorted(missing_in_doc):
+                print(f"    - {n}")
+        if extra_in_doc:
+            drift = True
+            print("  extra in doc (in CLAUDE.md, not in code):")
+            for n in sorted(extra_in_doc):
+                print(f"    - {n}")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_review_source_count.py
+++ b/scripts/audit_review_source_count.py
@@ -29,7 +29,7 @@ CLAIM_PATTERN = re.compile(
 def count_review_sources() -> int:
     if not SOURCES_PY.exists():
         return -1
-    tree = ast.parse(SOURCES_PY.read_text())
+    tree = ast.parse(SOURCES_PY.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == "ReviewSource":
             return sum(1 for n in node.body if isinstance(n, ast.Assign))
@@ -50,7 +50,7 @@ def main() -> int:
         print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
         return 2
 
-    text = CLAUDE_MD.read_text()
+    text = CLAUDE_MD.read_text(encoding="utf-8")
     print(f"ReviewSource enum members: {actual}")
     print(f"Claims in {CLAUDE_MD.name}:")
     print("-" * 50)

--- a/scripts/audit_review_source_count.py
+++ b/scripts/audit_review_source_count.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Verify CLAUDE.md's review-source count matches the ReviewSource enum.
+
+Counts members of `class ReviewSource` in
+atlas_brain/services/scraping/sources.py via `ast`. Scans CLAUDE.md
+for claims of the form "N review sources" / "N review sites" / etc.
+Reports each claim line with expected vs actual; exits 1 on any drift.
+
+Usage:
+    python scripts/audit_review_source_count.py
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCES_PY = REPO_ROOT / "atlas_brain" / "services" / "scraping" / "sources.py"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+CLAIM_PATTERN = re.compile(
+    r"(\d+)\s+review\s+(?:source[s]?|site[s]?)",
+    re.IGNORECASE,
+)
+
+
+def count_review_sources() -> int:
+    if not SOURCES_PY.exists():
+        return -1
+    tree = ast.parse(SOURCES_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ReviewSource":
+            return sum(1 for n in node.body if isinstance(n, ast.Assign))
+    return -1
+
+
+def main() -> int:
+    actual = count_review_sources()
+    if actual < 0:
+        print(
+            "Could not locate `class ReviewSource` in "
+            f"{SOURCES_PY.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not CLAUDE_MD.exists():
+        print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
+        return 2
+
+    text = CLAUDE_MD.read_text()
+    print(f"ReviewSource enum members: {actual}")
+    print(f"Claims in {CLAUDE_MD.name}:")
+    print("-" * 50)
+
+    drift = False
+    any_claim = False
+    for i, line in enumerate(text.splitlines(), start=1):
+        for m in CLAIM_PATTERN.finditer(line):
+            any_claim = True
+            claimed = int(m.group(1))
+            status = "OK" if claimed == actual else "DRIFT"
+            if status == "DRIFT":
+                drift = True
+            print(f"  line {i:>4}: claims {claimed:>2}  -> {status}")
+            print(f"           : {line.strip()}")
+
+    if not any_claim:
+        print("  (no review-source claims found)")
+        # No claim is not drift per se; treat as OK.
+        return 0
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Plan: plans/PR-Tier-1-Audits.md

PR #483 shipped the first three mechanical pre-push audits (CLAUDE.md MCP tool counts, plan-doc shape, wrapper). This slice ships the next three identified during PR #457's review.

## Scope
- `scripts/audit_mcp_tool_names_match_docs.py` — for each `### <Name> MCP Server` section in CLAUDE.md, gather backticked snake_case identifiers (claimed tool inventory) and compare to actual `@mcp.tool` function names parsed via `ast`. Reports missing-in-doc and extra-in-doc per server. **Catches exactly the drift Codex flagged on PR #457**: Email missing `list_folders`, Invoicing missing 3 names, Intelligence missing 16 names.
- `scripts/audit_extracted_manifests.py` — for each `extracted_*/manifest.json`: every `mappings[i].source` exists under `atlas_brain/`, every `target` exists in the package, and synced pairs are byte-identical. Surfaces silent drift that `sync_extracted.sh` otherwise has no audit for.
- `scripts/audit_review_source_count.py` — counts `class ReviewSource` enum members via `ast`, scans CLAUDE.md for "N review sources / sites" claims, reports drift with line numbers.

## Real findings on `main` (the auditors caught these immediately)

The manifest auditor surfaced **three preexisting sync drifts** that weren't introduced by this PR:

| Source (atlas_brain/) | Target (extracted_*/) |
|---|---|
| `services/b2b/vendor_briefing_delivery.py` | `extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py` |
| `services/b2b/llm_exact_cache.py` | `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py` |
| `services/b2b/product_claim.py` | `extracted_quality_gate/product_claim.py` |

Reporting drift is what the auditor exists to do; fixing the sync state is out of scope for this slice. Worth picking up in a follow-up `PR-Sync-Drift-Cleanup` once someone confirms which side is canonical for each.

## Intentional
- Off `main`, NOT stacked on PR #483. Each audit script is independently useful; wrapper integration is a 5-line follow-up after #483 merges. Stacking would couple this PR's mergeability to #483's review cycle.
- No update to `scripts/pre_push_audit.sh` here (deferred to `PR-Pre-Merge-Workflow-And-Wrapper` after #483 lands; that follow-up also adds the AGENTS.md mechanical-then-model gate section).
- `audit_mcp_tool_names_match_docs.py` uses a whole-section backtick-snake_case heuristic, not "lines starting with `Tools:`" — the inventory in CLAUDE.md spans multiple continuation lines and multiple `Tools (Group, N): ...` rows per server. Known noise: false positives on identifiers like `appointments` that appear in section prose (1 across all servers); acceptable trade-off vs. brittle line-prefix parsing.
- `audit_extracted_manifests.py` walks `extracted_*/manifest.json` globs, not a hardcoded list — survives future package additions/removals. Note: `extracted_reasoning_core/` has no manifest today, but the auditor doesn't complain about absence (only per-manifest consistency).
- All three scripts ASCII-only `.py` (matches existing policy).

## Deferred
- `scripts/pre_push_audit.sh` wiring → follow-up `PR-Pre-Merge-Workflow-And-Wrapper` (after PR #483 merges).
- AGENTS.md reference to the new auditors → same follow-up.
- Fix CLAUDE.md's `extracted_reasoning_core` "has manifest" claim → doc-only fix, separate slice.
- `scripts/audit_pr_claims.py` (Tier 3 broader claim verifier).
- CI integration (GitHub Actions) → Phase 2 of pre-merge gate plan.
- Group-count sub-claim auditing (e.g., "Tools (Strategic, 8): ..." sub-headers).

## Verification

All three documented commands run and produce the documented output:

```
python scripts/audit_mcp_tool_names_match_docs.py
  -> 5 DRIFT lines (Email/Invoicing/Intelligence/B2B Churn real drift;
     Calendar = 1 false-positive `appointments`); exit 1.

python scripts/audit_extracted_manifests.py
  -> 3 DRIFT lines (the real sync drifts surfaced above); exit 1.

python scripts/audit_review_source_count.py
  -> 1 DRIFT line (CLAUDE.md says "16 review sites", actual enum
     has 19 members); exit 1.
```

## Diff size

4 files, 544 LOC added (0 removed):
- `scripts/audit_mcp_tool_names_match_docs.py`: 136 LOC
- `scripts/audit_extracted_manifests.py`: 100 LOC
- `scripts/audit_review_source_count.py`: 79 LOC
- `plans/PR-Tier-1-Audits.md`: 229 LOC

**144 LOC over the 400 soft cap.** Same shape as PR #483 (plan doc ~42% of the total). Slice is indivisible — splitting one audit into its own PR would require three plan docs each ~150 LOC, net worse for review.

https://claude.ai/code/session_0195vGeXxDvdt63kEWknb4Hf

---
_Generated by [Claude Code](https://claude.ai/code/session_0195vGeXxDvdt63kEWknb4Hf)_