### PR TITLE
Add CLAUDE.md MCP count audit

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T01:52Z by codex-2026-05-12-mcp-port-audit
+Last updated: 2026-05-12T15:27Z by codex-2026-05-12-mcp-count-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add MCP port assignment audit | NEW: `plans/PR-Audit-MCP-Port-Assignments.md`; `scripts/audit_mcp_port_assignments.py`; `tests/test_audit_mcp_port_assignments.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-mcp-port-audit | `scripts/audit_claude_md_claims.py`; `scripts/audit_plan_doc.py`; `scripts/audit_plan_doc_files_touched.py`; `scripts/audit_plan_doc_diff_size.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add CLAUDE.md MCP tool-count audit | NEW: `plans/PR-Audit-Claude-Md-MCP-Counts.md`; `scripts/audit_claude_md_claims.py`; `tests/test_audit_claude_md_claims.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-mcp-count-audit | `scripts/audit_plan_doc.py`; `scripts/audit_plan_doc_files_touched.py`; `scripts/audit_plan_doc_diff_size.py`; `scripts/audit_mcp_port_assignments.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Claude-Md-MCP-Counts.md
+++ b/plans/PR-Audit-Claude-Md-MCP-Counts.md
@@ -29,7 +29,8 @@ code exports another.
 
 `audit_claude_md_claims.py` parses `### <Name> MCP Server (N tools)`
 headings in `CLAUDE.md`, maps each known server name to its source
-file, counts `@mcp.tool` decorator lines, and reports `OK` or `DRIFT`.
+file, counts exact `@mcp.tool` / `@mcp.tool(...)` decorator lines, and
+reports `OK` or `DRIFT`.
 
 The B2B Churn server is split across `atlas_brain/mcp/b2b/*.py`, so
 the auditor sums that directory through a sentinel mapping. Unknown
@@ -69,7 +70,7 @@ git diff --check
 | File | LOC (approx) |
 |---|---:|
 | `scripts/audit_claude_md_claims.py` | 100 |
-| `tests/test_audit_claude_md_claims.py` | 65 |
+| `tests/test_audit_claude_md_claims.py` | 85 |
 | `plans/PR-Audit-Claude-Md-MCP-Counts.md` | 70 |
 | `docs/extraction/coordination/inflight.md` | 2 |
-| **Total** | **~237** |
+| **Total** | **~260** |

--- a/plans/PR-Audit-Claude-Md-MCP-Counts.md
+++ b/plans/PR-Audit-Claude-Md-MCP-Counts.md
@@ -30,7 +30,8 @@ code exports another.
 `audit_claude_md_claims.py` parses `### <Name> MCP Server (N tools)`
 headings in `CLAUDE.md`, maps each known server name to its source
 file, counts exact `@mcp.tool` / `@mcp.tool(...)` decorator lines, and
-reports `OK` or `DRIFT`.
+reports `OK` or `DRIFT`. It also reports malformed MCP headings and
+missing expected server headings instead of silently skipping them.
 
 The B2B Churn server is split across `atlas_brain/mcp/b2b/*.py`, so
 the auditor sums that directory through a sentinel mapping. Unknown
@@ -70,7 +71,7 @@ git diff --check
 | File | LOC (approx) |
 |---|---:|
 | `scripts/audit_claude_md_claims.py` | 100 |
-| `tests/test_audit_claude_md_claims.py` | 85 |
+| `tests/test_audit_claude_md_claims.py` | 105 |
 | `plans/PR-Audit-Claude-Md-MCP-Counts.md` | 70 |
 | `docs/extraction/coordination/inflight.md` | 2 |
-| **Total** | **~260** |
+| **Total** | **~285** |

--- a/plans/PR-Audit-Claude-Md-MCP-Counts.md
+++ b/plans/PR-Audit-Claude-Md-MCP-Counts.md
@@ -42,8 +42,8 @@ skipped.
 
 - No wrapper script in this PR. The pre-push wrapper is a later slice
   after the individual auditors land.
-- No plan-doc-shape auditor in this PR. That becomes the next split
-  from #483.
+- Plan shape, files-touched, diff-size, and MCP port audits already
+  landed separately.
 - Soft counts like `60+` intentionally report drift because the code
   can provide an exact count.
 - Tests import the script directly through `importlib.util` because
@@ -51,10 +51,10 @@ skipped.
 
 ## Deferred
 
-- `scripts/audit_plan_doc.py` split from #483.
 - `scripts/pre_push_audit.sh` wrapper after the individual auditors
   exist on main.
-- Broader Tier-1/Tier-2 audit scripts from #484 and #485.
+- Remaining Tier-1 audit scripts from #484.
+- Fixture/meta-audit work from #486 and #487.
 - CI wiring.
 
 ## Verification
@@ -70,8 +70,8 @@ git diff --check
 
 | File | LOC (approx) |
 |---|---:|
-| `scripts/audit_claude_md_claims.py` | 100 |
-| `tests/test_audit_claude_md_claims.py` | 105 |
-| `plans/PR-Audit-Claude-Md-MCP-Counts.md` | 70 |
-| `docs/extraction/coordination/inflight.md` | 2 |
-| **Total** | **~285** |
+| `scripts/audit_claude_md_claims.py` | 124 |
+| `tests/test_audit_claude_md_claims.py` | 101 |
+| `plans/PR-Audit-Claude-Md-MCP-Counts.md` | 77 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~306** |

--- a/plans/PR-Audit-Claude-Md-MCP-Counts.md
+++ b/plans/PR-Audit-Claude-Md-MCP-Counts.md
@@ -1,0 +1,75 @@
+# PR-Audit-Claude-Md-MCP-Counts
+
+## Why this slice exists
+
+The oversized audit-kit PR #483 bundled three scripts and a long plan.
+Review rejected it under the repo's ~400 LOC review-size gate. This
+split lands the first useful piece only: a mechanical check that
+compares MCP tool-count claims in `CLAUDE.md` to the actual
+`@mcp.tool` decorators in the repo.
+
+This catches the exact drift class that caused repeated review
+round-trips: a documented MCP server count says one number while the
+code exports another.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_claude_md_claims.py`.
+2. Add focused fixture tests for its parser edge cases.
+3. Refresh the coordination row for this split slice.
+
+### Files touched
+
+- `scripts/audit_claude_md_claims.py`
+- `tests/test_audit_claude_md_claims.py`
+- `plans/PR-Audit-Claude-Md-MCP-Counts.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`audit_claude_md_claims.py` parses `### <Name> MCP Server (N tools)`
+headings in `CLAUDE.md`, maps each known server name to its source
+file, counts `@mcp.tool` decorator lines, and reports `OK` or `DRIFT`.
+
+The B2B Churn server is split across `atlas_brain/mcp/b2b/*.py`, so
+the auditor sums that directory through a sentinel mapping. Unknown
+MCP server headings are reported as `UNKNOWN` instead of silently
+skipped.
+
+## Intentional
+
+- No wrapper script in this PR. The pre-push wrapper is a later slice
+  after the individual auditors land.
+- No plan-doc-shape auditor in this PR. That becomes the next split
+  from #483.
+- Soft counts like `60+` intentionally report drift because the code
+  can provide an exact count.
+- Tests import the script directly through `importlib.util` because
+  `scripts/` is not a package.
+
+## Deferred
+
+- `scripts/audit_plan_doc.py` split from #483.
+- `scripts/pre_push_audit.sh` wrapper after the individual auditors
+  exist on main.
+- Broader Tier-1/Tier-2 audit scripts from #484 and #485.
+- CI wiring.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_claude_md_claims.py
+python -m py_compile scripts/audit_claude_md_claims.py tests/test_audit_claude_md_claims.py
+python scripts/audit_claude_md_claims.py
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC (approx) |
+|---|---:|
+| `scripts/audit_claude_md_claims.py` | 100 |
+| `tests/test_audit_claude_md_claims.py` | 65 |
+| `plans/PR-Audit-Claude-Md-MCP-Counts.md` | 70 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| **Total** | **~237** |

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -28,6 +28,7 @@ HEADER_PATTERN = re.compile(
     r"\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?\s*(?:,[^)]*)?\)",
     re.MULTILINE,
 )
+TOOL_DECORATOR_PATTERN = re.compile(r"^\s*@mcp\.tool(?:\s*\(|\s*$)")
 
 MISSING_FILE = "MISSING_FILE"
 MISSING_DIR = "MISSING_DIR"
@@ -39,7 +40,7 @@ def count_decorators(path: Path) -> int | str:
     return sum(
         1
         for line in path.read_text(encoding="utf-8").splitlines()
-        if line.lstrip().startswith("@mcp.tool")
+        if TOOL_DECORATOR_PATTERN.match(line)
     )
 
 

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -25,7 +25,7 @@ HEADER_TO_FILE = {
 
 HEADER_PATTERN = re.compile(
     r"^###\s+(?P<name>.+?)\s+MCP Server"
-    r"\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?\s*(?:,[^)]*)?\)",
+    r"\s*\(\s*(?P<count>\d+\+?)\s+tools\s*(?:,[^)]*)?\)",
     re.MULTILINE,
 )
 MCP_HEADING_PATTERN = re.compile(
@@ -105,10 +105,6 @@ def main() -> int:
         return 2
 
     rows = audit_claims(CLAUDE_MD.read_text(encoding="utf-8"))
-    if not rows:
-        print("No '### ... MCP Server (N tools)' headers found in CLAUDE.md.")
-        return 1
-
     name_w = max(len(row[0]) for row in rows)
     print(f"{'server'.ljust(name_w)}  claimed  actual  status")
     print("-" * (name_w + 28))

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Verify MCP tool counts claimed in CLAUDE.md match @mcp.tool decorators."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+MCP_DIR = REPO_ROOT / "atlas_brain" / "mcp"
+
+HEADER_TO_FILE = {
+    "CRM": "crm_server.py",
+    "Email": "email_server.py",
+    "Twilio": "twilio_server.py",
+    "Calendar": "calendar_server.py",
+    "Invoicing": "invoicing_server.py",
+    "Intelligence": "intelligence_server.py",
+    "Universal Scraper": "scraper_server.py",
+    "Memory": "memory_server.py",
+    "B2B Churn Intelligence": "_b2b_sum",
+}
+
+HEADER_PATTERN = re.compile(
+    r"^###\s+(?P<name>.+?)\s+MCP Server"
+    r"\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?\s*(?:,[^)]*)?\)",
+    re.MULTILINE,
+)
+
+MISSING_FILE = "MISSING_FILE"
+MISSING_DIR = "MISSING_DIR"
+
+
+def count_decorators(path: Path) -> int | str:
+    if not path.exists():
+        return MISSING_FILE
+    return sum(
+        1
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.lstrip().startswith("@mcp.tool")
+    )
+
+
+def actual_count_for(file_key: str) -> int | str:
+    if file_key == "_b2b_sum":
+        b2b = MCP_DIR / "b2b"
+        if not b2b.is_dir():
+            return MISSING_DIR
+        total = 0
+        for path in sorted(b2b.glob("*.py")):
+            count = count_decorators(path)
+            if isinstance(count, str):
+                return count
+            total += count
+        return total
+    return count_decorators(MCP_DIR / file_key)
+
+
+def audit_claims(text: str) -> list[tuple[str, str, str, str]]:
+    rows: list[tuple[str, str, str, str]] = []
+    for match in HEADER_PATTERN.finditer(text):
+        name = match.group("name").strip()
+        claimed = match.group("count")
+        file_key = HEADER_TO_FILE.get(name)
+        if file_key is None:
+            rows.append((name, claimed, "?", "UNKNOWN"))
+            continue
+
+        actual = actual_count_for(file_key)
+        if isinstance(actual, str):
+            rows.append((name, claimed, "N/A", actual))
+        elif claimed.endswith("+"):
+            rows.append((name, claimed, str(actual), "DRIFT (soft count)"))
+        else:
+            status = "OK" if int(claimed) == actual else "DRIFT"
+            rows.append((name, claimed, str(actual), status))
+    return rows
+
+
+def main() -> int:
+    if not CLAUDE_MD.exists():
+        print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
+        return 2
+
+    rows = audit_claims(CLAUDE_MD.read_text(encoding="utf-8"))
+    if not rows:
+        print("No '### ... MCP Server (N tools)' headers found in CLAUDE.md.")
+        return 1
+
+    name_w = max(len(row[0]) for row in rows)
+    print(f"{'server'.ljust(name_w)}  claimed  actual  status")
+    print("-" * (name_w + 28))
+    drift = False
+    for name, claimed, actual, status in rows:
+        if status != "OK":
+            drift = True
+        print(f"{name.ljust(name_w)}  {claimed:>7}  {actual:>6}  {status}")
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -28,6 +28,10 @@ HEADER_PATTERN = re.compile(
     r"\s*\(\s*(?P<count>\d+\+?)(?:\s+tools)?\s*(?:,[^)]*)?\)",
     re.MULTILINE,
 )
+MCP_HEADING_PATTERN = re.compile(
+    r"^###\s+(?P<name>.+?)\s+MCP Server(?P<suffix>.*)$",
+    re.MULTILINE,
+)
 TOOL_DECORATOR_PATTERN = re.compile(r"^\s*@mcp\.tool(?:\s*\(|\s*$)")
 
 MISSING_FILE = "MISSING_FILE"
@@ -61,13 +65,17 @@ def actual_count_for(file_key: str) -> int | str:
 
 def audit_claims(text: str) -> list[tuple[str, str, str, str]]:
     rows: list[tuple[str, str, str, str]] = []
+    matched_spans: set[tuple[int, int]] = set()
+    seen_known: set[str] = set()
     for match in HEADER_PATTERN.finditer(text):
+        matched_spans.add(match.span())
         name = match.group("name").strip()
         claimed = match.group("count")
         file_key = HEADER_TO_FILE.get(name)
         if file_key is None:
             rows.append((name, claimed, "?", "UNKNOWN"))
             continue
+        seen_known.add(name)
 
         actual = actual_count_for(file_key)
         if isinstance(actual, str):
@@ -77,6 +85,17 @@ def audit_claims(text: str) -> list[tuple[str, str, str, str]]:
         else:
             status = "OK" if int(claimed) == actual else "DRIFT"
             rows.append((name, claimed, str(actual), status))
+
+    for heading in MCP_HEADING_PATTERN.finditer(text):
+        if heading.span() in matched_spans:
+            continue
+        name = heading.group("name").strip()
+        suffix = heading.group("suffix").strip() or "<missing count>"
+        rows.append((name, suffix, "N/A", "MALFORMED"))
+
+    for name in HEADER_TO_FILE:
+        if name not in seen_known:
+            rows.append((name, "MISSING", "N/A", "MISSING"))
     return rows
 
 

--- a/tests/test_audit_claude_md_claims.py
+++ b/tests/test_audit_claude_md_claims.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "audit_claude_md_claims.py"
+
+
+def load_auditor():
+    spec = importlib.util.spec_from_file_location("audit_claude_md_claims", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_header_pattern_matches_supported_shapes():
+    auditor = load_auditor()
+
+    standard = "### Email MCP Server (9 tools)\n"
+    soft = "### B2B Churn Intelligence MCP Server (60+ tools)\n"
+    multi = "### B2B Churn Intelligence MCP Server (83 tools, 17 modules)\n"
+
+    assert auditor.HEADER_PATTERN.search(standard).group("count") == "9"
+    assert auditor.HEADER_PATTERN.search(soft).group("count") == "60+"
+    assert auditor.HEADER_PATTERN.search(multi).group("count") == "83"
+
+
+def test_header_pattern_rejects_missing_close_paren():
+    auditor = load_auditor()
+
+    assert auditor.HEADER_PATTERN.search("### Email MCP Server (9 tools\n") is None
+
+
+def test_count_decorators_missing_file_returns_sentinel(tmp_path):
+    auditor = load_auditor()
+
+    result = auditor.count_decorators(tmp_path / "missing.py")
+
+    assert result == auditor.MISSING_FILE
+    assert result != -1
+
+
+def test_count_decorators_counts_bare_and_called_tool_decorators(tmp_path):
+    auditor = load_auditor()
+    server = tmp_path / "server.py"
+    server.write_text(
+        "@mcp.tool\n"
+        "def alpha():\n"
+        "    pass\n\n"
+        "@mcp.tool()\n"
+        "def beta():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    assert auditor.count_decorators(server) == 2
+
+
+def test_audit_claims_surfaces_unknown_server_header():
+    auditor = load_auditor()
+
+    rows = auditor.audit_claims("### New Thing MCP Server (1 tools)\n")
+
+    assert rows == [("New Thing", "1", "?", "UNKNOWN")]

--- a/tests/test_audit_claude_md_claims.py
+++ b/tests/test_audit_claude_md_claims.py
@@ -82,4 +82,20 @@ def test_audit_claims_surfaces_unknown_server_header():
 
     rows = auditor.audit_claims("### New Thing MCP Server (1 tools)\n")
 
-    assert rows == [("New Thing", "1", "?", "UNKNOWN")]
+    assert ("New Thing", "1", "?", "UNKNOWN") in rows
+
+
+def test_audit_claims_surfaces_malformed_mcp_heading():
+    auditor = load_auditor()
+
+    rows = auditor.audit_claims("### Email MCP Server (9 tools\n")
+
+    assert ("Email", "(9 tools", "N/A", "MALFORMED") in rows
+
+
+def test_audit_claims_surfaces_missing_expected_server():
+    auditor = load_auditor()
+
+    rows = auditor.audit_claims("### Email MCP Server (9 tools)\n")
+
+    assert ("CRM", "MISSING", "N/A", "MISSING") in rows

--- a/tests/test_audit_claude_md_claims.py
+++ b/tests/test_audit_claude_md_claims.py
@@ -33,6 +33,13 @@ def test_header_pattern_rejects_missing_close_paren():
     assert auditor.HEADER_PATTERN.search("### Email MCP Server (9 tools\n") is None
 
 
+def test_header_pattern_requires_tools_token():
+    auditor = load_auditor()
+
+    assert auditor.HEADER_PATTERN.search("### Email MCP Server (9)\n") is None
+    assert auditor.HEADER_PATTERN.search("### Email MCP Server (9 modules)\n") is None
+
+
 def test_count_decorators_missing_file_returns_sentinel(tmp_path):
     auditor = load_auditor()
 
@@ -93,9 +100,26 @@ def test_audit_claims_surfaces_malformed_mcp_heading():
     assert ("Email", "(9 tools", "N/A", "MALFORMED") in rows
 
 
+def test_audit_claims_surfaces_missing_count_as_malformed_heading():
+    auditor = load_auditor()
+
+    rows = auditor.audit_claims("### Email MCP Server (9)\n")
+
+    assert ("Email", "(9)", "N/A", "MALFORMED") in rows
+
+
 def test_audit_claims_surfaces_missing_expected_server():
     auditor = load_auditor()
 
     rows = auditor.audit_claims("### Email MCP Server (9 tools)\n")
 
     assert ("CRM", "MISSING", "N/A", "MISSING") in rows
+
+
+def test_audit_claims_with_no_headers_reports_missing_expected_servers():
+    auditor = load_auditor()
+
+    rows = auditor.audit_claims("No MCP headings here.\n")
+
+    assert ("CRM", "MISSING", "N/A", "MISSING") in rows
+    assert ("Email", "MISSING", "N/A", "MISSING") in rows

--- a/tests/test_audit_claude_md_claims.py
+++ b/tests/test_audit_claude_md_claims.py
@@ -58,6 +58,25 @@ def test_count_decorators_counts_bare_and_called_tool_decorators(tmp_path):
     assert auditor.count_decorators(server) == 2
 
 
+def test_count_decorators_ignores_similar_non_tool_decorators(tmp_path):
+    auditor = load_auditor()
+    server = tmp_path / "server.py"
+    server.write_text(
+        "@mcp.toolbox\n"
+        "def not_a_tool():\n"
+        "    pass\n\n"
+        "@mcp.tool_extra()\n"
+        "def also_not_a_tool():\n"
+        "    pass\n\n"
+        "@mcp.tool(name='real')\n"
+        "def real_tool():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    assert auditor.count_decorators(server) == 1
+
+
 def test_audit_claims_surfaces_unknown_server_header():
     auditor = load_auditor()
 


### PR DESCRIPTION
Plan: plans/PR-Audit-Claude-Md-MCP-Counts.md

Split from oversized PR #483. This lands only the CLAUDE.md MCP tool-count auditor plus focused regression tests, staying below the review-size gate.

## What changed
- Added `scripts/audit_claude_md_claims.py` to compare `CLAUDE.md` MCP server count claims against actual `@mcp.tool` / `@mcp.tool(...)` decorators.
- Added fail-closed handling for malformed MCP headings and missing expected server headings so broken claims cannot silently disappear.
- Tightened heading parsing so the `(N tools)` token is required; headings like `(9)` or `(9 modules)` are reported as malformed.
- Added tests covering supported heading shapes, malformed/missing headings, missing-file sentinels, precise decorator counting, non-tool decorator rejection, unknown servers, and no-heading behavior.
- Added a narrow plan doc and refreshed the coordination row for this split slice.

## Intentional
- No wrapper script yet; `scripts/pre_push_audit.sh` will come after individual auditors land.
- Plan shape, files-touched, diff-size, and MCP port audits already landed separately.
- Soft counts like `60+` report drift because the code can provide an exact count.

## Deferred
- Add the pre-push wrapper after individual auditors exist on `main`.
- Split remaining Tier-1 audit scripts from #484.
- Decide whether to harvest or close fixture/meta-audit work from #486 and #487.
- CI wiring.

## Verification
- `python -m pytest tests/test_audit_claude_md_claims.py` -> 11 passed
- `python scripts/audit_claude_md_claims.py` -> all current MCP counts OK
- `python scripts/audit_plan_doc.py plans/PR-Audit-Claude-Md-MCP-Counts.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Claude-Md-MCP-Counts.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Claude-Md-MCP-Counts.md origin/main` -> estimate 306, actual 306, status OK
- `python -m py_compile scripts/audit_claude_md_claims.py tests/test_audit_claude_md_claims.py` -> passed
- `git diff --check` -> passed

## Migration / rollback notes
No schema, dependency, env var, or runtime behavior changes. Rollback is deleting this script/test/plan and removing the coordination row.
