### PR TITLE
Add plan-doc shape audit

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T16:25Z by codex-2026-05-11-live-execute-harness
+Last updated: 2026-05-11T16:58Z by codex-2026-05-11-plan-doc-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add Content Ops live execute test harness | NEW: `plans/PR-Content-Ops-Live-Execute-Harness.md`; `tests/content_ops_live_execute_harness.py`; `tests/test_extracted_content_ops_live_execute_harness.py`. EDIT: `scripts/run_extracted_pipeline_checks.sh`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-live-execute-harness | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
+| (in flight) | Add plan-doc shape audit | NEW: `plans/PR-Audit-Plan-Doc-Shape.md`; `scripts/audit_plan_doc.py`; `tests/test_audit_plan_doc.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-plan-doc-audit | `scripts/audit_claude_md_claims.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Plan-Doc-Shape.md
+++ b/plans/PR-Audit-Plan-Doc-Shape.md
@@ -1,0 +1,72 @@
+# PR-Audit-Plan-Doc-Shape
+
+## Why this slice exists
+
+The oversized audit-kit PR #483 bundled multiple auditors and was
+rejected under the repo's review-size gate. This split lands only the
+plan-doc shape auditor: a deterministic check that a PR plan contains
+the required AGENTS.md sections in order.
+
+This catches plan files that omit the contract sections reviewers rely
+on, or that accidentally satisfy `Scope` with a heading like `Out of
+scope`.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_plan_doc.py`.
+2. Add focused tests for happy path, missing section, out-of-order
+   sections, duplicate sections, and CLI boundary behavior.
+3. Refresh the coordination row for this split slice.
+
+### Files touched
+
+- `scripts/audit_plan_doc.py`
+- `tests/test_audit_plan_doc.py`
+- `plans/PR-Audit-Plan-Doc-Shape.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`audit_plan_doc.py` reads a plan document, extracts `##` headings, and
+checks the seven required sections in AGENTS.md order: Why, Scope,
+Mechanism, Intentional, Deferred, Verification, and Estimated diff size.
+
+Section matching uses normalized exact-title allowlists, not substring
+matching. That means `## Out of scope` does not satisfy `Scope`.
+Duplicate required sections and out-of-order sections are explicit
+drift states.
+
+## Intentional
+
+- No pre-push wrapper in this PR. The wrapper comes after individual
+  auditors land.
+- The auditor accepts `## Scope` and `## Scope (this PR)` because both
+  forms are common in current plans.
+- The auditor checks only top-level `##` plan sections. Subsections are
+  intentionally ignored.
+
+## Deferred
+
+- Files-touched-vs-diff auditing.
+- Diff-size estimate auditing.
+- Pre-push wrapper integration.
+- CI wiring.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_plan_doc.py
+python -m py_compile scripts/audit_plan_doc.py tests/test_audit_plan_doc.py
+python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Doc-Shape.md
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC (approx) |
+|---|---:|
+| `scripts/audit_plan_doc.py` | 105 |
+| `tests/test_audit_plan_doc.py` | 185 |
+| `plans/PR-Audit-Plan-Doc-Shape.md` | 72 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| **Total** | **~364** |

--- a/scripts/audit_plan_doc.py
+++ b/scripts/audit_plan_doc.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Verify a plan doc has the required AGENTS.md sections, in order."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REQUIRED: list[tuple[str, tuple[str, ...]]] = [
+    ("Why this slice exists", ("why this slice exists",)),
+    ("Scope", ("scope", "scope (this pr)")),
+    ("Mechanism", ("mechanism",)),
+    ("Intentional", ("intentional",)),
+    ("Deferred", ("deferred",)),
+    ("Verification", ("verification",)),
+    ("Estimated diff size", ("estimated diff size",)),
+]
+
+_WS = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class SectionAuditRow:
+    canonical: str
+    status: str
+    line_no: int | None = None
+    heading: str = ""
+
+
+def _normalize(heading: str) -> str:
+    return _WS.sub(" ", heading.strip().lower())
+
+
+def plan_headings(text: str) -> list[tuple[int, str]]:
+    return [
+        (line_no, line[3:].strip())
+        for line_no, line in enumerate(text.splitlines(), start=1)
+        if line.startswith("## ")
+    ]
+
+
+def audit_plan_text(text: str) -> list[SectionAuditRow]:
+    headings = plan_headings(text)
+    last_index = -1
+    rows: list[SectionAuditRow] = []
+
+    for canonical, variants in REQUIRED:
+        matches = [
+            (idx, line_no, heading)
+            for idx, (line_no, heading) in enumerate(headings)
+            if _normalize(heading) in variants
+        ]
+        if not matches:
+            rows.append(SectionAuditRow(canonical=canonical, status="MISSING"))
+            continue
+
+        idx, line_no, heading = matches[0]
+        if len(matches) > 1:
+            rows.append(
+                SectionAuditRow(
+                    canonical=canonical,
+                    status="DUPLICATE",
+                    line_no=line_no,
+                    heading=heading,
+                )
+            )
+        elif idx <= last_index:
+            rows.append(
+                SectionAuditRow(
+                    canonical=canonical,
+                    status="OUT OF ORDER",
+                    line_no=line_no,
+                    heading=heading,
+                )
+            )
+        else:
+            rows.append(
+                SectionAuditRow(
+                    canonical=canonical,
+                    status="OK",
+                    line_no=line_no,
+                    heading=heading,
+                )
+            )
+            last_index = idx
+    return rows
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: audit_plan_doc.py PATH", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"plan doc not found: {path}", file=sys.stderr)
+        return 2
+
+    print(f"plan doc: {path}")
+    print("-" * 60)
+
+    drift = False
+    for row in audit_plan_text(path.read_text(encoding="utf-8")):
+        if row.status != "OK":
+            drift = True
+        if row.line_no is None:
+            print(f"{row.status:<14} ## {row.canonical}")
+        else:
+            print(f"{row.status:<14} line {row.line_no:>4}: ## {row.heading}")
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_plan_doc.py
+++ b/tests/test_audit_plan_doc.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "audit_plan_doc.py"
+
+
+def load_auditor():
+    name = "audit_plan_doc"
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _statuses(text: str) -> dict[str, str]:
+    audit_plan_doc = load_auditor()
+    return {row.canonical: row.status for row in audit_plan_doc.audit_plan_text(text)}
+
+
+def test_happy_path_accepts_required_sections_in_order():
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Why this slice exists
+        ## Scope (this PR)
+        ## Mechanism
+        ## Intentional
+        ## Deferred
+        ## Verification
+        ## Estimated diff size
+        """
+    )
+
+    assert set(_statuses(text).values()) == {"OK"}
+
+
+def test_out_of_scope_does_not_satisfy_scope():
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Why this slice exists
+        ## Out of scope
+        ## Mechanism
+        ## Intentional
+        ## Deferred
+        ## Verification
+        ## Estimated diff size
+        """
+    )
+
+    statuses = _statuses(text)
+
+    assert statuses["Scope"] == "MISSING"
+
+
+def test_out_of_order_section_is_reported():
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Why this slice exists
+        ## Mechanism
+        ## Scope
+        ## Intentional
+        ## Deferred
+        ## Verification
+        ## Estimated diff size
+        """
+    )
+
+    statuses = _statuses(text)
+
+    assert statuses["Mechanism"] == "OUT OF ORDER"
+
+
+def test_duplicate_required_section_is_reported():
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Why this slice exists
+        ## Scope
+        ## Scope (this PR)
+        ## Mechanism
+        ## Intentional
+        ## Deferred
+        ## Verification
+        ## Estimated diff size
+        """
+    )
+
+    statuses = _statuses(text)
+
+    assert statuses["Scope"] == "DUPLICATE"
+
+
+def test_cli_returns_nonzero_for_missing_file():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "/tmp/atlas-plan-doc-does-not-exist.md"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "plan doc not found" in result.stderr
+
+
+def test_cli_accepts_valid_plan(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        textwrap.dedent(
+            """\
+            # Plan
+
+            ## Why this slice exists
+            ## Scope
+            ## Mechanism
+            ## Intentional
+            ## Deferred
+            ## Verification
+            ## Estimated diff size
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_cli_returns_nonzero_for_plan_drift(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        textwrap.dedent(
+            """\
+            # Plan
+
+            ## Why this slice exists
+            ## Out of scope
+            ## Mechanism
+            ## Intentional
+            ## Deferred
+            ## Verification
+            ## Estimated diff size
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "MISSING" in result.stdout
+    assert "## Scope" in result.stdout


### PR DESCRIPTION
Plan: plans/PR-Audit-Plan-Doc-Shape.md

Split from oversized PR #483. Lands only the plan-doc shape auditor plus active tests, under the review-size gate.

What changed:
- Added `scripts/audit_plan_doc.py` to verify required AGENTS.md plan sections are present and ordered.
- Added focused tests for happy path, missing `Scope`, out-of-order headings, duplicates, and CLI boundaries.
- Added the slice plan and refreshed the coordination row for this split PR.

Intentional:
- No pre-push wrapper in this PR; wrapper integration waits until the individual auditors land.
- `## Scope` and `## Scope (this PR)` are both accepted because current plans use both forms.
- Only top-level `##` plan sections are checked; subsections are ignored.

Deferred:
- Files-touched-vs-diff auditing.
- Diff-size estimate auditing.
- Pre-push wrapper integration and CI wiring.

Verification:
- `python -m pytest tests/test_audit_plan_doc.py` -> 7 passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Doc-Shape.md` -> all required sections OK
- `python -m py_compile scripts/audit_plan_doc.py tests/test_audit_plan_doc.py` -> passed
- `git diff --check` -> passed
- `ruff` not run locally: not installed in this environment

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.
