### PR TITLE
Add plan-doc files-touched audit

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T16:58Z by codex-2026-05-11-plan-doc-audit
+Last updated: 2026-05-11T17:10Z by codex-2026-05-11-plan-files-touched-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add plan-doc shape audit | NEW: `plans/PR-Audit-Plan-Doc-Shape.md`; `scripts/audit_plan_doc.py`; `tests/test_audit_plan_doc.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-plan-doc-audit | `scripts/audit_claude_md_claims.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add plan-doc files-touched audit | NEW: `plans/PR-Audit-Plan-Files-Touched.md`; `scripts/audit_plan_doc_files_touched.py`; `tests/test_audit_plan_doc_files_touched.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-plan-files-touched-audit | `scripts/audit_claude_md_claims.py`; `scripts/audit_plan_doc.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Plan-Files-Touched.md
+++ b/plans/PR-Audit-Plan-Files-Touched.md
@@ -1,0 +1,76 @@
+# PR-Audit-Plan-Files-Touched
+
+## Why this slice exists
+
+The reviewer framework depends on plan docs being a real scope source.
+The shape auditor verifies required sections exist, but it does not
+check whether the plan's declared files match the actual branch diff.
+
+This split lands only the files-touched auditor from the oversized
+audit-kit PRs. It catches drive-by files and stale plan claims before a
+reviewer has to discover scope drift manually.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_plan_doc_files_touched.py`.
+2. Add focused tests for extraction, mismatch classification, and real
+   CLI behavior against a temporary git repo.
+3. Refresh the coordination row for this split slice.
+
+### Files touched
+
+- `scripts/audit_plan_doc_files_touched.py`
+- `tests/test_audit_plan_doc_files_touched.py`
+- `plans/PR-Audit-Plan-Files-Touched.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The auditor reads a plan doc, extracts backticked paths only from the
+`### Files touched` subsection, and compares those paths against
+`git diff --name-only BASE_REF...HEAD`.
+
+It reports:
+
+- `MISSING` for files in the diff but absent from the plan.
+- `EXTRA` for files claimed in the plan but absent from the diff.
+- `OK` when both sets match.
+
+The default base ref is `origin/main`; callers can pass a different
+base ref for stacked PRs or tests.
+
+## Intentional
+
+- The script checks committed git diff state, not untracked working-tree
+  files. It is meant for PR/review validation after a slice is staged or
+  committed.
+- It parses only the explicit `### Files touched` subsection. Backticks
+  elsewhere in the plan do not count as file claims.
+- No wrapper integration in this PR. The wrapper comes after individual
+  auditors land.
+
+## Deferred
+
+- Untracked-file support for local pre-push usage.
+- Diff-size estimate auditing.
+- Wrapper and CI integration.
+- Cross-checking PR description file claims.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_plan_doc_files_touched.py
+python -m py_compile scripts/audit_plan_doc_files_touched.py tests/test_audit_plan_doc_files_touched.py
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Plan-Files-Touched.md origin/main
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC (approx) |
+|---|---:|
+| `scripts/audit_plan_doc_files_touched.py` | 119 |
+| `tests/test_audit_plan_doc_files_touched.py` | 164 |
+| `plans/PR-Audit-Plan-Files-Touched.md` | 76 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| **Total** | **~361** |

--- a/scripts/audit_plan_doc_files_touched.py
+++ b/scripts/audit_plan_doc_files_touched.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Compare a plan doc's declared files against the current git diff."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PATH_PATTERN = re.compile(r"`([^`\n]+)`")
+
+
+@dataclass(frozen=True)
+class FilesTouchedAudit:
+    claimed: set[str]
+    actual: set[str]
+
+    @property
+    def missing_in_plan(self) -> set[str]:
+        return self.actual - self.claimed
+
+    @property
+    def extra_in_plan(self) -> set[str]:
+        return self.claimed - self.actual
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing_in_plan and not self.extra_in_plan
+
+
+def _normalize_heading(line: str) -> str:
+    return line.lstrip("#").strip().lower()
+
+
+def _files_touched_lines(text: str) -> list[str]:
+    in_files_touched = False
+    lines: list[str] = []
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            in_files_touched = False
+        elif line.startswith("### "):
+            in_files_touched = _normalize_heading(line) == "files touched"
+            continue
+
+        if in_files_touched:
+            lines.append(line)
+    return lines
+
+
+def claimed_files_touched(text: str) -> set[str]:
+    claimed: set[str] = set()
+    for line in _files_touched_lines(text):
+        for match in PATH_PATTERN.finditer(line):
+            value = match.group(1).strip()
+            if value:
+                claimed.add(value)
+    return claimed
+
+
+def actual_diff_files(base_ref: str) -> set[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed")
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def audit_files_touched(plan_text: str, actual: set[str]) -> FilesTouchedAudit:
+    return FilesTouchedAudit(claimed=claimed_files_touched(plan_text), actual=actual)
+
+
+def _print_paths(label: str, paths: set[str]) -> None:
+    for path in sorted(paths):
+        print(f"{label:<15} {path}")
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print("usage: audit_plan_doc_files_touched.py PLAN [BASE_REF]", file=sys.stderr)
+        return 2
+
+    plan_path = Path(sys.argv[1])
+    base_ref = sys.argv[2] if len(sys.argv) == 3 else "origin/main"
+    if not plan_path.exists():
+        print(f"plan doc not found: {plan_path}", file=sys.stderr)
+        return 2
+
+    try:
+        actual = actual_diff_files(base_ref)
+    except RuntimeError as exc:
+        print(f"failed to read git diff: {exc}", file=sys.stderr)
+        return 2
+
+    audit = audit_files_touched(plan_path.read_text(encoding="utf-8"), actual)
+
+    print(f"plan doc: {plan_path}")
+    print(f"base ref: {base_ref}")
+    print(f"claimed files: {len(audit.claimed)}")
+    print(f"actual files: {len(audit.actual)}")
+    print("-" * 60)
+
+    if audit.ok:
+        print("OK             plan files match git diff")
+        return 0
+
+    _print_paths("MISSING", audit.missing_in_plan)
+    _print_paths("EXTRA", audit.extra_in_plan)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_plan_doc_files_touched.py
+++ b/tests/test_audit_plan_doc_files_touched.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "audit_plan_doc_files_touched.py"
+
+
+def load_auditor():
+    name = "audit_plan_doc_files_touched"
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _plan(files_section: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        # Plan
+
+        ## Scope
+
+        Backticks here, like `not-a-file.py`, are not file claims.
+
+        ### Files touched
+
+        {files_section}
+
+        ## Verification
+        """
+    )
+
+
+def test_claimed_files_only_come_from_files_touched_subsection():
+    auditor = load_auditor()
+    text = _plan(
+        """\
+        - `scripts/audit_plan_doc_files_touched.py`
+        - `tests/test_audit_plan_doc_files_touched.py`
+        """
+    )
+
+    assert auditor.claimed_files_touched(text) == {
+        "scripts/audit_plan_doc_files_touched.py",
+        "tests/test_audit_plan_doc_files_touched.py",
+    }
+
+
+def test_missing_actual_file_is_reported_as_missing_in_plan():
+    auditor = load_auditor()
+    audit = auditor.audit_files_touched(
+        _plan("- `scripts/audit_plan_doc_files_touched.py`"),
+        {
+            "scripts/audit_plan_doc_files_touched.py",
+            "tests/test_audit_plan_doc_files_touched.py",
+        },
+    )
+
+    assert audit.missing_in_plan == {"tests/test_audit_plan_doc_files_touched.py"}
+    assert audit.extra_in_plan == set()
+    assert not audit.ok
+
+
+def test_extra_claimed_file_is_reported_as_extra_in_plan():
+    auditor = load_auditor()
+    audit = auditor.audit_files_touched(
+        _plan(
+            """\
+            - `scripts/audit_plan_doc_files_touched.py`
+            - `docs/not-touched.md`
+            """
+        ),
+        {"scripts/audit_plan_doc_files_touched.py"},
+    )
+
+    assert audit.missing_in_plan == set()
+    assert audit.extra_in_plan == {"docs/not-touched.md"}
+    assert not audit.ok
+
+
+def test_cli_accepts_matching_plan_against_real_git_diff(tmp_path):
+    repo = _git_repo_with_base_commit(tmp_path)
+    plan = repo / "plans" / "slice.md"
+    plan.parent.mkdir()
+    plan.write_text(
+        _plan(
+            """\
+            - `plans/slice.md`
+            - `src/app.py`
+            """
+        ),
+        encoding="utf-8",
+    )
+    source = repo / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("print('ok')\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "change")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_cli_rejects_plan_that_omits_changed_file(tmp_path):
+    repo = _git_repo_with_base_commit(tmp_path)
+    plan = repo / "plans" / "slice.md"
+    plan.parent.mkdir()
+    plan.write_text(_plan("- `plans/slice.md`"), encoding="utf-8")
+    source = repo / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("print('ok')\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "change")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "MISSING" in result.stdout
+    assert "src/app.py" in result.stdout
+
+
+def _git_repo_with_base_commit(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)


### PR DESCRIPTION
Plan: plans/PR-Audit-Plan-Files-Touched.md

Split from oversized PR #485. Lands only the plan-doc files-touched auditor plus active tests, under the review-size gate.

What changed:
- Added `scripts/audit_plan_doc_files_touched.py` to compare a plan doc's `### Files touched` claims against `git diff --name-only BASE_REF...HEAD`.
- Added focused tests for extraction, missing/extra mismatch classification, and CLI behavior against a real temporary git repo.
- Added the slice plan and refreshed the coordination row for this split PR.

Intentional:
- Checks committed git diff state, not untracked working-tree files; this is for PR/review validation after a slice is committed.
- Parses only the explicit `### Files touched` subsection; backticks elsewhere in the plan do not count as file claims.
- No wrapper integration in this PR; wrapper/CI waits until individual auditors land.

Deferred:
- Untracked-file support for local pre-push usage.
- Diff-size estimate auditing.
- Wrapper/CI integration and PR-description claim checks.

Verification:
- `python -m pytest tests/test_audit_plan_doc_files_touched.py` -> 5 passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Files-Touched.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Plan-Files-Touched.md origin/main` -> claimed files match git diff
- `python -m py_compile scripts/audit_plan_doc_files_touched.py tests/test_audit_plan_doc_files_touched.py` -> passed
- `git diff --check` -> passed
- `ruff` not run locally: not installed in this environment

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.
