### PR TITLE
Add plan-doc diff-size audit

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T17:10Z by codex-2026-05-11-plan-files-touched-audit
+Last updated: 2026-05-11T17:27Z by codex-2026-05-11-plan-diff-size-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add plan-doc files-touched audit | NEW: `plans/PR-Audit-Plan-Files-Touched.md`; `scripts/audit_plan_doc_files_touched.py`; `tests/test_audit_plan_doc_files_touched.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-plan-files-touched-audit | `scripts/audit_claude_md_claims.py`; `scripts/audit_plan_doc.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add plan-doc diff-size audit | NEW: `plans/PR-Audit-Plan-Diff-Size.md`; `scripts/audit_plan_doc_diff_size.py`; `tests/test_audit_plan_doc_diff_size.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-plan-diff-size-audit | `scripts/audit_claude_md_claims.py`; `scripts/audit_plan_doc.py`; `scripts/audit_plan_doc_files_touched.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Plan-Diff-Size.md
+++ b/plans/PR-Audit-Plan-Diff-Size.md
@@ -1,0 +1,79 @@
+# PR-Audit-Plan-Diff-Size
+
+## Why this slice exists
+
+The reviewer framework now verifies that plan docs have the required
+sections and that their file list matches the branch diff. The remaining
+size drift gap is that a PR can claim a small slice while the actual
+diff grows far past the review-size budget.
+
+This split lands only the diff-size auditor from the oversized audit-kit
+PRs. It gives reviewers a deterministic signal when the estimate is
+still useful, merely stale, or no longer a credible scope contract.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_plan_doc_diff_size.py`.
+2. Add focused tests for total parsing, scoped parsing, threshold
+   behavior, missing totals, and real CLI behavior against a temporary
+   git repo.
+3. Refresh the coordination row for this split slice.
+
+### Files touched
+
+- `scripts/audit_plan_doc_diff_size.py`
+- `tests/test_audit_plan_doc_diff_size.py`
+- `plans/PR-Audit-Plan-Diff-Size.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The auditor reads the plan doc's `## Estimated diff size` section,
+parses the `Total` table row, and compares it against
+`git diff --numstat BASE_REF...HEAD`.
+
+It reports:
+
+- `OK` when drift is at or below 25%.
+- `WARN` when drift is above 25% and at or below 50%.
+- `FAIL` when drift is above 50%.
+
+Only `FAIL` exits non-zero. `WARN` is a review signal but still permits
+the PR to move if the author documented the size tradeoff.
+
+## Intentional
+
+- The script counts added plus deleted lines from git's numstat output.
+  Binary files are skipped because they do not have line counts.
+- It parses only the `## Estimated diff size` section. Example totals
+  elsewhere in the plan do not count.
+- No wrapper integration in this PR. The wrapper comes after individual
+  auditors land.
+
+## Deferred
+
+- Wrapper and CI integration.
+- Generated-file exemptions.
+- PR-description diff-size claim checks.
+- Combining shape, file-list, and diff-size outputs into one command.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_plan_doc_diff_size.py
+python -m py_compile scripts/audit_plan_doc_diff_size.py tests/test_audit_plan_doc_diff_size.py
+python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Diff-Size.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Plan-Diff-Size.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Plan-Diff-Size.md origin/main
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC (approx) |
+|---|---:|
+| `scripts/audit_plan_doc_diff_size.py` | 120 |
+| `tests/test_audit_plan_doc_diff_size.py` | 143 |
+| `plans/PR-Audit-Plan-Diff-Size.md` | 79 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| **Total** | **~344** |

--- a/plans/PR-Audit-Plan-Diff-Size.md
+++ b/plans/PR-Audit-Plan-Diff-Size.md
@@ -70,10 +70,10 @@ git diff --check
 
 ## Estimated diff size
 
-| File | LOC (approx) |
+| File | LOC churn (approx) |
 |---|---:|
-| `scripts/audit_plan_doc_diff_size.py` | 120 |
-| `tests/test_audit_plan_doc_diff_size.py` | 143 |
-| `plans/PR-Audit-Plan-Diff-Size.md` | 79 |
+| `scripts/audit_plan_doc_diff_size.py` | 125 |
+| `tests/test_audit_plan_doc_diff_size.py` | 179 |
+| `plans/PR-Audit-Plan-Diff-Size.md` | 83 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~346** |
+| **Total** | **~391** |

--- a/plans/PR-Audit-Plan-Diff-Size.md
+++ b/plans/PR-Audit-Plan-Diff-Size.md
@@ -72,8 +72,8 @@ git diff --check
 
 | File | LOC churn (approx) |
 |---|---:|
-| `scripts/audit_plan_doc_diff_size.py` | 125 |
+| `scripts/audit_plan_doc_diff_size.py` | 121 |
 | `tests/test_audit_plan_doc_diff_size.py` | 179 |
-| `plans/PR-Audit-Plan-Diff-Size.md` | 83 |
+| `plans/PR-Audit-Plan-Diff-Size.md` | 79 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~391** |
+| **Total** | **~383** |

--- a/plans/PR-Audit-Plan-Diff-Size.md
+++ b/plans/PR-Audit-Plan-Diff-Size.md
@@ -75,5 +75,5 @@ git diff --check
 | `scripts/audit_plan_doc_diff_size.py` | 120 |
 | `tests/test_audit_plan_doc_diff_size.py` | 143 |
 | `plans/PR-Audit-Plan-Diff-Size.md` | 79 |
-| `docs/extraction/coordination/inflight.md` | 2 |
-| **Total** | **~344** |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~346** |

--- a/scripts/audit_plan_doc_diff_size.py
+++ b/scripts/audit_plan_doc_diff_size.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Compare a plan doc's estimated diff size against the current git diff."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+TOTAL_PATTERN = re.compile(r"\|\s*\*{0,2}Total\*{0,2}\s*\|\s*\*{0,2}~?([0-9,]+)")
+
+
+@dataclass(frozen=True)
+class DiffSizeAudit:
+    estimate: int
+    actual: int
+    soft_threshold: float = 0.25
+    hard_threshold: float = 0.50
+
+    @property
+    def drift_ratio(self) -> float:
+        if self.estimate == 0:
+            return 0.0 if self.actual == 0 else 1.0
+        return abs(self.actual - self.estimate) / self.estimate
+
+    @property
+    def status(self) -> str:
+        if self.drift_ratio > self.hard_threshold:
+            return "FAIL"
+        if self.drift_ratio > self.soft_threshold:
+            return "WARN"
+        return "OK"
+
+    @property
+    def ok(self) -> bool:
+        return self.status != "FAIL"
+
+
+def _estimated_diff_size_section(text: str) -> str:
+    lines: list[str] = []
+    in_section = False
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            in_section = line[3:].strip().lower() == "estimated diff size"
+            continue
+        if in_section:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def estimated_total_loc(text: str) -> int | None:
+    section = _estimated_diff_size_section(text)
+    match = TOTAL_PATTERN.search(section)
+    if not match:
+        return None
+    return int(match.group(1).replace(",", ""))
+
+
+def actual_diff_loc(base_ref: str) -> int:
+    result = subprocess.run(
+        ["git", "diff", "--numstat", f"{base_ref}...HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed")
+
+    total = 0
+    for line in result.stdout.splitlines():
+        added, deleted, *_ = line.split("\t")
+        if added == "-" or deleted == "-":
+            continue
+        total += int(added) + int(deleted)
+    return total
+
+
+def audit_diff_size(plan_text: str, actual: int) -> DiffSizeAudit | None:
+    estimate = estimated_total_loc(plan_text)
+    if estimate is None:
+        return None
+    return DiffSizeAudit(estimate=estimate, actual=actual)
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print("usage: audit_plan_doc_diff_size.py PLAN [BASE_REF]", file=sys.stderr)
+        return 2
+
+    plan_path = Path(sys.argv[1])
+    base_ref = sys.argv[2] if len(sys.argv) == 3 else "origin/main"
+    if not plan_path.exists():
+        print(f"plan doc not found: {plan_path}", file=sys.stderr)
+        return 2
+
+    try:
+        actual = actual_diff_loc(base_ref)
+    except RuntimeError as exc:
+        print(f"failed to read git diff: {exc}", file=sys.stderr)
+        return 2
+
+    audit = audit_diff_size(plan_path.read_text(encoding="utf-8"), actual)
+    if audit is None:
+        print("estimated diff size total not found", file=sys.stderr)
+        return 2
+
+    print(f"plan doc: {plan_path}")
+    print(f"base ref: {base_ref}")
+    print(f"estimate loc: {audit.estimate}")
+    print(f"actual loc: {audit.actual}")
+    print(f"drift: {audit.drift_ratio:.1%}")
+    print(f"status: {audit.status}")
+    return 0 if audit.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_plan_doc_diff_size.py
+++ b/scripts/audit_plan_doc_diff_size.py
@@ -104,8 +104,9 @@ def main() -> int:
 
     audit = audit_diff_size(plan_path.read_text(encoding="utf-8"), actual)
     if audit is None:
-        print("estimated diff size total not found", file=sys.stderr)
-        return 2
+        print("status: FAIL")
+        print("estimated diff size total not found")
+        return 1
 
     print(f"plan doc: {plan_path}")
     print(f"base ref: {base_ref}")

--- a/tests/test_audit_plan_doc_diff_size.py
+++ b/tests/test_audit_plan_doc_diff_size.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "audit_plan_doc_diff_size.py"
+
+
+def load_auditor():
+    name = "audit_plan_doc_diff_size"
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _plan(total: str, earlier_example_total: str = "") -> str:
+    return textwrap.dedent(
+        f"""\
+        # Plan
+
+        ## Mechanism
+
+        {earlier_example_total}
+
+        ## Estimated diff size
+
+        | File | LOC |
+        |---|---:|
+        | `script.py` | 10 |
+        | **Total** | **{total}** |
+        """
+    )
+
+
+def test_estimated_total_loc_reads_only_estimated_diff_size_section():
+    auditor = load_auditor()
+    text = _plan("100", "| **Total** | **999** |")
+
+    assert auditor.estimated_total_loc(text) == 100
+
+
+def test_estimated_total_loc_accepts_approximate_and_comma_values():
+    auditor = load_auditor()
+
+    assert auditor.estimated_total_loc(_plan("~1,250")) == 1250
+
+
+def test_audit_diff_size_statuses():
+    auditor = load_auditor()
+
+    assert auditor.audit_diff_size(_plan("100"), 124).status == "OK"
+    assert auditor.audit_diff_size(_plan("100"), 126).status == "WARN"
+    assert auditor.audit_diff_size(_plan("100"), 151).status == "FAIL"
+
+
+def test_missing_total_returns_none():
+    auditor = load_auditor()
+    text = textwrap.dedent(
+        """\
+        # Plan
+
+        ## Estimated diff size
+
+        | File | LOC |
+        |---|---:|
+        | `script.py` | 10 |
+        """
+    )
+
+    assert auditor.audit_diff_size(text, 10) is None
+
+
+def test_cli_accepts_diff_within_soft_threshold(tmp_path):
+    repo = _git_repo_with_base_commit(tmp_path)
+    plan = repo / "plans" / "slice.md"
+    plan.parent.mkdir()
+    plan.write_text(_plan("14"), encoding="utf-8")
+    (repo / "script.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "change")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "status: OK" in result.stdout
+
+
+def test_cli_fails_diff_beyond_hard_threshold(tmp_path):
+    repo = _git_repo_with_base_commit(tmp_path)
+    plan = repo / "plans" / "slice.md"
+    plan.parent.mkdir()
+    plan.write_text(_plan("2"), encoding="utf-8")
+    (repo / "script.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "change")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "status: FAIL" in result.stdout
+
+
+def _git_repo_with_base_commit(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)

--- a/tests/test_audit_plan_doc_diff_size.py
+++ b/tests/test_audit_plan_doc_diff_size.py
@@ -85,6 +85,42 @@ def test_missing_total_returns_none():
     assert auditor.audit_diff_size(text, 10) is None
 
 
+def test_cli_treats_missing_total_as_audit_failure(tmp_path):
+    repo = _git_repo_with_base_commit(tmp_path)
+    plan = repo / "plans" / "slice.md"
+    plan.parent.mkdir()
+    plan.write_text(
+        textwrap.dedent(
+            """\
+            # Plan
+
+            ## Estimated diff size
+
+            | File | LOC |
+            |---|---:|
+            | `script.py` | 10 |
+            """
+        ),
+        encoding="utf-8",
+    )
+    (repo / "script.py").write_text("a = 1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "change")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(plan), "HEAD~1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "status: FAIL" in result.stdout
+    assert "estimated diff size total not found" in result.stdout
+    assert result.stderr == ""
+
+
 def test_cli_accepts_diff_within_soft_threshold(tmp_path):
     repo = _git_repo_with_base_commit(tmp_path)
     plan = repo / "plans" / "slice.md"


### PR DESCRIPTION
Plan: plans/PR-Audit-Plan-Diff-Size.md

Split from oversized PR #485. Lands only the plan-doc diff-size auditor plus active tests, under the review-size gate.

What changed:
- Added `scripts/audit_plan_doc_diff_size.py` to compare a plan doc's `Estimated diff size` total against `git diff --numstat BASE_REF...HEAD`.
- Added focused tests for scoped total parsing, approximate/comma values, OK/WARN/FAIL thresholds, missing totals, and CLI behavior against a real temporary git repo.
- Added the slice plan and refreshed the coordination row for this split PR.

Intentional:
- Counts added plus deleted lines from git numstat; binary files are skipped because they have no line count.
- Parses only the `## Estimated diff size` section; example totals elsewhere in the plan do not count.
- `WARN` exits zero; only `FAIL` blocks. Drift above 25% is review-visible, drift above 50% is a broken scope contract.
- No wrapper integration in this PR; wrapper/CI waits until individual auditors land.

Deferred:
- Wrapper/CI integration.
- Generated-file exemptions.
- PR-description diff-size claim checks.
- Combining shape, file-list, and diff-size outputs into one command.

Verification:
- `python -m pytest tests/test_audit_plan_doc_diff_size.py` -> 7 passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Diff-Size.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Plan-Diff-Size.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Plan-Diff-Size.md origin/main` -> estimate 383, actual 383, status OK
- `python -m py_compile scripts/audit_plan_doc_diff_size.py tests/test_audit_plan_doc_diff_size.py` -> passed
- `git diff --check` -> passed
- `ruff` not run locally: not installed in this environment

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.

