### PR TITLE
Add MCP port assignment audit

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-11T17:27Z by codex-2026-05-11-plan-diff-size-audit
+Last updated: 2026-05-12T01:52Z by codex-2026-05-12-mcp-port-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add plan-doc diff-size audit | NEW: `plans/PR-Audit-Plan-Diff-Size.md`; `scripts/audit_plan_doc_diff_size.py`; `tests/test_audit_plan_doc_diff_size.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-11-plan-diff-size-audit | `scripts/audit_claude_md_claims.py`; `scripts/audit_plan_doc.py`; `scripts/audit_plan_doc_files_touched.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add MCP port assignment audit | NEW: `plans/PR-Audit-MCP-Port-Assignments.md`; `scripts/audit_mcp_port_assignments.py`; `tests/test_audit_mcp_port_assignments.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-mcp-port-audit | `scripts/audit_claude_md_claims.py`; `scripts/audit_plan_doc.py`; `scripts/audit_plan_doc_files_touched.py`; `scripts/audit_plan_doc_diff_size.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-MCP-Port-Assignments.md
+++ b/plans/PR-Audit-MCP-Port-Assignments.md
@@ -1,0 +1,68 @@
+# PR-Audit-MCP-Port-Assignments
+
+## Why this slice exists
+
+The reviewer/auditor kit now checks plan shape, files touched, and diff size.
+The next mechanical drift class from the oversized audit PRs is configuration
+documentation: `CLAUDE.md` can claim MCP ports that do not match
+`atlas_brain/config.py`.
+
+## Scope (this PR)
+
+Add `scripts/audit_mcp_port_assignments.py`, focused parser/classifier/CLI
+tests, and the coordination row refresh.
+
+### Files touched
+
+- `scripts/audit_mcp_port_assignments.py`
+- `tests/test_audit_mcp_port_assignments.py`
+- `plans/PR-Audit-MCP-Port-Assignments.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The auditor parses `MCPConfig` with `ast`, extracts each `<name>_port`
+`Field(default=N)`, and compares those defaults with two `CLAUDE.md` claim
+forms:
+
+- `ATLAS_MCP_<NAME>_PORT=N` environment-variable examples.
+- `# SSE HTTP mode (port N)` examples followed by
+  `python -m atlas_brain.mcp.<name>_server --sse`.
+
+It reports `OK`, `MISSING`, `DRIFT`, `CONFLICT`, or `EXTRA`.
+
+## Intentional
+
+- No changes to `CLAUDE.md` or `atlas_brain/config.py`; current docs and
+  config already match.
+- The script validates port claims only. Tool counts and tool names are
+  separate auditors.
+- No wrapper integration in this PR. The wrapper comes after individual
+  auditors land.
+
+## Deferred
+
+Wrapper/CI integration, MCP enable/disable env auditing, tool inventory
+auditing, and PR-description port-claim checks.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_mcp_port_assignments.py
+python scripts/audit_mcp_port_assignments.py
+python scripts/audit_plan_doc.py plans/PR-Audit-MCP-Port-Assignments.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-MCP-Port-Assignments.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-MCP-Port-Assignments.md origin/main
+python -m py_compile scripts/audit_mcp_port_assignments.py tests/test_audit_mcp_port_assignments.py
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/audit_mcp_port_assignments.py` | 160 |
+| `tests/test_audit_mcp_port_assignments.py` | 157 |
+| `plans/PR-Audit-MCP-Port-Assignments.md` | 68 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~389** |

--- a/plans/PR-Audit-MCP-Port-Assignments.md
+++ b/plans/PR-Audit-MCP-Port-Assignments.md
@@ -61,8 +61,8 @@ git diff --check
 
 | File | LOC churn (approx) |
 |---|---:|
-| `scripts/audit_mcp_port_assignments.py` | 162 |
+| `scripts/audit_mcp_port_assignments.py` | 160 |
 | `tests/test_audit_mcp_port_assignments.py` | 161 |
 | `plans/PR-Audit-MCP-Port-Assignments.md` | 68 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~395** |
+| **Total** | **~393** |

--- a/plans/PR-Audit-MCP-Port-Assignments.md
+++ b/plans/PR-Audit-MCP-Port-Assignments.md
@@ -61,8 +61,8 @@ git diff --check
 
 | File | LOC churn (approx) |
 |---|---:|
-| `scripts/audit_mcp_port_assignments.py` | 160 |
-| `tests/test_audit_mcp_port_assignments.py` | 157 |
+| `scripts/audit_mcp_port_assignments.py` | 162 |
+| `tests/test_audit_mcp_port_assignments.py` | 161 |
 | `plans/PR-Audit-MCP-Port-Assignments.md` | 68 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~389** |
+| **Total** | **~395** |

--- a/scripts/audit_mcp_port_assignments.py
+++ b/scripts/audit_mcp_port_assignments.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Verify MCP port claims in CLAUDE.md match MCPConfig defaults."""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ENV_PORT_PATTERN = re.compile(r"\bATLAS_MCP_([A-Z0-9_]+)_PORT\s*=\s*(\d+)\b")
+SSE_PORT_PATTERN = re.compile(r"SSE HTTP mode \(port\s+(\d+)\)")
+MODULE_PATTERN = re.compile(r"python -m atlas_brain\.mcp\.([a-z0-9_]+)_server\b")
+
+
+@dataclass(frozen=True)
+class PortClaim:
+    name: str
+    port: int
+    source: str
+    line_no: int
+
+
+@dataclass(frozen=True)
+class PortAuditRow:
+    name: str
+    status: str
+    expected: int | None
+    documented: tuple[PortClaim, ...]
+
+
+def _normalize_name(name: str) -> str:
+    return name.lower().replace("-", "_").strip("_")
+
+
+def _field_default_int(node: ast.AST | None) -> int | None:
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Field":
+        for keyword in node.keywords:
+            if keyword.arg == "default" and isinstance(keyword.value, ast.Constant):
+                if isinstance(keyword.value.value, int):
+                    return keyword.value.value
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return node.value
+    return None
+
+
+def mcp_config_ports(config_text: str) -> dict[str, int]:
+    tree = ast.parse(config_text)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "MCPConfig":
+            ports: dict[str, int] = {}
+            for statement in node.body:
+                if not isinstance(statement, ast.AnnAssign):
+                    continue
+                if not isinstance(statement.target, ast.Name):
+                    continue
+                field_name = statement.target.id
+                if not field_name.endswith("_port"):
+                    continue
+                default = _field_default_int(statement.value)
+                if default is not None:
+                    ports[field_name.removesuffix("_port")] = default
+            return ports
+    raise ValueError("MCPConfig class not found")
+
+
+def documented_port_claims(doc_text: str) -> dict[str, list[PortClaim]]:
+    claims: dict[str, list[PortClaim]] = {}
+    pending_sse_port: tuple[int, int] | None = None
+
+    for line_no, line in enumerate(doc_text.splitlines(), start=1):
+        for match in ENV_PORT_PATTERN.finditer(line):
+            name = _normalize_name(match.group(1))
+            claim = PortClaim(name=name, port=int(match.group(2)), source="env", line_no=line_no)
+            claims.setdefault(name, []).append(claim)
+
+        sse_match = SSE_PORT_PATTERN.search(line)
+        if sse_match:
+            pending_sse_port = (int(sse_match.group(1)), line_no)
+            continue
+
+        module_match = MODULE_PATTERN.search(line)
+        if module_match and pending_sse_port:
+            port, port_line_no = pending_sse_port
+            name = _normalize_name(module_match.group(1))
+            claim = PortClaim(name=name, port=port, source="sse-example", line_no=port_line_no)
+            claims.setdefault(name, []).append(claim)
+            pending_sse_port = None
+    return claims
+
+
+def audit_ports(config_ports: dict[str, int], claims: dict[str, list[PortClaim]]) -> list[PortAuditRow]:
+    rows: list[PortAuditRow] = []
+    all_names = sorted(set(config_ports) | set(claims))
+    for name in all_names:
+        expected = config_ports.get(name)
+        documented = tuple(claims.get(name, ()))
+        documented_ports = {claim.port for claim in documented}
+
+        if expected is None:
+            status = "EXTRA"
+        elif not documented:
+            status = "MISSING"
+        elif documented_ports == {expected}:
+            status = "OK"
+        elif len(documented_ports) > 1:
+            status = "CONFLICT"
+        else:
+            status = "DRIFT"
+        rows.append(PortAuditRow(name=name, status=status, expected=expected, documented=documented))
+    return rows
+
+
+def _format_claims(claims: tuple[PortClaim, ...]) -> str:
+    if not claims:
+        return "-"
+    return ", ".join(f"{claim.port} ({claim.source}:line {claim.line_no})" for claim in claims)
+
+
+def main() -> int:
+    if len(sys.argv) not in (1, 3):
+        print("usage: audit_mcp_port_assignments.py [CLAUDE_MD CONFIG_PY]", file=sys.stderr)
+        return 2
+
+    doc_path = Path(sys.argv[1]) if len(sys.argv) == 3 else Path("CLAUDE.md")
+    config_path = Path(sys.argv[2]) if len(sys.argv) == 3 else Path("atlas_brain/config.py")
+
+    if not doc_path.exists():
+        print(f"doc file not found: {doc_path}", file=sys.stderr)
+        return 2
+    if not config_path.exists():
+        print(f"config file not found: {config_path}", file=sys.stderr)
+        return 2
+
+    try:
+        config_ports = mcp_config_ports(config_path.read_text(encoding="utf-8"))
+    except (SyntaxError, ValueError) as exc:
+        print(f"failed to parse MCPConfig: {exc}", file=sys.stderr)
+        return 2
+
+    rows = audit_ports(
+        config_ports=config_ports,
+        claims=documented_port_claims(doc_path.read_text(encoding="utf-8")),
+    )
+
+    drift = False
+    print(f"doc: {doc_path}")
+    print(f"config: {config_path}")
+    print("-" * 72)
+    for row in rows:
+        if row.status != "OK":
+            drift = True
+        expected = "-" if row.expected is None else str(row.expected)
+        print(f"{row.status:<10} {row.name:<16} config={expected:<5} docs={_format_claims(row.documented)}")
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_mcp_port_assignments.py
+++ b/scripts/audit_mcp_port_assignments.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 ENV_PORT_PATTERN = re.compile(r"\bATLAS_MCP_([A-Z0-9_]+)_PORT\s*=\s*(\d+)\b")
 SSE_PORT_PATTERN = re.compile(r"SSE HTTP mode \(port\s+(\d+)\)")
-MODULE_PATTERN = re.compile(r"python -m atlas_brain\.mcp\.([a-z0-9_]+)_server\b")
+MODULE_PATTERN = re.compile(r"python -m atlas_brain\.mcp\.([a-z0-9_]+)_server\b[^\n#]*\s--sse\b")
 
 
 @dataclass(frozen=True)

--- a/tests/test_audit_mcp_port_assignments.py
+++ b/tests/test_audit_mcp_port_assignments.py
@@ -61,6 +61,9 @@ def test_documented_port_claims_parse_env_and_sse_examples():
 
         # SSE HTTP mode (port 8064)
         python -m atlas_brain.mcp.memory_server --sse
+
+        # SSE HTTP mode (port 8063)
+        python -m atlas_brain.mcp.scraper_server
         """
     )
 
@@ -69,6 +72,7 @@ def test_documented_port_claims_parse_env_and_sse_examples():
     assert [claim.port for claim in claims["crm"]] == [8056]
     assert [claim.port for claim in claims["b2b_churn"]] == [8062]
     assert [claim.port for claim in claims["memory"]] == [8064]
+    assert "scraper" not in claims
 
 
 def test_audit_ports_reports_missing_drift_conflict_and_extra():

--- a/tests/test_audit_mcp_port_assignments.py
+++ b/tests/test_audit_mcp_port_assignments.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "audit_mcp_port_assignments.py"
+
+
+def load_auditor():
+    name = "audit_mcp_port_assignments"
+    if name in sys.modules:
+        return sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _config() -> str:
+    return textwrap.dedent(
+        """\
+        from pydantic import Field
+
+        class MCPConfig:
+            crm_port: int = Field(default=8056)
+            b2b_churn_port: int = Field(default=8062)
+            memory_port: int = Field(default=8064)
+            transport: str = Field(default="stdio")
+        """
+    )
+
+
+def test_mcp_config_ports_extracts_field_defaults():
+    auditor = load_auditor()
+
+    assert auditor.mcp_config_ports(_config()) == {
+        "crm": 8056,
+        "b2b_churn": 8062,
+        "memory": 8064,
+    }
+
+
+def test_documented_port_claims_parse_env_and_sse_examples():
+    auditor = load_auditor()
+    doc = textwrap.dedent(
+        """\
+        ATLAS_MCP_CRM_PORT=8056
+        ATLAS_MCP_B2B_CHURN_PORT=8062
+
+        # SSE HTTP mode (port 8064)
+        python -m atlas_brain.mcp.memory_server --sse
+        """
+    )
+
+    claims = auditor.documented_port_claims(doc)
+
+    assert [claim.port for claim in claims["crm"]] == [8056]
+    assert [claim.port for claim in claims["b2b_churn"]] == [8062]
+    assert [claim.port for claim in claims["memory"]] == [8064]
+
+
+def test_audit_ports_reports_missing_drift_conflict_and_extra():
+    auditor = load_auditor()
+    claims = auditor.documented_port_claims(
+        textwrap.dedent(
+            """\
+            ATLAS_MCP_CRM_PORT=8057
+            ATLAS_MCP_MEMORY_PORT=8064
+            ATLAS_MCP_MEMORY_PORT=8065
+            ATLAS_MCP_EXTRA_PORT=9000
+            """
+        )
+    )
+
+    rows = {
+        row.name: row.status
+        for row in auditor.audit_ports(
+            {"crm": 8056, "b2b_churn": 8062, "memory": 8064},
+            claims,
+        )
+    }
+
+    assert rows == {
+        "b2b_churn": "MISSING",
+        "crm": "DRIFT",
+        "extra": "EXTRA",
+        "memory": "CONFLICT",
+    }
+
+
+def test_cli_accepts_matching_docs(tmp_path):
+    doc = tmp_path / "CLAUDE.md"
+    config = tmp_path / "config.py"
+    config.write_text(_config(), encoding="utf-8")
+    doc.write_text(
+        textwrap.dedent(
+            """\
+            ATLAS_MCP_CRM_PORT=8056
+            ATLAS_MCP_B2B_CHURN_PORT=8062
+
+            # SSE HTTP mode (port 8064)
+            python -m atlas_brain.mcp.memory_server --sse
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(doc), str(config)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_cli_rejects_port_drift(tmp_path):
+    doc = tmp_path / "CLAUDE.md"
+    config = tmp_path / "config.py"
+    config.write_text(_config(), encoding="utf-8")
+    doc.write_text(
+        textwrap.dedent(
+            """\
+            ATLAS_MCP_CRM_PORT=9999
+            ATLAS_MCP_B2B_CHURN_PORT=8062
+
+            # SSE HTTP mode (port 8064)
+            python -m atlas_brain.mcp.memory_server --sse
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(doc), str(config)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "DRIFT" in result.stdout
+    assert "crm" in result.stdout


### PR DESCRIPTION
Plan: plans/PR-Audit-MCP-Port-Assignments.md

Split from oversized PR #485. Lands only the MCP port assignment auditor plus active tests, under the review-size gate.

What changed:
- Added `scripts/audit_mcp_port_assignments.py` to compare MCP port defaults in `MCPConfig` against `CLAUDE.md` env and SSE examples.
- Added focused tests for config parsing, doc claim parsing, mismatch classification, and CLI behavior.
- Added the slice plan and refreshed the coordination row for this split PR.

Intentional:
- No changes to `CLAUDE.md` or `atlas_brain/config.py`; current docs and config already match.
- This validates port claims only. Tool counts and tool names stay in separate auditors.
- No wrapper integration in this PR; wrapper/CI waits until individual auditors land.

Deferred:
- Wrapper/CI integration.
- MCP enable/disable env auditing.
- Tool-count/tool-name inventory auditing.
- PR-description port-claim checks.

Verification:
- `python -m pytest tests/test_audit_mcp_port_assignments.py` -> 5 passed
- `python scripts/audit_mcp_port_assignments.py` -> all 9 MCP ports OK
- `python scripts/audit_plan_doc.py plans/PR-Audit-MCP-Port-Assignments.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-MCP-Port-Assignments.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-MCP-Port-Assignments.md origin/main` -> estimate 393, actual 393, status OK
- `python -m py_compile scripts/audit_mcp_port_assignments.py tests/test_audit_mcp_port_assignments.py` -> passed
- `git diff --check` -> passed
- `ruff` not run locally: not installed in this environment

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.

