### PR TITLE
Add pre-push audit wrapper

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T15:27Z by codex-2026-05-12-mcp-count-audit
+Last updated: 2026-05-12T15:47Z by codex-2026-05-12-pre-push-wrapper
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add CLAUDE.md MCP tool-count audit | NEW: `plans/PR-Audit-Claude-Md-MCP-Counts.md`; `scripts/audit_claude_md_claims.py`; `tests/test_audit_claude_md_claims.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-mcp-count-audit | `scripts/audit_plan_doc.py`; `scripts/audit_plan_doc_files_touched.py`; `scripts/audit_plan_doc_diff_size.py`; `scripts/audit_mcp_port_assignments.py`; `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add pre-push audit wrapper | NEW: `plans/PR-Audit-Pre-Push-Wrapper.md`; `scripts/pre_push_audit.sh`; `tests/test_pre_push_audit.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-pre-push-wrapper | audit scripts already on `main`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Pre-Push-Wrapper.md
+++ b/plans/PR-Audit-Pre-Push-Wrapper.md
@@ -59,7 +59,7 @@ git diff --check
 | File | LOC churn (approx) |
 |---|---:|
 | `scripts/pre_push_audit.sh` | 90 |
-| `tests/test_pre_push_audit.py` | 194 |
+| `tests/test_pre_push_audit.py` | 226 |
 | `plans/PR-Audit-Pre-Push-Wrapper.md` | 65 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~353** |
+| **Total** | **~385** |

--- a/plans/PR-Audit-Pre-Push-Wrapper.md
+++ b/plans/PR-Audit-Pre-Push-Wrapper.md
@@ -1,0 +1,63 @@
+# PR-Audit-Pre-Push-Wrapper
+
+## Why this slice exists
+
+The individual audit scripts now exist on `main`: CLAUDE.md MCP counts,
+MCP ports, plan shape, files touched, and diff size. The remaining useful
+piece from oversized PR #483 is a single command that runs those checks
+before a builder opens or updates a PR.
+
+## Scope (this PR)
+
+Add `scripts/pre_push_audit.sh`, add a focused wrapper integration test,
+and refresh the coordination row.
+
+### Files touched
+
+- `scripts/pre_push_audit.sh`
+- `tests/test_pre_push_audit.py`
+- `plans/PR-Audit-Pre-Push-Wrapper.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The wrapper resolves trunk via `origin/HEAD` or `origin/main`, runs the
+repository-level MCP count and MCP port auditors, finds touched
+`plans/PR-*.md` files from branch diff plus working tree state, and runs
+shape/files-touched/diff-size checks for each plan.
+
+It also runs `scripts/check_ascii_python.sh` when present. Failures are
+accumulated so one run shows every broken mechanical check.
+
+## Intentional
+
+- No git hook installation. The command is manual for now.
+- No CI wiring in this slice.
+- The wrapper only calls auditors that already landed on `main`.
+
+## Deferred
+
+Git hook installer, GitHub Actions integration, extracted-package
+validator orchestration, and broader PR-claim auditing.
+
+## Verification
+
+```bash
+python -m pytest tests/test_pre_push_audit.py
+bash scripts/pre_push_audit.sh
+python scripts/audit_plan_doc.py plans/PR-Audit-Pre-Push-Wrapper.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Pre-Push-Wrapper.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Pre-Push-Wrapper.md origin/main
+python -m py_compile tests/test_pre_push_audit.py
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/pre_push_audit.sh` | 89 |
+| `tests/test_pre_push_audit.py` | 195 |
+| `plans/PR-Audit-Pre-Push-Wrapper.md` | 63 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~351** |

--- a/plans/PR-Audit-Pre-Push-Wrapper.md
+++ b/plans/PR-Audit-Pre-Push-Wrapper.md
@@ -24,7 +24,9 @@ and refresh the coordination row.
 The wrapper resolves trunk via `origin/HEAD` or `origin/main`, runs the
 repository-level MCP count and MCP port auditors, finds touched
 `plans/PR-*.md` files from branch diff plus working tree state, and runs
-shape/files-touched/diff-size checks for each plan.
+shape checks for each plan. Files-touched and diff-size checks run only
+for committed branch-diff plans because those auditors inspect
+`BASE...HEAD`.
 
 It also runs `scripts/check_ascii_python.sh` when present. Failures are
 accumulated so one run shows every broken mechanical check.
@@ -56,8 +58,8 @@ git diff --check
 
 | File | LOC churn (approx) |
 |---|---:|
-| `scripts/pre_push_audit.sh` | 89 |
-| `tests/test_pre_push_audit.py` | 195 |
-| `plans/PR-Audit-Pre-Push-Wrapper.md` | 63 |
+| `scripts/pre_push_audit.sh` | 90 |
+| `tests/test_pre_push_audit.py` | 194 |
+| `plans/PR-Audit-Pre-Push-Wrapper.md` | 65 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~351** |
+| **Total** | **~353** |

--- a/plans/PR-Audit-Pre-Push-Wrapper.md
+++ b/plans/PR-Audit-Pre-Push-Wrapper.md
@@ -58,8 +58,8 @@ git diff --check
 
 | File | LOC churn (approx) |
 |---|---:|
-| `scripts/pre_push_audit.sh` | 90 |
-| `tests/test_pre_push_audit.py` | 226 |
+| `scripts/pre_push_audit.sh` | 95 |
+| `tests/test_pre_push_audit.py` | 263 |
 | `plans/PR-Audit-Pre-Push-Wrapper.md` | 65 |
 | `docs/extraction/coordination/inflight.md` | 4 |
-| **Total** | **~385** |
+| **Total** | **~427** |

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -49,7 +49,7 @@ committed=$(
 )
 uncommitted=$(
     git status --porcelain -- 'plans/PR-*.md' 2>/dev/null |
-        awk 'substr($0, 1, 2) !~ /D/ {print $NF}' || true
+        awk 'substr($0, 1, 2) !~ /D/ {print substr($0, 4)}' || true
 )
 committed_plan_docs=$(printf '%s\n' "$committed" | sort -u | grep -v '^$' || true)
 uncommitted_plan_docs=$(printf '%s\n' "$uncommitted" | sort -u | grep -v '^$' || true)

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Run mechanical audit checks before opening or updating a PR.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+failures=0
+
+run_check() {
+    local label="$1"
+    shift
+    echo
+    echo "==> $label"
+    if "$@"; then
+        echo "    PASS"
+    else
+        echo "    FAIL"
+        failures=$((failures + 1))
+    fi
+}
+
+resolve_base_ref() {
+    local ref
+    if ref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+        echo "$ref"
+        return 0
+    fi
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+        echo "origin/main"
+        return 0
+    fi
+    return 1
+}
+
+if ! base_ref=$(resolve_base_ref); then
+    echo "pre_push_audit.sh: could not resolve trunk base ref." >&2
+    echo "tried: refs/remotes/origin/HEAD, origin/main" >&2
+    exit 2
+fi
+
+base="$(git merge-base HEAD "$base_ref")"
+
+run_check "CLAUDE.md MCP tool counts" python scripts/audit_claude_md_claims.py
+run_check "MCP port assignments" python scripts/audit_mcp_port_assignments.py
+
+committed=$(
+    git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null || true
+)
+uncommitted=$(
+    git status --porcelain -- 'plans/PR-*.md' 2>/dev/null | awk '{print $NF}' || true
+)
+committed_plan_docs=$(printf '%s\n' "$committed" | sort -u | grep -v '^$' || true)
+uncommitted_plan_docs=$(printf '%s\n' "$uncommitted" | sort -u | grep -v '^$' || true)
+plan_docs=$(printf '%s\n%s\n' "$committed_plan_docs" "$uncommitted_plan_docs" | sort -u | grep -v '^$' || true)
+
+if [ -n "$plan_docs" ]; then
+    while IFS= read -r doc; do
+        [ -z "$doc" ] && continue
+        run_check "Plan shape: $doc" python scripts/audit_plan_doc.py "$doc"
+    done <<< "$plan_docs"
+
+    while IFS= read -r doc; do
+        [ -z "$doc" ] && continue
+        run_check "Plan files touched: $doc" python scripts/audit_plan_doc_files_touched.py "$doc" "$base_ref"
+        run_check "Plan diff size: $doc" python scripts/audit_plan_doc_diff_size.py "$doc" "$base_ref"
+    done <<< "$committed_plan_docs"
+else
+    echo
+    echo "==> Plan docs"
+    echo "    SKIP (no plans/PR-*.md added or modified vs $base_ref or working tree)"
+fi
+
+if [ -f scripts/check_ascii_python.sh ]; then
+    run_check "ASCII Python policy" bash scripts/check_ascii_python.sh
+else
+    echo
+    echo "==> ASCII Python policy"
+    echo "    SKIP (scripts/check_ascii_python.sh not found)"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "all checks passed"
+    exit 0
+fi
+
+echo "$failures check(s) failed"
+exit 1

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -54,6 +54,11 @@ uncommitted=$(
 committed_plan_docs=$(printf '%s\n' "$committed" | sort -u | grep -v '^$' || true)
 uncommitted_plan_docs=$(printf '%s\n' "$uncommitted" | sort -u | grep -v '^$' || true)
 plan_docs=$(printf '%s\n%s\n' "$committed_plan_docs" "$uncommitted_plan_docs" | sort -u | grep -v '^$' || true)
+diff_plan_docs=$(
+    comm -23 \
+        <(printf '%s\n' "$committed_plan_docs" | grep -v '^$' || true) \
+        <(printf '%s\n' "$uncommitted_plan_docs" | grep -v '^$' || true) || true
+)
 
 if [ -n "$plan_docs" ]; then
     while IFS= read -r doc; do
@@ -65,7 +70,7 @@ if [ -n "$plan_docs" ]; then
         [ -z "$doc" ] && continue
         run_check "Plan files touched: $doc" python scripts/audit_plan_doc_files_touched.py "$doc" "$base_ref"
         run_check "Plan diff size: $doc" python scripts/audit_plan_doc_diff_size.py "$doc" "$base_ref"
-    done <<< "$committed_plan_docs"
+    done <<< "$diff_plan_docs"
 else
     echo
     echo "==> Plan docs"

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -48,7 +48,8 @@ committed=$(
     git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null || true
 )
 uncommitted=$(
-    git status --porcelain -- 'plans/PR-*.md' 2>/dev/null | awk '{print $NF}' || true
+    git status --porcelain -- 'plans/PR-*.md' 2>/dev/null |
+        awk 'substr($0, 1, 2) !~ /D/ {print $NF}' || true
 )
 committed_plan_docs=$(printf '%s\n' "$committed" | sort -u | grep -v '^$' || true)
 uncommitted_plan_docs=$(printf '%s\n' "$uncommitted" | sort -u | grep -v '^$' || true)

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "pre_push_audit.sh"
+
+
+def test_pre_push_audit_runs_plan_auditors_for_touched_plan(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+    plan = repo / "plans" / "PR-Wrapper-Smoke.md"
+    plan.parent.mkdir()
+    (repo / "scripts" / "wrapper_smoke.py").write_text("print('ok')\n", encoding="utf-8")
+    plan.write_text(_plan_text(total_loc=39), encoding="utf-8")
+    _git(repo, "add", "plans/PR-Wrapper-Smoke.md", "scripts/wrapper_smoke.py")
+    _git(repo, "commit", "-m", "add wrapper smoke")
+
+    result = subprocess.run(
+        ["bash", str(repo / "scripts" / "pre_push_audit.sh")],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(repo)},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Plan shape: plans/PR-Wrapper-Smoke.md" in result.stdout
+    assert "Plan files touched: plans/PR-Wrapper-Smoke.md" in result.stdout
+    assert "Plan diff size: plans/PR-Wrapper-Smoke.md" in result.stdout
+    assert "all checks passed" in result.stdout
+
+
+def _write_fixture_repo(repo: Path) -> None:
+    (repo / "scripts").mkdir(parents=True)
+    for name in (
+        "audit_claude_md_claims.py",
+        "audit_mcp_port_assignments.py",
+        "audit_plan_doc.py",
+        "audit_plan_doc_files_touched.py",
+        "audit_plan_doc_diff_size.py",
+        "pre_push_audit.sh",
+    ):
+        (repo / "scripts" / name).write_text(
+            (REPO_ROOT / "scripts" / name).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    _write_claude_md(repo / "CLAUDE.md")
+    _write_config(repo / "atlas_brain" / "config.py")
+    _write_mcp_servers(repo / "atlas_brain" / "mcp")
+
+
+def _write_claude_md(path: Path) -> None:
+    path.write_text(
+        """# Fixture
+
+ATLAS_MCP_CRM_PORT=8056
+ATLAS_MCP_EMAIL_PORT=8057
+ATLAS_MCP_TWILIO_PORT=8058
+ATLAS_MCP_CALENDAR_PORT=8059
+ATLAS_MCP_INVOICING_PORT=8060
+ATLAS_MCP_INTELLIGENCE_PORT=8061
+ATLAS_MCP_B2B_CHURN_PORT=8062
+
+### CRM MCP Server (10 tools)
+# SSE HTTP mode (port 8056)
+python -m atlas_brain.mcp.crm_server --sse
+### Email MCP Server (9 tools)
+# SSE HTTP mode (port 8057)
+python -m atlas_brain.mcp.email_server --sse
+### Twilio MCP Server (10 tools)
+# SSE HTTP mode (port 8058)
+python -m atlas_brain.mcp.twilio_server --sse
+### Calendar MCP Server (8 tools)
+# SSE HTTP mode (port 8059)
+python -m atlas_brain.mcp.calendar_server --sse
+### Invoicing MCP Server (18 tools)
+# SSE HTTP mode (port 8060)
+python -m atlas_brain.mcp.invoicing_server --sse
+### Intelligence MCP Server (33 tools)
+# SSE HTTP mode (port 8061)
+python -m atlas_brain.mcp.intelligence_server --sse
+### B2B Churn Intelligence MCP Server (83 tools)
+# SSE HTTP mode (port 8062)
+python -m atlas_brain.mcp.b2b_churn_server --sse
+### Universal Scraper MCP Server (5 tools)
+# SSE HTTP mode (port 8063)
+python -m atlas_brain.mcp.scraper_server --sse
+### Memory MCP Server (15 tools)
+# SSE HTTP mode (port 8064)
+python -m atlas_brain.mcp.memory_server --sse
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_config(path: Path) -> None:
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """from pydantic import Field
+
+class MCPConfig:
+    crm_port: int = Field(default=8056)
+    email_port: int = Field(default=8057)
+    twilio_port: int = Field(default=8058)
+    calendar_port: int = Field(default=8059)
+    invoicing_port: int = Field(default=8060)
+    intelligence_port: int = Field(default=8061)
+    b2b_churn_port: int = Field(default=8062)
+    scraper_port: int = Field(default=8063)
+    memory_port: int = Field(default=8064)
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_mcp_servers(mcp_dir: Path) -> None:
+    mcp_dir.mkdir(parents=True)
+    counts = {
+        "crm_server.py": 10,
+        "email_server.py": 9,
+        "twilio_server.py": 10,
+        "calendar_server.py": 8,
+        "invoicing_server.py": 18,
+        "intelligence_server.py": 33,
+        "scraper_server.py": 5,
+        "memory_server.py": 15,
+    }
+    for filename, count in counts.items():
+        (mcp_dir / filename).write_text(_decorators(count), encoding="utf-8")
+    (mcp_dir / "b2b").mkdir()
+    (mcp_dir / "b2b" / "fixture.py").write_text(_decorators(83), encoding="utf-8")
+
+
+def _decorators(count: int) -> str:
+    return "\n".join("@mcp.tool\ndef tool_%s():\n    pass\n" % idx for idx in range(count))
+
+
+def _plan_text(*, total_loc: int) -> str:
+    return """# PR-Wrapper-Smoke
+
+## Why this slice exists
+
+Test fixture.
+
+## Scope (this PR)
+
+### Files touched
+
+- `plans/PR-Wrapper-Smoke.md`
+- `scripts/wrapper_smoke.py`
+
+## Mechanism
+
+Test fixture.
+
+## Intentional
+
+Test fixture.
+
+## Deferred
+
+None.
+
+## Verification
+
+```bash
+bash scripts/pre_push_audit.sh
+```
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Wrapper-Smoke.md` | 38 |
+| `scripts/wrapper_smoke.py` | 1 |
+| **Total** | **~%d** |
+""" % total_loc
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -75,6 +75,43 @@ def test_pre_push_audit_ignores_deleted_working_tree_plan(tmp_path):
     assert "all checks passed" in result.stdout
 
 
+def test_pre_push_audit_runs_shape_only_for_locally_modified_committed_plan(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+    plan = repo / "plans" / "PR-Wrapper-Smoke.md"
+    plan.parent.mkdir()
+    (repo / "scripts" / "wrapper_smoke.py").write_text("print('ok')\n", encoding="utf-8")
+    plan.write_text(_plan_text(total_loc=39), encoding="utf-8")
+    _git(repo, "add", "plans/PR-Wrapper-Smoke.md", "scripts/wrapper_smoke.py")
+    _git(repo, "commit", "-m", "add wrapper smoke")
+    plan.write_text(_plan_text(total_loc=999), encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(repo / "scripts" / "pre_push_audit.sh")],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(repo)},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Plan shape: plans/PR-Wrapper-Smoke.md" in result.stdout
+    assert "Plan files touched: plans/PR-Wrapper-Smoke.md" not in result.stdout
+    assert "Plan diff size: plans/PR-Wrapper-Smoke.md" not in result.stdout
+    assert "all checks passed" in result.stdout
+
+
 def _write_fixture_repo(repo: Path) -> None:
     (repo / "scripts").mkdir(parents=True)
     for name in (

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -5,7 +5,6 @@ import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = REPO_ROOT / "scripts" / "pre_push_audit.sh"
 
 
 def test_pre_push_audit_runs_plan_auditors_for_touched_plan(tmp_path):

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -43,6 +43,38 @@ def test_pre_push_audit_runs_plan_auditors_for_touched_plan(tmp_path):
     assert "all checks passed" in result.stdout
 
 
+def test_pre_push_audit_ignores_deleted_working_tree_plan(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    plan = repo / "plans" / "PR-Deleted-Smoke.md"
+    plan.parent.mkdir()
+    plan.write_text(_plan_text(total_loc=38), encoding="utf-8")
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+    plan.unlink()
+
+    result = subprocess.run(
+        ["bash", str(repo / "scripts" / "pre_push_audit.sh")],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(repo)},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Plan shape: plans/PR-Deleted-Smoke.md" not in result.stdout
+    assert "all checks passed" in result.stdout
+
+
 def _write_fixture_repo(repo: Path) -> None:
     (repo / "scripts").mkdir(parents=True)
     for name in (


### PR DESCRIPTION
Plan: plans/PR-Audit-Pre-Push-Wrapper.md

Split from oversized PR #483. The individual audit scripts now exist on main; this lands only the wrapper that runs them together.

What changed:
- Added `scripts/pre_push_audit.sh` to run MCP count, MCP port, plan shape, plan files-touched, plan diff-size, and ASCII checks.
- Added focused integration coverage using a minimal fixture git repo, proving committed plan docs get all three plan auditors, deleted working-tree plan docs are ignored, and locally modified committed plan docs get shape-only checks.
- Added the narrow plan doc and refreshed the coordination row.

Intentional:
- No git hook installation. The wrapper is manual for now.
- No CI wiring in this slice.
- Working-tree plan docs get shape validation only; files-touched and diff-size run for committed branch diff docs that have no local working-tree edits because those auditors intentionally inspect `BASE...HEAD`.

Deferred:
- Git hook installer.
- GitHub Actions integration.
- Extracted-package validator orchestration.
- Broader PR-claim auditing.

Verification:
- `python -m pytest tests/test_pre_push_audit.py` -> 3 passed
- `bash scripts/pre_push_audit.sh` -> all checks passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Pre-Push-Wrapper.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Pre-Push-Wrapper.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Pre-Push-Wrapper.md origin/main` -> estimate 427, actual 427, status OK
- `python -m py_compile tests/test_pre_push_audit.py && bash -n scripts/pre_push_audit.sh` -> passed
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.