### PR TITLE
Add extracted manifest consistency auditor

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T15:47Z by codex-2026-05-12-pre-push-wrapper
+Last updated: 2026-05-12T16:31Z by codex-2026-05-12-extracted-manifest-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add pre-push audit wrapper | NEW: `plans/PR-Audit-Pre-Push-Wrapper.md`; `scripts/pre_push_audit.sh`; `tests/test_pre_push_audit.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-pre-push-wrapper | audit scripts already on `main`; other audit-kit split PRs |
+| (in flight) | Add extracted manifest consistency auditor | NEW: `plans/PR-Audit-Extracted-Manifests.md`; `scripts/audit_extracted_manifests.py`; `tests/audit_helpers.py`; `tests/test_audit_extracted_manifests.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-extracted-manifest-audit | `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Extracted-Manifests.md
+++ b/plans/PR-Audit-Extracted-Manifests.md
@@ -1,0 +1,84 @@
+# PR-Audit-Extracted-Manifests
+
+## Why this slice exists
+
+Oversized PR #484 bundled three unrelated Tier-1 auditors and was
+rejected as unreviewable. This split lands only the extracted-package
+manifest consistency auditor because it directly protects product
+extraction work from silent source/target drift.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_extracted_manifests.py`.
+2. Add focused fixture tests for the path-safety validator.
+3. Add `tests/audit_helpers.py` as a small shared loader for audit-script
+   tests.
+4. Refresh the in-flight coordination row for this split.
+
+### Files touched
+
+- `plans/PR-Audit-Extracted-Manifests.md`
+- `scripts/audit_extracted_manifests.py`
+- `tests/audit_helpers.py`
+- `tests/test_audit_extracted_manifests.py`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The auditor walks `extracted_*/manifest.json` files and checks:
+
+- every `mappings[].source` exists under `atlas_brain/`
+- every `mappings[].target` exists under the extracted package
+- every `owned[].target` exists under the extracted package
+- mapped source/target byte content is identical
+
+Before touching the filesystem, `_validate_path()` rejects absolute
+paths, parent traversal, and paths outside the expected tree. It checks
+POSIX, Windows drive-letter, and UNC absolute paths so malformed
+manifests cannot escape the repo subtree on non-POSIX platforms.
+
+## Intentional
+
+- The auditor is standalone and not wired into `scripts/pre_push_audit.sh`
+  yet. Main currently has known extracted sync drift, so wrapper
+  integration would make every pre-push run fail until that drift is
+  reconciled.
+- `tests/audit_helpers.py` raises on missing auditors instead of skipping.
+  This split lands the script and tests together, so dormant skip tests are
+  not needed.
+- The tests target the path validator directly. Full live-repo execution is
+  covered by running the script itself.
+
+## Deferred
+
+- Add the auditor to the pre-push wrapper after known sync drift is cleaned
+  up or explicitly accepted.
+- Split the remaining #484 auditors separately: MCP tool-name inventory and
+  review-source count.
+- Close or replace the oversized #484 after its useful pieces are harvested.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_extracted_manifests.py
+python -m py_compile scripts/audit_extracted_manifests.py tests/audit_helpers.py tests/test_audit_extracted_manifests.py
+python scripts/audit_plan_doc.py plans/PR-Audit-Extracted-Manifests.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Extracted-Manifests.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Extracted-Manifests.md origin/main
+git diff --check
+```
+
+`python scripts/audit_extracted_manifests.py` is expected to return
+non-zero on current main because #484 already surfaced preexisting sync
+drift. That is the auditor doing its job, not a failure of this slice.
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/audit_extracted_manifests.py` | 123 |
+| `tests/audit_helpers.py` | 27 |
+| `tests/test_audit_extracted_manifests.py` | 63 |
+| `plans/PR-Audit-Extracted-Manifests.md` | 76 |
+| `docs/extraction/coordination/inflight.md` | 25 |
+| **Total** | **~314** |

--- a/scripts/audit_extracted_manifests.py
+++ b/scripts/audit_extracted_manifests.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Verify every extracted_*/manifest.json is consistent with the filesystem.
+
+For each manifest:
+  - Every mappings[i].source path exists under atlas_brain/.
+  - Every mappings[i].target path exists in the package.
+  - Every owned[i].target path exists in the package.
+  - Synced pairs (mappings entries) are byte-identical between
+    source and target. Drift means sync_extracted.sh has not been run
+    since the source was edited.
+
+Exits 0 if all manifests are consistent. Exits 1 on any drift.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _validate_path(
+    rel: str, must_start_with: str, kind: str, idx: int
+) -> str | None:
+    """Return an error string if rel is unsafe or misplaced."""
+    if PurePosixPath(rel).is_absolute() or PureWindowsPath(rel).is_absolute():
+        return f"{kind}[{idx}]: absolute path rejected ({rel!r})"
+    parts = Path(rel).parts
+    if ".." in parts:
+        return f"{kind}[{idx}]: parent-dir traversal rejected ({rel!r})"
+    if not rel.startswith(must_start_with):
+        return (
+            f"{kind}[{idx}]: path not under expected tree "
+            f"(expected to start with {must_start_with!r}, got {rel!r})"
+        )
+    return None
+
+
+def check_manifest(manifest_path: Path) -> list[str]:
+    """Return failure descriptions for this manifest."""
+    failures: list[str] = []
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return [f"{manifest_path}: failed to parse JSON ({exc})"]
+
+    package_dir = manifest_path.parent.name + "/"
+    mappings = data.get("mappings", [])
+    owned = data.get("owned", [])
+
+    for i, entry in enumerate(mappings):
+        src_rel = entry.get("source")
+        tgt_rel = entry.get("target")
+        if not src_rel or not tgt_rel:
+            failures.append(
+                f"mappings[{i}]: missing source or target ({entry!r})"
+            )
+            continue
+
+        src_err = _validate_path(src_rel, "atlas_brain/", "mappings.source", i)
+        tgt_err = _validate_path(tgt_rel, package_dir, "mappings.target", i)
+        if src_err:
+            failures.append(src_err)
+        if tgt_err:
+            failures.append(tgt_err)
+        if src_err or tgt_err:
+            continue
+
+        src = REPO_ROOT / src_rel
+        tgt = REPO_ROOT / tgt_rel
+        if not src.exists():
+            failures.append(f"mappings[{i}].source missing: {src_rel}")
+        if not tgt.exists():
+            failures.append(f"mappings[{i}].target missing: {tgt_rel}")
+        if src.exists() and tgt.exists():
+            try:
+                if src.read_bytes() != tgt.read_bytes():
+                    failures.append(
+                        f"sync drift: {src_rel} != {tgt_rel} "
+                        "(run extracted/_shared/scripts/sync_extracted.sh)"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"mappings[{i}]: could not compare ({exc})")
+
+    for i, entry in enumerate(owned):
+        tgt_rel = entry.get("target")
+        if not tgt_rel:
+            failures.append(f"owned[{i}]: missing target ({entry!r})")
+            continue
+
+        tgt_err = _validate_path(tgt_rel, package_dir, "owned.target", i)
+        if tgt_err:
+            failures.append(tgt_err)
+            continue
+
+        tgt = REPO_ROOT / tgt_rel
+        if not tgt.exists():
+            failures.append(f"owned[{i}].target missing: {tgt_rel}")
+
+    return failures
+
+
+def main() -> int:
+    manifests = sorted(REPO_ROOT.glob("extracted_*/manifest.json"))
+    if not manifests:
+        print("No extracted_*/manifest.json files found.")
+        return 1
+
+    drift = False
+    for manifest in manifests:
+        rel = manifest.relative_to(REPO_ROOT)
+        failures = check_manifest(manifest)
+        if not failures:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            n_map = len(data.get("mappings", []))
+            n_own = len(data.get("owned", []))
+            print(f"OK     {rel}  (mappings={n_map}, owned={n_own})")
+            continue
+
+        drift = True
+        print(f"DRIFT  {rel}")
+        for failure in failures:
+            print(f"  - {failure}")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/audit_helpers.py
+++ b/tests/audit_helpers.py
@@ -1,0 +1,29 @@
+"""Shared loader for audit scripts under scripts/."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def load_auditor(name: str) -> ModuleType:
+    """Return the auditor module named `<name>` from scripts/."""
+    if name in sys.modules:
+        return sys.modules[name]
+
+    path = SCRIPTS_DIR / f"{name}.py"
+    if not path.exists():
+        raise AssertionError(f"required auditor missing: {path}")
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"could not build import spec for {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_audit_extracted_manifests.py
+++ b/tests/test_audit_extracted_manifests.py
@@ -1,0 +1,67 @@
+"""Fixture tests for scripts/audit_extracted_manifests.py."""
+from __future__ import annotations
+
+import pytest
+
+from tests.audit_helpers import load_auditor
+
+
+@pytest.fixture(scope="module")
+def auditor():
+    return load_auditor("audit_extracted_manifests")
+
+
+def test_posix_absolute_path_rejected(auditor):
+    err = auditor._validate_path(
+        "/etc/passwd", "atlas_brain/", "mappings.source", 0
+    )
+
+    assert err is not None
+    assert "absolute path rejected" in err
+
+
+def test_windows_absolute_path_rejected(auditor):
+    err = auditor._validate_path(
+        "C:\\Windows\\System32", "atlas_brain/", "mappings.source", 0
+    )
+
+    assert err is not None
+    assert "absolute path rejected" in err
+
+
+def test_unc_absolute_path_rejected(auditor):
+    err = auditor._validate_path(
+        "\\\\srv\\share\\foo", "atlas_brain/", "mappings.source", 0
+    )
+
+    assert err is not None
+    assert "absolute path rejected" in err
+
+
+def test_parent_dir_traversal_rejected(auditor):
+    err = auditor._validate_path(
+        "../etc/passwd", "atlas_brain/", "mappings.source", 0
+    )
+
+    assert err is not None
+    assert "parent-dir traversal rejected" in err
+
+
+def test_off_tree_path_rejected(auditor):
+    err = auditor._validate_path(
+        "elsewhere/x.py", "atlas_brain/", "mappings.source", 0
+    )
+
+    assert err is not None
+    assert "not under expected tree" in err
+
+
+def test_happy_path_accepted(auditor):
+    err = auditor._validate_path(
+        "atlas_brain/services/b2b/legit.py",
+        "atlas_brain/",
+        "mappings.source",
+        0,
+    )
+
+    assert err is None


### PR DESCRIPTION
Plan: plans/PR-Audit-Extracted-Manifests.md

Split from oversized PR #484. This lands only the extracted-package manifest consistency auditor plus focused path-safety regression tests.

What changed:
- Added `scripts/audit_extracted_manifests.py` to validate extracted manifest path safety, existence, and synced source/target byte parity.
- Added `tests/audit_helpers.py` and `tests/test_audit_extracted_manifests.py` with POSIX, Windows drive-letter, UNC, traversal, off-tree, and happy-path fixtures.
- Added the narrow plan doc and replaced the stale #493 coordination row with this split.

Intentional:
- Not wired into `scripts/pre_push_audit.sh` yet because current main has known extracted sync drift and the live auditor correctly exits non-zero.
- `tests/audit_helpers.py` raises on missing auditors instead of skipping; this PR lands the auditor and its tests together.
- Live `python scripts/audit_extracted_manifests.py` returning exit 1 is expected until the preexisting sync drift is reconciled.

Deferred:
- Wrapper integration after sync drift cleanup or explicit acceptance.
- Remaining #484 auditors: MCP tool-name inventory and review-source count.
- Closing/replacing oversized #484 after its useful pieces are harvested.

Verification:
- `python -m pytest tests/test_audit_extracted_manifests.py` -> 6 passed
- `python -m py_compile scripts/audit_extracted_manifests.py tests/audit_helpers.py tests/test_audit_extracted_manifests.py` -> passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Extracted-Manifests.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Extracted-Manifests.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Extracted-Manifests.md origin/main` -> estimate 314, actual 314, status OK
- `python scripts/audit_extracted_manifests.py` -> expected exit 1 with the three known preexisting sync drifts
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.