### PR TITLE
Add MCP tool-name inventory auditor

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T16:31Z by codex-2026-05-12-extracted-manifest-audit
+Last updated: 2026-05-12T16:39Z by codex-2026-05-12-mcp-tool-name-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add extracted manifest consistency auditor | NEW: `plans/PR-Audit-Extracted-Manifests.md`; `scripts/audit_extracted_manifests.py`; `tests/audit_helpers.py`; `tests/test_audit_extracted_manifests.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-extracted-manifest-audit | `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add MCP tool-name inventory auditor | NEW: `plans/PR-Audit-MCP-Tool-Names.md`; `scripts/audit_mcp_tool_names_match_docs.py`; `tests/test_audit_mcp_tool_names_match_docs.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-mcp-tool-name-audit | `scripts/pre_push_audit.sh`; other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-MCP-Tool-Names.md
+++ b/plans/PR-Audit-MCP-Tool-Names.md
@@ -1,0 +1,75 @@
+# PR-Audit-MCP-Tool-Names
+
+## Why this slice exists
+
+Oversized PR #484 bundled three Tier-1 auditors and was rejected as
+unreviewable. This split lands only the MCP tool-name inventory auditor:
+it catches drift where `CLAUDE.md` claims a server exposes a tool list
+that no longer matches the real `@mcp.tool` functions.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_mcp_tool_names_match_docs.py`.
+2. Add fixture tests for known and unknown MCP server header parsing.
+3. Refresh the in-flight coordination row for this split.
+
+### Files touched
+
+- `plans/PR-Audit-MCP-Tool-Names.md`
+- `scripts/audit_mcp_tool_names_match_docs.py`
+- `tests/test_audit_mcp_tool_names_match_docs.py`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`doc_claims()` scans `CLAUDE.md` for `### <Name> MCP Server` sections,
+collects backticked snake_case identifiers from each known section, and
+returns both known claims and unknown server headings. Unknown headings
+are reported as drift instead of being silently skipped.
+
+`tool_names_in_file()` parses each MCP server with `ast` and collects
+function names decorated with `@mcp.tool` or `@mcp.tool(...)`.
+`actual_for()` handles the B2B server as a summed directory because its
+tools are split across `atlas_brain/mcp/b2b/*.py`.
+
+## Intentional
+
+- The auditor is not wired into `scripts/pre_push_audit.sh` yet because
+  current `CLAUDE.md` has known tool-inventory drift. Wrapper integration
+  waits until the docs are reconciled or the drift is accepted.
+- The extraction uses section-wide backticked snake_case identifiers,
+  not a brittle single-line `Tools:` parser, because the docs use multiple
+  continuation lines.
+- This PR does not touch scraping/review-source count auditing.
+
+## Deferred
+
+- Add the auditor to the pre-push wrapper after the documented MCP tool
+  inventories are cleaned up.
+- Split or drop the remaining #484 review-source count auditor separately.
+- Close or replace oversized #484 after its useful pieces are harvested.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_mcp_tool_names_match_docs.py
+python -m py_compile scripts/audit_mcp_tool_names_match_docs.py tests/test_audit_mcp_tool_names_match_docs.py
+python scripts/audit_plan_doc.py plans/PR-Audit-MCP-Tool-Names.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-MCP-Tool-Names.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-MCP-Tool-Names.md origin/main
+git diff --check
+```
+
+`python scripts/audit_mcp_tool_names_match_docs.py` is expected to
+return non-zero on current main because #484 already surfaced preexisting
+`CLAUDE.md` tool-inventory drift.
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/audit_mcp_tool_names_match_docs.py` | 129 |
+| `tests/test_audit_mcp_tool_names_match_docs.py` | 61 |
+| `plans/PR-Audit-MCP-Tool-Names.md` | 75 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~269** |

--- a/scripts/audit_mcp_tool_names_match_docs.py
+++ b/scripts/audit_mcp_tool_names_match_docs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Verify MCP tool-name inventories in CLAUDE.md match @mcp.tool functions."""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+MCP_DIR = REPO_ROOT / "atlas_brain" / "mcp"
+
+HEADER_TO_FILE = {
+    "CRM": "crm_server.py",
+    "Email": "email_server.py",
+    "Twilio": "twilio_server.py",
+    "Calendar": "calendar_server.py",
+    "Invoicing": "invoicing_server.py",
+    "Intelligence": "intelligence_server.py",
+    "Universal Scraper": "scraper_server.py",
+    "Memory": "memory_server.py",
+    "B2B Churn Intelligence": "_b2b_sum",
+}
+
+HEADER_PATTERN = re.compile(
+    r"^###\s+(?P<name>.+?)\s+MCP Server", re.MULTILINE
+)
+BACKTICK_IDENT = re.compile(r"`([a-z][a-z0-9_]{3,})`")
+
+
+def section_slice(text: str, start: int) -> str:
+    """Return the substring from `start` up to the next server heading."""
+    rest = text[start:]
+    match = re.search(r"\n(?:## |### )", rest)
+    return rest if match is None else rest[: match.start()]
+
+
+def doc_claims(text: str) -> tuple[dict[str, set[str]], list[str]]:
+    """Return (known_claims, unknown_headers)."""
+    claims: dict[str, set[str]] = {}
+    unknown: list[str] = []
+    for match in HEADER_PATTERN.finditer(text):
+        name = match.group("name").strip()
+        if name not in HEADER_TO_FILE:
+            unknown.append(name)
+            continue
+        section = section_slice(text, match.end())
+        claims[name] = set(BACKTICK_IDENT.findall(section))
+    return claims, unknown
+
+
+def tool_names_in_file(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            target = decorator.func if isinstance(decorator, ast.Call) else decorator
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "tool"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "mcp"
+            ):
+                names.add(node.name)
+                break
+    return names
+
+
+def actual_for(file_key: str) -> set[str]:
+    if file_key == "_b2b_sum":
+        out: set[str] = set()
+        b2b = MCP_DIR / "b2b"
+        if b2b.is_dir():
+            for path in sorted(b2b.glob("*.py")):
+                out |= tool_names_in_file(path)
+        return out
+    return tool_names_in_file(MCP_DIR / file_key)
+
+
+def main() -> int:
+    if not CLAUDE_MD.exists():
+        print(f"CLAUDE.md not found at {CLAUDE_MD}", file=sys.stderr)
+        return 2
+
+    claims, unknown_headers = doc_claims(CLAUDE_MD.read_text(encoding="utf-8"))
+    if not claims and not unknown_headers:
+        print("No '### ... MCP Server' headers found in CLAUDE.md.")
+        return 1
+
+    drift = False
+    if unknown_headers:
+        drift = True
+        print("DRIFT: unknown MCP Server header(s) in CLAUDE.md:")
+        for name in unknown_headers:
+            print(f"  - {name!r} not in HEADER_TO_FILE (rename or new server?)")
+
+    for name in sorted(claims):
+        file_key = HEADER_TO_FILE[name]
+        actual = actual_for(file_key)
+        claimed = claims[name]
+        missing_in_doc = actual - claimed
+        extra_in_doc = claimed - actual
+        status = "OK" if not (missing_in_doc or extra_in_doc) else "DRIFT"
+        print(
+            f"\n{name} ({file_key})  "
+            f"claimed={len(claimed)}  actual={len(actual)}  {status}"
+        )
+        if missing_in_doc:
+            drift = True
+            print("  missing in doc (in code, not in CLAUDE.md):")
+            for missing in sorted(missing_in_doc):
+                print(f"    - {missing}")
+        if extra_in_doc:
+            drift = True
+            print("  extra in doc (in CLAUDE.md, not in code):")
+            for extra in sorted(extra_in_doc):
+                print(f"    - {extra}")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_mcp_tool_names_match_docs.py
+++ b/tests/test_audit_mcp_tool_names_match_docs.py
@@ -1,0 +1,61 @@
+"""Fixture tests for scripts/audit_mcp_tool_names_match_docs.py."""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from tests.audit_helpers import load_auditor
+
+
+@pytest.fixture(scope="module")
+def auditor():
+    return load_auditor("audit_mcp_tool_names_match_docs")
+
+
+KNOWN_SECTION = textwrap.dedent("""\
+    ### Email MCP Server (9 tools)
+
+    Tools: `send_email`, `read_inbox`, `list_folders`
+""")
+
+UNKNOWN_SECTION = textwrap.dedent("""\
+    ### Foobar MCP Server (5 tools)
+
+    Tools: `do_thing`, `do_other_thing`
+""")
+
+
+def test_doc_claims_returns_tuple_of_known_and_unknown(auditor):
+    out = auditor.doc_claims(KNOWN_SECTION)
+
+    assert isinstance(out, tuple)
+    assert len(out) == 2
+    claims, unknown = out
+    assert isinstance(claims, dict)
+    assert isinstance(unknown, list)
+
+
+def test_known_server_header_lands_in_claims(auditor):
+    claims, unknown = auditor.doc_claims(KNOWN_SECTION)
+
+    assert "Email" in claims
+    assert unknown == []
+    assert "send_email" in claims["Email"]
+    assert "list_folders" in claims["Email"]
+
+
+def test_unknown_server_header_surfaces_in_unknown_list(auditor):
+    claims, unknown = auditor.doc_claims(UNKNOWN_SECTION)
+
+    assert "Foobar" in unknown
+    assert "Foobar" not in claims
+
+
+def test_mixed_known_and_unknown(auditor):
+    text = KNOWN_SECTION + "\n" + UNKNOWN_SECTION
+
+    claims, unknown = auditor.doc_claims(text)
+
+    assert "Email" in claims
+    assert "Foobar" in unknown


### PR DESCRIPTION
Plan: plans/PR-Audit-MCP-Tool-Names.md

Split from oversized PR #484. This lands only the MCP tool-name inventory auditor and focused parser regression tests.

What changed:
- Added `scripts/audit_mcp_tool_names_match_docs.py` to compare `CLAUDE.md` MCP tool inventories against real `@mcp.tool` functions.
- Added `tests/test_audit_mcp_tool_names_match_docs.py` covering known/unknown MCP server header parsing and mixed-section behavior.
- Added the narrow plan doc and replaced the stale #494 coordination row with this split.

Intentional:
- Not wired into `scripts/pre_push_audit.sh` yet because current `CLAUDE.md` has known tool-inventory drift and the live auditor correctly exits non-zero.
- Uses section-wide backticked snake_case extraction instead of a brittle single-line `Tools:` parser.
- Does not include the review-source count auditor from #484.

Deferred:
- Wrapper integration after CLAUDE.md inventories are cleaned up or drift is explicitly accepted.
- Remaining #484 review-source count auditor, if still wanted.
- Closing/replacing oversized #484 after useful pieces are harvested.

Verification:
- `python -m pytest tests/test_audit_mcp_tool_names_match_docs.py` -> 4 passed
- `python -m py_compile scripts/audit_mcp_tool_names_match_docs.py tests/test_audit_mcp_tool_names_match_docs.py` -> passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-MCP-Tool-Names.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-MCP-Tool-Names.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-MCP-Tool-Names.md origin/main` -> estimate 269, actual 269, status OK
- `python scripts/audit_mcp_tool_names_match_docs.py` -> expected exit 1 with known CLAUDE.md tool-inventory drift
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.