### PR TITLE
Document audit-script guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,59 @@ grep -B2 '"target": "<path>"' <package>/manifest.json
 A `source` line means it's synced; absence (just a `target`) means
 it's owned.
 
+### 3e. Auditors must surface, never silently skip
+
+Mechanical audit scripts must report unfamiliar input as drift unless
+the skip is explicitly justified in code. Silent skips make the audit
+look green while the thing it was supposed to validate disappears from
+coverage.
+
+Recent examples this rule is meant to prevent:
+
+| What | Bad shape |
+|---|---|
+| Unknown `### <Name> MCP Server` headings disappearing from MCP tool-name coverage. | `if name not in HEADER_TO_FILE: continue` |
+| Port claims with names not in the normalizer disappearing from MCP port coverage. | `if norm is None: continue` |
+| Ports in `MCPConfig` missing from docs without any missing-in-doc check. | Only compare documented rows. |
+| Env-var regexes dropping real names with digits, such as `ATLAS_MCP_B2B_CHURN_PORT`. | `[A-Z_]+` without a digit fixture. |
+
+Preferred shape:
+
+```python
+norm = NAME_NORMALIZER.get(env_name)
+claims.append((line_no, norm or env_name, port, "env"))
+# main() then renders unknown names as DRIFT/UNKNOWN, not as skipped.
+```
+
+Safe skips are allowed only when the false-positive risk is named:
+
+```python
+# Unrelated markdown tables can share this row shape, so admit only
+# rows whose first cell normalizes to a known server.
+if norm is None:
+    continue
+```
+
+If the false-positive risk cannot be stated in one sentence, the skip
+is probably wrong.
+
+### 3f. Auditors ship with fixture tests
+
+Every new `scripts/audit_*.py` should ship with
+`tests/test_audit_<name>.py` in the same slice. The fixture set should
+cover:
+
+1. Happy path: known-good input produces the expected OK state.
+2. Parser-specific negative case: real-looking input that used to be
+   missed, such as `ATLAS_MCP_B2B_CHURN_PORT=8062`.
+3. Pathological rejection: absolute path, `..` traversal, malformed
+   header, empty section, or an "Out of scope" heading that must not
+   satisfy "Scope".
+
+The audit script's `main()` is the contract; fixture tests lock the
+parser behavior so a future small regex tweak cannot silently regress
+to false-green output.
+
 ---
 
 ## 4. Reviewer workflow

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T16:39Z by codex-2026-05-12-mcp-tool-name-audit
+Last updated: 2026-05-12T16:49Z by codex-2026-05-12-auditor-agents-principles
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add MCP tool-name inventory auditor | NEW: `plans/PR-Audit-MCP-Tool-Names.md`; `scripts/audit_mcp_tool_names_match_docs.py`; `tests/test_audit_mcp_tool_names_match_docs.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-mcp-tool-name-audit | `scripts/pre_push_audit.sh`; other audit-kit split PRs |
+| (in flight) | Add AGENTS.md auditor principles | EDIT: `AGENTS.md`; `docs/extraction/coordination/inflight.md`. NEW: `plans/PR-Audit-Agents-Auditor-Principles.md`. | codex-2026-05-12-auditor-agents-principles | other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Agents-Auditor-Principles.md
+++ b/plans/PR-Audit-Agents-Auditor-Principles.md
@@ -1,0 +1,61 @@
+# PR-Audit-Agents-Auditor-Principles
+
+## Why this slice exists
+
+Oversized PR #486 bundled AGENTS.md policy plus two meta-audit scripts
+and was rejected as unreviewable. This split lands only the policy:
+mechanical auditors must not silently skip unknown input, and new audit
+scripts need fixture tests that pin parser behavior.
+
+## Scope (this PR)
+
+1. Add AGENTS.md section 3e, "Auditors must surface, never silently skip."
+2. Add AGENTS.md section 3f, "Auditors ship with fixture tests."
+3. Refresh the in-flight coordination row for this split.
+
+### Files touched
+
+- `AGENTS.md`
+- `plans/PR-Audit-Agents-Auditor-Principles.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+This is a policy/documentation slice. The new AGENTS.md sections encode
+the review lessons from the audit-kit PRs:
+
+- unknown parser input should become `DRIFT` or `UNKNOWN`, not vanish
+- safe skips need an inline false-positive rationale
+- every new `scripts/audit_*.py` should land with fixture tests covering
+  happy path, parser-specific negative cases, and pathological rejects
+
+## Intentional
+
+- No code changes in this slice. The script hygiene and plan/code
+  consistency auditors from #486 will be split separately.
+- The guidance says "should" for fixture tests rather than retroactively
+  failing every legacy audit script in the repo.
+
+## Deferred
+
+- Split `scripts/audit_script_hygiene.sh` from #486.
+- Split `scripts/audit_plan_code_consistency.py` from #486.
+- Close or replace oversized #486 after useful pieces are harvested.
+
+## Verification
+
+```bash
+python scripts/audit_plan_doc.py plans/PR-Audit-Agents-Auditor-Principles.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Agents-Auditor-Principles.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Agents-Auditor-Principles.md origin/main
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `AGENTS.md` | 53 |
+| `plans/PR-Audit-Agents-Auditor-Principles.md` | 61 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~118** |


### PR DESCRIPTION
Plan: plans/PR-Audit-Agents-Auditor-Principles.md

Split from oversized PR #486. This lands only the AGENTS.md policy that mechanical auditors must surface unfamiliar input and ship parser fixtures.

What changed:
- Added AGENTS.md section 3e: auditors must surface unknown input as drift unless a safe skip is explicitly justified.
- Added AGENTS.md section 3f: new `scripts/audit_*.py` auditors should ship with fixture tests covering happy, parser-negative, and pathological inputs.
- Added the narrow plan doc and replaced the stale #495 coordination row with this split.

Intentional:
- Docs/policy only; the script hygiene and plan/code consistency auditors from #486 are deferred to separate slices.
- Uses "should" for fixture tests so this does not retroactively fail legacy audit scripts.

Deferred:
- Split `scripts/audit_script_hygiene.sh` from #486.
- Split `scripts/audit_plan_code_consistency.py` from #486.
- Close or replace oversized #486 after useful pieces are harvested.

Verification:
- `python scripts/audit_plan_doc.py plans/PR-Audit-Agents-Auditor-Principles.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Agents-Auditor-Principles.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Agents-Auditor-Principles.md origin/main` -> estimate 118, actual 118, status OK
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.