### PR TITLE
Add plan-code consistency auditor

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T16:49Z by codex-2026-05-12-auditor-agents-principles
+Last updated: 2026-05-12T16:57Z by codex-2026-05-12-plan-code-consistency-audit
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add AGENTS.md auditor principles | EDIT: `AGENTS.md`; `docs/extraction/coordination/inflight.md`. NEW: `plans/PR-Audit-Agents-Auditor-Principles.md`. | codex-2026-05-12-auditor-agents-principles | other audit-kit split PRs |
+| (in flight) | Add plan/code consistency auditor | NEW: `plans/PR-Audit-Plan-Code-Consistency.md`; `scripts/audit_plan_code_consistency.py`; `tests/test_audit_plan_code_consistency.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-plan-code-consistency-audit | other audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Plan-Code-Consistency.md
+++ b/plans/PR-Audit-Plan-Code-Consistency.md
@@ -1,0 +1,76 @@
+# PR-Audit-Plan-Code-Consistency
+
+## Why this slice exists
+
+Oversized PR #486 bundled this auditor with AGENTS.md policy and a shell
+hygiene script. This split lands only the plan/code consistency auditor,
+with the old review comments fixed: exact section matching, backticked
+path claims, root-level and hyphenated paths, and bounded bare-filename
+resolution.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_plan_code_consistency.py`.
+2. Add fixture tests for parser behavior and missing-claim reporting.
+3. Refresh the in-flight coordination row for this split.
+
+### Files touched
+
+- `plans/PR-Audit-Plan-Code-Consistency.md`
+- `scripts/audit_plan_code_consistency.py`
+- `tests/test_audit_plan_code_consistency.py`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The auditor reads a plan doc and extracts enforceable backticked claims
+from exact `Scope`, `Mechanism`, and `Verification` sections. Optional
+parentheticals like `Scope (this PR)` are allowed, but headings like
+`Out of scope` do not match.
+
+Path claims must be backticked tokens ending in a known file extension.
+Function claims must be backticked snake_case calls with at least four
+characters before `()`. Paths are resolved directly from the repo root,
+with bare filenames searched only under bounded roots (`scripts`,
+`plans`, `docs`, `tests`, `atlas_brain`, and `extracted_*` packages).
+
+## Intentional
+
+- The script reports missing path/function claims only. There is no
+  meaningful "extra" check because plans are claims about expected code,
+  not an exhaustive inventory of all code.
+- Code-fence contents are not parsed as function claims unless the claim
+  itself is backticked. That keeps prose examples from becoming accidental
+  enforcement.
+- The shell hygiene auditor from #486 is deferred because its old version
+  has separate review findings.
+
+## Deferred
+
+- Split `scripts/audit_script_hygiene.sh` from #486 after fixing its shell
+  review findings.
+- Wire this auditor into the pre-push wrapper after we decide which plan
+  docs should be checked automatically.
+- Close or replace oversized #486 after its useful pieces are harvested.
+
+## Verification
+
+```bash
+python -m pytest tests/test_audit_plan_code_consistency.py
+python -m py_compile scripts/audit_plan_code_consistency.py tests/test_audit_plan_code_consistency.py
+python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Code-Consistency.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Plan-Code-Consistency.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Plan-Code-Consistency.md origin/main
+python scripts/audit_plan_code_consistency.py plans/PR-Audit-Plan-Code-Consistency.md
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/audit_plan_code_consistency.py` | 148 |
+| `tests/test_audit_plan_code_consistency.py` | 115 |
+| `plans/PR-Audit-Plan-Code-Consistency.md` | 76 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~343** |

--- a/scripts/audit_plan_code_consistency.py
+++ b/scripts/audit_plan_code_consistency.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Verify a plan doc's backticked code/path claims match shipped code."""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BACKTICK_TOKEN = re.compile(r"`([^`]+)`")
+BACKTICK_FUNC = re.compile(r"^([a-z_][a-z0-9_]{3,})\(\)$")
+PATH_EXTENSIONS = (".md", ".py", ".sh", ".json", ".yaml", ".yml", ".toml", ".txt")
+PATH_SEARCH_ROOTS = ("scripts", "plans", "docs", "tests", "atlas_brain")
+
+
+def _slice_sections(plan_text: str, section_titles: tuple[str, ...]) -> str:
+    """Return bodies for exact matching section headings."""
+    out: list[str] = []
+    in_section = False
+    allowed = {title.lower() for title in section_titles}
+
+    for line in plan_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            heading = stripped[3:].strip().lower()
+            base = re.sub(r"\s*\([^)]*\)\s*$", "", heading).strip()
+            in_section = base in allowed
+            continue
+        if in_section:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _is_path_token(token: str) -> bool:
+    return token.endswith(PATH_EXTENSIONS) and not token.startswith("-")
+
+
+def parse_claims(plan_text: str) -> tuple[set[str], set[str]]:
+    """Return (path_claims, function_claims) from enforceable sections."""
+    path_body = _slice_sections(plan_text, ("Scope", "Mechanism", "Verification"))
+    func_body = _slice_sections(plan_text, ("Mechanism", "Verification"))
+
+    paths: set[str] = set()
+    for token in BACKTICK_TOKEN.findall(path_body):
+        if _is_path_token(token):
+            paths.add(token)
+
+    funcs: set[str] = set()
+    for token in BACKTICK_TOKEN.findall(func_body):
+        match = BACKTICK_FUNC.match(token)
+        if match:
+            funcs.add(match.group(1))
+
+    return paths, funcs
+
+
+def _candidate_roots() -> list[Path]:
+    roots = [REPO_ROOT / root for root in PATH_SEARCH_ROOTS]
+    roots.extend(path for path in REPO_ROOT.glob("extracted_*") if path.is_dir())
+    return roots
+
+
+def _path_resolves(claim: str) -> bool:
+    direct = REPO_ROOT / claim
+    if direct.exists():
+        return True
+    if "/" in claim:
+        return False
+    for root in _candidate_roots():
+        if not root.is_dir():
+            continue
+        for match in root.rglob(claim):
+            if match.is_file():
+                return True
+    return False
+
+
+def collect_def_names() -> set[str]:
+    names: set[str] = set()
+    for root in ("scripts", "atlas_brain"):
+        base = REPO_ROOT / root
+        if not base.is_dir():
+            continue
+        for py_file in base.rglob("*.py"):
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError):
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    names.add(node.name)
+    return names
+
+
+def audit_claims(plan_text: str) -> tuple[list[str], list[str]]:
+    path_claims, function_claims = parse_claims(plan_text)
+    missing_paths = sorted(claim for claim in path_claims if not _path_resolves(claim))
+    defs = collect_def_names() if function_claims else set()
+    missing_functions = sorted(function_claims - defs)
+    return missing_paths, missing_functions
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: audit_plan_code_consistency.py PLAN_PATH", file=sys.stderr)
+        return 2
+
+    plan_path = Path(sys.argv[1])
+    if not plan_path.exists():
+        print(f"plan doc not found: {plan_path}", file=sys.stderr)
+        return 2
+
+    plan_text = plan_path.read_text(encoding="utf-8")
+    claimed_paths, claimed_functions = parse_claims(plan_text)
+    missing_paths, missing_functions = audit_claims(plan_text)
+
+    print(f"plan doc: {plan_path}")
+    print(f"path claims:     {len(claimed_paths)}")
+    print(f"function claims: {len(claimed_functions)}")
+    print("-" * 60)
+
+    drift = False
+    if missing_paths:
+        drift = True
+        print(f"MISSING PATHS ({len(missing_paths)}):")
+        for claim in missing_paths:
+            print(f"  - {claim}")
+    else:
+        print(f"OK: all {len(claimed_paths)} path claims exist on disk.")
+
+    if missing_functions:
+        drift = True
+        print(
+            f"MISSING FUNCTION DEFS ({len(missing_functions)}); "
+            f"checked scripts/ and atlas_brain/:"
+        )
+        for function in missing_functions:
+            print(f"  - {function}()")
+    else:
+        print(f"OK: all {len(claimed_functions)} function claims resolve to a def.")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_plan_code_consistency.py
+++ b/tests/test_audit_plan_code_consistency.py
@@ -1,0 +1,115 @@
+"""Fixture tests for scripts/audit_plan_code_consistency.py."""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from tests.audit_helpers import load_auditor
+
+
+@pytest.fixture(scope="module")
+def auditor():
+    return load_auditor("audit_plan_code_consistency")
+
+
+def test_parse_claims_uses_exact_section_titles(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Out of scope
+
+        `scripts/imaginary.py`
+
+        ## Scope (this PR)
+
+        `scripts/audit_plan_code_consistency.py`
+    """)
+
+    paths, funcs = auditor.parse_claims(plan)
+
+    assert paths == {"scripts/audit_plan_code_consistency.py"}
+    assert funcs == set()
+
+
+def test_parse_claims_accepts_root_and_hyphenated_paths(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Scope (this PR)
+
+        `AGENTS.md`
+        `plans/PR-Audit-The-Auditors-1.md`
+    """)
+
+    paths, _ = auditor.parse_claims(plan)
+
+    assert "AGENTS.md" in paths
+    assert "plans/PR-Audit-The-Auditors-1.md" in paths
+
+
+def test_parse_claims_reads_only_backticked_paths(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Scope (this PR)
+
+        This prose mentions scripts/not_backticked.py but should not enforce it.
+        `scripts/audit_plan_code_consistency.py`
+    """)
+
+    paths, _ = auditor.parse_claims(plan)
+
+    assert paths == {"scripts/audit_plan_code_consistency.py"}
+
+
+def test_parse_claims_reads_backticked_function_calls(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Mechanism
+
+        Calls `parse_claims()` but ignores get() because it is too short.
+    """)
+
+    _, funcs = auditor.parse_claims(plan)
+
+    assert funcs == {"parse_claims"}
+
+
+def test_audit_claims_reports_missing_path_and_function(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Scope (this PR)
+
+        `scripts/does_not_exist.py`
+
+        ## Mechanism
+
+        Calls `function_that_does_not_exist()`.
+    """)
+
+    missing_paths, missing_functions = auditor.audit_claims(plan)
+
+    assert missing_paths == ["scripts/does_not_exist.py"]
+    assert missing_functions == ["function_that_does_not_exist"]
+
+
+def test_audit_claims_accepts_existing_root_path_and_function(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Scope (this PR)
+
+        `AGENTS.md`
+
+        ## Mechanism
+
+        Calls `parse_claims()`.
+    """)
+
+    missing_paths, missing_functions = auditor.audit_claims(plan)
+
+    assert missing_paths == []
+    assert missing_functions == []


### PR DESCRIPTION
Plan: plans/PR-Audit-Plan-Code-Consistency.md

Split from oversized PR #486. This lands only the plan/code consistency auditor, with the old review findings fixed in the implementation and tests.

What changed:
- Added `scripts/audit_plan_code_consistency.py` to verify backticked plan-doc path/function claims against shipped files and defs.
- Added `tests/test_audit_plan_code_consistency.py` covering exact section matching, root/hyphen path parsing, backtick-only path extraction, function claims, and missing-claim reporting.
- Added the narrow plan doc and replaced the stale #496 coordination row with this split.

Intentional:
- Reports missing path/function claims only; no "extra" check because a plan is not an exhaustive code inventory.
- Does not parse bare code-fence contents as function claims unless the claim itself is backticked.
- Defers the shell hygiene auditor from #486 because its old version has separate review findings.

Deferred:
- Split `scripts/audit_script_hygiene.sh` after fixing its shell review findings.
- Wrapper integration after deciding which plan docs should be checked automatically.
- Closing/replacing oversized #486 after useful pieces are harvested.

Verification:
- `python -m pytest tests/test_audit_plan_code_consistency.py` -> 6 passed
- `python -m py_compile scripts/audit_plan_code_consistency.py tests/test_audit_plan_code_consistency.py` -> passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Plan-Code-Consistency.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Plan-Code-Consistency.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Plan-Code-Consistency.md origin/main` -> estimate 343, actual 343, status OK
- `python scripts/audit_plan_code_consistency.py plans/PR-Audit-Plan-Code-Consistency.md` -> all path/function claims resolve
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.