### PR TITLE
Run pre-push audit wrapper in CI

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -1,0 +1,28 @@
+name: Pre-push Audit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-push-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Resolve origin HEAD
+        run: |
+          git remote set-head origin --auto || git remote set-head origin main
+
+      - name: Run pre-push audit wrapper
+        run: bash scripts/pre_push_audit.sh

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T16:57Z by codex-2026-05-12-plan-code-consistency-audit
+Last updated: 2026-05-12T17:15Z by codex-2026-05-12-pre-push-audit-ci
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add plan/code consistency auditor | NEW: `plans/PR-Audit-Plan-Code-Consistency.md`; `scripts/audit_plan_code_consistency.py`; `tests/test_audit_plan_code_consistency.py`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-plan-code-consistency-audit | other audit-kit split PRs |
+| (in flight) | Add pre-push audit CI workflow | NEW: `.github/workflows/pre_push_audit.yml`; `plans/PR-Audit-Pre-Push-CI.md`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-pre-push-audit-ci | `scripts/pre_push_audit.sh`; audit-kit split PRs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Pre-Push-CI.md
+++ b/plans/PR-Audit-Pre-Push-CI.md
@@ -1,0 +1,66 @@
+# PR-Audit-Pre-Push-CI
+
+## Why this slice exists
+
+The audit-kit wrapper exists on main, but it is still manual. This slice
+adds CI enforcement so every PR gets the same mechanical review-shape
+checks before merge.
+
+## Scope (this PR)
+
+1. Add a GitHub Actions workflow that runs `scripts/pre_push_audit.sh`.
+2. Trigger the workflow for every pull request and every push to `main`.
+3. Refresh the in-flight coordination row for this slice.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `plans/PR-Audit-Pre-Push-CI.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The workflow checks out full git history with `fetch-depth: 0`, sets up
+Python 3.11, resolves `origin/HEAD`, and runs the same wrapper developers
+can run locally:
+
+```bash
+bash scripts/pre_push_audit.sh
+```
+
+Full history matters because the wrapper compares branch changes against
+the trunk merge-base for plan files.
+
+## Intentional
+
+- This is CI-only. No local git hook installer is added in this slice.
+- The workflow runs on every pull request, not only audit-kit paths. Scope
+  and plan drift are cross-cutting PR risks, so path-filtering would leave
+  gaps.
+- Newer auditors that currently expose known drift remain outside the
+  wrapper; this workflow enforces only the wrapper's current contract.
+
+## Deferred
+
+- Local hook installer for developers who want pre-push feedback before CI.
+- Wiring additional auditors into `scripts/pre_push_audit.sh` after known
+  drift is reconciled or explicitly accepted.
+
+## Verification
+
+```bash
+bash scripts/pre_push_audit.sh
+python scripts/audit_plan_doc.py plans/PR-Audit-Pre-Push-CI.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Pre-Push-CI.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Pre-Push-CI.md origin/main
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `.github/workflows/pre_push_audit.yml` | 28 |
+| `plans/PR-Audit-Pre-Push-CI.md` | 66 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~98** |


### PR DESCRIPTION
Plan: plans/PR-Audit-Pre-Push-CI.md

This makes the existing audit wrapper run in GitHub Actions so review-shape checks are enforced on PRs instead of relying only on manual local execution.

What changed:
- Added `.github/workflows/pre_push_audit.yml` to run `bash scripts/pre_push_audit.sh` on every pull request and every push to `main`.
- Uses `actions/checkout` with `fetch-depth: 0` and resolves `origin/HEAD` before running the wrapper, because plan audits compare against trunk merge-base.
- Added the narrow plan doc and refreshed the coordination row.

Intentional:
- CI-only. No local git hook installer in this slice.
- Runs on every PR, not path-filtered, because plan/scope drift is cross-cutting.
- Enforces the current wrapper contract only; newer auditors with known drift remain outside the wrapper for now.

Deferred:
- Local hook installer.
- Wiring additional auditors into `scripts/pre_push_audit.sh` after known drift is reconciled or accepted.

Verification:
- `bash scripts/pre_push_audit.sh` -> all checks passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Pre-Push-CI.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Pre-Push-CI.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Pre-Push-CI.md origin/main` -> estimate 98, actual 98, status OK
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.
- Rollback is deleting `.github/workflows/pre_push_audit.yml`.