### PR TITLE
Add local PR review runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,28 @@ bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline   # 
 CI runs `scripts/run_extracted_pipeline_checks.sh`; locally is faster
 to triage.
 
-### 3c. Tests
+### 3c. Local review before PR
+
+Before opening or updating a PR, the builder runs the mechanical local
+review bundle:
+
+```bash
+bash scripts/local_pr_review.sh
+```
+
+This is the fast path. It catches plan-shape, diff-size, file-claim,
+MCP-doc, ASCII, plan/code, and whitespace failures before GitHub has to
+run anything.
+
+After the mechanical bundle passes, hand the branch to a separate local
+reviewer session for judgment review. The reviewer should read the plan
+doc and diff locally, run any focused tests needed to verify the claims,
+and return a verdict before the builder opens the GitHub PR.
+
+GitHub Actions still runs the same wrapper after the PR opens. Treat CI
+as the final enforcement layer, not the first reviewer.
+
+### 3d. Tests
 
 Each PR ships its own tests. Acceptable test patterns:
 
@@ -162,7 +183,7 @@ Locked-in regression tests for deferred follow-ups should name the
 future slice in their docstring (e.g. *"after PR-Foo-V2 lands this
 test is removed"*) so the test's lifetime is explicit.
 
-### 3d. Working with the manifest
+### 3e. Working with the manifest
 
 Files listed in `<package>/manifest.json` under `owned` are
 package-canonical -- the sync script does not overwrite them. Files
@@ -177,7 +198,7 @@ grep -B2 '"target": "<path>"' <package>/manifest.json
 A `source` line means it's synced; absence (just a `target`) means
 it's owned.
 
-### 3e. Auditors must surface, never silently skip
+### 3f. Auditors must surface, never silently skip
 
 Mechanical audit scripts must report unfamiliar input as drift unless
 the skip is explicitly justified in code. Silent skips make the audit
@@ -213,7 +234,7 @@ if norm is None:
 If the false-positive risk cannot be stated in one sentence, the skip
 is probably wrong.
 
-### 3f. Auditors ship with fixture tests
+### 3g. Auditors ship with fixture tests
 
 Every new `scripts/audit_*.py` should ship with
 `tests/test_audit_<name>.py` in the same slice. The fixture set should

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T17:15Z by codex-2026-05-12-pre-push-audit-ci
+Last updated: 2026-05-12T17:27Z by codex-2026-05-12-local-review-runner
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add pre-push audit CI workflow | NEW: `.github/workflows/pre_push_audit.yml`; `plans/PR-Audit-Pre-Push-CI.md`. EDIT: `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-pre-push-audit-ci | `scripts/pre_push_audit.sh`; audit-kit split PRs |
+| (in flight) | Add local PR review runner | NEW: `scripts/local_pr_review.sh`; `plans/PR-Audit-Local-Review-Runner.md`. EDIT: `AGENTS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-local-review-runner | `scripts/pre_push_audit.sh`; `.github/workflows/pre_push_audit.yml` |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Local-Review-Runner.md
+++ b/plans/PR-Audit-Local-Review-Runner.md
@@ -1,0 +1,73 @@
+# PR-Audit-Local-Review-Runner
+
+## Why this slice exists
+
+GitHub now runs the mechanical audit wrapper, but the preferred workflow
+is faster and cheaper: run the mechanical checks locally, hand the branch
+to a second local reviewer session, fix issues, and only then open the PR.
+This slice adds a local runner and documents that handoff.
+
+## Scope (this PR)
+
+1. Add `scripts/local_pr_review.sh`.
+2. Update `AGENTS.md` with the local builder/reviewer handoff.
+3. Refresh the in-flight coordination row for this slice.
+
+### Files touched
+
+- `scripts/local_pr_review.sh`
+- `plans/PR-Audit-Local-Review-Runner.md`
+- `AGENTS.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The local runner accepts an optional base ref, defaulting to
+`origin/main`, prints the branch diff footprint, then runs:
+
+```bash
+bash scripts/pre_push_audit.sh
+python scripts/audit_plan_code_consistency.py <changed plan doc>
+git diff --check
+```
+
+The script remains mechanical. It does not replace the second reviewer
+session's judgment review; it gives that session a cleaner branch and
+fewer predictable failures.
+
+## Intentional
+
+- No git hook installation. Developers can call the runner explicitly
+  before opening or updating a PR.
+- No model calls are made by this script. Model-based review remains a
+  separate local reviewer session.
+- No GitHub API calls are made. GitHub CI remains the final enforcement
+  layer after the local loop is clean.
+
+## Deferred
+
+- Optional hook installer for teams that want `local_pr_review.sh` to run
+  automatically before push.
+- A separate reviewer prompt/template update if we want a standardized
+  local model-review transcript.
+
+## Verification
+
+```bash
+bash scripts/local_pr_review.sh
+python scripts/audit_plan_doc.py plans/PR-Audit-Local-Review-Runner.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Local-Review-Runner.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Local-Review-Runner.md origin/main
+bash -n scripts/local_pr_review.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/local_pr_review.sh` | 73 |
+| `plans/PR-Audit-Local-Review-Runner.md` | 73 |
+| `AGENTS.md` | 29 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~179** |

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Run the local mechanical review bundle before opening or updating a PR.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+base_ref="${1:-origin/main}"
+
+failures=0
+
+run_check() {
+    local label="$1"
+    shift
+    echo
+    echo "==> $label"
+    if "$@"; then
+        echo "    PASS"
+    else
+        echo "    FAIL"
+        failures=$((failures + 1))
+    fi
+}
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    echo "local_pr_review.sh: base ref not found: $base_ref" >&2
+    echo "fetch trunk first, or pass an explicit base ref" >&2
+    exit 2
+fi
+
+base="$(git merge-base HEAD "$base_ref")"
+
+echo "local PR review"
+echo "base ref: $base_ref"
+echo "merge base: $base"
+echo
+echo "changed files:"
+git diff --name-status "$base"...HEAD || true
+
+run_check "Pre-push audit wrapper" bash scripts/pre_push_audit.sh
+
+committed_plan_docs=$(
+    git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null |
+        sort -u |
+        grep -v '^$' || true
+)
+
+if [ -n "$committed_plan_docs" ]; then
+    while IFS= read -r doc; do
+        [ -z "$doc" ] && continue
+        if [ -f scripts/audit_plan_code_consistency.py ]; then
+            run_check "Plan/code consistency: $doc" \
+                python scripts/audit_plan_code_consistency.py "$doc"
+        fi
+    done <<< "$committed_plan_docs"
+else
+    echo
+    echo "==> Plan/code consistency"
+    echo "    SKIP (no committed plans/PR-*.md changed vs $base_ref)"
+fi
+
+run_check "git diff --check" git diff --check
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "local PR review passed"
+    echo
+    echo "Next: hand this branch to the local reviewer session for judgment review."
+    exit 0
+fi
+
+echo "$failures local review check(s) failed"
+exit 1


### PR DESCRIPTION
Plan: plans/PR-Audit-Local-Review-Runner.md

This adds the local pre-PR review loop so builder sessions can run mechanical checks and hand off to a second local reviewer session before GitHub has to spend CI/model time.

What changed:
- Added `scripts/local_pr_review.sh`, which runs the pre-push wrapper, plan/code consistency for changed plan docs, and `git diff --check` against `origin/main` by default.
- Updated `AGENTS.md` with the local builder/reviewer handoff before opening or updating PRs.
- Added the narrow plan doc and refreshed the coordination row.

Intentional:
- No git hook installer. The runner is explicit/manual for now.
- No model calls or GitHub API calls from the script; model judgment remains a separate local reviewer session.
- GitHub CI remains the final enforcement layer after local review passes.

Deferred:
- Optional hook installer.
- Standardized local reviewer prompt/template if we want a saved transcript format.

Verification:
- `bash scripts/local_pr_review.sh` -> local PR review passed
- `python scripts/audit_plan_doc.py plans/PR-Audit-Local-Review-Runner.md` -> all required sections OK
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Local-Review-Runner.md origin/main` -> claimed files match git diff
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Local-Review-Runner.md origin/main` -> estimate 179, actual 179, status OK
- `bash -n scripts/local_pr_review.sh` -> passed
- `git diff --check` -> passed

Migration / rollback notes:
- No schema, env, dependency, or runtime behavior changes.