### PR TITLE
Close manifest and MCP tool-name audit drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,7 +412,7 @@ python -m atlas_brain.mcp.email_server --sse
 ```
 
 Tools: `send_email`, `send_estimate`, `send_proposal`, `list_inbox`,
-`get_message`, `search_inbox`, `get_thread`, `list_sent_history`
+`get_message`, `search_inbox`, `get_thread`, `list_sent_history`, `list_folders`
 
 **Sending**: Gmail preferred (OAuth2); falls back to Resend if Gmail is not configured.
 **Reading**: IMAP (provider-agnostic) when configured; Gmail API fallback.
@@ -467,7 +467,7 @@ Tools: `list_calendars`, `list_events`, `get_event`, `create_event`,
 
 **Does NocoDB have a calendar?** NocoDB can display date columns in a calendar view but
 does not manage calendar events.
-The `appointments` table in PostgreSQL is the schedule; `appointments.calendar_event_id`
+The appointments table in PostgreSQL is the schedule; `appointments.calendar_event_id`
 links each booking to a calendar event.  Use `sync_appointment` to keep them in sync.
 
 ```bash
@@ -583,6 +583,24 @@ For the full pipeline / schema / tool-module breakdown, see the
 
 **Content:** `list_blog_posts`, `get_blog_post`, `list_affiliate_partners`
 
+**Account intelligence:** `list_account_intelligence`, `get_account_intelligence`,
+`build_accounts_in_motion`
+
+**Category dynamics:** `list_category_dynamics`, `get_category_dynamics`
+
+**Segment & temporal intelligence:** `list_segment_intelligence`, `get_segment_intelligence`,
+`list_temporal_intelligence`, `get_temporal_intelligence`
+
+**Displacement dynamics:** `list_displacement_dynamics`, `get_displacement_dynamics`,
+`get_source_impact_ledger`
+
+**Evidence vaults:** `list_evidence_vaults`, `get_evidence_vault`
+
+**Cross-vendor conclusions:** `list_cross_vendor_conclusions`, `get_cross_vendor_conclusion`,
+`persist_conclusion`, `persist_report`, `reason_vendor`, `compare_vendors`
+
+**Generated assets:** `build_challenger_brief`, `draft_campaign`
+
 Data sourced from 19 review sites (incl. Twitter/X via Web Unlocker). See
 the **B2B Churn Intelligence Pipeline** section for the full source list.
 
@@ -621,7 +639,7 @@ python -m atlas_brain.mcp.memory_server --sse
 `add_fact`, `add_episode`, `delete_episode`, `enhance_prompt`,
 `analyze_sentiment`
 
-**Conversation tools** (Postgres `conversation_turns`): `search_conversations`,
+**Conversation tools** (Postgres conversation_turns): `search_conversations`,
 `get_session_history`, `list_sessions`
 
 **Combined**: `get_context` (parallel graph + conversation lookup, unified result).

--- a/atlas_brain/services/b2b/product_claim.py
+++ b/atlas_brain/services/b2b/product_claim.py
@@ -1,11 +1,10 @@
-"""ProductClaim contract — the shared envelope every UI card and every
+"""ProductClaim contract - the shared envelope every UI card and every
 report section consumes.
 
-Phase 10 Patch 1 (post-audit hardening). Operating rule: UI first,
-reports inherit. The dashboard / UI is the truth layer; reports are
-downstream renderings of the same validated objects.
+This module is the first standalone quality-gate core. It is pure,
+deterministic, sync, and free of Atlas runtime dependencies.
 
-Contract design (audit-driven):
+Contract design:
 
   - The caller provides OBJECTIVE FACTS (counts, witness_count,
     contradiction_count, denominator, evidence_links, claim_key).
@@ -30,10 +29,8 @@ Contract design (audit-driven):
     direct dataclass construction with hand-set gate fields and
     keeps build_product_claim() the only safe construction path.
 
-Pure deterministic, sync, pool-free. Persistence and aggregation
-land in Patch 2 onward.
-
-See docs/progress/product_claim_contract_plan_2026-04-26.md.
+Persistence, aggregation, and product-specific field mapping belong in
+adapters or packs outside this core module.
 """
 
 from __future__ import annotations
@@ -41,7 +38,13 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass, field
 from datetime import date
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python 3.10 compatibility
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
 
 
 class ClaimScope(StrEnum):

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T17:27Z by codex-2026-05-12-local-review-runner
+Last updated: 2026-05-12T17:51Z by codex-2026-05-12-close-manifest-mcp-drift
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Add local PR review runner | NEW: `scripts/local_pr_review.sh`; `plans/PR-Audit-Local-Review-Runner.md`. EDIT: `AGENTS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-local-review-runner | `scripts/pre_push_audit.sh`; `.github/workflows/pre_push_audit.yml` |
+| (in flight) | Close manifest and MCP tool-name audit drift | EDIT: `CLAUDE.md`; `atlas_brain/services/b2b/product_claim.py`; `extracted_content_pipeline/manifest.json`; `extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py`; `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`; `extracted_quality_gate/product_claim.py`; `scripts/pre_push_audit.sh`; `docs/extraction/coordination/inflight.md`. NEW: `plans/PR-Audit-Close-Manifest-MCP-Drift.md`. | codex-2026-05-12-close-manifest-mcp-drift | `scripts/pre_push_audit.sh`; extracted package manifests; `CLAUDE.md` MCP sections |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -368,9 +368,6 @@
       "target": "extracted_content_pipeline/services/b2b/vendor_briefing_ports.py"
     },
     {
-      "target": "extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py"
-    },
-    {
       "target": "extracted_content_pipeline/services/b2b/vendor_briefing_repository.py"
     },
     {

--- a/extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py
+++ b/extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py
@@ -1,4 +1,4 @@
-"""Shared delivery helpers for content-pipeline vendor briefings."""
+"""Shared delivery helpers for Competitive Intelligence vendor briefings."""
 
 from __future__ import annotations
 

--- a/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
+++ b/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
@@ -30,6 +30,35 @@ def is_b2b_llm_exact_cache_enabled() -> bool:
     return bool(getattr(settings.b2b_churn, "llm_exact_cache_enabled", False))
 
 
+# Namespace prefix that routes to the customer-facing LLM Gateway
+# product (PR-D6b). Cache rows written with ``namespace`` starting
+# with this prefix are gated by ``settings.llm_gateway.exact_cache_enabled``
+# rather than the B2B flag, so atlas's internal pipeline and the
+# Gateway can be toggled independently.
+LLM_GATEWAY_NAMESPACE_PREFIX = "llm_gateway."
+
+
+def is_llm_gateway_exact_cache_enabled() -> bool:
+    """Return whether the LLM Gateway product's exact cache is enabled."""
+    from ...config import settings
+
+    return bool(
+        getattr(
+            getattr(settings, "llm_gateway", None),
+            "exact_cache_enabled",
+            False,
+        )
+    )
+
+
+def _is_cache_enabled_for_namespace(namespace: str) -> bool:
+    """Dispatch the enablement check on the namespace prefix so the
+    B2B and LLM Gateway products own their own feature flags."""
+    if namespace.startswith(LLM_GATEWAY_NAMESPACE_PREFIX):
+        return is_llm_gateway_exact_cache_enabled()
+    return is_b2b_llm_exact_cache_enabled()
+
+
 def _normalize_maybe_json_string(value: str) -> Any:
     stripped = value.strip()
     if stripped and stripped[0] in "{[":
@@ -247,7 +276,7 @@ async def lookup_cached_text(
     so cross-tenant hits are impossible -- the (cache_key, account_id)
     composite PK guarantees isolation at the storage layer.
     """
-    if not namespace or not is_b2b_llm_exact_cache_enabled():
+    if not namespace or not _is_cache_enabled_for_namespace(namespace):
         return None
 
     db_pool = _resolve_pool(pool)
@@ -311,7 +340,7 @@ async def store_cached_text(
         not namespace
         or not response_text
         or not str(response_text).strip()
-        or not is_b2b_llm_exact_cache_enabled()
+        or not _is_cache_enabled_for_namespace(namespace)
     ):
         return False
 

--- a/extracted_quality_gate/product_claim.py
+++ b/extracted_quality_gate/product_claim.py
@@ -40,7 +40,7 @@ from dataclasses import dataclass, field
 from datetime import date
 try:
     from enum import StrEnum
-except ImportError:  # pragma: no cover - Python 3.10 CI compatibility
+except ImportError:  # pragma: no cover - Python 3.10 compatibility
     from enum import Enum
 
     class StrEnum(str, Enum):

--- a/plans/PR-Audit-Close-Manifest-MCP-Drift.md
+++ b/plans/PR-Audit-Close-Manifest-MCP-Drift.md
@@ -1,0 +1,94 @@
+# PR-Audit-Close-Manifest-MCP-Drift
+
+## Why this slice exists
+
+Two useful auditors were intentionally left out of the pre-push wrapper
+because they exposed known drift: extracted manifest sync drift and
+CLAUDE.md MCP tool-name inventory drift. This slice closes those drifts
+and wires both auditors into the local/GitHub mechanical review path.
+
+## Scope (this PR)
+
+1. Fix extracted manifest drift for content pipeline, LLM infrastructure,
+   and quality gate mapped files.
+2. Fix CLAUDE.md MCP tool-name inventory drift.
+3. Add the now-green manifest and tool-name auditors to
+   `scripts/pre_push_audit.sh`.
+4. Refresh the in-flight coordination row for this slice.
+
+### Files touched
+
+- `CLAUDE.md`
+- `atlas_brain/services/b2b/product_claim.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py`
+- `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`
+- `extracted_quality_gate/product_claim.py`
+- `scripts/pre_push_audit.sh`
+- `plans/PR-Audit-Close-Manifest-MCP-Drift.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+For extracted manifests:
+
+- `vendor_briefing_delivery.py` was listed as both mapped and owned in
+  `extracted_content_pipeline/manifest.json`. The owned duplicate was
+  removed so the mapped source is canonical, then the extracted target was
+  synced from Atlas.
+- `llm_exact_cache.py` was synced from Atlas into
+  `extracted_llm_infrastructure`, bringing the LLM Gateway namespace gate
+  into the extracted package.
+- `product_claim.py` now keeps the standalone-safe `StrEnum` fallback in
+  the Atlas source, then syncs the quality-gate target from that source.
+
+For MCP tool inventory drift:
+
+- `CLAUDE.md` now includes Email `list_folders`.
+- Calendar and Memory prose no longer backticks non-tool table names.
+- B2B Churn Intelligence now documents the 22 previously missing tools.
+
+After both auditors pass, `scripts/pre_push_audit.sh` runs them on every
+local review and GitHub pre-push-audit workflow.
+
+## Intentional
+
+- ProductClaim's module docstring is changed to standalone-core language so
+  the Atlas source and extracted quality-gate target can stay byte-identical.
+- The content-pipeline delivery helper is mapped-only now; the previous
+  mapped-plus-owned manifest state contradicted the sync contract.
+- This does not touch the deferred review-source count auditor.
+
+## Deferred
+
+- Optional local hook installer remains the next slice.
+- Shell hygiene auditor remains deferred from the previous audit-kit work.
+
+## Verification
+
+```bash
+python scripts/audit_extracted_manifests.py
+python scripts/audit_mcp_tool_names_match_docs.py
+bash scripts/local_pr_review.sh
+python scripts/audit_plan_doc.py plans/PR-Audit-Close-Manifest-MCP-Drift.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Close-Manifest-MCP-Drift.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Close-Manifest-MCP-Drift.md origin/main
+bash -n scripts/pre_push_audit.sh
+python -m py_compile atlas_brain/services/b2b/product_claim.py extracted_quality_gate/product_claim.py extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `CLAUDE.md` | 24 |
+| `atlas_brain/services/b2b/product_claim.py` | 23 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py` | 2 |
+| `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py` | 33 |
+| `extracted_quality_gate/product_claim.py` | 2 |
+| `scripts/pre_push_audit.sh` | 2 |
+| `plans/PR-Audit-Close-Manifest-MCP-Drift.md` | 94 |
+| **Total** | **~187** |

--- a/scripts/pre_push_audit.sh
+++ b/scripts/pre_push_audit.sh
@@ -43,6 +43,8 @@ base="$(git merge-base HEAD "$base_ref")"
 
 run_check "CLAUDE.md MCP tool counts" python scripts/audit_claude_md_claims.py
 run_check "MCP port assignments" python scripts/audit_mcp_port_assignments.py
+run_check "MCP tool-name inventories" python scripts/audit_mcp_tool_names_match_docs.py
+run_check "Extracted manifest sync" python scripts/audit_extracted_manifests.py
 
 committed=$(
     git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null || true


### PR DESCRIPTION
Plan: plans/PR-Audit-Close-Manifest-MCP-Drift.md

## What changed
- Fixed extracted manifest sync drift for content pipeline, LLM infrastructure, and quality gate mapped files.
- Fixed `CLAUDE.md` MCP tool-name inventory drift so documented tools match registered tools.
- Wired `audit_mcp_tool_names_match_docs.py` and `audit_extracted_manifests.py` into `scripts/pre_push_audit.sh`.
- Added a scoped plan doc and refreshed the in-flight coordination row.

## Intentional
- `ProductClaim` now uses standalone-core docstring language so Atlas source and extracted quality-gate target stay byte-identical.
- `vendor_briefing_delivery.py` is mapped-only now; the previous mapped-plus-owned manifest state contradicted the sync contract.
- Review-source count auditing remains deferred.

## Deferred
- Optional local hook installer is the next slice.
- Shell hygiene auditor remains deferred from the previous audit-kit work.

## Verification
- `python scripts/audit_extracted_manifests.py`
- `python scripts/audit_mcp_tool_names_match_docs.py`
- `bash scripts/local_pr_review.sh`
- `python scripts/audit_plan_doc.py plans/PR-Audit-Close-Manifest-MCP-Drift.md`
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Close-Manifest-MCP-Drift.md origin/main`
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Close-Manifest-MCP-Drift.md origin/main`
- `bash -n scripts/pre_push_audit.sh`
- `python -m py_compile atlas_brain/services/b2b/product_claim.py extracted_quality_gate/product_claim.py extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`
- `git diff --check`