### PR TITLE
Install optional local PR review hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,17 @@ This is the fast path. It catches plan-shape, diff-size, file-claim,
 MCP-doc, ASCII, plan/code, and whitespace failures before GitHub has to
 run anything.
 
+To make that automatic for this checkout, install the optional pre-push
+hook:
+
+```bash
+bash scripts/install_local_pr_hook.sh
+```
+
+The installer refuses to overwrite unmanaged hooks unless `--force` is
+passed. The installed hook can be bypassed intentionally with
+`ATLAS_SKIP_LOCAL_PR_REVIEW=1 git push`.
+
 After the mechanical bundle passes, hand the branch to a separate local
 reviewer session for judgment review. The reviewer should read the plan
 doc and diff locally, run any focused tests needed to verify the claims,

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-12T17:51Z by codex-2026-05-12-close-manifest-mcp-drift
+Last updated: 2026-05-12T18:08Z by codex-2026-05-12-install-local-review-hook
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,6 +10,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 | (in flight) | Lock route-level Content Ops consumed reasoning payloads | NEW: `plans/PR-Content-Ops-Route-Reasoning-Payload-Regression.md`. EDIT: `tests/test_extracted_content_control_surface_api.py`; `docs/extraction/coordination/inflight.md`. | codex-content-ops-route-reasoning-payload | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Fix Content Ops `blog_post` reasoning fixture/doc drift | NEW: `plans/PR-Content-Ops-Blog-Reasoning-Fixture-Doc.md`. EDIT: `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`; `extracted_content_pipeline/docs/control_surface_preview_api.md`; `docs/extraction/coordination/inflight.md`. | codex-content-blog-reasoning-fixture-doc | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
 | (in flight) | Log ordered AI Content Ops deferred backlog | NEW: `plans/PR-Content-Ops-Deferred-Backlog-Log.md`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`. EDIT: `extracted_content_pipeline/STATUS.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-11 | `extracted_competitive_intelligence/manifest.json`; `extracted_competitive_intelligence/autonomous/visibility.py`; `extracted_competitive_intelligence/storage/migrations/246_pipeline_visibility.sql` |
-| (in flight) | Close manifest and MCP tool-name audit drift | EDIT: `CLAUDE.md`; `atlas_brain/services/b2b/product_claim.py`; `extracted_content_pipeline/manifest.json`; `extracted_content_pipeline/services/b2b/vendor_briefing_delivery.py`; `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py`; `extracted_quality_gate/product_claim.py`; `scripts/pre_push_audit.sh`; `docs/extraction/coordination/inflight.md`. NEW: `plans/PR-Audit-Close-Manifest-MCP-Drift.md`. | codex-2026-05-12-close-manifest-mcp-drift | `scripts/pre_push_audit.sh`; extracted package manifests; `CLAUDE.md` MCP sections |
+| (in flight) | Install optional local PR review pre-push hook | NEW: `scripts/install_local_pr_hook.sh`; `tests/test_install_local_pr_hook.py`; `plans/PR-Audit-Install-Local-Review-Hook.md`. EDIT: `AGENTS.md`; `tests/test_pre_push_audit.py`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-12-install-local-review-hook | `scripts/local_pr_review.sh`; `scripts/pre_push_audit.sh`; `.git/hooks/pre-push` workflow docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Audit-Install-Local-Review-Hook.md
+++ b/plans/PR-Audit-Install-Local-Review-Hook.md
@@ -10,7 +10,7 @@ run automatically before `git push`.
 ## Scope (this PR)
 
 1. Add a safe installer for `.git/hooks/pre-push`.
-2. Make the installed hook run `bash scripts/local_pr_review.sh`.
+2. Make the installed hook run `scripts/local_pr_review.sh`.
 3. Refuse to overwrite unmanaged hooks unless explicitly forced.
 4. Repair the pre-push wrapper test fixture so the two newly wired auditors
    from the previous slice are covered.
@@ -30,7 +30,7 @@ run automatically before `git push`.
 
 `scripts/install_local_pr_hook.sh` writes a managed `.git/hooks/pre-push`
 wrapper containing the marker `ATLAS_LOCAL_PR_REVIEW_HOOK`. The hook changes
-to the repo root and executes `bash scripts/local_pr_review.sh`.
+to the repo root and executes `scripts/local_pr_review.sh` through Bash.
 
 If an existing hook does not contain the marker, the installer exits
 non-zero and leaves the hook unchanged. Passing `--force` replaces the

--- a/plans/PR-Audit-Install-Local-Review-Hook.md
+++ b/plans/PR-Audit-Install-Local-Review-Hook.md
@@ -1,0 +1,81 @@
+# PR-Audit-Install-Local-Review-Hook
+
+## Why this slice exists
+
+The local reviewer workflow now has a mechanical review bundle, but it
+still depends on humans remembering to run it before push. This slice adds
+an opt-in Git hook installer so builders can make the local review bundle
+run automatically before `git push`.
+
+## Scope (this PR)
+
+1. Add a safe installer for `.git/hooks/pre-push`.
+2. Make the installed hook run `bash scripts/local_pr_review.sh`.
+3. Refuse to overwrite unmanaged hooks unless explicitly forced.
+4. Repair the pre-push wrapper test fixture so the two newly wired auditors
+   from the previous slice are covered.
+5. Document the installer in the local review workflow.
+6. Refresh the in-flight coordination row for this slice.
+
+### Files touched
+
+- `AGENTS.md`
+- `scripts/install_local_pr_hook.sh`
+- `tests/test_install_local_pr_hook.py`
+- `tests/test_pre_push_audit.py`
+- `plans/PR-Audit-Install-Local-Review-Hook.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`scripts/install_local_pr_hook.sh` writes a managed `.git/hooks/pre-push`
+wrapper containing the marker `ATLAS_LOCAL_PR_REVIEW_HOOK`. The hook changes
+to the repo root and executes `bash scripts/local_pr_review.sh`.
+
+If an existing hook does not contain the marker, the installer exits
+non-zero and leaves the hook unchanged. Passing `--force` replaces the
+unmanaged hook.
+
+The installed hook supports `ATLAS_SKIP_LOCAL_PR_REVIEW=1` as an emergency
+escape hatch for local pushes when the operator intentionally wants to bypass
+the local mechanical review.
+
+## Intentional
+
+- This installer is opt-in. It does not install itself during tests, package
+  setup, or CI.
+- The hook runs `local_pr_review.sh`, not only `pre_push_audit.sh`, because
+  the local review bundle also runs plan/code consistency and whitespace
+  checks.
+- There is no uninstall command in this slice. Removing `.git/hooks/pre-push`
+  is simple and keeps the installer small.
+
+## Deferred
+
+- Shell hygiene auditor remains deferred from the previous audit-kit work.
+- Automatic invocation of the judgment reviewer remains a process step, not
+  a Git hook.
+
+## Verification
+
+```bash
+python -m pytest tests/test_install_local_pr_hook.py tests/test_pre_push_audit.py -q
+bash scripts/local_pr_review.sh
+python scripts/audit_plan_doc.py plans/PR-Audit-Install-Local-Review-Hook.md
+python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Install-Local-Review-Hook.md origin/main
+python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Install-Local-Review-Hook.md origin/main
+bash -n scripts/install_local_pr_hook.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `AGENTS.md` | 11 |
+| `scripts/install_local_pr_hook.sh` | 86 |
+| `tests/test_install_local_pr_hook.py` | 122 |
+| `tests/test_pre_push_audit.py` | 37 |
+| `plans/PR-Audit-Install-Local-Review-Hook.md` | 81 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| **Total** | **~341** |

--- a/scripts/install_local_pr_hook.sh
+++ b/scripts/install_local_pr_hook.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Install the local PR review bundle as this checkout's pre-push hook.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/install_local_pr_hook.sh [--force]
+
+Installs .git/hooks/pre-push as a managed wrapper around:
+
+  bash scripts/local_pr_review.sh
+
+Options:
+  --force   overwrite an existing unmanaged pre-push hook
+  -h, --help
+            show this help
+EOF
+}
+
+force=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --force)
+            force=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "install_local_pr_hook.sh: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ ! -f scripts/local_pr_review.sh ]; then
+    echo "install_local_pr_hook.sh: scripts/local_pr_review.sh not found" >&2
+    exit 2
+fi
+
+hook_dir="$(git rev-parse --git-path hooks)"
+hook_path="$hook_dir/pre-push"
+marker="ATLAS_LOCAL_PR_REVIEW_HOOK"
+
+mkdir -p "$hook_dir"
+
+if [ -e "$hook_path" ] && ! grep -q "$marker" "$hook_path"; then
+    if [ "$force" -ne 1 ]; then
+        cat >&2 <<EOF
+install_local_pr_hook.sh: refusing to overwrite unmanaged hook:
+  $hook_path
+
+Re-run with --force to replace it, or merge its behavior manually.
+EOF
+        exit 1
+    fi
+fi
+
+cat > "$hook_path" <<'EOF'
+#!/usr/bin/env bash
+# ATLAS_LOCAL_PR_REVIEW_HOOK
+# Managed by scripts/install_local_pr_hook.sh.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ "${ATLAS_SKIP_LOCAL_PR_REVIEW:-}" = "1" ]; then
+    echo "ATLAS local PR review hook skipped (ATLAS_SKIP_LOCAL_PR_REVIEW=1)."
+    exit 0
+fi
+
+exec bash scripts/local_pr_review.sh
+EOF
+
+chmod +x "$hook_path"
+echo "Installed ATLAS local PR review pre-push hook at $hook_path"

--- a/tests/test_install_local_pr_hook.py
+++ b/tests/test_install_local_pr_hook.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_installs_managed_pre_push_hook(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(repo, ["bash", "scripts/install_local_pr_hook.sh"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    hook = repo / ".git" / "hooks" / "pre-push"
+    text = hook.read_text(encoding="utf-8")
+    assert "ATLAS_LOCAL_PR_REVIEW_HOOK" in text
+    assert "exec bash scripts/local_pr_review.sh" in text
+    assert _is_executable(hook)
+
+
+def test_refuses_to_overwrite_unmanaged_pre_push_hook(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    hook = repo / ".git" / "hooks" / "pre-push"
+    hook.write_text("#!/usr/bin/env bash\necho custom\n", encoding="utf-8")
+
+    result = _run(repo, ["bash", "scripts/install_local_pr_hook.sh"])
+
+    assert result.returncode == 1
+    assert "refusing to overwrite unmanaged hook" in result.stderr
+    assert hook.read_text(encoding="utf-8") == "#!/usr/bin/env bash\necho custom\n"
+
+
+def test_force_overwrites_unmanaged_pre_push_hook(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    hook = repo / ".git" / "hooks" / "pre-push"
+    hook.write_text("#!/usr/bin/env bash\necho custom\n", encoding="utf-8")
+
+    result = _run(repo, ["bash", "scripts/install_local_pr_hook.sh", "--force"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    text = hook.read_text(encoding="utf-8")
+    assert "ATLAS_LOCAL_PR_REVIEW_HOOK" in text
+    assert "echo custom" not in text
+
+
+def test_installed_hook_invokes_local_review_bundle(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _run(repo, ["bash", "scripts/install_local_pr_hook.sh"])
+    _write_executable(repo / "scripts" / "local_pr_review.sh", "echo ran local review\n")
+
+    result = _run(repo, [".git/hooks/pre-push"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ran local review" in result.stdout
+
+
+def test_installed_hook_supports_explicit_skip(tmp_path):
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _run(repo, ["bash", "scripts/install_local_pr_hook.sh"])
+    _write_executable(
+        repo / "scripts" / "local_pr_review.sh",
+        "echo should not run\nexit 42\n",
+    )
+
+    result = _run(
+        repo,
+        [".git/hooks/pre-push"],
+        env={"ATLAS_SKIP_LOCAL_PR_REVIEW": "1"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ATLAS local PR review hook skipped" in result.stdout
+    assert "should not run" not in result.stdout
+
+
+def _write_fixture_repo(repo: Path) -> None:
+    (repo / "scripts").mkdir(parents=True)
+    for name in ("install_local_pr_hook.sh", "local_pr_review.sh"):
+        target = repo / "scripts" / name
+        _write_executable(
+            target,
+            (REPO_ROOT / "scripts" / name).read_text(encoding="utf-8"),
+        )
+
+    _git(repo, "init")
+
+
+def _run(
+    repo: Path,
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(repo), **(env or {})},
+    )
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _is_executable(path: Path) -> bool:
+    return bool(path.stat().st_mode & stat.S_IXUSR)

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -116,7 +116,9 @@ def _write_fixture_repo(repo: Path) -> None:
     (repo / "scripts").mkdir(parents=True)
     for name in (
         "audit_claude_md_claims.py",
+        "audit_extracted_manifests.py",
         "audit_mcp_port_assignments.py",
+        "audit_mcp_tool_names_match_docs.py",
         "audit_plan_doc.py",
         "audit_plan_doc_files_touched.py",
         "audit_plan_doc_diff_size.py",
@@ -129,11 +131,11 @@ def _write_fixture_repo(repo: Path) -> None:
     _write_claude_md(repo / "CLAUDE.md")
     _write_config(repo / "atlas_brain" / "config.py")
     _write_mcp_servers(repo / "atlas_brain" / "mcp")
+    _write_manifest(repo / "extracted_fixture" / "manifest.json")
 
 
 def _write_claude_md(path: Path) -> None:
-    path.write_text(
-        """# Fixture
+    text = """# Fixture
 
 ATLAS_MCP_CRM_PORT=8056
 ATLAS_MCP_EMAIL_PORT=8057
@@ -146,33 +148,51 @@ ATLAS_MCP_B2B_CHURN_PORT=8062
 ### CRM MCP Server (10 tools)
 # SSE HTTP mode (port 8056)
 python -m atlas_brain.mcp.crm_server --sse
+{crm_tools}
 ### Email MCP Server (9 tools)
 # SSE HTTP mode (port 8057)
 python -m atlas_brain.mcp.email_server --sse
+{email_tools}
 ### Twilio MCP Server (10 tools)
 # SSE HTTP mode (port 8058)
 python -m atlas_brain.mcp.twilio_server --sse
+{twilio_tools}
 ### Calendar MCP Server (8 tools)
 # SSE HTTP mode (port 8059)
 python -m atlas_brain.mcp.calendar_server --sse
+{calendar_tools}
 ### Invoicing MCP Server (18 tools)
 # SSE HTTP mode (port 8060)
 python -m atlas_brain.mcp.invoicing_server --sse
+{invoicing_tools}
 ### Intelligence MCP Server (33 tools)
 # SSE HTTP mode (port 8061)
 python -m atlas_brain.mcp.intelligence_server --sse
+{intelligence_tools}
 ### B2B Churn Intelligence MCP Server (83 tools)
 # SSE HTTP mode (port 8062)
 python -m atlas_brain.mcp.b2b_churn_server --sse
+{b2b_tools}
 ### Universal Scraper MCP Server (5 tools)
 # SSE HTTP mode (port 8063)
 python -m atlas_brain.mcp.scraper_server --sse
+{scraper_tools}
 ### Memory MCP Server (15 tools)
 # SSE HTTP mode (port 8064)
 python -m atlas_brain.mcp.memory_server --sse
-""",
-        encoding="utf-8",
+{memory_tools}
+""".format(
+        crm_tools=_tool_list(10),
+        email_tools=_tool_list(9),
+        twilio_tools=_tool_list(10),
+        calendar_tools=_tool_list(8),
+        invoicing_tools=_tool_list(18),
+        intelligence_tools=_tool_list(33),
+        b2b_tools=_tool_list(83),
+        scraper_tools=_tool_list(5),
+        memory_tools=_tool_list(15),
     )
+    path.write_text(text, encoding="utf-8")
 
 
 def _write_config(path: Path) -> None:
@@ -213,8 +233,17 @@ def _write_mcp_servers(mcp_dir: Path) -> None:
     (mcp_dir / "b2b" / "fixture.py").write_text(_decorators(83), encoding="utf-8")
 
 
+def _write_manifest(path: Path) -> None:
+    path.parent.mkdir(parents=True)
+    path.write_text('{"mappings": [], "owned": []}\n', encoding="utf-8")
+
+
 def _decorators(count: int) -> str:
     return "\n".join("@mcp.tool\ndef tool_%s():\n    pass\n" % idx for idx in range(count))
+
+
+def _tool_list(count: int) -> str:
+    return ", ".join(f"`tool_{idx}`" for idx in range(count))
 
 
 def _plan_text(*, total_loc: int) -> str:


### PR DESCRIPTION
Plan: plans/PR-Audit-Install-Local-Review-Hook.md

## What changed
- Added `scripts/install_local_pr_hook.sh`, an opt-in installer for a managed `.git/hooks/pre-push` wrapper around `scripts/local_pr_review.sh`.
- Documented the optional hook in `AGENTS.md`, including `--force` and `ATLAS_SKIP_LOCAL_PR_REVIEW=1` behavior.
- Added tests for install, unmanaged-hook refusal, force overwrite, runtime invocation, and explicit skip.
- Repaired the pre-push wrapper fixture so the manifest and MCP tool-name auditors added in the prior slice are covered.
- Refreshed the coordination row for this slice.

## Intentional
- Installer is opt-in and does not run from CI, package setup, or test setup.
- The hook runs the full local review bundle, not just `pre_push_audit.sh`, so plan/code consistency and whitespace checks are included.
- No uninstall command in this slice; removing `.git/hooks/pre-push` is the simple rollback.

## Deferred
- Shell hygiene auditor remains deferred from the audit-kit work.
- Automatic judgment-review invocation remains process, not a Git hook.

## Migration / rollback notes
- Local-only installer. To enable in a checkout: `bash scripts/install_local_pr_hook.sh`.
- To replace an existing unmanaged hook: `bash scripts/install_local_pr_hook.sh --force`.
- To bypass one push intentionally: `ATLAS_SKIP_LOCAL_PR_REVIEW=1 git push`.
- To roll back locally: remove `.git/hooks/pre-push`.

## Verification
- `python -m pytest tests/test_install_local_pr_hook.py tests/test_pre_push_audit.py -q`
- `bash scripts/local_pr_review.sh`
- `python scripts/audit_plan_doc.py plans/PR-Audit-Install-Local-Review-Hook.md`
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Audit-Install-Local-Review-Hook.md origin/main`
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Audit-Install-Local-Review-Hook.md origin/main`
- `bash -n scripts/install_local_pr_hook.sh`
- `python -m py_compile tests/test_install_local_pr_hook.py tests/test_pre_push_audit.py`
- `git diff --check`
- Actual `git push` on this branch ran the installed hook and passed before the remote push completed.