### PR TITLE
Add Content Ops live persistence smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-14T18:02Z by codex-2026-05-14
+Last updated: 2026-05-14T18:24Z by codex-2026-05-14-content-ops-live-persistence-smoke
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (none) | No active in-flight rows. | - | - | - |
+| (in flight) | Add Content Ops live execute persistence smoke | NEW: `plans/PR-Content-Ops-Live-Persistence-Smoke.md`. EDIT: `tests/test_extracted_content_ops_live_execute_harness.py`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-content-ops-live-persistence-smoke | audit-tooling split PRs; competitive-intelligence extraction files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Live-Persistence-Smoke.md
+++ b/plans/PR-Content-Ops-Live-Persistence-Smoke.md
@@ -1,0 +1,74 @@
+# PR-Content-Ops-Live-Persistence-Smoke
+
+## Why this slice exists
+
+`docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` lists live execute
+persistence smoke coverage as the top AI Content Ops deferral. Existing tests
+already prove the in-memory execution harness persists every generated asset,
+but the direct harness test bypasses the hosted `/content-ops/execute` route.
+
+This slice closes that route-level gap without adding new runtime behavior.
+
+## Scope
+
+1. Add a route-level smoke to `tests/test_extracted_content_ops_live_execute_harness.py`.
+2. Reuse `build_content_ops_live_execute_harness()` and
+   `default_content_ops_execute_payload()` instead of creating a parallel fixture.
+3. Assert the hosted `POST /content-ops/execute` route:
+   - enters the route endpoint,
+   - applies the provided tenant scope,
+   - uses host-injected services,
+   - persists every LLM-backed generated asset,
+   - reports saved ids and consumed reasoning audits.
+4. Claim this slice in `docs/extraction/coordination/inflight.md`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Live-Persistence-Smoke.md`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The test builds a router with the Content Ops control-surface router factory,
+injects the existing harness services and reasoning provider, resolves the
+`/content-ops/execute` route, and calls the route endpoint with the existing
+payload fixture.
+
+Persistence is verified through the harness repositories, not by trusting the
+response alone. The response is still checked for generated ids and reasoning
+audit fields because those are the customer-facing route contract.
+
+## Intentional
+
+- No production code changes are expected. This is a smoke-contract slice.
+- The test stays in-memory. It validates the host adapter seam without opening
+  a real database or provider connection.
+- The existing direct harness test remains in place because it gives a smaller
+  failure surface when the executor changes.
+
+## Deferred
+
+- A real Postgres-backed live smoke can follow once test infrastructure has a
+  stable database fixture for all generated asset repositories.
+- Blog blueprint population remains the next AI Content Ops backlog item after
+  this smoke contract lands.
+
+## Verification
+
+```bash
+python -m pytest tests/test_extracted_content_ops_live_execute_harness.py
+python -m pytest tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_execution.py
+python -m py_compile tests/test_extracted_content_ops_live_execute_harness.py
+bash scripts/local_pr_review.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Live-Persistence-Smoke.md` | 66 |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | 77 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| **Total** | **~145** |

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+import extracted_content_pipeline.api.control_surfaces as api_module
+from extracted_content_pipeline.api.control_surfaces import (
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
 from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
@@ -7,6 +14,20 @@ from tests.content_ops_live_execute_harness import (
     build_content_ops_live_execute_harness,
     default_content_ops_execute_payload,
 )
+
+
+pytestmark = pytest.mark.skipif(
+    api_module.APIRouter is None,
+    reason="fastapi is not installed in this test environment",
+)
+
+
+def _route(router, path: str, method: str):
+    for route in router.routes:
+        methods = getattr(route, "methods", set())
+        if getattr(route, "path", None) == path and method.upper() in methods:
+            return route
+    raise AssertionError(f"route not found: {method} {path}")
 
 
 async def test_live_execute_harness_runs_all_outputs_with_reasoning() -> None:
@@ -66,3 +87,59 @@ async def test_live_execute_harness_runs_all_outputs_with_reasoning() -> None:
         "digest/landing_page_generation",
         "digest/sales_brief_generation",
     }
+
+
+async def test_live_execute_route_persists_all_outputs_with_reasoning() -> None:
+    harness = build_content_ops_live_execute_harness()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(),
+        execution_services_provider=lambda: harness.services,
+        scope_provider=lambda: harness.scope,
+        reasoning_context_provider=lambda: harness.reasoning,
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint(default_content_ops_execute_payload())
+
+    assert payload["status"] == "completed"
+    steps = {step["output"]: step for step in payload["steps"]}
+    assert set(steps) == {
+        "email_campaign",
+        "blog_post",
+        "report",
+        "landing_page",
+        "sales_brief",
+        "signal_extraction",
+    }
+
+    for output in ("email_campaign", "blog_post", "report", "landing_page", "sales_brief"):
+        step = steps[output]
+        assert step["status"] == "completed"
+        assert step["result"]["generated"] >= 1
+        assert step["result"]["saved_ids"]
+        assert step["reasoning"]["provider_configured"] is True
+        assert step["reasoning"]["contexts_used"] >= 1
+        assert step["reasoning"]["consumed_contexts"]
+
+    assert steps["signal_extraction"]["status"] == "completed"
+    assert steps["signal_extraction"]["result"]["generated"] == 1
+    assert steps["signal_extraction"]["reasoning"]["requirement"] == "absent"
+
+    repositories = {
+        "campaigns": harness.campaigns,
+        "blog_posts": harness.blog_posts,
+        "reports": harness.reports,
+        "landing_pages": harness.landing_pages,
+        "sales_briefs": harness.sales_briefs,
+    }
+    assert {name: len(repo.saved) for name, repo in repositories.items()} == {
+        "campaigns": 2,
+        "blog_posts": 1,
+        "reports": 1,
+        "landing_pages": 1,
+        "sales_briefs": 1,
+    }
+    for repository in repositories.values():
+        for scope, _draft in repository.saved:
+            assert scope.account_id == "acct-live"
+            assert scope.user_id == "user-live"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Live-Persistence-Smoke.md

Adds the P0 AI Content Ops live execute persistence smoke from the deferred backlog.

What changed:
- Added a route-level smoke in `tests/test_extracted_content_ops_live_execute_harness.py` that calls the real `POST /content-ops/execute` route endpoint through `create_content_ops_control_surface_router`.
- Reuses the existing in-memory live execute harness instead of creating a parallel fixture.
- Asserts all LLM-backed outputs persist drafts, return saved ids, preserve tenant scope, use host-injected services, and report consumed reasoning audits.
- Claims the slice in `docs/extraction/coordination/inflight.md`.

Intentional:
- No production code changes.
- No real DB/provider connections; this validates the hosted route and adapter seam in-memory.
- Direct executor harness coverage remains in place for a smaller failure surface.

Verification:
- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py` -> 2 passed
- `python -m pytest tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_execution.py` -> 60 passed
- `python -m py_compile tests/test_extracted_content_ops_live_execute_harness.py` -> passed
- `git diff --check` -> passed
- `bash scripts/local_pr_review.sh` -> passed
- pre-push hook -> passed

Notes:
- `CLAUDE.md` is dirty in the local worktree from unrelated review-process text and was not staged or included in this PR.
