### PR TITLE
Add Content Ops blog blueprint ingestion CLI

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-14T18:24Z by codex-2026-05-14-content-ops-live-persistence-smoke
+Last updated: 2026-05-14T18:55Z by codex-2026-05-14-blog-blueprint-ingestion
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops live execute persistence smoke | NEW: `plans/PR-Content-Ops-Live-Persistence-Smoke.md`. EDIT: `tests/test_extracted_content_ops_live_execute_harness.py`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-content-ops-live-persistence-smoke | audit-tooling split PRs; competitive-intelligence extraction files |
+| (in flight) | Add Content Ops blog blueprint ingestion CLI | NEW: `plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md`; `extracted_content_pipeline/blog_blueprint_ingest.py`; `scripts/load_extracted_blog_blueprints.py`; `tests/test_extracted_blog_blueprint_ingest.py`. EDIT: `scripts/run_extracted_pipeline_checks.sh`; `extracted_content_pipeline/manifest.json`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/docs/standalone_productization.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-blog-blueprint-ingestion | reasoning-provider backlog slices; frontend Content Ops UI slices |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -310,6 +310,21 @@ the selected account and target mode before inserting the new rows.
 For the full database-backed host install path, see
 `docs/host_install_runbook.md`.
 
+Load host-produced blog blueprints into `blog_blueprints` before running the
+blog-post output. The JSON file can be an array, a single object, or an object
+with a `blueprints` array:
+
+```bash
+python scripts/load_extracted_blog_blueprints.py blog_blueprints.json \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --dry-run
+
+python scripts/load_extracted_blog_blueprints.py blog_blueprints.json \
+  --account-id acct_123 \
+  --target-mode vendor_retention
+```
+
 Before connecting workers to a customer database or provider, inspect local
 install readiness without opening network or DB handles:
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -139,6 +139,9 @@ source of truth for what remains.
   ports instead of calling the legacy autonomous task path. Blog generation
   retries unparseable LLM JSON once by default and records parse-attempt
   metadata on saved drafts.
+- `blog_blueprint_ingest` and `scripts/load_extracted_blog_blueprints.py`
+  provide the host-side population seam for `blog_blueprints`, so DB-backed
+  blog generation no longer depends on manually pre-seeded blueprint rows.
 - `report_generation`, `landing_page_generation`, and `sales_brief_generation`
   use the same parse-retry policy as campaign and blog assets, so all
   customer-facing generated asset services recover once from malformed LLM JSON

--- a/extracted_content_pipeline/blog_blueprint_ingest.py
+++ b/extracted_content_pipeline/blog_blueprint_ingest.py
@@ -9,10 +9,15 @@ from pathlib import Path
 import re
 from typing import Any, Literal
 
-from .blog_blueprint_postgres import BlogBlueprint
+from .blog_ports import BlogBlueprint
 
 
 BlogBlueprintDataFormat = Literal["auto", "json"]
+_SKIP_WARNING_CODES = frozenset({
+    "missing_slug",
+    "missing_target_mode",
+    "row_not_object",
+})
 
 
 @dataclass(frozen=True)
@@ -50,7 +55,7 @@ class BlogBlueprintLoadResult:
     def as_dict(self) -> dict[str, Any]:
         return {
             "loaded": len(self.blueprints),
-            "skipped": len(self.warnings),
+            "skipped": sum(1 for warning in self.warnings if warning.code in _SKIP_WARNING_CODES),
             "source": self.source,
             "warnings": self.warning_dicts(),
         }
@@ -122,8 +127,8 @@ def _normalize_row(
     row: Mapping[str, Any],
     *,
     row_index: int,
-    default_target_mode: str | None,
-    default_topic_type: str | None,
+    default_target_mode: str,
+    default_topic_type: str,
 ) -> tuple[BlogBlueprint | None, list[BlogBlueprintWarning]]:
     warnings: list[BlogBlueprintWarning] = []
     target_mode = _clean(row.get("target_mode")) or default_target_mode
@@ -192,6 +197,7 @@ def _load_json_rows(path: Path) -> list[Any]:
         value = data.get(key)
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
             return list(value)
+    # Bare object: treat as a single-blueprint row.
     return [dict(data)]
 
 
@@ -205,6 +211,7 @@ def _slugify(value: Any) -> str:
 
 
 __all__ = [
+    "BlogBlueprintDataFormat",
     "BlogBlueprintLoadResult",
     "BlogBlueprintWarning",
     "load_blog_blueprints_from_file",

--- a/extracted_content_pipeline/blog_blueprint_ingest.py
+++ b/extracted_content_pipeline/blog_blueprint_ingest.py
@@ -18,6 +18,14 @@ _SKIP_WARNING_CODES = frozenset({
     "missing_target_mode",
     "row_not_object",
 })
+_BLUEPRINT_ROW_KEYS = frozenset({
+    "slug",
+    "suggested_title",
+    "target_mode",
+    "title",
+    "topic",
+    "topic_type",
+})
 
 
 @dataclass(frozen=True)
@@ -193,12 +201,20 @@ def _load_json_rows(path: Path) -> list[Any]:
         return list(data)
     if not isinstance(data, Mapping):
         raise ValueError("JSON blog blueprint data must be an object or array")
+    if _looks_like_blueprint_row(data):
+        # Bare object: treat as a single-blueprint row, preserving payload keys
+        # such as "data" or "rows" when hosts use those names inside blueprints.
+        return [dict(data)]
     for key in ("blueprints", "rows", "data"):
         value = data.get(key)
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
             return list(value)
     # Bare object: treat as a single-blueprint row.
     return [dict(data)]
+
+
+def _looks_like_blueprint_row(row: Mapping[str, Any]) -> bool:
+    return any(str(key) in _BLUEPRINT_ROW_KEYS for key in row)
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/blog_blueprint_ingest.py
+++ b/extracted_content_pipeline/blog_blueprint_ingest.py
@@ -169,7 +169,7 @@ def _normalize_row(
         or default_topic_type
         or "blog_post"
     )
-    typed_keys = {"target_mode", "topic_type", "slug", "suggested_title", "title"}
+    typed_keys = _BLUEPRINT_ROW_KEYS
     payload = {str(key): value for key, value in row.items() if str(key) not in typed_keys}
     return (
         BlogBlueprint(
@@ -201,11 +201,14 @@ def _load_json_rows(path: Path) -> list[Any]:
         return list(data)
     if not isinstance(data, Mapping):
         raise ValueError("JSON blog blueprint data must be an object or array")
+    blueprints = data.get("blueprints")
+    if isinstance(blueprints, Sequence) and not isinstance(blueprints, (str, bytes, bytearray)):
+        return list(blueprints)
     if _looks_like_blueprint_row(data):
         # Bare object: treat as a single-blueprint row, preserving payload keys
         # such as "data" or "rows" when hosts use those names inside blueprints.
         return [dict(data)]
-    for key in ("blueprints", "rows", "data"):
+    for key in ("rows", "data"):
         value = data.get(key)
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
             return list(value)

--- a/extracted_content_pipeline/blog_blueprint_ingest.py
+++ b/extracted_content_pipeline/blog_blueprint_ingest.py
@@ -1,0 +1,212 @@
+"""File adapter for standalone blog-blueprint ingestion."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+from typing import Any, Literal
+
+from .blog_blueprint_postgres import BlogBlueprint
+
+
+BlogBlueprintDataFormat = Literal["auto", "json"]
+
+
+@dataclass(frozen=True)
+class BlogBlueprintWarning:
+    """Non-fatal warning for one loaded blueprint row."""
+
+    code: str
+    message: str
+    row_index: int | None = None
+    field: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.row_index is not None:
+            data["row_index"] = self.row_index
+        if self.field:
+            data["field"] = self.field
+        return data
+
+
+@dataclass(frozen=True)
+class BlogBlueprintLoadResult:
+    """Normalized blog blueprints plus non-fatal validation warnings."""
+
+    blueprints: tuple[BlogBlueprint, ...]
+    warnings: tuple[BlogBlueprintWarning, ...] = ()
+    source: str | None = None
+
+    def warning_dicts(self) -> list[dict[str, Any]]:
+        return [warning.as_dict() for warning in self.warnings]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "loaded": len(self.blueprints),
+            "skipped": len(self.warnings),
+            "source": self.source,
+            "warnings": self.warning_dicts(),
+        }
+
+
+def load_blog_blueprints_from_file(
+    path: str | Path,
+    *,
+    file_format: BlogBlueprintDataFormat = "auto",
+    target_mode: str | None = None,
+    topic_type: str | None = None,
+) -> BlogBlueprintLoadResult:
+    """Load host-supplied blog blueprints from a JSON file."""
+
+    source = Path(path)
+    resolved_format = _resolve_format(source, file_format)
+    if resolved_format != "json":
+        raise ValueError(f"Unsupported blog blueprint file format: {resolved_format}")
+    result = normalize_blog_blueprint_rows(
+        _load_json_rows(source),
+        target_mode=target_mode,
+        topic_type=topic_type,
+    )
+    return BlogBlueprintLoadResult(
+        blueprints=result.blueprints,
+        warnings=result.warnings,
+        source=str(source),
+    )
+
+
+def normalize_blog_blueprint_rows(
+    rows: Sequence[Any],
+    *,
+    target_mode: str | None = None,
+    topic_type: str | None = None,
+) -> BlogBlueprintLoadResult:
+    """Normalize loose JSON rows into ``BlogBlueprint`` objects."""
+
+    blueprints: list[BlogBlueprint] = []
+    warnings: list[BlogBlueprintWarning] = []
+    default_target_mode = _clean(target_mode)
+    default_topic_type = _clean(topic_type)
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            warnings.append(
+                BlogBlueprintWarning(
+                    code="row_not_object",
+                    row_index=index,
+                    message="Skipped row because it is not an object.",
+                )
+            )
+            continue
+        normalized, row_warnings = _normalize_row(
+            row,
+            row_index=index,
+            default_target_mode=default_target_mode,
+            default_topic_type=default_topic_type,
+        )
+        warnings.extend(row_warnings)
+        if normalized is not None:
+            blueprints.append(normalized)
+    return BlogBlueprintLoadResult(
+        blueprints=tuple(blueprints),
+        warnings=tuple(warnings),
+    )
+
+
+def _normalize_row(
+    row: Mapping[str, Any],
+    *,
+    row_index: int,
+    default_target_mode: str | None,
+    default_topic_type: str | None,
+) -> tuple[BlogBlueprint | None, list[BlogBlueprintWarning]]:
+    warnings: list[BlogBlueprintWarning] = []
+    target_mode = _clean(row.get("target_mode")) or default_target_mode
+    if not target_mode:
+        warnings.append(
+            BlogBlueprintWarning(
+                code="missing_target_mode",
+                row_index=row_index,
+                field="target_mode",
+                message="Skipped row because target_mode is missing.",
+            )
+        )
+        return None, warnings
+
+    title = _clean(row.get("suggested_title")) or _clean(row.get("title"))
+    slug = _clean(row.get("slug")) or _slugify(title or row.get("topic") or "")
+    if not slug:
+        warnings.append(
+            BlogBlueprintWarning(
+                code="missing_slug",
+                row_index=row_index,
+                field="slug",
+                message="Skipped row because slug is missing and no title can derive it.",
+            )
+        )
+        return None, warnings
+
+    resolved_topic_type = (
+        _clean(row.get("topic_type"))
+        or default_topic_type
+        or "blog_post"
+    )
+    typed_keys = {"target_mode", "topic_type", "slug", "suggested_title", "title"}
+    payload = {str(key): value for key, value in row.items() if str(key) not in typed_keys}
+    return (
+        BlogBlueprint(
+            target_mode=target_mode,
+            topic_type=resolved_topic_type,
+            slug=slug,
+            suggested_title=title or slug.replace("-", " ").title(),
+            payload=payload,
+        ),
+        warnings,
+    )
+
+
+def _resolve_format(
+    path: Path,
+    file_format: BlogBlueprintDataFormat,
+) -> Literal["json"]:
+    if file_format == "json":
+        return "json"
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "json"
+    raise ValueError(f"Cannot infer blog blueprint format from file suffix: {path}")
+
+
+def _load_json_rows(path: Path) -> list[Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return list(data)
+    if not isinstance(data, Mapping):
+        raise ValueError("JSON blog blueprint data must be an object or array")
+    for key in ("blueprints", "rows", "data"):
+        value = data.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return list(value)
+    return [dict(data)]
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    return re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+
+
+__all__ = [
+    "BlogBlueprintLoadResult",
+    "BlogBlueprintWarning",
+    "load_blog_blueprints_from_file",
+    "normalize_blog_blueprint_rows",
+]

--- a/extracted_content_pipeline/blog_blueprint_ingest.py
+++ b/extracted_content_pipeline/blog_blueprint_ingest.py
@@ -203,7 +203,7 @@ def _load_json_rows(path: Path) -> list[Any]:
         raise ValueError("JSON blog blueprint data must be an object or array")
     blueprints = data.get("blueprints")
     if isinstance(blueprints, Sequence) and not isinstance(blueprints, (str, bytes, bytearray)):
-        return list(blueprints)
+        return _merge_wrapper_defaults(blueprints, _wrapper_defaults(data))
     if _looks_like_blueprint_row(data):
         # Bare object: treat as a single-blueprint row, preserving payload keys
         # such as "data" or "rows" when hosts use those names inside blueprints.
@@ -218,6 +218,31 @@ def _load_json_rows(path: Path) -> list[Any]:
 
 def _looks_like_blueprint_row(row: Mapping[str, Any]) -> bool:
     return any(str(key) in _BLUEPRINT_ROW_KEYS for key in row)
+
+
+def _wrapper_defaults(row: Mapping[str, Any]) -> dict[str, Any]:
+    defaults: dict[str, Any] = {}
+    for key in ("target_mode", "topic_type"):
+        if _clean(row.get(key)):
+            defaults[key] = row[key]
+    return defaults
+
+
+def _merge_wrapper_defaults(
+    rows: Sequence[Any],
+    defaults: Mapping[str, Any],
+) -> list[Any]:
+    if not defaults:
+        return list(rows)
+    merged_rows: list[Any] = []
+    for row in rows:
+        if isinstance(row, Mapping):
+            merged = dict(defaults)
+            merged.update(row)
+            merged_rows.append(merged)
+        else:
+            merged_rows.append(row)
+    return merged_rows
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/blog_blueprint_postgres.py
+++ b/extracted_content_pipeline/blog_blueprint_postgres.py
@@ -23,27 +23,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Mapping, Sequence
 
+from .blog_ports import BlogBlueprint
 from .campaign_ports import JsonDict, TenantScope
 from .storage._jsonb_helpers import (
     decode_jsonb_field,
     json_dump_jsonb,
     row_to_dict,
 )
-
-
-@dataclass(frozen=True)
-class BlogBlueprint:
-    """In-memory representation of a stored blog blueprint row.
-
-    Only used by the ``save_blueprints`` writer; the read path
-    returns plain ``Mapping`` rows for the generator to consume.
-    """
-
-    target_mode: str
-    topic_type: str
-    slug: str
-    suggested_title: str = ""
-    payload: Mapping[str, Any] = ()  # type: ignore[assignment]
 
 
 def _row_to_blueprint(row: Mapping[str, Any]) -> JsonDict:

--- a/extracted_content_pipeline/blog_ports.py
+++ b/extracted_content_pipeline/blog_ports.py
@@ -36,6 +36,17 @@ class BlogPostDraft:
         }
 
 
+@dataclass(frozen=True)
+class BlogBlueprint:
+    """In-memory representation of a stored blog blueprint row."""
+
+    target_mode: str
+    topic_type: str
+    slug: str
+    suggested_title: str = ""
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
 class BlogBlueprintRepository(Protocol):
     """Read blog blueprints from host-owned intelligence storage."""
 
@@ -82,6 +93,7 @@ class BlogPostRepository(Protocol):
 
 
 __all__ = [
+    "BlogBlueprint",
     "BlogBlueprintRepository",
     "BlogPostDraft",
     "BlogPostRepository",

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -90,6 +90,32 @@ python scripts/run_extracted_content_pipeline_migrations.py \
   --migration-table customer_content_pipeline_migrations
 ```
 
+## Step 2a: Load Blog Blueprints
+
+Blog-post generation reads unconsumed rows from `blog_blueprints`. Host apps can
+populate that table from an ETL, reasoning layer, editorial queue, or a JSON
+export:
+
+```bash
+python scripts/load_extracted_blog_blueprints.py blog_blueprints.json \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --dry-run
+```
+
+Write the rows after the dry run passes:
+
+```bash
+python scripts/load_extracted_blog_blueprints.py blog_blueprints.json \
+  --account-id acct_123 \
+  --target-mode vendor_retention
+```
+
+The loader accepts a JSON array, a single JSON object, or an object with a
+`blueprints` array. Each row can provide its own `target_mode`; `--target-mode`
+fills rows that omit it. Rows without a target mode are skipped instead of being
+written into an ambiguous tenant queue.
+
 ## Step 3: Validate Customer Data Offline
 
 Before writing to Postgres, validate the same JSON or CSV file through the file

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -209,6 +209,12 @@ loop for generated assets. Hosts pass `--asset`, `--id`, `--status`, and an
 optional `--account-id`; the CLI calls the matching product-owned Postgres
 repository and emits a JSON hit/miss result without requiring ad hoc SQL.
 
+`extracted_content_pipeline/blog_blueprint_ingest.py` and
+`scripts/load_extracted_blog_blueprints.py` own the host-side blog blueprint
+population path. Hosts can validate a JSON blueprint export in dry-run mode or
+write normalized rows through `PostgresBlogBlueprintRepository` before running
+the blog-post generator.
+
 `extracted_content_pipeline/api/generated_assets.py` owns the host-mounted
 FastAPI surface for generated asset review workflows. It exposes list, CSV/JSON
 export, and status-update routes for reports, landing pages, and sales briefs

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -260,6 +260,9 @@
       "target": "extracted_content_pipeline/blog_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/blog_blueprint_ingest.py"
+    },
+    {
       "target": "extracted_content_pipeline/blog_post_postgres.py"
     },
     {

--- a/plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md
+++ b/plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md
@@ -1,0 +1,72 @@
+# PR: Content Ops Blog Blueprint Ingestion
+
+## Why this slice exists
+
+The deferred AI Content Ops backlog lists the blog blueprint population path as
+the next P1 gap. Blog execution can now read `blog_blueprints`, but a standalone
+host still needs a product-owned way to populate that table without hand-written
+SQL or Atlas autonomous task fanout.
+
+## Scope
+
+Add a small JSON-to-Postgres ingestion seam for blog blueprints:
+
+- Normalize host JSON rows into the existing `BlogBlueprint` model.
+- Add a CLI that validates in dry-run mode or writes through the existing
+  `PostgresBlogBlueprintRepository`.
+- Document the host install command and include the new tests in the extracted
+  Content Ops check runner.
+- Replace the stale merged #505 coordination row with this active claim.
+
+### Files touched
+
+- NEW: `extracted_content_pipeline/blog_blueprint_ingest.py`
+- NEW: `scripts/load_extracted_blog_blueprints.py`
+- NEW: `tests/test_extracted_blog_blueprint_ingest.py`
+- NEW: `plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md`
+- EDIT: `scripts/run_extracted_pipeline_checks.sh`
+- EDIT: `extracted_content_pipeline/manifest.json`
+- EDIT: `extracted_content_pipeline/README.md`
+- EDIT: `extracted_content_pipeline/STATUS.md`
+- EDIT: `extracted_content_pipeline/docs/host_install_runbook.md`
+- EDIT: `extracted_content_pipeline/docs/standalone_productization.md`
+- EDIT: `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+The loader accepts one JSON object, a JSON array, or an object containing a
+`blueprints` array. Each row must resolve to a target mode from the row or CLI
+default; rows that cannot are skipped with a structured warning. The CLI reuses
+the existing `EXTRACTED_DATABASE_URL` / `DATABASE_URL` convention and supports a
+dry-run mode that does not open a database connection.
+
+## Intentional
+
+- JSON only for this first seam. CSV blueprint shape is less obvious than
+  campaign opportunities and should not be guessed.
+- `--account-id` is required. A blueprint write without tenant ownership is a
+  dangerous host-install footgun.
+- Existing generator, repository, and schema behavior are unchanged.
+
+## Deferred
+
+- Autonomous reasoning or intervention output providers that create blueprints.
+- A hosted UI for editing blueprint rows.
+- Bulk replace/delete semantics for obsolete blueprints.
+
+## Verification
+
+- Python compile for the new loader, CLI, and tests.
+- Focused pytest for the new ingestion suite.
+- Blog-adjacent pytest across blueprint storage, generation, and ingestion.
+- Local PR review script.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Loader module | ~220 |
+| CLI | ~130 |
+| Tests | ~205 |
+| Docs, manifest, coordination, and runner | ~115 |
+| Total | ~670 |

--- a/plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md
+++ b/plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md
@@ -24,6 +24,8 @@ Add a small JSON-to-Postgres ingestion seam for blog blueprints:
 - NEW: `scripts/load_extracted_blog_blueprints.py`
 - NEW: `tests/test_extracted_blog_blueprint_ingest.py`
 - NEW: `plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md`
+- EDIT: `extracted_content_pipeline/blog_ports.py`
+- EDIT: `extracted_content_pipeline/blog_blueprint_postgres.py`
 - EDIT: `scripts/run_extracted_pipeline_checks.sh`
 - EDIT: `extracted_content_pipeline/manifest.json`
 - EDIT: `extracted_content_pipeline/README.md`
@@ -65,8 +67,8 @@ dry-run mode that does not open a database connection.
 
 | Area | Estimated LOC |
 |---|---:|
-| Loader module | ~220 |
+| Loader module | ~230 |
 | CLI | ~130 |
-| Tests | ~205 |
-| Docs, manifest, coordination, and runner | ~115 |
-| Total | ~670 |
+| Tests | ~235 |
+| Ports, docs, manifest, coordination, and runner | ~130 |
+| Total | ~725 |

--- a/scripts/load_extracted_blog_blueprints.py
+++ b/scripts/load_extracted_blog_blueprints.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Load host-supplied blog blueprints into the extracted product database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.blog_blueprint_ingest import (  # noqa: E402
+    load_blog_blueprints_from_file,
+)
+from extracted_content_pipeline.blog_blueprint_postgres import (  # noqa: E402
+    PostgresBlogBlueprintRepository,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Load JSON blog blueprints into Postgres."
+    )
+    parser.add_argument("path", type=Path, help="Blog blueprint JSON file.")
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("auto", "json"),
+        default="auto",
+        help="Blueprint file format.",
+    )
+    parser.add_argument(
+        "--account-id",
+        required=True,
+        help="Tenant/account id that owns the saved blueprints.",
+    )
+    parser.add_argument(
+        "--target-mode",
+        default=None,
+        help="Default target_mode for rows that omit target_mode.",
+    )
+    parser.add_argument(
+        "--topic-type",
+        default=None,
+        help="Default topic_type for rows that omit topic_type.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and count rows without connecting to Postgres.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON summary instead of a concise text summary.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to load blog blueprints; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main() -> int:
+    args = _parse_args()
+    loaded = load_blog_blueprints_from_file(
+        args.path,
+        file_format=args.format,
+        target_mode=args.target_mode,
+        topic_type=args.topic_type,
+    )
+    saved_ids: tuple[str, ...] = ()
+    pool = None
+    if not args.dry_run:
+        if not args.database_url:
+            raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+        pool = await _create_pool(args.database_url)
+    try:
+        if not args.dry_run:
+            repo = PostgresBlogBlueprintRepository(pool=pool)
+            saved_ids = tuple(
+                await repo.save_blueprints(
+                    loaded.blueprints,
+                    scope=TenantScope(account_id=args.account_id),
+                )
+            )
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+
+    summary = {
+        **loaded.as_dict(),
+        "dry_run": bool(args.dry_run),
+        "account_id": args.account_id,
+        "saved": len(saved_ids),
+        "saved_ids": list(saved_ids),
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        mode = "would save" if args.dry_run else "saved"
+        print(
+            f"{mode} {summary['loaded']} blog blueprint row(s); "
+            f"skipped {summary['skipped']}; warnings {len(summary['warnings'])}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/load_extracted_blog_blueprints.py
+++ b/scripts/load_extracted_blog_blueprints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import json
 import os
 from pathlib import Path
@@ -105,7 +106,7 @@ async def _main() -> int:
         close = getattr(pool, "close", None)
         if close is not None:
             maybe_awaitable = close()
-            if hasattr(maybe_awaitable, "__await__"):
+            if inspect.isawaitable(maybe_awaitable):
                 await maybe_awaitable
 
     summary = {
@@ -121,7 +122,7 @@ async def _main() -> int:
         mode = "would save" if args.dry_run else "saved"
         print(
             f"{mode} {summary['loaded']} blog blueprint row(s); "
-            f"skipped {summary['skipped']}; warnings {len(summary['warnings'])}"
+            f"skipped {summary['skipped']}"
         )
     return 0
 

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -26,6 +26,7 @@ pytest \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_extracted_blog_generation.py \
+  tests/test_extracted_blog_blueprint_ingest.py \
   tests/test_extracted_blog_post_postgres.py \
   tests/test_extracted_campaign_reasoning_postgres.py \
   tests/test_extracted_campaign_reasoning_postgres_check.py \

--- a/tests/test_extracted_blog_blueprint_ingest.py
+++ b/tests/test_extracted_blog_blueprint_ingest.py
@@ -111,6 +111,24 @@ def test_load_blog_blueprints_preserves_payload_data_on_bare_object(tmp_path: Pa
     assert loaded.warnings == ()
 
 
+def test_load_blog_blueprints_prefers_explicit_blueprints_wrapper(tmp_path: Path) -> None:
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps({
+            "topic_type": "pricing",
+            "blueprints": [{"title": "Wrapped blueprint"}],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_blog_blueprints_from_file(path, target_mode="vendor_retention")
+
+    assert len(loaded.blueprints) == 1
+    assert loaded.blueprints[0].slug == "wrapped-blueprint"
+    assert loaded.blueprints[0].target_mode == "vendor_retention"
+    assert loaded.warnings == ()
+
+
 def test_load_blog_blueprints_rejects_ambiguous_extension(tmp_path: Path) -> None:
     path = tmp_path / "blueprints.txt"
     path.write_text("[]", encoding="utf-8")
@@ -147,6 +165,15 @@ def test_normalize_blog_blueprint_rows_skips_missing_target_mode() -> None:
     assert loaded.blueprints == ()
     assert loaded.warnings[0].code == "missing_target_mode"
     assert loaded.warnings[0].field == "target_mode"
+
+
+def test_normalize_blog_blueprint_rows_uses_topic_without_storing_it_as_payload() -> None:
+    loaded = normalize_blog_blueprint_rows([
+        {"topic": "Pricing story", "target_mode": "vendor_retention"}
+    ])
+
+    assert loaded.blueprints[0].slug == "pricing-story"
+    assert "topic" not in loaded.blueprints[0].payload
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_blog_blueprint_ingest.py
+++ b/tests/test_extracted_blog_blueprint_ingest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from extracted_content_pipeline.blog_blueprint_ingest import (
+    BlogBlueprintDataFormat,
     load_blog_blueprints_from_file,
     normalize_blog_blueprint_rows,
 )
@@ -36,6 +37,7 @@ class _Pool:
 
     async def fetchval(self, query, *args):
         self.fetchval_calls.append((str(query), args))
+        assert self.fetchval_results, "unexpected extra fetchval call"
         return self.fetchval_results.pop(0)
 
     async def close(self):
@@ -70,6 +72,34 @@ def test_load_blog_blueprints_from_json_payload_normalizes_rows(tmp_path: Path) 
     assert blueprint.suggested_title == "Acme pricing pressure"
     assert blueprint.payload["sections"] == [{"id": "intro"}]
     assert "title" not in blueprint.payload
+
+
+def test_load_blog_blueprints_from_bare_json_object(tmp_path: Path) -> None:
+    path = tmp_path / "blueprint.json"
+    path.write_text(
+        json.dumps({
+            "target_mode": "vendor_retention",
+            "title": "Single blueprint",
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_blog_blueprints_from_file(path)
+
+    assert len(loaded.blueprints) == 1
+    assert loaded.blueprints[0].slug == "single-blueprint"
+
+
+def test_load_blog_blueprints_rejects_ambiguous_extension(tmp_path: Path) -> None:
+    path = tmp_path / "blueprints.txt"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Cannot infer blog blueprint format"):
+        load_blog_blueprints_from_file(path)
+
+
+def test_blog_blueprint_data_format_is_exported_for_type_hints() -> None:
+    assert BlogBlueprintDataFormat is not None
 
 
 def test_normalize_blog_blueprint_rows_applies_defaults_and_skips_bad_rows() -> None:

--- a/tests/test_extracted_blog_blueprint_ingest.py
+++ b/tests/test_extracted_blog_blueprint_ingest.py
@@ -90,6 +90,27 @@ def test_load_blog_blueprints_from_bare_json_object(tmp_path: Path) -> None:
     assert loaded.blueprints[0].slug == "single-blueprint"
 
 
+def test_load_blog_blueprints_preserves_payload_data_on_bare_object(tmp_path: Path) -> None:
+    path = tmp_path / "blueprint.json"
+    path.write_text(
+        json.dumps({
+            "target_mode": "vendor_retention",
+            "title": "Single blueprint",
+            "data": [{"section": "intro"}],
+            "rows": [{"section": "proof"}],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_blog_blueprints_from_file(path)
+
+    assert len(loaded.blueprints) == 1
+    assert loaded.blueprints[0].slug == "single-blueprint"
+    assert loaded.blueprints[0].payload["data"] == [{"section": "intro"}]
+    assert loaded.blueprints[0].payload["rows"] == [{"section": "proof"}]
+    assert loaded.warnings == ()
+
+
 def test_load_blog_blueprints_rejects_ambiguous_extension(tmp_path: Path) -> None:
     path = tmp_path / "blueprints.txt"
     path.write_text("[]", encoding="utf-8")

--- a/tests/test_extracted_blog_blueprint_ingest.py
+++ b/tests/test_extracted_blog_blueprint_ingest.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.blog_blueprint_ingest import (
+    load_blog_blueprints_from_file,
+    normalize_blog_blueprint_rows,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/load_extracted_blog_blueprints.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "load_extracted_blog_blueprints",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[str] = []
+        self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.closed = False
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append((str(query), args))
+        return self.fetchval_results.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+def test_load_blog_blueprints_from_json_payload_normalizes_rows(tmp_path: Path) -> None:
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps({
+            "blueprints": [
+                {
+                    "target_mode": "vendor_retention",
+                    "topic_type": "pricing_pressure",
+                    "title": "Acme pricing pressure",
+                    "sections": [{"id": "intro"}],
+                    "tags": ["pricing"],
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_blog_blueprints_from_file(path)
+
+    assert loaded.source == str(path)
+    assert loaded.warnings == ()
+    blueprint = loaded.blueprints[0]
+    assert blueprint.target_mode == "vendor_retention"
+    assert blueprint.topic_type == "pricing_pressure"
+    assert blueprint.slug == "acme-pricing-pressure"
+    assert blueprint.suggested_title == "Acme pricing pressure"
+    assert blueprint.payload["sections"] == [{"id": "intro"}]
+    assert "title" not in blueprint.payload
+
+
+def test_normalize_blog_blueprint_rows_applies_defaults_and_skips_bad_rows() -> None:
+    loaded = normalize_blog_blueprint_rows(
+        [
+            {"title": "Renewal story", "topic_type": "renewal"},
+            {"slug": "missing-mode"},
+            "bad-row",
+        ],
+        target_mode="vendor_retention",
+    )
+
+    assert len(loaded.blueprints) == 2
+    assert loaded.blueprints[0].target_mode == "vendor_retention"
+    assert loaded.blueprints[0].topic_type == "renewal"
+    assert loaded.blueprints[1].slug == "missing-mode"
+    assert loaded.warnings[-1].code == "row_not_object"
+    assert loaded.warnings[-1].row_index == 3
+
+
+def test_normalize_blog_blueprint_rows_skips_missing_target_mode() -> None:
+    loaded = normalize_blog_blueprint_rows([{"title": "No mode"}])
+
+    assert loaded.blueprints == ()
+    assert loaded.warnings[0].code == "missing_target_mode"
+    assert loaded.warnings[0].field == "target_mode"
+
+
+@pytest.mark.asyncio
+async def test_blog_blueprint_import_cli_dry_run_outputs_json(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps([{"title": "Pricing story"}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "load",
+            str(path),
+            "--account-id",
+            "acct_1",
+            "--target-mode",
+            "vendor_retention",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["dry_run"] is True
+    assert output["loaded"] == 1
+    assert output["saved"] == 0
+    assert output["account_id"] == "acct_1"
+
+
+@pytest.mark.asyncio
+async def test_blog_blueprint_import_cli_requires_database_url(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps([{"title": "Pricing story", "target_mode": "vendor_retention"}]),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(cli.sys, "argv", ["load", str(path), "--account-id", "acct_1"])
+
+    with pytest.raises(SystemExit, match="Missing --database-url"):
+        await cli._main()
+
+
+@pytest.mark.asyncio
+async def test_blog_blueprint_import_cli_wires_pool_and_closes(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    cli = _load_cli_module()
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps([{"title": "Pricing story", "target_mode": "vendor_retention"}]),
+        encoding="utf-8",
+    )
+    pool = _Pool()
+    pool.fetchval_results = ["bp_1"]
+    created_urls: list[str] = []
+
+    async def create_pool(database_url):
+        created_urls.append(database_url)
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "load",
+            str(path),
+            "--account-id",
+            "acct_1",
+            "--database-url",
+            "postgres://example",
+            "--json",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert created_urls == ["postgres://example"]
+    assert pool.closed is True
+    assert output["saved"] == 1
+    assert output["saved_ids"] == ["bp_1"]
+    query, args = pool.fetchval_calls[0]
+    assert "INSERT INTO blog_blueprints" in query
+    assert args[0] == "acct_1"
+    assert args[1] == "vendor_retention"

--- a/tests/test_extracted_blog_blueprint_ingest.py
+++ b/tests/test_extracted_blog_blueprint_ingest.py
@@ -126,6 +126,34 @@ def test_load_blog_blueprints_prefers_explicit_blueprints_wrapper(tmp_path: Path
     assert len(loaded.blueprints) == 1
     assert loaded.blueprints[0].slug == "wrapped-blueprint"
     assert loaded.blueprints[0].target_mode == "vendor_retention"
+    assert loaded.blueprints[0].topic_type == "pricing"
+    assert loaded.warnings == ()
+
+
+def test_load_blog_blueprints_applies_wrapper_defaults_to_child_rows(tmp_path: Path) -> None:
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps({
+            "target_mode": "vendor_retention",
+            "topic_type": "pricing",
+            "blueprints": [
+                {"title": "Defaulted blueprint"},
+                {"title": "Custom blueprint", "topic_type": "migration"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_blog_blueprints_from_file(path)
+
+    assert [blueprint.target_mode for blueprint in loaded.blueprints] == [
+        "vendor_retention",
+        "vendor_retention",
+    ]
+    assert [blueprint.topic_type for blueprint in loaded.blueprints] == [
+        "pricing",
+        "migration",
+    ]
     assert loaded.warnings == ()
 
 


### PR DESCRIPTION
@claude review

## Summary
- add product-owned JSON loader for blog blueprints
- add host-facing CLI to dry-run or save blueprints through PostgresBlogBlueprintRepository
- document the host install path and wire the new tests into extracted checks

## Verification
- python -m py_compile extracted_content_pipeline/blog_blueprint_ingest.py scripts/load_extracted_blog_blueprints.py tests/test_extracted_blog_blueprint_ingest.py
- python -m pytest tests/test_extracted_blog_blueprint_ingest.py tests/test_extracted_blog_blueprint_postgres.py tests/test_extracted_blog_generation.py
- bash scripts/local_pr_review.sh

## Plan
- plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md