### PR TITLE
Add Content Ops intervention reasoning provider

### DIFF
--- a/atlas_brain/_content_ops_reasoning.py
+++ b/atlas_brain/_content_ops_reasoning.py
@@ -37,10 +37,11 @@ the heavy ``atlas_brain.services`` import chain (same pattern as
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping, Sequence
 
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,10 @@ logger = logging.getLogger(__name__)
 
 _ENV_VAR = "ATLAS_CONTENT_OPS_REASONING_CONTEXT_PATH"
 _DB_ENV_VAR = "ATLAS_CONTENT_OPS_REASONING_DB_ENABLED"
+_INTERVENTION_ENV_VAR = "ATLAS_CONTENT_OPS_REASONING_INTERVENTION_ENABLED"
+_INTERVENTION_REPORT_TABLE = "intelligence_reports"
+_INTERVENTION_REPORT_TYPE = "intervention"
+_INTERVENTION_SUMMARY_LIMIT = 1200
 
 
 def build_content_ops_reasoning_context_provider(
@@ -182,19 +187,124 @@ def build_postgres_content_ops_reasoning_context_provider(
         return None
 
 
+def build_intervention_content_ops_reasoning_context_provider(
+    *,
+    enabled_factory: Callable[[], bool] | None = None,
+    pool_factory: Callable[[], Any] | None = None,
+    provider_factory: Callable[[Any], Any] | None = None,
+) -> Any | None:
+    """Return an Atlas intervention-report reasoning provider.
+
+    Hosts opt in by setting
+    ``ATLAS_CONTENT_OPS_REASONING_INTERVENTION_ENABLED`` to a truthy
+    value. The provider reads already-persisted
+    ``intelligence_reports`` rows with ``report_type='intervention'``
+    and normalizes them into the same campaign reasoning context port
+    used by file and DB providers.
+
+    A missing or uninitialized pool resolves to ``None`` with WARN so
+    the chooser can fall back to the file provider. This factory does
+    not run the intervention pipeline; it only consumes completed rows.
+    """
+
+    if not (enabled_factory or _read_intervention_enabled)():
+        return None
+
+    try:
+        pool = (pool_factory or _default_pool_factory)()
+    except Exception as exc:
+        logger.warning(
+            "Content Ops intervention reasoning pool acquire failed: %s; "
+            "intervention provider stays unwired.",
+            exc,
+        )
+        return None
+    if pool is None:
+        logger.warning(
+            "Content Ops intervention reasoning enabled but pool is not "
+            "available; intervention provider stays unwired.",
+        )
+        return None
+    if not getattr(pool, "is_initialized", True):
+        logger.warning(
+            "Content Ops intervention reasoning enabled but pool is not "
+            "initialized yet; intervention provider stays unwired.",
+        )
+        return None
+
+    factory = provider_factory or InterventionReportCampaignReasoningProvider
+    try:
+        return factory(pool)
+    except Exception as exc:
+        logger.warning(
+            "Failed to construct Content Ops intervention reasoning "
+            "provider: %s; intervention provider stays unwired.",
+            exc,
+        )
+        return None
+
+
+class InterventionReportCampaignReasoningProvider:
+    """Campaign reasoning provider backed by Atlas intervention reports."""
+
+    def __init__(self, pool: Any) -> None:
+        self.pool = pool
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: Any,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> Any | None:
+        """Return normalized reasoning from the latest matching report."""
+
+        del scope
+        del target_mode
+        selectors = _intervention_candidate_selectors(
+            target_id=target_id,
+            opportunity=opportunity,
+        )
+        if not selectors:
+            return None
+
+        row = await self.pool.fetchrow(
+            f"""
+            SELECT id, entity_name, entity_type, report_type,
+                   time_window_days, report_text, structured_data,
+                   pressure_snapshot, requested_by, created_at
+            FROM {_INTERVENTION_REPORT_TABLE}
+            WHERE report_type = $1
+              AND lower(entity_name) = ANY($2::text[])
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            _INTERVENTION_REPORT_TYPE,
+            list(selectors),
+        )
+        if row is None:
+            return None
+        context = _intervention_report_to_campaign_context(_row_to_dict(row))
+        return context if context.has_content() else None
+
+
 def select_content_ops_reasoning_context_provider(
     *,
     db_factory: Callable[[], Any | None] | None = None,
+    intervention_factory: Callable[[], Any | None] | None = None,
     file_factory: Callable[[], Any | None] | None = None,
 ) -> Any | None:
-    """Pick the configured reasoning provider (DB > file > None).
+    """Pick the configured reasoning provider (DB > intervention > file > None).
 
     The route mount passes this chooser as the
-    ``reasoning_context_provider`` kwarg. DB takes precedence
-    because it scales per-tenant; the file-backed adapter stays
-    available as a single-tenant / staging fallback. ``None``
-    means no provider is configured -- the bundle's existing
-    ``with_reasoning_context()`` derivation already handles that.
+    ``reasoning_context_provider`` kwarg. DB takes precedence because
+    explicit campaign context rows are tenant-scoped and product-owned.
+    Intervention output is the Atlas-native automatic fallback. The
+    file-backed adapter stays available as a single-tenant / staging
+    fallback. ``None`` means no provider is configured -- the bundle's
+    existing ``with_reasoning_context()`` derivation already handles
+    that.
 
     Both factories own their own WARN-and-fall-back behavior so
     the chooser stays trivial -- failing factories return
@@ -204,12 +314,18 @@ def select_content_ops_reasoning_context_provider(
     db_pick = (db_factory or build_postgres_content_ops_reasoning_context_provider)()
     if db_pick is not None:
         return db_pick
+    intervention_pick = (
+        intervention_factory or build_intervention_content_ops_reasoning_context_provider
+    )()
+    if intervention_pick is not None:
+        return intervention_pick
     return (file_factory or build_content_ops_reasoning_context_provider)()
 
 
 def describe_content_ops_reasoning_context_provider(
     *,
     db_factory: Callable[[], Any | None] | None = None,
+    intervention_factory: Callable[[], Any | None] | None = None,
     file_factory: Callable[[], Any | None] | None = None,
 ) -> dict[str, Any]:
     """Return the catalog-safe reasoning provider readiness.
@@ -224,6 +340,12 @@ def describe_content_ops_reasoning_context_provider(
     if db_pick is not None:
         return {"configured": True, "source": "db"}
 
+    intervention_pick = (
+        intervention_factory or build_intervention_content_ops_reasoning_context_provider
+    )()
+    if intervention_pick is not None:
+        return {"configured": True, "source": "intervention"}
+
     file_pick = (file_factory or build_content_ops_reasoning_context_provider)()
     if file_pick is not None:
         return {"configured": True, "source": "file"}
@@ -237,6 +359,167 @@ def _read_db_enabled() -> bool:
 
     value = os.environ.get(_DB_ENV_VAR, "").strip().lower()
     return value in {"true", "1", "yes", "on"}
+
+
+def _read_intervention_enabled() -> bool:
+    """Parse the intervention opt-in env var."""
+
+    value = os.environ.get(_INTERVENTION_ENV_VAR, "").strip().lower()
+    return value in {"true", "1", "yes", "on"}
+
+
+def _intervention_candidate_selectors(
+    *,
+    target_id: str,
+    opportunity: Mapping[str, Any],
+) -> tuple[str, ...]:
+    values = [
+        target_id,
+        opportunity.get("target_id"),
+        opportunity.get("id"),
+        opportunity.get("company_name"),
+        opportunity.get("company"),
+        opportunity.get("account_name"),
+        opportunity.get("account"),
+        opportunity.get("vendor_name"),
+        opportunity.get("vendor"),
+    ]
+    seen: set[str] = set()
+    selectors: list[str] = []
+    for value in values:
+        text = str(value or "").strip().lower()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        selectors.append(text)
+    return tuple(selectors)
+
+
+def _intervention_report_to_campaign_context(row: Mapping[str, Any]) -> Any:
+    from extracted_content_pipeline.services.campaign_reasoning_context import (
+        normalize_campaign_reasoning_context,
+    )
+
+    structured = _json_mapping(row.get("structured_data"))
+    pressure = _json_mapping(row.get("pressure_snapshot"))
+    report_text = str(row.get("report_text") or "").strip()
+    entity_name = str(row.get("entity_name") or "").strip()
+    pipeline_id = str(structured.get("pipeline_id") or "").strip()
+    stages = _json_mapping(structured.get("stage_statuses"))
+    safety_warnings = _json_list(structured.get("safety_warnings"))
+
+    payload: dict[str, Any] = {
+        "reasoning_context": {
+            "wedge": "intervention",
+            "summary": _truncate(report_text, _INTERVENTION_SUMMARY_LIMIT),
+            "why_now": _intervention_why_now(row, safety_warnings),
+            "recommended_action": "Use the latest intervention analysis to shape content.",
+            "top_theses": _intervention_top_theses(entity_name, report_text),
+            "proof_points": _intervention_proof_points(stages, pressure),
+            "coverage_limits": safety_warnings,
+            "reference_ids": _intervention_reference_ids(row, pipeline_id),
+            "scope_summary": {
+                "selection_strategy": "atlas_intervention_report",
+                "entity_name": entity_name,
+                "entity_type": row.get("entity_type"),
+                "report_type": row.get("report_type"),
+                "time_window_days": row.get("time_window_days"),
+                "created_at": str(row.get("created_at") or ""),
+                "requested_by": row.get("requested_by"),
+                "stages_completed": structured.get("stages_completed"),
+                "stages_total": structured.get("stages_total"),
+            },
+        }
+    }
+    return normalize_campaign_reasoning_context(payload)
+
+
+def _intervention_top_theses(
+    entity_name: str,
+    report_text: str,
+) -> list[dict[str, Any]]:
+    if not report_text:
+        return []
+    return [{
+        "claim": f"Latest intervention analysis for {entity_name or 'target'}",
+        "summary": _truncate(report_text, _INTERVENTION_SUMMARY_LIMIT),
+        "confidence": "medium",
+    }]
+
+
+def _intervention_proof_points(
+    stages: Mapping[str, Any],
+    pressure: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    points: list[dict[str, Any]] = []
+    for stage, status in stages.items():
+        if status in (None, "", [], {}):
+            continue
+        points.append({
+            "label": f"{stage} status",
+            "value": status,
+            "interpretation": "Intervention pipeline stage state.",
+        })
+    score = pressure.get("pressure_score")
+    if score not in (None, "", [], {}):
+        points.append({
+            "label": "pressure_score",
+            "value": score,
+            "interpretation": "Pressure snapshot at intervention generation time.",
+        })
+    return points
+
+
+def _intervention_reference_ids(
+    row: Mapping[str, Any],
+    pipeline_id: str,
+) -> dict[str, list[str]]:
+    refs: dict[str, list[str]] = {}
+    report_id = str(row.get("id") or "").strip()
+    if report_id:
+        refs["intelligence_reports"] = [report_id]
+    if pipeline_id:
+        refs["intervention_pipeline"] = [pipeline_id]
+    return refs
+
+
+def _intervention_why_now(
+    row: Mapping[str, Any],
+    safety_warnings: Sequence[Any],
+) -> str:
+    if safety_warnings:
+        return str(safety_warnings[0])
+    created_at = str(row.get("created_at") or "").strip()
+    if created_at:
+        return f"Latest intervention report created at {created_at}."
+    return "Latest intervention report matched this Content Ops target."
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _json_list(value: Any) -> list[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [item for item in value if item not in (None, "", [], {})]
+    return []
+
+
+def _truncate(value: str, limit: int) -> str:
+    text = str(value or "").strip()
+    return text[:limit]
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    return dict(row)
 
 
 def _default_pool_factory() -> Any:
@@ -269,7 +552,9 @@ def _default_repository_factory(pool: Any) -> Any:
 
 
 __all__ = [
+    "InterventionReportCampaignReasoningProvider",
     "build_content_ops_reasoning_context_provider",
+    "build_intervention_content_ops_reasoning_context_provider",
     "build_postgres_content_ops_reasoning_context_provider",
     "describe_content_ops_reasoning_context_provider",
     "select_content_ops_reasoning_context_provider",

--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -26,40 +26,12 @@ The following items appear in older plan docs but are no longer active backlog:
 - Generated asset export and review paths for report, blog post, landing page,
   and sales brief drafts.
 - `blog_post` reasoning catalog/fixture parity.
+- Live execute persistence smoke for all generated assets.
+- Blog blueprint population path.
 
 ## Active Backlog
 
-### 1. Live execute persistence smoke for all generated assets
-
-**Priority:** P0
-
-**Why:** This is the strongest operational proof that AI Content Ops is usable
-outside Atlas. Existing tests cover bundles, route boundaries, offline smokes,
-and provider contracts, but there is still no single live smoke proving:
-
-1. `POST /content-ops/execute` enters the hosted route.
-2. Tenant scope is applied.
-3. Host adapters are used.
-4. Each LLM-backed output persists a real draft.
-5. The response reports generated ids, reasoning usage, and failures correctly.
-
-**Likely slice:** one PR with a focused route-level smoke for the smallest
-fixture set, then expand asset-by-asset if the first version gets too large.
-
-### 2. Blog blueprint population path
-
-**Priority:** P1
-
-**Why:** Blog execution is wired, but the sellable blog path needs a reliable
-way to populate `blog_blueprints`. Older storage work intentionally deferred
-the host autonomous task or ETL that writes blueprints. Without this, blog
-generation can be technically wired while still depending on pre-seeded rows.
-
-**Likely slice:** define the host-side blueprint ingestion/population seam and
-add one CLI or task adapter that writes `PostBlueprint` rows through the
-product-owned repository.
-
-### 3. Intervention or autonomous reasoning provider
+### 1. Intervention or autonomous reasoning provider
 
 **Priority:** P1
 
@@ -72,7 +44,7 @@ layer that content products can consume.
 `intelligence/autonomous_narrative_architect` or equivalent intervention output
 and normalizes it into the existing `CampaignReasoningContextProvider` port.
 
-### 4. DB reasoning provider hardening
+### 2. DB reasoning provider hardening
 
 **Priority:** P2
 
@@ -88,7 +60,7 @@ polish:
 **Likely slice:** start with per-target-mode filtering and settings integration;
 defer admin UI until the storage semantics are stable.
 
-### 5. Full reasoning context drawer/detail UX
+### 3. Full reasoning context drawer/detail UX
 
 **Priority:** P2
 
@@ -101,7 +73,7 @@ contract is already inspectable at a compact level.
 payload first. Do not add a new backend shape unless the current bounded
 payload is insufficient.
 
-### 6. Operator review UX and richer result previews
+### 4. Operator review UX and richer result previews
 
 **Priority:** P3
 
@@ -114,7 +86,6 @@ because batch review improves operator throughput across all asset types.
 
 ## Current Pick Recommendation
 
-Take item 1 next: live execute persistence smoke. It proves the standalone
-product works end-to-end through the same route and adapter seams customers
-would use. If that smoke exposes setup friction, fix the friction before adding
-more UI surface.
+Take item 1 next: intervention/autonomous reasoning provider. It bridges the
+separate Atlas reasoning layer into the already-shipped Content Ops provider
+port without coupling the extracted package back to Atlas internals.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-14T18:55Z by codex-2026-05-14-blog-blueprint-ingestion
+Last updated: 2026-05-14T19:35Z by codex-2026-05-14-content-ops-intervention-reasoning
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops blog blueprint ingestion CLI | NEW: `plans/PR-Content-Ops-Blog-Blueprint-Ingestion.md`; `extracted_content_pipeline/blog_blueprint_ingest.py`; `scripts/load_extracted_blog_blueprints.py`; `tests/test_extracted_blog_blueprint_ingest.py`. EDIT: `scripts/run_extracted_pipeline_checks.sh`; `extracted_content_pipeline/manifest.json`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/docs/standalone_productization.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-blog-blueprint-ingestion | reasoning-provider backlog slices; frontend Content Ops UI slices |
+| (in flight) | Add Content Ops intervention reasoning provider | NEW: `plans/PR-Content-Ops-Intervention-Reasoning-Provider.md`. EDIT: `atlas_brain/_content_ops_reasoning.py`; `tests/test_atlas_content_ops_reasoning.py`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-content-ops-intervention-reasoning | frontend Content Ops UI slices; extracted reasoning core slices |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Intervention-Reasoning-Provider.md
+++ b/plans/PR-Content-Ops-Intervention-Reasoning-Provider.md
@@ -1,0 +1,89 @@
+# PR: Content Ops Intervention Reasoning Provider
+
+## Why this slice exists
+
+The AI Content Ops deferred backlog now has the live persistence smoke and blog
+blueprint ingestion path closed. The next P1 gap is the reasoning bridge:
+file-backed and DB-backed reasoning providers work, but Atlas intervention output
+is still not consumable by Content Ops unless another process copies it into a
+campaign reasoning file or table.
+
+This PR adds the smallest host-side bridge from persisted Atlas intervention
+reports into the existing `CampaignReasoningContextProvider` port. It keeps the
+extracted package decoupled from Atlas and makes the provider opt-in so existing
+installs keep their current DB/file behavior.
+
+## Scope
+
+1. Add an opt-in intervention-report provider factory in
+   `atlas_brain/_content_ops_reasoning.py`.
+2. Read the latest `intelligence_reports` row with `report_type='intervention'`
+   matching the request's target/company/vendor selectors.
+3. Normalize that row into the existing campaign reasoning context shape.
+4. Extend provider selection/status to include `intervention` between DB and
+   file fallback.
+5. Update tests and coordination docs for the new slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Intervention-Reasoning-Provider.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `atlas_brain/_content_ops_reasoning.py`
+- `tests/test_atlas_content_ops_reasoning.py`
+
+## Mechanism
+
+Operators opt in with `ATLAS_CONTENT_OPS_REASONING_INTERVENTION_ENABLED=true`.
+The factory binds to the host asyncpg pool, like the existing DB provider, and
+returns a lightweight provider object. On each `read_campaign_reasoning_context`
+call it builds the same target/company/vendor selector set used by the file and
+DB providers, finds the newest matching intervention report by lower-cased
+`entity_name`, and converts `report_text`, `structured_data`, and
+`pressure_snapshot` into canonical reasoning, top theses, proof points, reference
+ids, and scope summary.
+
+Provider chooser priority becomes `DB > intervention > file > none`: explicit
+campaign reasoning rows stay authoritative, intervention output becomes the
+Atlas-native automatic fallback, and file remains the staging/manual fallback.
+
+## Intentional
+
+- This is host-side only. `extracted_content_pipeline` does not import Atlas or
+  know about intervention reports.
+- The provider is opt-in. Existing installs with only DB/file providers keep the
+  same behavior.
+- The provider reads `intelligence_reports`, which is currently global Atlas
+  storage. This is suitable for Atlas-hosted internal deployments. Tenant-owned
+  intervention storage remains a later hardening slice if the table gets an
+  `account_id` or equivalent ownership column.
+- It does not run the intervention pipeline. It only consumes already-persisted
+  reports.
+
+## Deferred
+
+- Tenant-owned intervention storage / account-scoped `intelligence_reports`.
+- Admin UI for choosing which intervention report feeds a Content Ops run.
+- Writing intervention outputs into `campaign_reasoning_contexts` as durable
+  per-account rows.
+- Richer parsing of stage text into structured content recommendations.
+
+## Verification
+
+- Focused reasoning tests passed: 26 tests.
+- Python compile check passed for the touched production and test modules.
+- Diff whitespace check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Production provider and chooser updates | ~300 |
+| Tests | ~170 |
+| Plan and coordination docs | ~130 |
+| **Total** | **~600** |
+
+This is over the soft 400 LOC target because the provider is a new host adapter
+plus tests for factory behavior, selector reads, chooser priority, and status
+reporting. The production change stays in one existing host seam; no extracted
+package code is touched.

--- a/tests/test_atlas_content_ops_reasoning.py
+++ b/tests/test_atlas_content_ops_reasoning.py
@@ -30,19 +30,35 @@ DB-backed factory (this slice, 4 tests):
 11. Repository factory exception resolves to `None` with WARN
     (defensive against an upstream init bug).
 
-Chooser (3 tests):
+Intervention-report factory (7 tests):
 
-12. DB > file > `None` priority: when DB factory returns a
+12. Env var unset returns `None`.
+13. Env var set + pool present returns whatever the provider
+    factory produces.
+14. Env var set but pool factory returns `None` returns `None`
+    with WARN.
+15. Env var set but pool is uninitialized returns `None` with
+    WARN.
+16. Provider factory exception resolves to `None` with WARN.
+17. Matching report normalizes into campaign reasoning context.
+18. Missing selectors return `None`.
+
+Chooser (4 tests):
+
+19. DB > file > `None` priority: when DB factory returns a
     provider, the file factory is never called.
-13. DB returns `None`, file factory returns a provider --
+20. DB returns `None`, file factory returns a provider --
     chooser returns the file provider.
-14. Both factories return `None` -- chooser returns `None`.
+21. DB returns `None`, intervention returns a provider --
+    chooser returns the intervention provider before file.
+22. All factories return `None` -- chooser returns `None`.
 
-Status (3 tests):
+Status (4 tests):
 
-15. DB provider reports configured with source=db.
-16. File fallback reports configured with source=file.
-17. Neither provider reports configured=false with source=none.
+23. DB provider reports configured with source=db.
+24. Intervention fallback reports configured with source=intervention.
+25. File fallback reports configured with source=file.
+26. Neither provider reports configured=false with source=none.
 """
 
 from __future__ import annotations
@@ -53,11 +69,14 @@ from typing import Any
 import pytest
 
 from atlas_brain._content_ops_reasoning import (
+    InterventionReportCampaignReasoningProvider,
     build_content_ops_reasoning_context_provider,
+    build_intervention_content_ops_reasoning_context_provider,
     build_postgres_content_ops_reasoning_context_provider,
     describe_content_ops_reasoning_context_provider,
     select_content_ops_reasoning_context_provider,
 )
+from extracted_content_pipeline.campaign_ports import TenantScope
 
 
 def test_env_var_unset_returns_none() -> None:
@@ -273,6 +292,148 @@ def test_db_factory_repository_exception_returns_none_and_warns(
     assert any("Failed to construct" in rec.message for rec in caplog.records)
 
 
+# ---------- Intervention-report factory --------------------------------------
+
+
+def test_intervention_factory_disabled_returns_none() -> None:
+    provider = build_intervention_content_ops_reasoning_context_provider(
+        enabled_factory=lambda: False,
+    )
+    assert provider is None
+
+
+def test_intervention_factory_enabled_returns_provider() -> None:
+    sentinel = object()
+
+    provider = build_intervention_content_ops_reasoning_context_provider(
+        enabled_factory=lambda: True,
+        pool_factory=lambda: "fake-pool",
+        provider_factory=lambda pool: sentinel,
+    )
+
+    assert provider is sentinel
+
+
+def test_intervention_factory_missing_pool_returns_none_and_warns(
+    caplog: Any,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="atlas_brain._content_ops_reasoning")
+
+    provider = build_intervention_content_ops_reasoning_context_provider(
+        enabled_factory=lambda: True,
+        pool_factory=lambda: None,
+    )
+
+    assert provider is None
+    assert any("pool is not" in rec.message for rec in caplog.records)
+
+
+def test_intervention_factory_uninitialized_pool_returns_none_and_warns(
+    caplog: Any,
+) -> None:
+    class _UninitializedPool:
+        is_initialized = False
+
+    caplog.set_level(logging.WARNING, logger="atlas_brain._content_ops_reasoning")
+
+    provider = build_intervention_content_ops_reasoning_context_provider(
+        enabled_factory=lambda: True,
+        pool_factory=lambda: _UninitializedPool(),
+    )
+
+    assert provider is None
+    assert any("not initialized" in rec.message for rec in caplog.records)
+
+
+def test_intervention_factory_provider_exception_returns_none_and_warns(
+    caplog: Any,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="atlas_brain._content_ops_reasoning")
+
+    def _raise(_pool: Any) -> object:
+        raise RuntimeError("boom")
+
+    provider = build_intervention_content_ops_reasoning_context_provider(
+        enabled_factory=lambda: True,
+        pool_factory=lambda: "fake-pool",
+        provider_factory=_raise,
+    )
+
+    assert provider is None
+    assert any("Failed to construct" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_intervention_provider_reads_matching_report_as_reasoning_context() -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.args: tuple[Any, ...] | None = None
+
+        async def fetchrow(self, query: str, *args: Any) -> dict[str, Any]:
+            self.args = args
+            assert "FROM intelligence_reports" in query
+            return {
+                "id": "report-1",
+                "entity_name": "Acme",
+                "entity_type": "company",
+                "report_type": "intervention",
+                "time_window_days": 7,
+                "report_text": "Use a proof-led migration narrative.",
+                "structured_data": {
+                    "pipeline_id": "pipe-1",
+                    "stages_completed": 2,
+                    "stages_total": 3,
+                    "stage_statuses": {
+                        "playbook": "completed",
+                    },
+                    "safety_warnings": ["Narrative stage requires approval."],
+                },
+                "pressure_snapshot": {"pressure_score": 7},
+                "requested_by": "api",
+                "created_at": "2026-05-14T19:00:00Z",
+            }
+
+    pool = _Pool()
+    provider = InterventionReportCampaignReasoningProvider(pool)
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(account_id="acct-1"),
+        target_id="target-1",
+        target_mode="vendor_retention",
+        opportunity={"company_name": "Acme"},
+    )
+
+    assert context is not None
+    assert pool.args is not None
+    assert pool.args[0] == "intervention"
+    assert "acme" in pool.args[1]
+    assert context.canonical_reasoning["wedge"] == "intervention"
+    assert context.top_theses[0]["claim"] == "Latest intervention analysis for Acme"
+    assert context.proof_points[0]["label"] == "playbook status"
+    assert context.proof_points[-1]["label"] == "pressure_score"
+    assert context.reference_ids["intelligence_reports"] == ("report-1",)
+    assert context.reference_ids["intervention_pipeline"] == ("pipe-1",)
+    assert context.coverage_limits == ("Narrative stage requires approval.",)
+
+
+@pytest.mark.asyncio
+async def test_intervention_provider_returns_none_without_selector_match() -> None:
+    class _Pool:
+        async def fetchrow(self, _query: str, *_args: Any) -> None:
+            return None
+
+    provider = InterventionReportCampaignReasoningProvider(_Pool())
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(account_id="acct-1"),
+        target_id="",
+        target_mode="vendor_retention",
+        opportunity={"company_name": ""},
+    )
+
+    assert context is None
+
+
 # ---------- Chooser ----------------------------------------------------------
 
 
@@ -289,6 +450,7 @@ def test_chooser_prefers_db_provider() -> None:
 
     provider = select_content_ops_reasoning_context_provider(
         db_factory=lambda: db_sentinel,
+        intervention_factory=lambda: "intervention-provider",
         file_factory=_file_factory,
     )
 
@@ -304,10 +466,29 @@ def test_chooser_falls_back_to_file_when_db_none() -> None:
 
     provider = select_content_ops_reasoning_context_provider(
         db_factory=lambda: None,
+        intervention_factory=lambda: None,
         file_factory=lambda: file_sentinel,
     )
 
     assert provider is file_sentinel
+
+
+def test_chooser_uses_intervention_before_file() -> None:
+    file_called = {"hit": False}
+    intervention_sentinel = object()
+
+    def _file_factory() -> Any:
+        file_called["hit"] = True
+        return "file-provider"
+
+    provider = select_content_ops_reasoning_context_provider(
+        db_factory=lambda: None,
+        intervention_factory=lambda: intervention_sentinel,
+        file_factory=_file_factory,
+    )
+
+    assert provider is intervention_sentinel
+    assert file_called["hit"] is False
 
 
 def test_chooser_returns_none_when_neither_configured() -> None:
@@ -317,6 +498,7 @@ def test_chooser_returns_none_when_neither_configured() -> None:
 
     provider = select_content_ops_reasoning_context_provider(
         db_factory=lambda: None,
+        intervention_factory=lambda: None,
         file_factory=lambda: None,
     )
 
@@ -335,6 +517,7 @@ def test_reasoning_status_reports_db_provider() -> None:
 
     status = describe_content_ops_reasoning_context_provider(
         db_factory=lambda: object(),
+        intervention_factory=lambda: "intervention-provider",
         file_factory=_file_factory,
     )
 
@@ -345,15 +528,34 @@ def test_reasoning_status_reports_db_provider() -> None:
 def test_reasoning_status_reports_file_fallback() -> None:
     status = describe_content_ops_reasoning_context_provider(
         db_factory=lambda: None,
+        intervention_factory=lambda: None,
         file_factory=lambda: object(),
     )
 
     assert status == {"configured": True, "source": "file"}
 
 
+def test_reasoning_status_reports_intervention_provider() -> None:
+    file_called = {"hit": False}
+
+    def _file_factory() -> Any:
+        file_called["hit"] = True
+        return "file-provider"
+
+    status = describe_content_ops_reasoning_context_provider(
+        db_factory=lambda: None,
+        intervention_factory=lambda: object(),
+        file_factory=_file_factory,
+    )
+
+    assert status == {"configured": True, "source": "intervention"}
+    assert file_called["hit"] is False
+
+
 def test_reasoning_status_reports_none_when_unconfigured() -> None:
     status = describe_content_ops_reasoning_context_provider(
         db_factory=lambda: None,
+        intervention_factory=lambda: None,
         file_factory=lambda: None,
     )
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Intervention-Reasoning-Provider.md

Adds an opt-in Atlas-side intervention report provider for Content Ops reasoning context.

## Intentional
- Host-side only; no extracted package Atlas import.
- DB provider remains authoritative; intervention is fallback before file.
- Consumes persisted intervention reports only.

## Deferred
- Tenant-owned intervention report storage/account scoping.
- Admin selection UI.
- Writing intervention reports into campaign_reasoning_contexts.
- Richer stage parsing.

## Verification
- Focused reasoning tests: 26 passed.
- Py compile: passed for touched Python files.
- Diff check: passed.
- Local PR review: passed.

## Diff size
5 files, 560 insertions, 47 deletions.