### PR TITLE
Add Content Ops reasoning detail UI

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1043,18 +1043,33 @@ function ReasoningContextList({
   return (
     <div className="basis-full space-y-1 pt-1">
       {contexts.slice(0, 3).map((context, index) => (
-        <div
+        <details
           key={index}
-          className="rounded border border-emerald-500/20 bg-slate-950/50 px-2 py-1 text-[11px] text-emerald-100"
+          className="group rounded border border-emerald-500/20 bg-slate-950/50 px-2 py-1 text-[11px] text-emerald-100"
         >
-          <div className="font-medium">
-            {context.summary || `Reasoning context ${index + 1}`}
-          </div>
-          <div className="mt-0.5 text-emerald-200/70">
-            theses {context.topTheses?.length ?? 0} · proof points{' '}
-            {context.proofPoints?.length ?? 0}
-          </div>
-        </div>
+          <summary className="cursor-pointer list-none">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 gap-2">
+                <ChevronRight className="mt-0.5 h-3 w-3 shrink-0 text-emerald-200/60 transition-transform group-open:rotate-90" />
+                <div>
+                  <div className="font-medium">
+                    {context.summary || `Reasoning context ${index + 1}`}
+                  </div>
+                  <div className="mt-0.5 text-emerald-200/70">
+                    {reasoningContextCounts(context).join(' · ')}
+                  </div>
+                </div>
+              </div>
+              <span className="shrink-0 text-[10px] uppercase tracking-wide text-emerald-200/60 group-open:hidden">
+                Details
+              </span>
+              <span className="hidden shrink-0 text-[10px] uppercase tracking-wide text-emerald-200/60 group-open:inline">
+                Hide
+              </span>
+            </div>
+          </summary>
+          <ReasoningContextDetails context={context} />
+        </details>
       ))}
       {contexts.length > 3 && (
         <div className="text-[11px] text-emerald-200/70">
@@ -1063,6 +1078,242 @@ function ReasoningContextList({
       )}
     </div>
   )
+}
+
+function ReasoningContextDetails({
+  context,
+}: {
+  context: CampaignReasoningContextView
+}) {
+  const hasDetails =
+    hasItems(context.topTheses) ||
+    hasItems(context.proofPoints) ||
+    hasAnchorExamples(context.anchorExamples) ||
+    hasItems(context.witnessHighlights) ||
+    hasItems(context.accountSignals) ||
+    hasItems(context.timingWindows) ||
+    hasStringItems(context.coverageLimits) ||
+    hasObjectItems(context.referenceIds) ||
+    hasObjectItems(context.scopeSummary) ||
+    hasObjectItems(context.deltaSummary) ||
+    hasObjectItems(context.extra)
+
+  if (!hasDetails) {
+    return (
+      <div className="mt-2 border-t border-emerald-500/10 pt-2 text-emerald-200/70">
+        No structured reasoning detail returned.
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-2 space-y-2 border-t border-emerald-500/10 pt-2">
+      <ReasoningObjectList label="Top theses" rows={context.topTheses} />
+      <ReasoningObjectList label="Proof points" rows={context.proofPoints} />
+      <ReasoningAnchorExamples anchorExamples={context.anchorExamples} />
+      <ReasoningObjectList label="Witness highlights" rows={context.witnessHighlights} />
+      <ReasoningObjectList label="Account signals" rows={context.accountSignals} />
+      <ReasoningObjectList label="Timing windows" rows={context.timingWindows} />
+      <ReasoningReferenceIds referenceIds={context.referenceIds} />
+      <ReasoningStringList label="Coverage limits" values={context.coverageLimits} />
+      <ReasoningKeyValueBlock label="Scope" value={context.scopeSummary} />
+      <ReasoningKeyValueBlock label="Delta" value={context.deltaSummary} />
+      <ReasoningKeyValueBlock label="Other" value={context.extra} />
+    </div>
+  )
+}
+
+function reasoningContextCounts(context: CampaignReasoningContextView): string[] {
+  const counts = [
+    { label: 'theses', count: context.topTheses?.length ?? 0 },
+    { label: 'proof points', count: context.proofPoints?.length ?? 0 },
+    { label: 'anchors', count: anchorExampleCount(context.anchorExamples) },
+    { label: 'witnesses', count: context.witnessHighlights?.length ?? 0 },
+    { label: 'account signals', count: context.accountSignals?.length ?? 0 },
+    { label: 'timing windows', count: context.timingWindows?.length ?? 0 },
+  ].filter(({ count }) => count > 0)
+
+  if (counts.length === 0) {
+    return ['no structured detail']
+  }
+  return counts.map(({ label, count }) => `${label} ${count}`)
+}
+
+function anchorExampleCount(
+  value?: Record<string, Array<Record<string, unknown>>>,
+): number {
+  if (!value) return 0
+  return Object.values(value).reduce((total, rows) => total + rows.length, 0)
+}
+
+function ReasoningAnchorExamples({
+  anchorExamples,
+}: {
+  anchorExamples?: Record<string, Array<Record<string, unknown>>>
+}) {
+  if (!hasAnchorExamples(anchorExamples)) return null
+  return (
+    <div>
+      <div className="mb-1 font-medium text-emerald-100">Anchor examples</div>
+      <div className="space-y-2">
+        {Object.entries(anchorExamples)
+          .filter(([, rows]) => rows.length > 0)
+          .map(([label, rows]) => (
+            <div key={label} className="space-y-1">
+              <ReasoningObjectList label={labelFromKey(label)} rows={rows} />
+            </div>
+          ))}
+      </div>
+    </div>
+  )
+}
+
+function ReasoningObjectList({
+  label,
+  rows,
+}: {
+  label: string
+  rows?: Array<Record<string, unknown>>
+}) {
+  if (!hasItems(rows)) return null
+  return (
+    <div>
+      <div className="mb-1 font-medium text-emerald-100">{label}</div>
+      <div className="space-y-1">
+        {rows.map((row, index) => (
+          <div
+            key={index}
+            className="rounded border border-slate-800/80 bg-slate-950/70 px-2 py-1 text-emerald-50/90"
+          >
+            {objectEntries(row).map(([key, value]) => (
+              <div key={key} className="grid gap-1 sm:grid-cols-[120px_1fr]">
+                <span className="text-emerald-200/60">{labelFromKey(key)}</span>
+                <span className="break-words text-emerald-50/90">
+                  {formatReasoningValue(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ReasoningReferenceIds({
+  referenceIds,
+}: {
+  referenceIds?: Record<string, string[]>
+}) {
+  if (!referenceIds || Object.keys(referenceIds).length === 0) return null
+  return (
+    <div>
+      <div className="mb-1 font-medium text-emerald-100">Reference ids</div>
+      <div className="space-y-1">
+        {Object.entries(referenceIds).map(([key, values]) => (
+          <div key={key} className="grid gap-1 sm:grid-cols-[120px_1fr]">
+            <span className="text-emerald-200/60">{labelFromKey(key)}</span>
+            <span className="break-words font-mono text-[10px] text-emerald-50/90">
+              {Array.isArray(values) ? values.join(', ') : ''}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ReasoningStringList({
+  label,
+  values,
+}: {
+  label: string
+  values?: string[]
+}) {
+  if (!hasStringItems(values)) return null
+  return (
+    <div>
+      <div className="mb-1 font-medium text-emerald-100">{label}</div>
+      <ul className="space-y-1">
+        {values.map((value, index) => (
+          <li
+            key={`${value}-${index}`}
+            className="rounded border border-slate-800/80 bg-slate-950/70 px-2 py-1 text-emerald-50/90"
+          >
+            {value}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function ReasoningKeyValueBlock({
+  label,
+  value,
+}: {
+  label: string
+  value?: Record<string, unknown>
+}) {
+  if (!value || Object.keys(value).length === 0) return null
+  return (
+    <div>
+      <div className="mb-1 font-medium text-emerald-100">{label}</div>
+      <div className="rounded border border-slate-800/80 bg-slate-950/70 px-2 py-1">
+        {objectEntries(value).map(([key, item]) => (
+          <div key={key} className="grid gap-1 sm:grid-cols-[120px_1fr]">
+            <span className="text-emerald-200/60">{labelFromKey(key)}</span>
+            <span className="break-words text-emerald-50/90">
+              {formatReasoningValue(item)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function hasItems(rows?: Array<Record<string, unknown>>): rows is Array<Record<string, unknown>> {
+  return Array.isArray(rows) && rows.length > 0
+}
+
+function hasStringItems(values?: string[]): values is string[] {
+  return Array.isArray(values) && values.length > 0
+}
+
+function hasAnchorExamples(
+  value?: Record<string, Array<Record<string, unknown>>>,
+): value is Record<string, Array<Record<string, unknown>>> {
+  return Boolean(value && Object.values(value).some((rows) => rows.length > 0))
+}
+
+function hasObjectItems(value?: Record<string, unknown> | Record<string, string[]>): boolean {
+  return Boolean(value && Object.keys(value).length > 0)
+}
+
+function objectEntries(value: Record<string, unknown>): Array<[string, unknown]> {
+  return Object.entries(value).filter(([, item]) => item !== null && item !== undefined)
+}
+
+function labelFromKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function formatReasoningValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  if (Array.isArray(value)) {
+    return value.map(formatReasoningValue).filter(Boolean).join(', ')
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
 }
 
 function SignalExtractionSummary({ result }: { result: Record<string, unknown> }) {

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-14T19:35Z by codex-2026-05-14-content-ops-intervention-reasoning
+Last updated: 2026-05-14T19:55Z by codex-2026-05-14-content-ops-reasoning-detail-ui
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops intervention reasoning provider | NEW: `plans/PR-Content-Ops-Intervention-Reasoning-Provider.md`. EDIT: `atlas_brain/_content_ops_reasoning.py`; `tests/test_atlas_content_ops_reasoning.py`; `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-content-ops-intervention-reasoning | frontend Content Ops UI slices; extracted reasoning core slices |
+| (in flight) | Add Content Ops reasoning detail UI | NEW: `plans/PR-Content-Ops-Reasoning-Detail-UI.md`. EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-content-ops-reasoning-detail-ui | reasoning-provider backlog slices |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Reasoning-Detail-UI.md
+++ b/plans/PR-Content-Ops-Reasoning-Detail-UI.md
@@ -1,0 +1,75 @@
+# PR: Content Ops Reasoning Detail UI
+
+## Why this slice exists
+
+AI Content Ops execution responses already carry bounded
+`reasoning.consumed_contexts` payloads. The current Atlas Intel page only shows
+a compact summary for each context, so operators can see that reasoning was
+used but cannot inspect the theses, proof points, timing, coverage limits, or
+reference ids without opening the raw JSON result.
+
+This PR closes the deferred "full reasoning context drawer/detail UX" item with
+the smallest frontend-only surface: expandable detail panels inside the
+existing execution step reasoning badge.
+
+## Scope
+
+1. Replace the compact-only consumed-context list in
+   `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` with expandable context
+   detail cards.
+2. Render the existing consumed-context fields already defined by the frontend
+   domain contract; do not add a backend shape.
+3. Keep the first three context cap and "+N more" behavior so the execution
+   panel stays bounded.
+4. Update coordination and plan docs for this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Detail-UI.md`
+- `docs/extraction/coordination/inflight.md`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+
+## Mechanism
+
+`ReasoningContextList` keeps its existing input contract and still renders at
+most three consumed contexts. Each rendered context becomes a `details` element
+with the current summary/count header as the collapsed state. Opening the panel
+shows bounded sections for top theses, proof points, account signals, timing
+windows, reference ids, coverage limits, and optional scope/delta metadata.
+
+The implementation uses local formatting helpers in the same page component so
+the UI can display unknown object shapes without introducing a new dependency or
+changing domain types.
+
+## Intentional
+
+- No backend change. The current `reasoning.consumed_contexts` payload is
+  sufficient for this UI pass.
+- No modal or global drawer state. Inline expandable panels fit the current
+  execution card layout and keep the change surgical.
+- No component test is added because the Atlas Intel UI currently has no React
+  test runner or nearby component-test pattern. Verification uses the existing
+  TypeScript/Vite build.
+- This branch is independent of the intervention-provider PR. If that PR lands
+  first, this slice may need a coordination-ledger rebase only.
+
+## Deferred
+
+- A full-screen drawer with search/filtering across all consumed contexts.
+- Rich semantic rendering for every possible context sub-shape.
+- Frontend component tests once the UI has an established React test harness.
+
+## Verification
+
+- Atlas Intel production build passes.
+- Focused ESLint check passes for the touched page.
+- Diff whitespace check passes.
+- Local PR review passes before push.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Frontend detail UI | ~260 |
+| Plan and coordination docs | ~90 |
+| **Total** | **~350** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Detail-UI.md

Adds expandable consumed-reasoning detail panels to the Content Ops execution page so operators can inspect theses, proof points, references, timing, and coverage without opening raw JSON.

## Intentional
- Frontend-only; no backend or wire-shape change.
- Inline details instead of a global modal/drawer to keep the slice bounded.
- No React component test because this UI currently has no component-test harness; verified by TypeScript/Vite build and focused ESLint.

## Deferred
- Full-screen drawer with search/filtering across all contexts.
- Rich semantic rendering for every possible context sub-shape.
- Component tests once the UI test harness exists.

## Verification
- npm run build in atlas-intel-ui -> passed.
- npx eslint src/pages/ContentOpsNewRun.tsx -> passed.
- git diff --check -> passed.
- bash scripts/local_pr_review.sh -> passed.

## Diff size
3 files, 281 insertions, 12 deletions.

## Coordination
Code is independent from PR #508. If #508 merges first, this may need a coordination-ledger rebase only.