### PR TITLE
Refresh AI Content Ops deferred backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -28,23 +28,12 @@ The following items appear in older plan docs but are no longer active backlog:
 - `blog_post` reasoning catalog/fixture parity.
 - Live execute persistence smoke for all generated assets.
 - Blog blueprint population path.
+- Intervention or autonomous reasoning provider.
+- Full reasoning context drawer/detail UX.
 
 ## Active Backlog
 
-### 1. Intervention or autonomous reasoning provider
-
-**Priority:** P1
-
-**Why:** File and DB providers are enough for handoff, but they do not yet turn
-Atlas reasoning/intervention outputs into Content Ops context automatically.
-This is the bridge to the higher-value product story: reasoning as a separate
-layer that content products can consume.
-
-**Likely slice:** add a provider that reads
-`intelligence/autonomous_narrative_architect` or equivalent intervention output
-and normalizes it into the existing `CampaignReasoningContextProvider` port.
-
-### 2. DB reasoning provider hardening
+### 1. DB reasoning provider hardening
 
 **Priority:** P2
 
@@ -60,20 +49,7 @@ polish:
 **Likely slice:** start with per-target-mode filtering and settings integration;
 defer admin UI until the storage semantics are stable.
 
-### 3. Full reasoning context drawer/detail UX
-
-**Priority:** P2
-
-**Why:** Atlas Intel now renders compact consumed-context summaries. The richer
-drawer/detail UI remains deferred. This is useful for trust and debugging, but
-it should follow the live smoke/provider hardening work because the runtime
-contract is already inspectable at a compact level.
-
-**Likely slice:** add a drawer over the existing `reasoning.consumed_contexts`
-payload first. Do not add a new backend shape unless the current bounded
-payload is insufficient.
-
-### 4. Operator review UX and richer result previews
+### 2. Operator review UX and richer result previews
 
 **Priority:** P3
 
@@ -86,6 +62,6 @@ because batch review improves operator throughput across all asset types.
 
 ## Current Pick Recommendation
 
-Take item 1 next: intervention/autonomous reasoning provider. It bridges the
-separate Atlas reasoning layer into the already-shipped Content Ops provider
-port without coupling the extracted package back to Atlas internals.
+Take item 1 next: DB reasoning provider hardening. The intervention fallback
+and detail UI now exist, so the next highest-leverage work is tightening the
+durable provider semantics before adding more operator polish.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-14T19:55Z by codex-2026-05-14-content-ops-reasoning-detail-ui
+Last updated: 2026-05-15T01:08Z by codex-2026-05-15-content-ops-backlog-current
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| (in flight) | Add Content Ops reasoning detail UI | NEW: `plans/PR-Content-Ops-Reasoning-Detail-UI.md`. EDIT: `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`; `docs/extraction/coordination/inflight.md`. | codex-2026-05-14-content-ops-reasoning-detail-ui | reasoning-provider backlog slices |
+| — | — | — | — | — |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Backlog-Current.md
+++ b/plans/PR-Content-Ops-Backlog-Current.md
@@ -1,0 +1,57 @@
+# PR: Content Ops Backlog Current
+
+## Why this slice exists
+
+PRs #508 and #509 closed the intervention reasoning provider and consumed
+reasoning detail UI slices, but the AI Content Ops deferred backlog still lists
+both as active. The coordination ledger also still claims the merged #509 UI
+slice. That makes the next work item ambiguous and risks another session
+reclaiming completed work.
+
+## Scope
+
+1. Move the intervention provider and full reasoning detail UI items from active
+   backlog to retired historical deferrals.
+2. Renumber the remaining active backlog.
+3. Update the current pick recommendation to the next real slice: DB reasoning
+   provider hardening.
+4. Clear the merged Content Ops UI row from the in-flight ledger.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Backlog-Current.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+This is a documentation-only synchronization slice. No runtime code changes.
+The backlog keeps DB reasoning provider hardening and operator review UX as the
+remaining active items; the current recommendation points at DB hardening first
+because provider semantics should settle before adding more operator polish.
+
+## Intentional
+
+- No product code changes.
+- No new coordination owner row, because this PR itself is the ledger cleanup.
+- Operator review UX stays active; richer previews are still useful but lower
+  priority than the provider storage semantics.
+
+## Deferred
+
+- The actual DB reasoning provider hardening implementation.
+- Any broader roadmap rewrite outside the short AI Content Ops deferral list.
+
+## Verification
+
+- Local PR review passes.
+- Diff whitespace check passes.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Backlog doc | ~45 |
+| Coordination ledger | ~5 |
+| Plan doc | ~45 |
+| **Total** | **~95** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Backlog-Current.md

Updates the AI Content Ops backlog and in-flight ledger after #508 and #509 merged, so the next real slice is clear.

## Intentional
- Documentation-only.
- Clears stale in-flight rows rather than claiming new implementation work.

## Deferred
- Actual DB reasoning provider hardening implementation.
- Broader roadmap rewrite outside the short Content Ops deferral list.

## Verification
- bash scripts/local_pr_review.sh -> passed.
- git diff --check -> passed.

## Diff size
3 files, 66 insertions, 33 deletions.