### PR TITLE
Harden Content Ops DB reasoning provider

### DIFF
--- a/atlas_brain/_content_ops_reasoning.py
+++ b/atlas_brain/_content_ops_reasoning.py
@@ -354,18 +354,47 @@ def describe_content_ops_reasoning_context_provider(
 
 
 def _read_db_enabled() -> bool:
-    """Parse the DB opt-in env var; default ``False`` when unset
-    or unrecognized so a typo'd value resolves to "off"."""
+    """Parse the DB opt-in flag.
 
-    value = os.environ.get(_DB_ENV_VAR, "").strip().lower()
-    return value in {"true", "1", "yes", "on"}
+    The legacy top-level env var is the explicit override. When it
+    is unset, fall back to Atlas settings so operators can configure
+    the provider alongside the rest of ``b2b_campaign``.
+    """
+
+    value = os.environ.get(_DB_ENV_VAR)
+    if value is not None:
+        return _truthy(value)
+    return _settings_db_enabled()
 
 
 def _read_intervention_enabled() -> bool:
     """Parse the intervention opt-in env var."""
 
-    value = os.environ.get(_INTERVENTION_ENV_VAR, "").strip().lower()
-    return value in {"true", "1", "yes", "on"}
+    value = os.environ.get(_INTERVENTION_ENV_VAR, "")
+    return _truthy(value)
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"true", "1", "yes", "on"}
+
+
+def _settings_db_enabled() -> bool:
+    try:
+        from atlas_brain.config import settings
+    except Exception as exc:
+        logger.warning(
+            "Content Ops reasoning DB settings read failed: %s; "
+            "DB-backed provider stays disabled.",
+            exc,
+        )
+        return False
+    return bool(
+        getattr(
+            settings.b2b_campaign,
+            "content_ops_reasoning_db_enabled",
+            False,
+        )
+    )
 
 
 def _intervention_candidate_selectors(

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4729,6 +4729,14 @@ class B2BCampaignConfig(BaseSettings):
         default="vendor_retention",
         description="Campaign target mode: vendor_retention | challenger_intel | churning_company",
     )
+    content_ops_reasoning_db_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable DB-backed AI Content Ops reasoning context reads. "
+            "Legacy ATLAS_CONTENT_OPS_REASONING_DB_ENABLED still takes "
+            "precedence when set."
+        ),
+    )
     personas: list[str] = Field(
         default=["executive", "technical", "operations", "evaluator", "champion"],
         description="Persona types to generate campaigns for (buying committee coverage)",

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T01:08Z by codex-2026-05-15-content-ops-backlog-current
+Last updated: 2026-05-15T01:12Z by codex-2026-05-15-content-ops-db-reasoning-hardening
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| — | — | — | — | — |
+| draft | Content Ops DB reasoning hardening | `atlas_brain/_content_ops_reasoning.py`, `atlas_brain/config.py`, `extracted_content_pipeline/campaign_reasoning_postgres.py`, reasoning provider tests | codex-2026-05-15-content-ops-db-reasoning-hardening | Avoid DB reasoning provider/storage edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_reasoning_postgres.py
+++ b/extracted_content_pipeline/campaign_reasoning_postgres.py
@@ -21,11 +21,10 @@ implementation lets host scripts persist a normalized
 ``CampaignReasoningContext`` payload directly, mirroring
 ``PostgresBlogBlueprintRepository.save_blueprints``.
 
-target_mode is persisted but NOT filtered in the default read
-path -- this preserves parity with the file-backed provider's
-``del target_mode`` behavior so a single context row can serve
-all five LLM-using outputs. Per-mode filtering is a future
-slice; the column is already there.
+target_mode is persisted and filtered on reads. Blank target-mode
+rows are treated as global fallback contexts so legacy seed data can
+still serve multiple outputs, but a row saved for one nonblank mode
+does not satisfy another mode when selectors overlap.
 """
 
 from __future__ import annotations
@@ -125,17 +124,17 @@ class PostgresCampaignReasoningContextRepository:
         """Return the newest matching context for ``target_id``,
         or ``None`` when no row matches.
 
-        ``target_mode`` is accepted for protocol parity but not
-        filtered in this read -- mirrors the file-backed provider's
-        ``del target_mode`` behavior. The returned context is
+        ``target_mode`` filters nonblank rows so mode-specific
+        contexts do not leak across assets. Blank target-mode rows
+        remain global fallbacks. The returned context is
         ``normalize_campaign_reasoning_context``-normalized and
-        ``has_content()``-checked; rows that decode to empty
-        contexts resolve to ``None`` so callers fall back to
-        zero-context defaults rather than passing an empty bundle
-        through to the prompt.
+        ``has_content()``-checked; rows that decode to empty contexts
+        resolve to ``None`` so callers fall back to zero-context
+        defaults rather than passing an empty bundle through to the
+        prompt.
         """
 
-        del target_mode
+        mode = str(target_mode or "").strip().lower()
         selectors = _candidate_selectors(
             target_id=target_id,
             opportunity=opportunity,
@@ -162,16 +161,19 @@ class PostgresCampaignReasoningContextRepository:
             FROM {self.table}
             WHERE account_id = $1
               AND selectors && $2::text[]
+              AND ($3 = '' OR target_mode = $3 OR target_mode = '')
             ORDER BY (
                 SELECT MIN(c.idx)
                 FROM unnest($2::text[]) WITH ORDINALITY AS c(val, idx)
                 WHERE c.val = ANY(selectors)
             ) ASC NULLS LAST,
+            CASE WHEN $3 <> '' AND target_mode = $3 THEN 0 ELSE 1 END ASC,
             updated_at DESC
             LIMIT 1
             """,
             scope.account_id or "",
             list(selectors),
+            mode,
         )
         if row is None:
             return None
@@ -228,7 +230,7 @@ class PostgresCampaignReasoningContextRepository:
             RETURNING id
             """,
             scope.account_id or "",
-            target_mode or "",
+            str(target_mode or "").strip().lower(),
             list(cleaned),
             json_dump_jsonb(payload),
         )

--- a/extracted_content_pipeline/storage/migrations/277_campaign_reasoning_contexts.sql
+++ b/extracted_content_pipeline/storage/migrations/277_campaign_reasoning_contexts.sql
@@ -25,18 +25,14 @@
 -- normalize-then-emit helper already used by the file-backed
 -- loader) into the column.
 --
--- target_mode is persisted but the read path does NOT filter by it
--- by default -- this mirrors `FileCampaignReasoningContextProvider`'s
--- behavior (it ignores `target_mode` and serves the same context
--- across all five LLM-using outputs). Persisting the column lets
--- a future slice add per-mode filtering without a follow-up
--- migration.
+-- target_mode is persisted and filtered by the DB read path.
+-- Blank target_mode rows are treated as global fallback contexts
+-- so legacy seed data can still serve multiple outputs, but a row
+-- saved for one nonblank mode does not satisfy another mode when
+-- selectors overlap.
 --
--- updated_at drives the tie-breaker when multiple rows match the
--- same selectors -- newest wins. The file-backed provider uses
--- `setdefault` for first-key-wins; the DB read path uses
--- `ORDER BY updated_at DESC LIMIT 1` for the equivalent
--- "single row per lookup" semantic.
+-- updated_at drives the final tie-breaker when multiple rows match
+-- the same selector priority and target-mode specificity.
 
 CREATE TABLE IF NOT EXISTS campaign_reasoning_contexts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/plans/PR-Content-Ops-DB-Reasoning-Hardening.md
+++ b/plans/PR-Content-Ops-DB-Reasoning-Hardening.md
@@ -1,0 +1,102 @@
+# PR-Content-Ops-DB-Reasoning-Hardening
+
+## Why this slice exists
+
+The AI Content Ops deferred backlog now points at DB reasoning provider
+hardening as the next highest-leverage slice. The DB repository already
+persists `target_mode`, but the read path ignores it, which lets a row
+saved for one asset mode satisfy another mode when selectors overlap.
+The host factory also only reads the legacy top-level env var, so Atlas
+settings do not expose provider selection.
+
+## Scope (this PR)
+
+1. Make `PostgresCampaignReasoningContextRepository` filter reads by
+   `target_mode`, while preserving blank `target_mode` rows as global
+   fallback contexts.
+2. Add an Atlas settings field for the DB provider opt-in and use it
+   when the legacy env var is unset.
+3. Update tests for the read query, target-mode fallback semantics, and
+   settings-backed factory behavior.
+4. Claim this slice in the coordination ledger.
+
+### Files touched
+
+- `plans/PR-Content-Ops-DB-Reasoning-Hardening.md`
+- `docs/extraction/coordination/inflight.md`
+- `atlas_brain/config.py`
+- `atlas_brain/_content_ops_reasoning.py`
+- `extracted_content_pipeline/campaign_reasoning_postgres.py`
+- `extracted_content_pipeline/storage/migrations/277_campaign_reasoning_contexts.sql`
+- `scripts/smoke_extracted_content_ops_execution.py`
+- `tests/test_atlas_content_ops_reasoning.py`
+- `tests/test_extracted_campaign_reasoning_postgres.py`
+
+## Mechanism
+
+The repository read query keeps the existing account + selector overlap
+predicate and adds target-mode gating:
+
+```sql
+AND ($3 = '' OR target_mode = $3 OR target_mode = '')
+```
+
+That keeps legacy/global rows usable when `target_mode` is blank, while
+preventing a `challenger_intel` row from satisfying a
+`vendor_retention` request. Ordering stays selector-priority first, then
+prefers exact target-mode rows over blank fallback rows at the same
+selector priority.
+
+The host factory keeps `ATLAS_CONTENT_OPS_REASONING_DB_ENABLED` as the
+highest-precedence override. If it is unset, `_read_db_enabled()` falls
+back to `settings.b2b_campaign.content_ops_reasoning_db_enabled`.
+
+## Intentional
+
+- No upsert change in `save_context`; upsert semantics are a separate
+  backlog item and should ship with storage contract tests.
+- No stale-context sweeper or admin editing workflow; both depend on
+  stable storage semantics after this read-path hardening.
+- No change to file-backed provider behavior; target-mode filtering is
+  DB-only because the DB schema already has the column.
+
+## Deferred
+
+- `PR-Content-Ops-DB-Reasoning-Upsert` should add per-selector upsert
+  semantics and define conflict behavior.
+- `PR-Content-Ops-Reasoning-Stale-Sweeper` should delete or archive
+  old contexts once retention policy is defined.
+- `PR-Content-Ops-Reasoning-Admin-Editing` should add operator CRUD
+  after the repository contract settles.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_reasoning_postgres.py tests/test_atlas_content_ops_reasoning.py -q`
+  - 43 passed.
+- `pytest tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_exercises_postgres_reasoning_fixture -q`
+  - 1 passed.
+- `git diff --check`
+  - Passed.
+- `python -m py_compile atlas_brain/_content_ops_reasoning.py atlas_brain/config.py extracted_content_pipeline/campaign_reasoning_postgres.py tests/test_atlas_content_ops_reasoning.py tests/test_extracted_campaign_reasoning_postgres.py`
+  - Passed.
+- ASCII byte check across touched Python/docs/sql files.
+  - Passed.
+- `bash scripts/validate_extracted_content_pipeline.sh`
+  - Passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - Passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - Passed.
+- `bash scripts/check_ascii_python.sh`
+  - Passed.
+- `bash scripts/run_extracted_pipeline_checks.sh`
+  - 1469 passed, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Production + migration/smoke comment | ~105 LOC |
+| Tests | ~160 LOC |
+| Plan + coordination | ~75 LOC |
+| Total | ~390 LOC |

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -54,7 +54,14 @@ class _OfflinePostgresReasoningPool:
         _query: str,
         _account_id: str,
         selectors: list[str],
+        target_mode: str = "",
     ) -> dict[str, Any] | None:
+        if str(target_mode or "") not in {
+            "",
+            "vendor_retention",
+            "marketing_campaign",
+        }:
+            return None
         wanted = {"opp_smoke", "content ops smoke", "acme"}
         if wanted.intersection({str(item).strip().lower() for item in selectors}):
             return {"payload": _POSTGRES_FIXTURE_PAYLOAD}

--- a/tests/test_atlas_content_ops_reasoning.py
+++ b/tests/test_atlas_content_ops_reasoning.py
@@ -20,45 +20,49 @@ File-backed factory (PR #462, 7 tests):
 7. `loader_factory` DI kwarg short-circuits the lazy import
    of the package's file-backed loader.
 
-DB-backed factory (this slice, 4 tests):
+DB-backed factory (7 tests):
 
 8.  Env var unset returns `None` (default unwired path).
-9.  Env var set + pool present returns whatever the
+9.  Settings-backed DB opt-in is honored when the legacy env var
+    is unset.
+10. Legacy env var overrides settings-backed opt-in.
+11. B2B campaign config exposes the DB opt-in flag.
+12. Env var set + pool present returns whatever the
     repository factory produces.
-10. Env var set but pool factory returns `None` (DB not
+13. Env var set but pool factory returns `None` (DB not
     initialized yet) returns `None` with WARN.
-11. Repository factory exception resolves to `None` with WARN
+14. Repository factory exception resolves to `None` with WARN
     (defensive against an upstream init bug).
 
 Intervention-report factory (7 tests):
 
-12. Env var unset returns `None`.
-13. Env var set + pool present returns whatever the provider
+15. Env var unset returns `None`.
+16. Env var set + pool present returns whatever the provider
     factory produces.
-14. Env var set but pool factory returns `None` returns `None`
+17. Env var set but pool factory returns `None` returns `None`
     with WARN.
-15. Env var set but pool is uninitialized returns `None` with
+18. Env var set but pool is uninitialized returns `None` with
     WARN.
-16. Provider factory exception resolves to `None` with WARN.
-17. Matching report normalizes into campaign reasoning context.
-18. Missing selectors return `None`.
+19. Provider factory exception resolves to `None` with WARN.
+20. Matching report normalizes into campaign reasoning context.
+21. Missing selectors return `None`.
 
 Chooser (4 tests):
 
-19. DB > file > `None` priority: when DB factory returns a
+22. DB > file > `None` priority: when DB factory returns a
     provider, the file factory is never called.
-20. DB returns `None`, file factory returns a provider --
+23. DB returns `None`, file factory returns a provider --
     chooser returns the file provider.
-21. DB returns `None`, intervention returns a provider --
+24. DB returns `None`, intervention returns a provider --
     chooser returns the intervention provider before file.
-22. All factories return `None` -- chooser returns `None`.
+25. All factories return `None` -- chooser returns `None`.
 
 Status (4 tests):
 
-23. DB provider reports configured with source=db.
-24. Intervention fallback reports configured with source=intervention.
-25. File fallback reports configured with source=file.
-26. Neither provider reports configured=false with source=none.
+26. DB provider reports configured with source=db.
+27. Intervention fallback reports configured with source=intervention.
+28. File fallback reports configured with source=file.
+29. Neither provider reports configured=false with source=none.
 """
 
 from __future__ import annotations
@@ -74,8 +78,10 @@ from atlas_brain._content_ops_reasoning import (
     build_intervention_content_ops_reasoning_context_provider,
     build_postgres_content_ops_reasoning_context_provider,
     describe_content_ops_reasoning_context_provider,
+    _read_db_enabled,
     select_content_ops_reasoning_context_provider,
 )
+from atlas_brain.config import B2BCampaignConfig
 from extracted_content_pipeline.campaign_ports import TenantScope
 
 
@@ -212,6 +218,39 @@ def test_db_factory_disabled_returns_none() -> None:
         enabled_factory=lambda: False,
     )
     assert provider is None
+
+
+def test_db_enabled_reads_settings_when_legacy_env_unset(
+    monkeypatch: Any,
+) -> None:
+    """Settings integration: the host can enable the DB provider
+    through b2b_campaign config when the legacy top-level env var
+    is absent."""
+
+    monkeypatch.delenv("ATLAS_CONTENT_OPS_REASONING_DB_ENABLED", raising=False)
+    monkeypatch.setattr(
+        "atlas_brain._content_ops_reasoning._settings_db_enabled",
+        lambda: True,
+    )
+
+    assert _read_db_enabled() is True
+
+
+def test_db_enabled_legacy_env_overrides_settings(monkeypatch: Any) -> None:
+    """The old env var remains the explicit operator override."""
+
+    monkeypatch.setenv("ATLAS_CONTENT_OPS_REASONING_DB_ENABLED", "false")
+    monkeypatch.setattr(
+        "atlas_brain._content_ops_reasoning._settings_db_enabled",
+        lambda: True,
+    )
+
+    assert _read_db_enabled() is False
+
+
+def test_b2b_campaign_config_exposes_content_ops_reasoning_db_flag() -> None:
+    cfg = B2BCampaignConfig(content_ops_reasoning_db_enabled=True)
+    assert cfg.content_ops_reasoning_db_enabled is True
 
 
 def test_db_factory_enabled_returns_repository() -> None:

--- a/tests/test_extracted_campaign_reasoning_postgres.py
+++ b/tests/test_extracted_campaign_reasoning_postgres.py
@@ -8,7 +8,7 @@ so the host route mount (PR #402 / PR #462) can swap providers
 without touching the bundle's `with_reasoning_context()`
 derivation.
 
-Test inventory (8 tests):
+Test inventory (12 tests):
 
 1. `read_campaign_reasoning_context` builds the candidate
    selector array from `target_id` + opportunity keys
@@ -33,6 +33,12 @@ Test inventory (8 tests):
    `CampaignReasoningContext`) and round-trips through
    `normalize_campaign_reasoning_context` so the persisted
    payload matches the file-backed loader's expected layout.
+9. `read_campaign_reasoning_context` filters by target_mode,
+   with blank target-mode rows kept as fallback matches.
+10. Exact target-mode rows rank before blank fallback rows at
+    the same selector priority.
+11. Target-mode caller input is normalized before filtering.
+12. `save_context` normalizes target-mode values before writing.
 
 Test harness uses an asyncpg-shaped fake pool (matches
 `tests/test_extracted_blog_blueprint_postgres.py`).
@@ -95,6 +101,7 @@ async def test_read_uses_candidate_selectors_array() -> None:
     args = pool.fetchrow_calls[0]["args"]
     assert args[0] == "acct-1"
     selectors = args[1]
+    assert args[2] == "vendor"
     # case-as-given + lowercase variants for each non-empty key
     assert "ACME-123" in selectors
     assert "acme-123" in selectors
@@ -104,11 +111,13 @@ async def test_read_uses_candidate_selectors_array() -> None:
     query = pool.fetchrow_calls[0]["query"]
     assert "account_id = $1" in query
     assert "selectors && $2::text[]" in query
+    assert "target_mode = $3 OR target_mode = ''" in query
     # Priority ordering (Codex P2): exact target_id should beat a
     # broader newer company-name match. Selector-position MIN
     # subquery ranks rows by which of the candidates they matched.
     assert "unnest($2::text[]) WITH ORDINALITY" in query
     assert "ORDER BY" in query and "updated_at DESC" in query
+    assert "CASE WHEN $3 <> '' AND target_mode = $3" in query
     assert "LIMIT 1" in query
 
 
@@ -134,12 +143,77 @@ async def test_read_priority_subquery_ranks_before_updated_at() -> None:
 
     query = pool.fetchrow_calls[0]["query"]
     # Priority subquery must appear in the ORDER BY clause,
-    # before the updated_at DESC tie-breaker.
+    # before the target-mode and updated_at tie-breakers.
     priority_idx = query.find("MIN(c.idx)")
+    target_mode_idx = query.find("CASE WHEN $3 <> '' AND target_mode = $3")
     updated_idx = query.find("updated_at DESC")
     assert priority_idx >= 0
+    assert target_mode_idx >= 0
     assert updated_idx >= 0
-    assert priority_idx < updated_idx
+    assert priority_idx < target_mode_idx < updated_idx
+
+
+@pytest.mark.asyncio
+async def test_read_filters_by_target_mode_with_blank_fallback() -> None:
+    """A nonblank request mode must not read a row saved for a
+    different nonblank mode. Blank target-mode rows remain shared
+    fallback contexts for legacy/global seed data."""
+
+    pool = _Pool()
+    pool.fetchrow_result = None
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    await repo.read_campaign_reasoning_context(
+        scope=TenantScope(account_id="acct-1"),
+        target_id="ACME-123",
+        target_mode="vendor_retention",
+        opportunity={},
+    )
+
+    query = pool.fetchrow_calls[0]["query"]
+    args = pool.fetchrow_calls[0]["args"]
+    assert args[2] == "vendor_retention"
+    assert "AND ($3 = '' OR target_mode = $3 OR target_mode = '')" in query
+
+
+@pytest.mark.asyncio
+async def test_read_normalizes_target_mode_before_filtering() -> None:
+    """Target-mode values are persisted lowercase by convention;
+    normalize caller input so mixed-case request values still match."""
+
+    pool = _Pool()
+    pool.fetchrow_result = None
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    await repo.read_campaign_reasoning_context(
+        scope=TenantScope(account_id="acct-1"),
+        target_id="ACME-123",
+        target_mode="Vendor_Retention",
+        opportunity={},
+    )
+
+    args = pool.fetchrow_calls[0]["args"]
+    assert args[2] == "vendor_retention"
+
+
+@pytest.mark.asyncio
+async def test_read_empty_target_mode_preserves_legacy_unfiltered_lookup() -> None:
+    """Empty target_mode keeps the old broad lookup behavior for
+    callers that do not know their mode yet."""
+
+    pool = _Pool()
+    pool.fetchrow_result = None
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    await repo.read_campaign_reasoning_context(
+        scope=TenantScope(account_id="acct-1"),
+        target_id="ACME-123",
+        target_mode="",
+        opportunity={},
+    )
+
+    args = pool.fetchrow_calls[0]["args"]
+    assert args[2] == ""
 
 
 @pytest.mark.asyncio
@@ -268,6 +342,28 @@ async def test_save_context_round_trips_payload_jsonb() -> None:
     payload = json.loads(args[3])
     assert "reasoning_context" in payload
     assert payload["reasoning_context"]["top_theses"][0]["summary"] == "losing on price"
+
+
+@pytest.mark.asyncio
+async def test_save_context_normalizes_target_mode_before_writing() -> None:
+    """Persisted target_mode must match the read-path lowercase
+    convention so mixed-case writer input stays readable."""
+
+    pool = _Pool()
+    pool.fetchval_results = ["ctx-uuid-mode"]
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    await repo.save_context(
+        scope=TenantScope(account_id="acct-1"),
+        selectors=("Acme Corp",),
+        context=CampaignReasoningContext(
+            top_theses=({"summary": "Acme losing on price"},),
+        ),
+        target_mode=" Vendor_Retention ",
+    )
+
+    args = pool.fetchval_calls[0]["args"]
+    assert args[1] == "vendor_retention"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-DB-Reasoning-Hardening.md

Hardens the AI Content Ops DB-backed reasoning provider so stored target-mode-specific contexts do not leak across asset modes. Blank target_mode rows remain global fallback contexts, and Atlas settings can now enable the DB provider when the legacy env var is unset.

## Intentional
- No upsert change in save_context; upsert semantics remain a separate DB storage slice.
- No stale-context sweeper or admin editing workflow in this PR.
- No change to file-backed provider behavior.

## Deferred
- PR-Content-Ops-DB-Reasoning-Upsert for per-selector upsert semantics.
- PR-Content-Ops-Reasoning-Stale-Sweeper for retention cleanup.
- PR-Content-Ops-Reasoning-Admin-Editing for operator CRUD.

## Verification
- pytest tests/test_extracted_campaign_reasoning_postgres.py tests/test_atlas_content_ops_reasoning.py -q -> 41 passed.
- pytest tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_exercises_postgres_reasoning_fixture -q -> 1 passed.
- git diff --check -> passed.
- python -m py_compile atlas_brain/_content_ops_reasoning.py atlas_brain/config.py extracted_content_pipeline/campaign_reasoning_postgres.py tests/test_atlas_content_ops_reasoning.py tests/test_extracted_campaign_reasoning_postgres.py -> passed.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/run_extracted_pipeline_checks.sh -> 1467 passed, 1 existing torch/pynvml warning.
- bash scripts/local_pr_review.sh -> passed.

## Diff size
9 files, +289 / -54.