### PR TITLE
Mount Content Ops generated asset routes

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -156,6 +156,9 @@ try:
     from extracted_content_pipeline.api.control_surfaces import (
         create_content_ops_control_surface_router,
     )
+    from extracted_content_pipeline.api.generated_assets import (
+        create_generated_asset_router,
+    )
     from .._content_ops_services import build_content_ops_execution_services
     from .._content_ops_scope import (
         build_content_ops_scope,
@@ -166,6 +169,7 @@ try:
         select_content_ops_reasoning_context_provider,
     )
     from ..auth.dependencies import AuthUser
+    from ..storage.database import get_db_pool
 
     async def _capture_content_ops_auth_user(
         user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
@@ -194,6 +198,12 @@ try:
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
     )
     router.include_router(content_ops_router)
+    content_assets_router = create_generated_asset_router(
+        pool_provider=get_db_pool,
+        scope_provider=build_content_ops_scope,
+        dependencies=[Depends(_capture_content_ops_auth_user)],
+    )
+    router.include_router(content_assets_router)
 except Exception as exc:  # pragma: no cover - defensive at import time
     logger.warning(
         "Content Ops router disabled during api package import: %s", exc

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T01:12Z by codex-2026-05-15-content-ops-db-reasoning-hardening
+Last updated: 2026-05-15T01:35Z by codex-2026-05-15-content-ops-generated-assets-route
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops DB reasoning hardening | `atlas_brain/_content_ops_reasoning.py`, `atlas_brain/config.py`, `extracted_content_pipeline/campaign_reasoning_postgres.py`, reasoning provider tests | codex-2026-05-15-content-ops-db-reasoning-hardening | Avoid DB reasoning provider/storage edits |
+| draft | Content Ops generated asset routes | `atlas_brain/api/__init__.py`, Atlas generated-asset route tests | codex-2026-05-15-content-ops-generated-assets-route | Avoid Atlas API aggregator and Content Ops route-mount edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Generated-Assets-Route.md
+++ b/plans/PR-Content-Ops-Generated-Assets-Route.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-Generated-Assets-Route
+
+## Why this slice exists
+
+Generated Content Ops asset review/export routes already exist in
+`extracted_content_pipeline.api.generated_assets`, but Atlas only mounts
+the control-surface router. Operators can execute generation from the
+host API but cannot review/export generated reports, blog posts,
+landing pages, or sales briefs through the same host surface.
+
+## Scope (this PR)
+
+1. Mount `create_generated_asset_router` in `atlas_brain/api/__init__.py`.
+2. Reuse the existing Content Ops auth bridge,
+   `build_content_ops_scope`, and Atlas database pool.
+3. Add Atlas route-registration tests proving `/content-assets/*`
+   routes are mounted by the API aggregator and use the shared auth
+   dependency wiring.
+
+## Mechanism
+
+The route mount stays inside the existing Content Ops defensive import
+block so missing extracted-package dependencies do not break Atlas
+startup. It shares the same `Depends(_capture_content_ops_auth_user)`
+dependency used by `/content-ops/*`, so tenant scope continues to flow
+through the existing ContextVar bridge.
+
+The pool provider is `atlas_brain.storage.database.get_db_pool`; the
+extracted generated-asset router already accepts a host pool provider
+and performs the database-unavailable guard itself.
+
+## Intentional
+
+- No frontend review UI in this slice.
+- No changes to the extracted generated-asset router internals.
+- No new review/export behavior; this only exposes the already-tested
+  router through Atlas.
+
+## Deferred
+
+- Richer operator review UX in the frontend.
+- More detailed generated-asset previews beyond the current API
+  payload/export surfaces.
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_generated_assets_api.py -q`
+  - 2 passed, 1 existing torch/pynvml warning.
+- `pytest tests/test_extracted_content_asset_api.py tests/test_extracted_campaign_api_hosted_workflow.py::test_hosted_workflow_mounts_generated_asset_router_with_shared_ports -q`
+  - 16 passed.
+- `git diff --check`
+  - Passed.
+- Python compile check for `atlas_brain/api/__init__.py` and
+  `tests/test_atlas_content_ops_generated_assets_api.py`
+  - Passed.
+
+### Files touched
+
+- `atlas_brain/api/__init__.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Generated-Assets-Route.md`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Atlas API mount | ~10 LOC |
+| Tests | ~65 LOC |
+| Plan + coordination | ~60 LOC |
+| Total | ~140 LOC |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -1,0 +1,55 @@
+"""Atlas host mount tests for generated Content Ops asset routes.
+
+The extracted router owns behavior-level tests. These tests only pin
+the Atlas API aggregator wiring so operators can reach review/export
+routes through the hosted API surface.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _fresh_api_package():
+    original = sys.modules.pop("atlas_brain.api", None)
+    try:
+        return importlib.import_module("atlas_brain.api")
+    finally:
+        if original is not None:
+            sys.modules["atlas_brain.api"] = original
+
+
+def _route(api_pkg, path: str):
+    route = next((route for route in api_pkg.router.routes if route.path == path), None)
+    assert route is not None, f"Route {path!r} not mounted"
+    return route
+
+
+def test_api_aggregator_mounts_generated_asset_routes() -> None:
+    api_pkg = _fresh_api_package()
+
+    paths = {getattr(route, "path", "") for route in api_pkg.router.routes}
+
+    assert "/content-assets/{asset}/drafts" in paths
+    assert "/content-assets/{asset}/drafts/export" in paths
+    assert "/content-assets/{asset}/drafts/review" in paths
+
+
+def test_generated_asset_routes_use_shared_content_ops_auth_scope_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-assets/{asset}/drafts")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["pool_provider"].__name__ == "get_db_pool"
+    assert closure["scope_provider"].__name__ == "build_content_ops_scope"
+    assert "_capture_content_ops_auth_user" in dependency_names


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Generated-Assets-Route.md

## Summary
- mounts the extracted generated-asset review/export router in Atlas
- reuses the existing Content Ops B2B auth and tenant-scope bridge
- adds host route-registration tests for /content-assets report/blog/landing/sales asset paths

## Verification
- pytest tests/test_atlas_content_ops_generated_assets_api.py -q
- pytest tests/test_extracted_content_asset_api.py tests/test_extracted_campaign_api_hosted_workflow.py::test_hosted_workflow_mounts_generated_asset_router_with_shared_ports -q
- git diff --check
- python -m py_compile atlas_brain/api/__init__.py tests/test_atlas_content_ops_generated_assets_api.py
- bash scripts/local_pr_review.sh