### PR TITLE
Expose generated asset ids for review

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T01:35Z by codex-2026-05-15-content-ops-generated-assets-route
+Last updated: 2026-05-15T02:18Z by codex-2026-05-15-content-assets-review-row-ids
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops generated asset routes | `atlas_brain/api/__init__.py`, Atlas generated-asset route tests | codex-2026-05-15-content-ops-generated-assets-route | Avoid Atlas API aggregator and Content Ops route-mount edits |
+| draft | Content Ops asset review row ids | generated asset ports, Postgres adapters, export helpers, asset API tests | codex-2026-05-15-content-assets-review-row-ids | Avoid generated-asset list/export row-shape edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/blog_ports.py
+++ b/extracted_content_pipeline/blog_ports.py
@@ -21,6 +21,8 @@ class BlogPostDraft:
     charts: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     data_context: JsonDict = field(default_factory=dict)
     metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
 
     def as_dict(self) -> JsonDict:
         return {
@@ -33,6 +35,8 @@ class BlogPostDraft:
             "charts": [dict(chart) for chart in self.charts],
             "data_context": dict(self.data_context),
             "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
         }
 
 

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -35,6 +35,8 @@ _EXPORT_COLUMNS = (
     "charts",
     "data_context",
     "metadata",
+    "id",
+    "status",
 )
 
 

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -49,6 +49,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> BlogPostDraft:
         metadata["generation_model"] = str(row.get("llm_model"))
 
     return BlogPostDraft(
+        id=str(row.get("id") or ""),
         slug=str(row.get("slug") or ""),
         title=str(row.get("title") or ""),
         description=str(row.get("description") or ""),
@@ -58,6 +59,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> BlogPostDraft:
         charts=tuple(dict(chart) for chart in charts_raw if isinstance(chart, Mapping)),
         data_context=data_context,
         metadata=metadata,
+        status=str(row.get("status") or ""),
     )
 
 
@@ -149,8 +151,8 @@ class PostgresBlogPostRepository:
             params.append(topic_type)
             clauses.append(f"topic_type = ${len(params)}")
         sql = (
-            "SELECT slug, title, description, topic_type, tags, content, "
-            "charts, data_context, llm_model "
+            "SELECT id, slug, title, description, topic_type, tags, content, "
+            "charts, data_context, llm_model, status "
             "FROM blog_posts WHERE " + " AND ".join(clauses) + " "
             "ORDER BY created_at DESC"
         )

--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -37,6 +37,8 @@ _EXPORT_COLUMNS = (
     "meta",
     "reference_ids",
     "metadata",
+    "id",
+    "status",
 )
 
 

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -118,6 +118,8 @@ class LandingPageDraft:
     meta: Mapping[str, Any] = field(default_factory=dict)
     reference_ids: Sequence[str] = field(default_factory=tuple)
     metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
 
     def as_dict(self) -> JsonDict:
         return {
@@ -132,6 +134,8 @@ class LandingPageDraft:
             "meta": dict(self.meta),
             "reference_ids": list(self.reference_ids),
             "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
         }
 
 

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -88,6 +88,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> LandingPageDraft:
         metadata_raw = {}
 
     return LandingPageDraft(
+        id=str(row.get("id") or ""),
         campaign_name=str(row.get("campaign_name") or ""),
         persona=str(row.get("persona") or ""),
         value_prop=str(row.get("value_prop") or ""),
@@ -99,6 +100,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> LandingPageDraft:
         meta=dict(meta_raw),
         reference_ids=tuple(str(r) for r in reference_ids_raw),
         metadata=dict(metadata_raw),
+        status=str(row.get("status") or ""),
     )
 
 
@@ -181,8 +183,8 @@ class PostgresLandingPageRepository:
             params.append(slug)
             clauses.append(f"slug = ${len(params)}")
         sql = (
-            "SELECT campaign_name, persona, value_prop, title, slug, "
-            "hero, sections, cta, meta, reference_ids, metadata "
+            "SELECT id, campaign_name, persona, value_prop, title, slug, "
+            "hero, sections, cta, meta, reference_ids, metadata, status "
             "FROM landing_pages WHERE " + " AND ".join(clauses) + " "
             "ORDER BY created_at DESC"
         )

--- a/extracted_content_pipeline/report_export.py
+++ b/extracted_content_pipeline/report_export.py
@@ -34,6 +34,8 @@ _EXPORT_COLUMNS = (
     "sections",
     "reference_ids",
     "metadata",
+    "id",
+    "status",
 )
 
 

--- a/extracted_content_pipeline/report_ports.py
+++ b/extracted_content_pipeline/report_ports.py
@@ -79,6 +79,8 @@ class ReportDraft:
     sections: Sequence[ReportSection] = field(default_factory=tuple)
     reference_ids: Sequence[str] = field(default_factory=tuple)
     metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
 
     def as_dict(self) -> JsonDict:
         return {
@@ -90,6 +92,8 @@ class ReportDraft:
             "sections": [section.as_dict() for section in self.sections],
             "reference_ids": list(self.reference_ids),
             "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
         }
 
 

--- a/extracted_content_pipeline/report_postgres.py
+++ b/extracted_content_pipeline/report_postgres.py
@@ -67,6 +67,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> ReportDraft:
         metadata_raw = {}
 
     return ReportDraft(
+        id=str(row.get("id") or ""),
         target_id=str(row.get("target_id") or ""),
         target_mode=str(row.get("target_mode") or ""),
         report_type=str(row.get("report_type") or ""),
@@ -75,6 +76,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> ReportDraft:
         sections=tuple(_coerce_section(s) for s in sections_raw),
         reference_ids=tuple(str(r) for r in reference_ids_raw),
         metadata=dict(metadata_raw),
+        status=str(row.get("status") or ""),
     )
 
 
@@ -141,8 +143,8 @@ class PostgresReportRepository:
             params.append(report_type)
             clauses.append(f"report_type = ${len(params)}")
         sql = (
-            "SELECT target_id, target_mode, report_type, title, summary, "
-            "sections, reference_ids, metadata "
+            "SELECT id, target_id, target_mode, report_type, title, summary, "
+            "sections, reference_ids, metadata, status "
             "FROM reports WHERE " + " AND ".join(clauses) + " "
             "ORDER BY created_at DESC"
         )

--- a/extracted_content_pipeline/sales_brief_export.py
+++ b/extracted_content_pipeline/sales_brief_export.py
@@ -34,6 +34,8 @@ _EXPORT_COLUMNS = (
     "sections",
     "reference_ids",
     "metadata",
+    "id",
+    "status",
 )
 
 

--- a/extracted_content_pipeline/sales_brief_ports.py
+++ b/extracted_content_pipeline/sales_brief_ports.py
@@ -91,6 +91,8 @@ class SalesBriefDraft:
     sections: Sequence[SalesBriefSection] = field(default_factory=tuple)
     reference_ids: Sequence[str] = field(default_factory=tuple)
     metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
 
     def as_dict(self) -> JsonDict:
         return {
@@ -102,6 +104,8 @@ class SalesBriefDraft:
             "sections": [section.as_dict() for section in self.sections],
             "reference_ids": list(self.reference_ids),
             "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
         }
 
 

--- a/extracted_content_pipeline/sales_brief_postgres.py
+++ b/extracted_content_pipeline/sales_brief_postgres.py
@@ -75,6 +75,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> SalesBriefDraft:
         metadata_raw = {}
 
     return SalesBriefDraft(
+        id=str(row.get("id") or ""),
         target_id=str(row.get("target_id") or ""),
         target_mode=str(row.get("target_mode") or ""),
         brief_type=str(row.get("brief_type") or ""),
@@ -83,6 +84,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> SalesBriefDraft:
         sections=tuple(_coerce_section(s) for s in sections_raw),
         reference_ids=tuple(str(r) for r in reference_ids_raw),
         metadata=dict(metadata_raw),
+        status=str(row.get("status") or ""),
     )
 
 
@@ -152,8 +154,8 @@ class PostgresSalesBriefRepository:
             params.append(brief_type)
             clauses.append(f"brief_type = ${len(params)}")
         sql = (
-            "SELECT target_id, target_mode, brief_type, title, headline, "
-            "sections, reference_ids, metadata "
+            "SELECT id, target_id, target_mode, brief_type, title, headline, "
+            "sections, reference_ids, metadata, status "
             "FROM sales_briefs WHERE " + " AND ".join(clauses) + " "
             "ORDER BY created_at DESC"
         )

--- a/plans/PR-Content-Assets-Review-Row-Ids.md
+++ b/plans/PR-Content-Assets-Review-Row-Ids.md
@@ -1,0 +1,72 @@
+# PR: Content Ops asset review row ids
+
+## Plan
+
+Expose generated asset row `id` and `status` through the existing
+list/export path for reports, blog posts, landing pages, and sales briefs.
+
+## Why this slice exists
+
+The generated asset review route accepts `{id, status}`, but the list/export
+rows did not include the database id or current status. That makes the hosted
+review API hard to use from any UI or operator workflow without asking users
+to find ids through SQL.
+
+## Scope (this PR)
+
+- Add optional `id` and `status` fields to the four generated asset draft
+  port dataclasses.
+- Project `id` and `status` from the Postgres list queries.
+- Include those fields in export rows and CSV output.
+- Regression-lock the API list response for reports and blog posts.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/blog_ports.py`
+- `extracted_content_pipeline/blog_post_export.py`
+- `extracted_content_pipeline/blog_post_postgres.py`
+- `extracted_content_pipeline/landing_page_export.py`
+- `extracted_content_pipeline/landing_page_ports.py`
+- `extracted_content_pipeline/landing_page_postgres.py`
+- `extracted_content_pipeline/report_export.py`
+- `extracted_content_pipeline/report_ports.py`
+- `extracted_content_pipeline/report_postgres.py`
+- `extracted_content_pipeline/sales_brief_export.py`
+- `extracted_content_pipeline/sales_brief_ports.py`
+- `extracted_content_pipeline/sales_brief_postgres.py`
+- `plans/PR-Content-Assets-Review-Row-Ids.md`
+- `tests/test_extracted_content_asset_api.py`
+
+## Mechanism
+
+The Postgres adapters select the row primary key and status, `_row_to_draft`
+preserves them on the draft object, and the export helpers pass the draft
+dictionary through to API/CSV callers.
+
+## Intentional
+
+- Keep both fields optional/default-empty on port dataclasses so existing
+  in-memory tests and host adapters do not need constructor changes.
+- Append CSV columns at the end to preserve existing leading-column contracts.
+
+## Deferred
+
+- Frontend review UI that consumes these ids.
+- Bulk review actions.
+
+## Verification
+
+- Focused generated-asset API/export tests: 38 passed.
+- Python compile check for touched generated-asset port and Postgres adapter
+  files: passed.
+- Local PR review wrapper: passed.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Generated asset ports/adapters/export helpers | ~42 LOC |
+| API regression tests | ~12 LOC |
+| Plan + coordination | ~45 LOC |
+| Total | ~100 LOC |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -40,6 +40,8 @@ class _Pool:
 
 def _report_row():
     return {
+        "id": "report-uuid-1",
+        "status": "draft",
         "target_id": "vendor-acme",
         "target_mode": "vendor_retention",
         "report_type": "vendor_pressure",
@@ -56,6 +58,8 @@ def _report_row():
 
 def _blog_post_row():
     return {
+        "id": "blog-post-uuid-1",
+        "status": "draft",
         "slug": "acme-pricing-pressure",
         "title": "Acme Pricing Pressure",
         "description": "Pricing pressure dominates.",
@@ -75,6 +79,8 @@ def _blog_post_row():
 
 def _landing_page_row():
     return {
+        "id": "landing-page-uuid-1",
+        "status": "draft",
         "campaign_name": "acme-launch",
         "persona": "VP Engineering",
         "value_prop": "Catch pressure early",
@@ -91,6 +97,8 @@ def _landing_page_row():
 
 def _sales_brief_row():
     return {
+        "id": "brief-uuid-1",
+        "status": "draft",
         "target_id": "vendor-acme",
         "target_mode": "vendor_retention",
         "brief_type": "pre_call",
@@ -145,6 +153,8 @@ def test_generated_asset_router_lists_report_drafts_with_filters() -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["count"] == 1
+    assert body["rows"][0]["id"] == "report-uuid-1"
+    assert body["rows"][0]["status"] == "draft"
     assert body["rows"][0]["title"] == "Acme report"
     assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
     query, args = pool.fetch_calls[0]
@@ -166,6 +176,8 @@ def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["count"] == 1
+    assert body["rows"][0]["id"] == "blog-post-uuid-1"
+    assert body["rows"][0]["status"] == "draft"
     assert body["rows"][0]["slug"] == "acme-pricing-pressure"
     assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
     query, args = pool.fetch_calls[0]


### PR DESCRIPTION
Plan: plans/PR-Content-Assets-Review-Row-Ids.md

Expose generated asset row id/status through the existing Content Ops list/export path so hosted review APIs can be called from list results instead of requiring SQL lookup.

## Intentional
- Keep id/status optional/default-empty on port dataclasses to preserve host adapter compatibility.
- Append CSV columns at the end to avoid breaking leading-column checks.

## Deferred
- Frontend generated-asset review UI follows as the next slice.
- Bulk review actions remain deferred.

## Verification
- Focused generated-asset API/export tests: 38 passed.
- Python compile check for touched generated-asset files: passed.
- Local PR review wrapper: passed.

## Diff size
15 files, +126 / -10