### PR TITLE
Add generated asset review UI

### DIFF
--- a/atlas-intel-ui/src/App.tsx
+++ b/atlas-intel-ui/src/App.tsx
@@ -32,6 +32,7 @@ const B2BReports = lazy(() => import('./pages/b2b/B2BReports'))
 const B2BReviews = lazy(() => import('./pages/b2b/B2BReviews'))
 const B2BCampaigns = lazy(() => import('./pages/b2b/B2BCampaigns'))
 const ContentOpsNewRun = lazy(() => import('./pages/ContentOpsNewRun'))
+const ContentOpsAssetsReview = lazy(() => import('./pages/ContentOpsAssetsReview'))
 
 function renderLazyRoute(Component: ComponentType) {
   return (
@@ -87,6 +88,7 @@ export default function App() {
 
                     {/* Content Ops routes */}
                     <Route path="/content-ops/new" element={renderLazyRoute(ContentOpsNewRun)} />
+                    <Route path="/content-ops/assets" element={renderLazyRoute(ContentOpsAssetsReview)} />
                   </Routes>
                 </Layout>
               </ProtectedRoute>

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -2,12 +2,15 @@
  * AI Content Ops API adapter.
  *
  * Typed fetch wrappers + wire-shape types for the four
- * `/content-ops/*` routes the backend exposes:
+ * `/content-ops/*` and `/content-assets/*` routes the backend exposes:
  *
  *   GET  /content-ops/control-surfaces
  *   POST /content-ops/preview
  *   POST /content-ops/plan
  *   POST /content-ops/execute
+ *   GET  /content-assets/{asset}/drafts
+ *   GET  /content-assets/{asset}/drafts/export
+ *   POST /content-assets/{asset}/drafts/review
  *
  * Wire types are 1:1 with the backend JSON (snake_case), matching
  * the convention in `client.ts` / `b2bClient.ts`. camelCase
@@ -28,6 +31,7 @@ import { API_BASE } from './config'
 // via `ContentOpsControlSurfaceApiConfig(prefix="/api/v1/content-ops")`
 // or equivalent.
 const BASE = `${API_BASE}/api/v1/content-ops`
+const ASSETS_BASE = `${API_BASE}/api/v1/content-assets`
 
 // ---------------------------------------------------------------------------
 // Wire types
@@ -183,6 +187,63 @@ export type ContentOpsExecuteOutcome =
   | { kind: 'services_unavailable'; detail: string }             // 503
   | { kind: 'request_invalid'; detail: string }                  // 400 from ValueError
 
+// GET /content-assets/{asset}/drafts and review/export helpers.
+
+export type GeneratedAssetType =
+  | 'blog_post'
+  | 'report'
+  | 'landing_page'
+  | 'sales_brief'
+
+export interface GeneratedAssetDraft {
+  id?: string
+  title?: string
+  slug?: string
+  status?: string
+  target_id?: string
+  target_mode?: string
+  report_type?: string
+  topic_type?: string
+  campaign_name?: string
+  brief_type?: string
+  description?: string
+  summary?: string
+  headline?: string
+  generation_total_tokens?: number
+  generation_parse_attempts?: number
+  reasoning_context_used?: boolean
+  reasoning_wedge?: string
+  reasoning_confidence?: number
+  [key: string]: unknown
+}
+
+export interface GeneratedAssetListParams {
+  status?: string
+  target_mode?: string
+  report_type?: string
+  campaign_name?: string
+  slug?: string
+  topic_type?: string
+  brief_type?: string
+  format?: string
+  limit?: number
+}
+
+export interface GeneratedAssetListResponse {
+  count: number
+  limit: number
+  filters: Record<string, unknown>
+  rows: GeneratedAssetDraft[]
+}
+
+export interface GeneratedAssetReviewResponse {
+  account_id?: string | null
+  asset: GeneratedAssetType
+  id: string
+  status: string
+  updated: boolean
+}
+
 // ---------------------------------------------------------------------------
 // Internal fetch plumbing
 // ---------------------------------------------------------------------------
@@ -259,6 +320,66 @@ async function postJson<T>(path: string, body: ContentOpsRequestBody): Promise<T
   return rawJson<T>(res)
 }
 
+function queryString(params: GeneratedAssetListParams): string {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue
+    search.set(key, String(value))
+  }
+  const query = search.toString()
+  return query ? `?${query}` : ''
+}
+
+async function getAssetJson<T>(
+  asset: GeneratedAssetType,
+  path: string,
+  params: GeneratedAssetListParams = {},
+): Promise<T> {
+  const url = `${ASSETS_BASE}/${asset}${path}${queryString(params)}`
+  const doFetch = () => fetchWithApiFallback(url, { headers: authHeaders() })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const body = await rawText(res)
+    throw new Error(`API ${res.status}: ${body || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
+async function postAssetJson<T>(
+  asset: GeneratedAssetType,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const url = `${ASSETS_BASE}/${asset}${path}`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(body),
+    })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const text = await rawText(res)
+    throw new Error(`API ${res.status}: ${text || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
+async function getAssetText(
+  asset: GeneratedAssetType,
+  path: string,
+  params: GeneratedAssetListParams = {},
+): Promise<string> {
+  const url = `${ASSETS_BASE}/${asset}${path}${queryString(params)}`
+  const doFetch = () => fetchWithApiFallback(url, { headers: authHeaders() })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const body = await rawText(res)
+    throw new Error(`API ${res.status}: ${body || res.statusText}`)
+  }
+  return rawText(res)
+}
+
 // ---------------------------------------------------------------------------
 // Public fetch wrappers
 // ---------------------------------------------------------------------------
@@ -266,6 +387,34 @@ async function postJson<T>(path: string, body: ContentOpsRequestBody): Promise<T
 /** GET /content-ops/control-surfaces -- catalog + presets + execution flags. */
 export function fetchContentOpsControlSurfaces(): Promise<ContentOpsCatalogResponse> {
   return getJson<ContentOpsCatalogResponse>('/control-surfaces')
+}
+
+/** GET /content-assets/{asset}/drafts -- persisted generated assets. */
+export function fetchGeneratedAssetDrafts(
+  asset: GeneratedAssetType,
+  params: GeneratedAssetListParams = {},
+): Promise<GeneratedAssetListResponse> {
+  return getAssetJson<GeneratedAssetListResponse>(asset, '/drafts', params)
+}
+
+/** GET /content-assets/{asset}/drafts/export?format=csv -- CSV body. */
+export function exportGeneratedAssetDraftsCsv(
+  asset: GeneratedAssetType,
+  params: GeneratedAssetListParams = {},
+): Promise<string> {
+  return getAssetText(asset, '/drafts/export', { ...params, format: 'csv' })
+}
+
+/** POST /content-assets/{asset}/drafts/review -- approve/reject a draft. */
+export function reviewGeneratedAssetDraft(
+  asset: GeneratedAssetType,
+  id: string,
+  status: 'approved' | 'rejected',
+): Promise<GeneratedAssetReviewResponse> {
+  return postAssetJson<GeneratedAssetReviewResponse>(asset, '/drafts/review', {
+    id,
+    status,
+  })
 }
 
 /** POST /content-ops/preview -- preflight validation. */

--- a/atlas-intel-ui/src/components/Sidebar.tsx
+++ b/atlas-intel-ui/src/components/Sidebar.tsx
@@ -17,6 +17,8 @@ import {
   Users,
   FileText,
   Megaphone,
+  ClipboardCheck,
+  Sparkles,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAuth } from '../auth/AuthContext'
@@ -59,6 +61,8 @@ const b2bRetentionLinks: NavItem[] = [
   { to: '/b2b/reviews', icon: MessageSquareText, label: 'Reviews' },
   { to: '/b2b/reports', icon: FileText, label: 'Reports', minPlan: 'b2b_starter' },
   { to: '/b2b/campaigns', icon: Megaphone, label: 'Campaigns', minPlan: 'b2b_growth' },
+  { to: '/content-ops/new', icon: Sparkles, label: 'Content Ops', minPlan: 'b2b_growth' },
+  { to: '/content-ops/assets', icon: ClipboardCheck, label: 'Asset Review', minPlan: 'b2b_growth' },
 ]
 
 const b2bChallengerLinks: NavItem[] = [
@@ -69,6 +73,8 @@ const b2bChallengerLinks: NavItem[] = [
   { to: '/b2b/campaigns', icon: Megaphone, label: 'Campaigns', minPlan: 'b2b_growth' },
   { to: '/b2b/reports', icon: FileText, label: 'Reports', minPlan: 'b2b_starter' },
   { to: '/b2b/reviews', icon: MessageSquareText, label: 'Reviews' },
+  { to: '/content-ops/new', icon: Sparkles, label: 'Content Ops', minPlan: 'b2b_growth' },
+  { to: '/content-ops/assets', icon: ClipboardCheck, label: 'Asset Review', minPlan: 'b2b_growth' },
 ]
 
 const PRODUCT_TITLES: Record<string, string> = {

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -1,0 +1,387 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  ArrowRight,
+  CheckCircle2,
+  Download,
+  Loader2,
+  RefreshCw,
+  XCircle,
+} from 'lucide-react'
+import { clsx } from 'clsx'
+import {
+  exportGeneratedAssetDraftsCsv,
+  fetchGeneratedAssetDrafts,
+  reviewGeneratedAssetDraft,
+  type GeneratedAssetDraft,
+  type GeneratedAssetListResponse,
+  type GeneratedAssetType,
+} from '../api/contentOps'
+import { PageError } from '../components/ErrorBoundary'
+
+type StatusFilter = 'draft' | 'approved' | 'rejected' | 'all'
+
+const ASSETS: Array<{
+  id: GeneratedAssetType
+  label: string
+  description: string
+}> = [
+  {
+    id: 'report',
+    label: 'Reports',
+    description: 'Structured market, account, and vendor reports.',
+  },
+  {
+    id: 'blog_post',
+    label: 'Blog Posts',
+    description: 'SEO-ready long-form content drafts.',
+  },
+  {
+    id: 'landing_page',
+    label: 'Landing Pages',
+    description: 'Campaign pages with hero, sections, CTA, and metadata.',
+  },
+  {
+    id: 'sales_brief',
+    label: 'Sales Briefs',
+    description: 'Pre-call and account-facing sales enablement assets.',
+  },
+]
+
+const STATUSES: StatusFilter[] = ['draft', 'approved', 'rejected', 'all']
+
+export default function ContentOpsAssetsReview() {
+  const [asset, setAsset] = useState<GeneratedAssetType>('report')
+  const [status, setStatus] = useState<StatusFilter>('draft')
+  const [limit, setLimit] = useState(20)
+  const [data, setData] = useState<GeneratedAssetListResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
+
+  const params = useMemo(
+    () => ({
+      status: status === 'all' ? '' : status,
+      limit,
+    }),
+    [limit, status],
+  )
+
+  const load = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true)
+    else setLoading(true)
+    setError(null)
+    setActionError(null)
+    try {
+      const result = await fetchGeneratedAssetDrafts(asset, params)
+      setData(result)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [asset, params])
+
+  useEffect(() => {
+    void load(false)
+  }, [load])
+
+  const handleReview = async (row: GeneratedAssetDraft, nextStatus: 'approved' | 'rejected') => {
+    const id = assetId(row)
+    if (!id) return
+    setBusyId(id)
+    setActionError(null)
+    try {
+      await reviewGeneratedAssetDraft(asset, id, nextStatus)
+      await load(true)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const handleExport = async () => {
+    setExporting(true)
+    setActionError(null)
+    try {
+      const csv = await exportGeneratedAssetDraftsCsv(asset, params)
+      downloadCsv(csv, `${asset}_drafts.csv`)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  if (error && !data) {
+    return <PageError error={error} onRetry={() => void load(true)} />
+  }
+
+  const activeAsset = ASSETS.find((item) => item.id === asset) || ASSETS[0]
+  const rows = data?.rows || []
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-cyan-300">
+            AI Content Ops
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold text-white">
+            Generated Asset Review
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm text-slate-400">
+            Review persisted drafts from the Content Ops generation pipeline,
+            approve assets that are ready, reject misses, and export the current
+            queue for offline review.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            to="/content-ops/new"
+            className="inline-flex items-center gap-2 rounded-md border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-cyan-400 hover:text-cyan-200"
+          >
+            New run
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+          <button
+            type="button"
+            onClick={() => void load(true)}
+            disabled={refreshing}
+            className="inline-flex items-center gap-2 rounded-md border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-cyan-400 hover:text-cyan-200 disabled:opacity-60"
+          >
+            <RefreshCw className={clsx('h-4 w-4', refreshing && 'animate-spin')} />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        {ASSETS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => setAsset(item.id)}
+            className={clsx(
+              'rounded-lg border p-4 text-left transition',
+              asset === item.id
+                ? 'border-cyan-400 bg-cyan-500/10'
+                : 'border-slate-800 bg-slate-900/60 hover:border-slate-600',
+            )}
+          >
+            <div className="text-sm font-semibold text-white">{item.label}</div>
+            <p className="mt-1 text-xs text-slate-400">{item.description}</p>
+          </button>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-white">{activeAsset.label}</h2>
+            <p className="text-sm text-slate-400">{activeAsset.description}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={status}
+              onChange={(event) => setStatus(event.target.value as StatusFilter)}
+              className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+            >
+              {STATUSES.map((item) => (
+                <option key={item} value={item}>
+                  {item === 'all' ? 'All statuses' : item}
+                </option>
+              ))}
+            </select>
+            <select
+              value={limit}
+              onChange={(event) => setLimit(Number(event.target.value))}
+              className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+            >
+              {[10, 20, 50, 100].map((item) => (
+                <option key={item} value={item}>
+                  {item} rows
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handleExport}
+              disabled={exporting || loading}
+              className="inline-flex items-center gap-2 rounded-md bg-cyan-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-400 disabled:opacity-60"
+            >
+              {exporting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
+              Export CSV
+            </button>
+          </div>
+        </div>
+
+        {actionError && (
+          <div className="mt-4 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+            {actionError}
+          </div>
+        )}
+        {error && data && (
+          <div className="mt-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+            Refresh failed: {error.message}
+          </div>
+        )}
+
+        <div className="mt-4">
+          {loading ? (
+            <div className="flex items-center justify-center py-20 text-slate-400">
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Loading generated assets...
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="rounded-md border border-slate-800 bg-slate-950/50 px-4 py-10 text-center text-sm text-slate-400">
+              No {status === 'all' ? '' : status} {activeAsset.label.toLowerCase()} found.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {rows.map((row, index) => (
+                <AssetRow
+                  key={assetId(row) || `${asset}-${index}`}
+                  row={row}
+                  asset={asset}
+                  busy={busyId === assetId(row)}
+                  onReview={handleReview}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function AssetRow({
+  row,
+  asset,
+  busy,
+  onReview,
+}: {
+  row: GeneratedAssetDraft
+  asset: GeneratedAssetType
+  busy: boolean
+  onReview: (row: GeneratedAssetDraft, status: 'approved' | 'rejected') => void
+}) {
+  const id = assetId(row)
+  const title = assetTitle(row, asset)
+  const subtitle = assetSubtitle(row, asset)
+  const status = textValue(row.status) || 'unknown'
+  const canReview = Boolean(id)
+
+  return (
+    <article className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="truncate text-base font-semibold text-white">{title}</h3>
+            <span className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-300">
+              {status}
+            </span>
+            {row.reasoning_context_used && (
+              <span className="rounded bg-violet-500/10 px-2 py-0.5 text-xs text-violet-200">
+                reasoning
+              </span>
+            )}
+          </div>
+          {subtitle && <p className="mt-1 text-sm text-slate-400">{subtitle}</p>}
+          <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+            {id && <span className="font-mono">id: {id}</span>}
+            {row.reasoning_wedge && <span>wedge: {textValue(row.reasoning_wedge)}</span>}
+            {typeof row.generation_total_tokens === 'number' && (
+              <span>tokens: {row.generation_total_tokens}</span>
+            )}
+            {typeof row.generation_parse_attempts === 'number' && (
+              <span>parse attempts: {row.generation_parse_attempts}</span>
+            )}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => onReview(row, 'approved')}
+            disabled={!canReview || busy || status === 'approved'}
+            title={canReview ? 'Approve draft' : 'Draft id missing'}
+            className="inline-flex items-center gap-2 rounded-md border border-emerald-500/40 px-3 py-2 text-sm text-emerald-200 hover:bg-emerald-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+            Approve
+          </button>
+          <button
+            type="button"
+            onClick={() => onReview(row, 'rejected')}
+            disabled={!canReview || busy || status === 'rejected'}
+            title={canReview ? 'Reject draft' : 'Draft id missing'}
+            className="inline-flex items-center gap-2 rounded-md border border-rose-500/40 px-3 py-2 text-sm text-rose-200 hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <XCircle className="h-4 w-4" />}
+            Reject
+          </button>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function assetId(row: GeneratedAssetDraft): string {
+  return textValue(row.id)
+}
+
+function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string {
+  return (
+    textValue(row.title) ||
+    textValue(row.headline) ||
+    textValue(row.slug) ||
+    textValue(row.target_id) ||
+    textValue(row.campaign_name) ||
+    `${asset} draft`
+  )
+}
+
+function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string {
+  if (asset === 'blog_post') {
+    return [row.topic_type, row.description].map(textValue).filter(Boolean).join(' | ')
+  }
+  if (asset === 'landing_page') {
+    return [row.campaign_name, row.slug].map(textValue).filter(Boolean).join(' | ')
+  }
+  if (asset === 'sales_brief') {
+    return [row.target_mode, row.brief_type, row.target_id]
+      .map(textValue)
+      .filter(Boolean)
+      .join(' | ')
+  }
+  return [row.target_mode, row.report_type, row.summary]
+    .map(textValue)
+    .filter(Boolean)
+    .join(' | ')
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function downloadCsv(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  window.setTimeout(() => URL.revokeObjectURL(url), 0)
+}

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T02:18Z by codex-2026-05-15-content-assets-review-row-ids
+Last updated: 2026-05-15T02:29Z by codex-2026-05-15-content-ops-assets-review-ui
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops asset review row ids | generated asset ports, Postgres adapters, export helpers, asset API tests | codex-2026-05-15-content-assets-review-row-ids | Avoid generated-asset list/export row-shape edits |
+| draft | Content Ops generated asset review UI | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`, `atlas-intel-ui/src/App.tsx`, `atlas-intel-ui/src/components/Sidebar.tsx` | codex-2026-05-15-content-ops-assets-review-ui | Avoid Content Ops frontend routing/navigation and generated-asset API adapter edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Assets-Review-UI.md
+++ b/plans/PR-Content-Ops-Assets-Review-UI.md
@@ -1,0 +1,67 @@
+# PR: Content Ops generated assets review UI
+
+## Plan
+
+Expose the generated Content Ops asset review routes in the Atlas UI so an
+operator can review real persisted outputs after execution.
+
+## Why this slice exists
+
+The backend mounts `/api/v1/content-assets/*`, but the frontend only shows
+execution summaries. Operators need one protected screen to inspect generated
+reports, blog posts, landing pages, and sales briefs, approve or reject drafts,
+and export the current queue. The diff is above the normal target because the
+slice is the smallest useful vertical UI: API wrappers, route wiring, and the
+screen need to land together for the feature to be usable.
+
+## Scope (this PR)
+
+1. Add generated-asset API wrappers to the existing Content Ops adapter.
+2. Add a protected generated-assets review page with asset/status filters,
+   CSV export, and approve/reject actions.
+3. Mount the page at `/content-ops/assets`.
+4. Add B2B sidebar links for Content Ops execution and asset review.
+
+### Files touched
+
+- `atlas-intel-ui/src/App.tsx`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/components/Sidebar.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Assets-Review-UI.md`
+
+## Mechanism
+
+The UI fetches `/api/v1/content-assets/{asset}/drafts`, uses the returned
+`id` for `/drafts/review`, and downloads CSV through the existing export
+route using authenticated fetch. Status `all` maps to an empty status query
+because the backend already treats that as an all-status export.
+
+## Intentional
+
+- Keep the page wire-shaped and lightweight; no new domain mapper layer.
+- Disable review actions when a row has no id instead of guessing a natural key.
+- Keep CSV export authenticated through `fetch`, not `window.open`.
+
+## Deferred
+
+- Rich asset preview drawers for body/sections/content.
+- Bulk approve/reject actions.
+- Frontend unit tests for the page; current coverage is TypeScript build plus
+  backend route/export tests.
+
+## Verification
+
+- Frontend production build in `atlas-intel-ui`: passed.
+- Local PR review wrapper after rebasing onto the row-id prerequisite.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| API adapter | ~150 LOC |
+| Review page | ~390 LOC |
+| Route/sidebar wiring | ~10 LOC |
+| Plan + coordination | ~55 LOC |
+| Total | ~605 LOC |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Assets-Review-UI.md

Adds the protected Content Ops generated-assets review screen so operators can list persisted reports/blog posts/landing pages/sales briefs, approve or reject drafts, and export the current queue as CSV.

## Intentional
- Keep the page wire-shaped and lightweight; no new domain mapper layer.
- Disable review actions when a row has no id instead of guessing a natural key.
- Keep CSV export authenticated through fetch, not window.open.

## Deferred
- Rich asset preview drawers for body/sections/content.
- Bulk approve/reject actions.
- Frontend unit tests for the page; current validation is TypeScript build plus backend route/export tests.

## Verification
- npm run build in atlas-intel-ui: passed.
- bash scripts/local_pr_review.sh: passed.

## Diff size
6 files, +614 / -3