### PR TITLE
Add Content Ops reasoning context upsert

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T02:29Z by codex-2026-05-15-content-ops-assets-review-ui
+Last updated: 2026-05-15T02:14Z by codex-2026-05-15-content-ops-reasoning-upsert
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops generated asset review UI | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`, `atlas-intel-ui/src/App.tsx`, `atlas-intel-ui/src/components/Sidebar.tsx` | codex-2026-05-15-content-ops-assets-review-ui | Avoid Content Ops frontend routing/navigation and generated-asset API adapter edits |
+| draft | Content Ops reasoning context upsert | `extracted_content_pipeline/campaign_reasoning_postgres.py`, `extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql`, `extracted_content_pipeline/manifest.json`, `tests/test_extracted_campaign_reasoning_postgres.py`, `tests/test_extracted_campaign_manifest.py` | codex-2026-05-15-content-ops-reasoning-upsert | Avoid campaign reasoning context repository/migration edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_reasoning_postgres.py
+++ b/extracted_content_pipeline/campaign_reasoning_postgres.py
@@ -29,6 +29,7 @@ does not satisfy another mode when selectors overlap.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -104,6 +105,16 @@ def _dedupe_selectors(values: Sequence[Any]) -> tuple[str, ...]:
             seen.add(variant)
             cleaned.append(variant)
     return tuple(cleaned)
+
+
+def _selector_key(values: Sequence[str]) -> str:
+    """Return the order-independent persistence key for selectors."""
+
+    canonical = "\x1f".join(sorted(values))
+    return hashlib.md5(
+        canonical.encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -220,18 +231,26 @@ class PostgresCampaignReasoningContextRepository:
             )
 
         payload: JsonDict = campaign_reasoning_context_metadata(normalized)
+        selector_key = _selector_key(cleaned)
 
         context_id = await self.pool.fetchval(
             f"""
             INSERT INTO {self.table} (
-                account_id, target_mode, selectors, payload, updated_at
+                account_id, target_mode, selectors, selector_key,
+                payload, updated_at
             )
-            VALUES ($1, $2, $3::text[], $4::jsonb, NOW())
+            VALUES ($1, $2, $3::text[], $4, $5::jsonb, NOW())
+            ON CONFLICT (account_id, target_mode, selector_key)
+            DO UPDATE SET
+                selectors = EXCLUDED.selectors,
+                payload = EXCLUDED.payload,
+                updated_at = NOW()
             RETURNING id
             """,
             scope.account_id or "",
             str(target_mode or "").strip().lower(),
             list(cleaned),
+            selector_key,
             json_dump_jsonb(payload),
         )
         return str(context_id)

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -320,6 +320,9 @@
       "target": "extracted_content_pipeline/storage/migrations/277_campaign_reasoning_contexts.sql"
     },
     {
+      "target": "extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_reasoning_postgres.py"
     },
     {

--- a/extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql
+++ b/extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql
@@ -1,0 +1,52 @@
+-- Deterministic replay key for Content Ops campaign reasoning contexts.
+--
+-- Migration 277 introduced campaign_reasoning_contexts with insert-only
+-- writes. Hosts can rerun the same reasoning-context ETL, so the table needs
+-- a stable uniqueness contract for (account_id, target_mode, logical selector
+-- set). selector_key is the sorted-selector MD5 used by the extracted
+-- Postgres adapter; MD5 is only a compact deterministic key, not a security
+-- primitive.
+
+ALTER TABLE campaign_reasoning_contexts
+    ADD COLUMN IF NOT EXISTS selector_key TEXT;
+
+UPDATE campaign_reasoning_contexts
+SET selector_key = md5(
+    array_to_string(
+        ARRAY(
+            SELECT DISTINCT selector_value
+            FROM unnest(selectors) AS selector_item(selector_value)
+            ORDER BY selector_value
+        ),
+        E'\x1f'
+    )
+)
+WHERE selector_key IS NULL OR selector_key = '';
+
+DELETE FROM campaign_reasoning_contexts AS stale
+USING campaign_reasoning_contexts AS keep
+WHERE stale.id <> keep.id
+  AND stale.account_id = keep.account_id
+  AND stale.target_mode = keep.target_mode
+  AND stale.selector_key = keep.selector_key
+  AND (
+      keep.updated_at > stale.updated_at
+      OR (
+          keep.updated_at = stale.updated_at
+          AND keep.created_at > stale.created_at
+      )
+      OR (
+          keep.updated_at = stale.updated_at
+          AND keep.created_at = stale.created_at
+          AND keep.id::text > stale.id::text
+      )
+  );
+
+ALTER TABLE campaign_reasoning_contexts
+    ALTER COLUMN selector_key SET DEFAULT md5('');
+
+ALTER TABLE campaign_reasoning_contexts
+    ALTER COLUMN selector_key SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_campaign_reasoning_contexts_scope_mode_selector_key
+    ON campaign_reasoning_contexts (account_id, target_mode, selector_key);

--- a/plans/PR-Content-Ops-Reasoning-Upsert.md
+++ b/plans/PR-Content-Ops-Reasoning-Upsert.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-Reasoning-Upsert
+
+## Why this slice exists
+
+The DB-backed Content Ops reasoning context repository can read
+`campaign_reasoning_contexts`, but `save_context` only inserts. Re-running a
+host ETL for the same account, target mode, and selector set can leave duplicate
+rows where read behavior depends on `updated_at` instead of a deterministic
+write contract.
+
+This slice makes the write path replay-safe before more hosts depend on the
+Postgres reasoning provider.
+
+## Scope (this PR)
+
+1. Add a stable selector-key migration for `campaign_reasoning_contexts`.
+2. Change `PostgresCampaignReasoningContextRepository.save_context` to upsert
+   by account, target mode, and selector key.
+3. Add focused tests for upsert SQL, selector-key order independence, and
+   migration ownership.
+4. Claim the slice in the coordination ledger.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Upsert.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/campaign_reasoning_postgres.py`
+- `extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql`
+- `extracted_content_pipeline/manifest.json`
+- `tests/test_extracted_campaign_reasoning_postgres.py`
+- `tests/test_extracted_campaign_manifest.py`
+
+## Mechanism
+
+`save_context` already normalizes selectors into case-as-given and lowercase
+forms. This PR derives a stable MD5 selector key from the sorted cleaned
+selector set, writes it to `selector_key`, and uses:
+
+```sql
+ON CONFLICT (account_id, target_mode, selector_key)
+DO UPDATE SET selectors = EXCLUDED.selectors,
+              payload = EXCLUDED.payload,
+              updated_at = NOW()
+```
+
+Migration 278 adds and backfills `selector_key`, collapses pre-existing
+duplicates to the newest row for each replay key, then creates the unique index
+that makes replay writes deterministic.
+
+## Intentional
+
+- Existing read semantics are unchanged: reads still match with
+  `selectors && $2::text[]` and keep selector-priority ordering.
+- The selector key is internal persistence metadata; it is not exposed through
+  any public API or response model.
+- MD5 is used as a compact deterministic key, not as a security primitive. It
+  also keeps the SQL backfill extension-free.
+- Pre-existing duplicates are collapsed during migration with newest row
+  winning. That matches the existing read tie-breaker and prevents the unique
+  index from failing on already-replayed ETL data.
+
+## Deferred
+
+- No UI for reasoning context seed/update history.
+
+## Verification
+
+```bash
+python -m pytest tests/test_extracted_campaign_reasoning_postgres.py
+python -m pytest tests/test_extracted_campaign_manifest.py
+python -m py_compile extracted_content_pipeline/campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_manifest.py
+bash scripts/local_pr_review.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Upsert.md` | 87 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/campaign_reasoning_postgres.py` | 23 |
+| `extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql` | 52 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `tests/test_extracted_campaign_reasoning_postgres.py` | 91 |
+| `tests/test_extracted_campaign_manifest.py` | 9 |
+| **Total** | **~269** |

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -25,6 +25,7 @@ PRODUCT_OWNED_CAMPAIGN_MIGRATIONS = {
     "152_campaign_draft_export_indexes.sql",
     "092_subcategory_intelligence.sql",
     "276_blog_post_account_scope.sql",
+    "278_campaign_reasoning_context_upsert.sql",
 }
 
 DEFERRED_CROSS_PRODUCT_MIGRATIONS = {
@@ -107,6 +108,9 @@ def test_product_owned_campaign_migrations_define_product_tables() -> None:
     blog_post_scope_schema = (
         migrations_dir / "276_blog_post_account_scope.sql"
     ).read_text()
+    reasoning_upsert_schema = (
+        migrations_dir / "278_campaign_reasoning_context_upsert.sql"
+    ).read_text()
 
     assert "CREATE TABLE IF NOT EXISTS campaign_opportunities" in opportunity_schema
     assert "idx_campaign_opportunities_account_mode" in opportunity_schema
@@ -120,6 +124,10 @@ def test_product_owned_campaign_migrations_define_product_tables() -> None:
     )
     assert "idx_blog_posts_account_status" in blog_post_scope_schema
     assert "idx_blog_posts_account_topic" in blog_post_scope_schema
+    assert "ADD COLUMN IF NOT EXISTS selector_key TEXT" in reasoning_upsert_schema
+    assert "idx_campaign_reasoning_contexts_scope_mode_selector_key" in (
+        reasoning_upsert_schema
+    )
 
 
 def test_manifest_tracks_product_owned_adapter_files() -> None:
@@ -156,6 +164,7 @@ def test_manifest_tracks_product_owned_adapter_files() -> None:
     assert "extracted_content_pipeline/storage/migrations/152_campaign_draft_export_indexes.sql" in owned
     assert "extracted_content_pipeline/storage/migrations/092_subcategory_intelligence.sql" in owned
     assert "extracted_content_pipeline/storage/migrations/276_blog_post_account_scope.sql" in owned
+    assert "extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql" in owned
     assert "extracted_content_pipeline/reasoning/archetypes.py" in owned
     assert "extracted_content_pipeline/reasoning/temporal.py" in owned
     assert "extracted_content_pipeline/reasoning/evidence_engine.py" in owned

--- a/tests/test_extracted_campaign_reasoning_postgres.py
+++ b/tests/test_extracted_campaign_reasoning_postgres.py
@@ -8,7 +8,7 @@ so the host route mount (PR #402 / PR #462) can swap providers
 without touching the bundle's `with_reasoning_context()`
 derivation.
 
-Test inventory (12 tests):
+Test inventory (16 tests):
 
 1. `read_campaign_reasoning_context` builds the candidate
    selector array from `target_id` + opportunity keys
@@ -39,6 +39,10 @@ Test inventory (12 tests):
     the same selector priority.
 11. Target-mode caller input is normalized before filtering.
 12. `save_context` normalizes target-mode values before writing.
+13. `save_context` upserts by account, target_mode, and selector_key.
+14. Selector keys are order-independent for the same logical selector set.
+15. `save_context` accepts raw mappings after the selector-key SQL shape change.
+16. Migration 278 defines the selector_key column and unique replay index.
 
 Test harness uses an asyncpg-shaped fake pool (matches
 `tests/test_extracted_blog_blueprint_postgres.py`).
@@ -47,6 +51,7 @@ Test harness uses an asyncpg-shaped fake pool (matches
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -339,9 +344,72 @@ async def test_save_context_round_trips_payload_jsonb() -> None:
     assert "acme corp" in selectors
     assert "ACME-123" in selectors
     assert "acme-123" in selectors
-    payload = json.loads(args[3])
+    payload = json.loads(args[4])
     assert "reasoning_context" in payload
     assert payload["reasoning_context"]["top_theses"][0]["summary"] == "losing on price"
+
+
+@pytest.mark.asyncio
+async def test_save_context_upserts_by_selector_key() -> None:
+    """Replay writes update the existing row for the same account,
+    target_mode, and logical selector set."""
+
+    pool = _Pool()
+    pool.fetchval_results = ["ctx-uuid-upsert"]
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    saved = await repo.save_context(
+        scope=TenantScope(account_id="acct-1"),
+        selectors=("Acme Corp", "ACME-123"),
+        context=CampaignReasoningContext(
+            top_theses=({"summary": "Acme is losing on price"},),
+        ),
+        target_mode="vendor_retention",
+    )
+
+    assert saved == "ctx-uuid-upsert"
+    call = pool.fetchval_calls[0]
+    query = call["query"]
+    args = call["args"]
+    assert "selector_key" in query
+    assert "ON CONFLICT (account_id, target_mode, selector_key)" in query
+    assert "DO UPDATE SET" in query
+    assert "payload = EXCLUDED.payload" in query
+    assert args[0] == "acct-1"
+    assert args[1] == "vendor_retention"
+    assert "Acme Corp" in args[2]
+    assert len(args[3]) == 32
+    assert json.loads(args[4])["reasoning_context"]["top_theses"]
+
+
+@pytest.mark.asyncio
+async def test_save_context_selector_key_is_order_independent() -> None:
+    """The replay key depends on the set of cleaned selectors, not
+    caller ordering."""
+
+    pool = _Pool()
+    pool.fetchval_results = ["ctx-1", "ctx-1"]
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    context = CampaignReasoningContext(top_theses=({"summary": "x"},))
+    await repo.save_context(
+        scope=TenantScope(account_id="acct-1"),
+        selectors=("Acme Corp", "ACME-123"),
+        context=context,
+        target_mode="vendor",
+    )
+    await repo.save_context(
+        scope=TenantScope(account_id="acct-1"),
+        selectors=("ACME-123", "Acme Corp"),
+        context=context,
+        target_mode="vendor",
+    )
+
+    first_args = pool.fetchval_calls[0]["args"]
+    second_args = pool.fetchval_calls[1]["args"]
+    assert first_args[3] == second_args[3]
+    assert first_args[2] != []
+    assert second_args[2] != []
 
 
 @pytest.mark.asyncio
@@ -412,7 +480,24 @@ async def test_save_context_accepts_raw_mapping() -> None:
     )
 
     assert saved == "ctx-uuid-2"
-    payload = json.loads(pool.fetchval_calls[0]["args"][3])
+    payload = json.loads(pool.fetchval_calls[0]["args"][4])
     assert payload["reasoning_context"]["top_theses"][0]["summary"] == (
         "Acme losing on price"
     )
+
+
+def test_campaign_reasoning_context_upsert_migration_shape() -> None:
+    """Migration 278 owns the selector_key column and replay index."""
+
+    migration = (
+        Path(__file__).resolve().parents[1]
+        / "extracted_content_pipeline/storage/migrations"
+        / "278_campaign_reasoning_context_upsert.sql"
+    ).read_text()
+
+    assert "ADD COLUMN IF NOT EXISTS selector_key TEXT" in migration
+    assert "md5(" in migration
+    assert "DELETE FROM campaign_reasoning_contexts AS stale" in migration
+    assert "ALTER COLUMN selector_key SET NOT NULL" in migration
+    assert "idx_campaign_reasoning_contexts_scope_mode_selector_key" in migration
+    assert "(account_id, target_mode, selector_key)" in migration


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Upsert.md

The DB-backed Content Ops reasoning context repository currently inserts every saved context. Re-running host ETL for the same account, target mode, and selector set can leave duplicate rows where read behavior depends on updated_at. This PR adds a deterministic selector_key, backfills/collapses existing duplicates newest-row-wins, and changes save_context to upsert by account + target_mode + selector_key.

## Intentional
- Read behavior is unchanged: selectors overlap, selector-priority ordering, and target-mode fallback stay intact.
- MD5 is used only as a compact deterministic key and mirrors the extension-free SQL backfill.
- Migration 278 collapses pre-existing duplicate replay rows before adding the unique index.

## Deferred
- No UI for reasoning context seed/update history.

## Verification
- python -m pytest tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_manifest.py -> 23 passed
- python -m py_compile extracted_content_pipeline/campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_manifest.py -> passed
- bash scripts/local_pr_review.sh -> passed
- git diff --check -> passed

## Diff size
7 files, +262 / -7