### PR TITLE
Add generated asset batch review

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -11,6 +11,7 @@
  *   GET  /content-assets/{asset}/drafts
  *   GET  /content-assets/{asset}/drafts/export
  *   POST /content-assets/{asset}/drafts/review
+ *   POST /content-assets/{asset}/drafts/review-batch
  *
  * Wire types are 1:1 with the backend JSON (snake_case), matching
  * the convention in `client.ts` / `b2bClient.ts`. camelCase
@@ -244,6 +245,16 @@ export interface GeneratedAssetReviewResponse {
   updated: boolean
 }
 
+export interface GeneratedAssetBatchReviewResponse {
+  account_id?: string | null
+  asset: GeneratedAssetType
+  ids: string[]
+  status: string
+  updated: number
+  updated_ids: string[]
+  missing_ids: string[]
+}
+
 // ---------------------------------------------------------------------------
 // Internal fetch plumbing
 // ---------------------------------------------------------------------------
@@ -415,6 +426,19 @@ export function reviewGeneratedAssetDraft(
     id,
     status,
   })
+}
+
+/** POST /content-assets/{asset}/drafts/review-batch -- approve/reject drafts. */
+export function reviewGeneratedAssetDrafts(
+  asset: GeneratedAssetType,
+  ids: string[],
+  status: 'approved' | 'rejected',
+): Promise<GeneratedAssetBatchReviewResponse> {
+  return postAssetJson<GeneratedAssetBatchReviewResponse>(
+    asset,
+    '/drafts/review-batch',
+    { ids, status },
+  )
 }
 
 /** POST /content-ops/preview -- preflight validation. */

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -13,6 +13,7 @@ import {
   exportGeneratedAssetDraftsCsv,
   fetchGeneratedAssetDrafts,
   reviewGeneratedAssetDraft,
+  reviewGeneratedAssetDrafts,
   type GeneratedAssetDraft,
   type GeneratedAssetListResponse,
   type GeneratedAssetType,
@@ -60,6 +61,8 @@ export default function ContentOpsAssetsReview() {
   const [error, setError] = useState<Error | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
+  const [batchBusy, setBatchBusy] = useState<'approved' | 'rejected' | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
   const [exporting, setExporting] = useState(false)
 
   const params = useMemo(
@@ -78,6 +81,7 @@ export default function ContentOpsAssetsReview() {
     try {
       const result = await fetchGeneratedAssetDrafts(asset, params)
       setData(result)
+      setSelectedIds(new Set())
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
@@ -105,6 +109,26 @@ export default function ContentOpsAssetsReview() {
     }
   }
 
+  const handleBatchReview = async (nextStatus: 'approved' | 'rejected') => {
+    const ids = Array.from(selectedIds)
+    if (ids.length === 0) return
+    setBatchBusy(nextStatus)
+    setActionError(null)
+    try {
+      const result = await reviewGeneratedAssetDrafts(asset, ids, nextStatus)
+      await load(true)
+      if (result.missing_ids.length > 0) {
+        setActionError(
+          `${result.updated} updated. ${result.missing_ids.length} item(s) not found and skipped.`,
+        )
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBatchBusy(null)
+    }
+  }
+
   const handleExport = async () => {
     setExporting(true)
     setActionError(null)
@@ -124,6 +148,24 @@ export default function ContentOpsAssetsReview() {
 
   const activeAsset = ASSETS.find((item) => item.id === asset) || ASSETS[0]
   const rows = data?.rows || []
+  const reviewableIds = rows.map(assetId).filter(Boolean)
+  const selectedCount = reviewableIds.filter((id) => selectedIds.has(id)).length
+  const allSelected = reviewableIds.length > 0 && selectedCount === reviewableIds.length
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set())
+      return
+    }
+    setSelectedIds(new Set(reviewableIds))
+  }
+  const toggleRow = (id: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
@@ -187,6 +229,40 @@ export default function ContentOpsAssetsReview() {
             <p className="text-sm text-slate-400">{activeAsset.description}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={toggleAll}
+              disabled={reviewableIds.length === 0 || loading}
+              className="inline-flex items-center gap-2 rounded-md border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-cyan-400 hover:text-cyan-200 disabled:opacity-60"
+            >
+              {allSelected ? 'Clear' : 'Select all'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleBatchReview('approved')}
+              disabled={selectedCount === 0 || Boolean(batchBusy) || Boolean(busyId)}
+              className="inline-flex items-center gap-2 rounded-md border border-emerald-500/40 px-3 py-2 text-sm text-emerald-200 hover:bg-emerald-500/10 disabled:opacity-50"
+            >
+              {batchBusy === 'approved' ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle2 className="h-4 w-4" />
+              )}
+              Approve selected
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleBatchReview('rejected')}
+              disabled={selectedCount === 0 || Boolean(batchBusy) || Boolean(busyId)}
+              className="inline-flex items-center gap-2 rounded-md border border-rose-500/40 px-3 py-2 text-sm text-rose-200 hover:bg-rose-500/10 disabled:opacity-50"
+            >
+              {batchBusy === 'rejected' ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <XCircle className="h-4 w-4" />
+              )}
+              Reject selected
+            </button>
             <select
               value={status}
               onChange={(event) => setStatus(event.target.value as StatusFilter)}
@@ -211,7 +287,7 @@ export default function ContentOpsAssetsReview() {
             </select>
             <button
               type="button"
-              onClick={handleExport}
+              onClick={() => void handleExport()}
               disabled={exporting || loading}
               className="inline-flex items-center gap-2 rounded-md bg-cyan-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-cyan-400 disabled:opacity-60"
             >
@@ -254,6 +330,8 @@ export default function ContentOpsAssetsReview() {
                   row={row}
                   asset={asset}
                   busy={busyId === assetId(row)}
+                  selected={selectedIds.has(assetId(row))}
+                  onToggle={toggleRow}
                   onReview={handleReview}
                 />
               ))}
@@ -269,11 +347,15 @@ function AssetRow({
   row,
   asset,
   busy,
+  selected,
+  onToggle,
   onReview,
 }: {
   row: GeneratedAssetDraft
   asset: GeneratedAssetType
   busy: boolean
+  selected: boolean
+  onToggle: (id: string) => void
   onReview: (row: GeneratedAssetDraft, status: 'approved' | 'rejected') => void
 }) {
   const id = assetId(row)
@@ -285,28 +367,38 @@ function AssetRow({
   return (
     <article className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="truncate text-base font-semibold text-white">{title}</h3>
-            <span className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-300">
-              {status}
-            </span>
-            {row.reasoning_context_used && (
-              <span className="rounded bg-violet-500/10 px-2 py-0.5 text-xs text-violet-200">
-                reasoning
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => id && onToggle(id)}
+            disabled={!canReview || busy}
+            aria-label={`Select ${title}`}
+            className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-950 text-cyan-400 focus:ring-cyan-400 disabled:opacity-50"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="truncate text-base font-semibold text-white">{title}</h3>
+              <span className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-300">
+                {status}
               </span>
-            )}
-          </div>
-          {subtitle && <p className="mt-1 text-sm text-slate-400">{subtitle}</p>}
-          <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
-            {id && <span className="font-mono">id: {id}</span>}
-            {row.reasoning_wedge && <span>wedge: {textValue(row.reasoning_wedge)}</span>}
-            {typeof row.generation_total_tokens === 'number' && (
-              <span>tokens: {row.generation_total_tokens}</span>
-            )}
-            {typeof row.generation_parse_attempts === 'number' && (
-              <span>parse attempts: {row.generation_parse_attempts}</span>
-            )}
+              {row.reasoning_context_used && (
+                <span className="rounded bg-violet-500/10 px-2 py-0.5 text-xs text-violet-200">
+                  reasoning
+                </span>
+              )}
+            </div>
+            {subtitle && <p className="mt-1 text-sm text-slate-400">{subtitle}</p>}
+            <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+              {id && <span className="font-mono">id: {id}</span>}
+              {row.reasoning_wedge && <span>wedge: {textValue(row.reasoning_wedge)}</span>}
+              {typeof row.generation_total_tokens === 'number' && (
+                <span>tokens: {row.generation_total_tokens}</span>
+              )}
+              {typeof row.generation_parse_attempts === 'number' && (
+                <span>parse attempts: {row.generation_parse_attempts}</span>
+              )}
+            </div>
           </div>
         </div>
         <div className="flex gap-2">

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T02:14Z by codex-2026-05-15-content-ops-reasoning-upsert
+Last updated: 2026-05-15T02:31Z by codex-2026-05-15-content-ops-asset-bulk-review
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning context upsert | `extracted_content_pipeline/campaign_reasoning_postgres.py`, `extracted_content_pipeline/storage/migrations/278_campaign_reasoning_context_upsert.sql`, `extracted_content_pipeline/manifest.json`, `tests/test_extracted_campaign_reasoning_postgres.py`, `tests/test_extracted_campaign_manifest.py` | codex-2026-05-15-content-ops-reasoning-upsert | Avoid campaign reasoning context repository/migration edits |
+| draft | Content Ops asset bulk review | `extracted_content_pipeline/api/generated_assets.py`, `tests/test_extracted_content_asset_api.py`, `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | codex-2026-05-15-content-ops-asset-bulk-review | Avoid generated asset review API/UI edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -53,6 +53,7 @@ class GeneratedAssetApiConfig:
     default_status: str | None = "draft"
     default_limit: int = 20
     max_limit: int = 200
+    max_batch_size: int = 200
     export_filename_prefix: str = "content_assets"
 
     def __post_init__(self) -> None:
@@ -62,6 +63,8 @@ class GeneratedAssetApiConfig:
             raise ValueError("max_limit must be positive")
         if self.default_limit > self.max_limit:
             raise ValueError("default_limit must be less than or equal to max_limit")
+        if self.max_batch_size <= 0:
+            raise ValueError("max_batch_size must be positive")
         if not _clean(self.export_filename_prefix):
             raise ValueError("export_filename_prefix is required")
 
@@ -111,6 +114,22 @@ def _review_status(value: Any) -> str:
     if not status:
         raise HTTPException(status_code=400, detail="status is required")
     return status
+
+
+def _review_ids(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise HTTPException(status_code=400, detail="ids must be a non-empty list")
+    ids: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        asset_id = _clean(item)
+        if not asset_id or asset_id in seen:
+            continue
+        seen.add(asset_id)
+        ids.append(asset_id)
+    if not ids:
+        raise HTTPException(status_code=400, detail="ids must be a non-empty list")
+    return tuple(ids)
 
 
 def _asset_arg(value: str) -> str:
@@ -240,6 +259,49 @@ def create_generated_asset_router(
             "id": asset_id,
             "status": status,
             "updated": bool(updated),
+        }
+
+    @router.post("/{asset}/drafts/review-batch")
+    async def review_drafts_batch(
+        asset: str,
+        payload: dict[str, Any] = Body(...),
+    ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        tenant = _tenant_scope(scope)
+        ids = _review_ids(payload.get("ids") or payload.get("asset_ids"))
+        if len(ids) > resolved_config.max_batch_size:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "batch size exceeds max_batch_size "
+                    f"({resolved_config.max_batch_size})"
+                ),
+            )
+        status = _review_status(payload.get("status"))
+        updated_ids: list[str] = []
+        missing_ids: list[str] = []
+        for asset_id in ids:
+            updated = await _update_asset_status(
+                asset_name,
+                pool,
+                asset_id=asset_id,
+                status=status,
+                scope=tenant,
+            )
+            if updated:
+                updated_ids.append(asset_id)
+            else:
+                missing_ids.append(asset_id)
+        return {
+            "account_id": tenant.account_id,
+            "asset": asset_name,
+            "ids": list(ids),
+            "status": status,
+            "updated": len(updated_ids),
+            "updated_ids": updated_ids,
+            "missing_ids": missing_ids,
         }
 
     return router

--- a/plans/PR-Content-Ops-Asset-Bulk-Review.md
+++ b/plans/PR-Content-Ops-Asset-Bulk-Review.md
@@ -1,0 +1,72 @@
+# PR: Content Ops asset bulk review
+
+## Why this slice exists
+
+The current generated asset review surface lets operators approve or reject one
+draft at a time. The active AI Content Ops backlog calls out batch review/status
+updates before richer preview cards because batch actions improve operator
+throughput across all generated asset types.
+
+## Scope (this PR)
+
+1. Add a host-mounted batch review endpoint for generated assets.
+2. Add a typed frontend API wrapper for the batch review call.
+3. Add checkbox selection and batch approve/reject actions to the generated
+   asset review page.
+4. Add focused backend route coverage.
+5. Replace the merged reasoning-upsert coordination claim with this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Asset-Bulk-Review.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+
+## Mechanism
+
+The backend adds `POST /content-assets/{asset}/drafts/review-batch`. It
+validates the asset, status, non-empty ids, and configured batch cap, then
+reuses the same `_update_asset_status` helper as the single-row endpoint. The
+response reports requested ids, updated ids, missing ids, and updated count.
+
+The frontend keeps selection local to the current asset/filter page. Changing
+asset, status, limit, or reloading data clears selection so operators do not
+accidentally update stale rows.
+
+## Intentional
+
+- No new repository bulk SQL. Reusing the existing scoped `update_status`
+  methods keeps tenant filtering identical to the single-row path.
+- No cross-asset batch action. Operators review one asset type at a time because
+  each asset has a different repository and filter shape.
+- No richer preview cards in this slice.
+
+## Deferred
+
+- Native repository-level bulk update SQL if batch sizes become large.
+- Richer generated asset previews and component-level frontend tests.
+
+## Verification
+
+```bash
+python -m pytest tests/test_extracted_content_asset_api.py
+python -m py_compile extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py
+npm --prefix atlas-intel-ui run build
+bash scripts/local_pr_review.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Asset-Bulk-Review.md` | 70 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/api/generated_assets.py` | 62 |
+| `tests/test_extracted_content_asset_api.py` | 94 |
+| `atlas-intel-ui/src/api/contentOps.ts` | 20 |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | 138 |
+| **Total** | **~388** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -286,6 +286,97 @@ def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
     assert args == ("brief-uuid-1", "ready_for_call", "")
 
 
+def test_generated_asset_router_batch_reviews_reports() -> None:
+    pool = _Pool()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/report/drafts/review-batch",
+        json={
+            "ids": ["report-uuid-1", "report-uuid-2"],
+            "status": "approved",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "account_id": "acct_1",
+        "asset": "report",
+        "ids": ["report-uuid-1", "report-uuid-2"],
+        "status": "approved",
+        "updated": 2,
+        "updated_ids": ["report-uuid-1", "report-uuid-2"],
+        "missing_ids": [],
+    }
+    assert len(pool.execute_calls) == 2
+    first_query, first_args = pool.execute_calls[0]
+    second_query, second_args = pool.execute_calls[1]
+    assert "UPDATE reports" in first_query
+    assert "UPDATE reports" in second_query
+    assert first_args == ("report-uuid-1", "approved", "acct_1")
+    assert second_args == ("report-uuid-2", "approved", "acct_1")
+
+
+def test_generated_asset_router_batch_reviews_reports_misses() -> None:
+    pool = _Pool(execute_result="UPDATE 0")
+
+    response = _client(pool).post(
+        "/content-assets/report/drafts/review-batch",
+        json={"ids": ["report-uuid-1"], "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["updated"] == 0
+    assert response.json()["updated_ids"] == []
+    assert response.json()["missing_ids"] == ["report-uuid-1"]
+
+
+def test_generated_asset_router_batch_review_partial_update() -> None:
+    class _PartialPool(_Pool):
+        async def execute(self, query, *args):
+            self.execute_calls.append((str(query), args))
+            return "UPDATE 1" if len(self.execute_calls) == 1 else "UPDATE 0"
+
+    response = _client(_PartialPool(), scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review-batch",
+        json={
+            "ids": ["report-uuid-1", "report-uuid-missing"],
+            "status": "approved",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated"] == 1
+    assert body["updated_ids"] == ["report-uuid-1"]
+    assert body["missing_ids"] == ["report-uuid-missing"]
+
+
+def test_generated_asset_router_batch_review_enforces_configured_cap() -> None:
+    response = _client(
+        _Pool(),
+        config=GeneratedAssetApiConfig(max_batch_size=1),
+    ).post(
+        "/content-assets/report/drafts/review-batch",
+        json={"ids": ["report-uuid-1", "report-uuid-2"], "status": "approved"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "batch size exceeds max_batch_size (1)"
+
+
+def test_generated_asset_router_batch_review_rejects_empty_ids() -> None:
+    response = _client(_Pool()).post(
+        "/content-assets/report/drafts/review-batch",
+        json={"ids": ["", "  "], "status": "approved"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "ids must be a non-empty list"
+
+
 def test_generated_asset_router_rejects_unknown_asset() -> None:
     response = _client(_Pool()).get("/content-assets/podcast_episode/drafts")
 
@@ -357,6 +448,9 @@ def test_generated_asset_api_config_rejects_invalid_limits() -> None:
 
     with pytest.raises(ValueError, match="default_limit must be less"):
         GeneratedAssetApiConfig(default_limit=5, max_limit=4)
+
+    with pytest.raises(ValueError, match="max_batch_size must be positive"):
+        GeneratedAssetApiConfig(max_batch_size=0)
 
 
 def test_generated_asset_router_requires_fastapi(monkeypatch) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Asset-Bulk-Review.md

Add a generated asset batch-review endpoint and wire the Content Ops asset review page to select visible drafts and approve or reject them in one call. The backend reuses the existing scoped update_status helpers for each asset type, so tenant filtering matches the single-row review path.

## Intentional
- No repository-level bulk SQL; this keeps the first batch action on the existing per-asset status contract.
- No cross-asset batch action; operators review one generated asset type at a time.

## Deferred
- Native bulk update SQL if batch sizes become large.
- Richer generated asset preview cards and frontend component tests.

## Verification
- python -m pytest tests/test_extracted_content_asset_api.py -> 18 passed
- python -m py_compile extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py -> passed
- npm --prefix atlas-intel-ui ci -> passed, 6 existing audit findings
- npm --prefix atlas-intel-ui run build -> passed
- bash scripts/local_pr_review.sh -> passed
- git diff --check -> passed

## Diff size
6 files, +319 / -23