### PR TITLE
Add generated asset preview snippets

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -210,6 +210,12 @@ export interface GeneratedAssetDraft {
   description?: string
   summary?: string
   headline?: string
+  content?: string
+  tags?: string[] | string
+  hero?: Record<string, unknown>
+  sections?: Array<Record<string, unknown>> | string
+  cta?: Record<string, unknown>
+  reference_ids?: string[] | string
   generation_total_tokens?: number
   generation_parse_attempts?: number
   reasoning_context_used?: boolean

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -363,6 +363,7 @@ function AssetRow({
   const subtitle = assetSubtitle(row, asset)
   const status = textValue(row.status) || 'unknown'
   const canReview = Boolean(id)
+  const preview = assetPreview(row, asset)
 
   return (
     <article className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
@@ -399,6 +400,37 @@ function AssetRow({
                 <span>parse attempts: {row.generation_parse_attempts}</span>
               )}
             </div>
+            {preview && (
+              <div className="mt-4 rounded-md border border-slate-800 bg-slate-900/70 p-3">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Preview
+                </div>
+                <div className="mt-2 space-y-2">
+                  {preview.heading && (
+                    <div className="text-sm font-medium text-slate-200">
+                      {preview.heading}
+                    </div>
+                  )}
+                  {preview.body && (
+                    <p className="line-clamp-3 text-sm leading-6 text-slate-400">
+                      {preview.body}
+                    </p>
+                  )}
+                  {preview.meta.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {preview.meta.map((item, index) => (
+                        <span
+                          key={`${item}-${index}`}
+                          className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-300"
+                        >
+                          {item}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
           </div>
         </div>
         <div className="flex gap-2">
@@ -464,6 +496,81 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
 
 function textValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
+}
+
+function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): {
+  heading: string
+  body: string
+  meta: string[]
+} | null {
+  if (asset === 'blog_post') {
+    const tags = valueList(row.tags).slice(0, 4)
+    return previewOrNull({
+      heading: textValue(row.description),
+      body: excerpt(textValue(row.content)),
+      meta: tags,
+    })
+  }
+  if (asset === 'landing_page') {
+    const section = firstSection(row.sections)
+    return previewOrNull({
+      heading: objectText(row.hero, 'headline') || section.title,
+      body: excerpt(section.body),
+      meta: [objectText(row.cta, 'label')].filter(Boolean),
+    })
+  }
+  // Reports and sales briefs share the same section/summary preview shape.
+  const section = firstSection(row.sections)
+  return previewOrNull({
+    heading: section.title,
+    body: excerpt(section.body || textValue(row.summary) || textValue(row.headline)),
+    meta: valueList(row.reference_ids).slice(0, 3).map((id) => `ref: ${id}`),
+  })
+}
+
+function previewOrNull(preview: {
+  heading: string
+  body: string
+  meta: string[]
+}): { heading: string; body: string; meta: string[] } | null {
+  return preview.heading || preview.body || preview.meta.length > 0 ? preview : null
+}
+
+function firstSection(value: unknown): { title: string; body: string } {
+  let sections = Array.isArray(value) ? value : []
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      sections = Array.isArray(parsed) ? parsed : []
+    } catch {
+      sections = []
+    }
+  }
+  const first = sections.find((item) => item && typeof item === 'object')
+  if (!first || typeof first !== 'object') return { title: '', body: '' }
+  const section = first as Record<string, unknown>
+  return {
+    title: textValue(section.title),
+    body: textValue(section.body_markdown) || textValue(section.body),
+  }
+}
+
+function objectText(value: unknown, key: string): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return ''
+  return textValue((value as Record<string, unknown>)[key])
+}
+
+function valueList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(textValue).filter(Boolean)
+  const text = textValue(value)
+  if (!text) return []
+  return text.split(',').map((item) => item.trim()).filter(Boolean)
+}
+
+function excerpt(value: string, limit = 260): string {
+  const clean = value.replace(/\s+/g, ' ').trim()
+  if (clean.length <= limit) return clean
+  return `${clean.slice(0, limit - 3).trim()}...`
 }
 
 function downloadCsv(csv: string, filename: string): void {

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T02:31Z by codex-2026-05-15-content-ops-asset-bulk-review
+Last updated: 2026-05-15T02:41Z by codex-2026-05-15-content-ops-asset-preview
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops asset bulk review | `extracted_content_pipeline/api/generated_assets.py`, `tests/test_extracted_content_asset_api.py`, `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | codex-2026-05-15-content-ops-asset-bulk-review | Avoid generated asset review API/UI edits |
+| draft | Content Ops asset previews | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | codex-2026-05-15-content-ops-asset-preview | Avoid generated asset review UI/API-type edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Asset-Preview.md
+++ b/plans/PR-Content-Ops-Asset-Preview.md
@@ -1,0 +1,65 @@
+# PR: Content Ops asset previews
+
+## Why this slice exists
+
+After generated asset review and batch status updates, operators can approve or
+reject persisted assets but still see only metadata-level rows. The active AI
+Content Ops backlog calls out richer generated-asset previews as the next
+operator review UX improvement.
+
+## Scope (this PR)
+
+1. Add compact preview data fields to the generated asset wire type.
+2. Render per-row preview snippets for reports, blog posts, landing pages, and
+   sales briefs using fields already returned by the existing list endpoint.
+3. Replace the merged batch-review coordination claim with this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Asset-Preview.md`
+- `docs/extraction/coordination/inflight.md`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+
+## Mechanism
+
+The review page now derives a small preview model from each row:
+
+- `blog_post`: description/content excerpt plus tags.
+- `report` and `sales_brief`: first section title/body excerpt.
+- `landing_page`: hero headline, first section excerpt, and CTA label.
+
+The data is already present in the generated asset list/export rows, so this is
+a rendering-only slice.
+
+## Intentional
+
+- No backend changes. The existing API already returns the fields needed for a
+  compact preview.
+- No full document drawer. This PR improves scanability without introducing a
+  larger detail-view interaction.
+- No Markdown renderer. Preview bodies are plain excerpts to keep the review
+  list dense and safe.
+
+## Deferred
+
+- Full generated-asset detail drawer with rendered Markdown/sections.
+- Component-level frontend tests for the review page.
+
+## Verification
+
+```bash
+npm --prefix atlas-intel-ui run build
+bash scripts/local_pr_review.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Asset-Preview.md` | 55 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `atlas-intel-ui/src/api/contentOps.ts` | 10 |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | 120 |
+| **Total** | **~189** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Asset-Preview.md

Summary:
- Adds compact preview snippets to the generated asset review table for reports, blog posts, landing pages, and sales briefs.
- Extends the frontend asset row type with existing API/export fields used for previews.
- Claims the slice in the coordination ledger.

Intentional:
- Frontend-only; no generated asset API behavior changes.
- Plain text excerpts only, no Markdown renderer or full document drawer.

Deferred:
- Full generated-asset detail drawer with rendered Markdown/sections.
- Component-level frontend tests for the review page.

Verification:
- npm --prefix atlas-intel-ui run build
- bash scripts/local_pr_review.sh