### PR TITLE
Add Content Ops DB reasoning sweeper

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T02:41Z by codex-2026-05-15-content-ops-asset-preview
+Last updated: 2026-05-15T02:55Z by codex-2026-05-15-content-ops-db-reasoning-sweeper
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops asset previews | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | codex-2026-05-15-content-ops-asset-preview | Avoid generated asset review UI/API-type edits |
+| draft | Content Ops DB reasoning sweeper | `extracted_content_pipeline/campaign_reasoning_postgres.py`, `scripts/cleanup_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_postgres.py`, `tests/test_extracted_campaign_reasoning_cleanup_cli.py` | codex-2026-05-15-content-ops-db-reasoning-sweeper | Avoid DB reasoning repository cleanup and host cleanup CLI edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_reasoning_postgres.py
+++ b/extracted_content_pipeline/campaign_reasoning_postgres.py
@@ -255,6 +255,67 @@ class PostgresCampaignReasoningContextRepository:
         )
         return str(context_id)
 
+    async def delete_stale_contexts(
+        self,
+        *,
+        older_than_days: int,
+        scope: TenantScope | None = None,
+        target_mode: str | None = None,
+        dry_run: bool = False,
+    ) -> int:
+        """Delete or count stale reasoning contexts.
+
+        This is an operational cleanup hook for host installs that run
+        periodic reasoning ETL. ``target_mode=None`` means all modes;
+        a string value filters to that normalized mode, including the
+        blank global-fallback mode when ``target_mode=""``.
+        """
+
+        if older_than_days < 1:
+            raise ValueError("older_than_days must be at least 1")
+
+        account_id = None if scope is None else str(scope.account_id or "")
+        mode = None if target_mode is None else str(target_mode or "").strip().lower()
+        if dry_run:
+            stale_count = await self.pool.fetchval(
+                f"""
+                WITH stale AS (
+                    SELECT id
+                    FROM {self.table}
+                    WHERE updated_at < NOW() - ($1::int * INTERVAL '1 day')
+                      AND ($2::text IS NULL OR account_id = $2)
+                      AND ($3::text IS NULL OR target_mode = $3)
+                )
+                SELECT COUNT(*) FROM stale
+                """,
+                int(older_than_days),
+                account_id,
+                mode,
+            )
+            return int(stale_count or 0)
+
+        stale_count = await self.pool.fetchval(
+            f"""
+            WITH stale AS (
+                SELECT id
+                FROM {self.table}
+                WHERE updated_at < NOW() - ($1::int * INTERVAL '1 day')
+                  AND ($2::text IS NULL OR account_id = $2)
+                  AND ($3::text IS NULL OR target_mode = $3)
+            ),
+            deleted AS (
+                DELETE FROM {self.table}
+                WHERE id IN (SELECT id FROM stale)
+                RETURNING 1
+            )
+            SELECT COUNT(*) FROM deleted
+            """,
+            int(older_than_days),
+            account_id,
+            mode,
+        )
+        return int(stale_count or 0)
+
 
 __all__ = [
     "PostgresCampaignReasoningContextRepository",

--- a/plans/PR-Content-Ops-DB-Reasoning-Sweeper.md
+++ b/plans/PR-Content-Ops-DB-Reasoning-Sweeper.md
@@ -1,0 +1,75 @@
+# Content Ops DB Reasoning Sweeper
+
+## Why this slice exists
+
+The DB-backed Content Ops reasoning provider can now read, upsert, and smoke
+test durable reasoning contexts, but hosts still need a safe operational way to
+remove stale rows after repeated ETL runs. Without a cleanup seam, old global or
+mode-specific contexts can accumulate indefinitely.
+
+## Scope (this PR)
+
+1. Add a repository-level stale-context cleanup method to
+   `extracted_content_pipeline/campaign_reasoning_postgres.py`.
+2. Add `scripts/cleanup_extracted_campaign_reasoning_contexts.py` as the
+   host-facing dry-run/apply command.
+3. Add focused tests for repository SQL shape and CLI dry-run/apply behavior.
+4. Add the new CLI test to `scripts/run_extracted_pipeline_checks.sh`.
+5. Claim the slice in `docs/extraction/coordination/inflight.md`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-DB-Reasoning-Sweeper.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/campaign_reasoning_postgres.py`
+- `scripts/cleanup_extracted_campaign_reasoning_contexts.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_campaign_reasoning_cleanup_cli.py`
+- `tests/test_extracted_campaign_reasoning_postgres.py`
+
+## Mechanism
+
+`PostgresCampaignReasoningContextRepository.delete_stale_contexts(...)` accepts
+an explicit `older_than_days` threshold plus optional account and target-mode
+filters. It counts matching rows in dry-run mode and deletes only when callers
+request apply mode.
+
+The CLI requires `--older-than-days`, defaults to dry-run, and only deletes when
+`--apply` is passed. It uses the same DSN resolution as the existing Postgres
+reasoning check script: `--database-url`, `EXTRACTED_DATABASE_URL`, or
+`DATABASE_URL`.
+
+## Intentional
+
+- No generation/runtime path changes.
+- No scheduler is added; hosts decide when to run the sweeper.
+- No hidden age threshold default. Operators must provide `--older-than-days`.
+- `target_mode=None` means all modes; `--target-mode ""` can still target the
+  blank global-fallback mode.
+
+## Deferred
+
+- Admin UI for viewing/editing context rows.
+- Scheduled cleanup wiring in Atlas.
+- Per-row audit logging for deleted context ids.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_cleanup_cli.py
+python -m py_compile extracted_content_pipeline/campaign_reasoning_postgres.py scripts/cleanup_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_cleanup_cli.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-DB-Reasoning-Sweeper.md` | 65 |
+| `docs/extraction/coordination/inflight.md` | 5 |
+| `extracted_content_pipeline/campaign_reasoning_postgres.py` | 65 |
+| `scripts/cleanup_extracted_campaign_reasoning_contexts.py` | 120 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_campaign_reasoning_cleanup_cli.py` | 80 |
+| `tests/test_extracted_campaign_reasoning_postgres.py` | 65 |
+| **Total** | **~401** |

--- a/scripts/cleanup_extracted_campaign_reasoning_contexts.py
+++ b/scripts/cleanup_extracted_campaign_reasoning_contexts.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Dry-run or delete stale Content Ops campaign reasoning contexts."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_reasoning_postgres import (  # noqa: E402
+    PostgresCampaignReasoningContextRepository,
+)
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Count or delete stale campaign_reasoning_contexts rows. "
+            "Runs as a dry-run unless --apply is passed."
+        )
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--older-than-days",
+        type=_positive_int,
+        required=True,
+        help="Only rows older than this many days are counted or deleted.",
+    )
+    parser.add_argument("--account-id", default=None, help="Optional tenant/account filter.")
+    parser.add_argument("--target-mode", default=None, help="Optional target_mode filter.")
+    parser.add_argument(
+        "--table",
+        default="campaign_reasoning_contexts",
+        help="Reasoning context table name.",
+    )
+    parser.add_argument("--apply", action="store_true", help="Delete matching rows.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to clean campaign reasoning contexts; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _cleanup(
+    repository: PostgresCampaignReasoningContextRepository,
+    *,
+    account_id: str | None,
+    target_mode: str | None,
+    older_than_days: int,
+    apply: bool,
+) -> dict[str, Any]:
+    affected = await repository.delete_stale_contexts(
+        older_than_days=older_than_days,
+        scope=TenantScope(account_id=account_id) if account_id is not None else None,
+        target_mode=target_mode,
+        dry_run=not apply,
+    )
+    return {
+        "status": "deleted" if apply else "dry_run",
+        "affected": affected,
+        "older_than_days": older_than_days,
+        "account_id": account_id,
+        "target_mode": target_mode,
+    }
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        repository = PostgresCampaignReasoningContextRepository(
+            pool=pool,
+            table=args.table,
+        )
+        result = await _cleanup(
+            repository,
+            account_id=args.account_id,
+            target_mode=args.target_mode,
+            older_than_days=args.older_than_days,
+            apply=bool(args.apply),
+        )
+    finally:
+        await pool.close()
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        action = "deleted" if args.apply else "would delete"
+        print(
+            f"{action} {result['affected']} campaign reasoning context rows "
+            f"older_than_days={result['older_than_days']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -29,6 +29,7 @@ pytest \
   tests/test_extracted_blog_blueprint_ingest.py \
   tests/test_extracted_blog_post_postgres.py \
   tests/test_extracted_campaign_reasoning_postgres.py \
+  tests/test_extracted_campaign_reasoning_cleanup_cli.py \
   tests/test_extracted_campaign_reasoning_postgres_check.py \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \

--- a/tests/test_extracted_campaign_reasoning_cleanup_cli.py
+++ b/tests/test_extracted_campaign_reasoning_cleanup_cli.py
@@ -1,0 +1,98 @@
+"""Tests for the campaign reasoning context cleanup CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "cleanup_extracted_campaign_reasoning_contexts.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "cleanup_extracted_campaign_reasoning_contexts",
+    _SCRIPT_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+cleanup_cli = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(cleanup_cli)
+
+
+class _Repository:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def delete_stale_contexts(self, **kwargs: Any) -> int:
+        self.calls.append(kwargs)
+        return 4
+
+
+def test_parse_args_requires_explicit_age_threshold() -> None:
+    """Operators must choose the cleanup age instead of inheriting a hidden default."""
+
+    with pytest.raises(SystemExit):
+        cleanup_cli._parse_args(["--database-url", "postgres://example"])
+
+
+def test_parse_args_rejects_non_positive_age_threshold() -> None:
+    """Invalid age thresholds should fail through argparse, not a traceback."""
+
+    with pytest.raises(SystemExit):
+        cleanup_cli._parse_args([
+            "--database-url",
+            "postgres://example",
+            "--older-than-days",
+            "0",
+        ])
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dry_run_uses_repository_count_path() -> None:
+    """Default cleanup mode is dry-run and preserves account/mode filters."""
+
+    repository = _Repository()
+
+    result = await cleanup_cli._cleanup(
+        repository,  # type: ignore[arg-type]
+        account_id="acct-1",
+        target_mode="vendor_retention",
+        older_than_days=30,
+        apply=False,
+    )
+
+    assert result == {
+        "status": "dry_run",
+        "affected": 4,
+        "older_than_days": 30,
+        "account_id": "acct-1",
+        "target_mode": "vendor_retention",
+    }
+    assert repository.calls[0]["dry_run"] is True
+    assert repository.calls[0]["scope"].account_id == "acct-1"
+    assert repository.calls[0]["target_mode"] == "vendor_retention"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_apply_uses_repository_delete_path() -> None:
+    """The CLI only deletes when --apply is passed."""
+
+    repository = _Repository()
+
+    result = await cleanup_cli._cleanup(
+        repository,  # type: ignore[arg-type]
+        account_id=None,
+        target_mode=None,
+        older_than_days=45,
+        apply=True,
+    )
+
+    assert result["status"] == "deleted"
+    assert result["affected"] == 4
+    assert repository.calls[0]["dry_run"] is False
+    assert repository.calls[0]["scope"] is None
+    assert repository.calls[0]["target_mode"] is None

--- a/tests/test_extracted_campaign_reasoning_postgres.py
+++ b/tests/test_extracted_campaign_reasoning_postgres.py
@@ -8,7 +8,7 @@ so the host route mount (PR #402 / PR #462) can swap providers
 without touching the bundle's `with_reasoning_context()`
 derivation.
 
-Test inventory (16 tests):
+Test inventory (19 tests):
 
 1. `read_campaign_reasoning_context` builds the candidate
    selector array from `target_id` + opportunity keys
@@ -43,6 +43,9 @@ Test inventory (16 tests):
 14. Selector keys are order-independent for the same logical selector set.
 15. `save_context` accepts raw mappings after the selector-key SQL shape change.
 16. Migration 278 defines the selector_key column and unique replay index.
+17. `delete_stale_contexts` counts stale rows in dry-run mode.
+18. `delete_stale_contexts` deletes stale rows only when requested.
+19. `delete_stale_contexts` rejects non-positive age thresholds.
 
 Test harness uses an asyncpg-shaped fake pool (matches
 `tests/test_extracted_blog_blueprint_postgres.py`).
@@ -501,3 +504,64 @@ def test_campaign_reasoning_context_upsert_migration_shape() -> None:
     assert "ALTER COLUMN selector_key SET NOT NULL" in migration
     assert "idx_campaign_reasoning_contexts_scope_mode_selector_key" in migration
     assert "(account_id, target_mode, selector_key)" in migration
+
+
+@pytest.mark.asyncio
+async def test_delete_stale_contexts_dry_run_counts_matching_rows() -> None:
+    """Dry-run mode must count stale rows without deleting them."""
+
+    pool = _Pool()
+    pool.fetchval_results = [3]
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    affected = await repo.delete_stale_contexts(
+        older_than_days=30,
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="Vendor_Retention",
+        dry_run=True,
+    )
+
+    assert affected == 3
+    call = pool.fetchval_calls[0]
+    query = call["query"]
+    args = call["args"]
+    assert "SELECT COUNT(*) FROM stale" in query
+    assert "DELETE FROM campaign_reasoning_contexts" not in query
+    assert "updated_at < NOW() - ($1::int * INTERVAL '1 day')" in query
+    assert args == (30, "acct-1", "vendor_retention")
+
+
+@pytest.mark.asyncio
+async def test_delete_stale_contexts_deletes_matching_rows_when_not_dry_run() -> None:
+    """Apply mode deletes through the same stale-row predicate."""
+
+    pool = _Pool()
+    pool.fetchval_results = [2]
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    affected = await repo.delete_stale_contexts(
+        older_than_days=45,
+        scope=None,
+        target_mode=None,
+        dry_run=False,
+    )
+
+    assert affected == 2
+    call = pool.fetchval_calls[0]
+    query = call["query"]
+    args = call["args"]
+    assert "DELETE FROM campaign_reasoning_contexts" in query
+    assert "SELECT COUNT(*) FROM deleted" in query
+    assert args == (45, None, None)
+
+
+@pytest.mark.asyncio
+async def test_delete_stale_contexts_rejects_non_positive_days() -> None:
+    """A zero-day cleanup would be too broad for an operator action."""
+
+    pool = _Pool()
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    with pytest.raises(ValueError):
+        await repo.delete_stale_contexts(older_than_days=0)
+    assert pool.fetchval_calls == []


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-DB-Reasoning-Sweeper.md

Summary:
- Adds PostgresCampaignReasoningContextRepository.delete_stale_contexts(...) for dry-run counting or deleting stale campaign_reasoning_contexts rows.
- Adds scripts/cleanup_extracted_campaign_reasoning_contexts.py as the host-facing cleanup CLI.
- Adds focused repository and CLI tests, and includes the CLI tests in the extracted pipeline check runner.

Intentional:
- No generation/runtime path changes.
- No scheduler; hosts decide when to run cleanup.
- Dry-run by default; deletion requires --apply.

Deferred:
- Admin UI for context row editing.
- Scheduled cleanup wiring in Atlas.

Verification:
- pytest tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_cleanup_cli.py
- python -m py_compile extracted_content_pipeline/campaign_reasoning_postgres.py scripts/cleanup_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_cleanup_cli.py
- bash scripts/local_pr_review.sh