### PR TITLE
Add Content Ops reasoning context upsert CLI

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T02:55Z by codex-2026-05-15-content-ops-db-reasoning-sweeper
+Last updated: 2026-05-15T03:20Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops DB reasoning sweeper | `extracted_content_pipeline/campaign_reasoning_postgres.py`, `scripts/cleanup_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_postgres.py`, `tests/test_extracted_campaign_reasoning_cleanup_cli.py` | codex-2026-05-15-content-ops-db-reasoning-sweeper | Avoid DB reasoning repository cleanup and host cleanup CLI edits |
+| draft | Content Ops reasoning admin upsert CLI | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning admin/upsert CLI edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -206,6 +206,22 @@ python scripts/check_extracted_campaign_reasoning_postgres.py \
   --json
 ```
 
+To insert or update host-produced reasoning rows without hand-writing SQL, load
+a JSON file with selectors plus a context payload:
+
+```bash
+python scripts/upsert_extracted_campaign_reasoning_contexts.py \
+  reasoning-contexts.json \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --selector "Acme"
+```
+
+The input may be a single row, an array, or a wrapper such as
+`{"contexts": [...]}`. Each row can provide `selectors`, selector fields such as
+`target_id` / `company_name` / `contact_email`, and either `context`,
+`reasoning_context`, or `campaign_reasoning_context`.
+
 For lightweight installs that do not already have reasoning JSON, use
 `services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`.
 It calls the configured `LLMClient` once per opportunity with the packaged

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -340,6 +340,19 @@ python scripts/check_extracted_campaign_reasoning_postgres.py \
 The check exits non-zero when no matching context is found, making it suitable
 for deployment smoke tests after a reasoning ETL or migration run.
 
+If a host needs to seed or edit durable reasoning rows manually, use the upsert
+CLI instead of hand-writing SQL:
+
+```bash
+python scripts/upsert_extracted_campaign_reasoning_contexts.py \
+  reasoning-contexts.json \
+  --account-id acct_123 \
+  --target-mode vendor_retention
+```
+
+Rows can include `selectors` directly or selector fields such as `target_id`,
+`company_name`, `contact_email`, and `vendor_name`.
+
 ## Step 6: Add Optional Prompt Overrides
 
 Use packaged skills by default. To override copy strategy, provide a markdown

--- a/plans/PR-Content-Ops-Reasoning-Admin-Upsert-CLI.md
+++ b/plans/PR-Content-Ops-Reasoning-Admin-Upsert-CLI.md
@@ -1,0 +1,74 @@
+# Content Ops Reasoning Admin Upsert CLI
+
+## Why this slice exists
+
+The DB-backed Content Ops reasoning provider now supports read checks, replay
+upserts through the repository, and stale-row cleanup. The remaining operator
+gap is a simple way to seed or edit durable reasoning contexts without writing
+SQL directly.
+
+This is intentionally one slice even though the estimated diff is slightly over
+the 400 LOC target: the CLI, its focused tests, and the two host-facing docs are
+the smallest reviewable unit that gives operators a usable edit path without an
+undocumented script.
+
+## Scope (this PR)
+
+1. Add a host-facing upsert CLI for `campaign_reasoning_contexts`.
+2. Add focused CLI parsing/upsert tests.
+3. Add the new test file to the extracted pipeline check runner.
+4. Document the admin upsert command in the README and host runbook.
+5. Replace the stale merged sweeper coordination row with this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Admin-Upsert-CLI.md`
+- `docs/extraction/coordination/inflight.md`
+- `scripts/upsert_extracted_campaign_reasoning_contexts.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_campaign_reasoning_upsert_cli.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+
+## Mechanism
+
+`scripts/upsert_extracted_campaign_reasoning_contexts.py` reads a JSON object,
+array, or wrapper such as `{"contexts": [...]}`. Each row can provide selectors
+directly or selector fields such as `target_id`, `company_name`,
+`contact_email`, and `vendor_name`. The script calls the existing
+`PostgresCampaignReasoningContextRepository.save_context(...)` method so replay
+semantics stay centralized in the repository.
+
+## Intentional
+
+- No generation/runtime path changes.
+- No new table or migration.
+- No web admin UI. This is the smallest useful operator edit path.
+- Rows without selectors fail loudly because they would never be readable.
+
+## Deferred
+
+- Full admin UI for browsing and editing context rows.
+- Row-level audit logging around admin edits.
+- Bulk validation against live opportunity ids before saving.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
+python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Admin-Upsert-CLI.md` | 60 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `scripts/upsert_extracted_campaign_reasoning_contexts.py` | 180 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_campaign_reasoning_upsert_cli.py` | 130 |
+| `extracted_content_pipeline/README.md` | 20 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 15 |
+| **Total** | **~410** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -30,6 +30,7 @@ pytest \
   tests/test_extracted_blog_post_postgres.py \
   tests/test_extracted_campaign_reasoning_postgres.py \
   tests/test_extracted_campaign_reasoning_cleanup_cli.py \
+  tests/test_extracted_campaign_reasoning_upsert_cli.py \
   tests/test_extracted_campaign_reasoning_postgres_check.py \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \

--- a/scripts/upsert_extracted_campaign_reasoning_contexts.py
+++ b/scripts/upsert_extracted_campaign_reasoning_contexts.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Upsert Content Ops campaign reasoning contexts into Postgres."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_reasoning_postgres import (  # noqa: E402
+    PostgresCampaignReasoningContextRepository,
+)
+
+
+_ROW_KEYS = ("contexts", "rows", "data", "reasoning_contexts")
+_MATCH_KEYS = (
+    "target_id",
+    "id",
+    "company",
+    "company_name",
+    "account",
+    "account_name",
+    "email",
+    "contact_email",
+    "vendor",
+    "vendor_name",
+)
+_META_KEYS = {"account_id", "target_mode", "selectors", *_MATCH_KEYS}
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Upsert host-produced campaign reasoning contexts into "
+            "campaign_reasoning_contexts."
+        )
+    )
+    parser.add_argument("path", help="JSON object, array, or wrapper containing contexts.")
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--account-id", default="", help="Default tenant/account id.")
+    parser.add_argument("--target-mode", default="", help="Default target_mode.")
+    parser.add_argument(
+        "--selector",
+        action="append",
+        default=[],
+        help="Extra selector to apply to every row; repeatable.",
+    )
+    parser.add_argument(
+        "--table",
+        default="campaign_reasoning_contexts",
+        help="Reasoning context table name.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to upsert campaign reasoning contexts; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _load_payload(path: str | Path) -> Any:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _context_rows(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        return [row for row in payload if isinstance(row, Mapping)]
+    if not isinstance(payload, Mapping):
+        raise ValueError("reasoning context JSON must be an object or array")
+    for key in _ROW_KEYS:
+        value = payload.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [row for row in value if isinstance(row, Mapping)]
+        if isinstance(value, Mapping):
+            return [
+                {"target_id": str(row_key), "context": row_value}
+                for row_key, row_value in value.items()
+                if isinstance(row_value, Mapping)
+            ]
+    return [payload]
+
+
+def _clean_values(values: Sequence[Any]) -> tuple[str, ...]:
+    cleaned: list[str] = []
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            cleaned.extend(_clean_values(value))
+            continue
+        text = str(value or "").strip()
+        if not text:
+            continue
+        cleaned.append(text)
+    return tuple(cleaned)
+
+
+def _row_selectors(row: Mapping[str, Any], extra_selectors: Sequence[str]) -> tuple[str, ...]:
+    values: list[Any] = []
+    values.extend(_clean_values(extra_selectors))
+    values.append(row.get("selectors"))
+    values.extend(row.get(key) for key in _MATCH_KEYS)
+    return _clean_values(values)
+
+
+def _row_context(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = row.get("context")
+    if isinstance(nested, Mapping):
+        return nested
+    return {
+        str(key): value
+        for key, value in row.items()
+        if key not in _META_KEYS and value not in (None, "", [], {})
+    }
+
+
+async def _upsert_contexts(
+    repository: PostgresCampaignReasoningContextRepository,
+    *,
+    payload: Any,
+    default_account_id: str,
+    default_target_mode: str,
+    extra_selectors: Sequence[str],
+) -> dict[str, Any]:
+    rows = _context_rows(payload)
+    prepared: list[dict[str, Any]] = []
+    for index, row in enumerate(rows, start=1):
+        selectors = _row_selectors(row, extra_selectors)
+        if not selectors:
+            raise ValueError(f"row {index} has no selectors")
+        context = _row_context(row)
+        if not context:
+            raise ValueError(f"row {index} has no context")
+        prepared.append(
+            {
+                "scope": TenantScope(
+                    account_id=str(row.get("account_id") or default_account_id or ""),
+                ),
+                "selectors": selectors,
+                "target_mode": str(row.get("target_mode") or default_target_mode or ""),
+                "context": context,
+            }
+        )
+
+    saved_ids: list[str] = []
+    for item in prepared:
+        saved_id = await repository.save_context(
+            scope=item["scope"],
+            selectors=item["selectors"],
+            target_mode=item["target_mode"],
+            context=item["context"],
+        )
+        saved_ids.append(saved_id)
+    return {"status": "ok", "upserted": len(saved_ids), "ids": saved_ids}
+
+
+async def _main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        repository = PostgresCampaignReasoningContextRepository(
+            pool=pool,
+            table=args.table,
+        )
+        result = await _upsert_contexts(
+            repository,
+            payload=_load_payload(args.path),
+            default_account_id=str(args.account_id or ""),
+            default_target_mode=str(args.target_mode or ""),
+            extra_selectors=tuple(args.selector or ()),
+        )
+    finally:
+        await pool.close()
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"upserted {result['upserted']} campaign reasoning context rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_extracted_campaign_reasoning_upsert_cli.py
+++ b/tests/test_extracted_campaign_reasoning_upsert_cli.py
@@ -1,0 +1,212 @@
+"""Tests for the campaign reasoning context upsert CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "upsert_extracted_campaign_reasoning_contexts.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "upsert_extracted_campaign_reasoning_contexts",
+    _SCRIPT_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+upsert_cli = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(upsert_cli)
+
+
+class _Repository:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def save_context(self, **kwargs: Any) -> str:
+        self.calls.append(kwargs)
+        return f"ctx-{len(self.calls)}"
+
+
+def test_context_rows_accepts_array_wrapper_and_mapping_index() -> None:
+    """Host files can be arrays, wrapper objects, or keyed context maps."""
+
+    assert upsert_cli._context_rows([{"target_id": "a"}]) == [{"target_id": "a"}]
+    assert upsert_cli._context_rows({"contexts": [{"target_id": "b"}]}) == [
+        {"target_id": "b"}
+    ]
+    assert upsert_cli._context_rows({
+        "contexts": {
+            "opp-1": {"top_theses": [{"summary": "Pricing pressure"}]},
+        }
+    }) == [
+        {
+            "target_id": "opp-1",
+            "context": {"top_theses": [{"summary": "Pricing pressure"}]},
+        }
+    ]
+
+
+def test_row_selectors_use_cli_row_and_matching_fields() -> None:
+    """Selectors come from explicit CLI values plus row metadata."""
+
+    selectors = upsert_cli._row_selectors(
+        {
+            "selectors": ["row-selector", "row-selector-2"],
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "contact_email": "buyer@example.com",
+        },
+        ["cli-selector"],
+    )
+
+    assert selectors == (
+        "cli-selector",
+        "row-selector",
+        "row-selector-2",
+        "opp-1",
+        "Acme",
+        "buyer@example.com",
+    )
+
+
+def test_row_context_prefers_nested_context() -> None:
+    """A nested context field is saved as the reasoning payload."""
+
+    row = {
+        "target_id": "opp-1",
+        "selectors": ["opp-1"],
+        "context": {"top_theses": [{"summary": "Renewal risk"}]},
+        "ignored": "metadata outside context",
+    }
+
+    assert upsert_cli._row_context(row) == {
+        "top_theses": [{"summary": "Renewal risk"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_saves_each_row_with_defaults() -> None:
+    """Rows without account/mode values inherit CLI defaults."""
+
+    repository = _Repository()
+
+    result = await upsert_cli._upsert_contexts(
+        repository,  # type: ignore[arg-type]
+        payload={
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "context": {"top_theses": [{"summary": "Renewal risk"}]},
+                },
+                {
+                    "selectors": ["opp-2", "Acme"],
+                    "account_id": "acct-row",
+                    "target_mode": "challenger_intel",
+                    "reasoning_context": {"proof_points": [{"label": "source"}]},
+                },
+            ]
+        },
+        default_account_id="acct-default",
+        default_target_mode="vendor_retention",
+        extra_selectors=[],
+    )
+
+    assert result == {"status": "ok", "upserted": 2, "ids": ["ctx-1", "ctx-2"]}
+    first = repository.calls[0]
+    assert first["scope"].account_id == "acct-default"
+    assert first["target_mode"] == "vendor_retention"
+    assert first["selectors"] == ("opp-1",)
+    assert first["context"]["top_theses"][0]["summary"] == "Renewal risk"
+    second = repository.calls[1]
+    assert second["scope"].account_id == "acct-row"
+    assert second["target_mode"] == "challenger_intel"
+    assert second["selectors"] == ("opp-2", "Acme")
+    assert "reasoning_context" in second["context"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_preserves_commas_inside_selector_values() -> None:
+    """Exact selector values such as company names are not split on commas."""
+
+    repository = _Repository()
+
+    await upsert_cli._upsert_contexts(
+        repository,  # type: ignore[arg-type]
+        payload={
+            "contexts": [
+                {
+                    "company_name": "Acme, Inc.",
+                    "context": {"top_theses": [{"summary": "Renewal risk"}]},
+                }
+            ]
+        },
+        default_account_id="acct-default",
+        default_target_mode="vendor_retention",
+        extra_selectors=["Global, LLC"],
+    )
+
+    assert repository.calls[0]["selectors"] == ("Global, LLC", "Acme, Inc.")
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_rejects_rows_without_selectors() -> None:
+    """An unselectable row would never be read back, so fail loudly."""
+
+    repository = _Repository()
+
+    with pytest.raises(ValueError, match="row 1 has no selectors"):
+        await upsert_cli._upsert_contexts(
+            repository,  # type: ignore[arg-type]
+            payload={"context": {"top_theses": [{"summary": "x"}]}},
+            default_account_id="acct-1",
+            default_target_mode="vendor_retention",
+            extra_selectors=[],
+        )
+    assert repository.calls == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_validates_all_rows_before_writing() -> None:
+    """A malformed later row should not leave a partially applied file."""
+
+    repository = _Repository()
+
+    with pytest.raises(ValueError, match="row 2 has no selectors"):
+        await upsert_cli._upsert_contexts(
+            repository,  # type: ignore[arg-type]
+            payload={
+                "contexts": [
+                    {
+                        "target_id": "opp-1",
+                        "context": {"top_theses": [{"summary": "x"}]},
+                    },
+                    {"context": {"top_theses": [{"summary": "y"}]}},
+                ]
+            },
+            default_account_id="acct-1",
+            default_target_mode="vendor_retention",
+            extra_selectors=[],
+        )
+    assert repository.calls == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_rejects_rows_without_context() -> None:
+    """Do not overwrite an existing useful row with an empty payload."""
+
+    repository = _Repository()
+
+    with pytest.raises(ValueError, match="row 1 has no context"):
+        await upsert_cli._upsert_contexts(
+            repository,  # type: ignore[arg-type]
+            payload={"target_id": "opp-1"},
+            default_account_id="acct-1",
+            default_target_mode="vendor_retention",
+            extra_selectors=[],
+        )
+    assert repository.calls == []


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Admin-Upsert-CLI.md

Summary:
- Adds scripts/upsert_extracted_campaign_reasoning_contexts.py for host/operator upserts into campaign_reasoning_contexts.
- Supports single-row, array, and contexts-wrapper JSON shapes.
- Documents the command in the README and host install runbook.

Intentional:
- No generation/runtime path changes.
- No new table or migration.
- No web admin UI in this slice.

Deferred:
- Full admin UI for browsing and editing context rows.
- Row-level audit logging around admin edits.

Verification:
- pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
- python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
- bash scripts/local_pr_review.sh