### PR TITLE
Add Content Ops reasoning context list CLI

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T03:20Z by codex-2026-05-15
+Last updated: 2026-05-15T03:36Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning admin upsert CLI | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning admin/upsert CLI edits |
+| draft | Content Ops reasoning context list/export CLI | `extracted_content_pipeline/campaign_reasoning_postgres.py`, `scripts/list_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_list_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning repository inventory/export edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -206,6 +206,21 @@ python scripts/check_extracted_campaign_reasoning_postgres.py \
   --json
 ```
 
+To inventory or export durable reasoning rows before/after operator edits:
+
+```bash
+python scripts/list_extracted_campaign_reasoning_contexts.py \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --selector "Acme" \
+  --limit 100 \
+  --format csv \
+  --output reasoning-contexts.csv
+```
+
+The list/export CLI defaults to `--limit 20`; raise the limit deliberately for
+larger inventories.
+
 To insert or update host-produced reasoning rows without hand-writing SQL, load
 a JSON file with selectors plus a context payload:
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -252,6 +252,9 @@ source of truth for what remains.
   the packaged single-pass provider with `--single-pass-reasoning` or the
   extracted reasoning-core provider with `--multi-pass-reasoning` when the
   product LLM adapter is configured.
+- DB-backed reasoning context operations now include read/check, list/export,
+  upsert, and stale-row cleanup CLIs so hosts can run the durable reasoning
+  provider without hand-written SQL.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/campaign_reasoning_postgres.py
+++ b/extracted_content_pipeline/campaign_reasoning_postgres.py
@@ -29,9 +29,12 @@ does not satisfy another mode when selectors overlap.
 
 from __future__ import annotations
 
+import csv
 import hashlib
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from io import StringIO
 from typing import Any
 
 from .campaign_ports import CampaignReasoningContext, JsonDict, TenantScope
@@ -117,6 +120,75 @@ def _selector_key(values: Sequence[str]) -> str:
     ).hexdigest()
 
 
+def _identifier(value: str) -> str:
+    parts = str(value or "").strip().split(".")
+    if not parts or any(not part for part in parts):
+        raise ValueError(f"invalid SQL identifier: {value!r}")
+    for part in parts:
+        if not all(char.isalnum() or char == "_" for char in part):
+            raise ValueError(f"invalid SQL identifier: {value!r}")
+    return ".".join(f'"{part}"' for part in parts)
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _serializable_context_row(row: Mapping[str, Any]) -> JsonDict:
+    payload = decode_jsonb_field(row.get("payload"), default=None)
+    output = {
+        key: _json_ready(value)
+        for key, value in row.items()
+        if key != "payload"
+    }
+    output["payload"] = _json_ready({} if payload is None else payload)
+    return output
+
+
+@dataclass(frozen=True)
+class CampaignReasoningContextListResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        columns = (
+            "id",
+            "account_id",
+            "target_mode",
+            "selectors",
+            "selector_key",
+            "updated_at",
+            "payload",
+        )
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(columns))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({column: _csv_value(row.get(column)) for column in columns})
+        return handle.getvalue()
+
+
 @dataclass(frozen=True)
 class PostgresCampaignReasoningContextRepository:
     """Async Postgres adapter for per-tenant campaign reasoning contexts."""
@@ -152,6 +224,7 @@ class PostgresCampaignReasoningContextRepository:
         )
         if not selectors:
             return None
+        table = _identifier(self.table)
 
         # Preserve the file-backed provider's candidate-key
         # priority: ``_candidate_selectors`` emits target_id first,
@@ -169,7 +242,7 @@ class PostgresCampaignReasoningContextRepository:
         row = await self.pool.fetchrow(
             f"""
             SELECT payload
-            FROM {self.table}
+            FROM {table}
             WHERE account_id = $1
               AND selectors && $2::text[]
               AND ($3 = '' OR target_mode = $3 OR target_mode = '')
@@ -232,10 +305,11 @@ class PostgresCampaignReasoningContextRepository:
 
         payload: JsonDict = campaign_reasoning_context_metadata(normalized)
         selector_key = _selector_key(cleaned)
+        table = _identifier(self.table)
 
         context_id = await self.pool.fetchval(
             f"""
-            INSERT INTO {self.table} (
+            INSERT INTO {table} (
                 account_id, target_mode, selectors, selector_key,
                 payload, updated_at
             )
@@ -276,12 +350,13 @@ class PostgresCampaignReasoningContextRepository:
 
         account_id = None if scope is None else str(scope.account_id or "")
         mode = None if target_mode is None else str(target_mode or "").strip().lower()
+        table = _identifier(self.table)
         if dry_run:
             stale_count = await self.pool.fetchval(
                 f"""
                 WITH stale AS (
                     SELECT id
-                    FROM {self.table}
+                    FROM {table}
                     WHERE updated_at < NOW() - ($1::int * INTERVAL '1 day')
                       AND ($2::text IS NULL OR account_id = $2)
                       AND ($3::text IS NULL OR target_mode = $3)
@@ -298,13 +373,13 @@ class PostgresCampaignReasoningContextRepository:
             f"""
             WITH stale AS (
                 SELECT id
-                FROM {self.table}
+                FROM {table}
                 WHERE updated_at < NOW() - ($1::int * INTERVAL '1 day')
                   AND ($2::text IS NULL OR account_id = $2)
                   AND ($3::text IS NULL OR target_mode = $3)
             ),
             deleted AS (
-                DELETE FROM {self.table}
+                DELETE FROM {table}
                 WHERE id IN (SELECT id FROM stale)
                 RETURNING 1
             )
@@ -316,7 +391,54 @@ class PostgresCampaignReasoningContextRepository:
         )
         return int(stale_count or 0)
 
+    async def list_contexts(
+        self,
+        *,
+        scope: TenantScope | None = None,
+        target_mode: str | None = None,
+        selectors: Sequence[str] = (),
+        limit: int = 20,
+    ) -> CampaignReasoningContextListResult:
+        """Return reasoning-context rows for operator inventory/export."""
+
+        table = _identifier(self.table)
+        normalized_limit = int(limit)
+        if normalized_limit < 0:
+            raise ValueError("limit must be non-negative")
+
+        account_id = None if scope is None else str(scope.account_id or "")
+        mode = None if target_mode is None else str(target_mode or "").strip().lower()
+        cleaned_selectors = _dedupe_selectors(selectors)
+        rows = await self.pool.fetch(
+            f"""
+            SELECT
+                id, account_id, target_mode, selectors, selector_key,
+                COALESCE(payload, '{{}}'::jsonb) AS payload,
+                updated_at
+            FROM {table}
+            WHERE ($1::text IS NULL OR account_id = $1)
+              AND ($2::text IS NULL OR target_mode = $2)
+              AND ($3::text[] IS NULL OR selectors && $3::text[])
+            ORDER BY updated_at DESC
+            LIMIT $4
+            """,
+            account_id,
+            mode,
+            list(cleaned_selectors) if cleaned_selectors else None,
+            normalized_limit,
+        )
+        return CampaignReasoningContextListResult(
+            rows=tuple(_serializable_context_row(row_to_dict(row)) for row in rows),
+            limit=normalized_limit,
+            filters={
+                "account_id": account_id,
+                "target_mode": mode,
+                "selectors": cleaned_selectors,
+            },
+        )
+
 
 __all__ = [
+    "CampaignReasoningContextListResult",
     "PostgresCampaignReasoningContextRepository",
 ]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -326,8 +326,9 @@ Use `--multi-pass-pack-name`, `--multi-pass-max-continuations`, and
 See `reasoning_handoff_contract.md` for the accepted shape and the no-direct-
 import rule. AI Content Ops consumes compressed reasoning through a provider;
 the provider may be file-backed, single-pass, multi-pass, or host-owned.
-After applying migration 277 and loading DB-backed reasoning rows, verify a
-target can resolve through the same Postgres adapter used by hosted execution:
+After applying the packaged migrations and loading DB-backed reasoning rows,
+verify a target can resolve through the same Postgres adapter used by hosted
+execution:
 
 ```bash
 python scripts/check_extracted_campaign_reasoning_postgres.py \
@@ -339,6 +340,20 @@ python scripts/check_extracted_campaign_reasoning_postgres.py \
 
 The check exits non-zero when no matching context is found, making it suitable
 for deployment smoke tests after a reasoning ETL or migration run.
+
+To inspect or export stored reasoning rows before/after manual edits:
+
+```bash
+python scripts/list_extracted_campaign_reasoning_contexts.py \
+  --account-id acct_123 \
+  --target-mode vendor_retention \
+  --selector "Acme" \
+  --limit 100 \
+  --format json
+```
+
+The list/export CLI defaults to `--limit 20`; raise the limit deliberately for
+larger inventories.
 
 If a host needs to seed or edit durable reasoning rows manually, use the upsert
 CLI instead of hand-writing SQL:

--- a/plans/PR-Content-Ops-Reasoning-Context-List-CLI.md
+++ b/plans/PR-Content-Ops-Reasoning-Context-List-CLI.md
@@ -1,0 +1,78 @@
+# Content Ops Reasoning Context List CLI
+
+## Why this slice exists
+
+The DB-backed Content Ops reasoning workflow can now check one target, upsert
+operator-provided contexts, and sweep stale rows. Operators still need a
+read-only inventory/export path before and after those edits so they can audit
+stored context rows without hand-writing SQL.
+
+## Scope (this PR)
+
+1. Add a repository list/export helper for `campaign_reasoning_contexts`.
+2. Add a host-facing list CLI with JSON and CSV output.
+3. Add focused repository/CLI tests.
+4. Add the new test file to the extracted pipeline check runner.
+5. Document the list/export command in the README and host runbook.
+6. Replace the stale merged upsert coordination row with this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Context-List-CLI.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/campaign_reasoning_postgres.py`
+- `scripts/list_extracted_campaign_reasoning_contexts.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_campaign_reasoning_list_cli.py`
+- `tests/test_extracted_campaign_reasoning_postgres.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+
+## Mechanism
+
+`PostgresCampaignReasoningContextRepository.list_contexts(...)` reads rows from
+the configured reasoning context table with optional account, target-mode, and
+selector filters. It returns a small result object that renders JSON or CSV.
+The CLI wires that helper to `EXTRACTED_DATABASE_URL` / `DATABASE_URL`.
+
+## Intentional
+
+- Read-only only; no generation/runtime behavior changes.
+- No new table or migration.
+- No web admin UI. This is the operator inventory companion to the existing
+  check, upsert, and cleanup CLIs.
+
+## Deferred
+
+- Full admin UI for browsing/editing reasoning rows.
+- Row-level audit logging around admin edits.
+- Live opportunity-id validation before upserts.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_list_cli.py
+python -m py_compile extracted_content_pipeline/campaign_reasoning_postgres.py scripts/list_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_list_cli.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Context-List-CLI.md` | 55 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| `extracted_content_pipeline/campaign_reasoning_postgres.py` | 85 |
+| `scripts/list_extracted_campaign_reasoning_contexts.py` | 120 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `tests/test_extracted_campaign_reasoning_list_cli.py` | 150 |
+| `tests/test_extracted_campaign_reasoning_postgres.py` | 5 |
+| `extracted_content_pipeline/README.md` | 15 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 15 |
+| `extracted_content_pipeline/STATUS.md` | 5 |
+| **Total** | **~448** |
+
+This is intentionally one slice even though the estimate is above the 400 LOC
+target: repository helper, CLI, tests, and host-facing docs are the smallest
+usable read-only inventory feature.

--- a/scripts/list_extracted_campaign_reasoning_contexts.py
+++ b/scripts/list_extracted_campaign_reasoning_contexts.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""List/export Content Ops campaign reasoning contexts from Postgres."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_reasoning_postgres import (  # noqa: E402
+    PostgresCampaignReasoningContextRepository,
+)
+
+
+def _non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="List/export campaign_reasoning_contexts rows."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--account-id", default=None, help="Optional tenant/account id.")
+    parser.add_argument("--target-mode", default=None, help="Optional target_mode filter.")
+    parser.add_argument(
+        "--selector",
+        action="append",
+        default=[],
+        help="Only rows matching this selector; repeatable.",
+    )
+    parser.add_argument(
+        "--table",
+        default="campaign_reasoning_contexts",
+        help="Reasoning context table name.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=_non_negative_int,
+        default=20,
+        help="Maximum rows to return. Default: 20.",
+    )
+    parser.add_argument("--format", choices=("json", "csv"), default="json")
+    parser.add_argument("--output", type=Path, default=None, help="Optional output path.")
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to list campaign reasoning contexts; "
+            "install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main_from_args(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    pool = await _create_pool(args.database_url)
+    try:
+        repository = PostgresCampaignReasoningContextRepository(
+            pool=pool,
+            table=args.table,
+        )
+        result = await repository.list_contexts(
+            scope=TenantScope(account_id=args.account_id)
+            if args.account_id is not None
+            else None,
+            target_mode=args.target_mode,
+            selectors=tuple(args.selector or ()),
+            limit=args.limit,
+        )
+    finally:
+        await pool.close()
+    output = (
+        result.as_csv()
+        if args.format == "csv"
+        else json.dumps(result.as_dict(), indent=2, sort_keys=True)
+    )
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="" if output.endswith("\n") else "\n")
+    return 0
+
+
+async def _main() -> int:
+    return await _main_from_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -31,6 +31,7 @@ pytest \
   tests/test_extracted_campaign_reasoning_postgres.py \
   tests/test_extracted_campaign_reasoning_cleanup_cli.py \
   tests/test_extracted_campaign_reasoning_upsert_cli.py \
+  tests/test_extracted_campaign_reasoning_list_cli.py \
   tests/test_extracted_campaign_reasoning_postgres_check.py \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \

--- a/tests/test_extracted_campaign_reasoning_list_cli.py
+++ b/tests/test_extracted_campaign_reasoning_list_cli.py
@@ -1,0 +1,200 @@
+"""Tests for the campaign reasoning context list/export CLI."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_reasoning_postgres import (
+    CampaignReasoningContextListResult,
+    PostgresCampaignReasoningContextRepository,
+)
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "list_extracted_campaign_reasoning_contexts.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "list_extracted_campaign_reasoning_contexts",
+    _SCRIPT_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+list_cli = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(list_cli)
+
+
+class _Pool:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = rows or []
+        self.fetch_calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.rows
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "id": "ctx-1",
+        "account_id": "acct-1",
+        "target_mode": "vendor_retention",
+        "selectors": ["opp-1", "Acme"],
+        "selector_key": "abc123",
+        "payload": {"top_theses": [{"summary": "Renewal pressure"}]},
+        "updated_at": datetime(2026, 5, 15, tzinfo=timezone.utc),
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_repository_list_contexts_filters_and_serializes_rows() -> None:
+    """Operators can inventory rows by tenant, mode, and selector."""
+
+    pool = _Pool(rows=[_row(payload=json.dumps({"confidence": "high"}))])
+    repository = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    result = await repository.list_contexts(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="Vendor_Retention",
+        selectors=("Acme",),
+        limit=5,
+    )
+
+    query = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert 'FROM "campaign_reasoning_contexts"' in query
+    assert "account_id = $1" in query
+    assert "target_mode = $2" in query
+    assert "selectors && $3::text[]" in query
+    assert args == ("acct-1", "vendor_retention", ["Acme", "acme"], 5)
+    assert result.filters == {
+        "account_id": "acct-1",
+        "target_mode": "vendor_retention",
+        "selectors": ("Acme", "acme"),
+    }
+    assert result.rows[0]["payload"] == {"confidence": "high"}
+    assert result.rows[0]["updated_at"] == "2026-05-15 00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_repository_list_contexts_preserves_non_object_payloads() -> None:
+    """Inventory/export should surface unexpected stored payload shapes."""
+
+    pool = _Pool(rows=[_row(payload='["unexpected", "shape"]')])
+    repository = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    result = await repository.list_contexts(limit=1)
+
+    assert result.rows[0]["payload"] == ["unexpected", "shape"]
+
+
+@pytest.mark.asyncio
+async def test_repository_list_contexts_allows_unfiltered_inventory() -> None:
+    """No filter args means list the newest rows across accounts/modes."""
+
+    pool = _Pool(rows=[])
+    repository = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    result = await repository.list_contexts(limit=0)
+
+    assert pool.fetch_calls[0]["args"] == (None, None, None, 0)
+    assert result.as_dict()["rows"] == []
+    assert result.limit == 0
+
+
+@pytest.mark.asyncio
+async def test_repository_list_contexts_rejects_negative_limit() -> None:
+    repository = PostgresCampaignReasoningContextRepository(pool=_Pool())
+
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        await repository.list_contexts(limit=-1)
+
+
+@pytest.mark.asyncio
+async def test_repository_list_contexts_rejects_unsafe_table_name() -> None:
+    repository = PostgresCampaignReasoningContextRepository(
+        pool=_Pool(),
+        table="bad-table",
+    )
+
+    with pytest.raises(ValueError, match="invalid SQL identifier"):
+        await repository.list_contexts()
+
+
+def test_context_list_result_renders_csv() -> None:
+    result = CampaignReasoningContextListResult(
+        rows=(_row(),),
+        limit=1,
+        filters={"account_id": "acct-1"},
+    )
+
+    csv_text = result.as_csv()
+
+    assert "id,account_id,target_mode,selectors,selector_key,updated_at,payload" in csv_text
+    assert "ctx-1" in csv_text
+    assert "{\"\"top_theses\"\":[{\"\"summary\"\":\"\"Renewal pressure\"\"}]}" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_cli_outputs_json_and_closes_pool(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    pool = _Pool(rows=[_row()])
+    created_urls: list[str] = []
+
+    async def create_pool(database_url: str) -> _Pool:
+        created_urls.append(database_url)
+        return pool
+
+    monkeypatch.setattr(list_cli, "_create_pool", create_pool)
+    exit_code = await list_cli._main_from_args([
+        "--database-url",
+        "postgres://example",
+        "--account-id",
+        "acct-1",
+        "--selector",
+        "Acme",
+        "--limit",
+        "1",
+    ])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert created_urls == ["postgres://example"]
+    assert pool.closed is True
+    assert payload["count"] == 1
+    assert payload["rows"][0]["id"] == "ctx-1"
+
+
+@pytest.mark.asyncio
+async def test_cli_outputs_csv(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    pool = _Pool(rows=[_row()])
+
+    async def create_pool(database_url: str) -> _Pool:
+        return pool
+
+    monkeypatch.setattr(list_cli, "_create_pool", create_pool)
+    exit_code = await list_cli._main_from_args([
+        "--database-url",
+        "postgres://example",
+        "--format",
+        "csv",
+    ])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "id,account_id,target_mode,selectors,selector_key,updated_at,payload" in captured.out
+    assert "ctx-1" in captured.out
+    assert pool.closed is True

--- a/tests/test_extracted_campaign_reasoning_postgres.py
+++ b/tests/test_extracted_campaign_reasoning_postgres.py
@@ -526,7 +526,7 @@ async def test_delete_stale_contexts_dry_run_counts_matching_rows() -> None:
     query = call["query"]
     args = call["args"]
     assert "SELECT COUNT(*) FROM stale" in query
-    assert "DELETE FROM campaign_reasoning_contexts" not in query
+    assert 'DELETE FROM "campaign_reasoning_contexts"' not in query
     assert "updated_at < NOW() - ($1::int * INTERVAL '1 day')" in query
     assert args == (30, "acct-1", "vendor_retention")
 
@@ -550,7 +550,7 @@ async def test_delete_stale_contexts_deletes_matching_rows_when_not_dry_run() ->
     call = pool.fetchval_calls[0]
     query = call["query"]
     args = call["args"]
-    assert "DELETE FROM campaign_reasoning_contexts" in query
+    assert 'DELETE FROM "campaign_reasoning_contexts"' in query
     assert "SELECT COUNT(*) FROM deleted" in query
     assert args == (45, None, None)
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Context-List-CLI.md

## Summary
- add a read-only `list_contexts` repository helper for DB-backed Content Ops reasoning rows
- add `scripts/list_extracted_campaign_reasoning_contexts.py` with JSON/CSV output
- document the operator inventory/export command and wire focused tests into extracted checks

## Verification
- pytest tests/test_extracted_campaign_reasoning_list_cli.py
- pytest tests/test_extracted_campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_list_cli.py
- python -m py_compile extracted_content_pipeline/campaign_reasoning_postgres.py scripts/list_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_list_cli.py
- bash scripts/local_pr_review.sh