### PR TITLE
Add Content Ops reasoning upsert dry-run

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T03:36Z by codex-2026-05-15
+Last updated: 2026-05-15T04:04Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning context list/export CLI | `extracted_content_pipeline/campaign_reasoning_postgres.py`, `scripts/list_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_list_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning repository inventory/export edits |
+| draft | Content Ops reasoning upsert dry-run | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning admin/upsert CLI edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -229,13 +229,15 @@ python scripts/upsert_extracted_campaign_reasoning_contexts.py \
   reasoning-contexts.json \
   --account-id acct_123 \
   --target-mode vendor_retention \
-  --selector "Acme"
+  --selector "Acme" \
+  --dry-run
 ```
 
 The input may be a single row, an array, or a wrapper such as
 `{"contexts": [...]}`. Each row can provide `selectors`, selector fields such as
 `target_id` / `company_name` / `contact_email`, and either `context`,
-`reasoning_context`, or `campaign_reasoning_context`.
+`reasoning_context`, or `campaign_reasoning_context`. Omit `--dry-run` after
+validation to write the rows.
 
 For lightweight installs that do not already have reasoning JSON, use
 `services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -253,8 +253,8 @@ source of truth for what remains.
   extracted reasoning-core provider with `--multi-pass-reasoning` when the
   product LLM adapter is configured.
 - DB-backed reasoning context operations now include read/check, list/export,
-  upsert, and stale-row cleanup CLIs so hosts can run the durable reasoning
-  provider without hand-written SQL.
+  dry-run-safe upsert, and stale-row cleanup CLIs so hosts can run the durable
+  reasoning provider without hand-written SQL.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -362,11 +362,13 @@ CLI instead of hand-writing SQL:
 python scripts/upsert_extracted_campaign_reasoning_contexts.py \
   reasoning-contexts.json \
   --account-id acct_123 \
-  --target-mode vendor_retention
+  --target-mode vendor_retention \
+  --dry-run
 ```
 
 Rows can include `selectors` directly or selector fields such as `target_id`,
-`company_name`, `contact_email`, and `vendor_name`.
+`company_name`, `contact_email`, and `vendor_name`. Omit `--dry-run` after
+validation to write the rows.
 
 ## Step 6: Add Optional Prompt Overrides
 

--- a/plans/PR-Content-Ops-Reasoning-Upsert-Dry-Run.md
+++ b/plans/PR-Content-Ops-Reasoning-Upsert-Dry-Run.md
@@ -1,0 +1,68 @@
+# Content Ops Reasoning Upsert Dry Run
+
+## Why this slice exists
+
+The DB-backed reasoning context admin path now has list/export, upsert, and
+cleanup CLIs. The upsert CLI still writes immediately after parsing. Operators
+need the same safe preflight behavior the other host data-loading scripts
+provide before they edit durable reasoning rows.
+
+## Scope (this PR)
+
+1. Add `--dry-run` to `scripts/upsert_extracted_campaign_reasoning_contexts.py`.
+2. Reuse the same row validation path for dry-run and real upsert.
+3. Skip database pool creation when `--dry-run` is set.
+4. Add focused tests for dry-run validation and CLI behavior.
+5. Document the safer default operator flow in the README and host runbook.
+6. Replace the stale merged list/export coordination row with this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Upsert-Dry-Run.md`
+- `docs/extraction/coordination/inflight.md`
+- `scripts/upsert_extracted_campaign_reasoning_contexts.py`
+- `tests/test_extracted_campaign_reasoning_upsert_cli.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+
+## Mechanism
+
+The CLI factors the existing pre-write validation into `_prepare_contexts(...)`.
+Dry-run calls that helper and returns `{"status": "dry_run", "would_upsert": N}`
+without opening a database pool. Real upsert calls the same helper before
+writing, preserving the no-partial-write validation added in the previous
+upsert slice.
+
+## Intentional
+
+- No repository or schema changes.
+- No change to real upsert semantics.
+- No hidden database connection in dry-run mode.
+
+## Deferred
+
+- Full admin UI for browsing and editing context rows.
+- Row-level audit logging around admin edits.
+- Bulk validation against live opportunity ids before saving.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
+python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Upsert-Dry-Run.md` | 60 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| `scripts/upsert_extracted_campaign_reasoning_contexts.py` | 55 |
+| `tests/test_extracted_campaign_reasoning_upsert_cli.py` | 65 |
+| `extracted_content_pipeline/README.md` | 5 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 5 |
+| `extracted_content_pipeline/STATUS.md` | 3 |
+| **Total** | **~195** |

--- a/scripts/upsert_extracted_campaign_reasoning_contexts.py
+++ b/scripts/upsert_extracted_campaign_reasoning_contexts.py
@@ -66,6 +66,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Reasoning context table name.",
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate input rows and report how many would be upserted.",
+    )
     return parser.parse_args(argv)
 
 
@@ -134,14 +139,13 @@ def _row_context(row: Mapping[str, Any]) -> Mapping[str, Any]:
     }
 
 
-async def _upsert_contexts(
-    repository: PostgresCampaignReasoningContextRepository,
+def _prepare_contexts(
     *,
     payload: Any,
     default_account_id: str,
     default_target_mode: str,
     extra_selectors: Sequence[str],
-) -> dict[str, Any]:
+) -> list[dict[str, Any]]:
     rows = _context_rows(payload)
     prepared: list[dict[str, Any]] = []
     for index, row in enumerate(rows, start=1):
@@ -161,6 +165,23 @@ async def _upsert_contexts(
                 "context": context,
             }
         )
+    return prepared
+
+
+async def _upsert_contexts(
+    repository: PostgresCampaignReasoningContextRepository,
+    *,
+    payload: Any,
+    default_account_id: str,
+    default_target_mode: str,
+    extra_selectors: Sequence[str],
+) -> dict[str, Any]:
+    prepared = _prepare_contexts(
+        payload=payload,
+        default_account_id=default_account_id,
+        default_target_mode=default_target_mode,
+        extra_selectors=extra_selectors,
+    )
 
     saved_ids: list[str] = []
     for item in prepared:
@@ -174,30 +195,66 @@ async def _upsert_contexts(
     return {"status": "ok", "upserted": len(saved_ids), "ids": saved_ids}
 
 
-async def _main() -> int:
-    args = _parse_args()
-    if not args.database_url:
-        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
-    pool = await _create_pool(args.database_url)
-    try:
-        repository = PostgresCampaignReasoningContextRepository(
-            pool=pool,
-            table=args.table,
-        )
-        result = await _upsert_contexts(
-            repository,
-            payload=_load_payload(args.path),
+def _dry_run_contexts(
+    *,
+    payload: Any,
+    default_account_id: str,
+    default_target_mode: str,
+    extra_selectors: Sequence[str],
+) -> dict[str, Any]:
+    prepared = _prepare_contexts(
+        payload=payload,
+        default_account_id=default_account_id,
+        default_target_mode=default_target_mode,
+        extra_selectors=extra_selectors,
+    )
+    return {"status": "dry_run", "would_upsert": len(prepared)}
+
+
+async def _main_from_args(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    payload = _load_payload(args.path)
+    if args.dry_run:
+        result = _dry_run_contexts(
+            payload=payload,
             default_account_id=str(args.account_id or ""),
             default_target_mode=str(args.target_mode or ""),
             extra_selectors=tuple(args.selector or ()),
         )
-    finally:
-        await pool.close()
+    else:
+        if not args.database_url:
+            raise SystemExit(
+                "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"
+            )
+        pool = await _create_pool(args.database_url)
+        try:
+            repository = PostgresCampaignReasoningContextRepository(
+                pool=pool,
+                table=args.table,
+            )
+            result = await _upsert_contexts(
+                repository,
+                payload=payload,
+                default_account_id=str(args.account_id or ""),
+                default_target_mode=str(args.target_mode or ""),
+                extra_selectors=tuple(args.selector or ()),
+            )
+        finally:
+            await pool.close()
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
+    elif args.dry_run:
+        print(
+            "dry-run: would upsert "
+            f"{result['would_upsert']} campaign reasoning context rows"
+        )
     else:
         print(f"upserted {result['upserted']} campaign reasoning context rows")
     return 0
+
+
+async def _main() -> int:
+    return await _main_from_args()
 
 
 if __name__ == "__main__":

--- a/tests/test_extracted_campaign_reasoning_upsert_cli.py
+++ b/tests/test_extracted_campaign_reasoning_upsert_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from typing import Any
 
@@ -89,6 +90,26 @@ def test_row_context_prefers_nested_context() -> None:
     }
 
 
+def test_dry_run_contexts_validates_without_repository() -> None:
+    """Dry-run exercises row validation and reports write count only."""
+
+    result = upsert_cli._dry_run_contexts(
+        payload={
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "context": {"top_theses": [{"summary": "Renewal risk"}]},
+                }
+            ]
+        },
+        default_account_id="acct-default",
+        default_target_mode="vendor_retention",
+        extra_selectors=[],
+    )
+
+    assert result == {"status": "dry_run", "would_upsert": 1}
+
+
 @pytest.mark.asyncio
 async def test_upsert_contexts_saves_each_row_with_defaults() -> None:
     """Rows without account/mode values inherit CLI defaults."""
@@ -168,6 +189,44 @@ async def test_upsert_contexts_rejects_rows_without_selectors() -> None:
             extra_selectors=[],
         )
     assert repository.calls == []
+
+
+@pytest.mark.asyncio
+async def test_main_dry_run_skips_database_pool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: Any,
+) -> None:
+    """Dry-run should validate the file without needing DB credentials."""
+
+    payload_path = tmp_path / "contexts.json"
+    payload_path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "context": {"top_theses": [{"summary": "x"}]},
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    async def create_pool(database_url: str) -> Any:
+        raise AssertionError("dry-run must not open a database pool")
+
+    monkeypatch.setattr(upsert_cli, "_create_pool", create_pool)
+    exit_code = await upsert_cli._main_from_args([
+        str(payload_path),
+        "--dry-run",
+        "--json",
+    ])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "dry_run",
+        "would_upsert": 1,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Upsert-Dry-Run.md

## Summary
- add `--dry-run` to the DB reasoning context upsert CLI
- reuse the same validation path for dry-run and real writes
- skip DB pool creation in dry-run mode and document the safer operator flow

## Verification
- pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
- python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
- bash scripts/local_pr_review.sh