### PR TITLE
Add Content Ops reasoning upsert audit log

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T04:04Z by codex-2026-05-15
+Last updated: 2026-05-15T16:01Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning upsert dry-run | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning admin/upsert CLI edits |
+| draft | Content Ops reasoning upsert audit log | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-15 | Avoid DB reasoning admin/upsert CLI edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -230,6 +230,7 @@ python scripts/upsert_extracted_campaign_reasoning_contexts.py \
   --account-id acct_123 \
   --target-mode vendor_retention \
   --selector "Acme" \
+  --audit-log logs/reasoning-context-upserts.jsonl \
   --dry-run
 ```
 
@@ -237,7 +238,8 @@ The input may be a single row, an array, or a wrapper such as
 `{"contexts": [...]}`. Each row can provide `selectors`, selector fields such as
 `target_id` / `company_name` / `contact_email`, and either `context`,
 `reasoning_context`, or `campaign_reasoning_context`. Omit `--dry-run` after
-validation to write the rows.
+validation to write the rows. `--audit-log` appends metadata-only JSONL entries
+after successful writes.
 
 For lightweight installs that do not already have reasoning JSON, use
 `services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -253,8 +253,9 @@ source of truth for what remains.
   extracted reasoning-core provider with `--multi-pass-reasoning` when the
   product LLM adapter is configured.
 - DB-backed reasoning context operations now include read/check, list/export,
-  dry-run-safe upsert, and stale-row cleanup CLIs so hosts can run the durable
-  reasoning provider without hand-written SQL.
+  dry-run-safe upsert with optional metadata-only audit logging, and stale-row
+  cleanup CLIs so hosts can run the durable reasoning provider without
+  hand-written SQL.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -363,12 +363,14 @@ python scripts/upsert_extracted_campaign_reasoning_contexts.py \
   reasoning-contexts.json \
   --account-id acct_123 \
   --target-mode vendor_retention \
+  --audit-log logs/reasoning-context-upserts.jsonl \
   --dry-run
 ```
 
 Rows can include `selectors` directly or selector fields such as `target_id`,
 `company_name`, `contact_email`, and `vendor_name`. Omit `--dry-run` after
-validation to write the rows.
+validation to write the rows. `--audit-log` records one metadata-only JSONL
+entry per saved row after successful writes.
 
 ## Step 6: Add Optional Prompt Overrides
 

--- a/plans/PR-Content-Ops-Reasoning-Upsert-Audit-Log.md
+++ b/plans/PR-Content-Ops-Reasoning-Upsert-Audit-Log.md
@@ -1,0 +1,68 @@
+# Content Ops Reasoning Upsert Audit Log
+
+## Why this slice exists
+
+The DB reasoning admin workflow can now list/export, dry-run upsert, apply
+upserts, and clean stale rows. The remaining operator safety gap is edit
+traceability: hosts need a lightweight record of manual reasoning-row changes
+without adding a product schema or admin UI.
+
+## Scope (this PR)
+
+1. Add optional `--audit-log` support to the reasoning context upsert CLI.
+2. Append one metadata-only JSONL entry per saved row after successful writes.
+3. Keep dry-run read-only even when `--audit-log` is supplied.
+4. Add focused tests for audit logging and dry-run non-write behavior.
+5. Document the audit option in the README and host runbook.
+6. Update status and coordination docs.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Upsert-Audit-Log.md`
+- `docs/extraction/coordination/inflight.md`
+- `scripts/upsert_extracted_campaign_reasoning_contexts.py`
+- `tests/test_extracted_campaign_reasoning_upsert_cli.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+
+## Mechanism
+
+`--audit-log` accepts a JSONL path. After each successful `save_context(...)`
+call, the CLI appends an entry with action, timestamp, saved context id,
+account id, target mode, selectors, row index, and sorted context keys. The
+reasoning context payload itself is intentionally not written to the audit log.
+
+## Intentional
+
+- No repository or schema changes.
+- No audit write on failed upserts.
+- No audit write in dry-run mode.
+- No full reasoning payload in the audit file.
+
+## Deferred
+
+- Full admin UI for browsing and editing context rows.
+- Database-backed audit table for hosts that need centralized audit storage.
+- Bulk validation against live opportunity ids before saving.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
+python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Upsert-Audit-Log.md` | 60 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| `scripts/upsert_extracted_campaign_reasoning_contexts.py` | 45 |
+| `tests/test_extracted_campaign_reasoning_upsert_cli.py` | 175 |
+| `extracted_content_pipeline/README.md` | 5 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 5 |
+| `extracted_content_pipeline/STATUS.md` | 3 |
+| **Total** | **~300** |

--- a/scripts/upsert_extracted_campaign_reasoning_contexts.py
+++ b/scripts/upsert_extracted_campaign_reasoning_contexts.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import os
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 import sys
 from typing import Any
@@ -70,6 +71,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--dry-run",
         action="store_true",
         help="Validate input rows and report how many would be upserted.",
+    )
+    parser.add_argument(
+        "--audit-log",
+        type=Path,
+        default=None,
+        help="Optional JSONL file for one metadata-only entry per saved row.",
     )
     return parser.parse_args(argv)
 
@@ -175,6 +182,7 @@ async def _upsert_contexts(
     default_account_id: str,
     default_target_mode: str,
     extra_selectors: Sequence[str],
+    audit_log: Path | None = None,
 ) -> dict[str, Any]:
     prepared = _prepare_contexts(
         payload=payload,
@@ -184,7 +192,7 @@ async def _upsert_contexts(
     )
 
     saved_ids: list[str] = []
-    for item in prepared:
+    for index, item in enumerate(prepared, start=1):
         saved_id = await repository.save_context(
             scope=item["scope"],
             selectors=item["selectors"],
@@ -192,7 +200,35 @@ async def _upsert_contexts(
             context=item["context"],
         )
         saved_ids.append(saved_id)
+        if audit_log is not None:
+            _append_audit_log(
+                audit_log,
+                [_audit_entry(saved_id=saved_id, row_index=index, item=item)],
+            )
     return {"status": "ok", "upserted": len(saved_ids), "ids": saved_ids}
+
+
+def _audit_entry(*, saved_id: str, row_index: int, item: Mapping[str, Any]) -> dict[str, Any]:
+    scope = item["scope"]
+    context = item["context"]
+    return {
+        "action": "upsert_campaign_reasoning_context",
+        "recorded_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "row_index": row_index,
+        "context_id": saved_id,
+        "account_id": scope.account_id,
+        "target_mode": item["target_mode"],
+        "selectors": list(item["selectors"]),
+        "context_keys": sorted(str(key) for key in context.keys()),
+    }
+
+
+def _append_audit_log(path: Path, entries: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for entry in entries:
+            handle.write(json.dumps(entry, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
 
 
 def _dry_run_contexts(
@@ -238,6 +274,7 @@ async def _main_from_args(argv: list[str] | None = None) -> int:
                 default_account_id=str(args.account_id or ""),
                 default_target_mode=str(args.target_mode or ""),
                 extra_selectors=tuple(args.selector or ()),
+                audit_log=args.audit_log,
             )
         finally:
             await pool.close()

--- a/tests/test_extracted_campaign_reasoning_upsert_cli.py
+++ b/tests/test_extracted_campaign_reasoning_upsert_cli.py
@@ -33,6 +33,25 @@ class _Repository:
         return f"ctx-{len(self.calls)}"
 
 
+class _FailingRepository(_Repository):
+    def __init__(self, *, fail_on_call: int) -> None:
+        super().__init__()
+        self.fail_on_call = fail_on_call
+
+    async def save_context(self, **kwargs: Any) -> str:
+        self.calls.append(kwargs)
+        if len(self.calls) == self.fail_on_call:
+            raise RuntimeError("database write failed")
+        return f"ctx-{len(self.calls)}"
+
+
+def _read_audit_entries(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+
+
 def test_context_rows_accepts_array_wrapper_and_mapping_index() -> None:
     """Host files can be arrays, wrapper objects, or keyed context maps."""
 
@@ -175,6 +194,129 @@ async def test_upsert_contexts_preserves_commas_inside_selector_values() -> None
 
 
 @pytest.mark.asyncio
+async def test_upsert_contexts_appends_metadata_audit_log(tmp_path: Path) -> None:
+    """Audit entries record row metadata without serializing full context payloads."""
+
+    repository = _Repository()
+    audit_log = tmp_path / "audit" / "reasoning-upserts.jsonl"
+
+    result = await upsert_cli._upsert_contexts(
+        repository,  # type: ignore[arg-type]
+        payload={
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "account_id": "acct-row",
+                    "target_mode": "vendor_retention",
+                    "context": {
+                        "top_theses": [{"summary": "Renewal risk"}],
+                        "proof_points": [{"label": "source"}],
+                    },
+                }
+            ]
+        },
+        default_account_id="acct-default",
+        default_target_mode="",
+        extra_selectors=["Acme"],
+        audit_log=audit_log,
+    )
+
+    entries = _read_audit_entries(audit_log)
+    assert result["ids"] == ["ctx-1"]
+    assert entries[0]["action"] == "upsert_campaign_reasoning_context"
+    assert entries[0]["context_id"] == "ctx-1"
+    assert entries[0]["account_id"] == "acct-row"
+    assert entries[0]["target_mode"] == "vendor_retention"
+    assert entries[0]["selectors"] == ["Acme", "opp-1"]
+    assert entries[0]["context_keys"] == ["proof_points", "top_theses"]
+    assert "top_theses" not in entries[0]
+    assert entries[0]["recorded_at"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_audits_each_successful_row_before_later_failure(
+    tmp_path: Path,
+) -> None:
+    """Committed rows keep audit records even when a later write fails."""
+
+    repository = _FailingRepository(fail_on_call=2)
+    audit_log = tmp_path / "reasoning-upserts.jsonl"
+
+    with pytest.raises(RuntimeError, match="database write failed"):
+        await upsert_cli._upsert_contexts(
+            repository,  # type: ignore[arg-type]
+            payload={
+                "contexts": [
+                    {
+                        "target_id": "opp-1",
+                        "context": {"top_theses": [{"summary": "x"}]},
+                    },
+                    {
+                        "target_id": "opp-2",
+                        "context": {"top_theses": [{"summary": "y"}]},
+                    },
+                ]
+            },
+            default_account_id="acct-default",
+            default_target_mode="vendor_retention",
+            extra_selectors=[],
+            audit_log=audit_log,
+        )
+
+    entries = _read_audit_entries(audit_log)
+    assert [entry["row_index"] for entry in entries] == [1]
+    assert entries[0]["context_id"] == "ctx-1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_appends_audit_log_across_runs_and_rows(
+    tmp_path: Path,
+) -> None:
+    """Audit logs append JSONL entries and preserve one-based row indexes."""
+
+    audit_log = tmp_path / "reasoning-upserts.jsonl"
+
+    await upsert_cli._upsert_contexts(
+        _Repository(),  # type: ignore[arg-type]
+        payload={
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "context": {"top_theses": [{"summary": "x"}]},
+                },
+                {
+                    "target_id": "opp-2",
+                    "context": {"top_theses": [{"summary": "y"}]},
+                },
+            ]
+        },
+        default_account_id="acct-default",
+        default_target_mode="vendor_retention",
+        extra_selectors=[],
+        audit_log=audit_log,
+    )
+    await upsert_cli._upsert_contexts(
+        _Repository(),  # type: ignore[arg-type]
+        payload={
+            "contexts": [
+                {
+                    "target_id": "opp-3",
+                    "context": {"top_theses": [{"summary": "z"}]},
+                },
+            ]
+        },
+        default_account_id="acct-default",
+        default_target_mode="vendor_retention",
+        extra_selectors=[],
+        audit_log=audit_log,
+    )
+
+    entries = _read_audit_entries(audit_log)
+    assert [entry["row_index"] for entry in entries] == [1, 2, 1]
+    assert [entry["context_id"] for entry in entries] == ["ctx-1", "ctx-2", "ctx-1"]
+
+
+@pytest.mark.asyncio
 async def test_upsert_contexts_rejects_rows_without_selectors() -> None:
     """An unselectable row would never be read back, so fail loudly."""
 
@@ -227,6 +369,41 @@ async def test_main_dry_run_skips_database_pool(
         "status": "dry_run",
         "would_upsert": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_main_dry_run_does_not_write_audit_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dry-run remains read-only even when --audit-log is supplied."""
+
+    payload_path = tmp_path / "contexts.json"
+    audit_log = tmp_path / "audit.jsonl"
+    payload_path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "context": {"top_theses": [{"summary": "x"}]},
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    async def create_pool(database_url: str) -> Any:
+        raise AssertionError("dry-run must not open a database pool")
+
+    monkeypatch.setattr(upsert_cli, "_create_pool", create_pool)
+    await upsert_cli._main_from_args([
+        str(payload_path),
+        "--dry-run",
+        "--audit-log",
+        str(audit_log),
+    ])
+
+    assert not audit_log.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Upsert-Audit-Log.md

## Summary
- add optional `--audit-log` to the DB reasoning context upsert CLI
- append one metadata-only JSONL entry per successful saved row
- keep dry-run read-only even when an audit log path is supplied

## Verification
- pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
- python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
- bash scripts/local_pr_review.sh