### PR TITLE
Validate reasoning upserts against opportunities

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -39,6 +39,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - DB reasoning stale-context cleanup CLI.
 - DB reasoning upsert dry-run.
 - DB reasoning upsert metadata audit log.
+- DB reasoning upsert live-opportunity validation.
 - Generated asset batch review/status updates.
 
 ## Active Backlog
@@ -65,21 +66,7 @@ Remaining work:
 repository methods. Keep full audit-table persistence separate unless a host
 needs centralized audit storage immediately.
 
-### 2. Bulk validation before reasoning upsert
-
-**Priority:** P2
-
-**Why:** The upsert CLI validates row shape, selectors, and context payloads,
-but it does not verify that supplied selectors or target ids match live
-customer opportunity rows before saving. That is acceptable for trusted ETL,
-but risky for larger host imports where typoed selectors create unreachable or
-mis-scoped reasoning contexts.
-
-**Likely slice:** add an optional validation mode that checks input rows against
-the host opportunity table before write. Keep it opt-in so custom hosts that
-use nonstandard opportunity storage can continue using the existing CLI.
-
-### 3. Operator review UX and richer result previews
+### 2. Operator review UX and richer result previews
 
 **Priority:** P3
 
@@ -91,7 +78,7 @@ These are product polish, not core readiness blockers.
 and sales brief rows, then add component-level frontend tests for the review
 surface.
 
-### 4. Scale hardening for batch review
+### 3. Scale hardening for batch review
 
 **Priority:** P4
 
@@ -102,7 +89,7 @@ bulk SQL may be worth adding.
 
 **Likely slice:** defer until actual batch sizes justify it.
 
-### 5. Reasoning product depth and source breadth
+### 4. Reasoning product depth and source breadth
 
 **Priority:** P4
 
@@ -121,5 +108,5 @@ not as Content Ops cleanup.
 ## Current Pick Recommendation
 
 Take item 1 next if we want operator-facing progress: reasoning context admin
-workflow. Take item 2 next if we want a smaller backend-only safety slice:
-bulk validation before reasoning upsert.
+workflow. Take item 2 next if we want frontend polish: richer generated-asset
+previews and component tests.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T17:15Z by codex-2026-05-15
+Last updated: 2026-05-15T17:32Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops backlog refresh | `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md` | codex-2026-05-15 | Avoid Content Ops backlog/coordination doc edits |
+| draft | Content Ops reasoning upsert validation | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | codex-2026-05-15 | Avoid DB reasoning upsert/admin edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -230,6 +230,7 @@ python scripts/upsert_extracted_campaign_reasoning_contexts.py \
   --account-id acct_123 \
   --target-mode vendor_retention \
   --selector "Acme" \
+  --validate-opportunities \
   --audit-log logs/reasoning-context-upserts.jsonl \
   --dry-run
 ```
@@ -239,7 +240,9 @@ The input may be a single row, an array, or a wrapper such as
 `target_id` / `company_name` / `contact_email`, and either `context`,
 `reasoning_context`, or `campaign_reasoning_context`. Omit `--dry-run` after
 validation to write the rows. `--audit-log` appends metadata-only JSONL entries
-after successful writes.
+after successful writes. Add `--validate-opportunities` when the host wants the
+CLI to confirm each context row matches an active `campaign_opportunities` row
+before writing.
 
 For lightweight installs that do not already have reasoning JSON, use
 `services.single_pass_reasoning_provider.SinglePassCampaignReasoningProvider`.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -253,9 +253,9 @@ source of truth for what remains.
   extracted reasoning-core provider with `--multi-pass-reasoning` when the
   product LLM adapter is configured.
 - DB-backed reasoning context operations now include read/check, list/export,
-  dry-run-safe upsert with optional metadata-only audit logging, and stale-row
-  cleanup CLIs so hosts can run the durable reasoning provider without
-  hand-written SQL.
+  dry-run-safe upsert with optional live-opportunity validation and
+  metadata-only audit logging, plus stale-row cleanup CLIs so hosts can run the
+  durable reasoning provider without hand-written SQL.
 - `reasoning.archetypes` is product-owned and provides deterministic
   churn-archetype scoring, best-match selection, top-match filtering, and
   falsification-condition lookup without Atlas dependencies.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -363,6 +363,7 @@ python scripts/upsert_extracted_campaign_reasoning_contexts.py \
   reasoning-contexts.json \
   --account-id acct_123 \
   --target-mode vendor_retention \
+  --validate-opportunities \
   --audit-log logs/reasoning-context-upserts.jsonl \
   --dry-run
 ```
@@ -370,7 +371,9 @@ python scripts/upsert_extracted_campaign_reasoning_contexts.py \
 Rows can include `selectors` directly or selector fields such as `target_id`,
 `company_name`, `contact_email`, and `vendor_name`. Omit `--dry-run` after
 validation to write the rows. `--audit-log` records one metadata-only JSONL
-entry per saved row after successful writes.
+entry per saved row after successful writes. `--validate-opportunities` checks
+each row against active `campaign_opportunities` before saving, which catches
+typoed selectors during larger host imports.
 
 ## Step 6: Add Optional Prompt Overrides
 

--- a/plans/PR-Content-Ops-Reasoning-Upsert-Validation.md
+++ b/plans/PR-Content-Ops-Reasoning-Upsert-Validation.md
@@ -1,0 +1,78 @@
+# Content Ops Reasoning Upsert Validation
+
+## Why this slice exists
+
+The active Content Ops backlog called out a safety gap in the reasoning context
+upsert CLI: it validates row shape, selectors, and context payloads, but it does
+not verify those selectors against live customer opportunities before saving.
+That is fine for trusted ETL and risky for larger host imports where a typo can
+create unreachable or mis-scoped context rows.
+
+## Scope (this PR)
+
+1. Add an opt-in `--validate-opportunities` mode to the reasoning context upsert
+   CLI.
+2. Validate each prepared context row against active `campaign_opportunities`
+   before any write.
+3. Let dry-runs use the same validation path without saving context rows.
+4. Document the new flag and retire this backlog item.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Upsert-Validation.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `scripts/upsert_extracted_campaign_reasoning_contexts.py`
+- `tests/test_extracted_campaign_reasoning_upsert_cli.py`
+
+## Mechanism
+
+`--validate-opportunities` checks each prepared row against the opportunity
+table before saving. A row passes if any selector matches an active opportunity
+by `target_id`, `company_name`, `vendor_name`, or `contact_email` within the
+same account and compatible target mode. The check is opt-in so custom hosts
+with nonstandard opportunity storage can keep using the existing trusted-ETL
+path.
+
+Dry-run with validation opens the database, validates, closes the pool, and
+reports `validated_opportunities`; it still does not call `save_context`.
+
+## Intentional
+
+- No default behavior change.
+- No new database schema.
+- No validation against arbitrary `raw_payload` keys; this slice covers the
+  stable opportunity columns used by the generation path.
+
+## Deferred
+
+- Admin UI/API for browsing, editing, and deleting reasoning context rows.
+- Custom host validation adapters for nonstandard opportunity storage.
+- Batched opportunity validation query if hosts start importing hundreds or
+  thousands of reasoning rows at a time.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
+python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
+bash scripts/local_pr_review.sh
+git diff --check
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Upsert-Validation.md` | 60 |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | 18 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/README.md` | 4 |
+| `extracted_content_pipeline/STATUS.md` | 4 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 5 |
+| `scripts/upsert_extracted_campaign_reasoning_contexts.py` | 90 |
+| `tests/test_extracted_campaign_reasoning_upsert_cli.py` | 130 |
+| **Total** | **~315** |

--- a/scripts/upsert_extracted_campaign_reasoning_contexts.py
+++ b/scripts/upsert_extracted_campaign_reasoning_contexts.py
@@ -78,6 +78,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional JSONL file for one metadata-only entry per saved row.",
     )
+    parser.add_argument(
+        "--validate-opportunities",
+        action="store_true",
+        help=(
+            "Before writing, require each context row to match an active "
+            "campaign_opportunities row by selector."
+        ),
+    )
+    parser.add_argument(
+        "--opportunity-table",
+        default="campaign_opportunities",
+        help="Opportunity table used by --validate-opportunities.",
+    )
     return parser.parse_args(argv)
 
 
@@ -125,6 +138,16 @@ def _clean_values(values: Sequence[Any]) -> tuple[str, ...]:
             continue
         cleaned.append(text)
     return tuple(cleaned)
+
+
+def _identifier(value: str) -> str:
+    parts = str(value or "").strip().split(".")
+    if not parts or any(not part for part in parts):
+        raise ValueError(f"invalid SQL identifier: {value!r}")
+    for part in parts:
+        if not all(char.isalnum() or char == "_" for char in part):
+            raise ValueError(f"invalid SQL identifier: {value!r}")
+    return ".".join(f'"{part}"' for part in parts)
 
 
 def _row_selectors(row: Mapping[str, Any], extra_selectors: Sequence[str]) -> tuple[str, ...]:
@@ -175,6 +198,48 @@ def _prepare_contexts(
     return prepared
 
 
+async def _validate_opportunity_matches(
+    pool: Any,
+    prepared: Sequence[Mapping[str, Any]],
+    *,
+    opportunity_table: str,
+) -> None:
+    """Require each prepared context row to match an active opportunity."""
+
+    table = _identifier(opportunity_table)
+    missing: list[int] = []
+    for index, item in enumerate(prepared, start=1):
+        scope = item["scope"]
+        selectors = tuple(str(value) for value in item["selectors"])
+        lowered = tuple(value.lower() for value in selectors)
+        matched = await pool.fetchval(
+            f"""
+            SELECT 1
+            FROM {table}
+            WHERE status = 'active'
+              AND ($1 = '' OR account_id = $1)
+              -- NULL target_mode is a legacy/global opportunity row and remains compatible.
+              AND ($2 = '' OR target_mode = $2 OR target_mode IS NULL)
+              AND (
+                target_id = ANY($3::text[])
+                OR lower(company_name) = ANY($4::text[])
+                OR lower(vendor_name) = ANY($4::text[])
+                OR lower(contact_email) = ANY($4::text[])
+              )
+            LIMIT 1
+            """,
+            scope.account_id or "",
+            str(item["target_mode"] or "").strip().lower(),
+            list(selectors),
+            list(lowered),
+        )
+        if matched is None:
+            missing.append(index)
+    if missing:
+        rows = ", ".join(str(index) for index in missing)
+        raise ValueError(f"opportunity validation failed for rows: {rows}")
+
+
 async def _upsert_contexts(
     repository: PostgresCampaignReasoningContextRepository,
     *,
@@ -183,6 +248,9 @@ async def _upsert_contexts(
     default_target_mode: str,
     extra_selectors: Sequence[str],
     audit_log: Path | None = None,
+    validate_opportunities: bool = False,
+    opportunity_pool: Any | None = None,
+    opportunity_table: str = "campaign_opportunities",
 ) -> dict[str, Any]:
     prepared = _prepare_contexts(
         payload=payload,
@@ -190,6 +258,14 @@ async def _upsert_contexts(
         default_target_mode=default_target_mode,
         extra_selectors=extra_selectors,
     )
+    if validate_opportunities:
+        if opportunity_pool is None:
+            raise ValueError("opportunity_pool is required when validation is enabled")
+        await _validate_opportunity_matches(
+            opportunity_pool,
+            prepared,
+            opportunity_table=opportunity_table,
+        )
 
     saved_ids: list[str] = []
     for index, item in enumerate(prepared, start=1):
@@ -231,31 +307,44 @@ def _append_audit_log(path: Path, entries: Sequence[Mapping[str, Any]]) -> None:
             handle.write("\n")
 
 
-def _dry_run_contexts(
+def _dry_run_result(
+    prepared: Sequence[Mapping[str, Any]],
     *,
-    payload: Any,
-    default_account_id: str,
-    default_target_mode: str,
-    extra_selectors: Sequence[str],
+    validated_opportunities: bool = False,
 ) -> dict[str, Any]:
-    prepared = _prepare_contexts(
-        payload=payload,
-        default_account_id=default_account_id,
-        default_target_mode=default_target_mode,
-        extra_selectors=extra_selectors,
-    )
-    return {"status": "dry_run", "would_upsert": len(prepared)}
+    result = {"status": "dry_run", "would_upsert": len(prepared)}
+    if validated_opportunities:
+        result["validated_opportunities"] = len(prepared)
+    return result
 
 
 async def _main_from_args(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     payload = _load_payload(args.path)
     if args.dry_run:
-        result = _dry_run_contexts(
+        prepared = _prepare_contexts(
             payload=payload,
             default_account_id=str(args.account_id or ""),
             default_target_mode=str(args.target_mode or ""),
             extra_selectors=tuple(args.selector or ()),
+        )
+        if args.validate_opportunities:
+            if not args.database_url:
+                raise SystemExit(
+                    "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"
+                )
+            pool = await _create_pool(args.database_url)
+            try:
+                await _validate_opportunity_matches(
+                    pool,
+                    prepared,
+                    opportunity_table=args.opportunity_table,
+                )
+            finally:
+                await pool.close()
+        result = _dry_run_result(
+            prepared,
+            validated_opportunities=bool(args.validate_opportunities),
         )
     else:
         if not args.database_url:
@@ -275,6 +364,9 @@ async def _main_from_args(argv: list[str] | None = None) -> int:
                 default_target_mode=str(args.target_mode or ""),
                 extra_selectors=tuple(args.selector or ()),
                 audit_log=args.audit_log,
+                validate_opportunities=bool(args.validate_opportunities),
+                opportunity_pool=pool,
+                opportunity_table=args.opportunity_table,
             )
         finally:
             await pool.close()

--- a/tests/test_extracted_campaign_reasoning_upsert_cli.py
+++ b/tests/test_extracted_campaign_reasoning_upsert_cli.py
@@ -45,6 +45,20 @@ class _FailingRepository(_Repository):
         return f"ctx-{len(self.calls)}"
 
 
+class _Pool:
+    def __init__(self, matches: list[Any] | None = None) -> None:
+        self.matches = list(matches or [])
+        self.fetchval_calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.matches.pop(0) if self.matches else None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
 def _read_audit_entries(path: Path) -> list[dict[str, Any]]:
     return [
         json.loads(line)
@@ -109,10 +123,10 @@ def test_row_context_prefers_nested_context() -> None:
     }
 
 
-def test_dry_run_contexts_validates_without_repository() -> None:
-    """Dry-run exercises row validation and reports write count only."""
+def test_dry_run_result_reports_prepared_write_count() -> None:
+    """Dry-run output is derived from already validated prepared rows."""
 
-    result = upsert_cli._dry_run_contexts(
+    prepared = upsert_cli._prepare_contexts(
         payload={
             "contexts": [
                 {
@@ -126,7 +140,23 @@ def test_dry_run_contexts_validates_without_repository() -> None:
         extra_selectors=[],
     )
 
-    assert result == {"status": "dry_run", "would_upsert": 1}
+    assert upsert_cli._dry_run_result(prepared) == {
+        "status": "dry_run",
+        "would_upsert": 1,
+    }
+
+
+def test_dry_run_result_reports_validated_opportunities() -> None:
+    """Dry-run output can report DB opportunity validation without writes."""
+
+    assert upsert_cli._dry_run_result(
+        [{"selectors": ("opp-1",)}],
+        validated_opportunities=True,
+    ) == {
+        "status": "dry_run",
+        "would_upsert": 1,
+        "validated_opportunities": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -314,6 +344,159 @@ async def test_upsert_contexts_appends_audit_log_across_runs_and_rows(
     entries = _read_audit_entries(audit_log)
     assert [entry["row_index"] for entry in entries] == [1, 2, 1]
     assert [entry["context_id"] for entry in entries] == ["ctx-1", "ctx-2", "ctx-1"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_validates_opportunity_matches_before_writing() -> None:
+    """Optional validation requires a live opportunity match for every row."""
+
+    repository = _Repository()
+    pool = _Pool(matches=[1])
+
+    result = await upsert_cli._upsert_contexts(
+        repository,  # type: ignore[arg-type]
+        payload={
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "account_id": "acct-1",
+                    "target_mode": "Vendor_Retention",
+                    "context": {"top_theses": [{"summary": "x"}]},
+                },
+            ]
+        },
+        default_account_id="",
+        default_target_mode="",
+        extra_selectors=["Acme"],
+        validate_opportunities=True,
+        opportunity_pool=pool,
+    )
+
+    assert result["upserted"] == 1
+    assert len(repository.calls) == 1
+    call = pool.fetchval_calls[0]
+    assert 'FROM "campaign_opportunities"' in call["query"]
+    assert "status = 'active'" in call["query"]
+    assert "target_id = ANY($3::text[])" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "vendor_retention",
+        ["Acme", "opp-1"],
+        ["acme", "opp-1"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_rejects_unmatched_opportunity_before_writing() -> None:
+    """Validation failure happens before the reasoning row is saved."""
+
+    repository = _Repository()
+    pool = _Pool(matches=[None])
+
+    with pytest.raises(ValueError, match="opportunity validation failed for rows: 1"):
+        await upsert_cli._upsert_contexts(
+            repository,  # type: ignore[arg-type]
+            payload={
+                "contexts": [
+                    {
+                        "target_id": "missing-opp",
+                        "context": {"top_theses": [{"summary": "x"}]},
+                    },
+                ]
+            },
+            default_account_id="acct-1",
+            default_target_mode="vendor_retention",
+            extra_selectors=[],
+            validate_opportunities=True,
+            opportunity_pool=pool,
+        )
+
+    assert repository.calls == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_contexts_reports_all_unmatched_opportunity_rows_before_writing() -> None:
+    """Validation collects every missing row before rejecting the batch."""
+
+    repository = _Repository()
+    pool = _Pool(matches=[1, None, None])
+
+    with pytest.raises(
+        ValueError,
+        match="opportunity validation failed for rows: 2, 3",
+    ):
+        await upsert_cli._upsert_contexts(
+            repository,  # type: ignore[arg-type]
+            payload={
+                "contexts": [
+                    {
+                        "target_id": "opp-1",
+                        "context": {"top_theses": [{"summary": "x"}]},
+                    },
+                    {
+                        "target_id": "missing-2",
+                        "context": {"top_theses": [{"summary": "y"}]},
+                    },
+                    {
+                        "target_id": "missing-3",
+                        "context": {"top_theses": [{"summary": "z"}]},
+                    },
+                ]
+            },
+            default_account_id="acct-1",
+            default_target_mode="vendor_retention",
+            extra_selectors=[],
+            validate_opportunities=True,
+            opportunity_pool=pool,
+        )
+
+    assert len(pool.fetchval_calls) == 3
+    assert repository.calls == []
+
+
+@pytest.mark.asyncio
+async def test_main_dry_run_with_opportunity_validation_opens_db_but_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: Any,
+) -> None:
+    """Validated dry-runs check opportunity matches but skip context writes."""
+
+    payload_path = tmp_path / "contexts.json"
+    payload_path.write_text(
+        json.dumps({
+            "contexts": [
+                {
+                    "target_id": "opp-1",
+                    "context": {"top_theses": [{"summary": "x"}]},
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    pool = _Pool(matches=[1])
+
+    async def create_pool(database_url: str) -> Any:
+        assert database_url == "postgres://example"
+        return pool
+
+    monkeypatch.setattr(upsert_cli, "_create_pool", create_pool)
+    exit_code = await upsert_cli._main_from_args([
+        str(payload_path),
+        "--database-url",
+        "postgres://example",
+        "--dry-run",
+        "--validate-opportunities",
+        "--json",
+    ])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "dry_run",
+        "would_upsert": 1,
+        "validated_opportunities": 1,
+    }
+    assert pool.closed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Upsert-Validation.md

## Summary
- Add opt-in `--validate-opportunities` to the reasoning context upsert CLI
- Validate prepared rows against active `campaign_opportunities` before writes
- Support validated dry-runs without saving context rows
- Update docs/status/backlog and coordination row

## Verification
- pytest tests/test_extracted_campaign_reasoning_upsert_cli.py
- python -m py_compile scripts/upsert_extracted_campaign_reasoning_contexts.py tests/test_extracted_campaign_reasoning_upsert_cli.py
- bash scripts/local_pr_review.sh
- git diff --check

No GitHub Claude review requested; ready for local audit.