### PR TITLE
Add Content Ops reasoning context admin API

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T17:32Z by codex-2026-05-15
+Last updated: 2026-05-15T17:52Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning upsert validation | `scripts/upsert_extracted_campaign_reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_upsert_cli.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | codex-2026-05-15 | Avoid DB reasoning upsert/admin edits |
+| draft | Content Ops reasoning admin API | `extracted_content_pipeline/api/reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_context_api.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | codex-2026-05-15 | Avoid DB reasoning admin/API edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -221,6 +221,13 @@ python scripts/list_extracted_campaign_reasoning_contexts.py \
 The list/export CLI defaults to `--limit 20`; raise the limit deliberately for
 larger inventories.
 
+Hosts can also mount `api.reasoning_contexts` for `GET
+/campaign-reasoning-contexts` inventory and `POST /campaign-reasoning-contexts`
+single-row upsert. The host injects pool, auth, and tenant scope; scoped
+tenants cannot override `account_id` in the request body. Upsert requests must
+use an explicit `context` object; alias keys and typoed context keys are
+rejected. Pass auth dependencies when mounting the router.
+
 To insert or update host-produced reasoning rows without hand-writing SQL, load
 a JSON file with selectors plus a context payload:
 
@@ -856,6 +863,8 @@ Several small utility shims provide product-owned local behavior by default so t
   B2B draft list/export/review routes
 - `api/generated_assets.py`: optional FastAPI router factory for host-mounted
   report, landing page, and sales brief list/export/review routes
+- `api/reasoning_contexts.py`: optional FastAPI router factory for
+  host-mounted reasoning context list/upsert routes
 - `api/seller_campaigns.py`: optional FastAPI router factory for host-mounted
   seller target management, category refresh, opportunity preparation, and
   seller draft review routes

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -70,6 +70,10 @@ source of truth for what remains.
 - `api.generated_assets` provides a FastAPI router factory around generated
   report, blog post, landing page, and sales brief list/export/review
   workflows. Hosts inject pool providers, tenant scope, and auth dependencies.
+- `api.reasoning_contexts` provides a FastAPI router factory around DB-backed
+  campaign reasoning context list/upsert workflows. Hosts inject pool
+  providers, tenant scope, and auth dependencies; scoped tenants cannot
+  override `account_id` in request bodies.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/api/reasoning_contexts.py
+++ b/extracted_content_pipeline/api/reasoning_contexts.py
@@ -1,0 +1,188 @@
+"""FastAPI router factory for campaign reasoning context administration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Body, HTTPException, Query
+except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
+    APIRouter = None
+    Body = None
+    HTTPException = None
+    Query = None
+    _FASTAPI_IMPORT_ERROR: ImportError | None = exc
+else:
+    _FASTAPI_IMPORT_ERROR = None
+
+from ..campaign_ports import TenantScope
+from ..campaign_reasoning_postgres import PostgresCampaignReasoningContextRepository
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
+
+_MATCH_KEYS = ("target_id", "id", "company", "company_name", "account", "account_name", "email", "contact_email", "vendor", "vendor_name")
+
+
+def _require_fastapi() -> None:
+    if _FASTAPI_IMPORT_ERROR is None:
+        return
+    raise RuntimeError(
+        "FastAPI is required to create campaign reasoning context API routes. "
+        "Install fastapi in the host application environment."
+    ) from _FASTAPI_IMPORT_ERROR
+
+
+@dataclass(frozen=True)
+class ReasoningContextAdminApiConfig:
+    prefix: str = "/campaign-reasoning-contexts"
+    tags: tuple[str, ...] = ("campaign-reasoning-contexts",)
+    table: str = "campaign_reasoning_contexts"
+    default_limit: int = 20
+    max_limit: int = 200
+
+    def __post_init__(self) -> None:
+        if self.default_limit < 0:
+            raise ValueError("default_limit must be non-negative")
+        if self.max_limit <= 0:
+            raise ValueError("max_limit must be positive")
+        if self.default_limit > self.max_limit:
+            raise ValueError("default_limit must be less than or equal to max_limit")
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+async def _resolve_pool(pool_provider: PoolProvider) -> Any:
+    pool = await _maybe_await(pool_provider())
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    if getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    return pool
+
+
+async def _resolve_scope(scope_provider: ScopeProvider | None) -> TenantScope:
+    if scope_provider is None:
+        return TenantScope()
+    scope = await _maybe_await(scope_provider())
+    if scope is None:
+        return TenantScope()
+    if isinstance(scope, TenantScope):
+        return scope
+    if isinstance(scope, Mapping):
+        return TenantScope(
+            account_id=str(scope.get("account_id") or "") or None,
+            user_id=str(scope.get("user_id") or "") or None,
+        )
+    raise HTTPException(status_code=500, detail="Invalid tenant scope")
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _api_limit(value: int | None, config: ReasoningContextAdminApiConfig) -> int:
+    limit = config.default_limit if value is None else int(value)
+    if limit < 0:
+        raise HTTPException(status_code=400, detail="limit must be non-negative")
+    return min(limit, config.max_limit)
+
+
+def _clean_values(values: Sequence[Any]) -> tuple[str, ...]:
+    cleaned: list[str] = []
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            cleaned.extend(_clean_values(value))
+            continue
+        text = _clean(value)
+        if text:
+            cleaned.append(text)
+    return tuple(cleaned)
+
+
+def _row_selectors(row: Mapping[str, Any]) -> tuple[str, ...]:
+    values: list[Any] = [row.get("selectors")]
+    values.extend(row.get(key) for key in _MATCH_KEYS)
+    return _clean_values(values)
+
+
+def _row_context(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = row.get("context")
+    return value if isinstance(value, Mapping) else {}
+
+
+def create_reasoning_context_admin_router(
+    *,
+    pool_provider: PoolProvider,
+    scope_provider: ScopeProvider | None = None,
+    config: ReasoningContextAdminApiConfig | None = None,
+    dependencies: Sequence[Any] | None = None,
+    repository_factory: Callable[[Any, str], Any] | None = None,
+) -> APIRouter:
+    """Create host-mounted reasoning context admin routes.
+
+    Pass auth dependencies from the host application. The default leaves the
+    router unprotected for private mounts and tests.
+    """
+
+    _require_fastapi()
+    resolved_config = config or ReasoningContextAdminApiConfig()
+    repo_factory = repository_factory or (
+        lambda pool, table: PostgresCampaignReasoningContextRepository(pool=pool, table=table)
+    )
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+        dependencies=list(dependencies or ()),
+    )
+
+    @router.get("")
+    async def list_contexts(
+        target_mode: str | None = Query(None),
+        selector: list[str] | None = Query(None),
+        limit: int | None = Query(None, ge=0),
+    ) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        result = await repo_factory(pool, resolved_config.table).list_contexts(
+            scope=scope if scope.account_id else None,
+            target_mode=target_mode,
+            selectors=tuple(selector or ()),
+            limit=_api_limit(limit, resolved_config),
+        )
+        return result.as_dict()
+
+    @router.post("")
+    async def upsert_context(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        account_id = scope.account_id or _clean(payload.get("account_id"))
+        target_mode = _clean(payload.get("target_mode")).lower()
+        selectors = _row_selectors(payload)
+        if not selectors:
+            raise HTTPException(status_code=400, detail="selectors are required")
+        context = _row_context(payload)
+        if not context:
+            raise HTTPException(status_code=400, detail="context is required")
+        context_id = await repo_factory(pool, resolved_config.table).save_context(
+            scope=TenantScope(account_id=account_id or "", user_id=scope.user_id),
+            selectors=selectors,
+            context=context,
+            target_mode=target_mode,
+        )
+        return {
+            "status": "ok",
+            "id": context_id,
+            "account_id": account_id or "",
+            "target_mode": target_mode,
+            "selectors": list(selectors),
+        }
+
+    return router

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -302,6 +302,9 @@
       "target": "extracted_content_pipeline/api/generated_assets.py"
     },
     {
+      "target": "extracted_content_pipeline/api/reasoning_contexts.py"
+    },
+    {
       "target": "extracted_content_pipeline/api/seller_campaigns.py"
     },
     {

--- a/plans/PR-Content-Ops-Reasoning-Admin-Api.md
+++ b/plans/PR-Content-Ops-Reasoning-Admin-Api.md
@@ -1,0 +1,63 @@
+# PR: Content Ops Reasoning Admin API
+
+## Why this slice exists
+
+DB reasoning contexts can be listed and upserted by CLI, but hosts still need
+a small mounted API for operator workflows.
+
+## Scope
+
+- Add `api.reasoning_contexts` with list and single-row upsert routes.
+- Reuse `PostgresCampaignReasoningContextRepository`.
+- Preserve host-owned pool, tenant scope, and auth dependencies.
+- Add focused API tests and light docs.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Admin-Api.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/reasoning_contexts.py`
+- `extracted_content_pipeline/manifest.json`
+- `tests/test_extracted_campaign_reasoning_context_api.py`
+
+## Mechanism
+
+The router resolves injected pool/scope providers, calls the repository list
+path for browse, and calls the repository save path for create/edit. Request
+bodies accept explicit `selectors` or selector fields like `target_id` and
+`company_name`; the context payload must live under an explicit `context` key.
+
+## Intentional
+
+- Host tenant scope overrides request-body `account_id`.
+- This PR does not add destructive actions.
+- Auth stays host-owned; callers pass FastAPI dependencies at mount time.
+
+## Deferred
+
+- Scoped delete/retire contract.
+- API CSV export; the existing CLI still owns export.
+- Admin audit-log persistence and frontend UI.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_context_api.py
+python -m py_compile extracted_content_pipeline/api/reasoning_contexts.py tests/test_extracted_campaign_reasoning_context_api.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Admin-Api.md` | 50 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/README.md` | 7 |
+| `extracted_content_pipeline/STATUS.md` | 4 |
+| `extracted_content_pipeline/api/reasoning_contexts.py` | 190 |
+| `extracted_content_pipeline/manifest.json` | 3 |
+| `tests/test_extracted_campaign_reasoning_context_api.py` | 150 |
+| **Total** | **~400** |

--- a/tests/test_extracted_campaign_reasoning_context_api.py
+++ b/tests/test_extracted_campaign_reasoning_context_api.py
@@ -1,0 +1,150 @@
+"""Tests for the hosted campaign reasoning context admin API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from extracted_content_pipeline.api.reasoning_contexts import (
+    create_reasoning_context_admin_router,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_reasoning_postgres import (
+    CampaignReasoningContextListResult,
+)
+
+
+class _Pool:
+    is_initialized = True
+
+
+class _Repository:
+    def __init__(self) -> None:
+        self.list_calls: list[dict[str, Any]] = []
+        self.save_calls: list[dict[str, Any]] = []
+
+    async def list_contexts(self, **kwargs: Any) -> CampaignReasoningContextListResult:
+        self.list_calls.append(kwargs)
+        return CampaignReasoningContextListResult(
+            rows=(
+                {
+                    "id": "ctx-1",
+                    "account_id": "acct-1",
+                    "target_mode": "vendor_retention",
+                    "selectors": ["opp-1", "Acme"],
+                    "selector_key": "abc123",
+                    "updated_at": "2026-05-15T00:00:00Z",
+                    "payload": {"top_theses": [{"summary": "Renewal pressure"}]},
+                },
+            ),
+            limit=kwargs["limit"],
+            filters={"target_mode": kwargs.get("target_mode")},
+        )
+
+    async def save_context(self, **kwargs: Any) -> str:
+        self.save_calls.append(kwargs)
+        return "ctx-1"
+
+
+def _client(
+    repository: _Repository,
+    *,
+    scope: TenantScope | dict[str, Any] | None = TenantScope(account_id="acct-1"),
+    dependencies: list[Any] | None = None,
+) -> TestClient:
+    app = FastAPI()
+    pool = _Pool()
+
+    async def scope_provider() -> TenantScope | dict[str, Any] | None:
+        return scope
+
+    app.include_router(
+        create_reasoning_context_admin_router(
+            pool_provider=lambda: pool,
+            scope_provider=scope_provider if scope is not None else None,
+            dependencies=dependencies,
+            repository_factory=lambda pool_arg, table: repository,
+        )
+    )
+    return TestClient(app)
+
+
+def test_reasoning_context_admin_lists_rows_with_scope_and_filters() -> None:
+    repository = _Repository()
+
+    response = _client(repository).get(
+        "/campaign-reasoning-contexts?target_mode=vendor_retention&selector=Acme&limit=5"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["rows"][0]["id"] == "ctx-1"
+    call = repository.list_calls[0]
+    assert call["scope"].account_id == "acct-1"
+    assert call["target_mode"] == "vendor_retention"
+    assert call["selectors"] == ("Acme",)
+    assert call["limit"] == 5
+
+
+def test_reasoning_context_admin_upserts_context_with_scoped_account() -> None:
+    repository = _Repository()
+
+    response = _client(repository, scope=TenantScope(account_id="acct-scope")).post(
+        "/campaign-reasoning-contexts",
+        json={
+            "account_id": "acct-payload",
+            "target_mode": "Vendor_Retention",
+            "selectors": ["opp-1"],
+            "context": {"top_theses": [{"summary": "Renewal pressure"}]},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["account_id"] == "acct-scope"
+    call = repository.save_calls[0]
+    assert call["scope"].account_id == "acct-scope"
+    assert call["target_mode"] == "vendor_retention"
+    assert call["selectors"] == ("opp-1",)
+
+
+def test_reasoning_context_admin_upserts_selector_fields_without_scope() -> None:
+    repository = _Repository()
+
+    response = _client(repository, scope=None).post(
+        "/campaign-reasoning-contexts",
+        json={
+            "account_id": "acct-payload",
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "context": {"proof_points": [{"label": "pricing"}]},
+        },
+    )
+
+    assert response.status_code == 200
+    call = repository.save_calls[0]
+    assert call["scope"].account_id == "acct-payload"
+    assert call["selectors"] == ("opp-1", "Acme")
+    assert call["context"]["proof_points"][0]["label"] == "pricing"
+
+
+@pytest.mark.parametrize(
+    ("payload", "detail"),
+    [
+        ({"context": {"top_theses": [{"summary": "Renewal pressure"}]}}, "selectors are required"),
+        ({"selectors": ["opp-1"], "target_mode": "vendor_retention"}, "context is required"),
+        ({"selectors": ["opp-1"], "contextt": {"typo": True}}, "context is required"),
+    ],
+)
+def test_reasoning_context_admin_rejects_invalid_payloads(
+    payload: dict[str, Any],
+    detail: str,
+) -> None:
+    response = _client(_Repository()).post("/campaign-reasoning-contexts", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Admin-Api.md

## Summary
- add `api.reasoning_contexts` as a host-mounted FastAPI router for DB reasoning context list/upsert
- preserve host-injected pool, tenant scope, and auth dependency behavior
- document the route in README/status/manifest and claim the coordination slice

## Verification
- `pytest tests/test_extracted_campaign_reasoning_context_api.py -q`
- `python -m py_compile extracted_content_pipeline/api/reasoning_contexts.py tests/test_extracted_campaign_reasoning_context_api.py`
- `bash scripts/local_pr_review.sh`

## Deferred
- scoped delete/retire contract
- API CSV export; existing CLI still owns export
- admin audit-log persistence and frontend UI
