### PR TITLE
Add scoped reasoning context delete

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T17:52Z by codex-2026-05-15
+Last updated: 2026-05-15T18:04Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning admin API | `extracted_content_pipeline/api/reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_context_api.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | codex-2026-05-15 | Avoid DB reasoning admin/API edits |
+| draft | Content Ops reasoning context scoped delete | `extracted_content_pipeline/api/reasoning_contexts.py`, `extracted_content_pipeline/campaign_reasoning_postgres.py`, `tests/test_extracted_campaign_reasoning_context_api.py`, `tests/test_extracted_campaign_reasoning_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/STATUS.md` | codex-2026-05-15 | Avoid DB reasoning admin/API edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -222,11 +222,13 @@ The list/export CLI defaults to `--limit 20`; raise the limit deliberately for
 larger inventories.
 
 Hosts can also mount `api.reasoning_contexts` for `GET
-/campaign-reasoning-contexts` inventory and `POST /campaign-reasoning-contexts`
-single-row upsert. The host injects pool, auth, and tenant scope; scoped
+/campaign-reasoning-contexts` inventory, `POST /campaign-reasoning-contexts`
+single-row upsert, and scoped `DELETE /campaign-reasoning-contexts/{id}`. The
+host injects pool, auth, and tenant scope; scoped
 tenants cannot override `account_id` in the request body. Upsert requests must
 use an explicit `context` object; alias keys and typoed context keys are
-rejected. Pass auth dependencies when mounting the router.
+rejected. Delete requests require tenant scope or an explicit `account_id`
+query parameter. Pass auth dependencies when mounting the router.
 
 To insert or update host-produced reasoning rows without hand-writing SQL, load
 a JSON file with selectors plus a context payload:
@@ -864,7 +866,7 @@ Several small utility shims provide product-owned local behavior by default so t
 - `api/generated_assets.py`: optional FastAPI router factory for host-mounted
   report, landing page, and sales brief list/export/review routes
 - `api/reasoning_contexts.py`: optional FastAPI router factory for
-  host-mounted reasoning context list/upsert routes
+  host-mounted reasoning context list/upsert/delete routes
 - `api/seller_campaigns.py`: optional FastAPI router factory for host-mounted
   seller target management, category refresh, opportunity preparation, and
   seller draft review routes

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -71,9 +71,9 @@ source of truth for what remains.
   report, blog post, landing page, and sales brief list/export/review
   workflows. Hosts inject pool providers, tenant scope, and auth dependencies.
 - `api.reasoning_contexts` provides a FastAPI router factory around DB-backed
-  campaign reasoning context list/upsert workflows. Hosts inject pool
+  campaign reasoning context list/upsert/delete workflows. Hosts inject pool
   providers, tenant scope, and auth dependencies; scoped tenants cannot
-  override `account_id` in request bodies.
+  override `account_id` in request bodies, and deletes require account scope.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/api/reasoning_contexts.py
+++ b/extracted_content_pipeline/api/reasoning_contexts.py
@@ -185,4 +185,25 @@ def create_reasoning_context_admin_router(
             "selectors": list(selectors),
         }
 
+    @router.delete("/{context_id}")
+    async def delete_context(
+        context_id: str,
+        account_id: str | None = Query(None),
+    ) -> dict[str, Any]:
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        scoped_account_id = scope.account_id or _clean(account_id)
+        if not scoped_account_id:
+            raise HTTPException(status_code=400, detail="account_id is required")
+        deleted = await repo_factory(pool, resolved_config.table).delete_context(
+            context_id,
+            scope=TenantScope(account_id=scoped_account_id, user_id=scope.user_id),
+        )
+        return {
+            "status": "ok",
+            "id": context_id,
+            "account_id": scoped_account_id,
+            "deleted": bool(deleted),
+        }
+
     return router

--- a/extracted_content_pipeline/campaign_reasoning_postgres.py
+++ b/extracted_content_pipeline/campaign_reasoning_postgres.py
@@ -45,6 +45,7 @@ from .services.campaign_reasoning_context import (
 from .storage._jsonb_helpers import (
     decode_jsonb_field,
     json_dump_jsonb,
+    parse_command_tag,
     row_to_dict,
 )
 
@@ -390,6 +391,32 @@ class PostgresCampaignReasoningContextRepository:
             mode,
         )
         return int(stale_count or 0)
+
+    async def delete_context(
+        self,
+        context_id: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Delete one reasoning context by id within a tenant scope."""
+
+        cleaned_id = str(context_id or "").strip()
+        if not cleaned_id:
+            raise ValueError("context_id is required")
+        account_id = str(scope.account_id or "").strip()
+        if not account_id:
+            raise ValueError("delete_context requires scope.account_id")
+        table = _identifier(self.table)
+        result = await self.pool.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE id = $1
+              AND account_id = $2
+            """,
+            cleaned_id,
+            account_id,
+        )
+        return parse_command_tag(result)
 
     async def list_contexts(
         self,

--- a/plans/PR-Content-Ops-Reasoning-Context-Delete.md
+++ b/plans/PR-Content-Ops-Reasoning-Context-Delete.md
@@ -1,0 +1,63 @@
+# PR: Content Ops Reasoning Context Delete
+
+## Why this slice exists
+
+The reasoning admin API can list and upsert rows, but operators still need a
+deliberate scoped way to remove bad or stale rows.
+
+## Scope
+
+- Add a scoped `delete_context` repository method.
+- Expose `DELETE /campaign-reasoning-contexts/{id}`.
+- Require an account scope for destructive deletes.
+- Add focused repository and API tests.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Context-Delete.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/reasoning_contexts.py`
+- `extracted_content_pipeline/campaign_reasoning_postgres.py`
+- `tests/test_extracted_campaign_reasoning_context_api.py`
+- `tests/test_extracted_campaign_reasoning_postgres.py`
+
+## Mechanism
+
+The repository deletes by `id` and `account_id` only. The API uses the host
+tenant scope when present, otherwise it requires `account_id` as a query
+parameter.
+
+## Intentional
+
+- No unscoped delete path.
+- No bulk delete.
+- No audit-table persistence in this slice.
+
+## Deferred
+
+- Admin audit-log persistence.
+- Frontend delete/retire UX.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_context_api.py tests/test_extracted_campaign_reasoning_postgres.py
+python -m py_compile extracted_content_pipeline/api/reasoning_contexts.py extracted_content_pipeline/campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_context_api.py tests/test_extracted_campaign_reasoning_postgres.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Context-Delete.md` | 55 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/README.md` | 4 |
+| `extracted_content_pipeline/STATUS.md` | 4 |
+| `extracted_content_pipeline/api/reasoning_contexts.py` | 35 |
+| `extracted_content_pipeline/campaign_reasoning_postgres.py` | 30 |
+| `tests/test_extracted_campaign_reasoning_context_api.py` | 45 |
+| `tests/test_extracted_campaign_reasoning_postgres.py` | 55 |
+| **Total** | **~230** |

--- a/tests/test_extracted_campaign_reasoning_context_api.py
+++ b/tests/test_extracted_campaign_reasoning_context_api.py
@@ -28,6 +28,7 @@ class _Repository:
     def __init__(self) -> None:
         self.list_calls: list[dict[str, Any]] = []
         self.save_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
 
     async def list_contexts(self, **kwargs: Any) -> CampaignReasoningContextListResult:
         self.list_calls.append(kwargs)
@@ -50,6 +51,10 @@ class _Repository:
     async def save_context(self, **kwargs: Any) -> str:
         self.save_calls.append(kwargs)
         return "ctx-1"
+
+    async def delete_context(self, context_id: str, **kwargs: Any) -> bool:
+        self.delete_calls.append({"context_id": context_id, **kwargs})
+        return True
 
 
 def _client(
@@ -148,3 +153,27 @@ def test_reasoning_context_admin_rejects_invalid_payloads(
 
     assert response.status_code == 400
     assert response.json()["detail"] == detail
+
+
+def test_reasoning_context_admin_deletes_with_scoped_account() -> None:
+    repository = _Repository()
+
+    response = _client(repository, scope=TenantScope(account_id="acct-scope")).delete(
+        "/campaign-reasoning-contexts/ctx-1?account_id=acct-payload"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "id": "ctx-1",
+        "account_id": "acct-scope",
+        "deleted": True,
+    }
+    assert repository.delete_calls[0]["scope"].account_id == "acct-scope"
+
+
+def test_reasoning_context_admin_rejects_unscoped_delete() -> None:
+    response = _client(_Repository(), scope=None).delete("/campaign-reasoning-contexts/ctx-1")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "account_id is required"

--- a/tests/test_extracted_campaign_reasoning_postgres.py
+++ b/tests/test_extracted_campaign_reasoning_postgres.py
@@ -8,7 +8,7 @@ so the host route mount (PR #402 / PR #462) can swap providers
 without touching the bundle's `with_reasoning_context()`
 derivation.
 
-Test inventory (19 tests):
+Test inventory (21 tests):
 
 1. `read_campaign_reasoning_context` builds the candidate
    selector array from `target_id` + opportunity keys
@@ -46,6 +46,8 @@ Test inventory (19 tests):
 17. `delete_stale_contexts` counts stale rows in dry-run mode.
 18. `delete_stale_contexts` deletes stale rows only when requested.
 19. `delete_stale_contexts` rejects non-positive age thresholds.
+20. `delete_context` deletes one row by id within account scope.
+21. `delete_context` rejects empty ids or unscoped deletes.
 
 Test harness uses an asyncpg-shaped fake pool (matches
 `tests/test_extracted_blog_blueprint_postgres.py`).
@@ -74,6 +76,8 @@ class _Pool:
         self.fetchrow_result: Any = None
         self.fetchval_calls: list[dict[str, Any]] = []
         self.fetchrow_calls: list[dict[str, Any]] = []
+        self.execute_calls: list[dict[str, Any]] = []
+        self.execute_result: Any = "DELETE 1"
 
     async def fetchval(self, query: str, *args: Any) -> Any:
         self.fetchval_calls.append({"query": query, "args": args})
@@ -82,6 +86,10 @@ class _Pool:
     async def fetchrow(self, query: str, *args: Any) -> Any:
         self.fetchrow_calls.append({"query": query, "args": args})
         return self.fetchrow_result
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
 
 
 @pytest.mark.asyncio
@@ -565,3 +573,30 @@ async def test_delete_stale_contexts_rejects_non_positive_days() -> None:
     with pytest.raises(ValueError):
         await repo.delete_stale_contexts(older_than_days=0)
     assert pool.fetchval_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delete_context_deletes_one_scoped_row() -> None:
+    pool = _Pool()
+    repo = PostgresCampaignReasoningContextRepository(pool=pool)
+
+    deleted = await repo.delete_context(
+        "ctx-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert deleted is True
+    call = pool.execute_calls[0]
+    assert 'DELETE FROM "campaign_reasoning_contexts"' in call["query"]
+    assert "account_id = $2" in call["query"]
+    assert call["args"] == ("ctx-1", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_context_rejects_unscoped_or_empty_ids() -> None:
+    repo = PostgresCampaignReasoningContextRepository(pool=_Pool())
+
+    with pytest.raises(ValueError, match="context_id is required"):
+        await repo.delete_context("", scope=TenantScope(account_id="acct-1"))
+    with pytest.raises(ValueError, match="scope.account_id"):
+        await repo.delete_context("ctx-1", scope=TenantScope())


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Context-Delete.md

## Summary
- add a scoped `delete_context` repository method for campaign reasoning contexts
- expose `DELETE /campaign-reasoning-contexts/{id}` through the reasoning admin router
- require tenant scope or explicit `account_id` for destructive deletes

## Verification
- `pytest tests/test_extracted_campaign_reasoning_context_api.py tests/test_extracted_campaign_reasoning_postgres.py -q`
- `python -m py_compile extracted_content_pipeline/api/reasoning_contexts.py extracted_content_pipeline/campaign_reasoning_postgres.py tests/test_extracted_campaign_reasoning_context_api.py tests/test_extracted_campaign_reasoning_postgres.py`
- `bash scripts/local_pr_review.sh`

## Deferred
- admin audit-log persistence
- frontend delete/retire UX
