### PR TITLE
Emit reasoning admin visibility events

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T18:04Z by codex-2026-05-15
+Last updated: 2026-05-15T18:11Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning context scoped delete | `extracted_content_pipeline/api/reasoning_contexts.py`, `extracted_content_pipeline/campaign_reasoning_postgres.py`, `tests/test_extracted_campaign_reasoning_context_api.py`, `tests/test_extracted_campaign_reasoning_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/STATUS.md` | codex-2026-05-15 | Avoid DB reasoning admin/API edits |
+| draft | Content Ops reasoning admin visibility | `extracted_content_pipeline/api/reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_context_api.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/STATUS.md` | codex-2026-05-15 | Avoid DB reasoning admin/API edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -228,7 +228,9 @@ host injects pool, auth, and tenant scope; scoped
 tenants cannot override `account_id` in the request body. Upsert requests must
 use an explicit `context` object; alias keys and typoed context keys are
 rejected. Delete requests require tenant scope or an explicit `account_id`
-query parameter. Pass auth dependencies when mounting the router.
+query parameter. Pass auth dependencies when mounting the router. Hosts can
+also inject a `VisibilitySink` provider to emit metadata-only admin events for
+reasoning context upserts and deletes.
 
 To insert or update host-produced reasoning rows without hand-writing SQL, load
 a JSON file with selectors plus a context payload:
@@ -866,7 +868,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `api/generated_assets.py`: optional FastAPI router factory for host-mounted
   report, landing page, and sales brief list/export/review routes
 - `api/reasoning_contexts.py`: optional FastAPI router factory for
-  host-mounted reasoning context list/upsert/delete routes
+  host-mounted reasoning context list/upsert/delete routes with optional
+  `VisibilitySink` audit events
 - `api/seller_campaigns.py`: optional FastAPI router factory for host-mounted
   seller target management, category refresh, opportunity preparation, and
   seller draft review routes

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -74,6 +74,7 @@ source of truth for what remains.
   campaign reasoning context list/upsert/delete workflows. Hosts inject pool
   providers, tenant scope, and auth dependencies; scoped tenants cannot
   override `account_id` in request bodies, and deletes require account scope.
+  Hosts can inject a `VisibilitySink` provider for metadata-only admin events.
 - `scripts/smoke_extracted_content_pipeline_host.py` provides a one-command
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or

--- a/extracted_content_pipeline/api/reasoning_contexts.py
+++ b/extracted_content_pipeline/api/reasoning_contexts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+import logging
 from typing import Any
 
 try:
@@ -17,14 +18,19 @@ except ImportError as exc:  # pragma: no cover - exercised in dependency-light C
 else:
     _FASTAPI_IMPORT_ERROR = None
 
-from ..campaign_ports import TenantScope
+from ..campaign_ports import TenantScope, VisibilitySink
+from ..campaign_visibility import emit_operation_event
 from ..campaign_reasoning_postgres import PostgresCampaignReasoningContextRepository
 
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
+VisibilityProvider = Callable[[], VisibilitySink | Awaitable[VisibilitySink]]
 
 _MATCH_KEYS = ("target_id", "id", "company", "company_name", "account", "account_name", "email", "contact_email", "vendor", "vendor_name")
+_CONTEXT_UPSERT_EVENT = "campaign_reasoning_context_upserted"
+_CONTEXT_DELETE_EVENT = "campaign_reasoning_context_deleted"
+logger = logging.getLogger(__name__)
 
 
 def _require_fastapi() -> None:
@@ -125,6 +131,7 @@ def create_reasoning_context_admin_router(
     config: ReasoningContextAdminApiConfig | None = None,
     dependencies: Sequence[Any] | None = None,
     repository_factory: Callable[[Any, str], Any] | None = None,
+    visibility_provider: VisibilityProvider | None = None,
 ) -> APIRouter:
     """Create host-mounted reasoning context admin routes.
 
@@ -177,6 +184,16 @@ def create_reasoning_context_admin_router(
             context=context,
             target_mode=target_mode,
         )
+        await _emit_admin_event(
+            visibility_provider,
+            _CONTEXT_UPSERT_EVENT,
+            {
+                "context_id": context_id,
+                "account_id": account_id or "",
+                "target_mode": target_mode,
+                "selectors_count": len(selectors),
+            },
+        )
         return {
             "status": "ok",
             "id": context_id,
@@ -199,6 +216,15 @@ def create_reasoning_context_admin_router(
             context_id,
             scope=TenantScope(account_id=scoped_account_id, user_id=scope.user_id),
         )
+        await _emit_admin_event(
+            visibility_provider,
+            _CONTEXT_DELETE_EVENT,
+            {
+                "context_id": context_id,
+                "account_id": scoped_account_id,
+                "deleted": bool(deleted),
+            },
+        )
         return {
             "status": "ok",
             "id": context_id,
@@ -207,3 +233,23 @@ def create_reasoning_context_admin_router(
         }
 
     return router
+
+
+async def _emit_admin_event(
+    visibility_provider: VisibilityProvider | None,
+    event_type: str,
+    payload: Mapping[str, Any],
+) -> None:
+    if visibility_provider is None:
+        return
+    try:
+        visibility = await _maybe_await(visibility_provider())
+        await emit_operation_event(
+            visibility,
+            event_type,
+            "campaign_reasoning_context_admin",
+            payload,
+        )
+    except Exception as exc:
+        logger.warning("Reasoning context admin visibility emit failed: %s", exc)
+        return

--- a/plans/PR-Content-Ops-Reasoning-Admin-Visibility.md
+++ b/plans/PR-Content-Ops-Reasoning-Admin-Visibility.md
@@ -1,0 +1,58 @@
+# PR: Content Ops Reasoning Admin Visibility
+
+## Why this slice exists
+
+Reasoning context admin upsert/delete actions are now exposed by API, but hosts
+need a lightweight operator-visible audit hook without a new product table.
+
+## Scope
+
+- Add optional `visibility_provider` injection to `api.reasoning_contexts`.
+- Emit metadata-only events for reasoning context upsert and delete.
+- Keep events best-effort and omit full reasoning payloads.
+- Add focused API tests.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reasoning-Admin-Visibility.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/reasoning_contexts.py`
+- `tests/test_extracted_campaign_reasoning_context_api.py`
+
+## Mechanism
+
+The router resolves an optional `VisibilitySink` provider and emits metadata
+after successful upsert/delete operations. Failures in the visibility sink do
+not break the admin action.
+
+## Intentional
+
+- No full reasoning context payload in visibility events.
+- No new database schema.
+
+## Deferred
+
+- Persistent admin audit table.
+- Frontend audit-log display.
+
+## Verification
+
+```bash
+pytest tests/test_extracted_campaign_reasoning_context_api.py
+python -m py_compile extracted_content_pipeline/api/reasoning_contexts.py tests/test_extracted_campaign_reasoning_context_api.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Admin-Visibility.md` | 55 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/README.md` | 4 |
+| `extracted_content_pipeline/STATUS.md` | 4 |
+| `extracted_content_pipeline/api/reasoning_contexts.py` | 45 |
+| `tests/test_extracted_campaign_reasoning_context_api.py` | 55 |
+| **Total** | **~170** |

--- a/tests/test_extracted_campaign_reasoning_context_api.py
+++ b/tests/test_extracted_campaign_reasoning_context_api.py
@@ -15,6 +15,7 @@ from extracted_content_pipeline.api.reasoning_contexts import (
     create_reasoning_context_admin_router,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_visibility import InMemoryVisibilitySink
 from extracted_content_pipeline.campaign_reasoning_postgres import (
     CampaignReasoningContextListResult,
 )
@@ -62,6 +63,7 @@ def _client(
     *,
     scope: TenantScope | dict[str, Any] | None = TenantScope(account_id="acct-1"),
     dependencies: list[Any] | None = None,
+    visibility: Any = None,
 ) -> TestClient:
     app = FastAPI()
     pool = _Pool()
@@ -75,6 +77,7 @@ def _client(
             scope_provider=scope_provider if scope is not None else None,
             dependencies=dependencies,
             repository_factory=lambda pool_arg, table: repository,
+            visibility_provider=(lambda: visibility) if visibility is not None else None,
         )
     )
     return TestClient(app)
@@ -177,3 +180,75 @@ def test_reasoning_context_admin_rejects_unscoped_delete() -> None:
 
     assert response.status_code == 400
     assert response.json()["detail"] == "account_id is required"
+
+
+def test_reasoning_context_admin_emits_visibility_for_upsert() -> None:
+    visibility = InMemoryVisibilitySink()
+
+    response = _client(_Repository(), visibility=visibility).post(
+        "/campaign-reasoning-contexts",
+        json={
+            "selectors": ["opp-1", "Acme"],
+            "target_mode": "vendor_retention",
+            "context": {"top_theses": [{"summary": "Renewal pressure"}]},
+        },
+    )
+
+    assert response.status_code == 200
+    event = visibility.as_dicts()[0]
+    assert event["event_type"] == "campaign_reasoning_context_upserted"
+    assert event["payload"] == {
+        "operation": "campaign_reasoning_context_admin",
+        "context_id": "ctx-1",
+        "account_id": "acct-1",
+        "target_mode": "vendor_retention",
+        "selectors_count": 2,
+    }
+
+
+def test_reasoning_context_admin_emits_visibility_for_delete() -> None:
+    visibility = InMemoryVisibilitySink()
+
+    response = _client(_Repository(), visibility=visibility).delete(
+        "/campaign-reasoning-contexts/ctx-1"
+    )
+
+    assert response.status_code == 200
+    event = visibility.as_dicts()[0]
+    assert event["event_type"] == "campaign_reasoning_context_deleted"
+    assert event["payload"] == {
+        "operation": "campaign_reasoning_context_admin",
+        "context_id": "ctx-1",
+        "account_id": "acct-1",
+        "deleted": True,
+    }
+
+
+def test_reasoning_context_admin_visibility_failure_does_not_break_upsert() -> None:
+    class _FailingVisibility:
+        async def emit(self, event_type: str, payload: dict[str, Any]) -> None:
+            raise RuntimeError("visibility down")
+
+    response = _client(_Repository(), visibility=_FailingVisibility()).post(
+        "/campaign-reasoning-contexts",
+        json={
+            "selectors": ["opp-1"],
+            "context": {"top_theses": [{"summary": "Renewal pressure"}]},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "ctx-1"
+
+
+def test_reasoning_context_admin_visibility_failure_does_not_break_delete() -> None:
+    class _FailingVisibility:
+        async def emit(self, event_type: str, payload: dict[str, Any]) -> None:
+            raise RuntimeError("visibility down")
+
+    response = _client(_Repository(), visibility=_FailingVisibility()).delete(
+        "/campaign-reasoning-contexts/ctx-1"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["deleted"] is True


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Admin-Visibility.md

## Summary
- add optional `VisibilitySink` injection to the reasoning context admin router
- emit metadata-only events after admin upsert/delete actions
- keep visibility best-effort so sink failures do not break admin writes

## Verification
- `pytest tests/test_extracted_campaign_reasoning_context_api.py -q`
- `python -m py_compile extracted_content_pipeline/api/reasoning_contexts.py tests/test_extracted_campaign_reasoning_context_api.py`
- `bash scripts/local_pr_review.sh`

## Deferred
- persistent admin audit table
- frontend audit-log display
