### PR TITLE
Refresh Content Ops backlog after reasoning admin

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -40,35 +40,16 @@ The following items appear in older plan docs but are no longer active backlog:
 - DB reasoning upsert dry-run.
 - DB reasoning upsert metadata audit log.
 - DB reasoning upsert live-opportunity validation.
+- DB reasoning context hosted admin list/upsert API.
+- DB reasoning context scoped delete/retire API.
+- DB reasoning context admin visibility events.
 - Generated asset batch review/status updates.
 
 ## Active Backlog
 
-### 1. Reasoning context admin workflow
+### 1. Operator review UX and richer result previews
 
 **Priority:** P2
-
-**Why:** DB-backed reasoning context storage is now functional and has CLI
-coverage for read, export, upsert, dry-run, stale cleanup, and metadata audit
-logging. What is still missing is an operator-facing workflow for managing
-those rows without hand-running scripts.
-
-Remaining work:
-
-- Browse and inspect reasoning context rows from the hosted admin surface.
-- Create or edit a context row with the same validation rules as the upsert
-  CLI.
-- Delete or retire a row deliberately, with tenant/account scoping.
-- Show recent metadata audit-log entries or equivalent operator-visible
-  provenance.
-
-**Likely slice:** start with a small API/admin surface over the existing
-repository methods. Keep full audit-table persistence separate unless a host
-needs centralized audit storage immediately.
-
-### 2. Operator review UX and richer result previews
-
-**Priority:** P3
 
 **Why:** Batch review/status updates are now done. Older frontend/result-summary
 plans still deferred richer generated-asset previews and component-level tests.
@@ -78,7 +59,7 @@ These are product polish, not core readiness blockers.
 and sales brief rows, then add component-level frontend tests for the review
 surface.
 
-### 3. Scale hardening for batch review
+### 2. Scale hardening for batch review
 
 **Priority:** P4
 
@@ -89,7 +70,7 @@ bulk SQL may be worth adding.
 
 **Likely slice:** defer until actual batch sizes justify it.
 
-### 4. Reasoning product depth and source breadth
+### 3. Reasoning product depth and source breadth
 
 **Priority:** P4
 
@@ -107,6 +88,6 @@ not as Content Ops cleanup.
 
 ## Current Pick Recommendation
 
-Take item 1 next if we want operator-facing progress: reasoning context admin
-workflow. Take item 2 next if we want frontend polish: richer generated-asset
-previews and component tests.
+Take item 1 next if we want operator-facing polish: richer generated-asset
+previews and component tests. Take item 3 if we want to switch back to the
+larger reasoning-core/product-depth track.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T18:11Z by codex-2026-05-15
+Last updated: 2026-05-15T18:42Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning admin visibility | `extracted_content_pipeline/api/reasoning_contexts.py`, `tests/test_extracted_campaign_reasoning_context_api.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/STATUS.md` | codex-2026-05-15 | Avoid DB reasoning admin/API edits |
+| draft | Content Ops backlog refresh after reasoning admin | `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Backlog-Reasoning-Admin-Close.md` | codex-2026-05-15 | Avoid AI Content Ops backlog docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Backlog-Reasoning-Admin-Close.md
+++ b/plans/PR-Content-Ops-Backlog-Reasoning-Admin-Close.md
@@ -1,0 +1,53 @@
+# PR: Refresh Content Ops Backlog After Reasoning Admin
+
+## Why This Slice Exists
+
+The DB reasoning context admin API, scoped delete path, and visibility events
+have merged. The active AI Content Ops backlog still lists that work as open,
+which makes the next slice look less clear than it is.
+
+## Scope
+
+Refresh the docs so the completed reasoning-admin work moves to retired
+deferrals and the next active Content Ops work item is the generated-asset
+preview UX.
+
+### Files Touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Backlog-Reasoning-Admin-Close.md`
+
+## Mechanism
+
+- Retire the merged hosted admin list/upsert, scoped delete, and visibility
+  event work.
+- Remove the stale active reasoning-admin backlog item.
+- Promote generated-asset preview UX as the next recommended Content Ops slice.
+- Replace the stale in-flight coordination row with this docs-only claim.
+
+## Intentional
+
+- No production code changes.
+- No frontend implementation in this slice.
+- No changes to reasoning-core or generated-asset runtime behavior.
+
+## Deferred
+
+- Generated-asset preview UX implementation.
+- Frontend component tests for richer result previews.
+- Reasoning-core/product-depth work.
+
+## Verification
+
+- `git diff --check`
+- `scripts/local_pr_review.sh`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Backlog doc | ~50 |
+| Coordination row | ~2 |
+| Plan doc | ~50 |
+| **Total** | ~102 |


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Backlog-Reasoning-Admin-Close.md`

## Summary

- Retire the merged reasoning context hosted admin list/upsert, scoped delete, and visibility event work from the AI Content Ops backlog.
- Remove the stale active reasoning-admin item so the next active Content Ops slice is generated-asset preview UX.
- Replace the stale in-flight coordination row from the visibility PR with this docs-only claim.

## Verification

- `git diff --check`
- `bash scripts/local_pr_review.sh`