### PR TITLE
Clear stale Content Ops inflight row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T18:46Z by codex-2026-05-15
+Last updated: 2026-05-15T18:35Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops generated asset preview UX | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Generated-Asset-Preview-UX.md` | codex-2026-05-15 | Avoid generated asset review UI |
+| _none_ | _No active coordinated PRs_ | _none_ | _none_ | _none_ |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Clear-Stale-Inflight.md
+++ b/plans/PR-Content-Ops-Clear-Stale-Inflight.md
@@ -1,0 +1,42 @@
+# PR: Clear Stale Content Ops Inflight Row
+
+## Why This Slice Exists
+
+The coordination ledger still shows the generated asset preview UX claim after
+that PR merged. Keeping stale locks slows the next sessions down.
+
+## Scope
+
+Clear the stale row in `docs/extraction/coordination/inflight.md`.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Clear-Stale-Inflight.md`
+
+## Mechanism
+
+- Replace the stale draft row with the ledger's explicit empty-state row.
+
+## Intentional
+
+- No product code changes.
+- No frontend changes.
+- No generated asset behavior changes.
+
+## Deferred
+
+- Next Content Ops product slice.
+
+## Verification
+
+- `scripts/local_pr_review.sh`.
+- `git diff --check`.
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination row | ~2 |
+| Plan doc | ~45 |
+| **Total** | ~47 |


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Clear-Stale-Inflight.md`

## Summary

- Replace the stale generated asset preview UX coordination row after #530 merged.
- Leave the coordination ledger in its explicit empty state.

## Verification

- `bash scripts/local_pr_review.sh`
- `git diff --check`