### PR TITLE
Scale generated asset batch review updates

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -8,7 +8,7 @@ Last updated: 2026-05-15
 This is the current ordered backlog for AI Content Ops deferrals surfaced by
 older PR plans and post-merge audits. It is not a full product roadmap; it is
 the short list of follow-up work that still matters after the execution,
-reasoning, export, compact UI parity, and DB reasoning admin seams already
+reasoning, export, review, preview, detail, and DB reasoning admin seams already
 merged.
 
 ## Retired Historical Deferrals
@@ -27,6 +27,8 @@ The following items appear in older plan docs but are no longer active backlog:
   assets.
 - Generated asset export and review paths for report, blog post, landing page,
   and sales brief drafts.
+- Generated asset batch review/status updates and one-query batch updates.
+- Generated asset preview cards and detail drawer.
 - `blog_post` reasoning catalog/fixture parity.
 - Live execute persistence smoke for all generated assets.
 - Blog blueprint population path.
@@ -43,51 +45,33 @@ The following items appear in older plan docs but are no longer active backlog:
 - DB reasoning context hosted admin list/upsert API.
 - DB reasoning context scoped delete/retire API.
 - DB reasoning context admin visibility events.
-- Generated asset batch review/status updates.
 
 ## Active Backlog
 
-### 1. Operator review UX and richer result previews
+### 1. Reasoning product depth and source breadth
 
 **Priority:** P2
 
-**Why:** Batch review/status updates are now done. Older frontend/result-summary
-plans still deferred richer generated-asset previews and component-level tests.
-These are product polish, not core readiness blockers.
-
-**Likely slice:** improve preview cards for report, blog post, landing page,
-and sales brief rows, then add component-level frontend tests for the review
-surface.
-
-### 2. Scale hardening for batch review
-
-**Priority:** P4
-
-**Why:** Generated asset batch review currently reuses the existing scoped
-single-row status update path. That preserves tenant filtering and keeps the
-implementation simple. If hosts start reviewing large batches, repository-level
-bulk SQL may be worth adding.
-
-**Likely slice:** defer until actual batch sizes justify it.
-
-### 3. Reasoning product depth and source breadth
-
-**Priority:** P4
-
 **Why:** AI Content Ops can consume file-backed, DB-backed, single-pass, and
-multi-pass reasoning context. The remaining strategic questions are broader
-than this backlog:
+multi-pass reasoning context. The next value step is deciding how much of the
+standalone reasoning layer each content type should expose and how hosts should
+feed richer customer-specific source bundles into it.
+
+Remaining work:
 
 - More source adapters for customer-specific data bundles.
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
 - Host policy for richer falsification/cache/narrative-planning knobs.
+- Per-content-type opt-in rules so simple assets avoid heavy reasoning paths
+  while long-form assets can use stateful reasoning.
 
-**Likely slice:** handle through product roadmap or the reasoning-core backlog,
-not as Content Ops cleanup.
+**Likely slice:** start with a narrow source-bundle adapter or a small
+reasoning-provider capability check that directly improves host setup, rather
+than a broad architecture refactor.
 
 ## Current Pick Recommendation
 
-Take item 1 next if we want operator-facing polish: richer generated-asset
-previews and component tests. Take item 3 if we want to switch back to the
-larger reasoning-core/product-depth track.
+Take item 1 next. The generated asset operator workflow is now usable; the
+remaining leverage is increasing the quality and breadth of reasoning/source
+inputs that feed AI Content Ops.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T18:39Z by codex-2026-05-15
+Last updated: 2026-05-15T18:58Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops generated asset detail drawer | `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Generated-Asset-Detail-Drawer.md` | codex-2026-05-15 | Avoid generated asset review UI |
+| draft | Content Ops generated asset batch scale | `extracted_content_pipeline/api/generated_assets.py`, `extracted_content_pipeline/blog_post_postgres.py`, `extracted_content_pipeline/report_postgres.py`, `extracted_content_pipeline/landing_page_postgres.py`, `extracted_content_pipeline/sales_brief_postgres.py`, `extracted_content_pipeline/blog_ports.py`, `extracted_content_pipeline/report_ports.py`, `extracted_content_pipeline/landing_page_ports.py`, `extracted_content_pipeline/sales_brief_ports.py`, `tests/test_extracted_content_asset_api.py`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Generated-Asset-Batch-Scale.md` | codex-2026-05-15 | Avoid generated asset review backend and backlog docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 try:
     from fastapi import APIRouter, Body, HTTPException, Query, Response
@@ -130,6 +131,19 @@ def _review_ids(value: Any) -> tuple[str, ...]:
     if not ids:
         raise HTTPException(status_code=400, detail="ids must be a non-empty list")
     return tuple(ids)
+
+
+def _partition_uuid_ids(ids: Sequence[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    valid: list[str] = []
+    invalid: list[str] = []
+    for asset_id in ids:
+        try:
+            UUID(asset_id)
+        except ValueError:
+            invalid.append(asset_id)
+        else:
+            valid.append(asset_id)
+    return tuple(valid), tuple(invalid)
 
 
 def _asset_arg(value: str) -> str:
@@ -278,22 +292,20 @@ def create_generated_asset_router(
                     "batch size exceeds max_batch_size "
                     f"({resolved_config.max_batch_size})"
                 ),
-            )
+        )
         status = _review_status(payload.get("status"))
-        updated_ids: list[str] = []
-        missing_ids: list[str] = []
-        for asset_id in ids:
-            updated = await _update_asset_status(
-                asset_name,
-                pool,
-                asset_id=asset_id,
-                status=status,
-                scope=tenant,
-            )
-            if updated:
-                updated_ids.append(asset_id)
-            else:
-                missing_ids.append(asset_id)
+        valid_ids, invalid_ids = _partition_uuid_ids(ids)
+        updated = set(await _update_asset_statuses(
+            asset_name,
+            pool,
+            asset_ids=valid_ids,
+            status=status,
+            scope=tenant,
+        ))
+        updated_ids = [asset_id for asset_id in ids if asset_id in updated]
+        missing = set(invalid_ids)
+        missing.update(asset_id for asset_id in valid_ids if asset_id not in updated)
+        missing_ids = [asset_id for asset_id in ids if asset_id in missing]
         return {
             "account_id": tenant.account_id,
             "asset": asset_name,
@@ -375,6 +387,25 @@ async def _update_asset_status(
         return await PostgresLandingPageRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "sales_brief":
         return await PostgresSalesBriefRepository(pool).update_status(asset_id, status, scope=scope)
+    raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
+
+
+async def _update_asset_statuses(
+    asset: str,
+    pool: Any,
+    *,
+    asset_ids: Sequence[str],
+    status: str,
+    scope: TenantScope,
+) -> Sequence[str]:
+    if asset == "blog_post":
+        return await PostgresBlogPostRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "report":
+        return await PostgresReportRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "landing_page":
+        return await PostgresLandingPageRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "sales_brief":
+        return await PostgresSalesBriefRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
 
 

--- a/extracted_content_pipeline/blog_ports.py
+++ b/extracted_content_pipeline/blog_ports.py
@@ -95,6 +95,15 @@ class BlogPostRepository(Protocol):
     ) -> bool:
         """Update a draft status and return True on hit."""
 
+    async def update_statuses(
+        self,
+        blog_post_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched the tenant scope."""
+
 
 __all__ = [
     "BlogBlueprint",

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -186,6 +186,34 @@ class PostgresBlogPostRepository:
         )
         return parse_command_tag(result)
 
+    async def update_statuses(
+        self,
+        blog_post_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in blog_post_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE blog_posts
+               SET status = $2,
+                   published_at = CASE
+                       WHEN $2 = 'published' THEN COALESCE(published_at, NOW())
+                       ELSE published_at
+                   END
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
 
 __all__ = [
     "PostgresBlogPostRepository",

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -178,6 +178,15 @@ class LandingPageRepository(Protocol):
         learn about it at the call site, not silently succeed.
         """
 
+    async def update_statuses(
+        self,
+        landing_page_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched the tenant scope."""
+
 
 __all__ = [
     "LandingPageDraft",

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -221,6 +221,31 @@ class PostgresLandingPageRepository:
         )
         return parse_command_tag(result)
 
+    async def update_statuses(
+        self,
+        landing_page_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in landing_page_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE landing_pages
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
 
 __all__ = [
     "PostgresLandingPageRepository",

--- a/extracted_content_pipeline/report_ports.py
+++ b/extracted_content_pipeline/report_ports.py
@@ -131,6 +131,15 @@ class ReportRepository(Protocol):
         Returns True on hit, False on miss (wrong id or wrong tenant).
         """
 
+    async def update_statuses(
+        self,
+        report_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched the tenant scope."""
+
 
 __all__ = [
     "ReportDraft",

--- a/extracted_content_pipeline/report_postgres.py
+++ b/extracted_content_pipeline/report_postgres.py
@@ -182,6 +182,31 @@ class PostgresReportRepository:
         )
         return parse_command_tag(result)
 
+    async def update_statuses(
+        self,
+        report_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in report_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE reports
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
 
 __all__ = [
     "PostgresReportRepository",

--- a/extracted_content_pipeline/sales_brief_ports.py
+++ b/extracted_content_pipeline/sales_brief_ports.py
@@ -140,6 +140,15 @@ class SalesBriefRepository(Protocol):
     ) -> bool:
         """Update a draft's status. Returns True on hit, False on miss."""
 
+    async def update_statuses(
+        self,
+        brief_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched the tenant scope."""
+
 
 __all__ = [
     "BriefType",

--- a/extracted_content_pipeline/sales_brief_postgres.py
+++ b/extracted_content_pipeline/sales_brief_postgres.py
@@ -192,6 +192,31 @@ class PostgresSalesBriefRepository:
         )
         return parse_command_tag(result)
 
+    async def update_statuses(
+        self,
+        brief_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in brief_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE sales_briefs
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
 
 __all__ = [
     "PostgresSalesBriefRepository",

--- a/plans/PR-Content-Ops-Generated-Asset-Batch-Scale.md
+++ b/plans/PR-Content-Ops-Generated-Asset-Batch-Scale.md
@@ -1,0 +1,72 @@
+# PR: Content Ops Generated Asset Batch Scale
+
+## Why This Slice Exists
+
+Generated asset batch review currently loops one scoped status update per draft.
+That preserves correctness, but it scales linearly in database round trips when
+operators approve or reject larger review queues.
+
+## Scope
+
+Move generated asset batch review to one repository-level bulk update per asset
+type while preserving the existing API response shape.
+
+### Files Touched
+
+- `extracted_content_pipeline/api/generated_assets.py`
+- `extracted_content_pipeline/blog_post_postgres.py`
+- `extracted_content_pipeline/report_postgres.py`
+- `extracted_content_pipeline/landing_page_postgres.py`
+- `extracted_content_pipeline/sales_brief_postgres.py`
+- `extracted_content_pipeline/blog_ports.py`
+- `extracted_content_pipeline/report_ports.py`
+- `extracted_content_pipeline/landing_page_ports.py`
+- `extracted_content_pipeline/sales_brief_ports.py`
+- `tests/test_extracted_content_asset_api.py`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Generated-Asset-Batch-Scale.md`
+
+## Mechanism
+
+- Add bulk `update_statuses` repository methods for the four generated asset
+  stores.
+- Route `POST /content-assets/{asset}/drafts/review-batch` through the bulk
+  method.
+- Preserve ordered `updated_ids` and `missing_ids` in the API response by
+  comparing returned ids against the original request order.
+- Treat malformed UUIDs as missing IDs before the bulk SQL call so one bad
+  operator-supplied ID cannot poison the whole batch.
+- Refresh the stale Content Ops backlog and coordination row.
+
+## Intentional
+
+- No frontend changes.
+- No response contract changes.
+- No new migration.
+- Host implementations of generated asset repository ports must add
+  `update_statuses`; the hosted API now depends on the bulk method for batch
+  review.
+
+## Deferred
+
+- Reasoning product-depth/source-breadth work.
+- Dedicated performance benchmark.
+
+## Verification
+
+- `tests/test_extracted_content_asset_api.py`.
+- `scripts/local_pr_review.sh`.
+- `git diff --check`.
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| API batch dispatch | ~55 |
+| Repository bulk methods | ~110 |
+| Port protocols | ~40 |
+| Tests | ~65 |
+| Backlog and coordination docs | ~90 |
+| Plan doc | ~65 |
+| **Total** | ~425 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -15,6 +15,11 @@ import extracted_content_pipeline.api.generated_assets as asset_api
 from extracted_content_pipeline.campaign_ports import TenantScope
 
 
+BATCH_REPORT_ID_1 = "11111111-1111-1111-1111-111111111111"
+BATCH_REPORT_ID_2 = "22222222-2222-2222-2222-222222222222"
+BATCH_REPORT_ID_MISSING = "33333333-3333-3333-3333-333333333333"
+
+
 class _Pool:
     def __init__(
         self,
@@ -287,7 +292,7 @@ def test_generated_asset_router_returns_miss_without_hiding_result() -> None:
 
 
 def test_generated_asset_router_batch_reviews_reports() -> None:
-    pool = _Pool()
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}, {"id": BATCH_REPORT_ID_2}])
 
     response = _client(
         pool,
@@ -295,7 +300,7 @@ def test_generated_asset_router_batch_reviews_reports() -> None:
     ).post(
         "/content-assets/report/drafts/review-batch",
         json={
-            "ids": ["report-uuid-1", "report-uuid-2"],
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
             "status": "approved",
         },
     )
@@ -304,45 +309,43 @@ def test_generated_asset_router_batch_reviews_reports() -> None:
     assert response.json() == {
         "account_id": "acct_1",
         "asset": "report",
-        "ids": ["report-uuid-1", "report-uuid-2"],
+        "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
         "status": "approved",
         "updated": 2,
-        "updated_ids": ["report-uuid-1", "report-uuid-2"],
+        "updated_ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
         "missing_ids": [],
     }
-    assert len(pool.execute_calls) == 2
-    first_query, first_args = pool.execute_calls[0]
-    second_query, second_args = pool.execute_calls[1]
-    assert "UPDATE reports" in first_query
-    assert "UPDATE reports" in second_query
-    assert first_args == ("report-uuid-1", "approved", "acct_1")
-    assert second_args == ("report-uuid-2", "approved", "acct_1")
+    assert pool.execute_calls == []
+    assert len(pool.fetch_calls) == 1
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE reports" in query
+    assert "RETURNING id" in query
+    assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "approved", "acct_1")
 
 
 def test_generated_asset_router_batch_reviews_reports_misses() -> None:
-    pool = _Pool(execute_result="UPDATE 0")
+    pool = _Pool(rows=[])
 
     response = _client(pool).post(
         "/content-assets/report/drafts/review-batch",
-        json={"ids": ["report-uuid-1"], "status": "approved"},
+        json={"ids": [BATCH_REPORT_ID_1], "status": "approved"},
     )
 
     assert response.status_code == 200
     assert response.json()["updated"] == 0
     assert response.json()["updated_ids"] == []
-    assert response.json()["missing_ids"] == ["report-uuid-1"]
+    assert response.json()["missing_ids"] == [BATCH_REPORT_ID_1]
+    assert len(pool.fetch_calls) == 1
+    assert pool.execute_calls == []
 
 
 def test_generated_asset_router_batch_review_partial_update() -> None:
-    class _PartialPool(_Pool):
-        async def execute(self, query, *args):
-            self.execute_calls.append((str(query), args))
-            return "UPDATE 1" if len(self.execute_calls) == 1 else "UPDATE 0"
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}])
 
-    response = _client(_PartialPool(), scope={"account_id": "acct_1"}).post(
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
         "/content-assets/report/drafts/review-batch",
         json={
-            "ids": ["report-uuid-1", "report-uuid-missing"],
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_MISSING],
             "status": "approved",
         },
     )
@@ -350,8 +353,51 @@ def test_generated_asset_router_batch_review_partial_update() -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["updated"] == 1
-    assert body["updated_ids"] == ["report-uuid-1"]
-    assert body["missing_ids"] == ["report-uuid-missing"]
+    assert body["updated_ids"] == [BATCH_REPORT_ID_1]
+    assert body["missing_ids"] == [BATCH_REPORT_ID_MISSING]
+    assert len(pool.fetch_calls) == 1
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_batch_review_treats_invalid_uuid_as_missing() -> None:
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}])
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review-batch",
+        json={
+            "ids": [BATCH_REPORT_ID_1, "not-a-uuid"],
+            "status": "approved",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated_ids"] == [BATCH_REPORT_ID_1]
+    assert body["missing_ids"] == ["not-a-uuid"]
+    assert len(pool.fetch_calls) == 1
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE reports" in query
+    assert args == (
+        [BATCH_REPORT_ID_1],
+        "approved",
+        "acct_1",
+    )
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_batch_review_all_invalid_ids_skip_sql() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/report/drafts/review-batch",
+        json={"ids": ["not-a-uuid"], "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["updated_ids"] == []
+    assert response.json()["missing_ids"] == ["not-a-uuid"]
+    assert pool.fetch_calls == []
+    assert pool.execute_calls == []
 
 
 def test_generated_asset_router_batch_review_enforces_configured_cap() -> None:


### PR DESCRIPTION
Plan: `plans/PR-Content-Ops-Generated-Asset-Batch-Scale.md`

## Summary

- Route generated asset batch review through one bulk repository update per asset type instead of one update per draft.
- Preserve the existing response shape, including ordered updated_ids and missing_ids.
- Refresh the stale AI Content Ops backlog and coordination row after recent merged UI/admin work.

## Verification

- `pytest tests/test_extracted_content_asset_api.py`
- `python -m py_compile extracted_content_pipeline/api/generated_assets.py extracted_content_pipeline/blog_post_postgres.py extracted_content_pipeline/report_postgres.py extracted_content_pipeline/landing_page_postgres.py extracted_content_pipeline/sales_brief_postgres.py extracted_content_pipeline/blog_ports.py extracted_content_pipeline/report_ports.py extracted_content_pipeline/landing_page_ports.py extracted_content_pipeline/sales_brief_ports.py tests/test_extracted_content_asset_api.py`
- `bash scripts/local_pr_review.sh`
- `git diff --check`