### PR TITLE
Support ticket thread source rows for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T19:20Z by codex-2026-05-15
+Last updated: 2026-05-15T19:31Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops support-ticket source adapter | `extracted_content_pipeline/campaign_source_adapters.py`, `extracted_content_pipeline/examples/campaign_source_rows.jsonl`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Ticket-Adapter.md` | codex-2026-05-15 | Avoid source-row adapter and source-row docs |
+| draft | Content Ops ticket-thread source adapter | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Ticket-Thread-Adapter.md` | codex-2026-05-15 | Avoid source-row adapter and source-row docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -158,6 +158,10 @@ python scripts/run_extracted_campaign_generation_example.py customer_opportuniti
 When multiple source-text fields are present, the adapter uses the first
 recognized field in this order: `text`, `review_text`, `transcript`,
 `content`, `body`, `quote`, `complaint`, `message`, `description`, `summary`,
+then `notes`. If none of those scalar fields are present, it can build
+evidence text from nested `messages`, `comments`, `thread`, `conversation`, or
+`entries` arrays. Within each nested message, message-shaped fields win first:
+`text`, `message`, `body`, `content`, `comment`, `description`, `summary`,
 then `notes`.
 
 For quick offline previews, the generation CLI can consume those source rows

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -44,6 +44,9 @@ source of truth for what remains.
   can consume these source rows directly with `--source-rows`; JSON, JSONL, and
   CSV source-row exports are supported, and
   `examples/campaign_source_rows.jsonl` provides a packaged starter input.
+  Ticket and conversation rows can also provide nested `messages`, `comments`,
+  `thread`, `conversation`, or `entries` arrays when the source text is not
+  available as one scalar field.
 - `signal_extraction` exposes source-row normalization as a runnable AI Content
   Ops output. It converts inline source material into normalized opportunities
   without LLM, database, or Atlas dependencies.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -54,6 +54,20 @@ _TEXT_KEYS = (
     "summary",
     "notes",
 )
+_THREAD_KEYS = ("messages", "comments", "thread", "conversation", "entries")
+# Thread items favor message-shaped keys before generic body/content keys,
+# while row-level source text keeps document/review body precedence.
+_THREAD_TEXT_KEYS = (
+    "text",
+    "message",
+    "body",
+    "content",
+    "comment",
+    "description",
+    "summary",
+    "notes",
+)
+_THREAD_SPEAKER_KEYS = ("speaker", "author", "role", "name")
 _SOURCE_TYPE_KEYS = ("source_type", "type", "kind")
 _SOURCE_TITLE_KEYS = ("source_title", "ticket_subject", "subject", "title", "name")
 _SOURCE_TITLE_COLLISION_KEYS = ("subject", "ticket_subject", "title", "name")
@@ -128,7 +142,7 @@ def source_row_to_campaign_opportunity(
     """Convert one source row while preserving original non-empty fields."""
 
     warnings: list[CampaignOpportunityWarning] = []
-    text = _first_text(row, _TEXT_KEYS)
+    text = _source_text(row)
     if not text:
         warnings.append(CampaignOpportunityWarning(
             code="missing_source_text",
@@ -136,7 +150,8 @@ def source_row_to_campaign_opportunity(
             field="text",
             message=(
                 "Source row did not contain text, review_text, transcript, "
-                "content, body, quote, or complaint."
+                "content, body, quote, complaint, message, description, "
+                "summary, notes, or thread messages."
             ),
         ))
         return {}, tuple(warnings)
@@ -252,6 +267,52 @@ def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
         if text:
             return text
     return ""
+
+
+def _source_text(row: Mapping[str, Any]) -> str:
+    scalar_text = _first_text(row, _TEXT_KEYS)
+    if scalar_text:
+        return scalar_text
+    return _thread_text(row)
+
+
+def _thread_text(row: Mapping[str, Any]) -> str:
+    for key in _THREAD_KEYS:
+        value = row.get(key)
+        lines = _thread_lines(value)
+        if lines:
+            return "\n".join(lines)
+    return ""
+
+
+def _thread_lines(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, Mapping):
+        return _thread_lines([value])
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return []
+    lines: list[str] = []
+    for item in value:
+        line = _thread_line(item)
+        if line:
+            lines.append(line)
+    return lines
+
+
+def _thread_line(item: Any) -> str:
+    if isinstance(item, str):
+        return item.strip()
+    if not isinstance(item, Mapping):
+        return ""
+    text = _first_text(item, _THREAD_TEXT_KEYS)
+    if not text:
+        return ""
+    speaker = _first_text(item, _THREAD_SPEAKER_KEYS)
+    return f"{speaker}: {text}" if speaker else text
 
 
 def _first_text_list(row: Mapping[str, Any], keys: Sequence[str]) -> list[str]:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -189,6 +189,10 @@ CSV; pass `--format csv` for CSV source exports.
 When a source export includes more than one source-text field, the adapter uses
 the first recognized field in this order: `text`, `review_text`, `transcript`,
 `content`, `body`, `quote`, `complaint`, `message`, `description`, `summary`,
+then `notes`. If none of those scalar fields are present, it can build
+evidence text from nested `messages`, `comments`, `thread`, `conversation`, or
+`entries` arrays. Within each nested message, message-shaped fields win first:
+`text`, `message`, `body`, `content`, `comment`, `description`, `summary`,
 then `notes`.
 
 For an offline draft preview without writing the intermediate opportunity file:

--- a/plans/PR-Content-Ops-Ticket-Thread-Adapter.md
+++ b/plans/PR-Content-Ops-Ticket-Thread-Adapter.md
@@ -1,0 +1,69 @@
+# Content Ops Ticket Thread Adapter
+
+## Why This Slice Exists
+
+Support exports often arrive as ticket rows with nested comments or messages,
+not as a single `message` or `description` string. AI Content Ops can now
+accept support-ticket rows, but it still skips useful ticket threads when the
+primary text lives inside an array.
+
+## Scope
+
+- Extend `extracted_content_pipeline/campaign_source_adapters.py` to build
+  evidence text from nested ticket/conversation message arrays.
+- Add focused source-adapter tests for comment/message arrays and scalar
+  precedence.
+- Refresh host-facing source-row docs and coordination state.
+
+## Mechanism
+
+- Add recognized thread keys such as `messages`, `comments`, `thread`, and
+  `conversation`.
+- Use scalar source text first; only fall back to thread arrays when scalar
+  fields are missing.
+- Convert message dictionaries into newline-separated text with optional
+  speaker labels from `speaker`, `author`, `role`, or `name`.
+- Use message-shaped keys before generic `body`/`content` keys inside nested
+  thread items; row-level scalar source text keeps the existing document/review
+  precedence.
+- Keep the existing `max_text_chars` truncation in `_source_evidence`.
+
+## Intentional
+
+- No new CLI flags.
+- No database, API, or generated-asset changes.
+- No attachment parsing.
+- No multi-message reasoning or summarization; this is deterministic
+  source-to-evidence normalization only.
+
+## Deferred
+
+- Attachment extraction.
+- Thread-aware source-quality scoring.
+- LLM summarization over long conversations before opportunity generation.
+
+## Verification
+
+- Focused source-adapter tests.
+- Compile check for touched Python files.
+- Local PR review gate.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `plans/PR-Content-Ops-Ticket-Thread-Adapter.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source adapter | ~45 |
+| Tests | ~45 |
+| Docs and coordination | ~30 |
+| Plan doc | ~55 |
+| **Total** | ~175 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -125,6 +125,50 @@ def test_source_row_prefers_body_over_ticket_message() -> None:
     )
 
 
+def test_source_row_maps_ticket_comments_to_evidence_text() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "ticket_id": "ticket-thread-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "subject": "Reporting export blocked",
+        "comments": [
+            {
+                "author": "Customer",
+                "body": "We cannot export attribution data before renewal.",
+            },
+            {
+                "role": "Agent",
+                "message": "The export requires a higher plan.",
+            },
+        ],
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "ticket-thread-1"
+    assert opportunity["evidence"][0] == {
+        "text": (
+            "Customer: We cannot export attribution data before renewal.\n"
+            "Agent: The export requires a higher plan."
+        ),
+        "source_id": "ticket-thread-1",
+        "source_type": "support_ticket",
+        "source_title": "Reporting export blocked",
+    }
+
+
+def test_source_row_prefers_scalar_text_over_thread_messages() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "ticket_id": "ticket-thread-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "message": "Use this exported ticket summary.",
+        "comments": [{"body": "Do not use this comment when scalar text exists."}],
+    })
+
+    assert warnings == ()
+    assert opportunity["evidence"][0]["text"] == "Use this exported ticket summary."
+
+
 def test_load_source_campaign_opportunities_from_jsonl(tmp_path: Path) -> None:
     path = tmp_path / "sources.jsonl"
     path.write_text(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ticket-Thread-Adapter.md\n\n## Summary\n- convert nested ticket/conversation comment arrays into deterministic evidence text\n- preserve scalar source-text precedence when both summary text and thread arrays exist\n- update host-facing source-row docs and coordination\n\n## Verification\n- pytest tests/test_extracted_campaign_source_adapters.py\n- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py scripts/build_extracted_campaign_opportunities_from_sources.py\n- git diff --check\n- bash scripts/local_pr_review.sh