### PR TITLE
Add survey source rows for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T19:31Z by codex-2026-05-15
+Last updated: 2026-05-15T22:43Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops ticket-thread source adapter | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Ticket-Thread-Adapter.md` | codex-2026-05-15 | Avoid source-row adapter and source-row docs |
+| draft | Content Ops survey source adapter | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Survey-Source-Adapter.md` | codex-2026-05-15 | Avoid source-row adapter and source-row docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -115,9 +115,9 @@ draft metadata fields while preserving custom columns.
 customer exports before wiring a database integration.
 
 `campaign_source_adapters.py` adds a source-to-opportunity adapter for richer
-review, transcript, complaint, support-ticket, conversation, case, or document
-rows. It preserves source text as campaign evidence and outputs the same
-payload shape as the customer-data adapter.
+review, transcript, complaint, support-ticket, conversation, case, survey,
+NPS, CSAT, or document rows. It preserves source text as campaign evidence and
+outputs the same payload shape as the customer-data adapter.
 
 ## Campaign generation example
 
@@ -143,9 +143,9 @@ draft metadata:
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.csv --format csv
 ```
 
-Review, transcript, complaint, support-ticket, conversation, case, and document
-source rows can be converted into the same opportunity payload first. Source
-rows can be JSON, JSONL, or CSV:
+Review, transcript, complaint, support-ticket, conversation, case, survey, NPS,
+CSAT, and document source rows can be converted into the same opportunity
+payload first. Source rows can be JSON, JSONL, or CSV:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -158,9 +158,11 @@ python scripts/run_extracted_campaign_generation_example.py customer_opportuniti
 When multiple source-text fields are present, the adapter uses the first
 recognized field in this order: `text`, `review_text`, `transcript`,
 `content`, `body`, `quote`, `complaint`, `message`, `description`, `summary`,
-then `notes`. If none of those scalar fields are present, it can build
-evidence text from nested `messages`, `comments`, `thread`, `conversation`, or
-`entries` arrays. Within each nested message, message-shaped fields win first:
+`notes`, `feedback`, `feedback_text`, `response_text`, `comment_text`, then
+`open_ended_response`. This precedence is global: a survey-shaped row with
+`body` and `feedback` uses `body`. If none of those scalar fields are present,
+it can build evidence text from nested `messages`, `comments`, `thread`,
+`conversation`, or `entries` arrays. Within each nested message, message-shaped fields win first:
 `text`, `message`, `body`, `content`, `comment`, `description`, `summary`,
 then `notes`.
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -38,11 +38,11 @@ source of truth for what remains.
   `campaign_opportunities`, with dry-run validation and optional
   replace-existing semantics for repeatable customer imports.
 - `campaign_source_adapters` converts review, transcript, complaint,
-  support-ticket, conversation, case, or document source rows into normalized
-  campaign opportunities so hosts can feed richer text sources into the same
-  generation/import path. The Postgres import CLI and offline generation CLI
-  can consume these source rows directly with `--source-rows`; JSON, JSONL, and
-  CSV source-row exports are supported, and
+  support-ticket, conversation, case, survey, NPS, CSAT, or document source
+  rows into normalized campaign opportunities so hosts can feed richer text
+  sources into the same generation/import path. The Postgres import CLI and
+  offline generation CLI can consume these source rows directly with
+  `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
   `examples/campaign_source_rows.jsonl` provides a packaged starter input.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -28,6 +28,11 @@ _ROW_LIST_KEYS = (
     "tickets",
     "cases",
     "conversations",
+    "survey_responses",
+    "surveys",
+    "nps_responses",
+    "csat_responses",
+    "feedback",
     "rows",
     "data",
 )
@@ -40,6 +45,9 @@ _SOURCE_ID_KEYS = (
     "ticket_id",
     "case_id",
     "conversation_id",
+    "survey_id",
+    "response_id",
+    "feedback_id",
 )
 _TEXT_KEYS = (
     "text",
@@ -53,6 +61,11 @@ _TEXT_KEYS = (
     "description",
     "summary",
     "notes",
+    "feedback",
+    "feedback_text",
+    "response_text",
+    "comment_text",
+    "open_ended_response",
 )
 _THREAD_KEYS = ("messages", "comments", "thread", "conversation", "entries")
 # Thread items favor message-shaped keys before generic body/content keys,
@@ -354,6 +367,12 @@ def _infer_source_type(row: Mapping[str, Any]) -> str:
         return "case"
     if row.get("conversation_id") is not None:
         return "conversation"
+    if row.get("nps_score") is not None or row.get("nps") is not None:
+        return "nps_response"
+    if row.get("csat_score") is not None or row.get("csat") is not None:
+        return "csat_response"
+    if row.get("survey_id") is not None or row.get("response_id") is not None:
+        return "survey_response"
     return "document"
 
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -171,8 +171,8 @@ Unknown columns are preserved in draft metadata and prompt context through the
 normalized opportunity payload.
 
 If a host starts from reviews, transcripts, complaints, support tickets,
-conversations, cases, or document rows instead of ready-made opportunities,
-they can preview the normalized opportunity payload:
+conversations, cases, surveys, NPS, CSAT, or document rows instead of
+ready-made opportunities, they can preview the normalized opportunity payload:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -181,17 +181,20 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
 ```
 
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
-`description`, `summary`, `notes`, `content`, `body`, `quote`, or `text` into
-the opportunity `evidence` field, preserving source ids and inferred source
-types for prompt context and later review. Source rows can be JSON, JSONL, or
-CSV; pass `--format csv` for CSV source exports.
+`description`, `summary`, `notes`, `feedback`, `feedback_text`,
+`response_text`, `comment_text`, `open_ended_response`, `content`, `body`,
+`quote`, or `text` into the opportunity `evidence` field, preserving source
+ids and inferred source types for prompt context and later review. Source rows
+can be JSON, JSONL, or CSV; pass `--format csv` for CSV source exports.
 
 When a source export includes more than one source-text field, the adapter uses
 the first recognized field in this order: `text`, `review_text`, `transcript`,
 `content`, `body`, `quote`, `complaint`, `message`, `description`, `summary`,
-then `notes`. If none of those scalar fields are present, it can build
-evidence text from nested `messages`, `comments`, `thread`, `conversation`, or
-`entries` arrays. Within each nested message, message-shaped fields win first:
+`notes`, `feedback`, `feedback_text`, `response_text`, `comment_text`, then
+`open_ended_response`. This precedence is global: a survey-shaped row with
+`body` and `feedback` uses `body`. If none of those scalar fields are present,
+it can build evidence text from nested `messages`, `comments`, `thread`,
+`conversation`, or `entries` arrays. Within each nested message, message-shaped fields win first:
 `text`, `message`, `body`, `content`, `comment`, `description`, `summary`,
 then `notes`.
 

--- a/plans/PR-Content-Ops-Survey-Source-Adapter.md
+++ b/plans/PR-Content-Ops-Survey-Source-Adapter.md
@@ -1,0 +1,68 @@
+# Content Ops Survey Source Adapter
+
+## Why This Slice Exists
+
+AI Content Ops can ingest review, transcript, complaint, document, support
+ticket, and ticket-thread source rows. Hosts also commonly have NPS, CSAT, or
+survey exports where the useful source text lives in feedback/comment fields
+and the score should stay attached as prompt-visible context.
+
+## Scope
+
+- Extend `extracted_content_pipeline/campaign_source_adapters.py` to recognize
+  survey/NPS/CSAT source-row collections and ids.
+- Preserve survey score fields on the normalized opportunity while using
+  feedback/comment text as evidence.
+- Add focused source-adapter tests.
+- Refresh host-facing source-row docs and coordination state.
+
+## Mechanism
+
+- Add collection keys such as `survey_responses`, `surveys`, `nps_responses`,
+  and `csat_responses`.
+- Add id keys such as `survey_id`, `response_id`, and `feedback_id`.
+- Treat `response_id` as a survey response identifier when it appears in a
+  source row.
+- Add text keys such as `feedback`, `feedback_text`, `response_text`,
+  `comment_text`, and `open_ended_response`.
+- Infer `source_type` as `nps_response`, `csat_response`, or
+  `survey_response` when score/id fields indicate a survey bundle.
+
+## Intentional
+
+- No scoring logic or quality classification.
+- No generated-asset, API, or database changes.
+- No new CLI flags or source file formats.
+- Score fields remain ordinary preserved source metadata.
+
+## Deferred
+
+- Survey-specific source quality and sentiment scoring.
+- Longitudinal aggregation across repeated surveys.
+- Dedicated survey reasoning pack inputs.
+
+## Verification
+
+- Focused source-adapter tests.
+- Compile check for touched Python files.
+- Local PR review gate.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `plans/PR-Content-Ops-Survey-Source-Adapter.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source adapter | ~30 |
+| Tests | ~45 |
+| Docs and coordination | ~30 |
+| Plan doc | ~55 |
+| **Total** | ~160 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -169,6 +169,43 @@ def test_source_row_prefers_scalar_text_over_thread_messages() -> None:
     assert opportunity["evidence"][0]["text"] == "Use this exported ticket summary."
 
 
+def test_source_row_maps_nps_feedback_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "response_id": "nps-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "nps_score": 3,
+        "feedback_text": "Renewal pricing is hard to defend against Salesforce.",
+        "pain_category": "pricing pressure",
+    })
+
+    assert warnings == ()
+    assert opportunity["id"] == "nps-1"
+    assert opportunity["target_id"] == "nps-1"
+    assert opportunity["nps_score"] == 3
+    assert opportunity["source_type"] == "nps_response"
+    assert opportunity["pain_points"] == ["pricing pressure"]
+    assert opportunity["evidence"] == [{
+        "text": "Renewal pricing is hard to defend against Salesforce.",
+        "source_id": "nps-1",
+        "source_type": "nps_response",
+    }]
+
+
+def test_source_row_prefers_nps_over_csat_when_both_scores_exist() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "response_id": "survey-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "nps_score": 5,
+        "csat_score": 4,
+        "feedback": "The team is still evaluating alternatives.",
+    })
+
+    assert warnings == ()
+    assert opportunity["source_type"] == "nps_response"
+
+
 def test_load_source_campaign_opportunities_from_jsonl(tmp_path: Path) -> None:
     path = tmp_path / "sources.jsonl"
     path.write_text(
@@ -262,6 +299,37 @@ def test_load_source_campaign_opportunities_from_support_ticket_object(tmp_path:
         "source_id": "ticket-1",
         "source_type": "support_ticket",
         "source_title": "Reporting export issue",
+    }
+
+
+def test_load_source_campaign_opportunities_from_survey_object(tmp_path: Path) -> None:
+    path = tmp_path / "survey_responses.json"
+    path.write_text(
+        json.dumps({
+            "survey_responses": [
+                {
+                    "survey_id": "survey-1",
+                    "company": "Beta Retail",
+                    "vendor": "Zendesk",
+                    "csat_score": "2",
+                    "open_ended_response": (
+                        "Support responses take too long and the team is comparing Intercom."
+                    ),
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert loaded.opportunities[0]["target_id"] == "survey-1"
+    assert loaded.opportunities[0]["csat_score"] == "2"
+    assert loaded.opportunities[0]["source_type"] == "csat_response"
+    assert loaded.opportunities[0]["evidence"][0] == {
+        "text": "Support responses take too long and the team is comparing Intercom.",
+        "source_id": "survey-1",
+        "source_type": "csat_response",
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Survey-Source-Adapter.md\n\n## Summary\n- add survey/NPS/CSAT source-row collection, id, text, and source-type recognition\n- preserve score fields as opportunity metadata while feedback text becomes evidence\n- update source-row docs and coordination\n\n## Verification\n- pytest tests/test_extracted_campaign_source_adapters.py\n- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py scripts/build_extracted_campaign_opportunities_from_sources.py\n- git diff --check\n- bash scripts/local_pr_review.sh