### PR TITLE
Expose reasoning status capabilities in Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T22:43Z by codex-2026-05-15
+Last updated: 2026-05-15T22:52Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops survey source adapter | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Survey-Source-Adapter.md` | codex-2026-05-15 | Avoid source-row adapter and source-row docs |
+| draft | Content Ops reasoning status capabilities | `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/docs/control_surface_preview_api.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Reasoning-Status-Capabilities.md` | codex-2026-05-15 | Avoid control-surface reasoning status API/docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Sequence
@@ -385,7 +386,7 @@ def _sanitize_reasoning_status(
         item = status[key]
         if key == "configured" or item is None:
             continue
-        if isinstance(item, (str, int, float, bool)):
+        if _is_status_scalar(item):
             continue
         scalar_items = _clean_status_scalar_sequence(item)
         if scalar_items:
@@ -404,9 +405,15 @@ def _clean_status_scalar_sequence(value: Any) -> list[str | int | float | bool]:
     for index, item in enumerate(value):
         if index >= _MAX_REASONING_STATUS_LIST_ITEMS:
             break
-        if isinstance(item, (str, int, float, bool)):
+        if _is_status_scalar(item):
             cleaned.append(item)
     return cleaned
+
+
+def _is_status_scalar(value: Any) -> bool:
+    if isinstance(value, float) and not math.isfinite(value):
+        return False
+    return isinstance(value, (str, int, float, bool))
 
 
 async def _resolve_scope(provider: ScopeProvider | None) -> TenantScope | None:

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -61,6 +61,7 @@ logger = logging.getLogger(__name__)
 _MAX_INPUT_KEYS = 50
 _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
+_MAX_REASONING_STATUS_LIST_ITEMS = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
 
 
@@ -386,8 +387,26 @@ def _sanitize_reasoning_status(
             continue
         if isinstance(item, (str, int, float, bool)):
             continue
+        scalar_items = _clean_status_scalar_sequence(item)
+        if scalar_items:
+            status[key] = scalar_items
+            continue
         status.pop(key)
     return status
+
+
+def _clean_status_scalar_sequence(value: Any) -> list[str | int | float | bool]:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return []
+    if not isinstance(value, Sequence):
+        return []
+    cleaned: list[str | int | float | bool] = []
+    for index, item in enumerate(value):
+        if index >= _MAX_REASONING_STATUS_LIST_ITEMS:
+            break
+        if isinstance(item, (str, int, float, bool)):
+            cleaned.append(item)
+    return cleaned
 
 
 async def _resolve_scope(provider: ScopeProvider | None) -> TenantScope | None:

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -77,6 +77,12 @@ exciting than shipping a toggle that lies to users. That is the point.
 a host or separate reasoning product, but does not run synthesis internally.
 `absent` means the output does not use the reasoning-provider path.
 
+The catalog response also includes a top-level `reasoning` object. By default
+it reports only `configured`; hosts can inject a reasoning status provider to
+add scalar fields and bounded scalar lists such as `source`, `modes`, `packs`,
+or `capabilities`. Nested objects are filtered out before the status reaches
+the API response.
+
 ## Presets
 
 Current preset ids:

--- a/plans/PR-Content-Ops-Reasoning-Status-Capabilities.md
+++ b/plans/PR-Content-Ops-Reasoning-Status-Capabilities.md
@@ -1,0 +1,60 @@
+# Content Ops Reasoning Status Capabilities
+
+## Why This Slice Exists
+
+The Content Ops control-surface API exposes a host-provided reasoning status,
+but it currently preserves only scalar fields. Hosts cannot report useful
+capability lists such as available reasoning modes, pack names, or supported
+knobs without those lists being stripped.
+
+## Scope
+
+- Allow bounded list/tuple fields containing scalar values in
+  `extracted_content_pipeline/api/control_surfaces.py` reasoning status output.
+- Keep nested objects and mixed complex values filtered out.
+- Add focused API tests.
+- Refresh control-surface docs and coordination state.
+
+## Mechanism
+
+- Add a small scalar-sequence sanitizer used only by reasoning status.
+- Preserve lists such as `modes`, `packs`, and `capabilities` when each item is
+  a string, number, or boolean.
+- Drop nested mappings and object values exactly as before.
+
+## Intentional
+
+- No new route.
+- No provider construction.
+- No change to execution behavior.
+- No requirement that hosts supply capability fields.
+
+## Deferred
+
+- Standardized capability taxonomy.
+- Per-output reasoning capability matching.
+- UI rendering for richer capability lists.
+
+## Verification
+
+- Focused control-surface API tests.
+- Compile check for touched Python files.
+- Local PR review gate.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `plans/PR-Content-Ops-Reasoning-Status-Capabilities.md`
+- `tests/test_extracted_content_control_surface_api.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| API sanitizer | ~25 |
+| Tests | ~30 |
+| Docs and coordination | ~20 |
+| Plan doc | ~55 |
+| **Total** | ~130 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -161,6 +161,42 @@ async def test_describe_control_surfaces_sanitizes_reasoning_status_lists():
 
 
 @pytest.mark.asyncio
+async def test_describe_control_surfaces_caps_reasoning_status_lists():
+    router = create_content_ops_control_surface_router(
+        reasoning_context_provider=lambda: object(),
+        reasoning_status_provider=lambda: {
+            "configured": True,
+            "modes": [f"mode-{index}" for index in range(25)],
+        },
+    )
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    assert payload["reasoning"]["modes"] == [f"mode-{index}" for index in range(20)]
+
+
+@pytest.mark.asyncio
+async def test_describe_control_surfaces_drops_non_finite_reasoning_status_floats():
+    router = create_content_ops_control_surface_router(
+        reasoning_context_provider=lambda: object(),
+        reasoning_status_provider=lambda: {
+            "configured": True,
+            "score": float("nan"),
+            "capabilities": ["cache", float("inf"), "falsification"],
+        },
+    )
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    assert payload["reasoning"] == {
+        "configured": True,
+        "capabilities": ["cache", "falsification"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_describe_control_surfaces_status_provider_failure_falls_back():
     def _failing_status_provider():
         raise RuntimeError("status unavailable")

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -123,6 +123,8 @@ async def test_describe_control_surfaces_reports_rich_reasoning_status():
         reasoning_status_provider=lambda: {
             "configured": True,
             "source": "db",
+            "modes": ["file", "db", "multi_pass"],
+            "packs": ("campaign", "long_form"),
             "unsafe": {"nested": "value"},
         },
     )
@@ -130,7 +132,32 @@ async def test_describe_control_surfaces_reports_rich_reasoning_status():
     route = _route(router, "/content-ops/control-surfaces", "GET")
     payload = await route.endpoint()
 
-    assert payload["reasoning"] == {"configured": True, "source": "db"}
+    assert payload["reasoning"] == {
+        "configured": True,
+        "source": "db",
+        "modes": ["file", "db", "multi_pass"],
+        "packs": ["campaign", "long_form"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_describe_control_surfaces_sanitizes_reasoning_status_lists():
+    router = create_content_ops_control_surface_router(
+        reasoning_context_provider=lambda: object(),
+        reasoning_status_provider=lambda: {
+            "configured": True,
+            "capabilities": ["falsification", {"unsafe": "nested"}, "cache"],
+            "details": [{"unsafe": "nested"}],
+        },
+    )
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    assert payload["reasoning"] == {
+        "configured": True,
+        "capabilities": ["falsification", "cache"],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Status-Capabilities.md

## Summary
- preserve bounded scalar capability lists in the Content Ops reasoning status payload
- keep nested objects filtered from status output
- document the richer reasoning status shape

## Verification
- pytest tests/test_extracted_content_control_surface_api.py
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py
- git diff --check
- bash scripts/local_pr_review.sh