### PR TITLE
Show Content Ops reasoning status capabilities

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -73,6 +73,9 @@ export interface ContentOpsCatalogResponse {
   reasoning: {
     configured: boolean
     source?: 'db' | 'file' | 'none' | string
+    modes?: Array<string | number | boolean>
+    packs?: Array<string | number | boolean>
+    capabilities?: Array<string | number | boolean>
   }
   ingestion_profiles: string[]
 }

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -79,9 +79,18 @@ export function fromWireCatalog(
     reasoning: {
       configured: wire.reasoning.configured,
       source: wire.reasoning.source,
+      modes: copyScalarList(wire.reasoning.modes),
+      packs: copyScalarList(wire.reasoning.packs),
+      capabilities: copyScalarList(wire.reasoning.capabilities),
     },
     ingestionProfiles: [...wire.ingestion_profiles],
   }
+}
+
+function copyScalarList(
+  value: Array<string | number | boolean> | undefined,
+): Array<string | number | boolean> | undefined {
+  return value ? [...value] : undefined
 }
 
 // ---------------------------------------------------------------------------

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -52,6 +52,9 @@ export interface ContentOpsCatalog {
   reasoning: {
     configured: boolean
     source?: 'db' | 'file' | 'none' | string
+    modes?: Array<string | number | boolean>
+    packs?: Array<string | number | boolean>
+    capabilities?: Array<string | number | boolean>
   }
   ingestionProfiles: string[]
 }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1336,7 +1336,10 @@ function reasoningStatusHint(
     .filter(Boolean)
 
   if (values.length === 0) return ''
-  return `(${values.slice(0, 3).join(', ')}${values.length > 3 ? ', +' : ''})`
+  const shown = values.slice(0, 3)
+  const suffix = values.length > shown.length ? ` +${values.length - shown.length} more` : ''
+  const hint = `${shown.join(', ')}${suffix}`
+  return hint.length > 42 ? `(${values.length} capabilities)` : `(${hint})`
 }
 
 function SignalExtractionSummary({ result }: { result: Record<string, unknown> }) {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -97,6 +97,9 @@ export default function ContentOpsNewRun() {
   }
   const reasoningConfigured = catalog.reasoning.configured
   const reasoningSource = catalog.reasoning.source
+  const reasoningCapabilityHint = reasoningConfigured
+    ? reasoningStatusHint(catalog.reasoning)
+    : ''
 
   // Codex P2 fix: any form mutation invalidates a stale preview verdict
   // and plan panel so the user never sees a "Can run" badge or plan
@@ -299,6 +302,11 @@ export default function ContentOpsNewRun() {
             )}
           >
             Reasoning {reasoningConfigured ? 'ready' : 'not configured'}
+            {reasoningCapabilityHint && (
+              <span className="ml-1 text-slate-400">
+                {reasoningCapabilityHint}
+              </span>
+            )}
           </span>
           <button
             type="button"
@@ -1314,6 +1322,21 @@ function formatReasoningValue(value: unknown): string {
     return JSON.stringify(value)
   }
   return String(value)
+}
+
+function reasoningStatusHint(
+  reasoning: ContentOpsCatalog['reasoning'],
+): string {
+  const values = [
+    ...(reasoning.modes ?? []),
+    ...(reasoning.packs ?? []),
+    ...(reasoning.capabilities ?? []),
+  ]
+    .map((value) => String(value).trim())
+    .filter(Boolean)
+
+  if (values.length === 0) return ''
+  return `(${values.slice(0, 3).join(', ')}${values.length > 3 ? ', +' : ''})`
 }
 
 function SignalExtractionSummary({ result }: { result: Record<string, unknown> }) {

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T22:52Z by codex-2026-05-15
+Last updated: 2026-05-15T23:05Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning status capabilities | `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/docs/control_surface_preview_api.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Reasoning-Status-Capabilities.md` | codex-2026-05-15 | Avoid control-surface reasoning status API/docs |
+| draft | Content Ops reasoning status UI parity | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/domain/contentOps/types.ts`, `atlas-intel-ui/src/domain/contentOps/fromWire.ts`, `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Reasoning-Status-UI-Parity.md` | codex-2026-05-15 | Avoid Content Ops frontend reasoning status rendering/types |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Reasoning-Status-UI-Parity.md
+++ b/plans/PR-Content-Ops-Reasoning-Status-UI-Parity.md
@@ -1,0 +1,62 @@
+# Content Ops Reasoning Status UI Parity
+
+## Why This Slice Exists
+
+PR #537 widened the Content Ops control-surface `reasoning` payload so hosts
+can expose bounded scalar lists such as available modes, packs, and
+capabilities. The Atlas Intel adapter still only keeps `configured` and
+`source`, so the UI cannot show those host-provided capability hints.
+
+## Scope
+
+1. Preserve `reasoning.modes`, `reasoning.packs`, and
+   `reasoning.capabilities` in the Content Ops wire and domain types.
+2. Map the three optional list fields through `fromWireCatalog`.
+3. Render a compact hint in the New Run reasoning badge when those fields are
+   present.
+4. Clean the stale in-flight row from the merged reasoning status capabilities
+   slice and claim this slice.
+
+## Mechanism
+
+The backend already sanitizes the list fields. The frontend keeps them as
+display-only scalar arrays and limits the badge text to the first few values so
+long host capability lists do not overwhelm the header.
+
+## Intentional
+
+- No backend route changes.
+- No reasoning execution behavior changes.
+- No new capability taxonomy or per-output capability matching.
+
+## Deferred
+
+- Per-output reasoning capability matching.
+- Fuller reasoning-provider details drawer.
+- Standardized reasoning capability vocabulary.
+
+## Verification
+
+- Atlas Intel UI production build.
+- Git diff whitespace check.
+- Local PR review wrapper.
+
+### Files Touched
+
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Reasoning-Status-UI-Parity.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Wire and domain types | ~15 |
+| Wire mapper | ~15 |
+| New Run badge rendering | ~20 |
+| Coordination | ~5 |
+| Plan doc | ~45 |
+| **Total** | ~100 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Status-UI-Parity.md

## Summary
- preserve reasoning status modes, packs, and capabilities through the Content Ops frontend adapter
- show a compact capability hint in the New Run reasoning badge
- refresh the coordination claim for this slice

## Verification
- npm --prefix atlas-intel-ui run build
- git diff --check
- bash scripts/local_pr_review.sh