### PR TITLE
Load multi-collection Content Ops source bundles

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T23:05Z by codex-2026-05-15
+Last updated: 2026-05-15T23:24Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning status UI parity | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/domain/contentOps/types.ts`, `atlas-intel-ui/src/domain/contentOps/fromWire.ts`, `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Reasoning-Status-UI-Parity.md` | codex-2026-05-15 | Avoid Content Ops frontend reasoning status rendering/types |
+| draft | Content Ops source bundle ingest | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Bundle-Ingest.md` | codex-2026-05-15 | Avoid source-row adapter loader and source-adapter tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -85,6 +85,7 @@ _SOURCE_TYPE_KEYS = ("source_type", "type", "kind")
 _SOURCE_TITLE_KEYS = ("source_title", "ticket_subject", "subject", "title", "name")
 _SOURCE_TITLE_COLLISION_KEYS = ("subject", "ticket_subject", "title", "name")
 _PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
+_PARENT_EXCLUDE_KEYS = set(_ROW_LIST_KEYS) | set(_SOURCE_TITLE_COLLISION_KEYS)
 
 
 def load_source_campaign_opportunities_from_file(
@@ -215,11 +216,63 @@ def _load_source_rows(path: Path, *, file_format: SourceDataFormat) -> list[Any]
         return list(data)
     if not isinstance(data, Mapping):
         raise ValueError("Source JSON must be an object or array")
+    return _source_rows_from_bundle(data)
+
+
+def _source_rows_from_bundle(
+    bundle: Mapping[str, Any],
+    *,
+    parent_fields: Mapping[str, Any] | None = None,
+) -> list[Any]:
+    inherited = {
+        **dict(parent_fields or {}),
+        **_safe_parent_fields(bundle),
+    }
+    rows: list[Any] = []
     for key in _ROW_LIST_KEYS:
-        value = data.get(key)
+        value = bundle.get(key)
+        if isinstance(value, Mapping):
+            rows.extend(_source_rows_from_bundle(value, parent_fields=inherited))
+            continue
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-            return list(value)
-    return [dict(data)]
+            rows.extend(_rows_with_parent_fields(value, inherited))
+    if rows:
+        return rows
+    if parent_fields:
+        return [{**dict(parent_fields), **dict(bundle)}]
+    return [dict(bundle)]
+
+
+def _rows_with_parent_fields(
+    rows: Sequence[Any],
+    parent_fields: Mapping[str, Any],
+) -> list[Any]:
+    out: list[Any] = []
+    for row in rows:
+        if isinstance(row, Mapping):
+            out.append({**dict(parent_fields), **dict(row)})
+        else:
+            out.append(row)
+    return out
+
+
+def _safe_parent_fields(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): value
+        for key, value in bundle.items()
+        if key not in _PARENT_EXCLUDE_KEYS
+        and _is_safe_parent_value(value)
+    }
+
+
+def _is_safe_parent_value(value: Any) -> bool:
+    if value in (None, "", [], {}):
+        return False
+    if isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, Mapping)):
+        return all(isinstance(item, (str, int, float, bool)) for item in value)
+    return False
 
 
 def _load_source_csv_rows(path: Path) -> list[dict[str, Any]]:

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -86,6 +86,7 @@ _SOURCE_TITLE_KEYS = ("source_title", "ticket_subject", "subject", "title", "nam
 _SOURCE_TITLE_COLLISION_KEYS = ("subject", "ticket_subject", "title", "name")
 _PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
 _PARENT_EXCLUDE_KEYS = set(_ROW_LIST_KEYS) | set(_SOURCE_TITLE_COLLISION_KEYS)
+_MAX_BUNDLE_DEPTH = 8
 
 
 def load_source_campaign_opportunities_from_file(
@@ -223,7 +224,10 @@ def _source_rows_from_bundle(
     bundle: Mapping[str, Any],
     *,
     parent_fields: Mapping[str, Any] | None = None,
+    depth: int = 0,
 ) -> list[Any]:
+    if depth > _MAX_BUNDLE_DEPTH:
+        return []
     inherited = {
         **dict(parent_fields or {}),
         **_safe_parent_fields(bundle),
@@ -232,7 +236,11 @@ def _source_rows_from_bundle(
     for key in _ROW_LIST_KEYS:
         value = bundle.get(key)
         if isinstance(value, Mapping):
-            rows.extend(_source_rows_from_bundle(value, parent_fields=inherited))
+            rows.extend(_source_rows_from_bundle(
+                value,
+                parent_fields=inherited,
+                depth=depth + 1,
+            ))
             continue
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
             rows.extend(_rows_with_parent_fields(value, inherited))

--- a/plans/PR-Content-Ops-Source-Bundle-Ingest.md
+++ b/plans/PR-Content-Ops-Source-Bundle-Ingest.md
@@ -1,0 +1,59 @@
+# Content Ops Source Bundle Ingest
+
+## Why This Slice Exists
+
+AI Content Ops source-row ingest supports many individual row types, but a
+customer bundle JSON object with multiple collections only loads the first
+recognized list key. A host export that contains reviews and support tickets in
+one file can silently drop the later collections.
+
+## Scope
+
+- Flatten multiple recognized source collections from one JSON object.
+- Support nested `sources` objects that group collections under one account.
+- Inherit safe top-level account/vendor metadata into child rows without
+  overriding child fields.
+- Add focused source-adapter tests and refresh the active coordination row.
+
+## Mechanism
+
+`campaign_source_adapters._load_source_rows()` will delegate JSON object loading
+to a small bundle helper. The helper collects all recognized row-list keys,
+recurses into nested source bundle objects, and merges safe scalar parent fields
+into child mapping rows.
+
+## Intentional
+
+- No CLI flag changes.
+- No target-mode or generation behavior changes.
+- No attempt to define a full customer-bundle schema.
+
+## Deferred
+
+- Explicit versioned source-bundle schema.
+- Per-collection source-type overrides.
+- Frontend bundle upload UX.
+
+## Verification
+
+- Focused source-adapter tests.
+- Python compile check for touched source-adapter files.
+- Git diff whitespace check.
+- Local PR review wrapper.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `plans/PR-Content-Ops-Source-Bundle-Ingest.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source bundle loader helper | ~70 |
+| Tests | ~105 |
+| Coordination | ~5 |
+| Plan doc | ~45 |
+| **Total** | ~225 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -417,6 +417,58 @@ def test_load_source_campaign_opportunities_from_nested_sources_bundle(tmp_path:
     assert loaded.opportunities[1]["source_type"] == "csat_response"
 
 
+def test_load_source_campaign_opportunities_from_deep_nested_sources_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "deep_nested_sources.json"
+    path.write_text(
+        json.dumps({
+            "company": "Beta Retail",
+            "sources": {
+                "sources": {
+                    "reviews": [
+                        {
+                            "id": "review-1",
+                            "review_text": "The team is comparing Intercom.",
+                        }
+                    ]
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert loaded.opportunities[0]["target_id"] == "review-1"
+    assert loaded.opportunities[0]["company_name"] == "Beta Retail"
+    assert loaded.opportunities[0]["source_type"] == "review"
+
+
+def test_source_bundle_nested_mapping_without_collection_loads_as_row(tmp_path: Path) -> None:
+    path = tmp_path / "nested_single_source.json"
+    path.write_text(
+        json.dumps({
+            "company": "Parent Co",
+            "vendor": "HubSpot",
+            "sources": {
+                "id": "review-1",
+                "review_text": "The account is comparing alternatives.",
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert loaded.opportunities[0]["target_id"] == "review-1"
+    assert loaded.opportunities[0]["company_name"] == "Parent Co"
+    assert loaded.opportunities[0]["vendor"] == "HubSpot"
+    assert loaded.opportunities[0]["evidence"][0] == {
+        "text": "The account is comparing alternatives.",
+        "source_id": "review-1",
+        "source_type": "review",
+    }
+
+
 def test_source_bundle_child_fields_override_parent_metadata(tmp_path: Path) -> None:
     path = tmp_path / "child_override.json"
     path.write_text(

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -333,6 +333,114 @@ def test_load_source_campaign_opportunities_from_survey_object(tmp_path: Path) -
     }
 
 
+def test_load_source_campaign_opportunities_from_multi_collection_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "customer_bundle.json"
+    path.write_text(
+        json.dumps({
+            "account_id": "acct-1",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "reviews": [
+                {
+                    "review_id": "review-1",
+                    "review_text": "Renewal pricing is hard to defend.",
+                }
+            ],
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1",
+                    "subject": "Reporting exports blocked",
+                    "description": "Exports require a higher tier before renewal.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "review-1",
+        "ticket-1",
+    ]
+    assert [row["company_name"] for row in loaded.opportunities] == [
+        "Acme Logistics",
+        "Acme Logistics",
+    ]
+    assert [row["vendor"] for row in loaded.opportunities] == ["HubSpot", "HubSpot"]
+    assert loaded.opportunities[0]["account_id"] == "acct-1"
+    assert loaded.opportunities[0]["evidence"][0]["source_type"] == "review"
+    assert loaded.opportunities[1]["evidence"][0] == {
+        "text": "Exports require a higher tier before renewal.",
+        "source_id": "ticket-1",
+        "source_type": "support_ticket",
+        "source_title": "Reporting exports blocked",
+    }
+
+
+def test_load_source_campaign_opportunities_from_nested_sources_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "nested_sources.json"
+    path.write_text(
+        json.dumps({
+            "company": "Beta Retail",
+            "vendor": "Zendesk",
+            "sources": {
+                "reviews": [
+                    {
+                        "id": "review-1",
+                        "review_text": "The team is comparing Intercom.",
+                    }
+                ],
+                "surveys": [
+                    {
+                        "response_id": "survey-1",
+                        "csat_score": 2,
+                        "open_ended_response": "Support takes too long.",
+                    }
+                ],
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "review-1",
+        "survey-1",
+    ]
+    assert [row["company_name"] for row in loaded.opportunities] == [
+        "Beta Retail",
+        "Beta Retail",
+    ]
+    assert loaded.opportunities[0]["source_type"] == "review"
+    assert loaded.opportunities[1]["source_type"] == "csat_response"
+
+
+def test_source_bundle_child_fields_override_parent_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "child_override.json"
+    path.write_text(
+        json.dumps({
+            "company": "Parent Co",
+            "vendor": "HubSpot",
+            "reviews": [
+                {
+                    "id": "review-1",
+                    "company": "Child Co",
+                    "vendor": "Salesforce",
+                    "review_text": "The team is switching platforms.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert loaded.opportunities[0]["company_name"] == "Child Co"
+    assert loaded.opportunities[0]["vendor"] == "Salesforce"
+
+
 def test_source_adapter_cli_outputs_generation_payload(tmp_path: Path) -> None:
     path = tmp_path / "sources.json"
     path.write_text(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-Bundle-Ingest.md

## Summary
- flatten multiple recognized source collections from one customer bundle JSON object
- support nested sources objects and safe parent metadata inheritance
- add source-adapter coverage for multi-collection bundles, nested bundles, and child overrides

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py
- git diff --check
- bash scripts/local_pr_review.sh