### PR TITLE
Add Content Ops source bundle example

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T23:24Z by codex-2026-05-15
+Last updated: 2026-05-15T23:34Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops source bundle ingest | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Bundle-Ingest.md` | codex-2026-05-15 | Avoid source-row adapter loader and source-adapter tests |
+| draft | Content Ops source bundle example | `extracted_content_pipeline/examples/campaign_source_bundle.json`, `tests/test_extracted_campaign_source_adapters.py`, `tests/test_extracted_content_host_smoke.py`, `tests/test_extracted_campaign_generation_example.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Bundle-Example.md` | codex-2026-05-15 | Avoid source-bundle examples/docs and source-row smoke tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -152,6 +152,11 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --output customer_opportunities.json
 
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --format json \
+  --output customer_bundle_opportunities.json
+
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.json
 ```
 
@@ -174,6 +179,11 @@ python scripts/run_extracted_campaign_generation_example.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --source-rows \
   --source-format jsonl
+
+python scripts/run_extracted_campaign_generation_example.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --source-rows \
+  --source-format json
 ```
 
 They can also be loaded directly into the Postgres opportunity table:
@@ -188,6 +198,10 @@ python scripts/load_extracted_campaign_opportunities.py \
 
 For source-row CSV exports, pass `--source-format csv` to the same conversion,
 generation, import, or smoke commands.
+For customer bundle JSON files that group collections such as `reviews`,
+`support_tickets`, and `surveys` under shared account metadata, use
+`--source-format json`; the packaged `campaign_source_bundle.json` demonstrates
+that shape.
 
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:
@@ -332,6 +346,11 @@ python scripts/smoke_extracted_content_pipeline_host.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --source-rows \
   --source-format jsonl
+
+python scripts/smoke_extracted_content_pipeline_host.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --source-rows \
+  --source-format json
 ```
 
 For source-row CSV exports, use `--source-format csv`.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -40,10 +40,11 @@ source of truth for what remains.
 - `campaign_source_adapters` converts review, transcript, complaint,
   support-ticket, conversation, case, survey, NPS, CSAT, or document source
   rows into normalized campaign opportunities so hosts can feed richer text
-  sources into the same generation/import path. The Postgres import CLI and
-  offline generation CLI can consume these source rows directly with
-  `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
-  `examples/campaign_source_rows.jsonl` provides a packaged starter input.
+	  sources into the same generation/import path. The Postgres import CLI and
+	  offline generation CLI can consume these source rows directly with
+	  `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
+	  `examples/campaign_source_rows.jsonl` plus
+	  `examples/campaign_source_bundle.json` provide packaged starter inputs.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not
   available as one scalar field.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -145,6 +145,11 @@ python scripts/smoke_extracted_content_pipeline_host.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --source-rows \
   --source-format jsonl
+
+python scripts/smoke_extracted_content_pipeline_host.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --source-rows \
+  --source-format json
 ```
 
 For source-row CSV exports, pass `--source-format csv` to the same smoke
@@ -178,6 +183,11 @@ ready-made opportunities, they can preview the normalized opportunity payload:
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --output customer_opportunities.json
+
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --format json \
+  --output customer_bundle_opportunities.json
 ```
 
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
@@ -186,6 +196,9 @@ The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
 `quote`, or `text` into the opportunity `evidence` field, preserving source
 ids and inferred source types for prompt context and later review. Source rows
 can be JSON, JSONL, or CSV; pass `--format csv` for CSV source exports.
+Customer bundle JSON can group `reviews`, `support_tickets`, `surveys`, and
+other recognized collections under shared account metadata; use `--format json`
+or `--source-format json` for that shape.
 
 When a source export includes more than one source-text field, the adapter uses
 the first recognized field in this order: `text`, `review_text`, `transcript`,
@@ -205,6 +218,12 @@ python scripts/run_extracted_campaign_generation_example.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --source-rows \
   --source-format jsonl \
+  --limit 1
+
+python scripts/run_extracted_campaign_generation_example.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --source-rows \
+  --source-format json \
   --limit 1
 ```
 
@@ -237,6 +256,12 @@ python scripts/load_extracted_campaign_opportunities.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --source-rows \
   --source-format jsonl \
+  --account-id acct_123
+
+python scripts/load_extracted_campaign_opportunities.py \
+  extracted_content_pipeline/examples/campaign_source_bundle.json \
+  --source-rows \
+  --source-format json \
   --account-id acct_123
 ```
 

--- a/extracted_content_pipeline/examples/campaign_source_bundle.json
+++ b/extracted_content_pipeline/examples/campaign_source_bundle.json
@@ -1,0 +1,38 @@
+{
+  "account_id": "acct_demo_bundle",
+  "company": "Acme Logistics",
+  "vendor": "HubSpot",
+  "email": "ops@example.com",
+  "title": "VP Revenue Operations",
+  "segment": "enterprise logistics",
+  "reviews": [
+    {
+      "review_id": "bundle-review-acme-1",
+      "review_text": "Pricing increased again this quarter, and the RevOps team is comparing HubSpot with Salesforce before renewal.",
+      "pain_category": "pricing pressure",
+      "rating": 2,
+      "source_url": "https://example.com/reviews/bundle-acme-1"
+    }
+  ],
+  "support_tickets": [
+    {
+      "ticket_id": "bundle-ticket-acme-1",
+      "subject": "Reporting export blocked before renewal",
+      "message": "The operations team cannot export campaign attribution data without upgrading to a higher tier.",
+      "pain_category": "reporting friction",
+      "source_url": "https://example.com/tickets/bundle-acme-1"
+    }
+  ],
+  "surveys": [
+    {
+      "response_id": "bundle-survey-acme-1",
+      "nps_score": 4,
+      "open_ended_response": "We need campaign follow-up tied to buyer signals, not another manual spreadsheet.",
+      "pain_points": [
+        "manual follow-up",
+        "buyer signal gaps"
+      ],
+      "source_url": "https://example.com/surveys/bundle-acme-1"
+    }
+  ]
+}

--- a/plans/PR-Content-Ops-Source-Bundle-Example.md
+++ b/plans/PR-Content-Ops-Source-Bundle-Example.md
@@ -1,0 +1,62 @@
+# Content Ops Source Bundle Example
+
+## Why This Slice Exists
+
+PR #539 made multi-collection source bundles load correctly, but the shipped
+examples and host docs still point mostly at flat JSONL rows. Hosts need an
+executable customer-bundle example that demonstrates the new path end to end.
+
+## Scope
+
+- Add a packaged `campaign_source_bundle.json` example with shared account
+  metadata plus multiple source collections.
+- Add focused tests proving the example loads, smokes, and generates drafts
+  through the existing `--source-rows --source-format json` path.
+- Update README, host runbook, and status docs to mention bundle JSON support.
+- Refresh the active coordination row.
+
+## Mechanism
+
+No source-adapter logic changes. The new example rides on the existing loader,
+offline smoke command, and offline generation CLI.
+
+## Intentional
+
+- No new CLI flags.
+- No database or LLM provider dependencies.
+- No schema versioning for source bundles.
+
+## Deferred
+
+- Versioned customer-source-bundle schema.
+- Frontend bundle upload UX.
+- Per-collection source-type overrides.
+
+## Verification
+
+- Focused source-adapter and host-smoke tests.
+- Focused campaign-generation example tests.
+- Git diff whitespace check.
+- Local PR review wrapper.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/examples/campaign_source_bundle.json`
+- `plans/PR-Content-Ops-Source-Bundle-Example.md`
+- `tests/test_extracted_campaign_generation_example.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_content_host_smoke.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Example bundle | ~45 |
+| Tests | ~80 |
+| Docs and coordination | ~60 |
+| Plan doc | ~50 |
+| **Total** | ~235 |

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -31,6 +31,9 @@ EXAMPLE_PAYLOAD = (
 EXAMPLE_SOURCE_ROWS = (
     ROOT / "extracted_content_pipeline/examples/campaign_source_rows.jsonl"
 )
+EXAMPLE_SOURCE_BUNDLE = (
+    ROOT / "extracted_content_pipeline/examples/campaign_source_bundle.json"
+)
 CLI = ROOT / "scripts/run_extracted_campaign_generation_example.py"
 
 
@@ -293,6 +296,35 @@ def test_campaign_generation_example_cli_generates_from_source_rows() -> None:
     assert source["target_id"] == "review-acme-1"
     assert source["evidence"][0]["source_type"] == "review"
     assert source["contact_email"] == "ops@example.com"
+
+
+def test_campaign_generation_example_cli_generates_from_source_bundle_json() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(EXAMPLE_SOURCE_BUNDLE),
+            "--source-rows",
+            "--source-format",
+            "json",
+            "--channels",
+            "email_cold,email_followup",
+            "--limit",
+            "1",
+            "--llm",
+            "offline",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["result"]["generated"] == 2
+    source = result["drafts"][0]["metadata"]["source_opportunity"]
+    assert source["target_id"] == "bundle-review-acme-1"
+    assert source["company_name"] == "Acme Logistics"
+    assert source["evidence"][0]["source_type"] == "review"
 
 
 def test_campaign_generation_example_cli_rejects_invalid_source_text_limit(tmp_path) -> None:

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -17,6 +17,9 @@ CLI = ROOT / "scripts/build_extracted_campaign_opportunities_from_sources.py"
 EXAMPLE_SOURCE_ROWS = (
     ROOT / "extracted_content_pipeline/examples/campaign_source_rows.jsonl"
 )
+EXAMPLE_SOURCE_BUNDLE = (
+    ROOT / "extracted_content_pipeline/examples/campaign_source_bundle.json"
+)
 
 
 def test_source_row_maps_review_text_to_campaign_opportunity() -> None:
@@ -269,6 +272,27 @@ def test_packaged_source_rows_example_loads() -> None:
     assert loaded.opportunities[0]["evidence"][0]["source_type"] == "review"
     assert loaded.opportunities[1]["evidence"][0]["source_type"] == "transcript"
     assert loaded.opportunities[2]["evidence"][0]["source_type"] == "support_ticket"
+    assert loaded.warnings == ()
+
+
+def test_packaged_source_bundle_example_loads_all_collections() -> None:
+    loaded = load_source_campaign_opportunities_from_file(EXAMPLE_SOURCE_BUNDLE)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "bundle-review-acme-1",
+        "bundle-ticket-acme-1",
+        "bundle-survey-acme-1",
+    ]
+    assert [row["company_name"] for row in loaded.opportunities] == [
+        "Acme Logistics",
+        "Acme Logistics",
+        "Acme Logistics",
+    ]
+    assert [row["source_type"] for row in loaded.opportunities] == [
+        "review",
+        "support_ticket",
+        "nps_response",
+    ]
     assert loaded.warnings == ()
 
 

--- a/tests/test_extracted_content_host_smoke.py
+++ b/tests/test_extracted_content_host_smoke.py
@@ -16,6 +16,9 @@ EXAMPLE_CSV = ROOT / "extracted_content_pipeline/examples/campaign_generation_pa
 EXAMPLE_SOURCE_ROWS = (
     ROOT / "extracted_content_pipeline/examples/campaign_source_rows.jsonl"
 )
+EXAMPLE_SOURCE_BUNDLE = (
+    ROOT / "extracted_content_pipeline/examples/campaign_source_bundle.json"
+)
 
 
 def _load_smoke_module():
@@ -130,6 +133,27 @@ def test_host_smoke_cli_accepts_source_rows() -> None:
             "--source-rows",
             "--source-format",
             "jsonl",
+            "--limit",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "AI Content Ops host smoke passed" in completed.stdout
+    assert "generated=2" in completed.stdout
+
+
+def test_host_smoke_cli_accepts_source_bundle_json() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(EXAMPLE_SOURCE_BUNDLE),
+            "--source-rows",
+            "--source-format",
+            "json",
             "--limit",
             "1",
         ],


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-Bundle-Example.md

## Summary
- add a packaged multi-collection source-bundle JSON example
- document bundle conversion, smoke, generation, and import commands
- add focused tests proving the bundle example loads and generates drafts

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_host_smoke.py tests/test_extracted_campaign_generation_example.py
- python -m py_compile tests/test_extracted_campaign_source_adapters.py tests/test_extracted_content_host_smoke.py tests/test_extracted_campaign_generation_example.py
- git diff --check
- bash scripts/local_pr_review.sh