### PR TITLE
Support call and meeting source rows

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T23:34Z by codex-2026-05-15
+Last updated: 2026-05-15T23:43Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops source bundle example | `extracted_content_pipeline/examples/campaign_source_bundle.json`, `tests/test_extracted_campaign_source_adapters.py`, `tests/test_extracted_content_host_smoke.py`, `tests/test_extracted_campaign_generation_example.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Bundle-Example.md` | codex-2026-05-15 | Avoid source-bundle examples/docs and source-row smoke tests |
+| draft | Content Ops call and meeting source rows | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Call-Meeting-Source-Rows.md` | codex-2026-05-15 | Avoid source-row adapter keys and source-row docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -199,9 +199,12 @@ python scripts/load_extracted_campaign_opportunities.py \
 For source-row CSV exports, pass `--source-format csv` to the same conversion,
 generation, import, or smoke commands.
 For customer bundle JSON files that group collections such as `reviews`,
-`support_tickets`, and `surveys` under shared account metadata, use
-`--source-format json`; the packaged `campaign_source_bundle.json` demonstrates
-that shape.
+`support_tickets`, `surveys`, `calls`, or `meetings` under shared account
+metadata, use `--source-format json`; the packaged
+`campaign_source_bundle.json` demonstrates that shape.
+Rows with `recording_id` are treated as sales-call rows; hosts should rename
+ambiguous screen-recording or webinar identifiers before import if they are not
+sales-call evidence.
 
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -37,14 +37,14 @@ source of truth for what remains.
 - `campaign_postgres_import` loads normalized JSON/CSV opportunity rows into
   `campaign_opportunities`, with dry-run validation and optional
   replace-existing semantics for repeatable customer imports.
-- `campaign_source_adapters` converts review, transcript, complaint,
-  support-ticket, conversation, case, survey, NPS, CSAT, or document source
-  rows into normalized campaign opportunities so hosts can feed richer text
-	  sources into the same generation/import path. The Postgres import CLI and
-	  offline generation CLI can consume these source rows directly with
-	  `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
-	  `examples/campaign_source_rows.jsonl` plus
-	  `examples/campaign_source_bundle.json` provide packaged starter inputs.
+- `campaign_source_adapters` converts review, transcript, sales-call,
+  meeting, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
+  or document source rows into normalized campaign opportunities so hosts can
+  feed richer text sources into the same generation/import path. The Postgres
+  import CLI and offline generation CLI can consume these source rows directly
+  with `--source-rows`; JSON, JSONL, and CSV source-row exports are supported,
+  and `examples/campaign_source_rows.jsonl` plus
+  `examples/campaign_source_bundle.json` provide packaged starter inputs.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not
   available as one scalar field.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -23,6 +23,10 @@ _ROW_LIST_KEYS = (
     "documents",
     "reviews",
     "transcripts",
+    "calls",
+    "call_transcripts",
+    "meetings",
+    "meeting_transcripts",
     "complaints",
     "support_tickets",
     "tickets",
@@ -41,6 +45,9 @@ _SOURCE_ID_KEYS = (
     "id",
     "review_id",
     "transcript_id",
+    "call_id",
+    "meeting_id",
+    "recording_id",
     "document_id",
     "ticket_id",
     "case_id",
@@ -67,7 +74,17 @@ _TEXT_KEYS = (
     "comment_text",
     "open_ended_response",
 )
-_THREAD_KEYS = ("messages", "comments", "thread", "conversation", "entries")
+_THREAD_KEYS = (
+    "messages",
+    "comments",
+    "thread",
+    "conversation",
+    "entries",
+    "turns",
+    "segments",
+    "utterances",
+    "dialogue",
+)
 # Thread items favor message-shaped keys before generic body/content keys,
 # while row-level source text keeps document/review body precedence.
 _THREAD_TEXT_KEYS = (
@@ -420,6 +437,10 @@ def _infer_source_type(row: Mapping[str, Any]) -> str:
         return "review"
     if row.get("transcript") is not None:
         return "transcript"
+    if row.get("call_id") is not None or row.get("recording_id") is not None:
+        return "sales_call"
+    if row.get("meeting_id") is not None:
+        return "meeting"
     if row.get("complaint") is not None:
         return "complaint"
     if row.get("ticket_id") is not None:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -413,6 +413,14 @@ entry per saved row after successful writes. `--validate-opportunities` checks
 each row against active `campaign_opportunities` before saving, which catches
 typoed selectors during larger host imports.
 
+Source-row bundles can also include sales-call and meeting exports under
+`calls`, `call_transcripts`, `meetings`, or `meeting_transcripts`. Use
+`call_id`, `meeting_id`, or `recording_id` as the source identifier and provide
+`transcript`, `summary`, `notes`, or threaded `messages` / `turns` / `segments`
+when the export does not have a single `review_text` field. `recording_id`
+infers `sales_call`; rename ambiguous non-call recording identifiers before
+import.
+
 ## Step 6: Add Optional Prompt Overrides
 
 Use packaged skills by default. To override copy strategy, provide a markdown

--- a/plans/PR-Content-Ops-Call-Meeting-Source-Rows.md
+++ b/plans/PR-Content-Ops-Call-Meeting-Source-Rows.md
@@ -1,0 +1,67 @@
+# Content Ops Call And Meeting Source Rows
+
+## Why This Slice Exists
+
+AI Content Ops already accepts reviews, tickets, surveys, transcripts, and
+documents as customer source rows. A common host export shape is sales-call or
+meeting data from tools such as call recorders and CRM activity logs. Without
+explicit identifiers and collection keys, those rows fall back to generic
+document behavior or require hosts to reshape data before import.
+
+## Scope
+
+- Add `calls`, `call_transcripts`, `meetings`, and `meeting_transcripts` as
+  source-bundle collection keys.
+- Add `call_id`, `meeting_id`, and `recording_id` as source identifiers.
+- Infer `sales_call` and `meeting` source types when rows use call/meeting
+  identifiers without an explicit `transcript` field.
+- Document the new accepted bundle shape.
+
+## Mechanism
+
+The existing `campaign_source_adapters` source-row pipeline stays intact:
+collection expansion, source text extraction, evidence construction, and final
+opportunity normalization are reused. This slice only teaches that pipeline
+about common call/meeting export keys.
+
+## Intentional
+
+- Rows with a `transcript` field still infer `source_type="transcript"` for
+  backward compatibility.
+- `recording_id` presence infers `sales_call`; hosts should rename ambiguous
+  non-call recording identifiers before import.
+- `meeting_id` presence infers `meeting`.
+
+## Deferred
+
+- No provider-specific schemas for Gong, Fireflies, Zoom, or HubSpot activity
+  exports. Hosts can map those into the generic call/meeting keys first.
+- No new packaged example file; the existing source-bundle example remains the
+  starter fixture, and focused tests lock the new keys.
+
+## Verification
+
+- Focused source-adapter tests.
+- Python compile check for the adapter and focused tests.
+- Git diff whitespace check.
+- Local PR review wrapper.
+
+### Files Touched
+
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `plans/PR-Content-Ops-Call-Meeting-Source-Rows.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Adapter keys | ~20 |
+| Tests | ~115 |
+| Docs and coordination | ~35 |
+| Plan doc | ~75 |
+| **Total** | ~245 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -159,6 +159,83 @@ def test_source_row_maps_ticket_comments_to_evidence_text() -> None:
     }
 
 
+def test_source_row_maps_call_transcript_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "call_id": "call-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "title": "Renewal discovery call",
+        "transcript": "Buyer: We are comparing Salesforce before the renewal.",
+        "pain_category": "renewal pressure",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "call-1"
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["source_title"] == "Renewal discovery call"
+    assert opportunity["source_type"] == "transcript"
+    assert opportunity["pain_points"] == ["renewal pressure"]
+    assert opportunity["evidence"][0] == {
+        "text": "Buyer: We are comparing Salesforce before the renewal.",
+        "source_id": "call-1",
+        "source_type": "transcript",
+        "source_title": "Renewal discovery call",
+    }
+
+
+def test_source_row_maps_recording_notes_to_sales_call() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "recording_id": "rec-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "notes": "RevOps asked for attribution exports before renewal.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "rec-1"
+    assert opportunity["source_type"] == "sales_call"
+    assert opportunity["evidence"][0] == {
+        "text": "RevOps asked for attribution exports before renewal.",
+        "source_id": "rec-1",
+        "source_type": "sales_call",
+    }
+
+
+def test_source_row_maps_call_speaker_turns_to_evidence_text() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "call_id": "call-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "turns": [
+            {"speaker": "Buyer", "text": "Attribution exports are blocked."},
+            {"speaker": "AE", "text": "That requires the next plan."},
+        ],
+    })
+
+    assert warnings == ()
+    assert opportunity["source_type"] == "sales_call"
+    assert opportunity["evidence"][0] == {
+        "text": (
+            "Buyer: Attribution exports are blocked.\n"
+            "AE: That requires the next plan."
+        ),
+        "source_id": "call-1",
+        "source_type": "sales_call",
+    }
+
+
+def test_source_row_with_call_and_meeting_ids_prefers_sales_call() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "call_id": "call-1",
+        "meeting_id": "meeting-1",
+        "summary": "The buyer asked about Salesforce migration risk.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "call-1"
+    assert opportunity["source_type"] == "sales_call"
+
+
 def test_source_row_prefers_scalar_text_over_thread_messages() -> None:
     opportunity, warnings = source_row_to_campaign_opportunity({
         "ticket_id": "ticket-thread-1",
@@ -399,6 +476,48 @@ def test_load_source_campaign_opportunities_from_multi_collection_bundle(tmp_pat
         "source_id": "ticket-1",
         "source_type": "support_ticket",
         "source_title": "Reporting exports blocked",
+    }
+
+
+def test_load_source_campaign_opportunities_from_meeting_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "meeting_bundle.json"
+    path.write_text(
+        json.dumps({
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "meetings": [
+                {
+                    "meeting_id": "meeting-1",
+                    "subject": "Renewal checkpoint",
+                    "summary": "The buying team asked for Salesforce migration risk.",
+                }
+            ],
+            "call_transcripts": [
+                {
+                    "recording_id": "recording-1",
+                    "transcript": "Buyer: Attribution exports are blocked.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "recording-1",
+        "meeting-1",
+    ]
+    assert [row["source_type"] for row in loaded.opportunities] == [
+        "transcript",
+        "meeting",
+    ]
+    assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
+    assert loaded.opportunities[1]["evidence"][0] == {
+        "text": "The buying team asked for Salesforce migration risk.",
+        "source_id": "meeting-1",
+        "source_type": "meeting",
+        "source_title": "Renewal checkpoint",
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Call-Meeting-Source-Rows.md

## Summary
- add call/meeting source-bundle collection keys
- recognize call_id, meeting_id, and recording_id as source identifiers
- document call and meeting source-row support

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py
- git diff --check
- bash scripts/local_pr_review.sh