### PR TITLE
Support CRM source rows for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-15T23:43Z by codex-2026-05-15
+Last updated: 2026-05-16T00:08Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops call and meeting source rows | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Call-Meeting-Source-Rows.md` | codex-2026-05-15 | Avoid source-row adapter keys and source-row docs |
+| draft | Content Ops CRM source rows | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-CRM-Source-Rows.md` | codex-2026-05-15 | Avoid source-row adapter keys and source-row docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -115,9 +115,10 @@ draft metadata fields while preserving custom columns.
 customer exports before wiring a database integration.
 
 `campaign_source_adapters.py` adds a source-to-opportunity adapter for richer
-review, transcript, complaint, support-ticket, conversation, case, survey,
-NPS, CSAT, or document rows. It preserves source text as campaign evidence and
-outputs the same payload shape as the customer-data adapter.
+review, transcript, sales-call, meeting, CRM deal/note, complaint,
+support-ticket, conversation, case, survey, NPS, CSAT, or document rows. It
+preserves source text as campaign evidence and outputs the same payload shape
+as the customer-data adapter.
 
 ## Campaign generation example
 
@@ -143,9 +144,10 @@ draft metadata:
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.csv --format csv
 ```
 
-Review, transcript, complaint, support-ticket, conversation, case, survey, NPS,
-CSAT, and document source rows can be converted into the same opportunity
-payload first. Source rows can be JSON, JSONL, or CSV:
+Review, transcript, sales-call, meeting, CRM deal/note, complaint,
+support-ticket, conversation, case, survey, NPS, CSAT, and document source rows
+can be converted into the same opportunity payload first. Source rows can be
+JSON, JSONL, or CSV:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -199,12 +201,14 @@ python scripts/load_extracted_campaign_opportunities.py \
 For source-row CSV exports, pass `--source-format csv` to the same conversion,
 generation, import, or smoke commands.
 For customer bundle JSON files that group collections such as `reviews`,
-`support_tickets`, `surveys`, `calls`, or `meetings` under shared account
-metadata, use `--source-format json`; the packaged
+`support_tickets`, `surveys`, `calls`, `meetings`, `deals`, or `account_notes`
+under shared account metadata, use `--source-format json`; the packaged
 `campaign_source_bundle.json` demonstrates that shape.
 Rows with `recording_id` are treated as sales-call rows; hosts should rename
 ambiguous screen-recording or webinar identifiers before import if they are not
 sales-call evidence.
+Rows with `deal_id` or `opportunity_id` are treated as CRM deal evidence; rows
+with `note_id` or `activity_id` are treated as CRM note evidence.
 
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -38,12 +38,13 @@ source of truth for what remains.
   `campaign_opportunities`, with dry-run validation and optional
   replace-existing semantics for repeatable customer imports.
 - `campaign_source_adapters` converts review, transcript, sales-call,
-  meeting, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
-  or document source rows into normalized campaign opportunities so hosts can
-  feed richer text sources into the same generation/import path. The Postgres
-  import CLI and offline generation CLI can consume these source rows directly
-  with `--source-rows`; JSON, JSONL, and CSV source-row exports are supported,
-  and `examples/campaign_source_rows.jsonl` plus
+  meeting, CRM deal/note, complaint, support-ticket, conversation, case,
+  survey, NPS, CSAT, or document source rows into normalized campaign
+  opportunities so hosts can feed richer text sources into the same
+  generation/import path. The Postgres import CLI and offline generation CLI
+  can consume these source rows directly with `--source-rows`; JSON, JSONL,
+  and CSV source-row exports are supported, and
+  `examples/campaign_source_rows.jsonl` plus
   `examples/campaign_source_bundle.json` provide packaged starter inputs.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -27,6 +27,14 @@ _ROW_LIST_KEYS = (
     "call_transcripts",
     "meetings",
     "meeting_transcripts",
+    "deals",
+    "crm_deals",
+    "crm_opportunities",
+    "deal_notes",
+    "opportunity_notes",
+    "account_notes",
+    "crm_notes",
+    "activities",
     "complaints",
     "support_tickets",
     "tickets",
@@ -48,6 +56,10 @@ _SOURCE_ID_KEYS = (
     "call_id",
     "meeting_id",
     "recording_id",
+    "deal_id",
+    "opportunity_id",
+    "note_id",
+    "activity_id",
     "document_id",
     "ticket_id",
     "case_id",
@@ -441,6 +453,10 @@ def _infer_source_type(row: Mapping[str, Any]) -> str:
         return "sales_call"
     if row.get("meeting_id") is not None:
         return "meeting"
+    if row.get("deal_id") is not None or row.get("opportunity_id") is not None:
+        return "crm_deal"
+    if row.get("note_id") is not None or row.get("activity_id") is not None:
+        return "crm_note"
     if row.get("complaint") is not None:
         return "complaint"
     if row.get("ticket_id") is not None:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -175,9 +175,10 @@ Minimum useful columns:
 Unknown columns are preserved in draft metadata and prompt context through the
 normalized opportunity payload.
 
-If a host starts from reviews, transcripts, complaints, support tickets,
-conversations, cases, surveys, NPS, CSAT, or document rows instead of
-ready-made opportunities, they can preview the normalized opportunity payload:
+If a host starts from reviews, transcripts, sales calls, meetings, CRM deals,
+CRM notes, complaints, support tickets, conversations, cases, surveys, NPS,
+CSAT, or document rows instead of ready-made opportunities, they can preview the
+normalized opportunity payload:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -196,9 +197,11 @@ The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
 `quote`, or `text` into the opportunity `evidence` field, preserving source
 ids and inferred source types for prompt context and later review. Source rows
 can be JSON, JSONL, or CSV; pass `--format csv` for CSV source exports.
-Customer bundle JSON can group `reviews`, `support_tickets`, `surveys`, and
-other recognized collections under shared account metadata; use `--format json`
-or `--source-format json` for that shape.
+Customer bundle JSON can group `reviews`, `support_tickets`, `surveys`,
+`calls`, `meetings`, `deals`, and `account_notes` under shared account
+metadata; use `--format json` or `--source-format json` for that shape.
+Rows with `deal_id` or `opportunity_id` are inferred as CRM deal evidence; rows
+with `note_id` or `activity_id` are inferred as CRM note evidence.
 
 When a source export includes more than one source-text field, the adapter uses
 the first recognized field in this order: `text`, `review_text`, `transcript`,

--- a/plans/PR-Content-Ops-CRM-Source-Rows.md
+++ b/plans/PR-Content-Ops-CRM-Source-Rows.md
@@ -1,0 +1,67 @@
+# Content Ops CRM Source Rows
+
+## Why This Slice Exists
+
+AI Content Ops already accepts reviews, tickets, surveys, calls, meetings, and
+generic documents as source rows. Many hosts will start with CRM deal exports
+and account notes before they have cleaner review or support-ticket exports.
+This slice lets those rows enter the same deterministic source-to-opportunity
+path without adding a CRM provider integration.
+
+## Scope
+
+- Recognize CRM deal and note collection keys in source bundle JSON.
+- Recognize CRM deal/note identifiers on individual rows.
+- Infer source types for CRM deals and CRM notes.
+- Preserve the existing normalized opportunity contract.
+- Document the new accepted row shapes.
+
+## Mechanism
+
+The source adapter extends the existing static key lists and source-type
+inference. Rows with `deal_id` or `opportunity_id` are treated as `crm_deal`
+evidence. Rows with `note_id` or `activity_id` are treated as `crm_note`
+evidence. Existing source text precedence remains unchanged, so CRM rows use
+`summary`, `notes`, `description`, `message`, or any other already-supported
+text field.
+
+## Intentional
+
+- No new CRM API client.
+- No schema migration.
+- No changes to generation prompts or the campaign draft contract.
+- No special handling for provider-specific fields beyond preserving them as
+  normal custom opportunity metadata.
+
+## Deferred
+
+- Provider-specific CRM importers for HubSpot, Salesforce, or Pipedrive.
+- Rich account/contact reconciliation across multiple CRM rows.
+- Source-bundle examples that include every supported CRM shape.
+
+## Verification
+
+- Focused source-adapter tests.
+- Python compile check for the adapter and tests.
+- Diff whitespace check.
+- Local PR review script.
+
+### Files Touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-CRM-Source-Rows.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Adapter keys | ~20 |
+| Tests | ~100 |
+| Docs and coordination | ~35 |
+| Plan doc | ~70 |
+| **Total** | ~225 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -236,6 +236,58 @@ def test_source_row_with_call_and_meeting_ids_prefers_sales_call() -> None:
     assert opportunity["source_type"] == "sales_call"
 
 
+def test_source_row_maps_crm_deal_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "deal_id": "deal-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "stage": "renewal_review",
+        "summary": "The account is evaluating Salesforce before renewal.",
+        "pain_category": "renewal pressure",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "deal-1"
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["stage"] == "renewal_review"
+    assert opportunity["source_type"] == "crm_deal"
+    assert opportunity["pain_points"] == ["renewal pressure"]
+    assert opportunity["evidence"][0] == {
+        "text": "The account is evaluating Salesforce before renewal.",
+        "source_id": "deal-1",
+        "source_type": "crm_deal",
+    }
+
+
+def test_source_row_maps_crm_note_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "note_id": "note-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "notes": "Champion asked for pricing proof before the renewal call.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "note-1"
+    assert opportunity["source_type"] == "crm_note"
+    assert opportunity["evidence"][0] == {
+        "text": "Champion asked for pricing proof before the renewal call.",
+        "source_id": "note-1",
+        "source_type": "crm_note",
+    }
+
+
+def test_source_row_prefers_review_type_over_crm_deal_id() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "deal_id": "deal-1",
+        "review_text": "The reviewer called out reporting limits.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "deal-1"
+    assert opportunity["source_type"] == "review"
+
+
 def test_source_row_prefers_scalar_text_over_thread_messages() -> None:
     opportunity, warnings = source_row_to_campaign_opportunity({
         "ticket_id": "ticket-thread-1",
@@ -518,6 +570,52 @@ def test_load_source_campaign_opportunities_from_meeting_bundle(tmp_path: Path) 
         "source_id": "meeting-1",
         "source_type": "meeting",
         "source_title": "Renewal checkpoint",
+    }
+
+
+def test_load_source_campaign_opportunities_from_crm_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "crm_bundle.json"
+    path.write_text(
+        json.dumps({
+            "account_id": "acct-1",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "deals": [
+                {
+                    "deal_id": "deal-1",
+                    "stage": "renewal_review",
+                    "summary": "The buying committee is comparing Salesforce.",
+                }
+            ],
+            "account_notes": [
+                {
+                    "note_id": "note-1",
+                    "notes": "RevOps asked for proof on attribution exports.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "deal-1",
+        "note-1",
+    ]
+    assert [row["source_type"] for row in loaded.opportunities] == [
+        "crm_deal",
+        "crm_note",
+    ]
+    assert [row["company_name"] for row in loaded.opportunities] == [
+        "Acme Logistics",
+        "Acme Logistics",
+    ]
+    assert loaded.opportunities[0]["account_id"] == "acct-1"
+    assert loaded.opportunities[1]["evidence"][0] == {
+        "text": "RevOps asked for proof on attribution exports.",
+        "source_id": "note-1",
+        "source_type": "crm_note",
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-CRM-Source-Rows.md

## Summary
- add CRM deal/note source-row keys and source-type inference
- cover direct CRM rows and CRM bundle collections in adapter tests
- document CRM source-row support in Content Ops docs/status

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py
- git diff --check
- bash scripts/local_pr_review.sh