### PR TITLE
Filter file reasoning contexts by target mode

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T00:08Z by codex-2026-05-15
+Last updated: 2026-05-16T00:15Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops CRM source rows | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-CRM-Source-Rows.md` | codex-2026-05-15 | Avoid source-row adapter keys and source-row docs |
+| draft | Content Ops file reasoning target-mode parity | `extracted_content_pipeline/campaign_reasoning_data.py`, `tests/test_extracted_campaign_reasoning_data.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/reasoning_handoff_contract.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-File-Reasoning-Target-Mode.md` | codex-2026-05-15 | Avoid file-backed reasoning provider edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -225,9 +225,10 @@ python scripts/run_extracted_campaign_generation_example.py \
 ```
 
 `campaign_reasoning_data.FileCampaignReasoningContextProvider` matches context
-rows by target id, company, email, or vendor and feeds the normalized
-`CampaignReasoningContextProvider` port documented in
-`docs/reasoning_handoff_contract.md`.
+rows by target id, company, email, or vendor, filters rows by `target_mode`
+when provided, and feeds the normalized `CampaignReasoningContextProvider` port
+documented in `docs/reasoning_handoff_contract.md`. Rows with blank
+`target_mode` remain global fallbacks for lightweight legacy files.
 For DB-backed installs, validate a loaded `campaign_reasoning_contexts` row
 without running generation:
 

--- a/extracted_content_pipeline/campaign_reasoning_data.py
+++ b/extracted_content_pipeline/campaign_reasoning_data.py
@@ -31,6 +31,12 @@ _CONTEXT_FIELD_KEYS = {"context", "reasoning_context", "campaign_reasoning_conte
 
 
 @dataclass(frozen=True)
+class _IndexedReasoningContext:
+    target_mode: str
+    context: CampaignReasoningContext
+
+
+@dataclass(frozen=True)
 class FileCampaignReasoningContextProvider:
     """CampaignReasoningContextProvider backed by loaded JSON rows.
 
@@ -40,7 +46,7 @@ class FileCampaignReasoningContextProvider:
     reasoning producer.
     """
 
-    contexts: Mapping[str, CampaignReasoningContext]
+    contexts: Mapping[str, tuple[_IndexedReasoningContext, ...]]
     source: str | None = None
 
     @classmethod
@@ -69,9 +75,9 @@ class FileCampaignReasoningContextProvider:
         opportunity: Mapping[str, Any],
     ) -> CampaignReasoningContext | None:
         del scope
-        del target_mode
+        mode = str(target_mode or "").strip().lower()
         for key in _candidate_keys(target_id=target_id, opportunity=opportunity):
-            context = self.contexts.get(key)
+            context = _select_context(self.contexts.get(key, ()), target_mode=mode)
             if context is not None:
                 return context
         return None
@@ -119,16 +125,41 @@ def _looks_like_mapping_index(payload: Mapping[str, Any]) -> bool:
     return all(isinstance(value, Mapping) for value in payload.values())
 
 
-def _index_contexts(rows: Sequence[Mapping[str, Any]]) -> dict[str, CampaignReasoningContext]:
-    indexed: dict[str, CampaignReasoningContext] = {}
+def _index_contexts(rows: Sequence[Mapping[str, Any]]) -> dict[str, tuple[_IndexedReasoningContext, ...]]:
+    indexed: dict[str, tuple[_IndexedReasoningContext, ...]] = {}
     for row in rows:
         selectors = _row_selectors(row)
         context = normalize_campaign_reasoning_context(_row_context(row))
         if not selectors or not context.has_content():
             continue
+        indexed_context = _IndexedReasoningContext(
+            target_mode=str(row.get("target_mode") or "").strip().lower(),
+            context=context,
+        )
         for selector in selectors:
-            indexed.setdefault(selector, context)
+            existing = indexed.get(selector, ())
+            if any(item.target_mode == indexed_context.target_mode for item in existing):
+                continue
+            indexed[selector] = (*existing, indexed_context)
     return indexed
+
+
+def _select_context(
+    entries: Sequence[_IndexedReasoningContext],
+    *,
+    target_mode: str,
+) -> CampaignReasoningContext | None:
+    if not entries:
+        return None
+    if not target_mode:
+        return entries[0].context
+    for entry in entries:
+        if entry.target_mode == target_mode:
+            return entry.context
+    for entry in entries:
+        if entry.target_mode == "":
+            return entry.context
+    return None
 
 
 def _row_context(row: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/extracted_content_pipeline/docs/reasoning_handoff_contract.md
+++ b/extracted_content_pipeline/docs/reasoning_handoff_contract.md
@@ -114,8 +114,9 @@ class HostReasoningProvider:
 `campaign_reasoning_data.FileCampaignReasoningContextProvider` is the reference
 adapter for hosts that already have reasoning output as JSON. It accepts
 context rows keyed by target id, company, email, or vendor, normalizes them into
-`CampaignReasoningContext`, and keeps AI Content Ops independent from any
-reasoning producer.
+`CampaignReasoningContext`, filters mode-specific rows by `target_mode`, and
+keeps AI Content Ops independent from any reasoning producer. Rows that omit
+`target_mode` remain shared fallback contexts for simple installs.
 
 ```bash
 python scripts/run_extracted_campaign_generation_example.py \

--- a/plans/PR-Content-Ops-File-Reasoning-Target-Mode.md
+++ b/plans/PR-Content-Ops-File-Reasoning-Target-Mode.md
@@ -1,0 +1,64 @@
+# Content Ops File Reasoning Target-Mode Parity
+
+## Why This Slice Exists
+
+The Postgres reasoning context provider filters mode-specific rows by
+`target_mode`, but the file-backed provider ignored `target_mode`. That could
+let a host-provided JSON context for one asset type satisfy another asset type
+when selectors overlap. The file-backed path is used by examples, smoke tests,
+and lightweight installs, so it should match the durable provider contract.
+
+## Scope
+
+- Preserve the existing selector matching order.
+- Add target-mode aware selection to the file-backed provider.
+- Keep blank target-mode rows as global fallback contexts.
+- Document the file-backed target-mode behavior.
+- Add focused regression tests for mode-specific rows and fallback rows.
+
+## Mechanism
+
+The provider indexes each selector to one or more contexts, keyed by normalized
+`target_mode`. Reads still walk candidate selectors in the existing order. For
+each selector, an exact target-mode row wins; if none exists, a blank-mode row
+can satisfy the request. When the caller passes a blank target mode, the first
+indexed row is returned to preserve legacy broad lookup behavior.
+
+## Intentional
+
+- No changes to the Postgres provider.
+- No changes to the reasoning provider Protocol.
+- No migration or schema change.
+- No changes to generated asset services.
+
+## Deferred
+
+- Rich conflict diagnostics when a JSON file contains multiple rows for the
+  same selector and target mode.
+- Settings-level defaulting for file-backed context paths.
+
+## Verification
+
+- Focused file-backed reasoning provider tests.
+- Python compile check for provider and tests.
+- Diff whitespace check.
+- Local PR review script.
+
+### Files Touched
+
+- `extracted_content_pipeline/campaign_reasoning_data.py`
+- `tests/test_extracted_campaign_reasoning_data.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/reasoning_handoff_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-File-Reasoning-Target-Mode.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Provider index/selection | ~55 |
+| Tests | ~110 |
+| Docs and coordination | ~20 |
+| Plan doc | ~70 |
+| **Total** | ~255 |

--- a/tests/test_extracted_campaign_reasoning_data.py
+++ b/tests/test_extracted_campaign_reasoning_data.py
@@ -136,6 +136,122 @@ async def test_file_reasoning_provider_does_not_match_on_target_mode_only() -> N
 
 
 @pytest.mark.asyncio
+async def test_file_reasoning_provider_filters_contexts_by_target_mode() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "target_mode": "sales_brief",
+                "reasoning_context": {"summary": "Sales brief context"},
+            },
+            {
+                "target_id": "opp-1",
+                "target_mode": "vendor_retention",
+                "reasoning_context": {"summary": "Campaign context"},
+            },
+        ]
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={},
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "Campaign context"
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_uses_blank_mode_as_fallback() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "reasoning_context": {"summary": "Global fallback"},
+            }
+        ]
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="landing_page",
+        opportunity={},
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "Global fallback"
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_rejects_other_mode_without_fallback() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "target_mode": "sales_brief",
+                "reasoning_context": {"summary": "Sales brief context"},
+            }
+        ]
+    })
+
+    assert await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="vendor_retention",
+        opportunity={},
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_normalizes_target_mode() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "target_mode": "Vendor_Retention",
+                "reasoning_context": {"summary": "Campaign context"},
+            }
+        ]
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode=" vendor_retention ",
+        opportunity={},
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "Campaign context"
+
+
+@pytest.mark.asyncio
+async def test_file_reasoning_provider_empty_mode_keeps_legacy_broad_lookup() -> None:
+    provider = FileCampaignReasoningContextProvider.from_payload({
+        "contexts": [
+            {
+                "target_id": "opp-1",
+                "target_mode": "sales_brief",
+                "reasoning_context": {"summary": "First indexed context"},
+            }
+        ]
+    })
+
+    context = await provider.read_campaign_reasoning_context(
+        scope=TenantScope(),
+        target_id="opp-1",
+        target_mode="",
+        opportunity={},
+    )
+
+    assert context is not None
+    assert context.as_dict()["summary"] == "First indexed context"
+
+
+@pytest.mark.asyncio
 async def test_load_file_reasoning_provider(tmp_path) -> None:
     path = tmp_path / "reasoning.json"
     path.write_text(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Reasoning-Target-Mode.md

## Summary
- make file-backed reasoning context reads target-mode aware
- preserve blank target_mode rows as global fallbacks
- document parity with DB-backed reasoning context behavior

## Verification
- pytest tests/test_extracted_campaign_reasoning_data.py
- python -m py_compile extracted_content_pipeline/campaign_reasoning_data.py tests/test_extracted_campaign_reasoning_data.py
- git diff --check
- bash scripts/local_pr_review.sh