### PR TITLE
Support renewal source rows for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T00:15Z by codex-2026-05-15
+Last updated: 2026-05-16T00:35Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops file reasoning target-mode parity | `extracted_content_pipeline/campaign_reasoning_data.py`, `tests/test_extracted_campaign_reasoning_data.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/reasoning_handoff_contract.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-File-Reasoning-Target-Mode.md` | codex-2026-05-15 | Avoid file-backed reasoning provider edits |
+| draft | Content Ops renewal source rows | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Renewal-Source-Rows.md` | codex-2026-05-15 | Avoid source-row adapter taxonomy edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -115,10 +115,10 @@ draft metadata fields while preserving custom columns.
 customer exports before wiring a database integration.
 
 `campaign_source_adapters.py` adds a source-to-opportunity adapter for richer
-review, transcript, sales-call, meeting, CRM deal/note, complaint,
-support-ticket, conversation, case, survey, NPS, CSAT, or document rows. It
-preserves source text as campaign evidence and outputs the same payload shape
-as the customer-data adapter.
+review, transcript, sales-call, meeting, CRM deal/note, contract, renewal,
+subscription, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
+or document rows. It preserves source text as campaign evidence and outputs the
+same payload shape as the customer-data adapter.
 
 ## Campaign generation example
 
@@ -144,10 +144,10 @@ draft metadata:
 python scripts/run_extracted_campaign_generation_example.py customer_opportunities.csv --format csv
 ```
 
-Review, transcript, sales-call, meeting, CRM deal/note, complaint,
-support-ticket, conversation, case, survey, NPS, CSAT, and document source rows
-can be converted into the same opportunity payload first. Source rows can be
-JSON, JSONL, or CSV:
+Review, transcript, sales-call, meeting, CRM deal/note, contract, renewal,
+subscription, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
+and document source rows can be converted into the same opportunity payload
+first. Source rows can be JSON, JSONL, or CSV:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -201,14 +201,17 @@ python scripts/load_extracted_campaign_opportunities.py \
 For source-row CSV exports, pass `--source-format csv` to the same conversion,
 generation, import, or smoke commands.
 For customer bundle JSON files that group collections such as `reviews`,
-`support_tickets`, `surveys`, `calls`, `meetings`, `deals`, or `account_notes`
-under shared account metadata, use `--source-format json`; the packaged
-`campaign_source_bundle.json` demonstrates that shape.
+`support_tickets`, `surveys`, `calls`, `meetings`, `deals`, `account_notes`,
+`contracts`, `renewals`, or `subscriptions` under shared account metadata, use
+`--source-format json`; the packaged `campaign_source_bundle.json` demonstrates
+that shape.
 Rows with `recording_id` are treated as sales-call rows; hosts should rename
 ambiguous screen-recording or webinar identifiers before import if they are not
 sales-call evidence.
 Rows with `deal_id` or `opportunity_id` are treated as CRM deal evidence; rows
 with `note_id` or `activity_id` are treated as CRM note evidence.
+Rows with `contract_id`, `renewal_id`, or `subscription_id` are treated as
+contract, renewal, or subscription evidence.
 
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -38,12 +38,12 @@ source of truth for what remains.
   `campaign_opportunities`, with dry-run validation and optional
   replace-existing semantics for repeatable customer imports.
 - `campaign_source_adapters` converts review, transcript, sales-call,
-  meeting, CRM deal/note, complaint, support-ticket, conversation, case,
-  survey, NPS, CSAT, or document source rows into normalized campaign
-  opportunities so hosts can feed richer text sources into the same
-  generation/import path. The Postgres import CLI and offline generation CLI
-  can consume these source rows directly with `--source-rows`; JSON, JSONL,
-  and CSV source-row exports are supported, and
+  meeting, CRM deal/note, contract, renewal, subscription, complaint,
+  support-ticket, conversation, case, survey, NPS, CSAT, or document source
+  rows into normalized campaign opportunities so hosts can feed richer text
+  sources into the same generation/import path. The Postgres import CLI and
+  offline generation CLI can consume these source rows directly with
+  `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
   `examples/campaign_source_rows.jsonl` plus
   `examples/campaign_source_bundle.json` provide packaged starter inputs.
   Ticket and conversation rows can also provide nested `messages`, `comments`,

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -35,6 +35,12 @@ _ROW_LIST_KEYS = (
     "account_notes",
     "crm_notes",
     "activities",
+    "contracts",
+    "contract_notes",
+    "renewals",
+    "renewal_notes",
+    "subscriptions",
+    "subscription_notes",
     "complaints",
     "support_tickets",
     "tickets",
@@ -60,6 +66,9 @@ _SOURCE_ID_KEYS = (
     "opportunity_id",
     "note_id",
     "activity_id",
+    "renewal_id",
+    "contract_id",
+    "subscription_id",
     "document_id",
     "ticket_id",
     "case_id",
@@ -457,6 +466,14 @@ def _infer_source_type(row: Mapping[str, Any]) -> str:
         return "crm_deal"
     if row.get("note_id") is not None or row.get("activity_id") is not None:
         return "crm_note"
+    # Notes stay typed as notes even when attached to a contract, renewal, or
+    # subscription export; the lifecycle id is context, not the evidence row.
+    if row.get("renewal_id") is not None:
+        return "renewal"
+    if row.get("contract_id") is not None:
+        return "contract"
+    if row.get("subscription_id") is not None:
+        return "subscription"
     if row.get("complaint") is not None:
         return "complaint"
     if row.get("ticket_id") is not None:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -176,9 +176,9 @@ Unknown columns are preserved in draft metadata and prompt context through the
 normalized opportunity payload.
 
 If a host starts from reviews, transcripts, sales calls, meetings, CRM deals,
-CRM notes, complaints, support tickets, conversations, cases, surveys, NPS,
-CSAT, or document rows instead of ready-made opportunities, they can preview the
-normalized opportunity payload:
+CRM notes, contracts, renewals, subscriptions, complaints, support tickets,
+conversations, cases, surveys, NPS, CSAT, or document rows instead of
+ready-made opportunities, they can preview the normalized opportunity payload:
 
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
@@ -198,10 +198,13 @@ The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
 ids and inferred source types for prompt context and later review. Source rows
 can be JSON, JSONL, or CSV; pass `--format csv` for CSV source exports.
 Customer bundle JSON can group `reviews`, `support_tickets`, `surveys`,
-`calls`, `meetings`, `deals`, and `account_notes` under shared account
-metadata; use `--format json` or `--source-format json` for that shape.
+`calls`, `meetings`, `deals`, `account_notes`, `contracts`, `renewals`, and
+`subscriptions` under shared account metadata; use `--format json` or
+`--source-format json` for that shape.
 Rows with `deal_id` or `opportunity_id` are inferred as CRM deal evidence; rows
 with `note_id` or `activity_id` are inferred as CRM note evidence.
+Rows with `contract_id`, `renewal_id`, or `subscription_id` are inferred as
+contract, renewal, or subscription evidence.
 
 When a source export includes more than one source-text field, the adapter uses
 the first recognized field in this order: `text`, `review_text`, `transcript`,

--- a/plans/PR-Content-Ops-Renewal-Source-Rows.md
+++ b/plans/PR-Content-Ops-Renewal-Source-Rows.md
@@ -1,0 +1,80 @@
+# Content Ops Renewal Source Rows
+
+## Why This Slice Exists
+
+AI Content Ops can already turn reviews, transcripts, support tickets, CRM
+deals, and CRM notes into normalized campaign opportunities. Customer revenue
+teams also export contract, renewal, and subscription records as the source of
+truth for expansion and retention plays. Those rows should enter the same
+source-row adapter instead of forcing hosts to pre-map them into generic CRM
+deal rows.
+
+This slice keeps the existing source-row contract and extends the taxonomy to
+cover commercial lifecycle records.
+
+## Scope
+
+- Accept contract, renewal, and subscription collection keys in JSON bundles.
+- Preserve contract, renewal, and subscription identifiers as source ids.
+- Infer stable source types for rows carrying those identifiers.
+- Cover direct rows and bundled rows with focused tests.
+- Update the host-facing docs and coordination ledger.
+
+## Mechanism
+
+The adapter continues to normalize source rows through the existing campaign
+opportunity path. New commercial row shapes only affect source discovery and
+source-type inference:
+
+- bundle collections: contracts, contract notes, renewals, renewal notes,
+  subscriptions, and subscription notes
+- identifier fields: contract id, renewal id, and subscription id
+- inferred types: contract, renewal, and subscription
+
+Text extraction, evidence shaping, parent metadata inheritance, warning
+behavior, and downstream opportunity normalization are unchanged.
+
+## Intentional
+
+- Contract, renewal, and subscription rows are source evidence, not separate
+  generation modes.
+- Review and transcript text still wins over commercial ids when both appear in
+  one row, preserving the existing source-type precedence.
+- Existing CRM deal and CRM note behavior stays unchanged.
+
+## Deferred
+
+- No new packaged example file is added in this slice. Existing tests cover the
+  bundle shape without expanding the starter data surface.
+- No database import schema changes are needed because the source adapter emits
+  the existing normalized opportunity payload.
+- No UI changes are included; this is host ingestion support only.
+
+## Verification
+
+- Focused source-adapter tests cover direct contract, renewal, and subscription
+  rows plus a bundled renewal export.
+- Python compile and diff checks cover the changed adapter and tests.
+- Local PR review covers repository policy checks before the branch is pushed.
+
+### Files Touched
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-Renewal-Source-Rows.md` | 80 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/README.md` | 25 |
+| `extracted_content_pipeline/STATUS.md` | 12 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 19 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 13 |
+| `tests/test_extracted_campaign_source_adapters.py` | 164 |
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Adapter keys and precedence comment | ~20 |
+| Tests | ~165 |
+| Docs and coordination | ~35 |
+| Plan doc | ~80 |
+| **Total** | ~315 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -288,6 +288,116 @@ def test_source_row_prefers_review_type_over_crm_deal_id() -> None:
     assert opportunity["source_type"] == "review"
 
 
+def test_source_row_maps_contract_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "contract_id": "contract-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "contract_end_date": "2026-07-01",
+        "summary": "The contract is up for renewal while Salesforce is in evaluation.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "contract-1"
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["contract_end_date"] == "2026-07-01"
+    assert opportunity["source_type"] == "contract"
+    assert opportunity["evidence"][0] == {
+        "text": "The contract is up for renewal while Salesforce is in evaluation.",
+        "source_id": "contract-1",
+        "source_type": "contract",
+    }
+
+
+def test_source_row_maps_renewal_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "renewal_id": "renewal-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "notes": "Renewal is blocked until attribution exports are resolved.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "renewal-1"
+    assert opportunity["source_type"] == "renewal"
+    assert opportunity["evidence"][0] == {
+        "text": "Renewal is blocked until attribution exports are resolved.",
+        "source_id": "renewal-1",
+        "source_type": "renewal",
+    }
+
+
+def test_source_row_maps_subscription_to_campaign_opportunity() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "subscription_id": "subscription-1",
+        "company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "message": "The team reduced seats after pricing changed.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "subscription-1"
+    assert opportunity["source_type"] == "subscription"
+    assert opportunity["evidence"][0] == {
+        "text": "The team reduced seats after pricing changed.",
+        "source_id": "subscription-1",
+        "source_type": "subscription",
+    }
+
+
+def test_source_row_prefers_review_type_over_contract_id() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "contract_id": "contract-1",
+        "review_text": "The reviewer called out implementation delays.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "contract-1"
+    assert opportunity["source_type"] == "review"
+
+
+def test_source_row_prefers_renewal_over_contract_id() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "renewal_id": "renewal-1",
+        "contract_id": "contract-1",
+        "summary": "Renewal approval is blocked on contract pricing proof.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "renewal-1"
+    assert opportunity["source_id"] == "renewal-1"
+    assert opportunity["source_type"] == "renewal"
+    assert opportunity["evidence"][0] == {
+        "text": "Renewal approval is blocked on contract pricing proof.",
+        "source_id": "renewal-1",
+        "source_type": "renewal",
+    }
+
+
+def test_source_row_prefers_renewal_over_subscription_id() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "renewal_id": "renewal-1",
+        "subscription_id": "subscription-1",
+        "message": "Renewal is at risk after the subscription seat reduction.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "renewal-1"
+    assert opportunity["source_type"] == "renewal"
+
+
+def test_source_row_prefers_note_type_over_subscription_context() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "note_id": "note-1",
+        "subscription_id": "subscription-1",
+        "notes": "CSM logged a subscription downgrade note.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "note-1"
+    assert opportunity["source_type"] == "crm_note"
+
+
 def test_source_row_prefers_scalar_text_over_thread_messages() -> None:
     opportunity, warnings = source_row_to_campaign_opportunity({
         "ticket_id": "ticket-thread-1",
@@ -616,6 +726,60 @@ def test_load_source_campaign_opportunities_from_crm_bundle(tmp_path: Path) -> N
         "text": "RevOps asked for proof on attribution exports.",
         "source_id": "note-1",
         "source_type": "crm_note",
+    }
+
+
+def test_load_source_campaign_opportunities_from_renewal_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "renewal_bundle.json"
+    path.write_text(
+        json.dumps({
+            "account_id": "acct-1",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "contracts": [
+                {
+                    "contract_id": "contract-1",
+                    "summary": "Contract renewal is due this quarter.",
+                }
+            ],
+            "renewal_notes": [
+                {
+                    "renewal_id": "renewal-1",
+                    "notes": "Procurement asked for proof before renewal approval.",
+                }
+            ],
+            "subscriptions": [
+                {
+                    "subscription_id": "subscription-1",
+                    "message": "Seat count dropped after the new pricing tier.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "contract-1",
+        "renewal-1",
+        "subscription-1",
+    ]
+    assert [row["source_type"] for row in loaded.opportunities] == [
+        "contract",
+        "renewal",
+        "subscription",
+    ]
+    assert [row["company_name"] for row in loaded.opportunities] == [
+        "Acme Logistics",
+        "Acme Logistics",
+        "Acme Logistics",
+    ]
+    assert loaded.opportunities[0]["account_id"] == "acct-1"
+    assert loaded.opportunities[2]["evidence"][0] == {
+        "text": "Seat count dropped after the new pricing tier.",
+        "source_id": "subscription-1",
+        "source_type": "subscription",
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Renewal-Source-Rows.md

## Summary
- add contract, renewal, and subscription source-row keys
- infer contract, renewal, and subscription source types
- document commercial lifecycle source-row support

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py
- git diff --check
- bash scripts/local_pr_review.sh