### PR TITLE
Report Content Ops reasoning capabilities

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -45,6 +45,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - DB reasoning context hosted admin list/upsert API.
 - DB reasoning context scoped delete/retire API.
 - DB reasoning context admin visibility events.
+- Campaign operations status reasoning-provider capability check.
 
 ## Active Backlog
 
@@ -66,9 +67,9 @@ Remaining work:
 - Per-content-type opt-in rules so simple assets avoid heavy reasoning paths
   while long-form assets can use stateful reasoning.
 
-**Likely slice:** start with a narrow source-bundle adapter or a small
-reasoning-provider capability check that directly improves host setup, rather
-than a broad architecture refactor.
+**Likely slice:** continue with narrow source-bundle adapters or a focused
+reasoning-provider setup improvement, rather than a broad architecture
+refactor.
 
 ## Current Pick Recommendation
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T00:35Z by codex-2026-05-15
+Last updated: 2026-05-16T04:29Z by codex-2026-05-15
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops renewal source rows | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Renewal-Source-Rows.md` | codex-2026-05-15 | Avoid source-row adapter taxonomy edits |
+| draft | Content Ops reasoning capability check | `extracted_content_pipeline/api/campaign_operations.py`, `tests/test_extracted_campaign_api_operations.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Reasoning-Capability-Check.md` | codex-2026-05-15 | Avoid campaign operations status/readiness edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -128,10 +128,11 @@ source of truth for what remains.
   packaged single-pass reasoning provider through config when LLM and skill
   providers are injected. The router also exposes `GET
   /campaigns/operations/status` for admin dashboards to inspect database
-  availability, provider presence, feature readiness, and configured limits
-  without exposing credentials. Hosts can inject a `VisibilitySink` provider
-  so operation triggers emit best-effort start/completed/failed telemetry
-  without making dashboard storage a product dependency.
+  availability, provider presence, feature readiness, configured limits, and
+  per-mode reasoning capability readiness with active-mode and missing-input
+  signals without exposing credentials. Hosts can inject a `VisibilitySink`
+  provider so operation triggers emit best-effort start/completed/failed
+  telemetry without making dashboard storage a product dependency.
 - `content_ops_execution` provides the host-injected execution seam for
   runnable AI Content Ops control-surface plans. It dispatches executable
   outputs to configured campaign, blog-post, report, landing-page, and

--- a/extracted_content_pipeline/api/campaign_operations.py
+++ b/extracted_content_pipeline/api/campaign_operations.py
@@ -490,12 +490,67 @@ def _operation_readiness(
             "single_pass_ready": single_pass_ready,
             "multi_pass_configured": bool(config.generation_multi_pass_reasoning),
             "multi_pass_ready": multi_pass_ready,
+            "capabilities": _reasoning_capabilities(
+                active_mode=reasoning_mode,
+                explicit_provider=explicit_reasoning,
+                single_pass_configured=bool(config.generation_single_pass_reasoning),
+                multi_pass_configured=bool(config.generation_multi_pass_reasoning),
+                llm_configured=llm_configured,
+                skills_configured=skills_configured,
+            ),
         },
         "features": {
             "draft_generation": generation_ready,
             "send_queued": database_available and sender_provider is not None,
             "sequence_progression": sequence_ready,
             "analytics_refresh": database_available,
+        },
+    }
+
+
+def _reasoning_capabilities(
+    *,
+    active_mode: str,
+    explicit_provider: bool,
+    single_pass_configured: bool,
+    multi_pass_configured: bool,
+    llm_configured: bool,
+    skills_configured: bool,
+) -> dict[str, Any]:
+    """Return host-facing readiness for each supported reasoning mode."""
+
+    single_missing = []
+    if not llm_configured:
+        single_missing.append("llm")
+    if not skills_configured:
+        single_missing.append("skills")
+    multi_missing = [] if llm_configured else ["llm"]
+    return {
+        "explicit_provider": {
+            "configured": explicit_provider,
+            "ready": explicit_provider,
+            "active": active_mode == "explicit_provider",
+            "missing": [] if explicit_provider else ["reasoning_provider"],
+        },
+        "single_pass": {
+            "configured": single_pass_configured,
+            "ready": single_pass_configured and not single_missing,
+            "active": active_mode == "single_pass",
+            "missing": (
+                single_missing
+                if single_pass_configured
+                else ["generation_single_pass_reasoning"]
+            ),
+        },
+        "multi_pass": {
+            "configured": multi_pass_configured,
+            "ready": multi_pass_configured and not multi_missing,
+            "active": active_mode == "multi_pass",
+            "missing": (
+                multi_missing
+                if multi_pass_configured
+                else ["generation_multi_pass_reasoning"]
+            ),
         },
     }
 

--- a/plans/PR-Content-Ops-Reasoning-Capability-Check.md
+++ b/plans/PR-Content-Ops-Reasoning-Capability-Check.md
@@ -1,0 +1,78 @@
+# Content Ops Reasoning Capability Check
+
+## Why This Slice Exists
+
+AI Content Ops can now consume explicit, single-pass, and multi-pass reasoning
+providers. The hosted operations status endpoint already reports whether those
+paths are configured, but hosts still have to infer the missing runtime
+requirements from several flat booleans.
+
+This slice makes the existing status endpoint a clearer host setup check by
+reporting per-mode reasoning capability readiness.
+
+## Scope
+
+- Add a nested reasoning capability report to campaign operations status.
+- Report whether explicit, single-pass, and multi-pass modes are configured.
+- Report whether each configured mode is runnable.
+- Report missing config flags or runtime requirements for unavailable modes.
+- Mark which ready mode is active after precedence is applied.
+- Keep generation readiness behavior unchanged.
+
+## Mechanism
+
+The router still uses provider presence as the readiness source of truth:
+
+- explicit provider readiness requires an injected reasoning provider
+- single-pass readiness requires the config flag plus LLM and skill providers
+- multi-pass readiness requires the config flag plus an LLM provider
+
+The new `reasoning.capabilities` object mirrors those rules so admin UIs and
+host smoke checks can show the operator exactly what is missing. It also marks
+the active mode so consumers do not have to reimplement precedence.
+
+## Intentional
+
+- No provider handles are opened by the status endpoint.
+- No LLM, skill, or reasoning provider calls are made.
+- Existing `reasoning.mode`, `single_pass_ready`, and `multi_pass_ready` fields
+  remain in place for compatibility.
+- Explicit providers still take precedence over packaged single-pass or
+  multi-pass config when deciding the active mode.
+
+## Deferred
+
+- No standalone CLI is added in this slice; the hosted status endpoint is the
+  lowest-conflict capability surface already used by host installs.
+- No UI changes are included; the response contract is ready for a later admin
+  display pass.
+- No deeper reasoning-core health check is added because that would require
+  invoking host LLM/provider dependencies.
+
+## Verification
+
+- Campaign operations API tests cover explicit, single-pass, and multi-pass
+  capability payloads.
+- Focused tests verify generation readiness still follows the existing rules.
+- Python compile, diff, and local PR review checks cover the modified files.
+
+### Files Touched
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-Reasoning-Capability-Check.md` | 78 |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | 7 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/STATUS.md` | 10 |
+| `extracted_content_pipeline/api/campaign_operations.py` | 55 |
+| `tests/test_extracted_campaign_api_operations.py` | 54 |
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Status capability helper | ~55 |
+| Tests | ~54 |
+| Docs and coordination | ~21 |
+| Plan doc | ~78 |
+| **Total** | ~207 |

--- a/tests/test_extracted_campaign_api_operations.py
+++ b/tests/test_extracted_campaign_api_operations.py
@@ -122,6 +122,25 @@ def _client(
     return TestClient(app)
 
 
+def _reasoning_capabilities(
+    *,
+    active_mode: str = "none",
+    explicit_provider: bool = False,
+    single_pass_configured: bool = False,
+    multi_pass_configured: bool = False,
+    llm_configured: bool = False,
+    skills_configured: bool = False,
+) -> dict[str, Any]:
+    return operations_api._reasoning_capabilities(
+        active_mode=active_mode,
+        explicit_provider=explicit_provider,
+        single_pass_configured=single_pass_configured,
+        multi_pass_configured=multi_pass_configured,
+        llm_configured=llm_configured,
+        skills_configured=skills_configured,
+    )
+
+
 def test_campaign_operations_router_generates_campaign_drafts(monkeypatch) -> None:
     pool = _Pool()
     llm = _LLM()
@@ -391,6 +410,12 @@ def test_campaign_operations_router_reports_status() -> None:
             "single_pass_ready": False,
             "multi_pass_configured": False,
             "multi_pass_ready": False,
+            "capabilities": _reasoning_capabilities(
+                active_mode="explicit_provider",
+                explicit_provider=True,
+                llm_configured=True,
+                skills_configured=True,
+            ),
         },
         "features": {
             "draft_generation": True,
@@ -452,6 +477,10 @@ def test_campaign_operations_router_status_reports_single_pass_readiness() -> No
         "single_pass_ready": False,
         "multi_pass_configured": False,
         "multi_pass_ready": False,
+        "capabilities": _reasoning_capabilities(
+            active_mode="single_pass",
+            single_pass_configured=True,
+        ),
     }
     assert payload["features"]["draft_generation"] is False
 
@@ -472,6 +501,12 @@ def test_campaign_operations_router_status_marks_single_pass_ready() -> None:
         "single_pass_ready": True,
         "multi_pass_configured": False,
         "multi_pass_ready": False,
+        "capabilities": _reasoning_capabilities(
+            active_mode="single_pass",
+            single_pass_configured=True,
+            llm_configured=True,
+            skills_configured=True,
+        ),
     }
     assert payload["features"]["draft_generation"] is True
 
@@ -491,6 +526,11 @@ def test_campaign_operations_router_status_treats_explicit_reasoning_as_ready() 
         "single_pass_ready": False,
         "multi_pass_configured": False,
         "multi_pass_ready": False,
+        "capabilities": _reasoning_capabilities(
+            active_mode="explicit_provider",
+            explicit_provider=True,
+            single_pass_configured=True,
+        ),
     }
     assert payload["features"]["draft_generation"] is True
 
@@ -1409,6 +1449,10 @@ def test_campaign_operations_router_status_reports_multi_pass_readiness() -> Non
         "single_pass_ready": False,
         "multi_pass_configured": True,
         "multi_pass_ready": False,
+        "capabilities": _reasoning_capabilities(
+            active_mode="multi_pass",
+            multi_pass_configured=True,
+        ),
     }
     # Configured but no LLM provider -> draft_generation gated off.
     assert payload["features"]["draft_generation"] is False
@@ -1429,6 +1473,11 @@ def test_campaign_operations_router_status_marks_multi_pass_ready() -> None:
         "single_pass_ready": False,
         "multi_pass_configured": True,
         "multi_pass_ready": True,
+        "capabilities": _reasoning_capabilities(
+            active_mode="multi_pass",
+            multi_pass_configured=True,
+            llm_configured=True,
+        ),
     }
     # Multi-pass needs LLM only (no SkillStore required) -> ready when LLM
     # provider is wired, even without skills.
@@ -1452,6 +1501,11 @@ def test_campaign_operations_router_status_explicit_provider_beats_multi_pass() 
         "single_pass_ready": False,
         "multi_pass_configured": True,
         "multi_pass_ready": False,
+        "capabilities": _reasoning_capabilities(
+            active_mode="explicit_provider",
+            explicit_provider=True,
+            multi_pass_configured=True,
+        ),
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Capability-Check.md

## Summary
- add per-mode reasoning capability readiness to campaign operations status
- report missing requirements for configured single-pass and multi-pass reasoning
- update AI Content Ops status/backlog and coordination docs

## Verification
- pytest tests/test_extracted_campaign_api_operations.py -q
- python -m py_compile extracted_content_pipeline/api/campaign_operations.py tests/test_extracted_campaign_api_operations.py
- git diff --check
- bash scripts/local_pr_review.sh