### PR TITLE
Surface Content Ops reasoning capability status

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -161,6 +161,29 @@
   ],
   "reasoning": {
     "configured": true,
-    "source": "db"
+    "source": "db",
+    "capabilities": {
+      "explicit_provider": {
+        "configured": true,
+        "ready": true,
+        "active": true
+      },
+      "single_pass": {
+        "configured": false,
+        "ready": false,
+        "active": false,
+        "missing": [
+          "generation_single_pass_reasoning"
+        ]
+      },
+      "multi_pass": {
+        "configured": false,
+        "ready": false,
+        "active": false,
+        "missing": [
+          "generation_multi_pass_reasoning"
+        ]
+      }
+    }
   }
 }

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -75,9 +75,18 @@ export interface ContentOpsCatalogResponse {
     source?: 'db' | 'file' | 'none' | string
     modes?: Array<string | number | boolean>
     packs?: Array<string | number | boolean>
-    capabilities?: Array<string | number | boolean>
+    capabilities?:
+      | Array<string | number | boolean>
+      | Record<string, ContentOpsReasoningCapabilityStatus>
   }
   ingestion_profiles: string[]
+}
+
+export interface ContentOpsReasoningCapabilityStatus {
+  configured?: boolean
+  ready?: boolean
+  active?: boolean
+  missing?: string[]
 }
 
 // POST /content-ops/preview, /plan, /execute share this body shape.

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -32,6 +32,7 @@ import type {
   GenerationPlan,
   GenerationPlanStep,
   OutputDefinitionView,
+  ReasoningCapabilityStatus,
 } from './types'
 
 // ---------------------------------------------------------------------------
@@ -81,7 +82,7 @@ export function fromWireCatalog(
       source: wire.reasoning.source,
       modes: copyScalarList(wire.reasoning.modes),
       packs: copyScalarList(wire.reasoning.packs),
-      capabilities: copyScalarList(wire.reasoning.capabilities),
+      capabilities: copyReasoningCapabilities(wire.reasoning.capabilities),
     },
     ingestionProfiles: [...wire.ingestion_profiles],
   }
@@ -91,6 +92,28 @@ function copyScalarList(
   value: Array<string | number | boolean> | undefined,
 ): Array<string | number | boolean> | undefined {
   return value ? [...value] : undefined
+}
+
+function copyReasoningCapabilities(
+  value:
+    | Array<string | number | boolean>
+    | Record<string, ReasoningCapabilityStatus>
+    | undefined,
+):
+  | Array<string | number | boolean>
+  | Record<string, ReasoningCapabilityStatus>
+  | undefined {
+  if (!value) return undefined
+  if (Array.isArray(value)) return [...value]
+  return Object.fromEntries(
+    Object.entries(value).map(([key, status]) => [
+      key,
+      {
+        ...status,
+        missing: status.missing ? [...status.missing] : undefined,
+      },
+    ]),
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -54,9 +54,18 @@ export interface ContentOpsCatalog {
     source?: 'db' | 'file' | 'none' | string
     modes?: Array<string | number | boolean>
     packs?: Array<string | number | boolean>
-    capabilities?: Array<string | number | boolean>
+    capabilities?:
+      | Array<string | number | boolean>
+      | Record<string, ReasoningCapabilityStatus>
   }
   ingestionProfiles: string[]
+}
+
+export interface ReasoningCapabilityStatus {
+  configured?: boolean
+  ready?: boolean
+  active?: boolean
+  missing?: string[]
 }
 
 // ---------------------------------------------------------------------------

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1330,7 +1330,7 @@ function reasoningStatusHint(
   const values = [
     ...(reasoning.modes ?? []),
     ...(reasoning.packs ?? []),
-    ...(reasoning.capabilities ?? []),
+    ...reasoningCapabilityValues(reasoning.capabilities),
   ]
     .map((value) => String(value).trim())
     .filter(Boolean)
@@ -1340,6 +1340,27 @@ function reasoningStatusHint(
   const suffix = values.length > shown.length ? ` +${values.length - shown.length} more` : ''
   const hint = `${shown.join(', ')}${suffix}`
   return hint.length > 42 ? `(${values.length} capabilities)` : `(${hint})`
+}
+
+function reasoningCapabilityValues(
+  capabilities: ContentOpsCatalog['reasoning']['capabilities'],
+): string[] {
+  if (!capabilities) return []
+  if (Array.isArray(capabilities)) {
+    return capabilities.map((value) => String(value))
+  }
+  return Object.entries(capabilities)
+    .map(([name, status]) => {
+      const label = name.replace(/_/g, ' ')
+      if (status.active && status.ready) return `${label} active`
+      if (status.ready) return `${label} ready`
+      if (status.configured) {
+        const missing = status.missing?.filter(Boolean).join('/')
+        return missing ? `${label} missing ${missing}` : `${label} configured`
+      }
+      return ''
+    })
+    .filter(Boolean)
 }
 
 function SignalExtractionSummary({ result }: { result: Record<string, unknown> }) {

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T04:29Z by codex-2026-05-15
+Last updated: 2026-05-16T05:25Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| draft | Content Ops reasoning capability check | `extracted_content_pipeline/api/campaign_operations.py`, `tests/test_extracted_campaign_api_operations.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Reasoning-Capability-Check.md` | codex-2026-05-15 | Avoid campaign operations status/readiness edits |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -386,6 +386,13 @@ def _sanitize_reasoning_status(
         item = status[key]
         if key == "configured" or item is None:
             continue
+        if key == "capabilities" and isinstance(item, Mapping):
+            capabilities = _sanitize_reasoning_capabilities(item)
+            if capabilities:
+                status[key] = capabilities
+                continue
+            status.pop(key)
+            continue
         if _is_status_scalar(item):
             continue
         scalar_items = _clean_status_scalar_sequence(item)
@@ -394,6 +401,28 @@ def _sanitize_reasoning_status(
             continue
         status.pop(key)
     return status
+
+
+def _sanitize_reasoning_capabilities(value: Mapping[str, Any]) -> dict[str, Any]:
+    capabilities: dict[str, Any] = {}
+    for name, raw_status in value.items():
+        capability_name = _clean(name)
+        if not capability_name or not isinstance(raw_status, Mapping):
+            continue
+        item: dict[str, Any] = {}
+        for flag in ("configured", "ready", "active"):
+            if flag in raw_status:
+                item[flag] = bool(raw_status.get(flag))
+        missing = [
+            str(entry).strip()
+            for entry in _clean_status_scalar_sequence(raw_status.get("missing"))
+            if str(entry).strip()
+        ]
+        if missing:
+            item["missing"] = missing
+        if item:
+            capabilities[capability_name] = item
+    return capabilities
 
 
 def _clean_status_scalar_sequence(value: Any) -> list[str | int | float | bool]:

--- a/plans/PR-Content-Ops-Reasoning-Capability-UI-Parity.md
+++ b/plans/PR-Content-Ops-Reasoning-Capability-UI-Parity.md
@@ -1,0 +1,78 @@
+# Content Ops Reasoning Capability UI Parity
+
+## Goal
+
+Expose the per-mode reasoning capability readiness shape through the
+`/content-ops/control-surfaces` catalog and render it cleanly in the New Run
+screen. PR #545 added the detailed shape to campaign operations status; this
+slice makes the existing Content Ops catalog path preserve and display the same
+contract instead of reducing it to scalar-only hints.
+
+## Why this slice exists
+
+The Content Ops UI reads `/content-ops/control-surfaces`, not
+`/campaigns/operations/status`. Without this slice, hosts can expose detailed
+reasoning capability readiness through campaign operations while the New Run
+screen only sees a coarse configured flag or scalar hints.
+
+## Scope
+
+- Preserve nested `reasoning.capabilities` readiness maps in the control-surface
+  reasoning status sanitizer.
+- Keep legacy scalar capability lists supported for hosts that already pass
+  simple strings.
+- Update frontend wire/domain types and the Content Ops New Run reasoning hint
+  to summarize object-shaped capabilities.
+- Update the canonical catalog fixture so TypeScript contract checks cover the
+  object shape.
+
+## Mechanism
+
+- Add a narrow sanitizer branch for object-shaped `reasoning.capabilities`.
+- Keep the existing scalar-list sanitizer for legacy capability hints.
+- Type `reasoning.capabilities` as either a scalar list or a per-mode status map.
+- Summarize active/ready/configured capability statuses in the New Run badge.
+
+## Intentional
+
+- No frontend call to campaign operations status; the catalog remains the
+  screen's single readiness source.
+- Unknown nested capability fields are dropped by the API sanitizer.
+- Legacy scalar capability arrays remain valid.
+
+## Deferred
+
+- Adding a new frontend request to `/campaigns/operations/status`.
+- Changing campaign operations readiness logic.
+- Changing execution behavior or provider wiring.
+
+## Verification
+
+- Focused control-surface API tests.
+- Atlas Intel UI production build.
+- Local PR review wrapper.
+
+### Files Touched
+
+| File | LOC |
+|---|---:|
+| `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json` | 25 |
+| `atlas-intel-ui/src/api/contentOps.ts` | 11 |
+| `atlas-intel-ui/src/domain/contentOps/fromWire.ts` | 28 |
+| `atlas-intel-ui/src/domain/contentOps/types.ts` | 11 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 23 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| `extracted_content_pipeline/api/control_surfaces.py` | 29 |
+| `plans/PR-Content-Ops-Reasoning-Capability-UI-Parity.md` | 78 |
+| `tests/test_extracted_content_control_surface_api.py` | 47 |
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Backend sanitizer | ~29 |
+| Backend tests | ~47 |
+| Frontend wire/domain/page and fixture | ~98 |
+| Coordination | ~2 |
+| Plan doc | ~78 |
+| **Total** | ~253 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -161,6 +161,53 @@ async def test_describe_control_surfaces_sanitizes_reasoning_status_lists():
 
 
 @pytest.mark.asyncio
+async def test_describe_control_surfaces_preserves_reasoning_capability_statuses():
+    router = create_content_ops_control_surface_router(
+        reasoning_context_provider=lambda: object(),
+        reasoning_status_provider=lambda: {
+            "configured": True,
+            "capabilities": {
+                "explicit_provider": {
+                    "configured": False,
+                    "ready": False,
+                    "active": False,
+                    "missing": ["reasoning_provider"],
+                    "unsafe": {"nested": "value"},
+                },
+                "multi_pass": {
+                    "configured": True,
+                    "ready": True,
+                    "active": True,
+                    "missing": [],
+                },
+                "bad": {"missing": [{"nested": "value"}]},
+                "": {"ready": True},
+            },
+        },
+    )
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    assert payload["reasoning"] == {
+        "configured": True,
+        "capabilities": {
+            "explicit_provider": {
+                "configured": False,
+                "ready": False,
+                "active": False,
+                "missing": ["reasoning_provider"],
+            },
+            "multi_pass": {
+                "configured": True,
+                "ready": True,
+                "active": True,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_describe_control_surfaces_caps_reasoning_status_lists():
     router = create_content_ops_control_surface_router(
         reasoning_context_provider=lambda: object(),


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Capability-UI-Parity.md

## Summary
- Preserve object-shaped `reasoning.capabilities` in the Content Ops control-surface status sanitizer.
- Update Atlas Intel wire/domain types and the New Run reasoning badge to render per-mode capability readiness.
- Refresh the catalog fixture and add backend regression coverage for sanitized capability maps.

## Verification
- pytest tests/test_extracted_content_control_surface_api.py -q
- npm run build (atlas-intel-ui)
- bash scripts/local_pr_review.sh

## Coordination
- Claimed in docs/extraction/coordination/inflight.md.
- No campaign operations readiness behavior changes.