### PR TITLE
Support Content Ops source-row field aliases

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -212,6 +212,9 @@ Rows with `deal_id` or `opportunity_id` are treated as CRM deal evidence; rows
 with `note_id` or `activity_id` are treated as CRM note evidence.
 Rows with `contract_id`, `renewal_id`, or `subscription_id` are treated as
 contract, renewal, or subscription evidence.
+Source-row keys are matched leniently for common export labels, so `Ticket ID`,
+`Account Name`, `Pain Category`, and `Open Ended Response` normalize like
+`ticket_id`, `account_name`, `pain_category`, and `open_ended_response`.
 
 Generate cold-email and follow-up drafts for each opportunity by passing
 channels:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -48,7 +48,9 @@ source of truth for what remains.
   `examples/campaign_source_bundle.json` provide packaged starter inputs.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not
-  available as one scalar field.
+  available as one scalar field. Source-row field labels are matched leniently
+  for common CSV/export variants such as `Ticket ID`, `Account Name`,
+  `Pain Category`, and `Open Ended Response`.
 - `signal_extraction` exposes source-row normalization as a runnable AI Content
   Ops output. It converts inline source material into normalized opportunities
   without LLM, database, or Atlas dependencies.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 import csv
 import json
 from pathlib import Path
+import re
 from typing import Any, Literal
 
 from .campaign_customer_data import (
@@ -124,6 +125,26 @@ _SOURCE_TITLE_KEYS = ("source_title", "ticket_subject", "subject", "title", "nam
 _SOURCE_TITLE_COLLISION_KEYS = ("subject", "ticket_subject", "title", "name")
 _PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
 _PARENT_EXCLUDE_KEYS = set(_ROW_LIST_KEYS) | set(_SOURCE_TITLE_COLLISION_KEYS)
+_COMPANY_KEYS = (
+    "company_name",
+    "company",
+    "account_name",
+    "reviewer_company",
+    "customer_name",
+)
+_VENDOR_KEYS = (
+    "vendor_name",
+    "vendor",
+    "incumbent_vendor",
+    "current_vendor",
+    "product_name",
+)
+_CONTACT_NAME_KEYS = ("contact_name", "recipient_name", "person_name")
+_CONTACT_EMAIL_KEYS = ("contact_email", "recipient_email", "email")
+_CONTACT_TITLE_KEYS = ("contact_title", "recipient_title", "job_title")
+_NPS_SCORE_KEYS = ("nps_score", "nps")
+_CSAT_SCORE_KEYS = ("csat_score", "csat")
+_FIELD_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
 _MAX_BUNDLE_DEPTH = 8
 
 
@@ -216,6 +237,13 @@ def source_row_to_campaign_opportunity(
         for key, value in row.items()
         if value not in (None, "", [], {}) and key not in _SOURCE_TITLE_COLLISION_KEYS
     }
+    _copy_alias_text(opportunity, row, "company_name", _COMPANY_KEYS)
+    _copy_alias_text(opportunity, row, "vendor_name", _VENDOR_KEYS)
+    _copy_alias_text(opportunity, row, "contact_name", _CONTACT_NAME_KEYS)
+    _copy_alias_text(opportunity, row, "contact_email", _CONTACT_EMAIL_KEYS)
+    _copy_alias_text(opportunity, row, "contact_title", _CONTACT_TITLE_KEYS)
+    _copy_alias_value(opportunity, row, "nps_score", _NPS_SCORE_KEYS)
+    _copy_alias_value(opportunity, row, "csat_score", _CSAT_SCORE_KEYS)
     if source_title:
         opportunity["source_title"] = source_title
     if source_id and "source_id" not in opportunity:
@@ -272,7 +300,7 @@ def _source_rows_from_bundle(
     }
     rows: list[Any] = []
     for key in _ROW_LIST_KEYS:
-        value = bundle.get(key)
+        value = _field_value(bundle, key)
         if isinstance(value, Mapping):
             rows.extend(_source_rows_from_bundle(
                 value,
@@ -375,7 +403,7 @@ def _source_evidence(
 
 def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
     for key in keys:
-        text = str(row.get(key) or "").strip()
+        text = str(_field_value(row, key) or "").strip()
         if text:
             return text
     return ""
@@ -429,7 +457,7 @@ def _thread_line(item: Any) -> str:
 
 def _first_text_list(row: Mapping[str, Any], keys: Sequence[str]) -> list[str]:
     for key in keys:
-        value = row.get(key)
+        value = _field_value(row, key)
         values = _text_list(value)
         if values:
             return values
@@ -454,41 +482,99 @@ def _text_list(value: Any) -> list[str]:
 
 
 def _infer_source_type(row: Mapping[str, Any]) -> str:
-    if row.get("review_text") is not None:
+    if _has_field_value(row, ("review_text",)):
         return "review"
-    if row.get("transcript") is not None:
+    if _has_field_value(row, ("transcript",)):
         return "transcript"
-    if row.get("call_id") is not None or row.get("recording_id") is not None:
+    if _has_field_value(row, ("call_id", "recording_id")):
         return "sales_call"
-    if row.get("meeting_id") is not None:
+    if _has_field_value(row, ("meeting_id",)):
         return "meeting"
-    if row.get("deal_id") is not None or row.get("opportunity_id") is not None:
+    if _has_field_value(row, ("deal_id", "opportunity_id")):
         return "crm_deal"
-    if row.get("note_id") is not None or row.get("activity_id") is not None:
+    if _has_field_value(row, ("note_id", "activity_id")):
         return "crm_note"
     # Notes stay typed as notes even when attached to a contract, renewal, or
     # subscription export; the lifecycle id is context, not the evidence row.
-    if row.get("renewal_id") is not None:
+    if _has_field_value(row, ("renewal_id",)):
         return "renewal"
-    if row.get("contract_id") is not None:
+    if _has_field_value(row, ("contract_id",)):
         return "contract"
-    if row.get("subscription_id") is not None:
+    if _has_field_value(row, ("subscription_id",)):
         return "subscription"
-    if row.get("complaint") is not None:
+    if _has_field_value(row, ("complaint",)):
         return "complaint"
-    if row.get("ticket_id") is not None:
+    if _has_field_value(row, ("ticket_id",)):
         return "support_ticket"
-    if row.get("case_id") is not None:
+    if _has_field_value(row, ("case_id",)):
         return "case"
-    if row.get("conversation_id") is not None:
+    if _has_field_value(row, ("conversation_id",)):
         return "conversation"
-    if row.get("nps_score") is not None or row.get("nps") is not None:
+    if _has_field_value(row, ("nps_score", "nps")):
         return "nps_response"
-    if row.get("csat_score") is not None or row.get("csat") is not None:
+    if _has_field_value(row, ("csat_score", "csat")):
         return "csat_response"
-    if row.get("survey_id") is not None or row.get("response_id") is not None:
+    if _has_field_value(row, ("survey_id", "response_id")):
         return "survey_response"
     return "document"
+
+
+def _copy_alias_text(
+    opportunity: dict[str, Any],
+    row: Mapping[str, Any],
+    canonical_key: str,
+    keys: Sequence[str],
+) -> None:
+    if opportunity.get(canonical_key):
+        return
+    text = _first_text(row, keys)
+    if text:
+        opportunity[canonical_key] = text
+
+
+def _copy_alias_value(
+    opportunity: dict[str, Any],
+    row: Mapping[str, Any],
+    canonical_key: str,
+    keys: Sequence[str],
+) -> None:
+    if opportunity.get(canonical_key) not in (None, "", [], {}):
+        return
+    for key in keys:
+        value = _field_value(row, key)
+        if value not in (None, "", [], {}):
+            opportunity[canonical_key] = value
+            return
+
+
+def _field_value(row: Mapping[str, Any], key: str) -> Any:
+    if key in row:
+        return row.get(key)
+    normalized = _normalized_field_key(key)
+    compact = _compact_field_key(key)
+    for raw_key, value in row.items():
+        raw_text = str(raw_key)
+        if (
+            _normalized_field_key(raw_text) == normalized
+            or _compact_field_key(raw_text) == compact
+        ):
+            return value
+    return None
+
+
+def _has_field_value(row: Mapping[str, Any], keys: Sequence[str]) -> bool:
+    for key in keys:
+        if _field_value(row, key) not in (None, "", [], {}):
+            return True
+    return False
+
+
+def _normalized_field_key(key: str) -> str:
+    return _FIELD_SEPARATOR_RE.sub("_", key.strip().lower()).strip("_")
+
+
+def _compact_field_key(key: str) -> str:
+    return _FIELD_SEPARATOR_RE.sub("", key.strip().lower())
 
 
 __all__ = [

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -205,6 +205,9 @@ Rows with `deal_id` or `opportunity_id` are inferred as CRM deal evidence; rows
 with `note_id` or `activity_id` are inferred as CRM note evidence.
 Rows with `contract_id`, `renewal_id`, or `subscription_id` are inferred as
 contract, renewal, or subscription evidence.
+Source-row field labels are matched leniently for case, spaces, dashes, and
+underscores. A CSV export with `Ticket ID`, `Account Name`, `Pain Category`, or
+`Open Ended Response` can load without first renaming those columns.
 
 When a source export includes more than one source-text field, the adapter uses
 the first recognized field in this order: `text`, `review_text`, `transcript`,

--- a/plans/PR-Content-Ops-Source-Field-Aliases.md
+++ b/plans/PR-Content-Ops-Source-Field-Aliases.md
@@ -1,0 +1,63 @@
+# PR: Content Ops Source Field Aliases
+
+## Why this slice exists
+
+AI Content Ops source adapters support reviews, calls, CRM rows, tickets,
+surveys, renewals, and bundles, but the row-key lookup is exact. Real host CSV
+and JSON exports commonly use labels such as "Ticket ID", "Account Name",
+"Pain Category", and "Open Ended Response". Those rows should enter the same
+source-to-opportunity path without host-side pre-renaming.
+
+## Scope
+
+1. Add tolerant source-row key lookup for case, spacing, dash, and underscore
+   differences.
+2. Canonicalize common buyer/vendor/contact fields inside the source adapter
+   before the existing opportunity normalizer runs.
+3. Add focused tests for ticket and survey/provider-style field labels.
+4. Refresh host-facing docs and coordination state.
+
+## Mechanism
+
+The source adapter will keep exact-key precedence, then fall back to normalized
+key comparisons. Normalization is local to source-row ingestion and does not
+change the general customer-opportunity adapter.
+
+## Intentional
+
+- No new source format.
+- No provider API clients.
+- No database, generation, or prompt changes.
+- No change to the normalized campaign opportunity contract.
+
+## Deferred
+
+- Provider-specific importers for Salesforce, HubSpot, Zendesk, Intercom, or
+  Gong exports.
+- Complex nested object flattening beyond the existing source-bundle path.
+
+## Verification
+
+- Run the focused source-adapter tests.
+- Compile the touched Python files.
+- Run the local PR review script.
+- Run diff whitespace checks.
+
+### Files Touched
+
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `plans/PR-Content-Ops-Source-Field-Aliases.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source adapter | ~125 |
+| Tests | ~80 |
+| Docs and coordination | ~40 |
+| Plan doc | ~55 |
+| **Total** | ~300 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -113,6 +113,30 @@ def test_source_row_maps_support_ticket_to_campaign_opportunity() -> None:
     }]
 
 
+def test_source_row_accepts_provider_style_ticket_field_labels() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "Ticket ID": "ticket-1",
+        "Account Name": "Acme Logistics",
+        "Vendor Name": "HubSpot",
+        "Subject": "Renewal pricing escalation",
+        "Description": "The renewal quote jumped before the team could export reports.",
+        "Pain Category": "pricing pressure",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "ticket-1"
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["vendor_name"] == "HubSpot"
+    assert opportunity["source_title"] == "Renewal pricing escalation"
+    assert opportunity["pain_points"] == ["pricing pressure"]
+    assert opportunity["evidence"] == [{
+        "text": "The renewal quote jumped before the team could export reports.",
+        "source_id": "ticket-1",
+        "source_type": "support_ticket",
+        "source_title": "Renewal pricing escalation",
+    }]
+
+
 def test_source_row_prefers_body_over_ticket_message() -> None:
     opportunity, warnings = source_row_to_campaign_opportunity({
         "ticket_id": "ticket-1",
@@ -434,6 +458,28 @@ def test_source_row_maps_nps_feedback_to_campaign_opportunity() -> None:
     }]
 
 
+def test_source_row_accepts_provider_style_survey_field_labels() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "Response ID": "survey-1",
+        "Company": "Beta Retail",
+        "Vendor": "Zendesk",
+        "NPS Score": "4",
+        "Open Ended Response": "Support takes too long and we are comparing Intercom.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "survey-1"
+    assert opportunity["company_name"] == "Beta Retail"
+    assert opportunity["vendor_name"] == "Zendesk"
+    assert opportunity["nps_score"] == "4"
+    assert opportunity["source_type"] == "nps_response"
+    assert opportunity["evidence"] == [{
+        "text": "Support takes too long and we are comparing Intercom.",
+        "source_id": "survey-1",
+        "source_type": "nps_response",
+    }]
+
+
 def test_source_row_prefers_nps_over_csat_when_both_scores_exist() -> None:
     opportunity, warnings = source_row_to_campaign_opportunity({
         "response_id": "survey-1",
@@ -559,6 +605,39 @@ def test_load_source_campaign_opportunities_from_support_ticket_object(tmp_path:
     assert loaded.opportunities[0]["source_title"] == "Reporting export issue"
     assert loaded.opportunities[0]["evidence"][0] == {
         "text": "The team cannot export attribution data before renewal.",
+        "source_id": "ticket-1",
+        "source_type": "support_ticket",
+        "source_title": "Reporting export issue",
+    }
+
+
+def test_load_source_campaign_opportunities_from_provider_style_bundle_keys(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "provider_bundle.json"
+    path.write_text(
+        json.dumps({
+            "Account Name": "Acme Logistics",
+            "Vendor Name": "HubSpot",
+            "Support Tickets": [
+                {
+                    "Ticket ID": "ticket-1",
+                    "Subject": "Reporting export issue",
+                    "Description": "Exports require a higher tier before renewal.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [warning.code for warning in loaded.warnings] == ["missing_contact_email"]
+    assert loaded.opportunities[0]["target_id"] == "ticket-1"
+    assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
+    assert loaded.opportunities[0]["vendor_name"] == "HubSpot"
+    assert loaded.opportunities[0]["evidence"][0] == {
+        "text": "Exports require a higher tier before renewal.",
         "source_id": "ticket-1",
         "source_type": "support_ticket",
         "source_title": "Reporting export issue",


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-Field-Aliases.md

## Summary
- add tolerant source-row key lookup for case/space/dash/underscore export labels
- canonicalize source-row company/vendor/contact and NPS/CSAT score aliases before opportunity normalization
- cover provider-style ticket/survey rows and bundle collection labels

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py -q
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py
- git diff --check
- bash scripts/local_pr_review.sh