### PR TITLE
Audit Content Ops source adapter shape

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -60,19 +60,26 @@ feed richer customer-specific source bundles into it.
 
 Remaining work:
 
-- More source adapters for customer-specific data bundles.
+- More source adapters for customer-specific data bundles, only when backed by
+  a real host export or evidence that cannot be represented by existing
+  generic fields without losing important context.
+- Source-adapter consolidation when the next source family would extend the
+  existing key-list / inference-chain pattern without a concrete export.
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
 - Host policy for richer falsification/cache/narrative-planning knobs.
 - Per-content-type opt-in rules so simple assets avoid heavy reasoning paths
   while long-form assets can use stateful reasoning.
 
-**Likely slice:** continue with narrow source-bundle adapters or a focused
-reasoning-provider setup improvement, rather than a broad architecture
-refactor.
+**Likely slice:** if a real customer/source export is available, add the
+minimum adapter support for that file. If not, prefer a small source-adapter
+consolidation or a focused reasoning-provider setup improvement over another
+speculative source-shape PR.
 
 ## Current Pick Recommendation
 
-Take item 1 next. The generated asset operator workflow is now usable; the
-remaining leverage is increasing the quality and breadth of reasoning/source
-inputs that feed AI Content Ops.
+Take item 1 next, but do not add more source breadth speculatively. The
+generated asset operator workflow is now usable; the remaining leverage is
+increasing the quality and breadth of reasoning/source inputs that feed AI
+Content Ops, anchored to real host data, documented field-loss risk, or a clear
+adapter-maintenance win.

--- a/docs/audits/content_ops_source_adapter_audit_2026-05-16.md
+++ b/docs/audits/content_ops_source_adapter_audit_2026-05-16.md
@@ -1,0 +1,146 @@
+# Content Ops Source Adapter Audit
+
+Created: 2026-05-16
+
+## Verdict
+
+Pause speculative source-shape additions. The adapter is useful and still
+working, but the cumulative shape is now large enough that the next source
+slice should be chosen by customer/export demand or by a small consolidation
+step, not by adding another possible row family.
+
+## Current Surface
+
+The source adapter converts host source rows into the existing campaign
+opportunity payload. It supports JSON, JSONL, CSV, nested source bundles, and
+direct source-row ingestion through the campaign generation/import/smoke paths.
+
+Current supported source families:
+
+- Review and generic document rows.
+- Transcripts, sales calls, meetings, and nested call/message turns.
+- CRM deals, CRM notes, account notes, and activity records.
+- Contracts, renewals, subscriptions, and commercial lifecycle notes.
+- Complaints, support tickets, support cases, conversations, and nested ticket
+  threads.
+- Surveys, NPS, CSAT, feedback rows, and bundled collections.
+
+Current size markers:
+
+- 34 bundle collection keys.
+- 21 source-id keys.
+- 16 scalar source-text keys.
+- 9 nested thread collection keys.
+- 16 source-type inference branches.
+
+## What Works
+
+- The adapter keeps the host-facing contract stable: every source row becomes
+  the same normalized campaign opportunity shape.
+- Source text flows into `evidence`, preserving source id, source type, and
+  source title.
+- Exact-key inputs stay fast. Tolerant field aliases only run after exact key
+  lookup misses.
+- Parent account metadata flows into child source rows for bundled customer
+  exports.
+- Rows with no usable source text fail closed with a warning instead of
+  producing generic drafts.
+
+## Accumulated Risks
+
+### Source-Type Precedence Is Implicit
+
+The inference chain is ordered, and that order is now part of the product
+contract. For example, review text wins over CRM ids, transcript text wins over
+call ids, and renewal ids win over contract/subscription context in specific
+tests. The order is tested in fragments, but not documented as a table in the
+code.
+
+Risk: a future source family can accidentally shift precedence for ambiguous
+rows.
+
+### Key Lists Are Becoming The Configuration Surface
+
+Adding one source shape usually touches several lists: collection keys,
+identifier keys, text keys, title keys, pain keys, and source-type inference.
+That is still manageable, but it is no longer cheap enough to add every
+plausible platform export proactively.
+
+Risk: maintenance cost grows faster than product value if each hypothetical
+export becomes a PR.
+
+### Source Type Labels May Outrun Downstream Behavior
+
+The generator currently receives source type as prompt context, but the
+generation path does not yet select different prompts or policies per source
+type. The labels are still useful for evidence review and future reasoning, but
+not every new label creates immediate generation-quality lift.
+
+Risk: adding more fine-grained labels can look like product progress without
+changing output behavior.
+
+### Alias Matching Is Broad By Design
+
+Field matching now tolerates case, spacing, dashes, underscores, and compact
+forms. This makes real CSV exports easier to ingest, but broad matching can
+also accept typo-like labels.
+
+Risk: unexpected host fields can silently map when a warning would be more
+helpful.
+
+## Decision Rules
+
+Add a new source family only when at least one condition is true:
+
+- A customer or host export has that row family now.
+- The row family carries evidence that cannot be represented by an existing
+  generic field without losing important context.
+- The row family unlocks a visible workflow, smoke, or import path that hosts
+  can run immediately.
+
+The slice owner should document the qualifying export, field-loss risk, or
+workflow unlock in the PR plan. Reviewers should push back when a new source
+shape is justified only by plausibility.
+
+Do not add a new source family when:
+
+- It is only a plausible future platform export.
+- Existing `document`, `transcript`, `crm_note`, or `support_ticket` handling
+  preserves the same evidence and metadata.
+- The only difference is a provider-specific field name that the tolerant alias
+  lookup already covers.
+
+## Recommended Next Source Work
+
+1. If a real host export is available, add only the minimal alias/source keys
+   needed to load that file and include a fixture shaped like the export.
+2. If no export is available, do a consolidation slice before more breadth:
+   document the source-type precedence table in code and tests.
+
+## Performance Improvements
+
+If ingestion performance becomes visible, add a per-row normalized key index so
+provider-style rows do not scan keys repeatedly. This is a performance fix, not
+a reason to add more source families.
+
+## Refactor Triggers
+
+Move from static tuples and an if-chain to a data-driven registry when one of
+these happens:
+
+- Source-type inference grows beyond 20 branches.
+- A new source family requires edits to more than five independent constants.
+- Two source families need custom precedence beyond simple ordered checks.
+- Downstream generation starts selecting prompts or quality policy by
+  `source_type`.
+
+## Testing Gaps
+
+Current tests are strong at adapter level. The remaining gap is end-to-end
+value testing: source row to opportunity to generated asset, with assertions
+that the generated prompt or saved metadata actually uses the source-type
+distinction.
+
+This should be added when a real export fixture is available. Without that
+fixture, broad end-to-end tests risk checking plumbing rather than product
+quality.

--- a/plans/PR-Content-Ops-Source-Adapter-Audit.md
+++ b/plans/PR-Content-Ops-Source-Adapter-Audit.md
@@ -1,0 +1,55 @@
+# PR: Content Ops Source Adapter Cumulative Audit
+
+## Why this slice exists
+
+The source-adapter stream has added reviews, calls, CRM rows, renewals,
+tickets, surveys, bundles, nested threads, and tolerant field aliases. The
+individual PRs were small, but the cumulative adapter now has enough branches
+and key lists that another shape PR risks completionism instead of product
+leverage.
+
+## Scope
+
+1. Add a current audit of the source-adapter shape, supported surfaces, risks,
+   and refactor triggers.
+2. Update the active AI Content Ops backlog so the next source work requires
+   demand signal or a small refactor decision.
+3. Keep the change docs-only.
+
+## Mechanism
+
+The audit records the current branch/key counts, what downstream paths consume
+the normalized opportunities, what is still intentionally generic, and the
+criteria for choosing more source breadth versus adapter consolidation.
+
+## Intentional
+
+- No source-adapter code changes.
+- No generated-asset, API, database, or frontend changes.
+- No attempt to refactor the adapter in this slice.
+
+## Deferred
+
+- A data-driven source-type registry.
+- End-to-end generation tests that compare output quality by source type.
+- Provider-specific importers for named CRM/support/call platforms.
+
+## Verification
+
+- Run the local PR review script.
+- Run diff whitespace checks.
+
+### Files Touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/audits/content_ops_source_adapter_audit_2026-05-16.md`
+- `plans/PR-Content-Ops-Source-Adapter-Audit.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Audit doc | ~120 |
+| Backlog and coordination | ~25 |
+| Plan doc | ~55 |
+| **Total** | ~200 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-Adapter-Audit.md

## Summary
- add a cumulative source-adapter audit after the source-shape stream
- document current key/branch counts, risks, decision rules, and refactor triggers
- update active backlog to require real export demand or consolidation before more speculative source breadth

## Verification
- git diff --check
- bash scripts/local_pr_review.sh