### PR TITLE
Fail local PR review on dirty worktrees

### DIFF
--- a/plans/PR-Audit-Local-Review-Dirty-Guard.md
+++ b/plans/PR-Audit-Local-Review-Dirty-Guard.md
@@ -1,0 +1,56 @@
+# PR: Local PR Review Dirty Worktree Guard
+
+## Why this slice exists
+
+`scripts/local_pr_review.sh` compares the committed branch diff against
+`origin/main`. When it runs with uncommitted edits, some plan/code checks can
+skip or report against an incomplete committed diff. The script should fail
+early unless the caller explicitly opts into dirty-worktree mode.
+
+## Scope
+
+1. Add a clean-worktree guard to the local PR review script.
+2. Add an explicit `--allow-dirty` escape hatch.
+3. Preserve the existing optional base-ref argument.
+4. Add focused script tests for dirty failure and allow-dirty behavior.
+
+## Mechanism
+
+The script parses `--allow-dirty` and a single optional base ref before running
+checks. When dirty mode is not allowed, it checks `git status --porcelain` and
+exits with guidance if any tracked, staged, or untracked changes are present.
+
+## Intentional
+
+- No changes to the pre-push audit wrapper.
+- No automatic pytest or npm expansion.
+- No changes to the installed git hook.
+
+## Deferred
+
+- Changed-file test suggestions.
+- PR-size warnings.
+- A broader shell hygiene auditor.
+
+## Verification
+
+- Run the focused local PR review tests.
+- Run a shell syntax check for the script.
+- Run the local PR review script with the explicit dirty override because this
+  PR intentionally edits files before commit.
+- Run diff whitespace checks.
+
+### Files Touched
+
+- `plans/PR-Audit-Local-Review-Dirty-Guard.md`
+- `scripts/local_pr_review.sh`
+- `tests/test_local_pr_review.py`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Script | ~35 |
+| Tests | ~110 |
+| Plan and coordination | ~55 |
+| **Total** | ~200 |

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -5,7 +5,41 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-base_ref="${1:-origin/main}"
+base_ref="origin/main"
+base_ref_set=0
+allow_dirty=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --allow-dirty)
+            allow_dirty=1
+            shift
+            ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: bash scripts/local_pr_review.sh [--allow-dirty] [base-ref]
+
+Run the local mechanical review bundle before opening or updating a PR.
+By default, the worktree must be clean so committed-diff checks cannot
+silently ignore uncommitted edits.
+EOF
+            exit 0
+            ;;
+        --*)
+            echo "local_pr_review.sh: unknown option: $1" >&2
+            exit 2
+            ;;
+        *)
+            if [ "$base_ref_set" -eq 1 ]; then
+                echo "local_pr_review.sh: multiple base refs supplied" >&2
+                exit 2
+            fi
+            base_ref="$1"
+            base_ref_set=1
+            shift
+            ;;
+    esac
+done
 
 failures=0
 
@@ -26,6 +60,14 @@ if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
     echo "local_pr_review.sh: base ref not found: $base_ref" >&2
     echo "fetch trunk first, or pass an explicit base ref" >&2
     exit 2
+fi
+
+if [ "$allow_dirty" -ne 1 ] && [ -n "$(git status --porcelain)" ]; then
+    echo "local_pr_review.sh: worktree has uncommitted changes." >&2
+    echo "Commit or stash them before running local review, or pass --allow-dirty for a partial/advisory run." >&2
+    echo >&2
+    git status --short >&2
+    exit 1
 fi
 
 base="$(git merge-base HEAD "$base_ref")"

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_local_pr_review_fails_on_dirty_worktree(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    (repo / "dirty.txt").write_text("not committed\n", encoding="utf-8")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"])
+
+    assert result.returncode == 1
+    assert "worktree has uncommitted changes" in result.stderr
+    assert "dirty.txt" in result.stderr
+    assert "Pre-push audit wrapper" not in result.stdout
+
+
+def test_local_pr_review_allow_dirty_runs_checks(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    (repo / "dirty.txt").write_text("not committed\n", encoding="utf-8")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh", "--allow-dirty"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Pre-push audit wrapper" in result.stdout
+    assert "local PR review passed" in result.stdout
+
+
+def test_local_pr_review_allow_dirty_preserves_base_ref_arg(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    (repo / "dirty.txt").write_text("not committed\n", encoding="utf-8")
+
+    result = _run(
+        repo,
+        ["bash", "scripts/local_pr_review.sh", "--allow-dirty", "origin/main"],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "base ref: origin/main" in result.stdout
+
+
+def test_local_pr_review_help_exits_cleanly(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh", "--help"])
+
+    assert result.returncode == 0
+    assert "Usage: bash scripts/local_pr_review.sh" in result.stdout
+
+
+def test_local_pr_review_rejects_unknown_option(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh", "--unknown"])
+
+    assert result.returncode == 2
+    assert "unknown option: --unknown" in result.stderr
+
+
+def test_local_pr_review_rejects_multiple_base_refs(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+
+    result = _run(
+        repo,
+        ["bash", "scripts/local_pr_review.sh", "origin/main", "origin/main"],
+    )
+
+    assert result.returncode == 2
+    assert "multiple base refs supplied" in result.stderr
+
+
+def _write_fixture_repo(repo: Path) -> None:
+    (repo / "scripts").mkdir(parents=True)
+    _write_executable(
+        repo / "scripts" / "local_pr_review.sh",
+        (REPO_ROOT / "scripts" / "local_pr_review.sh").read_text(encoding="utf-8"),
+    )
+    _write_executable(
+        repo / "scripts" / "pre_push_audit.sh",
+        "#!/usr/bin/env bash\nset -euo pipefail\necho pre-push ok\n",
+    )
+    _write_executable(
+        repo / "scripts" / "audit_plan_code_consistency.py",
+        "#!/usr/bin/env python3\nprint('plan ok')\n",
+    )
+    (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+
+def _run(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(repo)},
+    )
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)


### PR DESCRIPTION
Plan: plans/PR-Audit-Local-Review-Dirty-Guard.md

## Summary
- make local_pr_review fail early when the worktree has uncommitted changes
- add --allow-dirty for explicit advisory runs
- add focused script tests for dirty failure, allow-dirty, and base-ref compatibility

## Verification
- pytest tests/test_local_pr_review.py -q
- bash -n scripts/local_pr_review.sh
- bash scripts/local_pr_review.sh
- git diff --check