### PR TITLE
Document Content Ops source type precedence

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -144,6 +144,27 @@ _CONTACT_EMAIL_KEYS = ("contact_email", "recipient_email", "email")
 _CONTACT_TITLE_KEYS = ("contact_title", "recipient_title", "job_title")
 _NPS_SCORE_KEYS = ("nps_score", "nps")
 _CSAT_SCORE_KEYS = ("csat_score", "csat")
+# Ordered source-type contract for ambiguous rows. Text-bearing source fields
+# win over ids, and note ids win over lifecycle ids because lifecycle ids can
+# travel as context on notes without changing the evidence row type.
+_SOURCE_TYPE_PRECEDENCE = (
+    (("review_text",), "review"),
+    (("transcript",), "transcript"),
+    (("call_id", "recording_id"), "sales_call"),
+    (("meeting_id",), "meeting"),
+    (("deal_id", "opportunity_id"), "crm_deal"),
+    (("note_id", "activity_id"), "crm_note"),
+    (("renewal_id",), "renewal"),
+    (("contract_id",), "contract"),
+    (("subscription_id",), "subscription"),
+    (("complaint",), "complaint"),
+    (("ticket_id",), "support_ticket"),
+    (("case_id",), "case"),
+    (("conversation_id",), "conversation"),
+    (("nps_score", "nps"), "nps_response"),
+    (("csat_score", "csat"), "csat_response"),
+    (("survey_id", "response_id"), "survey_response"),
+)
 _FIELD_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
 _MAX_BUNDLE_DEPTH = 8
 
@@ -482,40 +503,9 @@ def _text_list(value: Any) -> list[str]:
 
 
 def _infer_source_type(row: Mapping[str, Any]) -> str:
-    if _has_field_value(row, ("review_text",)):
-        return "review"
-    if _has_field_value(row, ("transcript",)):
-        return "transcript"
-    if _has_field_value(row, ("call_id", "recording_id")):
-        return "sales_call"
-    if _has_field_value(row, ("meeting_id",)):
-        return "meeting"
-    if _has_field_value(row, ("deal_id", "opportunity_id")):
-        return "crm_deal"
-    if _has_field_value(row, ("note_id", "activity_id")):
-        return "crm_note"
-    # Notes stay typed as notes even when attached to a contract, renewal, or
-    # subscription export; the lifecycle id is context, not the evidence row.
-    if _has_field_value(row, ("renewal_id",)):
-        return "renewal"
-    if _has_field_value(row, ("contract_id",)):
-        return "contract"
-    if _has_field_value(row, ("subscription_id",)):
-        return "subscription"
-    if _has_field_value(row, ("complaint",)):
-        return "complaint"
-    if _has_field_value(row, ("ticket_id",)):
-        return "support_ticket"
-    if _has_field_value(row, ("case_id",)):
-        return "case"
-    if _has_field_value(row, ("conversation_id",)):
-        return "conversation"
-    if _has_field_value(row, ("nps_score", "nps")):
-        return "nps_response"
-    if _has_field_value(row, ("csat_score", "csat")):
-        return "csat_response"
-    if _has_field_value(row, ("survey_id", "response_id")):
-        return "survey_response"
+    for keys, source_type in _SOURCE_TYPE_PRECEDENCE:
+        if _has_field_value(row, keys):
+            return source_type
     return "document"
 
 

--- a/plans/PR-Content-Ops-Source-Type-Precedence.md
+++ b/plans/PR-Content-Ops-Source-Type-Precedence.md
@@ -1,0 +1,58 @@
+# PR: Content Ops Source-Type Precedence Table
+
+## Why this slice exists
+
+The source adapter now supports reviews, transcripts, calls, meetings, CRM
+rows, lifecycle rows, tickets, surveys, bundles, and tolerant field aliases.
+The current source-type inference order is product behavior, but it lives as
+an implicit if-chain.
+
+This slice makes that order explicit without adding new source families.
+
+## Scope
+
+1. Replace the implicit `_infer_source_type` if-chain with a local ordered
+   source-type precedence table.
+2. Add focused tests that lock the table order and preserve ambiguous-row
+   behavior.
+3. Keep the normalized opportunity contract unchanged.
+
+## Mechanism
+
+`_SOURCE_TYPE_PRECEDENCE` maps ordered key groups to the source type they
+produce. `_infer_source_type` iterates the table and returns the first match,
+falling back to `document`.
+
+## Intentional
+
+- No new source-type labels.
+- No provider-specific source adapters.
+- No changes to generated asset behavior.
+- No public API or function signature changes.
+
+## Deferred
+
+- Data-driven source-family registry.
+- Provider-specific source importers.
+- End-to-end generated-asset quality tests by source type.
+
+## Verification
+
+- Run pytest tests/test_extracted_campaign_source_adapters.py -q.
+- Run python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py.
+- Run bash scripts/local_pr_review.sh.
+
+### Files Touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `plans/PR-Content-Ops-Source-Type-Precedence.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source adapter | ~30 |
+| Tests | ~25 |
+| Plan | ~40 |
+| **Total** | ~145 |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
     source_row_to_campaign_opportunity,
@@ -20,6 +21,42 @@ EXAMPLE_SOURCE_ROWS = (
 EXAMPLE_SOURCE_BUNDLE = (
     ROOT / "extracted_content_pipeline/examples/campaign_source_bundle.json"
 )
+
+
+def test_source_type_precedence_table_matches_current_contract() -> None:
+    # This intentionally locks a private table: source-type order is product behavior.
+    assert adapters._SOURCE_TYPE_PRECEDENCE == (
+        (("review_text",), "review"),
+        (("transcript",), "transcript"),
+        (("call_id", "recording_id"), "sales_call"),
+        (("meeting_id",), "meeting"),
+        (("deal_id", "opportunity_id"), "crm_deal"),
+        (("note_id", "activity_id"), "crm_note"),
+        (("renewal_id",), "renewal"),
+        (("contract_id",), "contract"),
+        (("subscription_id",), "subscription"),
+        (("complaint",), "complaint"),
+        (("ticket_id",), "support_ticket"),
+        (("case_id",), "case"),
+        (("conversation_id",), "conversation"),
+        (("nps_score", "nps"), "nps_response"),
+        (("csat_score", "csat"), "csat_response"),
+        (("survey_id", "response_id"), "survey_response"),
+    )
+
+
+def test_source_type_precedence_table_controls_ambiguous_rows() -> None:
+    row = {
+        keys[0]: f"{source_type}-value"
+        for keys, source_type in adapters._SOURCE_TYPE_PRECEDENCE
+    }
+    row["summary"] = "Ambiguous source row with every source-type key."
+
+    opportunity, warnings = source_row_to_campaign_opportunity(row)
+
+    assert warnings == ()
+    assert opportunity["source_type"] == "review"
+    assert opportunity["target_id"] == "sales_call-value"
 
 
 def test_source_row_maps_review_text_to_campaign_opportunity() -> None:


### PR DESCRIPTION
## Summary
- make Content Ops source-type inference precedence explicit with an ordered table
- preserve existing inference behavior by routing _infer_source_type through the table
- add focused tests that lock the table order and ambiguous-row outcome

Plan: plans/PR-Content-Ops-Source-Type-Precedence.md

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py -q
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py
- bash scripts/local_pr_review.sh