### PR TITLE
Refresh Content Ops backlog after source consolidation

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -1,7 +1,7 @@
 # AI Content Ops Deferred Backlog
 
 Created: 2026-05-11
-Last updated: 2026-05-15
+Last updated: 2026-05-16
 
 ## Purpose
 
@@ -46,40 +46,57 @@ The following items appear in older plan docs but are no longer active backlog:
 - DB reasoning context scoped delete/retire API.
 - DB reasoning context admin visibility events.
 - Campaign operations status reasoning-provider capability check.
+- Source-adapter field alias support for common provider-style exports.
+- Source-adapter cumulative audit and decision rules.
+- Source-type precedence consolidation.
+- Source-row field lookup cache for provider-style aliases.
 
 ## Active Backlog
 
-### 1. Reasoning product depth and source breadth
+### 1. Reasoning product depth
 
 **Priority:** P2
 
 **Why:** AI Content Ops can consume file-backed, DB-backed, single-pass, and
-multi-pass reasoning context. The next value step is deciding how much of the
-standalone reasoning layer each content type should expose and how hosts should
-feed richer customer-specific source bundles into it.
+multi-pass reasoning context. Source ingestion is now broad enough for current
+standalone use. The next value step is deciding how much of the standalone
+reasoning layer each content type should expose.
 
 Remaining work:
 
-- More source adapters for customer-specific data bundles, only when backed by
-  a real host export or evidence that cannot be represented by existing
-  generic fields without losing important context.
-- Source-adapter consolidation when the next source family would extend the
-  existing key-list / inference-chain pattern without a concrete export.
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
 - Host policy for richer falsification/cache/narrative-planning knobs.
 - Per-content-type opt-in rules so simple assets avoid heavy reasoning paths
   while long-form assets can use stateful reasoning.
 
-**Likely slice:** if a real customer/source export is available, add the
-minimum adapter support for that file. If not, prefer a small source-adapter
-consolidation or a focused reasoning-provider setup improvement over another
-speculative source-shape PR.
+**Likely slice:** audit and document host-facing reasoning policy choices for
+falsification, narrative planning, output validation, and per-content-type
+opt-in depth. Use that audit to pick the first small wiring slice. Do not add
+more source-adapter breadth unless a real customer/source export requires it.
+
+### 2. Source breadth from real host exports
+
+**Priority:** P3
+
+**Why:** The source adapter now supports the current generic families, explicit
+source-type precedence, tolerant field aliases, nested bundles, and cached
+field lookup. More breadth should be driven by an actual customer export, not
+by plausible platform shapes.
+
+Remaining work:
+
+- Add the minimum aliases/source keys required by a real host export fixture.
+- Add end-to-end generated-asset quality tests by source type when that fixture
+  exists.
+
+**Likely slice:** wait for a real export. If none exists, skip this item.
+If no export appears after the next reasoning-policy pass, decide whether this
+remains roadmap work or should be removed from active backlog.
 
 ## Current Pick Recommendation
 
-Take item 1 next, but do not add more source breadth speculatively. The
-generated asset operator workflow is now usable; the remaining leverage is
-increasing the quality and breadth of reasoning/source inputs that feed AI
-Content Ops, anchored to real host data, documented field-loss risk, or a clear
-adapter-maintenance win.
+Take item 1 next. Source-adapter consolidation is complete for now; the
+remaining leverage is reasoning-policy depth for long-form and multi-asset
+outputs. Source breadth should pause until a real host export or field-loss
+risk appears.

--- a/docs/audits/content_ops_source_adapter_audit_2026-05-16.md
+++ b/docs/audits/content_ops_source_adapter_audit_2026-05-16.md
@@ -9,6 +9,11 @@ working, but the cumulative shape is now large enough that the next source
 slice should be chosen by customer/export demand or by a small consolidation
 step, not by adding another possible row family.
 
+Update: the immediate consolidation follow-ups from this audit are complete.
+PR #550 made source-type precedence explicit in code/tests, and PR #551 added
+the per-row field lookup cache for provider-style aliases. Further source work
+should now require a real host export or field-loss risk.
+
 ## Current Surface
 
 The source adapter converts host source rows into the existing campaign
@@ -48,16 +53,15 @@ Current size markers:
 
 ## Accumulated Risks
 
-### Source-Type Precedence Is Implicit
+### Source-Type Precedence Is Explicit
 
-The inference chain is ordered, and that order is now part of the product
-contract. For example, review text wins over CRM ids, transcript text wins over
-call ids, and renewal ids win over contract/subscription context in specific
-tests. The order is tested in fragments, but not documented as a table in the
-code.
+The inference chain is ordered, and that order is part of the product contract.
+PR #550 records that order as `_SOURCE_TYPE_PRECEDENCE` and locks the table in
+tests. For example, review text wins over CRM ids, transcript text wins over
+call ids, and renewal ids win over contract/subscription context.
 
-Risk: a future source family can accidentally shift precedence for ambiguous
-rows.
+Remaining risk: a future source family can still shift precedence, but that
+now requires an explicit table/test update.
 
 ### Key Lists Are Becoming The Configuration Surface
 
@@ -88,6 +92,9 @@ also accept typo-like labels.
 Risk: unexpected host fields can silently map when a warning would be more
 helpful.
 
+Mitigation: PR #551 added a per-row lookup cache so broad matching does not
+repeat normalized/compact scans for every helper call.
+
 ## Decision Rules
 
 Add a new source family only when at least one condition is true:
@@ -114,23 +121,24 @@ Do not add a new source family when:
 
 1. If a real host export is available, add only the minimal alias/source keys
    needed to load that file and include a fixture shaped like the export.
-2. If no export is available, do a consolidation slice before more breadth:
-   document the source-type precedence table in code and tests.
+2. If no export is available, do not add more source breadth. The current
+   consolidation items are complete; move to reasoning-policy depth instead.
 
 ## Performance Improvements
 
-If ingestion performance becomes visible, add a per-row normalized key index so
-provider-style rows do not scan keys repeatedly. This is a performance fix, not
-a reason to add more source families.
+Provider-style field lookup now uses a per-row normalized/compact key cache.
+Future performance work should be driven by measured ingestion bottlenecks, not
+by source-shape breadth.
 
 ## Refactor Triggers
 
-Move from static tuples and an if-chain to a data-driven registry when one of
-these happens:
+Move from the static precedence table and helper constants to a data-driven
+registry when one of these happens:
 
-- Source-type inference grows beyond 20 branches.
+- Source-type precedence grows beyond 20 table entries.
 - A new source family requires edits to more than five independent constants.
-- Two source families need custom precedence beyond simple ordered checks.
+- Two source families need custom precedence beyond a simple ordered table.
+- Hosts need runtime extension of source families without product code changes.
 - Downstream generation starts selecting prompts or quality policy by
   `source_type`.
 
@@ -143,4 +151,6 @@ distinction.
 
 This should be added when a real export fixture is available. Without that
 fixture, broad end-to-end tests risk checking plumbing rather than product
-quality.
+quality. This is still a real coverage gap: until a fixture exists, source-type
+distinctions could remain label-only without an output-quality regression test
+catching it.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -50,7 +50,8 @@ source of truth for what remains.
   `thread`, `conversation`, or `entries` arrays when the source text is not
   available as one scalar field. Source-row field labels are matched leniently
   for common CSV/export variants such as `Ticket ID`, `Account Name`,
-  `Pain Category`, and `Open Ended Response`.
+  `Pain Category`, and `Open Ended Response`; source-type precedence is
+  explicit and provider-style field lookups are cached per row.
 - `signal_extraction` exposes source-row normalization as a runnable AI Content
   Ops output. It converts inline source material into normalized opportunities
   without LLM, database, or Atlas dependencies.

--- a/plans/PR-Content-Ops-Backlog-After-Source-Consolidation.md
+++ b/plans/PR-Content-Ops-Backlog-After-Source-Consolidation.md
@@ -1,0 +1,58 @@
+# PR: Content Ops Backlog After Source Consolidation
+
+## Why this slice exists
+
+PR #550 made source-type precedence explicit, and PR #551 added the per-row
+field lookup cache recommended by the source-adapter audit. The active backlog
+still describes source consolidation as remaining work, which would steer the
+next session back into completed territory.
+
+This slice refreshes the coordination docs so the next AI Content Ops work
+starts from the current state.
+
+## Scope
+
+1. Move source-adapter consolidation into retired/completed backlog notes.
+2. Update the source-adapter audit to record the completed consolidation PRs.
+3. Update product status to mention explicit source precedence and cached field
+   lookup behavior.
+4. Point the next recommendation at reasoning-policy depth unless a real host
+   export arrives.
+
+## Mechanism
+
+Docs-only update. No code, API, schema, runtime, or test behavior changes.
+
+## Intentional
+
+- No source-adapter code changes.
+- No new source-family support.
+- No reasoning provider behavior changes.
+- No generated-asset behavior changes.
+
+## Deferred
+
+- Host-facing reasoning policy presets or knobs.
+- More source adapters backed by a concrete host export.
+- End-to-end generated-asset quality tests by source type.
+
+## Verification
+
+- Run rg for stale source-consolidation backlog wording.
+- Run bash scripts/local_pr_review.sh.
+
+### Files Touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/audits/content_ops_source_adapter_audit_2026-05-16.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-Content-Ops-Backlog-After-Source-Consolidation.md`
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Backlog and audit docs | ~45 |
+| Status doc | ~10 |
+| Plan | ~55 |
+| **Total** | ~165 |


### PR DESCRIPTION
## Summary
- mark source-adapter consolidation work as completed after #550 and #551
- update the source-adapter audit and STATUS docs with explicit precedence + cached field lookup state
- redirect the current AI Content Ops recommendation toward reasoning-policy depth unless a real host export appears

Plan: plans/PR-Content-Ops-Backlog-After-Source-Consolidation.md

## Verification
- rg checks for stale source-consolidation wording
- bash scripts/local_pr_review.sh