### PR TITLE
Add Content Ops reasoning preset catalog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -52,6 +52,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - Source-row field lookup cache for provider-style aliases.
 - Host-facing reasoning policy audit for falsification, narrative planning,
   validation, and per-content-type depth.
+- Reasoning preset catalog for host-facing depth choices.
 
 ## Active Backlog
 
@@ -68,18 +69,21 @@ Current policy audit:
 
 - `docs/audits/content_ops_reasoning_policy_audit_2026-05-16.md`
 
+Current policy catalog:
+
+- `extracted_content_pipeline/reasoning_policy.py`
+
 Remaining work:
 
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
-- Reasoning preset catalog for `none`, `context_only`, `single_pass`,
-  `multi_pass_light`, `multi_pass_structured`, and `multi_pass_strict`.
 - First runtime wiring for structured reasoning on `report` and `sales_brief`.
 - Validation metadata surfacing before any strict blocking mode.
 
-**Likely slice:** add the reasoning preset catalog as a pure policy/config
-layer first. Do not wire every typed policy object into runtime yet. Use the
-catalog to make the next report/sales-brief structured-reasoning slice small.
+**Likely slice:** use the reasoning preset catalog to wire structured
+multi-pass reasoning for `report` and `sales_brief`. Keep provider construction
+scoped to those two outputs; do not add strict blocking until validation
+metadata is visible to operators.
 
 ### 2. Source breadth from real host exports
 
@@ -102,7 +106,8 @@ remains roadmap work or should be removed from active backlog.
 
 ## Current Pick Recommendation
 
-Take item 1 next, specifically the reasoning preset catalog. Source-adapter
-consolidation is complete for now; the remaining leverage is controlled
-reasoning-policy depth for long-form and multi-asset outputs. Source breadth
-should pause until a real host export or field-loss risk appears.
+Take item 1 next, specifically structured reasoning for `report` and
+`sales_brief` using the preset catalog. Source-adapter consolidation is
+complete for now; the remaining leverage is controlled reasoning-policy depth
+for long-form and multi-asset outputs. Source breadth should pause until a
+real host export or field-loss risk appears.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -181,6 +181,13 @@ source of truth for what remains.
   presets instead of raw policy objects, start structured multi-pass wiring
   with reports and sales briefs, and keep Evidence-to-Story separate from AI
   Content Ops.
+- `reasoning_policy` provides the product-owned preset catalog for those named
+  reasoning-depth choices. It maps generated-asset outputs to supported
+  presets (`none`, `context_only`, `single_pass`, `multi_pass_light`,
+  `multi_pass_structured`, `multi_pass_strict`) without constructing providers
+  or changing runtime behavior. `blog_post` defaults to `multi_pass_light` as
+  a quality-over-cost choice; hosts that want cheaper blog runs can select
+  `single_pass`.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -269,6 +269,9 @@
       "target": "extracted_content_pipeline/content_ops_execution.py"
     },
     {
+      "target": "extracted_content_pipeline/reasoning_policy.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_opportunities.py"
     },
     {

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -1,0 +1,185 @@
+"""Reasoning-depth preset catalog for AI Content Ops.
+
+This module is pure policy data. It does not construct providers, call LLMs,
+read storage, or change generation behavior. Runtime seams can use it to
+validate host-facing choices before later slices wire richer reasoning.
+
+Source recommendations:
+``docs/audits/content_ops_reasoning_policy_audit_2026-05-16.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal, Mapping
+
+
+ReasoningPreset = Literal[
+    "none", "context_only", "single_pass", "multi_pass_light",
+    "multi_pass_structured", "multi_pass_strict",
+]
+
+
+@dataclass(frozen=True)
+class ReasoningPresetDefinition:
+    id: ReasoningPreset
+    label: str
+    description: str
+    generated_reasoning: bool = False
+    multi_pass: bool = False
+    narrative_planning: bool = False
+    falsification: bool = False
+    output_validation: bool = False
+    blocking_validation: bool = False
+
+
+@dataclass(frozen=True)
+class OutputReasoningPolicy:
+    output: str
+    default_preset: ReasoningPreset
+    supported_presets: tuple[ReasoningPreset, ...]
+
+    def __post_init__(self) -> None:
+        if not self.supported_presets:
+            raise ValueError(f"{self.output}: supported_presets must not be empty")
+        unknown = [p for p in self.supported_presets if p not in REASONING_PRESETS]
+        if self.default_preset not in REASONING_PRESETS:
+            unknown.append(self.default_preset)
+        if unknown:
+            raise ValueError(f"{self.output}: unknown reasoning preset(s): {unknown}")
+        if self.default_preset not in self.supported_presets:
+            raise ValueError(
+                f"{self.output}: default_preset must be included in supported_presets"
+            )
+
+    def supports(self, preset: str) -> bool:
+        """Return membership only; use resolve_reasoning_policy for validation."""
+        return preset in self.supported_presets
+
+
+REASONING_PRESETS: Mapping[str, ReasoningPresetDefinition] = MappingProxyType({
+    "none": ReasoningPresetDefinition(
+        id="none",
+        label="None",
+        description="No reasoning provider is used.",
+    ),
+    "context_only": ReasoningPresetDefinition(
+        id="context_only",
+        label="Context Only",
+        description="Use host-provided reasoning context; do not generate new reasoning.",
+    ),
+    "single_pass": ReasoningPresetDefinition(
+        id="single_pass",
+        label="Single Pass",
+        description="Generate lightweight reasoning with one LLM call.",
+        generated_reasoning=True,
+    ),
+    "multi_pass_light": ReasoningPresetDefinition(
+        id="multi_pass_light",
+        label="Multi-Pass Light",
+        description="Run bounded multi-pass reasoning without rich policy gates.",
+        generated_reasoning=True,
+        multi_pass=True,
+    ),
+    "multi_pass_structured": ReasoningPresetDefinition(
+        id="multi_pass_structured",
+        label="Multi-Pass Structured",
+        description="Run multi-pass reasoning with planning and validation metadata.",
+        generated_reasoning=True,
+        multi_pass=True,
+        narrative_planning=True,
+        output_validation=True,
+    ),
+    "multi_pass_strict": ReasoningPresetDefinition(
+        id="multi_pass_strict",
+        label="Multi-Pass Strict",
+        description="Run structured multi-pass reasoning with planning and validation gates.",
+        generated_reasoning=True,
+        multi_pass=True,
+        narrative_planning=True,
+        falsification=True,
+        output_validation=True,
+        blocking_validation=True,
+    ),
+})
+
+
+_MULTI_PASS_OPTIONAL: tuple[ReasoningPreset, ...] = (
+    "none", "context_only", "single_pass", "multi_pass_light",
+)
+_STRUCTURED_PRESETS: tuple[ReasoningPreset, ...] = (
+    "none", "context_only", "single_pass", "multi_pass_light",
+    "multi_pass_structured", "multi_pass_strict",
+)
+_LANDING_PAGE_PRESETS: tuple[ReasoningPreset, ...] = (
+    "none", "context_only", "single_pass", "multi_pass_light",
+    "multi_pass_structured",
+)
+
+
+OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyType({
+    "signal_extraction": OutputReasoningPolicy(
+        output="signal_extraction",
+        default_preset="none",
+        supported_presets=("none",),
+    ),
+    "email_campaign": OutputReasoningPolicy(
+        output="email_campaign",
+        default_preset="single_pass",
+        supported_presets=_MULTI_PASS_OPTIONAL,
+    ),
+    "landing_page": OutputReasoningPolicy(
+        output="landing_page",
+        default_preset="single_pass",
+        supported_presets=_LANDING_PAGE_PRESETS,
+    ),
+    "blog_post": OutputReasoningPolicy(
+        output="blog_post",
+        default_preset="multi_pass_light",
+        supported_presets=_STRUCTURED_PRESETS,
+    ),
+    "report": OutputReasoningPolicy(
+        output="report",
+        default_preset="multi_pass_structured",
+        supported_presets=_STRUCTURED_PRESETS,
+    ),
+    "sales_brief": OutputReasoningPolicy(
+        output="sales_brief",
+        default_preset="multi_pass_structured",
+        supported_presets=_STRUCTURED_PRESETS,
+    ),
+})
+
+
+def reasoning_preset_definition(preset: str) -> ReasoningPresetDefinition:
+    try:
+        return REASONING_PRESETS[preset]
+    except KeyError as exc:
+        raise ValueError(f"unknown reasoning preset: {preset}") from exc
+
+
+def output_reasoning_policy(output: str) -> OutputReasoningPolicy:
+    try:
+        return OUTPUT_REASONING_POLICIES[output]
+    except KeyError as exc:
+        raise ValueError(f"unknown content output: {output}") from exc
+
+
+def supported_reasoning_presets(output: str) -> tuple[ReasoningPreset, ...]:
+    return output_reasoning_policy(output).supported_presets
+
+
+def resolve_reasoning_policy(
+    output: str,
+    preset: str | None = None,
+) -> tuple[OutputReasoningPolicy, ReasoningPresetDefinition]:
+    """Resolve output policy and preset; None or blank preset uses the default."""
+    policy = output_reasoning_policy(output)
+    selected = preset if preset else policy.default_preset
+    definition = reasoning_preset_definition(selected)
+    if not policy.supports(definition.id):
+        raise ValueError(
+            f"reasoning preset {definition.id!r} is not supported for output {output!r}"
+        )
+    return policy, definition

--- a/plans/PR-Content-Ops-Reasoning-Preset-Catalog.md
+++ b/plans/PR-Content-Ops-Reasoning-Preset-Catalog.md
@@ -1,0 +1,52 @@
+# PR: Content Ops Reasoning Preset Catalog
+
+## Why this slice exists
+
+PR #553 documented the Content Ops reasoning-policy boundary. This slice adds
+the pure preset catalog for selecting reasoning depth per output without
+constructing providers or changing generation behavior.
+
+## Scope
+
+Add `reasoning_policy` with the six audit preset IDs, per-output defaults,
+supported-preset validation helpers, and docs/status updates.
+
+### Files Touched
+
+`extracted_content_pipeline/reasoning_policy.py`,
+`tests/test_extracted_content_reasoning_policy.py`,
+`docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`,
+`extracted_content_pipeline/STATUS.md`,
+`extracted_content_pipeline/manifest.json`,
+`plans/PR-Content-Ops-Reasoning-Preset-Catalog.md`
+
+## Mechanism
+
+`ReasoningPresetDefinition` describes each preset, `OutputReasoningPolicy` maps
+output IDs to supported presets/defaults, and the helpers resolve policies for
+future runtime wiring. No provider construction happens here.
+
+## Intentional
+
+No runtime behavior, FastAPI schema, provider-construction, cache, state,
+falsification, narrative-plan, or validation wiring changes.
+
+## Deferred
+
+- API/control-surface exposure.
+- Report/sales-brief structured-reasoning construction.
+- Validation metadata surfacing and blog-specific narrative packs.
+
+## Verification
+
+- Run focused reasoning-policy tests.
+- Run the local review script at `scripts/local_pr_review.sh`.
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Policy module | ~200 |
+| Tests | ~130 |
+| Docs/status/plan | ~70 |
+| **Total** | ~400 |

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -1,0 +1,129 @@
+"""Tests for the AI Content Ops reasoning preset catalog."""
+
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.reasoning_policy import (
+    OUTPUT_REASONING_POLICIES,
+    REASONING_PRESETS,
+    OutputReasoningPolicy,
+    output_reasoning_policy,
+    reasoning_preset_definition,
+    resolve_reasoning_policy,
+    supported_reasoning_presets,
+)
+
+
+def test_reasoning_preset_catalog_contains_expected_ids() -> None:
+    assert tuple(REASONING_PRESETS) == (
+        "none",
+        "context_only",
+        "single_pass",
+        "multi_pass_light",
+        "multi_pass_structured",
+        "multi_pass_strict",
+    )
+
+
+def test_preset_capabilities_increase_by_depth() -> None:
+    assert not REASONING_PRESETS["none"].generated_reasoning
+    assert not REASONING_PRESETS["context_only"].generated_reasoning
+    assert REASONING_PRESETS["single_pass"].generated_reasoning
+    assert not REASONING_PRESETS["single_pass"].multi_pass
+    assert REASONING_PRESETS["multi_pass_light"].multi_pass
+    assert REASONING_PRESETS["multi_pass_structured"].narrative_planning
+    assert REASONING_PRESETS["multi_pass_structured"].output_validation
+    assert not REASONING_PRESETS["multi_pass_structured"].blocking_validation
+    assert REASONING_PRESETS["multi_pass_strict"].falsification
+    assert REASONING_PRESETS["multi_pass_strict"].blocking_validation
+
+
+def test_output_policy_defaults_match_audit_recommendations() -> None:
+    defaults = {
+        output: policy.default_preset
+        for output, policy in OUTPUT_REASONING_POLICIES.items()
+    }
+    assert defaults == {
+        "signal_extraction": "none",
+        "email_campaign": "single_pass",
+        "landing_page": "single_pass",
+        "blog_post": "multi_pass_light",
+        "report": "multi_pass_structured",
+        "sales_brief": "multi_pass_structured",
+    }
+
+
+def test_reasoning_policies_cover_every_output_catalog_entry() -> None:
+    from extracted_content_pipeline.control_surfaces import OUTPUT_CATALOG
+
+    assert set(OUTPUT_REASONING_POLICIES) == set(OUTPUT_CATALOG)
+
+
+def test_output_policy_invariants_are_enforced() -> None:
+    with pytest.raises(ValueError, match="supported_presets must not be empty"):
+        OutputReasoningPolicy("report", "single_pass", ())
+    with pytest.raises(ValueError, match="unknown reasoning preset"):
+        OutputReasoningPolicy("report", "single_pass", ("multi_pass_lite",))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="default_preset must be included"):
+        OutputReasoningPolicy("report", "single_pass", ("multi_pass_light",))
+
+
+def test_signal_extraction_only_supports_no_reasoning() -> None:
+    assert supported_reasoning_presets("signal_extraction") == ("none",)
+    with pytest.raises(ValueError, match="not supported"):
+        resolve_reasoning_policy("signal_extraction", "single_pass")
+
+
+def test_email_campaign_does_not_support_structured_or_strict_presets() -> None:
+    supported = supported_reasoning_presets("email_campaign")
+    assert supported == ("none", "context_only", "single_pass", "multi_pass_light")
+    assert "multi_pass_structured" not in supported
+    assert "multi_pass_strict" not in supported
+
+
+def test_landing_page_supports_structured_but_not_strict_preset() -> None:
+    supported = supported_reasoning_presets("landing_page")
+    assert supported == (
+        "none",
+        "context_only",
+        "single_pass",
+        "multi_pass_light",
+        "multi_pass_structured",
+    )
+    assert "multi_pass_strict" not in supported
+
+
+@pytest.mark.parametrize("output", ("blog_post", "report", "sales_brief"))
+def test_long_form_assets_support_structured_presets(output: str) -> None:
+    assert supported_reasoning_presets(output) == (
+        "none",
+        "context_only",
+        "single_pass",
+        "multi_pass_light",
+        "multi_pass_structured",
+        "multi_pass_strict",
+    )
+
+
+def test_resolve_reasoning_policy_uses_output_default_when_preset_missing() -> None:
+    assert resolve_reasoning_policy("report")[1].id == "multi_pass_structured"
+    assert resolve_reasoning_policy("report", "")[1].id == "multi_pass_structured"
+    assert resolve_reasoning_policy("report", "context_only")[1].id == "context_only"
+
+
+@pytest.mark.parametrize(
+    ("call", "message"),
+    (
+        (lambda: output_reasoning_policy("podcast_repurpose"), "unknown content output"),
+        (lambda: reasoning_preset_definition("deep_magic"), "unknown reasoning preset"),
+    ),
+)
+def test_unknown_policy_inputs_raise_value_error(call, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        call()
+
+
+def test_policy_catalog_is_immutable() -> None:
+    with pytest.raises(TypeError):
+        OUTPUT_REASONING_POLICIES["report"] = output_reasoning_policy("report")  # type: ignore[index]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Preset-Catalog.md

Adds the pure Content Ops reasoning preset catalog selected by the policy audit. The catalog defines the six preset IDs, maps outputs to supported/default presets, and provides lookup/validation helpers without constructing providers or changing generation behavior.

## Intentional
- Pure policy catalog; no provider construction or runtime behavior changes.
- No FastAPI schema changes.
- Coordination row remains while the draft PR is open.

## Deferred
- Expose the preset catalog through control-surface API responses.
- Use the catalog for report/sales-brief structured reasoning.
- Validation metadata surfacing before strict mode.

## Verification
- pytest tests/test_extracted_content_reasoning_policy.py -> 14 passed
- python -m py_compile extracted_content_pipeline/reasoning_policy.py tests/test_extracted_content_reasoning_policy.py
- git diff --check
- bash scripts/local_pr_review.sh

## Diff size
6 files, +382 / -9