### PR TITLE
Wire report and sales brief reasoning presets

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T05:25Z by codex-2026-05-16
+Last updated: 2026-05-16T18:15Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| #555 | Content Ops report/sales reasoning presets | `extracted_content_pipeline/control_surfaces.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/manifest.json`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_ops_execution.py`, `plans/PR-Content-Ops-Report-Sales-Reasoning-Presets.md` | codex-2026-05-16 | Avoid editing Content Ops control-surface reasoning preset wiring until this lands. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -33,9 +33,12 @@ from ..control_surfaces import (
     OUTPUT_CATALOG,
     PRESETS,
     preview_from_mapping,
+    request_from_mapping,
     retry_adjusted_unit_cost_usd,
+    resolve_outputs,
 )
-from ..generation_plan import build_generation_plan_from_mapping
+from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
+from ..reasoning_policy import ReasoningPreset, resolve_reasoning_policy
 
 ExecutionServicesProvider = Callable[
     [],
@@ -56,6 +59,7 @@ ReasoningStatusProvider = Callable[
     [],
     Mapping[str, Any] | None | Awaitable[Mapping[str, Any] | None],
 ]
+LLMProvider = Callable[[], Any | Awaitable[Any]]
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +68,7 @@ _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
+_RUNTIME_STRUCTURED_REASONING_OUTPUTS = frozenset({"report", "sales_brief"})
 
 
 def _build_static_catalog_payload() -> Mapping[str, Any]:
@@ -161,10 +166,25 @@ class ContentOpsControlSurfaceApiConfig:
 
     prefix: str = "/content-ops"
     tags: tuple[str, ...] = ("content-ops",)
+    structured_reasoning_default_goal: str = "synthesize content reasoning context"
+    structured_reasoning_depth: str = "L3"
+    structured_reasoning_pack_name: str = "content_ops_structured"
+    structured_reasoning_top_thesis_limit: int = 5
+    structured_reasoning_max_continuations: int = 8
 
     def __post_init__(self) -> None:
         if not str(self.prefix or "").strip().startswith("/"):
             raise ValueError("prefix must start with /")
+        if not str(self.structured_reasoning_default_goal or "").strip():
+            raise ValueError("structured_reasoning_default_goal is required")
+        if not str(self.structured_reasoning_pack_name or "").strip():
+            raise ValueError("structured_reasoning_pack_name is required")
+        if self.structured_reasoning_depth not in {"L1", "L2", "L3", "L4", "L5"}:
+            raise ValueError("structured_reasoning_depth must be L1-L5")
+        if self.structured_reasoning_top_thesis_limit <= 0:
+            raise ValueError("structured_reasoning_top_thesis_limit must be positive")
+        if self.structured_reasoning_max_continuations < 0:
+            raise ValueError("structured_reasoning_max_continuations must be non-negative")
 
 
 if BaseModel is not None:
@@ -176,6 +196,7 @@ if BaseModel is not None:
 
         target_mode: str = Field("vendor_retention", min_length=1, max_length=80)
         preset: str | None = Field(default=None, max_length=80)
+        reasoning_preset: ReasoningPreset | None = Field(default=None)
         outputs: tuple[str, ...] = Field(default_factory=tuple, max_length=20)
         limit: int = Field(1, ge=1, le=1000)
         max_cost_usd: float | None = Field(default=None, gt=0)
@@ -191,6 +212,16 @@ if BaseModel is not None:
                 text = str(item or "").strip()
                 if not text or len(text) > 80:
                     raise ValueError("outputs entries must be 1-80 characters")
+            return value
+
+        @field_validator("reasoning_preset", mode="before")
+        @classmethod
+        def _normalize_reasoning_preset(cls, value: Any) -> Any:
+            if value is None:
+                return None
+            if isinstance(value, str):
+                text = value.strip()
+                return text or None
             return value
 
         @field_validator("inputs")
@@ -210,6 +241,7 @@ def create_content_ops_control_surface_router(
     scope_provider: ScopeProvider | None = None,
     reasoning_context_provider: ReasoningContextProvider | None = None,
     reasoning_status_provider: ReasoningStatusProvider | None = None,
+    llm_provider: LLMProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
     """Create host-mounted AI Content Ops control-surface routes.
@@ -295,15 +327,32 @@ def create_content_ops_control_surface_router(
         # bundle is derived with reasoning rebound to None (predictable,
         # no leak of construction-time reasoning). When the kwarg was
         # never supplied, leave the host-baked reasoning alone.
+        payload_mapping = _payload_to_mapping(payload)
         if reasoning_context_provider is not None:
+            if _clean(payload_mapping.get("reasoning_preset")):
+                logger.info(
+                    "Content Ops reasoning_preset ignored because host provider is configured"
+                )
             reasoning_context = await _resolve_reasoning_context(
                 reasoning_context_provider
             )
             services = services.with_reasoning_context(reasoning_context)
+        else:
+            reasoning_context, reasoning_outputs = await _structured_reasoning_context(
+                payload_mapping,
+                config=resolved_config,
+                services=services,
+                llm_provider=llm_provider,
+            )
+            if reasoning_context is not None:
+                services = services.with_reasoning_context(
+                    reasoning_context,
+                    outputs=reasoning_outputs,
+                )
         scope = await _resolve_scope(scope_provider)
         try:
             result = await execute_content_ops_from_mapping(
-                _payload_to_mapping(payload),
+                payload_mapping,
                 services=services,
                 scope=scope,
             )
@@ -355,6 +404,103 @@ async def _resolve_reasoning_context(
             detail="Content Ops reasoning context provider is unavailable.",
         ) from exc
     return value
+
+
+async def _structured_reasoning_context(
+    payload: Mapping[str, Any],
+    *,
+    config: ContentOpsControlSurfaceApiConfig,
+    services: ContentOpsExecutionServices,
+    llm_provider: LLMProvider | None,
+) -> tuple[Any | None, tuple[str, ...]]:
+    preset = _clean(payload.get("reasoning_preset"))
+    if not preset:
+        return None, ()
+    if preset in {"none", "context_only"}:
+        return None, ()
+    try:
+        request = request_from_mapping(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
+        plan = build_generation_plan(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not plan.can_execute:
+        return None, ()
+    supported_outputs = [
+        str(output)
+        for output in resolve_outputs(request)
+        if output in _RUNTIME_STRUCTURED_REASONING_OUTPUTS
+    ]
+    if not supported_outputs:
+        raise HTTPException(
+            status_code=400,
+            detail="reasoning_preset currently applies only to report and sales_brief.",
+        )
+    for output in supported_outputs:
+        try:
+            _policy, definition = resolve_reasoning_policy(output, preset)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if definition.id != "multi_pass_structured":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Content Ops packaged reasoning currently supports "
+                    "multi_pass_structured for report and sales_brief."
+                ),
+            )
+    selected_outputs = [
+        output for output in supported_outputs if output in services.configured_outputs()
+    ]
+    if not selected_outputs:
+        return None, ()
+    for output in selected_outputs:
+        service = services.for_output(output)
+        if not callable(getattr(service, "with_reasoning_context", None)):
+            raise HTTPException(
+                status_code=503,
+                detail=f"{output} service does not support structured reasoning.",
+            )
+    if llm_provider is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops structured reasoning LLM is unavailable.",
+        )
+    try:
+        llm = await _resolve_provider(llm_provider)
+    except Exception as exc:
+        logger.exception("Content Ops structured reasoning LLM provider failed")
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops structured reasoning LLM is unavailable.",
+        ) from exc
+    if llm is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops structured reasoning LLM is unavailable.",
+        )
+    # Lazy import keeps hosts without structured reasoning free of these deps.
+    from extracted_reasoning_core.types import ReasoningPack, ReasoningPorts
+
+    from ..services.multi_pass_reasoning_provider import (
+        MultiPassCampaignReasoningProvider,
+        MultiPassReasoningProviderConfig,
+    )
+
+    return MultiPassCampaignReasoningProvider(
+        ports=ReasoningPorts(llm=llm),
+        config=MultiPassReasoningProviderConfig(
+            default_goal=config.structured_reasoning_default_goal,
+            default_depth=config.structured_reasoning_depth,
+            top_thesis_limit=config.structured_reasoning_top_thesis_limit,
+            max_continuations=config.structured_reasoning_max_continuations,
+            narrative_plan_pack=ReasoningPack(
+                name=config.structured_reasoning_pack_name,
+            ),
+        ),
+    ), tuple(selected_outputs)
 
 
 async def _resolve_reasoning_status(

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -33,6 +33,7 @@ class ContentOpsExecutionServices:
     sales_brief: Any | None = None
     signal_extraction: Any | None = None
     reasoning_provider_configured: bool = False
+    reasoning_provider_outputs: tuple[str, ...] = ()
 
     def for_output(self, output: str) -> Any | None:
         if output == "email_campaign":
@@ -66,6 +67,7 @@ class ContentOpsExecutionServices:
     def with_reasoning_context(
         self,
         provider: Any | None,
+        outputs: Sequence[str] | None = None,
     ) -> "ContentOpsExecutionServices":
         """Return a derived bundle with each reasoning-aware service rebound.
 
@@ -75,19 +77,44 @@ class ContentOpsExecutionServices:
         in ``execution_services_provider`` are not mutated. Services that
         opt in expose ``with_reasoning_context(provider) -> Self``;
         services that don't (e.g. signal_extraction, which doesn't
-        consume reasoning context) are passed through unchanged.
+        consume reasoning context) are passed through unchanged. When
+        ``outputs`` is ``None``, all reasoning-aware services are rebound.
+        Passing a sequence scopes rebinding to those output ids; an empty
+        sequence rebinds none.
         """
 
+        if isinstance(outputs, str):
+            raise TypeError("outputs must be a sequence of output ids, not a string")
+        selected = frozenset((
+            "email_campaign",
+            "blog_post",
+            "report",
+            "landing_page",
+            "sales_brief",
+        ) if outputs is None else outputs)
         return ContentOpsExecutionServices(
-            campaign=_rebind_reasoning(self.campaign, provider),
-            blog_post=_rebind_reasoning(self.blog_post, provider),
-            report=_rebind_reasoning(self.report, provider),
-            landing_page=_rebind_reasoning(self.landing_page, provider),
-            sales_brief=_rebind_reasoning(self.sales_brief, provider),
+            campaign=_rebind_reasoning(self.campaign, provider)
+            if "email_campaign" in selected else self.campaign,
+            blog_post=_rebind_reasoning(self.blog_post, provider)
+            if "blog_post" in selected else self.blog_post,
+            report=_rebind_reasoning(self.report, provider)
+            if "report" in selected else self.report,
+            landing_page=_rebind_reasoning(self.landing_page, provider)
+            if "landing_page" in selected else self.landing_page,
+            sales_brief=_rebind_reasoning(self.sales_brief, provider)
+            if "sales_brief" in selected else self.sales_brief,
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
-            reasoning_provider_configured=provider is not None,
+            reasoning_provider_configured=provider is not None and bool(selected),
+            reasoning_provider_outputs=tuple(sorted(selected)) if provider is not None else (),
         )
+
+    def reasoning_provider_active_for(self, output: str) -> bool:
+        if not self.reasoning_provider_configured:
+            return False
+        if not self.reasoning_provider_outputs:
+            return True
+        return output in self.reasoning_provider_outputs
 
 
 def _rebind_reasoning(service: Any | None, provider: Any | None) -> Any | None:
@@ -178,7 +205,9 @@ async def execute_content_ops_request(
             service=services.for_output(step.output),
             scope=resolved_scope,
             filters=filters,
-            reasoning_provider_configured=services.reasoning_provider_configured,
+            reasoning_provider_configured=services.reasoning_provider_active_for(
+                step.output
+            ),
         )
         for step in plan.steps
     ))

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -46,6 +46,7 @@ class ContentOpsRequest:
 
     target_mode: str = "vendor_retention"
     preset: str | None = None
+    reasoning_preset: str | None = None
     outputs: tuple[str, ...] = ()
     limit: int = 1
     max_cost_usd: float | None = None
@@ -80,6 +81,7 @@ class ControlSurfacePreview:
             else {
                 "target_mode": self.normalized_request.target_mode,
                 "preset": self.normalized_request.preset,
+                "reasoning_preset": self.normalized_request.reasoning_preset,
                 "outputs": list(self.normalized_request.outputs),
                 "limit": self.normalized_request.limit,
                 "max_cost_usd": self.normalized_request.max_cost_usd,
@@ -237,6 +239,9 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
         preset=(str(payload.get("preset")).strip() or None)
         if payload.get("preset") is not None
         else None,
+        reasoning_preset=(str(payload.get("reasoning_preset")).strip() or None)
+        if payload.get("reasoning_preset") is not None
+        else None,
         outputs=normalize_outputs(payload.get("outputs")),
         limit=limit,
         max_cost_usd=max_cost_usd,
@@ -362,6 +367,7 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
     normalized_request = ContentOpsRequest(
         target_mode=request.target_mode,
         preset=request.preset,
+        reasoning_preset=request.reasoning_preset,
         outputs=selected_outputs,
         limit=request.limit,
         max_cost_usd=request.max_cost_usd,

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -20,9 +20,16 @@ from .control_surfaces import (
     request_from_mapping,
 )
 from .landing_page_generation import LandingPageGenerationConfig
+from .reasoning_policy import resolve_reasoning_policy
 from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
+
+_RUNTIME_PACKAGED_REASONING_PRESETS = frozenset({
+    "none",
+    "context_only",
+    "multi_pass_structured",
+})
 
 
 @dataclass(frozen=True)
@@ -100,6 +107,26 @@ def _report_config_for_request(request: ContentOpsRequest) -> ReportGenerationCo
         default_report_type=report_type,
         limit=request.limit,
     )
+
+
+def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dict[str, Any]:
+    # Informational plan metadata only. Runtime behavior is applied by
+    # ContentOpsExecutionServices.with_reasoning_context at execute time.
+    if request.reasoning_preset is None:
+        return {}
+    _policy, definition = resolve_reasoning_policy(output, request.reasoning_preset)
+    if definition.id not in _RUNTIME_PACKAGED_REASONING_PRESETS:
+        raise ValueError(
+            "Content Ops packaged reasoning currently supports "
+            "multi_pass_structured for report and sales_brief."
+        )
+    return {
+        "reasoning_preset": definition.id,
+        "reasoning_multi_pass": definition.multi_pass,
+        "reasoning_narrative_planning": definition.narrative_planning,
+        "reasoning_output_validation": definition.output_validation,
+        "reasoning_blocking_validation": definition.blocking_validation,
+    }
 
 
 def _landing_page_config_for_request(request: ContentOpsRequest) -> LandingPageGenerationConfig:
@@ -196,6 +223,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_gates_enabled": request.require_quality_gates,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_reasoning_config_for_output(output, request),
             },
         )
     if output == "landing_page":
@@ -228,6 +256,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_gates_enabled": request.require_quality_gates,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_reasoning_config_for_output(output, request),
             },
         )
     if output == "blog_post":

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -269,6 +269,12 @@
       "target": "extracted_content_pipeline/content_ops_execution.py"
     },
     {
+      "target": "extracted_content_pipeline/control_surfaces.py"
+    },
+    {
+      "target": "extracted_content_pipeline/generation_plan.py"
+    },
+    {
       "target": "extracted_content_pipeline/reasoning_policy.py"
     },
     {

--- a/plans/PR-Content-Ops-Report-Sales-Reasoning-Presets.md
+++ b/plans/PR-Content-Ops-Report-Sales-Reasoning-Presets.md
@@ -1,0 +1,29 @@
+# PR: Content Ops Report/Sales Reasoning Presets
+## Why this slice exists
+PR #554 added the preset catalog; this wires the first runtime consumer.
+## Scope (this PR)
+Add `reasoning_preset`, report/sales-brief plan metadata, and scoped
+`multi_pass_structured` provider construction. Host providers still win.
+### Files Touched
+`docs/extraction/coordination/inflight.md` `extracted_content_pipeline/api/control_surfaces.py`
+`extracted_content_pipeline/content_ops_execution.py` `extracted_content_pipeline/control_surfaces.py`
+`extracted_content_pipeline/generation_plan.py` `extracted_content_pipeline/manifest.json`
+`plans/PR-Content-Ops-Report-Sales-Reasoning-Presets.md` `tests/test_extracted_content_control_surface_api.py`
+`tests/test_extracted_content_generation_plan.py` `tests/test_extracted_content_ops_execution.py`
+## Mechanism
+The API turns `multi_pass_structured` into a `MultiPassCampaignReasoningProvider`
+only for configured `report` and `sales_brief` services.
+## Intentional
+No strict mode, cache/state store, blog/email/landing provider, or behavior
+change when `reasoning_preset` is absent. Runtime structured report/brief
+reasoning uses `L3`; the bare provider default stays `L2`.
+## Deferred
+Runtime `OutputPolicy`/`multi_pass_strict` stay deferred; validation flags are plan metadata here.
+## Verification
+ pytest focused generation-plan/execution/API suite -> 99 passed.
+py_compile -> passed. git diff check -> passed.
+ASCII grep on touched Python files -> passed. local PR review -> passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~580 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -716,6 +716,19 @@ class _ReasoningPayloadService(_ReasoningCapturingService):
         return payload
 
 
+class _ProviderRecordingService:
+    def __init__(self, providers=None):
+        self.providers = providers if providers is not None else []
+
+    def with_reasoning_context(self, provider):
+        self.providers.append(provider)
+        return _ProviderRecordingService(self.providers)
+
+    async def generate(self, *, scope, target_mode, limit=None, filters=None, **kwargs):
+        del scope, target_mode, limit, filters, kwargs
+        return {"generated": 1, "saved_ids": ["draft-1"]}
+
+
 @pytest.mark.asyncio
 async def test_execute_route_threads_reasoning_provider_into_services():
     """A configured ``reasoning_context_provider`` reaches the service
@@ -851,3 +864,224 @@ async def test_execute_route_reasoning_provider_returning_none_rebinds_to_none()
     # itself is unchanged (cached service stays intact).
     assert base.calls == []  # original untouched, kept its construction-time reasoning
     assert base._reasoning_context is sentinel_construction_time  # preserved
+
+
+@pytest.mark.asyncio
+async def test_execute_route_builds_structured_reasoning_for_report_only():
+    campaign = _ReasoningCapturingService()
+    recorded_providers = []
+    report = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            campaign=campaign,
+            report=report,
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign", "report"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Audit",
+                "opportunity_id": "opp-1",
+            },
+        }
+    )
+
+    assert len(recorded_providers) == 1
+    provider = recorded_providers[0]
+    assert provider._config.default_goal == "synthesize content reasoning context"
+    assert provider._config.narrative_plan_pack.name == "content_ops_structured"
+    assert provider._config.output_policy is None
+    assert campaign.calls[0]["reasoning_context"] is None
+    email_step = next(step for step in payload["steps"] if step["output"] == "email_campaign")
+    assert email_step["reasoning"]["provider_configured"] is False
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_status", "expected_detail"),
+    (
+        (
+            {
+                "outputs": ["report"],
+                "reasoning_preset": "garbage",
+                "inputs": {"opportunity_id": "opp-1"},
+            },
+            422,
+            "multi_pass_strict",
+        ),
+        (
+            {
+                "outputs": ["report"],
+                "reasoning_preset": "multi_pass_strict",
+                "inputs": {"opportunity_id": "opp-1"},
+            },
+            400,
+            "multi_pass_structured",
+        ),
+        (
+            {
+                "outputs": ["blog_post"],
+                "reasoning_preset": "multi_pass_structured",
+                "inputs": {"topic": "Churn pressure"},
+            },
+            400,
+            "report and sales_brief",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_execute_route_rejects_invalid_reasoning_preset_requests(
+    payload,
+    expected_status,
+    expected_detail,
+):
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            blog_post=_ProviderRecordingService(),
+            report=_ProviderRecordingService(),
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(payload)
+
+    assert exc.value.status_code == expected_status
+    assert expected_detail in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_execute_route_host_reasoning_provider_beats_reasoning_preset():
+    base = _ReasoningCapturingService()
+    sentinel = object()
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(report=base),
+        reasoning_context_provider=lambda: sentinel,
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {"opportunity_id": "opp-1"},
+        }
+    )
+
+    assert base.calls == []
+
+
+@pytest.mark.parametrize("preset", ("none", "context_only", " "))
+@pytest.mark.asyncio
+async def test_execute_route_noop_reasoning_presets_skip_packaged_provider(preset):
+    base = _ReasoningCapturingService()
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(report=base),
+        llm_provider=lambda: pytest.fail("packaged reasoning should be skipped"),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint({
+        "outputs": ["report"],
+        "reasoning_preset": preset,
+        "inputs": {"opportunity_id": "opp-1"},
+    })
+
+    assert len(base.calls) == 1
+    assert base.calls[0]["reasoning_context"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_route_validates_plan_before_structured_reasoning_provider():
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            report=_ProviderRecordingService()
+        ),
+        llm_provider=lambda: pytest.fail("llm provider should not be resolved"),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {},
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["errors"] == [{"reason": "plan_not_executable"}]
+
+
+@pytest.mark.asyncio
+async def test_execute_route_validates_packaged_preset_before_service_capability():
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            report=_CampaignService()
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_strict",
+            "inputs": {"opportunity_id": "opp-1"},
+        })
+
+    assert exc.value.status_code == 400
+    assert "multi_pass_structured" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_execute_route_structured_reasoning_requires_reasoning_aware_service():
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            report=_CampaignService()
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {"opportunity_id": "opp-1"},
+        })
+
+    assert exc.value.status_code == 503
+    assert "does not support structured reasoning" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_execute_route_structured_reasoning_requires_llm_provider():
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            report=_ProviderRecordingService()
+        )
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["report"],
+                "reasoning_preset": "multi_pass_structured",
+                "inputs": {"opportunity_id": "opp-1"},
+            }
+        )
+
+    assert exc.value.status_code == 503
+
+
+def test_content_ops_config_rejects_blank_structured_reasoning_pack_name():
+    with pytest.raises(ValueError, match="structured_reasoning_pack_name"):
+        ContentOpsControlSurfaceApiConfig(structured_reasoning_pack_name=" ")

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -67,6 +67,49 @@ def test_plan_maps_report_to_report_generation_service():
     }
 
 
+def test_plan_threads_structured_reasoning_preset_to_report_and_sales_brief():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["report", "sales_brief"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {
+                "opportunity_id": "opp_123",
+                "target_account": "Acme",
+            },
+        }
+    )
+
+    for step in plan["steps"]:
+        assert step["config"]["reasoning_preset"] == "multi_pass_structured"
+        assert step["config"]["reasoning_multi_pass"] is True
+        assert step["config"]["reasoning_narrative_planning"] is True
+        assert step["config"]["reasoning_output_validation"] is True
+        assert step["config"]["reasoning_blocking_validation"] is False
+
+
+def test_plan_rejects_unknown_reasoning_preset_for_report():
+    with pytest.raises(ValueError, match="unknown reasoning preset"):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": ["report"],
+                "reasoning_preset": "unsupported",
+                "inputs": {"opportunity_id": "opp_123"},
+            }
+        )
+
+
+@pytest.mark.parametrize("preset", ("single_pass", "multi_pass_light", "multi_pass_strict"))
+def test_plan_rejects_runtime_unsupported_reasoning_preset_for_report(preset):
+    with pytest.raises(ValueError, match="multi_pass_structured"):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": ["report"],
+                "reasoning_preset": preset,
+                "inputs": {"opportunity_id": "opp_123"},
+            }
+        )
+
+
 def test_plan_maps_blog_to_blog_generation_service():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -97,6 +97,41 @@ class _ReasoningAwareOpportunityService(_OpportunityService):
         return _ReasoningAwareOpportunityService(reasoning_context=provider)
 
 
+def test_services_with_reasoning_context_can_target_specific_outputs() -> None:
+    provider = object()
+    campaign = _ReasoningAwareOpportunityService()
+    report = _ReasoningAwareOpportunityService()
+    bundle = ContentOpsExecutionServices(campaign=campaign, report=report)
+
+    derived = bundle.with_reasoning_context(provider, outputs=("report",))
+
+    assert derived.campaign is campaign
+    assert derived.report is not report
+    assert derived.report._reasoning_context is provider
+    assert derived.reasoning_provider_active_for("report") is True
+    assert derived.reasoning_provider_active_for("email_campaign") is False
+
+
+def test_services_with_reasoning_context_honors_empty_output_selection() -> None:
+    campaign = _ReasoningAwareOpportunityService()
+    derived = ContentOpsExecutionServices(campaign=campaign).with_reasoning_context(
+        object(),
+        outputs=(),
+    )
+
+    assert derived.campaign is campaign
+    assert derived.reasoning_provider_configured is False
+
+
+def test_services_with_reasoning_context_rejects_string_outputs() -> None:
+    campaign = _ReasoningAwareOpportunityService()
+    with pytest.raises(TypeError, match="outputs must be a sequence"):
+        ContentOpsExecutionServices(campaign=campaign).with_reasoning_context(
+            object(),
+            outputs="report",
+        )
+
+
 class _LandingPageService:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []


### PR DESCRIPTION
# PR: Content Ops Report/Sales Reasoning Presets

## Why this slice exists

PR #554 added the pure reasoning preset catalog. This slice is the first
runtime consumer: report and sales-brief execution can explicitly request the
structured multi-pass preset and receive narrative-plan-enabled reasoning.

## Scope

- Add a `reasoning_preset` request field.
- Thread report/sales-brief preset choices into generation plans.
- Let `/content-ops/execute` construct a multi-pass provider from the host LLM
  only for report/sales-brief when `multi_pass_structured` is requested.
- Keep host-supplied `reasoning_context_provider` precedence unchanged.

### Files Touched

`extracted_content_pipeline/control_surfaces.py`,
`extracted_content_pipeline/generation_plan.py`,
`extracted_content_pipeline/content_ops_execution.py`,
`extracted_content_pipeline/api/control_surfaces.py`,
`tests/test_extracted_content_control_surface_api.py`,
`tests/test_extracted_content_generation_plan.py`,
`tests/test_extracted_content_ops_execution.py`,
`docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`,
`docs/extraction/coordination/inflight.md`,
`extracted_content_pipeline/STATUS.md`,
`plans/PR-Content-Ops-Report-Sales-Reasoning-Presets.md`

## Mechanism

The control-surface request carries an optional `reasoning_preset`. Report and
sales-brief plan steps resolve that preset through `reasoning_policy`. At
execute time, if no explicit provider is supplied and the request asks for
`multi_pass_structured`, the router builds `MultiPassCampaignReasoningProvider`
with a narrative `ReasoningPack` and rebinds only report/sales-brief services.

## Intentional

- No strict/blocking validation mode.
- No cache or state-store construction.
- No blog/email/landing-page provider construction.
- No change when `reasoning_preset` is absent.

## Deferred

- Validation metadata surfacing.
- Strict reasoning mode.
- Blog-specific narrative pack.

## Verification

- Focused generation-plan and control-surface API tests.
- Python compile, diff check, ASCII policy, and local PR review.

## Estimated Diff Size

| Area | Estimated LOC |
|---|---:|
| Runtime wiring | ~150 |
| Tests | ~160 |
| Docs/status/plan | ~90 |
| **Total** | ~400 |
