### PR TITLE
Enable strict reasoning policy for Content Ops

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -77,13 +77,15 @@ Remaining work:
 
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
-- First runtime wiring for structured reasoning on `report` and `sales_brief`.
-- Validation metadata surfacing before any strict blocking mode.
+- Host-owned falsification policy wiring for strict presets.
+- Operator-facing validation telemetry beyond the current strict failure
+  reason surfaced through generated-asset errors.
 
-**Likely slice:** use the reasoning preset catalog to wire structured
-multi-pass reasoning for `report` and `sales_brief`. Keep provider construction
-scoped to those two outputs; do not add strict blocking until validation
-metadata is visible to operators.
+**Shipped slice:** structured and strict multi-pass reasoning are wired for
+`report` and `sales_brief`. Strict mode now fails closed before those assets are
+generated when validation blockers are present, and the generated-asset error
+reason includes the validation blocker identifiers. Richer operator telemetry
+is still a follow-up.
 
 ### 2. Source breadth from real host exports
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T18:15Z by codex-2026-05-16
+Last updated: 2026-05-16T18:45Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #555 | Content Ops report/sales reasoning presets | `extracted_content_pipeline/control_surfaces.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/manifest.json`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_ops_execution.py`, `plans/PR-Content-Ops-Report-Sales-Reasoning-Presets.md` | codex-2026-05-16 | Avoid editing Content Ops control-surface reasoning preset wiring until this lands. |
+| #556 | Content Ops strict reasoning output policy | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/reasoning_policy.py`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_report_generation.py`, `tests/test_extracted_sales_brief_generation.py`, `plans/PR-Content-Ops-Strict-Reasoning-Policy.md` | codex-2026-05-16 | Avoid report/sales packaged reasoning preset runtime policy edits. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -188,6 +188,12 @@ source of truth for what remains.
   or changing runtime behavior. `blog_post` defaults to `multi_pass_light` as
   a quality-over-cost choice; hosts that want cheaper blog runs can select
   `single_pass`.
+- `/content-ops/execute` can construct packaged `multi_pass_structured` or
+  `multi_pass_strict` reasoning for `report` and `sales_brief` when the
+  request explicitly sets `reasoning_preset` and the host supplies an LLM
+  provider. Strict mode uses the same provider plus citation validation and
+  fails closed before report/sales generation when validation blockers are
+  present.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -171,6 +171,7 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_pack_name: str = "content_ops_structured"
     structured_reasoning_top_thesis_limit: int = 5
     structured_reasoning_max_continuations: int = 8
+    structured_reasoning_require_citations: bool = True
 
     def __post_init__(self) -> None:
         if not str(self.prefix or "").strip().startswith("/"):
@@ -185,6 +186,56 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError("structured_reasoning_top_thesis_limit must be positive")
         if self.structured_reasoning_max_continuations < 0:
             raise ValueError("structured_reasoning_max_continuations must be non-negative")
+
+
+@dataclass(frozen=True)
+class _BlockingReasoningContextProvider:
+    provider: Any
+
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope: TenantScope,
+        target_id: str,
+        target_mode: str,
+        opportunity: Mapping[str, Any],
+    ) -> Any:
+        context = await self.provider.read_campaign_reasoning_context(
+            scope=scope,
+            target_id=target_id,
+            target_mode=target_mode,
+            opportunity=opportunity,
+        )
+        if context is None:
+            raise RuntimeError("reasoning_validation_blocked")
+        validation = _reasoning_validation_from_context(context)
+        if validation is not None and validation.get("passed") is False:
+            blockers = [
+                str(item).strip()
+                for item in _clean_status_scalar_sequence(validation.get("blockers"))
+                if str(item).strip()
+            ]
+            suffix = f":{','.join(blockers)}" if blockers else ""
+            raise RuntimeError(f"reasoning_validation_blocked{suffix}")
+        return context
+
+
+def _reasoning_validation_from_context(context: Any) -> Mapping[str, Any] | None:
+    canonical = getattr(context, "canonical_reasoning", None)
+    if isinstance(canonical, Mapping):
+        validation = canonical.get("validation")
+        if isinstance(validation, Mapping):
+            return validation
+    if isinstance(context, Mapping):
+        validation = context.get("validation")
+        if isinstance(validation, Mapping):
+            return validation
+        canonical = context.get("canonical_reasoning")
+        if isinstance(canonical, Mapping):
+            validation = canonical.get("validation")
+            if isinstance(validation, Mapping):
+                return validation
+    return None
 
 
 if BaseModel is not None:
@@ -438,23 +489,28 @@ async def _structured_reasoning_context(
             status_code=400,
             detail="reasoning_preset currently applies only to report and sales_brief.",
         )
+    reasoning_definition = None
     for output in supported_outputs:
         try:
             _policy, definition = resolve_reasoning_policy(output, preset)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if definition.id != "multi_pass_structured":
+        reasoning_definition = definition
+        if definition.id not in {"multi_pass_structured", "multi_pass_strict"}:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     "Content Ops packaged reasoning currently supports "
-                    "multi_pass_structured for report and sales_brief."
+                    "multi_pass_structured or multi_pass_strict for report "
+                    "and sales_brief."
                 ),
             )
     selected_outputs = [
         output for output in supported_outputs if output in services.configured_outputs()
     ]
     if not selected_outputs:
+        return None, ()
+    if reasoning_definition is None:
         return None, ()
     for output in selected_outputs:
         service = services.for_output(output)
@@ -482,14 +538,14 @@ async def _structured_reasoning_context(
             detail="Content Ops structured reasoning LLM is unavailable.",
         )
     # Lazy import keeps hosts without structured reasoning free of these deps.
-    from extracted_reasoning_core.types import ReasoningPack, ReasoningPorts
+    from extracted_reasoning_core.types import OutputPolicy, ReasoningPack, ReasoningPorts
 
     from ..services.multi_pass_reasoning_provider import (
         MultiPassCampaignReasoningProvider,
         MultiPassReasoningProviderConfig,
     )
 
-    return MultiPassCampaignReasoningProvider(
+    provider = MultiPassCampaignReasoningProvider(
         ports=ReasoningPorts(llm=llm),
         config=MultiPassReasoningProviderConfig(
             default_goal=config.structured_reasoning_default_goal,
@@ -499,8 +555,17 @@ async def _structured_reasoning_context(
             narrative_plan_pack=ReasoningPack(
                 name=config.structured_reasoning_pack_name,
             ),
+            output_policy=OutputPolicy(
+                require_citations=config.structured_reasoning_require_citations,
+            ),
+            # Keep the inner provider nonblocking so strict wrappers can
+            # surface validation blocker details instead of a generic None.
+            block_on_validation_failure=False,
         ),
-    ), tuple(selected_outputs)
+    )
+    if reasoning_definition.blocking_validation:
+        provider = _BlockingReasoningContextProvider(provider)
+    return provider, tuple(selected_outputs)
 
 
 async def _resolve_reasoning_status(

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -29,6 +29,7 @@ _RUNTIME_PACKAGED_REASONING_PRESETS = frozenset({
     "none",
     "context_only",
     "multi_pass_structured",
+    "multi_pass_strict",
 })
 
 
@@ -118,7 +119,7 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
     if definition.id not in _RUNTIME_PACKAGED_REASONING_PRESETS:
         raise ValueError(
             "Content Ops packaged reasoning currently supports "
-            "multi_pass_structured for report and sales_brief."
+            "multi_pass_structured or multi_pass_strict for report and sales_brief."
         )
     return {
         "reasoning_preset": definition.id,

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -98,7 +98,6 @@ REASONING_PRESETS: Mapping[str, ReasoningPresetDefinition] = MappingProxyType({
         generated_reasoning=True,
         multi_pass=True,
         narrative_planning=True,
-        falsification=True,
         output_validation=True,
         blocking_validation=True,
     ),

--- a/plans/PR-Content-Ops-Strict-Reasoning-Policy.md
+++ b/plans/PR-Content-Ops-Strict-Reasoning-Policy.md
@@ -1,0 +1,61 @@
+# Content Ops Strict Reasoning Policy
+
+## Why this slice exists
+
+PR #555 made packaged `multi_pass_structured` usable for report and sales
+brief generation, but `multi_pass_strict` still failed at plan/runtime
+boundaries even though the multi-pass provider already supports output
+validation and blocking validation.
+
+## Scope (this PR)
+
+1. Allow report and sales brief requests to use `multi_pass_strict`.
+2. Map packaged reasoning presets onto the existing `OutputPolicy` runtime
+   knobs.
+3. Keep `multi_pass_structured` nonblocking, and make `multi_pass_strict`
+   fail closed via a strict wrapper that preserves validation blocker details.
+4. Keep the catalog honest by leaving falsification disabled until host-owned
+   rules are wired.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `plans/PR-Content-Ops-Strict-Reasoning-Policy.md`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+- `tests/test_extracted_report_generation.py`
+- `tests/test_extracted_sales_brief_generation.py`
+
+## Mechanism
+
+Update generation-plan preset validation, API provider construction, and
+focused tests for report/sales strict reasoning. The API still builds only
+host-injected LLM ports; no database, provider routing, or storage surface is
+added.
+
+## Intentional
+
+No falsification policy is auto-created. The provider supports it, but the
+control-surface request has no host-owned falsification rules to pass yet.
+
+## Deferred
+
+Host-configured falsification rules remain separate product-policy work.
+
+## Verification
+
+pytest focused generation-plan/API/policy/report/sales suite -> 132 passed.
+py_compile -> passed. git diff check -> passed. ASCII grep on touched Python
+files -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~370 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -5,6 +5,7 @@ from extracted_content_pipeline.api.control_surfaces import (
     ContentOpsControlSurfaceApiConfig,
     create_content_ops_control_surface_router,
 )
+from extracted_content_pipeline.campaign_ports import CampaignReasoningContext
 from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
 
 
@@ -729,6 +730,15 @@ class _ProviderRecordingService:
         return {"generated": 1, "saved_ids": ["draft-1"]}
 
 
+class _StaticReasoningProvider:
+    def __init__(self, context):
+        self.context = context
+
+    async def read_campaign_reasoning_context(self, **kwargs):
+        del kwargs
+        return self.context
+
+
 @pytest.mark.asyncio
 async def test_execute_route_threads_reasoning_provider_into_services():
     """A configured ``reasoning_context_provider`` reaches the service
@@ -897,10 +907,87 @@ async def test_execute_route_builds_structured_reasoning_for_report_only():
     provider = recorded_providers[0]
     assert provider._config.default_goal == "synthesize content reasoning context"
     assert provider._config.narrative_plan_pack.name == "content_ops_structured"
-    assert provider._config.output_policy is None
+    assert provider._config.output_policy is not None
+    assert provider._config.output_policy.require_citations is True
+    assert provider._config.block_on_validation_failure is False
     assert campaign.calls[0]["reasoning_context"] is None
     email_step = next(step for step in payload["steps"] if step["output"] == "email_campaign")
     assert email_step["reasoning"]["provider_configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_execute_route_wraps_strict_reasoning_with_blocking_provider():
+    recorded_providers = []
+    report = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(report=report),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_strict",
+            "inputs": {"opportunity_id": "opp-1"},
+        }
+    )
+
+    provider = recorded_providers[0]
+    assert provider.provider._config.output_policy is not None
+    assert provider.provider._config.block_on_validation_failure is False
+
+
+@pytest.mark.asyncio
+async def test_execute_route_can_relax_strict_reasoning_citation_policy():
+    recorded_providers = []
+    report = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_require_citations=False,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(report=report),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_strict",
+            "inputs": {"opportunity_id": "opp-1"},
+        }
+    )
+
+    provider = recorded_providers[0]
+    assert provider.provider._config.output_policy is not None
+    assert provider.provider._config.output_policy.require_citations is False
+    assert provider.provider._config.block_on_validation_failure is False
+
+
+@pytest.mark.asyncio
+async def test_blocking_reasoning_provider_surfaces_validation_blockers():
+    context = CampaignReasoningContext(
+        canonical_reasoning={
+            "validation": {
+                "passed": False,
+                "blockers": ("claim_missing_citations:0",),
+            }
+        }
+    )
+    provider = api_module._BlockingReasoningContextProvider(
+        _StaticReasoningProvider(context)
+    )
+
+    with pytest.raises(RuntimeError, match="claim_missing_citations:0"):
+        await provider.read_campaign_reasoning_context(
+            scope=None,
+            target_id="opp-1",
+            target_mode="vendor_retention",
+            opportunity={},
+        )
 
 
 @pytest.mark.parametrize(
@@ -917,12 +1004,21 @@ async def test_execute_route_builds_structured_reasoning_for_report_only():
         ),
         (
             {
+                "outputs": ["blog_post"],
+                "reasoning_preset": "garbage",
+                "inputs": {"topic": "Churn pressure"},
+            },
+            422,
+            "multi_pass_strict",
+        ),
+        (
+            {
                 "outputs": ["report"],
-                "reasoning_preset": "multi_pass_strict",
+                "reasoning_preset": "multi_pass_light",
                 "inputs": {"opportunity_id": "opp-1"},
             },
             400,
-            "multi_pass_structured",
+            "multi_pass_structured or multi_pass_strict",
         ),
         (
             {
@@ -1032,12 +1128,12 @@ async def test_execute_route_validates_packaged_preset_before_service_capability
     with pytest.raises(api_module.HTTPException) as exc:
         await route.endpoint({
             "outputs": ["report"],
-            "reasoning_preset": "multi_pass_strict",
+            "reasoning_preset": "multi_pass_light",
             "inputs": {"opportunity_id": "opp-1"},
         })
 
     assert exc.value.status_code == 400
-    assert "multi_pass_structured" in str(exc.value.detail)
+    assert "multi_pass_structured or multi_pass_strict" in str(exc.value.detail)
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -87,6 +87,26 @@ def test_plan_threads_structured_reasoning_preset_to_report_and_sales_brief():
         assert step["config"]["reasoning_blocking_validation"] is False
 
 
+def test_plan_threads_strict_reasoning_preset_to_report_and_sales_brief():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["report", "sales_brief"],
+            "reasoning_preset": "multi_pass_strict",
+            "inputs": {
+                "opportunity_id": "opp_123",
+                "target_account": "Acme",
+            },
+        }
+    )
+
+    for step in plan["steps"]:
+        assert step["config"]["reasoning_preset"] == "multi_pass_strict"
+        assert step["config"]["reasoning_multi_pass"] is True
+        assert step["config"]["reasoning_narrative_planning"] is True
+        assert step["config"]["reasoning_output_validation"] is True
+        assert step["config"]["reasoning_blocking_validation"] is True
+
+
 def test_plan_rejects_unknown_reasoning_preset_for_report():
     with pytest.raises(ValueError, match="unknown reasoning preset"):
         build_generation_plan_from_mapping(
@@ -98,9 +118,9 @@ def test_plan_rejects_unknown_reasoning_preset_for_report():
         )
 
 
-@pytest.mark.parametrize("preset", ("single_pass", "multi_pass_light", "multi_pass_strict"))
+@pytest.mark.parametrize("preset", ("single_pass", "multi_pass_light"))
 def test_plan_rejects_runtime_unsupported_reasoning_preset_for_report(preset):
-    with pytest.raises(ValueError, match="multi_pass_structured"):
+    with pytest.raises(ValueError, match="multi_pass_structured or multi_pass_strict"):
         build_generation_plan_from_mapping(
             {
                 "outputs": ["report"],

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -35,7 +35,7 @@ def test_preset_capabilities_increase_by_depth() -> None:
     assert REASONING_PRESETS["multi_pass_structured"].narrative_planning
     assert REASONING_PRESETS["multi_pass_structured"].output_validation
     assert not REASONING_PRESETS["multi_pass_structured"].blocking_validation
-    assert REASONING_PRESETS["multi_pass_strict"].falsification
+    assert REASONING_PRESETS["multi_pass_strict"].falsification is False
     assert REASONING_PRESETS["multi_pass_strict"].blocking_validation
 
 

--- a/tests/test_extracted_report_generation.py
+++ b/tests/test_extracted_report_generation.py
@@ -114,6 +114,19 @@ class _ReasoningProvider:
         return self.context
 
 
+class _BlockingReasoningProvider:
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        del scope, target_id, target_mode, opportunity
+        raise RuntimeError("reasoning_validation_blocked")
+
+
 def _opportunity():
     return {
         "id": "opp-1",
@@ -401,6 +414,29 @@ async def test_generate_consumes_reasoning_context_via_provider() -> None:
     assert result_dict["consumed_reasoning_contexts"][0]["top_theses"][0]["claim"] == (
         "Renewal pricing"
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_strict_reasoning_blocks_context() -> None:
+    intelligence = _Intelligence([_opportunity()])
+    reports = _Reports()
+    llm = _LLM([_valid_report_json()])
+    skills = _Skills({"digest/report_generation": "TEMPLATE {opportunity_json}"})
+    service = ReportGenerationService(
+        intelligence=intelligence,
+        reports=reports,
+        llm=llm,
+        skills=skills,
+        reasoning_context=_BlockingReasoningProvider(),
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert reports.saved == []
+    assert llm.calls == []
+    assert result.errors[0]["reason"] == "reasoning_validation_blocked"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -114,6 +114,19 @@ class _ReasoningProvider:
         return self.context
 
 
+class _BlockingReasoningProvider:
+    async def read_campaign_reasoning_context(
+        self,
+        *,
+        scope,
+        target_id,
+        target_mode,
+        opportunity,
+    ):
+        del scope, target_id, target_mode, opportunity
+        raise RuntimeError("reasoning_validation_blocked")
+
+
 def _opportunity():
     return {
         "id": "opp-1",
@@ -466,6 +479,29 @@ async def test_generate_consumes_reasoning_context_via_provider() -> None:
     assert result_dict["consumed_reasoning_contexts"][0]["top_theses"][0]["claim"] == (
         "Renewal pricing"
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_when_strict_reasoning_blocks_context() -> None:
+    intelligence = _Intelligence([_opportunity()])
+    sales_briefs = _SalesBriefs()
+    llm = _LLM([_valid_brief_json()])
+    skills = _Skills({"digest/sales_brief_generation": "TEMPLATE {opportunity_json}"})
+    service = SalesBriefGenerationService(
+        intelligence=intelligence,
+        sales_briefs=sales_briefs,
+        llm=llm,
+        skills=skills,
+        reasoning_context=_BlockingReasoningProvider(),
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), target_mode="vendor")
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert sales_briefs.saved == []
+    assert llm.calls == []
+    assert result.errors[0]["reason"] == "reasoning_validation_blocked"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Strict-Reasoning-Policy.md

## Summary
- allow report/sales brief packaged `multi_pass_strict` requests
- map structured/strict presets to `OutputPolicy` runtime config
- make strict validation blocking while structured remains non-blocking

## Verification
- pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_control_surface_api.py
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/generation_plan.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_generation_plan.py
- git diff --check
- bash scripts/local_pr_review.sh

## Deferred
- host-configured falsification rules and output-policy tuning