### PR TITLE
Expose strict validation telemetry in content ops execution

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -53,6 +53,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - Host-facing reasoning policy audit for falsification, narrative planning,
   validation, and per-content-type depth.
 - Reasoning preset catalog for host-facing depth choices.
+- Operator-facing strict validation telemetry in Content Ops execution results.
 
 ## Active Backlog
 
@@ -78,14 +79,13 @@ Remaining work:
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
 - Host-owned falsification policy wiring for strict presets.
-- Operator-facing validation telemetry beyond the current strict failure
-  reason surfaced through generated-asset errors.
 
 **Shipped slice:** structured and strict multi-pass reasoning are wired for
 `report` and `sales_brief`. Strict mode now fails closed before those assets are
 generated when validation blockers are present, and the generated-asset error
-reason includes the validation blocker identifiers. Richer operator telemetry
-is still a follow-up.
+reason includes the validation blocker identifiers. Content Ops execution also
+mirrors those strict validation failures into per-step reasoning telemetry for
+operator inspection.
 
 ### 2. Source breadth from real host exports
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T18:45Z by codex-2026-05-16
+Last updated: 2026-05-16T19:44Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #556 | Content Ops strict reasoning output policy | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/reasoning_policy.py`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_report_generation.py`, `tests/test_extracted_sales_brief_generation.py`, `plans/PR-Content-Ops-Strict-Reasoning-Policy.md` | codex-2026-05-16 | Avoid report/sales packaged reasoning preset runtime policy edits. |
+| #557 | Content Ops strict validation telemetry | `extracted_content_pipeline/content_ops_execution.py`, `tests/test_extracted_content_ops_execution.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Strict-Validation-Telemetry.md` | codex-2026-05-16 | Avoid step-level reasoning audit / strict validation telemetry edits. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -172,9 +172,12 @@ source of truth for what remains.
   bounded consumed-context payloads for the five LLM-backed generated-asset
   services. Runner results include `reasoning_contexts_used` and, when
   reasoning reached the prompt, `consumed_reasoning_contexts`; the per-step
-  `reasoning` audit mirrors those as `contexts_used` and `consumed_contexts`
-  for UI inspection. Atlas Intel renders compact consumed-context summaries;
-  a fuller drawer/detail UX remains a frontend follow-up.
+  `reasoning` audit mirrors those as `contexts_used` and `consumed_contexts`.
+  When strict reasoning validation blocks an asset before prompt generation,
+  the same per-step audit marks `validation_blocked` and includes compact
+  `validation_failures` for operator inspection. Atlas Intel renders compact
+  consumed-context summaries; a fuller drawer/detail UX remains a frontend
+  follow-up.
 - `docs/audits/content_ops_reasoning_policy_audit_2026-05-16.md` defines the
   next reasoning-depth direction: keep reasoning behind the
   `CampaignReasoningContextProvider` boundary, expose depth through named

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -39,6 +39,7 @@ from ..control_surfaces import (
 )
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
 from ..reasoning_policy import ReasoningPreset, resolve_reasoning_policy
+from ..reasoning_signals import reasoning_validation_blocked_reason
 
 ExecutionServicesProvider = Callable[
     [],
@@ -207,7 +208,7 @@ class _BlockingReasoningContextProvider:
             opportunity=opportunity,
         )
         if context is None:
-            raise RuntimeError("reasoning_validation_blocked")
+            raise RuntimeError(reasoning_validation_blocked_reason(()))
         validation = _reasoning_validation_from_context(context)
         if validation is not None and validation.get("passed") is False:
             blockers = [
@@ -215,8 +216,7 @@ class _BlockingReasoningContextProvider:
                 for item in _clean_status_scalar_sequence(validation.get("blockers"))
                 if str(item).strip()
             ]
-            suffix = f":{','.join(blockers)}" if blockers else ""
-            raise RuntimeError(f"reasoning_validation_blocked{suffix}")
+            raise RuntimeError(reasoning_validation_blocked_reason(tuple(blockers)))
         return context
 
 

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -11,6 +11,7 @@ from .campaign_ports import TenantScope
 from .control_surfaces import OUTPUT_CATALOG, ContentOpsRequest, request_from_mapping
 from .generation_plan import GenerationPlan, GenerationPlanStep, build_generation_plan
 from .landing_page_ports import MarketingCampaign
+from .reasoning_signals import REASONING_VALIDATION_BLOCKED
 
 
 @dataclass(frozen=True)
@@ -509,6 +510,8 @@ _DISPATCH: Mapping[str, Any] = {
     "signal_extraction": _dispatch_signal_extraction,
 }
 
+_MAX_REASONING_VALIDATION_FAILURES = 50
+
 
 def _step_config_text(config: Mapping[str, Any], key: str) -> str | None:
     """Pull a non-empty string from step.config or return None."""
@@ -737,6 +740,14 @@ def _step_reasoning_audit(
     consumed_contexts = _consumed_reasoning_contexts(result)
     if consumed_contexts:
         audit["consumed_contexts"] = consumed_contexts
+    validation_failures, validation_failures_truncated = (
+        _reasoning_validation_failures(result)
+    )
+    if validation_failures:
+        audit["validation_blocked"] = True
+        audit["validation_failures"] = validation_failures
+        if validation_failures_truncated:
+            audit["validation_failures_truncated"] = True
     return audit
 
 
@@ -766,6 +777,49 @@ def _consumed_reasoning_contexts(
         if isinstance(item, Mapping) and item:
             contexts.append(dict(item))
     return contexts
+
+
+def _reasoning_validation_failures(
+    result: Mapping[str, Any] | None,
+) -> tuple[list[dict[str, Any]], bool]:
+    if result is None:
+        return [], False
+    raw_errors = result.get("errors")
+    if isinstance(raw_errors, Mapping):
+        candidates = (raw_errors,)
+    elif isinstance(raw_errors, Sequence) and not isinstance(
+        raw_errors, (str, bytes, bytearray)
+    ):
+        candidates = tuple(item for item in raw_errors if isinstance(item, Mapping))
+    else:
+        return [], False
+    failures: list[dict[str, Any]] = []
+    truncated = False
+    for item in candidates:
+        reason = _clean(item.get("reason") or item.get("error"))
+        if reason != REASONING_VALIDATION_BLOCKED and not reason.startswith(
+            f"{REASONING_VALIDATION_BLOCKED}:"
+        ):
+            continue
+        if len(failures) >= _MAX_REASONING_VALIDATION_FAILURES:
+            truncated = True
+            break
+        failure: dict[str, Any] = {"reason": REASONING_VALIDATION_BLOCKED}
+        target_id = _clean(item.get("target_id"))
+        if target_id:
+            failure["target_id"] = target_id
+        blockers = _reasoning_validation_blockers(reason)
+        if blockers:
+            failure["blockers"] = blockers
+        failures.append(failure)
+    return failures, truncated
+
+
+def _reasoning_validation_blockers(reason: str) -> list[str]:
+    suffix = reason.removeprefix(REASONING_VALIDATION_BLOCKED)
+    if not suffix.startswith(":"):
+        return []
+    return [item.strip() for item in suffix[1:].split(",") if item.strip()]
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -278,6 +278,9 @@
       "target": "extracted_content_pipeline/reasoning_policy.py"
     },
     {
+      "target": "extracted_content_pipeline/reasoning_signals.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_opportunities.py"
     },
     {

--- a/extracted_content_pipeline/reasoning_signals.py
+++ b/extracted_content_pipeline/reasoning_signals.py
@@ -1,0 +1,10 @@
+"""Shared signal names for Content Ops reasoning flows."""
+
+from __future__ import annotations
+
+REASONING_VALIDATION_BLOCKED = "reasoning_validation_blocked"
+
+
+def reasoning_validation_blocked_reason(blockers: list[str] | tuple[str, ...]) -> str:
+    suffix = f":{','.join(blockers)}" if blockers else ""
+    return f"{REASONING_VALIDATION_BLOCKED}{suffix}"

--- a/plans/PR-Content-Ops-Strict-Validation-Telemetry.md
+++ b/plans/PR-Content-Ops-Strict-Validation-Telemetry.md
@@ -1,0 +1,62 @@
+# Content Ops Strict Validation Telemetry
+
+## Why this slice exists
+
+PR #556 made `multi_pass_strict` fail closed for report and sales brief
+generation. The strict failure reason reached generated-asset result errors,
+but the operator-facing Content Ops step reasoning audit did not expose a
+stable validation field.
+
+## Scope (this PR)
+
+1. Detect strict validation failures in generated-asset result errors.
+2. Mirror those failures into the per-step `reasoning` audit as compact
+   validation telemetry.
+3. Preserve existing generated-asset result shapes and execution statuses.
+4. Refresh the Content Ops backlog/status/coordination docs for the shipped
+   telemetry follow-up.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/reasoning_signals.py`
+- `plans/PR-Content-Ops-Strict-Validation-Telemetry.md`
+- `tests/test_extracted_content_ops_execution.py`
+
+## Mechanism
+
+`_step_reasoning_audit(...)` now scans `result["errors"]` for
+`reasoning_validation_blocked` entries. When present, it adds
+`validation_blocked: true` and a bounded `validation_failures` list containing
+the normalized reason, optional `target_id`, and parsed blocker identifiers.
+The strict-validation reason signal is shared with the API wrapper so producer
+and executor stay on the same string contract.
+
+## Intentional
+
+No report/sales generation contract changes. Services still return their own
+`errors`; the executor only mirrors strict validation failures into the compact
+reasoning audit so UI/operator automation has one stable place to inspect them.
+
+## Deferred
+
+Host-owned falsification policy wiring for strict presets remains separate
+product-policy work.
+
+## Verification
+
+pytest tests/test_extracted_content_ops_execution.py
+tests/test_extracted_content_control_surface_api.py -> 86 passed.
+py_compile -> passed. git diff check -> passed. ASCII grep on touched Python
+files -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~255 |

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -1047,6 +1047,104 @@ async def test_execute_step_reports_consumed_reasoning_contexts_when_result_incl
 
 
 @pytest.mark.asyncio
+async def test_execute_step_reports_strict_validation_failures_from_result_errors():
+    class _StrictBlockedService(_ReasoningAwareOpportunityService):
+        async def generate(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(dict(kwargs))
+            return {
+                "generated": 0,
+                "skipped": 1,
+                "reasoning_contexts_used": 0,
+                "errors": [
+                    {
+                        "target_id": "vendor-acme",
+                        "reason": (
+                            "reasoning_validation_blocked:"
+                            "claim_missing_citations:0,no_claims"
+                        ),
+                    }
+                ],
+            }
+
+    services = ContentOpsExecutionServices(
+        report=_StrictBlockedService(),
+        reasoning_provider_configured=True,
+        reasoning_provider_outputs=("report",),
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["report"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Audit",
+                "opportunity_id": "opp-1",
+            },
+        },
+        services=services,
+    )
+
+    assert result["steps"][0]["reasoning"] == {
+        "requirement": "optional_host_context",
+        "service_supports_reasoning": True,
+        "provider_configured": True,
+        "contexts_used": 0,
+        "validation_blocked": True,
+        "validation_failures": [
+            {
+                "reason": "reasoning_validation_blocked",
+                "target_id": "vendor-acme",
+                "blockers": ["claim_missing_citations:0", "no_claims"],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_step_caps_strict_validation_failures():
+    class _StrictBlockedService(_ReasoningAwareOpportunityService):
+        async def generate(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(dict(kwargs))
+            return {
+                "generated": 0,
+                "skipped": 55,
+                "reasoning_contexts_used": 0,
+                "errors": [
+                    {
+                        "target_id": f"vendor-{index}",
+                        "reason": "reasoning_validation_blocked:no_claims",
+                    }
+                    for index in range(55)
+                ],
+            }
+
+    services = ContentOpsExecutionServices(
+        report=_StrictBlockedService(),
+        reasoning_provider_configured=True,
+        reasoning_provider_outputs=("report",),
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["report"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Audit",
+                "opportunity_id": "opp-1",
+            },
+        },
+        services=services,
+    )
+
+    reasoning = result["steps"][0]["reasoning"]
+    assert reasoning["validation_blocked"] is True
+    assert reasoning["validation_failures_truncated"] is True
+    assert len(reasoning["validation_failures"]) == 50
+    assert reasoning["validation_failures"][0]["target_id"] == "vendor-0"
+    assert reasoning["validation_failures"][-1]["target_id"] == "vendor-49"
+
+
+@pytest.mark.asyncio
 async def test_execute_step_ignores_malformed_consumed_reasoning_contexts():
     class _MalformedReasoningPayloadService(_ReasoningAwareOpportunityService):
         async def generate(self, **kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
# Content Ops Strict Validation Telemetry

## Why this slice exists

PR #556 made `multi_pass_strict` fail closed for report and sales brief
generation. The strict failure reason reached generated-asset result errors,
but the operator-facing Content Ops step reasoning audit did not expose a
stable validation field.

## Scope (this PR)

1. Detect strict validation failures in generated-asset result errors.
2. Mirror those failures into the per-step `reasoning` audit as compact
   validation telemetry.
3. Preserve existing generated-asset result shapes and execution statuses.
4. Refresh the Content Ops backlog/status/coordination docs for the shipped
   telemetry follow-up.

### Files touched

- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
- `docs/extraction/coordination/inflight.md`
- `extracted_content_pipeline/STATUS.md`
- `extracted_content_pipeline/content_ops_execution.py`
- `plans/PR-Content-Ops-Strict-Validation-Telemetry.md`
- `tests/test_extracted_content_ops_execution.py`

## Mechanism

`_step_reasoning_audit(...)` now scans `result["errors"]` for
`reasoning_validation_blocked` entries. When present, it adds
`validation_blocked: true` and a bounded `validation_failures` list containing
the normalized reason, optional `target_id`, and parsed blocker identifiers.

## Intentional

No report/sales generation contract changes. Services still return their own
`errors`; the executor only mirrors strict validation failures into the compact
reasoning audit so UI/operator automation has one stable place to inspect them.

## Deferred

Host-owned falsification policy wiring for strict presets remains separate
product-policy work.

## Verification

pytest tests/test_extracted_content_ops_execution.py -> 38 passed.
py_compile -> passed. git diff check -> passed. ASCII grep on touched Python
files -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| **Total** | ~176 |
