### PR TITLE
Log strict validation blocks in content ops execution

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -54,6 +54,7 @@ The following items appear in older plan docs but are no longer active backlog:
   validation, and per-content-type depth.
 - Reasoning preset catalog for host-facing depth choices.
 - Operator-facing strict validation telemetry in Content Ops execution results.
+- Strict validation blocked-event logging in Content Ops execution.
 
 ## Active Backlog
 
@@ -85,7 +86,8 @@ Remaining work:
 generated when validation blockers are present, and the generated-asset error
 reason includes the validation blocker identifiers. Content Ops execution also
 mirrors those strict validation failures into per-step reasoning telemetry for
-operator inspection.
+operator inspection and logs a structured warning when strict validation
+blocks a step.
 
 ### 2. Source breadth from real host exports
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T19:44Z by codex-2026-05-16
+Last updated: 2026-05-16T20:26Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #557 | Content Ops strict validation telemetry | `extracted_content_pipeline/content_ops_execution.py`, `tests/test_extracted_content_ops_execution.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Strict-Validation-Telemetry.md` | codex-2026-05-16 | Avoid step-level reasoning audit / strict validation telemetry edits. |
+| TBD | Content Ops strict validation observability | `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/reasoning_signals.py`, `tests/test_extracted_content_ops_execution.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Strict-Validation-Observability.md` | codex-2026-05-16 | Avoid strict validation logging / reason-signal serialization edits. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -175,9 +175,10 @@ source of truth for what remains.
   `reasoning` audit mirrors those as `contexts_used` and `consumed_contexts`.
   When strict reasoning validation blocks an asset before prompt generation,
   the same per-step audit marks `validation_blocked` and includes compact
-  `validation_failures` for operator inspection. Atlas Intel renders compact
-  consumed-context summaries; a fuller drawer/detail UX remains a frontend
-  follow-up.
+  `validation_failures` for operator inspection, and the executor logs
+  `content_ops_strict_validation_blocked` with output/failure-count metadata.
+  Atlas Intel renders compact consumed-context summaries; a fuller
+  drawer/detail UX remains a frontend follow-up.
 - `docs/audits/content_ops_reasoning_policy_audit_2026-05-16.md` defines the
   next reasoning-depth direction: keep reasoning behind the
   `CampaignReasoningContextProvider` boundary, expose depth through named

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -12,6 +13,8 @@ from .control_surfaces import OUTPUT_CATALOG, ContentOpsRequest, request_from_ma
 from .generation_plan import GenerationPlan, GenerationPlanStep, build_generation_plan
 from .landing_page_ports import MarketingCampaign
 from .reasoning_signals import REASONING_VALIDATION_BLOCKED
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -748,6 +751,14 @@ def _step_reasoning_audit(
         audit["validation_failures"] = validation_failures
         if validation_failures_truncated:
             audit["validation_failures_truncated"] = True
+        logger.warning(
+            "content_ops_strict_validation_blocked",
+            extra={
+                "output": step.output,
+                "failure_count": len(validation_failures),
+                "truncated": validation_failures_truncated,
+            },
+        )
     return audit
 
 

--- a/extracted_content_pipeline/reasoning_signals.py
+++ b/extracted_content_pipeline/reasoning_signals.py
@@ -6,5 +6,12 @@ REASONING_VALIDATION_BLOCKED = "reasoning_validation_blocked"
 
 
 def reasoning_validation_blocked_reason(blockers: list[str] | tuple[str, ...]) -> str:
+    """Serialize strict-validation blockers into the current reason string.
+
+    The executor parses comma-separated blocker identifiers from this string.
+    Callers should pass stable blocker IDs, not display text that may contain
+    commas.
+    """
+
     suffix = f":{','.join(blockers)}" if blockers else ""
     return f"{REASONING_VALIDATION_BLOCKED}{suffix}"

--- a/plans/PR-Content-Ops-Strict-Validation-Observability.md
+++ b/plans/PR-Content-Ops-Strict-Validation-Observability.md
@@ -1,0 +1,57 @@
+# Content Ops Strict Validation Observability
+
+## Why this slice exists
+
+PR #557 exposed strict reasoning validation failures in the Content Ops step
+audit. Review left one operator-observability follow-up: emit a grep-able log
+record when strict validation blocks generated assets.
+
+## Scope (this PR)
+
+1. Log strict validation blockers from the execution layer when they are
+   mirrored into the step reasoning audit.
+2. Document the current comma-separated blocker reason contract at the shared
+   signal helper.
+3. Remove the stale #557 coordination row and claim this follow-up slice.
+4. Refresh the Content Ops backlog/status docs for the shipped observability
+   follow-up.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/reasoning_signals.py`
+- `plans/PR-Content-Ops-Strict-Validation-Observability.md`
+- `tests/test_extracted_content_ops_execution.py`
+
+## Mechanism
+
+When `_step_reasoning_audit(...)` detects strict validation failures, it still
+returns the same `validation_blocked` / `validation_failures` response shape,
+and now also logs `content_ops_strict_validation_blocked` at warning level with
+the output name, visible failure count, and truncation flag.
+
+## Intentional
+
+No result-shape changes. No blocker wire-format migration. The current
+serialized blocker reason remains comma-separated stable IDs; richer structured
+blocker payloads are separate contract work.
+
+## Deferred
+
+Host-owned falsification policy wiring for strict presets remains separate
+product-policy work.
+
+## Verification
+
+pytest tests/test_extracted_content_ops_execution.py -> 40 passed.
+py_compile -> passed. git diff check -> passed. ASCII grep on touched Python
+files -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~140 |

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Any, Mapping
 
@@ -1098,6 +1099,56 @@ async def test_execute_step_reports_strict_validation_failures_from_result_error
             }
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_execute_step_logs_strict_validation_failures(caplog: pytest.LogCaptureFixture):
+    class _StrictBlockedService(_ReasoningAwareOpportunityService):
+        async def generate(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(dict(kwargs))
+            return {
+                "generated": 0,
+                "skipped": 1,
+                "reasoning_contexts_used": 0,
+                "errors": [
+                    {
+                        "target_id": "vendor-acme",
+                        "reason": "reasoning_validation_blocked:no_claims",
+                    }
+                ],
+            }
+
+    caplog.set_level(
+        logging.WARNING,
+        logger="extracted_content_pipeline.content_ops_execution",
+    )
+    services = ContentOpsExecutionServices(
+        report=_StrictBlockedService(),
+        reasoning_provider_configured=True,
+        reasoning_provider_outputs=("report",),
+    )
+
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["report"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Audit",
+                "opportunity_id": "opp-1",
+            },
+        },
+        services=services,
+    )
+
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "content_ops_strict_validation_blocked"
+    ]
+    assert len(records) == 1
+    assert records[0].output == "report"
+    assert records[0].failure_count == 1
+    assert records[0].truncated is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Strict-Validation-Observability.md

## Summary
- log content_ops_strict_validation_blocked when strict reasoning validation failures are mirrored into step audit telemetry
- document the current comma-separated blocker signal contract
- remove the stale #557 coordination row and claim this follow-up slice

## Verification
- pytest tests/test_extracted_content_ops_execution.py -> 40 passed
- python -m py_compile extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_signals.py tests/test_extracted_content_ops_execution.py -> passed
- git diff --check -> passed
- ASCII check on touched Python files -> passed
- bash scripts/local_pr_review.sh -> passed