### PR TITLE
Align content ops reasoning plan runtime invariants

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -87,7 +87,8 @@ generated when validation blockers are present, and the generated-asset error
 reason includes the validation blocker identifiers. Content Ops execution also
 mirrors those strict validation failures into per-step reasoning telemetry for
 operator inspection and logs a structured warning when strict validation
-blocks a step.
+blocks a step. Plan and execute paths also share packaged reasoning runtime
+constants so unsupported reasoning requests fail consistently.
 
 ### 2. Source breadth from real host exports
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T20:26Z by codex-2026-05-16
+Last updated: 2026-05-16T21:07Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | Content Ops strict validation observability | `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/reasoning_signals.py`, `tests/test_extracted_content_ops_execution.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Strict-Validation-Observability.md` | codex-2026-05-16 | Avoid strict validation logging / reason-signal serialization edits. |
+| #559 | Content Ops reasoning runtime invariants | `extracted_content_pipeline/reasoning_policy.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Reasoning-Runtime-Invariants.md` | codex-2026-05-16 | Avoid reasoning preset/runtime packaged-output validation edits. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -197,7 +197,9 @@ source of truth for what remains.
   request explicitly sets `reasoning_preset` and the host supplies an LLM
   provider. Strict mode uses the same provider plus citation validation and
   fails closed before report/sales generation when validation blockers are
-  present.
+  present. The plan and execute paths share the same packaged runtime
+  output/preset constants so unsupported reasoning requests fail consistently
+  instead of silently dropping requested reasoning.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -38,7 +38,12 @@ from ..control_surfaces import (
     resolve_outputs,
 )
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
-from ..reasoning_policy import ReasoningPreset, resolve_reasoning_policy
+from ..reasoning_policy import (
+    PACKAGED_REASONING_RUNTIME_OUTPUTS,
+    PACKAGED_REASONING_RUNTIME_PRESETS,
+    ReasoningPreset,
+    resolve_reasoning_policy,
+)
 from ..reasoning_signals import reasoning_validation_blocked_reason
 
 ExecutionServicesProvider = Callable[
@@ -69,7 +74,6 @@ _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
-_RUNTIME_STRUCTURED_REASONING_OUTPUTS = frozenset({"report", "sales_brief"})
 
 
 def _build_static_catalog_payload() -> Mapping[str, Any]:
@@ -482,7 +486,7 @@ async def _structured_reasoning_context(
     supported_outputs = [
         str(output)
         for output in resolve_outputs(request)
-        if output in _RUNTIME_STRUCTURED_REASONING_OUTPUTS
+        if output in PACKAGED_REASONING_RUNTIME_OUTPUTS
     ]
     if not supported_outputs:
         raise HTTPException(
@@ -496,7 +500,7 @@ async def _structured_reasoning_context(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         reasoning_definition = definition
-        if definition.id not in {"multi_pass_structured", "multi_pass_strict"}:
+        if definition.id not in PACKAGED_REASONING_RUNTIME_PRESETS:
             raise HTTPException(
                 status_code=400,
                 detail=(

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -20,17 +20,15 @@ from .control_surfaces import (
     request_from_mapping,
 )
 from .landing_page_generation import LandingPageGenerationConfig
-from .reasoning_policy import resolve_reasoning_policy
+from .reasoning_policy import (
+    NOOP_REASONING_PRESETS,
+    PACKAGED_REASONING_RUNTIME_OUTPUTS,
+    PACKAGED_REASONING_RUNTIME_PRESETS,
+    resolve_reasoning_policy,
+)
 from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
-
-_RUNTIME_PACKAGED_REASONING_PRESETS = frozenset({
-    "none",
-    "context_only",
-    "multi_pass_structured",
-    "multi_pass_strict",
-})
 
 
 @dataclass(frozen=True)
@@ -116,7 +114,9 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
     if request.reasoning_preset is None:
         return {}
     _policy, definition = resolve_reasoning_policy(output, request.reasoning_preset)
-    if definition.id not in _RUNTIME_PACKAGED_REASONING_PRESETS:
+    if definition.id in NOOP_REASONING_PRESETS:
+        return {}
+    if definition.id not in PACKAGED_REASONING_RUNTIME_PRESETS:
         raise ValueError(
             "Content Ops packaged reasoning currently supports "
             "multi_pass_structured or multi_pass_strict for report and sales_brief."
@@ -128,6 +128,27 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
         "reasoning_output_validation": definition.output_validation,
         "reasoning_blocking_validation": definition.blocking_validation,
     }
+
+
+def _validate_reasoning_runtime_request(
+    outputs: tuple[str, ...],
+    request: ContentOpsRequest,
+) -> None:
+    preset = request.reasoning_preset
+    if preset is None:
+        return
+    selected = str(preset or "").strip()
+    if not selected or selected in NOOP_REASONING_PRESETS:
+        return
+    runtime_outputs = tuple(
+        output for output in outputs if output in PACKAGED_REASONING_RUNTIME_OUTPUTS
+    )
+    if not runtime_outputs:
+        raise ValueError(
+            "reasoning_preset currently applies only to report and sales_brief."
+        )
+    for output in runtime_outputs:
+        _reasoning_config_for_output(output, request)
 
 
 def _landing_page_config_for_request(request: ContentOpsRequest) -> LandingPageGenerationConfig:
@@ -306,6 +327,7 @@ def build_generation_plan(request: ContentOpsRequest) -> GenerationPlan:
 
     preview = preview_control_surface(request)
     normalized = preview.normalized_request or request
+    _validate_reasoning_runtime_request(preview.outputs, normalized)
     steps = tuple(_step_for_output(output, normalized) for output in preview.outputs)
     can_execute = (
         preview.can_run

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -116,6 +116,17 @@ _LANDING_PAGE_PRESETS: tuple[ReasoningPreset, ...] = (
     "multi_pass_structured",
 )
 
+PACKAGED_REASONING_RUNTIME_OUTPUTS: tuple[str, ...] = ("report", "sales_brief")
+PACKAGED_REASONING_RUNTIME_PRESETS: tuple[ReasoningPreset, ...] = (
+    "multi_pass_structured",
+    "multi_pass_strict",
+)
+NOOP_REASONING_PRESETS: tuple[ReasoningPreset, ...] = tuple(
+    preset
+    for preset, definition in REASONING_PRESETS.items()
+    if not definition.generated_reasoning
+)
+
 
 OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyType({
     "signal_extraction": OutputReasoningPolicy(

--- a/plans/PR-Content-Ops-Reasoning-Runtime-Invariants.md
+++ b/plans/PR-Content-Ops-Reasoning-Runtime-Invariants.md
@@ -1,0 +1,64 @@
+# Content Ops Reasoning Runtime Invariants
+
+## Why this slice exists
+
+The reasoning preset catalog can describe broader future policy than the
+packaged runtime currently executes. Before the next reasoning-depth slice, the
+plan and execute paths need one shared runtime contract so unsupported
+`reasoning_preset` requests fail consistently.
+
+## Scope (this PR)
+
+1. Centralize packaged reasoning runtime outputs and presets in the reasoning
+   policy module.
+2. Use those shared constants from generation planning and the execute API.
+3. Make `/plan` reject generated reasoning presets when no packaged runtime
+   output is selected, matching `/execute`.
+4. Preserve mixed-output behavior: packaged reasoning applies to report/sales
+   steps while non-runtime outputs continue without reasoning config.
+5. Refresh status/backlog/coordination docs for the invariant slice.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `plans/PR-Content-Ops-Reasoning-Runtime-Invariants.md`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+
+## Mechanism
+
+`PACKAGED_REASONING_RUNTIME_OUTPUTS` and
+`PACKAGED_REASONING_RUNTIME_PRESETS` now live in `reasoning_policy.py`.
+Generation planning validates explicit generated-reasoning requests against
+those constants before building steps, while the execute API uses the same
+constants when constructing packaged structured/strict providers.
+
+## Intentional
+
+This does not add packaged reasoning to blog posts, landing pages, or email.
+Those outputs can still consume host-provided reasoning context; this slice
+only prevents plan/execute drift for generated packaged reasoning presets.
+
+## Deferred
+
+Host-owned falsification policy wiring for strict presets remains separate
+product-policy work.
+
+## Verification
+
+pytest tests/test_extracted_content_reasoning_policy.py
+tests/test_extracted_content_generation_plan.py
+tests/test_extracted_content_control_surface_api.py -> 91 passed.
+py_compile -> passed. git diff check -> passed. ASCII grep on touched Python
+files -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~230 |

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -1,6 +1,10 @@
 import pytest
 
 from extracted_content_pipeline.generation_plan import build_generation_plan_from_mapping
+from extracted_content_pipeline.reasoning_policy import (
+    PACKAGED_REASONING_RUNTIME_OUTPUTS,
+    PACKAGED_REASONING_RUNTIME_PRESETS,
+)
 
 
 def test_plan_maps_email_campaign_to_campaign_generation_service():
@@ -107,6 +111,27 @@ def test_plan_threads_strict_reasoning_preset_to_report_and_sales_brief():
         assert step["config"]["reasoning_blocking_validation"] is True
 
 
+@pytest.mark.parametrize("output", PACKAGED_REASONING_RUNTIME_OUTPUTS)
+@pytest.mark.parametrize("preset", PACKAGED_REASONING_RUNTIME_PRESETS)
+def test_plan_threads_all_packaged_runtime_reasoning_presets(output, preset):
+    inputs = {
+        "report": {"opportunity_id": "opp_123"},
+        "sales_brief": {"target_account": "Acme"},
+    }[output]
+
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": [output],
+            "reasoning_preset": preset,
+            "inputs": inputs,
+        }
+    )
+
+    step = plan["steps"][0]
+    assert step["config"]["reasoning_preset"] == preset
+    assert step["config"]["reasoning_multi_pass"] is True
+
+
 def test_plan_rejects_unknown_reasoning_preset_for_report():
     with pytest.raises(ValueError, match="unknown reasoning preset"):
         build_generation_plan_from_mapping(
@@ -128,6 +153,55 @@ def test_plan_rejects_runtime_unsupported_reasoning_preset_for_report(preset):
                 "inputs": {"opportunity_id": "opp_123"},
             }
         )
+
+
+@pytest.mark.parametrize(
+    ("output", "inputs", "preset"),
+    (
+        ("blog_post", {"topic": "Churn pressure"}, "multi_pass_structured"),
+        (
+            "landing_page",
+            {"offer": "Audit", "audience": "RevOps"},
+            "multi_pass_structured",
+        ),
+        (
+            "email_campaign",
+            {"target_account": "Acme", "offer": "Audit"},
+            "single_pass",
+        ),
+    ),
+)
+def test_plan_rejects_runtime_reasoning_when_no_packaged_output_selected(
+    output,
+    inputs,
+    preset,
+):
+    with pytest.raises(ValueError, match="only to report and sales_brief"):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": [output],
+                "reasoning_preset": preset,
+                "inputs": inputs,
+            }
+        )
+
+
+def test_plan_ignores_non_runtime_outputs_when_packaged_output_selected():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["email_campaign", "report"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Audit",
+                "opportunity_id": "opp_123",
+            },
+        }
+    )
+
+    configs = {step["output"]: step["config"] for step in plan["steps"]}
+    assert "reasoning_preset" not in configs["email_campaign"]
+    assert configs["report"]["reasoning_preset"] == "multi_pass_structured"
 
 
 def test_plan_maps_blog_to_blog_generation_service():

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pytest
 
 from extracted_content_pipeline.reasoning_policy import (
+    NOOP_REASONING_PRESETS,
     OUTPUT_REASONING_POLICIES,
+    PACKAGED_REASONING_RUNTIME_OUTPUTS,
+    PACKAGED_REASONING_RUNTIME_PRESETS,
     REASONING_PRESETS,
     OutputReasoningPolicy,
     output_reasoning_policy,
@@ -58,6 +61,23 @@ def test_reasoning_policies_cover_every_output_catalog_entry() -> None:
     from extracted_content_pipeline.control_surfaces import OUTPUT_CATALOG
 
     assert set(OUTPUT_REASONING_POLICIES) == set(OUTPUT_CATALOG)
+
+
+def test_packaged_runtime_reasoning_surface_is_catalog_supported() -> None:
+    from extracted_content_pipeline.control_surfaces import OUTPUT_CATALOG
+
+    assert set(PACKAGED_REASONING_RUNTIME_OUTPUTS) <= set(OUTPUT_CATALOG)
+    for output in PACKAGED_REASONING_RUNTIME_OUTPUTS:
+        assert OUTPUT_CATALOG[output].implemented is True
+        policy = output_reasoning_policy(output)
+        for preset in PACKAGED_REASONING_RUNTIME_PRESETS:
+            assert policy.supports(preset)
+
+
+def test_noop_reasoning_presets_are_derived_from_catalog() -> None:
+    assert NOOP_REASONING_PRESETS == ("none", "context_only")
+    for preset in NOOP_REASONING_PRESETS:
+        assert not REASONING_PRESETS[preset].generated_reasoning
 
 
 def test_output_policy_invariants_are_enforced() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Runtime-Invariants.md

## Summary
- centralize packaged reasoning runtime outputs/presets in reasoning_policy
- make generation planning reject generated reasoning presets when no packaged runtime output is selected
- keep mixed-output behavior: report/sales receive packaged reasoning config while non-runtime outputs continue without it
- update API execution path to use the same runtime constants

## Verification
- pytest tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_control_surface_api.py -> 90 passed
- python -m py_compile extracted_content_pipeline/reasoning_policy.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_control_surface_api.py -> passed
- git diff --check -> passed
- ASCII check on touched Python files -> passed
- bash scripts/local_pr_review.sh -> passed