### PR TITLE
Wire strict content ops falsification policy

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -79,7 +79,6 @@ Remaining work:
 
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
-- Host-owned falsification policy wiring for strict presets.
 
 **Shipped slice:** structured and strict multi-pass reasoning are wired for
 `report` and `sales_brief`. Strict mode now fails closed before those assets are
@@ -88,7 +87,9 @@ reason includes the validation blocker identifiers. Content Ops execution also
 mirrors those strict validation failures into per-step reasoning telemetry for
 operator inspection and logs a structured warning when strict validation
 blocks a step. Plan and execute paths also share packaged reasoning runtime
-constants so unsupported reasoning requests fail consistently.
+constants so unsupported reasoning requests fail consistently. Hosts can now
+attach explicit falsification rules to the strict preset; no falsification LLM
+calls are made unless the host supplies those rules.
 
 ### 2. Source breadth from real host exports
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T21:07Z by codex-2026-05-16
+Last updated: 2026-05-16T21:12Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #559 | Content Ops reasoning runtime invariants | `extracted_content_pipeline/reasoning_policy.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Reasoning-Runtime-Invariants.md` | codex-2026-05-16 | Avoid reasoning preset/runtime packaged-output validation edits. |
+| #560 | Content Ops strict falsification policy wiring | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/reasoning_policy.py`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_reasoning_policy.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Strict-Falsification-Policy.md` | codex-2026-05-16 | Avoid strict preset falsification config / control-surface provider edits. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -199,7 +199,14 @@ source of truth for what remains.
   fails closed before report/sales generation when validation blockers are
   present. The plan and execute paths share the same packaged runtime
   output/preset constants so unsupported reasoning requests fail consistently
-  instead of silently dropping requested reasoning.
+  instead of silently dropping requested reasoning. Hosts can attach explicit
+  falsification rules to `multi_pass_strict`; the control surface wires those
+  into `FalsificationPolicy` and never runs falsification checks by default
+  when no host-owned rules are supplied. Falsification rules are evaluated per
+  generated claim, so strict runs with rules can add one extra LLM call per
+  claim before any falsified claims are dropped. The host config rejects
+  `drop_falsified=True` without rules and caps strict falsification rules at 20
+  to keep per-claim prompt growth bounded.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any
 
 try:
     from fastapi import APIRouter, Body, HTTPException
@@ -73,6 +73,7 @@ _MAX_INPUT_KEYS = 50
 _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
+_MAX_FALSIFICATION_RULES = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
 
 
@@ -167,7 +168,18 @@ def _require_fastapi() -> None:
 
 @dataclass(frozen=True)
 class ContentOpsControlSurfaceApiConfig:
-    """Host-owned API defaults for content-ops planning routes."""
+    """Host-owned API defaults for content-ops planning routes.
+
+    Falsification rules are opt-in and only apply to strict packaged reasoning.
+    Each rule should be a mapping with a human-readable predicate, for example
+    ``{"id": "renewal_completed", "predicate": "fresh evidence shows renewal completed"}``.
+    Falsification is evaluated per generated claim, so enabling rules can add
+    one LLM call per claim before any falsified claims are dropped.
+    ``structured_reasoning_falsification_conservative=True`` means ambiguous or
+    malformed falsification responses preserve the claim instead of invalidating
+    it. ``structured_reasoning_drop_falsified=True`` validates the filtered
+    surviving claim set, which can increase strict-mode validation blocks.
+    """
 
     prefix: str = "/content-ops"
     tags: tuple[str, ...] = ("content-ops",)
@@ -177,6 +189,9 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_top_thesis_limit: int = 5
     structured_reasoning_max_continuations: int = 8
     structured_reasoning_require_citations: bool = True
+    structured_reasoning_falsification_rules: Sequence[Mapping[str, Any]] = ()
+    structured_reasoning_falsification_conservative: bool = True
+    structured_reasoning_drop_falsified: bool = False
 
     def __post_init__(self) -> None:
         if not str(self.prefix or "").strip().startswith("/"):
@@ -191,6 +206,32 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError("structured_reasoning_top_thesis_limit must be positive")
         if self.structured_reasoning_max_continuations < 0:
             raise ValueError("structured_reasoning_max_continuations must be non-negative")
+        if not isinstance(
+            self.structured_reasoning_falsification_rules,
+            Sequence,
+        ) or isinstance(
+            self.structured_reasoning_falsification_rules,
+            (str, bytes, bytearray, Mapping),
+        ):
+            raise ValueError("structured_reasoning_falsification_rules must be a sequence")
+        if (
+            self.structured_reasoning_drop_falsified
+            and not self.structured_reasoning_falsification_rules
+        ):
+            raise ValueError(
+                "structured_reasoning_drop_falsified=True requires "
+                "non-empty structured_reasoning_falsification_rules"
+            )
+        if len(self.structured_reasoning_falsification_rules) > _MAX_FALSIFICATION_RULES:
+            raise ValueError(
+                "structured_reasoning_falsification_rules cannot exceed "
+                f"{_MAX_FALSIFICATION_RULES}"
+            )
+        for rule in self.structured_reasoning_falsification_rules:
+            if not isinstance(rule, Mapping):
+                raise ValueError(
+                    "structured_reasoning_falsification_rules entries must be mappings"
+                )
 
 
 @dataclass(frozen=True)
@@ -542,12 +583,27 @@ async def _structured_reasoning_context(
             detail="Content Ops structured reasoning LLM is unavailable.",
         )
     # Lazy import keeps hosts without structured reasoning free of these deps.
-    from extracted_reasoning_core.types import OutputPolicy, ReasoningPack, ReasoningPorts
+    from extracted_reasoning_core.types import (
+        FalsificationPolicy,
+        OutputPolicy,
+        ReasoningPack,
+        ReasoningPorts,
+    )
 
     from ..services.multi_pass_reasoning_provider import (
         MultiPassCampaignReasoningProvider,
         MultiPassReasoningProviderConfig,
     )
+
+    falsification_policy = None
+    if reasoning_definition.falsification and config.structured_reasoning_falsification_rules:
+        falsification_policy = FalsificationPolicy(
+            rules=tuple(
+                dict(rule)
+                for rule in config.structured_reasoning_falsification_rules
+            ),
+            conservative=config.structured_reasoning_falsification_conservative,
+        )
 
     provider = MultiPassCampaignReasoningProvider(
         ports=ReasoningPorts(llm=llm),
@@ -561,6 +617,11 @@ async def _structured_reasoning_context(
             ),
             output_policy=OutputPolicy(
                 require_citations=config.structured_reasoning_require_citations,
+            ),
+            falsification_policy=falsification_policy,
+            drop_falsified=bool(
+                falsification_policy is not None
+                and config.structured_reasoning_drop_falsified
             ),
             # Keep the inner provider nonblocking so strict wrappers can
             # surface validation blocker details instead of a generic None.

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -127,6 +127,7 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
         "reasoning_narrative_planning": definition.narrative_planning,
         "reasoning_output_validation": definition.output_validation,
         "reasoning_blocking_validation": definition.blocking_validation,
+        "reasoning_falsification": definition.falsification,
     }
 
 

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -23,6 +23,14 @@ ReasoningPreset = Literal[
 
 @dataclass(frozen=True)
 class ReasoningPresetDefinition:
+    """Catalog metadata for a host-selectable reasoning preset.
+
+    Most capability flags are delivered whenever the preset is requested.
+    ``falsification`` means the preset can run falsification when the host also
+    supplies explicit falsification rules; the catalog flag alone does not
+    create an implicit default falsification policy.
+    """
+
     id: ReasoningPreset
     label: str
     description: str
@@ -98,6 +106,7 @@ REASONING_PRESETS: Mapping[str, ReasoningPresetDefinition] = MappingProxyType({
         generated_reasoning=True,
         multi_pass=True,
         narrative_planning=True,
+        falsification=True,
         output_validation=True,
         blocking_validation=True,
     ),

--- a/plans/PR-Content-Ops-Strict-Falsification-Policy.md
+++ b/plans/PR-Content-Ops-Strict-Falsification-Policy.md
@@ -1,0 +1,70 @@
+# Content Ops Strict Falsification Policy
+
+## Why this slice exists
+
+The strict reasoning preset is the right place for falsification, but the host
+must own the rules. Running an empty/default falsification policy would add
+extra LLM calls without a concrete product policy.
+
+## Scope (this PR)
+
+1. Mark `multi_pass_strict` as the catalog preset that supports
+   falsification.
+2. Add host-owned falsification rule config to the Content Ops control-surface
+   API config.
+3. Wire those rules into `FalsificationPolicy` only for strict packaged
+   reasoning.
+4. Surface the strict preset's falsification capability in generation-plan
+   metadata.
+5. Preserve no-op behavior when the host does not supply falsification rules.
+6. Refresh status/backlog/coordination docs for the shipped strict
+   falsification seam.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `plans/PR-Content-Ops-Strict-Falsification-Policy.md`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+
+## Mechanism
+
+`ContentOpsControlSurfaceApiConfig` now accepts a sequence of falsification
+rule mappings plus conservative/drop behavior. `_structured_reasoning_context`
+creates `FalsificationPolicy` only when the selected preset advertises
+falsification and rules were supplied by the host.
+`generation_plan` exposes `reasoning_falsification` as capability metadata;
+runtime still requires host-supplied rules before a falsification policy runs.
+Rules are documented as host-owned predicate mappings. Falsification runs per
+generated claim, so enabling rules can add one LLM call per claim. Config
+validation rejects `drop_falsified=True` without rules and caps rule count at
+20 to keep every per-claim falsification prompt bounded.
+
+## Intentional
+
+No hidden falsification defaults. `multi_pass_structured` ignores the
+falsification rule config, and `multi_pass_strict` leaves
+`falsification_policy` unset when the rule list is empty.
+
+## Deferred
+
+Continued `extracted_reasoning_core` work remains separate if reasoning is
+sold as a stronger standalone layer.
+
+## Verification
+
+pytest tests/test_extracted_content_reasoning_policy.py
+tests/test_extracted_content_control_surface_api.py
+tests/test_extracted_content_generation_plan.py -> 94 passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~190 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -936,7 +936,79 @@ async def test_execute_route_wraps_strict_reasoning_with_blocking_provider():
 
     provider = recorded_providers[0]
     assert provider.provider._config.output_policy is not None
+    assert provider.provider._config.falsification_policy is None
     assert provider.provider._config.block_on_validation_failure is False
+
+
+@pytest.mark.asyncio
+async def test_execute_route_wires_strict_reasoning_falsification_policy():
+    recorded_providers = []
+    report = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_falsification_rules=(
+                {
+                    "id": "renewal_signal_lost",
+                    "predicate": "fresh evidence shows renewal completed",
+                },
+            ),
+            structured_reasoning_falsification_conservative=False,
+            structured_reasoning_drop_falsified=True,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(report=report),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_strict",
+            "inputs": {"opportunity_id": "opp-1"},
+        }
+    )
+
+    provider = recorded_providers[0].provider
+    assert provider._config.falsification_policy is not None
+    assert provider._config.falsification_policy.rules == (
+        {
+            "id": "renewal_signal_lost",
+            "predicate": "fresh evidence shows renewal completed",
+        },
+    )
+    assert provider._config.falsification_policy.conservative is False
+    assert provider._config.drop_falsified is True
+
+
+@pytest.mark.asyncio
+async def test_execute_route_does_not_wire_falsification_for_structured_preset():
+    recorded_providers = []
+    report = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_falsification_rules=(
+                {"id": "renewal_signal_lost"},
+            ),
+            structured_reasoning_drop_falsified=True,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(report=report),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["report"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {"opportunity_id": "opp-1"},
+        }
+    )
+
+    provider = recorded_providers[0]
+    assert provider._config.falsification_policy is None
+    assert provider._config.drop_falsified is False
 
 
 @pytest.mark.asyncio
@@ -1181,3 +1253,34 @@ async def test_execute_route_structured_reasoning_requires_llm_provider():
 def test_content_ops_config_rejects_blank_structured_reasoning_pack_name():
     with pytest.raises(ValueError, match="structured_reasoning_pack_name"):
         ContentOpsControlSurfaceApiConfig(structured_reasoning_pack_name=" ")
+
+
+def test_content_ops_config_rejects_invalid_falsification_rules_shape():
+    with pytest.raises(ValueError, match="must be a sequence"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_falsification_rules={"id": "rule-1"}
+        )
+    with pytest.raises(ValueError, match="must be a sequence"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_falsification_rules=5
+        )
+    with pytest.raises(ValueError, match="entries must be mappings"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_falsification_rules=("rule-1",)
+        )
+
+
+def test_content_ops_config_rejects_drop_falsified_without_rules():
+    with pytest.raises(ValueError, match="requires non-empty"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_drop_falsified=True,
+        )
+
+
+def test_content_ops_config_rejects_too_many_falsification_rules():
+    rules = tuple({"id": f"rule-{index}"} for index in range(21))
+
+    with pytest.raises(ValueError, match="cannot exceed 20"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_falsification_rules=rules,
+        )

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -89,6 +89,7 @@ def test_plan_threads_structured_reasoning_preset_to_report_and_sales_brief():
         assert step["config"]["reasoning_narrative_planning"] is True
         assert step["config"]["reasoning_output_validation"] is True
         assert step["config"]["reasoning_blocking_validation"] is False
+        assert step["config"]["reasoning_falsification"] is False
 
 
 def test_plan_threads_strict_reasoning_preset_to_report_and_sales_brief():
@@ -109,6 +110,7 @@ def test_plan_threads_strict_reasoning_preset_to_report_and_sales_brief():
         assert step["config"]["reasoning_narrative_planning"] is True
         assert step["config"]["reasoning_output_validation"] is True
         assert step["config"]["reasoning_blocking_validation"] is True
+        assert step["config"]["reasoning_falsification"] is True
 
 
 @pytest.mark.parametrize("output", PACKAGED_REASONING_RUNTIME_OUTPUTS)

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -38,7 +38,7 @@ def test_preset_capabilities_increase_by_depth() -> None:
     assert REASONING_PRESETS["multi_pass_structured"].narrative_planning
     assert REASONING_PRESETS["multi_pass_structured"].output_validation
     assert not REASONING_PRESETS["multi_pass_structured"].blocking_validation
-    assert REASONING_PRESETS["multi_pass_strict"].falsification is False
+    assert REASONING_PRESETS["multi_pass_strict"].falsification
     assert REASONING_PRESETS["multi_pass_strict"].blocking_validation
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Strict-Falsification-Policy.md

## Summary
- mark multi_pass_strict as the catalog preset that supports falsification
- add host-owned falsification rule config to the Content Ops control surface
- wire rules into FalsificationPolicy only for strict packaged reasoning
- preserve no-op behavior when hosts do not provide falsification rules

## Verification
- pytest tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py -> 67 passed
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_reasoning_policy.py -> passed
- git diff --check -> passed
- ASCII check on touched Python files -> passed
- bash scripts/local_pr_review.sh -> passed