### PR TITLE
Add blog structured reasoning narrative pack

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -55,6 +55,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - Reasoning preset catalog for host-facing depth choices.
 - Operator-facing strict validation telemetry in Content Ops execution results.
 - Strict validation blocked-event logging in Content Ops execution.
+- Blog-specific packaged narrative pack for structured reasoning.
 
 ## Active Backlog
 
@@ -80,16 +81,19 @@ Remaining work:
 - Continued `extracted_reasoning_core` work if reasoning is sold as a stronger
   standalone layer.
 
-**Shipped slice:** structured and strict multi-pass reasoning are wired for
-`report` and `sales_brief`. Strict mode now fails closed before those assets are
-generated when validation blockers are present, and the generated-asset error
-reason includes the validation blocker identifiers. Content Ops execution also
-mirrors those strict validation failures into per-step reasoning telemetry for
-operator inspection and logs a structured warning when strict validation
-blocks a step. Plan and execute paths also share packaged reasoning runtime
-constants so unsupported reasoning requests fail consistently. Hosts can now
-attach explicit falsification rules to the strict preset; no falsification LLM
-calls are made unless the host supplies those rules.
+**Shipped slice:** structured multi-pass reasoning is wired for `blog_post`,
+`report`, and `sales_brief`; strict multi-pass reasoning is wired for `report`
+and `sales_brief`. Blog posts use a separate `content_ops_blog` narrative pack
+so they do not inherit generic report section policy. Strict mode now fails
+closed before report/sales generation when validation blockers are present, and
+the generated-asset error reason includes the validation blocker identifiers.
+Content Ops execution also mirrors those strict validation failures into
+per-step reasoning telemetry for operator inspection and logs a structured
+warning when strict validation blocks a step. Plan and execute paths share
+packaged reasoning runtime constants so unsupported reasoning requests fail
+consistently. Hosts can now attach explicit falsification rules to the strict
+preset; no falsification LLM calls are made unless the host supplies those
+rules.
 
 ### 2. Source breadth from real host exports
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T21:12Z by codex-2026-05-16
+Last updated: 2026-05-16T21:45Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #560 | Content Ops strict falsification policy wiring | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/reasoning_policy.py`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_reasoning_policy.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Strict-Falsification-Policy.md` | codex-2026-05-16 | Avoid strict preset falsification config / control-surface provider edits. |
+| #561 | Content Ops blog narrative pack | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/reasoning_policy.py`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_ops_execution.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_reasoning_policy.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Blog-Narrative-Pack.md` | codex-2026-05-16 | Avoid packaged reasoning runtime output/preset edits and blog structured reasoning router changes. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -189,20 +189,23 @@ source of truth for what remains.
   reasoning-depth choices. It maps generated-asset outputs to supported
   presets (`none`, `context_only`, `single_pass`, `multi_pass_light`,
   `multi_pass_structured`, `multi_pass_strict`) without constructing providers
-  or changing runtime behavior. `blog_post` defaults to `multi_pass_light` as
-  a quality-over-cost choice; hosts that want cheaper blog runs can select
-  `single_pass`.
-- `/content-ops/execute` can construct packaged `multi_pass_structured` or
-  `multi_pass_strict` reasoning for `report` and `sales_brief` when the
+  or changing runtime behavior. `blog_post` defaults to
+  `multi_pass_structured` so its catalog default matches the packaged runtime;
+  hosts that want cheaper blog runs can select `single_pass`.
+- `/content-ops/execute` can construct packaged `multi_pass_structured`
+  reasoning for `blog_post`, `report`, and `sales_brief`, or
+  `multi_pass_strict` reasoning for `report` and `sales_brief`, when the
   request explicitly sets `reasoning_preset` and the host supplies an LLM
-  provider. Strict mode uses the same provider plus citation validation and
-  fails closed before report/sales generation when validation blockers are
-  present. The plan and execute paths share the same packaged runtime
-  output/preset constants so unsupported reasoning requests fail consistently
-  instead of silently dropping requested reasoning. Hosts can attach explicit
-  falsification rules to `multi_pass_strict`; the control surface wires those
-  into `FalsificationPolicy` and never runs falsification checks by default
-  when no host-owned rules are supplied. Falsification rules are evaluated per
+  provider. Blog posts use the `content_ops_blog` narrative pack; reports and
+  sales briefs keep the `content_ops_structured` pack. Strict mode uses the
+  same provider plus citation validation and fails closed before report/sales
+  generation when validation blockers are present. The plan and execute paths
+  share the same packaged runtime output/preset constants so unsupported
+  reasoning requests fail consistently instead of silently dropping requested
+  reasoning. Hosts can attach explicit falsification rules to
+  `multi_pass_strict`; the control surface wires those into
+  `FalsificationPolicy` and never runs falsification checks by default when no
+  host-owned rules are supplied. Falsification rules are evaluated per
   generated claim, so strict runs with rules can add one extra LLM call per
   claim before any falsified claims are dropped. The host config rejects
   `drop_falsified=True` without rules and caps strict falsification rules at 20

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -6,6 +6,7 @@ import logging
 import math
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 try:
@@ -40,8 +41,8 @@ from ..control_surfaces import (
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
 from ..reasoning_policy import (
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
-    PACKAGED_REASONING_RUNTIME_PRESETS,
     ReasoningPreset,
+    packaged_reasoning_runtime_presets_for_output,
     resolve_reasoning_policy,
 )
 from ..reasoning_signals import reasoning_validation_blocked_reason
@@ -186,6 +187,7 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_default_goal: str = "synthesize content reasoning context"
     structured_reasoning_depth: str = "L3"
     structured_reasoning_pack_name: str = "content_ops_structured"
+    structured_reasoning_output_pack_names: Mapping[str, str] | None = None
     structured_reasoning_top_thesis_limit: int = 5
     structured_reasoning_max_continuations: int = 8
     structured_reasoning_require_citations: bool = True
@@ -200,6 +202,29 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError("structured_reasoning_default_goal is required")
         if not str(self.structured_reasoning_pack_name or "").strip():
             raise ValueError("structured_reasoning_pack_name is required")
+        output_pack_names = self.structured_reasoning_output_pack_names
+        if output_pack_names is None:
+            output_pack_names = {"blog_post": "content_ops_blog"}
+        if not isinstance(output_pack_names, Mapping):
+            raise ValueError("structured_reasoning_output_pack_names must be a mapping")
+        normalized_pack_names: dict[str, str] = {}
+        for output, pack_name in output_pack_names.items():
+            output_key = str(output or "").strip()
+            pack_value = str(pack_name or "").strip()
+            if not output_key:
+                raise ValueError(
+                    "structured_reasoning_output_pack_names keys must be non-empty"
+                )
+            if not pack_value:
+                raise ValueError(
+                    "structured_reasoning_output_pack_names values must be non-empty"
+                )
+            normalized_pack_names[output_key] = pack_value
+        object.__setattr__(
+            self,
+            "structured_reasoning_output_pack_names",
+            MappingProxyType(normalized_pack_names),
+        )
         if self.structured_reasoning_depth not in {"L1", "L2", "L3", "L4", "L5"}:
             raise ValueError("structured_reasoning_depth must be L1-L5")
         if self.structured_reasoning_top_thesis_limit <= 0:
@@ -434,13 +459,13 @@ def create_content_ops_control_surface_router(
             )
             services = services.with_reasoning_context(reasoning_context)
         else:
-            reasoning_context, reasoning_outputs = await _structured_reasoning_context(
+            reasoning_groups = await _structured_reasoning_contexts(
                 payload_mapping,
                 config=resolved_config,
                 services=services,
                 llm_provider=llm_provider,
             )
-            if reasoning_context is not None:
+            for reasoning_context, reasoning_outputs in reasoning_groups:
                 services = services.with_reasoning_context(
                     reasoning_context,
                     outputs=reasoning_outputs,
@@ -502,18 +527,18 @@ async def _resolve_reasoning_context(
     return value
 
 
-async def _structured_reasoning_context(
+async def _structured_reasoning_contexts(
     payload: Mapping[str, Any],
     *,
     config: ContentOpsControlSurfaceApiConfig,
     services: ContentOpsExecutionServices,
     llm_provider: LLMProvider | None,
-) -> tuple[Any | None, tuple[str, ...]]:
+) -> tuple[tuple[Any, tuple[str, ...]], ...]:
     preset = _clean(payload.get("reasoning_preset"))
     if not preset:
-        return None, ()
+        return ()
     if preset in {"none", "context_only"}:
-        return None, ()
+        return ()
     try:
         request = request_from_mapping(payload)
     except ValueError as exc:
@@ -523,7 +548,7 @@ async def _structured_reasoning_context(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not plan.can_execute:
-        return None, ()
+        return ()
     supported_outputs = [
         str(output)
         for output in resolve_outputs(request)
@@ -532,20 +557,25 @@ async def _structured_reasoning_context(
     if not supported_outputs:
         raise HTTPException(
             status_code=400,
-            detail="reasoning_preset currently applies only to report and sales_brief.",
+            detail=(
+                "reasoning_preset currently applies only to blog_post, report, "
+                "and sales_brief."
+            ),
         )
-    reasoning_definition = None
+    reasoning_definitions: dict[str, Any] = {}
     for output in supported_outputs:
         try:
             _policy, definition = resolve_reasoning_policy(output, preset)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        reasoning_definition = definition
-        if definition.id not in PACKAGED_REASONING_RUNTIME_PRESETS:
+        reasoning_definitions[output] = definition
+        runtime_presets = packaged_reasoning_runtime_presets_for_output(output)
+        if definition.id not in runtime_presets:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     "Content Ops packaged reasoning currently supports "
+                    "multi_pass_structured for blog_post and "
                     "multi_pass_structured or multi_pass_strict for report "
                     "and sales_brief."
                 ),
@@ -554,9 +584,7 @@ async def _structured_reasoning_context(
         output for output in supported_outputs if output in services.configured_outputs()
     ]
     if not selected_outputs:
-        return None, ()
-    if reasoning_definition is None:
-        return None, ()
+        return ()
     for output in selected_outputs:
         service = services.for_output(output)
         if not callable(getattr(service, "with_reasoning_context", None)):
@@ -596,7 +624,8 @@ async def _structured_reasoning_context(
     )
 
     falsification_policy = None
-    if reasoning_definition.falsification and config.structured_reasoning_falsification_rules:
+    definitions = tuple(reasoning_definitions[output] for output in selected_outputs)
+    if any(item.falsification for item in definitions) and config.structured_reasoning_falsification_rules:
         falsification_policy = FalsificationPolicy(
             rules=tuple(
                 dict(rule)
@@ -605,32 +634,53 @@ async def _structured_reasoning_context(
             conservative=config.structured_reasoning_falsification_conservative,
         )
 
-    provider = MultiPassCampaignReasoningProvider(
-        ports=ReasoningPorts(llm=llm),
-        config=MultiPassReasoningProviderConfig(
-            default_goal=config.structured_reasoning_default_goal,
-            default_depth=config.structured_reasoning_depth,
-            top_thesis_limit=config.structured_reasoning_top_thesis_limit,
-            max_continuations=config.structured_reasoning_max_continuations,
-            narrative_plan_pack=ReasoningPack(
-                name=config.structured_reasoning_pack_name,
+    groups: dict[str, list[str]] = {}
+    for output in selected_outputs:
+        groups.setdefault(_structured_reasoning_pack_name(output, config), []).append(output)
+
+    provider_groups: list[tuple[Any, tuple[str, ...]]] = []
+    for pack_name, outputs in groups.items():
+        # The reasoning preset is request-level, so every output in this group
+        # resolves to the same ReasoningPresetDefinition.
+        group_definition = reasoning_definitions[outputs[0]]
+        provider = MultiPassCampaignReasoningProvider(
+            ports=ReasoningPorts(llm=llm),
+            config=MultiPassReasoningProviderConfig(
+                default_goal=config.structured_reasoning_default_goal,
+                default_depth=config.structured_reasoning_depth,
+                top_thesis_limit=config.structured_reasoning_top_thesis_limit,
+                max_continuations=config.structured_reasoning_max_continuations,
+                narrative_plan_pack=ReasoningPack(name=pack_name),
+                output_policy=OutputPolicy(
+                    require_citations=config.structured_reasoning_require_citations,
+                ),
+                falsification_policy=falsification_policy
+                if group_definition.falsification else None,
+                drop_falsified=bool(
+                    group_definition.falsification
+                    and falsification_policy is not None
+                    and config.structured_reasoning_drop_falsified
+                ),
+                # Keep the inner provider nonblocking so strict wrappers can
+                # surface validation blocker details instead of a generic None.
+                block_on_validation_failure=False,
             ),
-            output_policy=OutputPolicy(
-                require_citations=config.structured_reasoning_require_citations,
-            ),
-            falsification_policy=falsification_policy,
-            drop_falsified=bool(
-                falsification_policy is not None
-                and config.structured_reasoning_drop_falsified
-            ),
-            # Keep the inner provider nonblocking so strict wrappers can
-            # surface validation blocker details instead of a generic None.
-            block_on_validation_failure=False,
-        ),
-    )
-    if reasoning_definition.blocking_validation:
-        provider = _BlockingReasoningContextProvider(provider)
-    return provider, tuple(selected_outputs)
+        )
+        if group_definition.blocking_validation:
+            provider = _BlockingReasoningContextProvider(provider)
+        provider_groups.append((provider, tuple(outputs)))
+    return tuple(provider_groups)
+
+
+def _structured_reasoning_pack_name(
+    output: str,
+    config: ContentOpsControlSurfaceApiConfig,
+) -> str:
+    configured = config.structured_reasoning_output_pack_names or {}
+    pack_name = configured.get(output)
+    if pack_name:
+        return str(pack_name)
+    return config.structured_reasoning_pack_name
 
 
 async def _resolve_reasoning_status(

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any
 
 from .campaign_ports import TenantScope
@@ -15,6 +16,15 @@ from .landing_page_ports import MarketingCampaign
 from .reasoning_signals import REASONING_VALIDATION_BLOCKED
 
 logger = logging.getLogger(__name__)
+
+_REASONING_OUTPUT_TO_ATTR: Mapping[str, str] = MappingProxyType({
+    "email_campaign": "campaign",
+    "blog_post": "blog_post",
+    "report": "report",
+    "landing_page": "landing_page",
+    "sales_brief": "sales_brief",
+})
+_REASONING_AWARE_OUTPUTS = tuple(_REASONING_OUTPUT_TO_ATTR)
 
 
 @dataclass(frozen=True)
@@ -38,6 +48,12 @@ class ContentOpsExecutionServices:
     signal_extraction: Any | None = None
     reasoning_provider_configured: bool = False
     reasoning_provider_outputs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.reasoning_provider_outputs and not self.reasoning_provider_configured:
+            raise ValueError(
+                "reasoning_provider_outputs requires reasoning_provider_configured=True"
+            )
 
     def for_output(self, output: str) -> Any | None:
         if output == "email_campaign":
@@ -84,33 +100,55 @@ class ContentOpsExecutionServices:
         consume reasoning context) are passed through unchanged. When
         ``outputs`` is ``None``, all reasoning-aware services are rebound.
         Passing a sequence scopes rebinding to those output ids; an empty
-        sequence rebinds none.
+        sequence rebinds none. Multiple targeted calls accumulate active
+        output metadata. Passing ``provider=None`` for selected outputs clears
+        those outputs from the active metadata while preserving other bindings.
         """
 
         if isinstance(outputs, str):
             raise TypeError("outputs must be a sequence of output ids, not a string")
-        selected = frozenset((
-            "email_campaign",
-            "blog_post",
-            "report",
-            "landing_page",
-            "sales_brief",
-        ) if outputs is None else outputs)
+        selected = frozenset(_REASONING_AWARE_OUTPUTS if outputs is None else outputs)
+        unknown = selected - frozenset(_REASONING_AWARE_OUTPUTS)
+        if unknown:
+            joined = ", ".join(sorted(unknown))
+            raise ValueError(f"unknown reasoning-aware outputs: {joined}")
+        existing_outputs = (
+            frozenset(self.reasoning_provider_outputs)
+            if self.reasoning_provider_outputs
+            else frozenset(_REASONING_AWARE_OUTPUTS)
+            if self.reasoning_provider_configured
+            else frozenset()
+        )
+        active_outputs = (
+            existing_outputs | selected
+            if provider is not None
+            else existing_outputs - selected
+        )
+        active_tuple = (
+            ()
+            if active_outputs == frozenset(_REASONING_AWARE_OUTPUTS)
+            else tuple(sorted(active_outputs))
+        )
+        services = {
+            "campaign": self.campaign,
+            "blog_post": self.blog_post,
+            "report": self.report,
+            "landing_page": self.landing_page,
+            "sales_brief": self.sales_brief,
+        }
+        for output, attr in _REASONING_OUTPUT_TO_ATTR.items():
+            if output in selected:
+                services[attr] = _rebind_reasoning(services[attr], provider)
         return ContentOpsExecutionServices(
-            campaign=_rebind_reasoning(self.campaign, provider)
-            if "email_campaign" in selected else self.campaign,
-            blog_post=_rebind_reasoning(self.blog_post, provider)
-            if "blog_post" in selected else self.blog_post,
-            report=_rebind_reasoning(self.report, provider)
-            if "report" in selected else self.report,
-            landing_page=_rebind_reasoning(self.landing_page, provider)
-            if "landing_page" in selected else self.landing_page,
-            sales_brief=_rebind_reasoning(self.sales_brief, provider)
-            if "sales_brief" in selected else self.sales_brief,
+            campaign=services["campaign"],
+            blog_post=services["blog_post"],
+            report=services["report"],
+            landing_page=services["landing_page"],
+            sales_brief=services["sales_brief"],
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
-            reasoning_provider_configured=provider is not None and bool(selected),
-            reasoning_provider_outputs=tuple(sorted(selected)) if provider is not None else (),
+            reasoning_provider_configured=bool(active_outputs),
+            reasoning_provider_outputs=active_tuple,
         )
 
     def reasoning_provider_active_for(self, output: str) -> bool:

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -23,7 +23,7 @@ from .landing_page_generation import LandingPageGenerationConfig
 from .reasoning_policy import (
     NOOP_REASONING_PRESETS,
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
-    PACKAGED_REASONING_RUNTIME_PRESETS,
+    packaged_reasoning_runtime_presets_for_output,
     resolve_reasoning_policy,
 )
 from .report_generation import ReportGenerationConfig
@@ -116,9 +116,11 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
     _policy, definition = resolve_reasoning_policy(output, request.reasoning_preset)
     if definition.id in NOOP_REASONING_PRESETS:
         return {}
-    if definition.id not in PACKAGED_REASONING_RUNTIME_PRESETS:
+    runtime_presets = packaged_reasoning_runtime_presets_for_output(output)
+    if definition.id not in runtime_presets:
         raise ValueError(
             "Content Ops packaged reasoning currently supports "
+            "multi_pass_structured for blog_post and "
             "multi_pass_structured or multi_pass_strict for report and sales_brief."
         )
     return {
@@ -146,7 +148,8 @@ def _validate_reasoning_runtime_request(
     )
     if not runtime_outputs:
         raise ValueError(
-            "reasoning_preset currently applies only to report and sales_brief."
+            "reasoning_preset currently applies only to blog_post, report, "
+            "and sales_brief."
         )
     for output in runtime_outputs:
         _reasoning_config_for_output(output, request)
@@ -297,6 +300,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
                 "topic": request.inputs.get("topic"),
+                **_reasoning_config_for_output(output, request),
             },
         )
     if output == "signal_extraction":

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -124,12 +124,26 @@ _LANDING_PAGE_PRESETS: tuple[ReasoningPreset, ...] = (
     "none", "context_only", "single_pass", "multi_pass_light",
     "multi_pass_structured",
 )
+_BLOG_POST_PRESETS: tuple[ReasoningPreset, ...] = (
+    "none", "context_only", "single_pass", "multi_pass_light",
+    "multi_pass_structured",
+)
 
-PACKAGED_REASONING_RUNTIME_OUTPUTS: tuple[str, ...] = ("report", "sales_brief")
+PACKAGED_REASONING_RUNTIME_OUTPUTS: tuple[str, ...] = (
+    "blog_post", "report", "sales_brief",
+)
 PACKAGED_REASONING_RUNTIME_PRESETS: tuple[ReasoningPreset, ...] = (
     "multi_pass_structured",
     "multi_pass_strict",
 )
+_PACKAGED_REASONING_RUNTIME_PRESETS_BY_OUTPUT: Mapping[
+    str,
+    tuple[ReasoningPreset, ...],
+] = MappingProxyType({
+    "blog_post": ("multi_pass_structured",),
+    "report": PACKAGED_REASONING_RUNTIME_PRESETS,
+    "sales_brief": PACKAGED_REASONING_RUNTIME_PRESETS,
+})
 NOOP_REASONING_PRESETS: tuple[ReasoningPreset, ...] = tuple(
     preset
     for preset, definition in REASONING_PRESETS.items()
@@ -155,8 +169,8 @@ OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyTyp
     ),
     "blog_post": OutputReasoningPolicy(
         output="blog_post",
-        default_preset="multi_pass_light",
-        supported_presets=_STRUCTURED_PRESETS,
+        default_preset="multi_pass_structured",
+        supported_presets=_BLOG_POST_PRESETS,
     ),
     "report": OutputReasoningPolicy(
         output="report",
@@ -176,6 +190,14 @@ def reasoning_preset_definition(preset: str) -> ReasoningPresetDefinition:
         return REASONING_PRESETS[preset]
     except KeyError as exc:
         raise ValueError(f"unknown reasoning preset: {preset}") from exc
+
+
+def packaged_reasoning_runtime_presets_for_output(
+    output: str,
+) -> tuple[ReasoningPreset, ...]:
+    """Return packaged runtime presets supported for a generated output."""
+
+    return _PACKAGED_REASONING_RUNTIME_PRESETS_BY_OUTPUT.get(str(output), ())
 
 
 def output_reasoning_policy(output: str) -> OutputReasoningPolicy:

--- a/plans/PR-Content-Ops-Blog-Narrative-Pack.md
+++ b/plans/PR-Content-Ops-Blog-Narrative-Pack.md
@@ -1,0 +1,67 @@
+# Content Ops Blog Narrative Pack
+
+## Why this slice exists
+
+The reasoning policy audit called out blog posts as the next long-form asset
+after report and sales brief. Blog posts can already consume reasoning context,
+but packaged structured reasoning still rejects them at the plan and execute
+surfaces.
+
+## Scope (this PR)
+
+1. Add `blog_post` to the packaged structured reasoning runtime surface.
+2. Keep `multi_pass_strict` unavailable for blog posts until a blog-specific
+   blocking policy exists.
+3. Add a host-configurable output-to-pack mapping with a blog-safe default.
+4. Group packaged reasoning providers by pack name so mixed output requests do
+   not reuse the blog pack for report or sales brief.
+5. Remove the merged #560 row from the coordination ledger and claim this PR.
+6. Refresh status/backlog docs for the shipped blog narrative seam.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `plans/PR-Content-Ops-Blog-Narrative-Pack.md`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+
+## Mechanism
+
+`blog_post` joins packaged runtime only for `multi_pass_structured`. The API
+router builds one provider group for blog output using the configured blog
+pack, defaulting to `content_ops_blog`, and keeps report/sales brief on the
+existing `content_ops_structured` pack.
+Execution-service reasoning metadata now accumulates targeted output bindings
+so mixed requests can report every provider-bound output correctly.
+
+## Intentional
+
+Strict blog reasoning remains blocked. Blog output validation should stay soft
+until a concrete blog-specific blocking policy ships.
+
+## Deferred
+
+Strict blog reasoning remains deferred until a blog-specific blocking policy is
+defined. Landing-page narrative planning remains opt-in host wiring, not a
+packaged runtime default.
+
+## Verification
+
+pytest tests/test_extracted_content_reasoning_policy.py
+tests/test_extracted_content_generation_plan.py
+tests/test_extracted_content_control_surface_api.py
+tests/test_extracted_content_ops_execution.py -> 148 passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~620 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -916,6 +916,95 @@ async def test_execute_route_builds_structured_reasoning_for_report_only():
 
 
 @pytest.mark.asyncio
+async def test_execute_route_builds_blog_specific_structured_reasoning_pack():
+    recorded_providers = []
+    blog_post = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            blog_post=blog_post,
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["blog_post"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {"topic": "Churn pressure"},
+        }
+    )
+
+    assert len(recorded_providers) == 1
+    provider = recorded_providers[0]
+    assert provider._config.narrative_plan_pack.name == "content_ops_blog"
+    assert provider._config.output_policy is not None
+    assert provider._config.block_on_validation_failure is False
+
+
+@pytest.mark.asyncio
+async def test_execute_route_uses_configured_output_pack_mapping():
+    recorded_providers = []
+    blog_post = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            blog_post=blog_post,
+        ),
+        llm_provider=lambda: object(),
+        config=ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_output_pack_names={
+                "blog_post": "custom_blog_pack",
+            },
+        ),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["blog_post"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {"topic": "Churn pressure"},
+        }
+    )
+
+    assert recorded_providers[0]._config.narrative_plan_pack.name == "custom_blog_pack"
+
+
+@pytest.mark.parametrize("outputs", (("blog_post", "report"), ("report", "blog_post")))
+@pytest.mark.asyncio
+async def test_execute_route_keeps_blog_and_report_reasoning_packs_separate(outputs):
+    blog_providers = []
+    report_providers = []
+    blog_post = _ProviderRecordingService(blog_providers)
+    report = _ProviderRecordingService(report_providers)
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            blog_post=blog_post,
+            report=report,
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": list(outputs),
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {
+                "topic": "Churn pressure",
+                "opportunity_id": "opp-1",
+            },
+        }
+    )
+
+    assert blog_providers[0]._config.narrative_plan_pack.name == "content_ops_blog"
+    assert report_providers[0]._config.narrative_plan_pack.name == "content_ops_structured"
+
+
+@pytest.mark.asyncio
 async def test_execute_route_wraps_strict_reasoning_with_blocking_provider():
     recorded_providers = []
     report = _ProviderRecordingService(recorded_providers)
@@ -1095,11 +1184,11 @@ async def test_blocking_reasoning_provider_surfaces_validation_blockers():
         (
             {
                 "outputs": ["blog_post"],
-                "reasoning_preset": "multi_pass_structured",
+                "reasoning_preset": "multi_pass_strict",
                 "inputs": {"topic": "Churn pressure"},
             },
             400,
-            "report and sales_brief",
+            "not supported",
         ),
     ),
 )
@@ -1253,6 +1342,30 @@ async def test_execute_route_structured_reasoning_requires_llm_provider():
 def test_content_ops_config_rejects_blank_structured_reasoning_pack_name():
     with pytest.raises(ValueError, match="structured_reasoning_pack_name"):
         ContentOpsControlSurfaceApiConfig(structured_reasoning_pack_name=" ")
+
+
+def test_content_ops_config_rejects_invalid_output_pack_names():
+    with pytest.raises(ValueError, match="must be a mapping"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_output_pack_names="content_ops_blog"
+        )
+    with pytest.raises(ValueError, match="keys must be non-empty"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_output_pack_names={" ": "content_ops_blog"}
+        )
+    with pytest.raises(ValueError, match="values must be non-empty"):
+        ContentOpsControlSurfaceApiConfig(
+            structured_reasoning_output_pack_names={"blog_post": " "}
+        )
+
+
+def test_content_ops_config_stores_output_pack_names_immutably():
+    config = ContentOpsControlSurfaceApiConfig(
+        structured_reasoning_output_pack_names={"blog_post": "content_ops_blog"}
+    )
+
+    with pytest.raises(TypeError):
+        config.structured_reasoning_output_pack_names["blog_post"] = "other_pack"  # type: ignore[index]
 
 
 def test_content_ops_config_rejects_invalid_falsification_rules_shape():

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -3,7 +3,7 @@ import pytest
 from extracted_content_pipeline.generation_plan import build_generation_plan_from_mapping
 from extracted_content_pipeline.reasoning_policy import (
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
-    PACKAGED_REASONING_RUNTIME_PRESETS,
+    packaged_reasoning_runtime_presets_for_output,
 )
 
 
@@ -113,25 +113,46 @@ def test_plan_threads_strict_reasoning_preset_to_report_and_sales_brief():
         assert step["config"]["reasoning_falsification"] is True
 
 
-@pytest.mark.parametrize("output", PACKAGED_REASONING_RUNTIME_OUTPUTS)
-@pytest.mark.parametrize("preset", PACKAGED_REASONING_RUNTIME_PRESETS)
-def test_plan_threads_all_packaged_runtime_reasoning_presets(output, preset):
-    inputs = {
-        "report": {"opportunity_id": "opp_123"},
-        "sales_brief": {"target_account": "Acme"},
-    }[output]
-
+def test_plan_threads_structured_reasoning_preset_to_blog_post():
     plan = build_generation_plan_from_mapping(
         {
-            "outputs": [output],
-            "reasoning_preset": preset,
-            "inputs": inputs,
+            "outputs": ["blog_post"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {
+                "topic": "Churn pressure",
+            },
         }
     )
 
     step = plan["steps"][0]
-    assert step["config"]["reasoning_preset"] == preset
+    assert step["config"]["reasoning_preset"] == "multi_pass_structured"
     assert step["config"]["reasoning_multi_pass"] is True
+    assert step["config"]["reasoning_narrative_planning"] is True
+    assert step["config"]["reasoning_output_validation"] is True
+    assert step["config"]["reasoning_blocking_validation"] is False
+    assert step["config"]["reasoning_falsification"] is False
+
+
+@pytest.mark.parametrize("output", PACKAGED_REASONING_RUNTIME_OUTPUTS)
+def test_plan_threads_all_packaged_runtime_reasoning_presets(output):
+    inputs = {
+        "blog_post": {"topic": "Churn pressure"},
+        "report": {"opportunity_id": "opp_123"},
+        "sales_brief": {"target_account": "Acme"},
+    }[output]
+
+    for preset in packaged_reasoning_runtime_presets_for_output(output):
+        plan = build_generation_plan_from_mapping(
+            {
+                "outputs": [output],
+                "reasoning_preset": preset,
+                "inputs": inputs,
+            }
+        )
+
+        step = plan["steps"][0]
+        assert step["config"]["reasoning_preset"] == preset
+        assert step["config"]["reasoning_multi_pass"] is True
 
 
 def test_plan_rejects_unknown_reasoning_preset_for_report():
@@ -145,14 +166,47 @@ def test_plan_rejects_unknown_reasoning_preset_for_report():
         )
 
 
-@pytest.mark.parametrize("preset", ("single_pass", "multi_pass_light"))
-def test_plan_rejects_runtime_unsupported_reasoning_preset_for_report(preset):
-    with pytest.raises(ValueError, match="multi_pass_structured or multi_pass_strict"):
+@pytest.mark.parametrize(
+    ("output", "inputs", "preset", "expected_match"),
+    (
+        (
+            "report",
+            {"opportunity_id": "opp_123"},
+            "single_pass",
+            "multi_pass_structured or multi_pass_strict",
+        ),
+        (
+            "report",
+            {"opportunity_id": "opp_123"},
+            "multi_pass_light",
+            "multi_pass_structured or multi_pass_strict",
+        ),
+        (
+            "blog_post",
+            {"topic": "Churn pressure"},
+            "multi_pass_light",
+            "multi_pass_structured or multi_pass_strict",
+        ),
+        (
+            "blog_post",
+            {"topic": "Churn pressure"},
+            "multi_pass_strict",
+            "not supported",
+        ),
+    ),
+)
+def test_plan_rejects_runtime_unsupported_reasoning_preset(
+    output,
+    inputs,
+    preset,
+    expected_match,
+):
+    with pytest.raises(ValueError, match=expected_match):
         build_generation_plan_from_mapping(
             {
-                "outputs": ["report"],
+                "outputs": [output],
                 "reasoning_preset": preset,
-                "inputs": {"opportunity_id": "opp_123"},
+                "inputs": inputs,
             }
         )
 
@@ -160,7 +214,6 @@ def test_plan_rejects_runtime_unsupported_reasoning_preset_for_report(preset):
 @pytest.mark.parametrize(
     ("output", "inputs", "preset"),
     (
-        ("blog_post", {"topic": "Churn pressure"}, "multi_pass_structured"),
         (
             "landing_page",
             {"offer": "Audit", "audience": "RevOps"},
@@ -178,7 +231,7 @@ def test_plan_rejects_runtime_reasoning_when_no_packaged_output_selected(
     inputs,
     preset,
 ):
-    with pytest.raises(ValueError, match="only to report and sales_brief"):
+    with pytest.raises(ValueError, match="only to blog_post, report, and sales_brief"):
         build_generation_plan_from_mapping(
             {
                 "outputs": [output],

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -113,6 +113,73 @@ def test_services_with_reasoning_context_can_target_specific_outputs() -> None:
     assert derived.reasoning_provider_active_for("email_campaign") is False
 
 
+def test_services_with_reasoning_context_accumulates_targeted_outputs() -> None:
+    campaign_provider = object()
+    report_provider = object()
+    campaign = _ReasoningAwareOpportunityService()
+    report = _ReasoningAwareOpportunityService()
+    bundle = ContentOpsExecutionServices(campaign=campaign, report=report)
+
+    derived = bundle.with_reasoning_context(
+        campaign_provider,
+        outputs=("email_campaign",),
+    ).with_reasoning_context(
+        report_provider,
+        outputs=("report",),
+    )
+
+    assert derived.reasoning_provider_active_for("email_campaign") is True
+    assert derived.reasoning_provider_active_for("report") is True
+    assert derived.campaign._reasoning_context is campaign_provider
+    assert derived.report._reasoning_context is report_provider
+
+
+def test_services_with_reasoning_context_none_clears_targeted_output() -> None:
+    campaign_provider = object()
+    report_provider = object()
+    campaign = _ReasoningAwareOpportunityService()
+    report = _ReasoningAwareOpportunityService()
+    bundle = ContentOpsExecutionServices(campaign=campaign, report=report)
+
+    derived = bundle.with_reasoning_context(
+        campaign_provider,
+        outputs=("email_campaign",),
+    ).with_reasoning_context(
+        report_provider,
+        outputs=("report",),
+    ).with_reasoning_context(
+        None,
+        outputs=("email_campaign",),
+    )
+
+    assert derived.reasoning_provider_active_for("email_campaign") is False
+    assert derived.reasoning_provider_active_for("report") is True
+    assert derived.campaign._reasoning_context is None
+    assert derived.report._reasoning_context is report_provider
+
+
+def test_services_with_reasoning_context_none_clears_from_global_provider() -> None:
+    campaign = _ReasoningAwareOpportunityService(reasoning_context=object())
+    report = _ReasoningAwareOpportunityService(reasoning_context=object())
+    bundle = ContentOpsExecutionServices(
+        campaign=campaign,
+        report=report,
+        reasoning_provider_configured=True,
+    )
+
+    derived = bundle.with_reasoning_context(None, outputs=("email_campaign",))
+
+    assert derived.reasoning_provider_active_for("email_campaign") is False
+    assert derived.reasoning_provider_active_for("report") is True
+    assert derived.campaign._reasoning_context is None
+    assert derived.report is report
+
+
+def test_services_rejects_outputs_without_provider_flag() -> None:
+    with pytest.raises(ValueError, match="requires reasoning_provider_configured"):
+        ContentOpsExecutionServices(reasoning_provider_outputs=("report",))
+
+
 def test_services_with_reasoning_context_honors_empty_output_selection() -> None:
     campaign = _ReasoningAwareOpportunityService()
     derived = ContentOpsExecutionServices(campaign=campaign).with_reasoning_context(
@@ -130,6 +197,15 @@ def test_services_with_reasoning_context_rejects_string_outputs() -> None:
         ContentOpsExecutionServices(campaign=campaign).with_reasoning_context(
             object(),
             outputs="report",
+        )
+
+
+def test_services_with_reasoning_context_rejects_unknown_outputs() -> None:
+    campaign = _ReasoningAwareOpportunityService()
+    with pytest.raises(ValueError, match="unknown reasoning-aware outputs"):
+        ContentOpsExecutionServices(campaign=campaign).with_reasoning_context(
+            object(),
+            outputs=("signal_extraction",),
         )
 
 

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -8,10 +8,10 @@ from extracted_content_pipeline.reasoning_policy import (
     NOOP_REASONING_PRESETS,
     OUTPUT_REASONING_POLICIES,
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
-    PACKAGED_REASONING_RUNTIME_PRESETS,
     REASONING_PRESETS,
     OutputReasoningPolicy,
     output_reasoning_policy,
+    packaged_reasoning_runtime_presets_for_output,
     reasoning_preset_definition,
     resolve_reasoning_policy,
     supported_reasoning_presets,
@@ -51,7 +51,7 @@ def test_output_policy_defaults_match_audit_recommendations() -> None:
         "signal_extraction": "none",
         "email_campaign": "single_pass",
         "landing_page": "single_pass",
-        "blog_post": "multi_pass_light",
+        "blog_post": "multi_pass_structured",
         "report": "multi_pass_structured",
         "sales_brief": "multi_pass_structured",
     }
@@ -70,7 +70,8 @@ def test_packaged_runtime_reasoning_surface_is_catalog_supported() -> None:
     for output in PACKAGED_REASONING_RUNTIME_OUTPUTS:
         assert OUTPUT_CATALOG[output].implemented is True
         policy = output_reasoning_policy(output)
-        for preset in PACKAGED_REASONING_RUNTIME_PRESETS:
+        assert policy.default_preset in packaged_reasoning_runtime_presets_for_output(output)
+        for preset in packaged_reasoning_runtime_presets_for_output(output):
             assert policy.supports(preset)
 
 
@@ -114,8 +115,19 @@ def test_landing_page_supports_structured_but_not_strict_preset() -> None:
     assert "multi_pass_strict" not in supported
 
 
-@pytest.mark.parametrize("output", ("blog_post", "report", "sales_brief"))
-def test_long_form_assets_support_structured_presets(output: str) -> None:
+def test_blog_post_supports_structured_but_not_strict_preset() -> None:
+    assert supported_reasoning_presets("blog_post") == (
+        "none",
+        "context_only",
+        "single_pass",
+        "multi_pass_light",
+        "multi_pass_structured",
+    )
+    assert "multi_pass_strict" not in supported_reasoning_presets("blog_post")
+
+
+@pytest.mark.parametrize("output", ("report", "sales_brief"))
+def test_report_and_sales_brief_support_structured_presets(output: str) -> None:
     assert supported_reasoning_presets(output) == (
         "none",
         "context_only",


### PR DESCRIPTION
# Content Ops Blog Narrative Pack

## Why this slice exists

The reasoning policy audit called out blog posts as the next long-form asset
after report and sales brief. Blog posts can already consume reasoning context,
but packaged structured reasoning still rejects them at the plan and execute
surfaces.

## Scope (this PR)

1. Add `blog_post` to the packaged structured reasoning runtime surface.
2. Keep `multi_pass_strict` unavailable for blog posts until a blog-specific
   blocking policy exists.
3. Add a host-configurable blog narrative pack name with a safe default.
4. Group packaged reasoning providers by pack name so mixed output requests do
   not reuse the blog pack for report or sales brief.
5. Remove the merged #560 row from the coordination ledger and claim this PR.
6. Refresh status/backlog docs for the shipped blog narrative seam.

### Files touched

- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
- `docs/extraction/coordination/inflight.md`
- `extracted_content_pipeline/STATUS.md`
- `extracted_content_pipeline/api/control_surfaces.py`
- `extracted_content_pipeline/content_ops_execution.py`
- `extracted_content_pipeline/generation_plan.py`
- `extracted_content_pipeline/reasoning_policy.py`
- `plans/PR-Content-Ops-Blog-Narrative-Pack.md`
- `tests/test_extracted_content_control_surface_api.py`
- `tests/test_extracted_content_ops_execution.py`
- `tests/test_extracted_content_generation_plan.py`
- `tests/test_extracted_content_reasoning_policy.py`

## Mechanism

`blog_post` joins packaged runtime only for `multi_pass_structured`. The API
router builds one provider group for blog output using `content_ops_blog` and
keeps report/sales brief on the existing `content_ops_structured` pack.
Execution-service reasoning metadata now accumulates targeted output bindings
so mixed requests can report every provider-bound output correctly.

## Intentional

Strict blog reasoning remains blocked. Blog output validation should stay soft
until a concrete blog-specific blocking policy ships.

## Deferred

Strict blog reasoning remains deferred until a blog-specific blocking policy is
defined. Landing-page narrative planning remains opt-in host wiring, not a
packaged runtime default.

## Verification

pytest tests/test_extracted_content_reasoning_policy.py
tests/test_extracted_content_generation_plan.py
tests/test_extracted_content_control_surface_api.py
tests/test_extracted_content_ops_execution.py -> 139 passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| **Total** | ~420 |
