### PR TITLE
Close out Content Ops reasoning backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -116,8 +116,20 @@ remains roadmap work or should be removed from active backlog.
 
 ## Current Pick Recommendation
 
-Take item 1 next, specifically structured reasoning for `report` and
-`sales_brief` using the preset catalog. Source-adapter consolidation is
-complete for now; the remaining leverage is controlled reasoning-policy depth
-for long-form and multi-asset outputs. Source breadth should pause until a
-real host export or field-loss risk appears.
+The host-facing AI Content Ops reasoning-policy arc is complete for the current
+standalone product surface: preset catalog, structured report/sales/blog
+execution, strict report/sales validation, explicit strict falsification rules,
+and blog-specific narrative packs have shipped.
+
+Do not take another AI Content Ops reasoning-policy slice unless it answers one
+of these concrete needs:
+
+- A host asks for a new packaged runtime output or preset.
+- A real generated-asset run exposes validation metadata that operators cannot
+  act on.
+- `extracted_reasoning_core` advances enough that AI Content Ops needs a new
+  stable provider port or capability check.
+
+Until then, pause speculative Content Ops reasoning-policy work. The next
+highest-leverage code should come from either a real source export fixture
+(item 2) or the separate `extracted_reasoning_core` productization track.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T21:45Z by codex-2026-05-16
+Last updated: 2026-05-16T22:32Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #561 | Content Ops blog narrative pack | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/reasoning_policy.py`, `tests/test_extracted_content_control_surface_api.py`, `tests/test_extracted_content_ops_execution.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_reasoning_policy.py`, `extracted_content_pipeline/STATUS.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Blog-Narrative-Pack.md` | codex-2026-05-16 | Avoid packaged reasoning runtime output/preset edits and blog structured reasoning router changes. |
+| #562 | Content Ops reasoning backlog closeout | `docs/extraction/coordination/inflight.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Reasoning-Backlog-Closeout.md` | codex-2026-05-16 | Avoid editing the AI Content Ops deferred backlog recommendation while this closes the shipped reasoning-policy arc. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Reasoning-Backlog-Closeout.md
+++ b/plans/PR-Content-Ops-Reasoning-Backlog-Closeout.md
@@ -1,0 +1,48 @@
+# Content Ops Reasoning Backlog Closeout
+
+## Why this slice exists
+
+PR #561 merged the blog narrative pack slice, closing the current AI Content
+Ops reasoning-policy arc. The coordination ledger still listed #561 as
+in-flight, and the deferred backlog still recommended already-shipped
+report/sales structured reasoning as the next pick.
+
+## Scope (this PR)
+
+1. Remove the merged #561 coordination lock.
+2. Claim this closeout PR while it updates the backlog.
+3. Replace the stale current-pick recommendation with a stop condition for
+   speculative Content Ops reasoning-policy work.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `plans/PR-Content-Ops-Reasoning-Backlog-Closeout.md`
+
+## Mechanism
+
+The backlog now states that the current host-facing Content Ops reasoning
+policy surface is complete unless a real host/runtime need appears. Future work
+should move to real source fixtures or the separate `extracted_reasoning_core`
+track instead of inventing another Content Ops policy slice.
+
+## Intentional
+
+This is docs-only. It does not alter runtime policy, generated assets,
+reasoning providers, or UI behavior.
+
+## Deferred
+
+Any new packaged reasoning runtime output, strict blog policy, or deeper
+reasoning-core provider wiring should start with a concrete product trigger.
+
+## Verification
+
+Command run: bash scripts/local_pr_review.sh -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| **Total** | ~60 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reasoning-Backlog-Closeout.md

Summary:
- Remove the merged #561 coordination lock.
- Refresh the AI Content Ops deferred backlog so it no longer recommends already-shipped report/sales structured reasoning.
- Set the next-work rule: pause speculative Content Ops reasoning-policy slices unless a real host/runtime trigger appears; otherwise move to source fixtures or the separate extracted_reasoning_core track.

Verification:
- bash scripts/local_pr_review.sh -> passed