### PR TITLE
Reconcile extracted reasoning core current state

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-16T22:32Z by codex-2026-05-16
+Last updated: 2026-05-17T00:53Z by codex-2026-05-16
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #562 | Content Ops reasoning backlog closeout | `docs/extraction/coordination/inflight.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Reasoning-Backlog-Closeout.md` | codex-2026-05-16 | Avoid editing the AI Content Ops deferred backlog recommendation while this closes the shipped reasoning-policy arc. |
+| #563 | Reconcile extracted reasoning core current state | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`, `docs/extraction/reasoning_boundary_audit_2026-05-03.md`, `plans/PR-Reasoning-Core-Current-State.md` | codex-2026-05-16 | Avoid editing extracted_reasoning_core status, queue, or next-slice recommendation while this reconciles stale reasoning-core docs. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-04T04:55Z by claude-2026-05-03-b
+Last updated: 2026-05-17T00:53Z by codex-2026-05-16
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -9,4 +9,5 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
-| PR-C1 | `extracted_reasoning_core` | claude-2026-05-03 | PR #80, PR #82 (both merged) | Consolidate evidence/temporal/archetypes per merged PR #82 audit. NEW in core: `archetypes.py`, `evidence_engine.py` (slim conclusions+suppression surface), `evidence_map.yaml`, `temporal.py` (with `_numeric_value` / `_row_get` helpers + parameterized `MIN_DAYS_FOR_PERCENTILES`). Atlas-side: NEW `atlas_brain/reasoning/review_enrichment.py`; slim `atlas_brain/reasoning/evidence_engine.py`. Convert `extracted_content_pipeline/reasoning/{archetypes,evidence_engine,temporal}.py` to re-export wrappers. EDIT `extracted_reasoning_core/api.py` (impl 3 stubs) and `extracted_reasoning_core/types.py` (rich `TemporalEvidence` + 4 sub-types + `ConclusionResult` + `SuppressionResult`). Rename + redirect `tests/test_extracted_reasoning_*.py`. PR #79 contract amendment lands in the same commit. |
+| PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
+| PR-C3-enrichment-pack-split | `extracted_reasoning_core` | unclaimed | PR-C2-current-state-reset | Recommended next code slice: carve atlas-side per-review enrichment into an explicit product pack. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-05T03:34Z by codex-2026-05-05
+Last updated: 2026-05-17T00:53Z by codex-2026-05-16
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #209 | — | Seller category-intelligence refresh landed. Next decision: hosted orchestration/API trigger and dashboard hardening, or optional subcategory intelligence producer. | none |
-| `extracted_reasoning_core` | 1 (scaffold + archetypes/evidence_map moved; PR-C1 series merged through #163) | #163 | — | Continue temporal/types/evidence_engine/API/wrapper follow-up slices per merged PR #82 audit | none |
+| `extracted_reasoning_core` | 1 -> 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, and partial product wrappers landed; no standalone env toggle claimed yet) | #163 | #563 | Reconcile current-state audit, then continue with the smallest remaining productization gap: atlas-side per-review enrichment pack split. | reasoning-core status docs |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/docs/extraction/reasoning_boundary_audit_2026-05-03.md
+++ b/docs/extraction/reasoning_boundary_audit_2026-05-03.md
@@ -471,7 +471,17 @@ larger engine modules.
 
 ## PR-C1 Implementation Outcomes (2026-05-04)
 
-This section records the actual outcomes from the PR-C1 sequence (PR-C1a → PR-C1k) so the audit reflects what shipped, not just what was planned. The original PR 2 / PR 3 acceptance criteria from the "Follow-Up PR Sequence" above are now satisfied; the PR 4 / PR 5 / PR 6 / PR 7 sequence remains as planned.
+This section records the actual outcomes from the PR-C1 sequence (PR-C1a → PR-C1k) so the audit reflects what shipped, not just what was planned. The original PR 2 / PR 3 acceptance criteria from the "Follow-Up PR Sequence" above are now satisfied. The older PR 4 / PR 5 / PR 6 / PR 7 plan was later advanced by follow-up work and is no longer the source of truth; see the 2026-05-17 reconciliation below.
+
+## Current-State Reconciliation (2026-05-17)
+
+See `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`.
+
+The PR 4 / PR 5 / PR 6 / PR 7 backlog below is superseded as a planning
+source. Current main already contains semantic-cache key and port split work,
+the pack registry, graph/state ports, content-pipeline wrappers, atlas wrapper
+tests, and the extracted-product import-boundary guard. Use the current-state
+audit for next-slice selection instead of replaying the older backlog verbatim.
 
 ### Slices that landed
 

--- a/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
+++ b/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
@@ -1,0 +1,77 @@
+# Extracted Reasoning Core Current State
+
+Date: 2026-05-17
+
+## Purpose
+
+The original 2026-05-03 reasoning boundary audit is stale. It says PR 4
+through PR 7 remain untouched, but current main already contains large parts of
+those tracks. This note resets the next-slice decision against the code that
+actually exists.
+
+## Current Shipped Surface
+
+`extracted_reasoning_core` now contains:
+
+- Public API: `api.py` with `score_archetypes`, `evaluate_evidence`,
+  `build_temporal_evidence`, `run_reasoning`, `continue_reasoning`,
+  `check_falsification`, `build_narrative_plan`,
+  `validate_reasoning_output`, `compute_evidence_hash`,
+  `build_semantic_cache_key`, and `load_reasoning_pack`.
+- Public types and ports: `types.py` and `ports.py`, including
+  `ReasoningPorts`, `SemanticCacheStore`, `ReasoningStateStore`,
+  `EventSink`, `TraceSink`, `WitnessContextPort`, `LLMClient`, and `Clock`.
+- Deterministic core modules: `archetypes.py`, `temporal.py`,
+  `evidence_engine.py`, `semantic_cache_keys.py`, `wedge_registry.py`,
+  `tiers.py`, and `domains.py`.
+- Pack/runtime modules: `pack_registry.py`, `skills/registry.py`,
+  `_synthesis.py`.
+- Graph/state modules: `graph.py`, `graph_nodes.py`, `graph_helpers.py`,
+  and `state.py`.
+- Core test coverage under `tests/test_extracted_reasoning_core_*.py`.
+
+## Status Against The Old PR 4-7 Backlog
+
+| Old backlog item | Current status | Notes |
+|---|---|---|
+| PR 4: Semantic cache split | Mostly shipped at the core boundary | `semantic_cache_keys.py`, `SemanticCacheStore`, `compute_evidence_hash`, and `build_semantic_cache_key` exist. Concrete storage remains outside core, which is the intended port split. |
+| PR 5: Reasoning pack registry | Mostly shipped | `pack_registry.py` exists, and atlas single-pass prompt packs register into it. The remaining gap is per-review enrichment, still atlas-side in `atlas_brain.reasoning.evidence_engine`. |
+| PR 6: Graph/state engine with ports | Partially shipped | Core graph, graph node, graph helper, and state modules exist. Atlas graph still has host-specific LLM resolution and orchestration wrappers. |
+| PR 7: Product migration pass | Partially shipped | `extracted_content_pipeline.reasoning.*` wrappers point at core. Atlas wrappers for archetypes, temporal, evidence engine, and graph helpers are covered by alias tests. Import-boundary guard exists and is wired for extracted products. |
+
+## Remaining Gaps
+
+1. **Per-review enrichment pack split.**
+   `atlas_brain.reasoning.evidence_engine.EvidenceEngine` subclasses core and
+   keeps atlas-only enrichment methods: `compute_urgency`, `override_pain`,
+   `derive_recommend`, `derive_price_complaint`, `derive_budget_authority`,
+   and `_check_derivation_rule`. This is the clearest remaining PR 5 gap.
+
+2. **Atlas graph/state host wrapper split.**
+   `atlas_brain.reasoning.graph` still owns host-specific LLM resolution,
+   timeout handling, and orchestration glue. Core owns graph helpers/nodes, but
+   a full migration would be larger and riskier than the enrichment pack split.
+
+3. **Queue/status drift.**
+   Coordination docs still pointed at PR-C1 even though the code had advanced
+   through semantic cache keys, pack registry, graph/state, and migration
+   guards. This PR fixes that planning drift before more code work starts.
+
+4. **Standalone-toggle status.**
+   The reasoning core is moving toward the phase-2 boundary, but this audit did
+   not find a dedicated `EXTRACTED_REASONING_CORE_STANDALONE` toggle. The state
+   table therefore marks it as `1 -> 2 in progress`, not fully phase 2.
+
+## Recommendation
+
+Take the next code slice as the **per-review enrichment pack split**:
+
+- Create a product-owned enrichment pack module outside core.
+- Keep `extracted_reasoning_core.evidence_engine` slim.
+- Preserve the atlas wrapper behavior so existing callers still get the same
+  `EvidenceEngine` object shape.
+- Add tests that prove the atlas wrapper delegates slim evidence decisions to
+  core while enrichment methods live in the product pack.
+
+Do not rebuild semantic cache, pack registry, graph helpers, or public API
+surfaces from the old audit wording; those already exist.

--- a/plans/PR-Reasoning-Core-Current-State.md
+++ b/plans/PR-Reasoning-Core-Current-State.md
@@ -1,0 +1,74 @@
+# Reasoning Core Current-State Reset
+
+## Why this slice exists
+
+The coordination queue and the 2026-05-03 reasoning boundary audit still point
+at the old PR 4-7 backlog as if semantic cache split, pack registry, graph/state
+ports, and product migration guards were untouched. Current main already has
+large parts of those tracks. Without a reset doc, the next reasoning-core slice
+risks repeating shipped work instead of targeting the remaining gap.
+
+## Scope (this PR)
+
+1. Update coordination state so other sessions know this branch owns the
+   reasoning-core current-state reset.
+2. Add a current-state audit that lists the shipped reasoning-core surfaces and
+   the remaining gaps.
+3. Amend the older boundary audit with a pointer to the current-state audit.
+4. Recommend the next code slice without changing runtime code.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`
+- `docs/extraction/reasoning_boundary_audit_2026-05-03.md`
+- `plans/PR-Reasoning-Core-Current-State.md`
+
+## Mechanism
+
+This is a documentation-only reconciliation. It compares the old audit backlog
+against the current repository surface:
+
+- public APIs, types, ports, and semantic cache key helpers in
+  `extracted_reasoning_core`;
+- pack registry and graph/state modules in `extracted_reasoning_core`;
+- content-pipeline and atlas wrapper tests that already route through core;
+- extracted-product import-boundary guard scripts.
+
+The resulting doc names the remaining high-value gap as the atlas-side
+per-review enrichment pack split.
+
+## Intentional
+
+- No runtime code changes. This PR only resets planning state.
+- No attempt to finish the per-review enrichment split here; that belongs in a
+  focused code PR after this doc lands.
+- No semantic-cache storage implementation inside core. Storage stays behind
+  the existing `SemanticCacheStore` port.
+
+## Deferred
+
+- Per-review enrichment pack split: carve the atlas-side enrichment methods out
+  of `atlas_brain.reasoning.evidence_engine` into an explicit product pack or
+  document why the atlas wrapper remains the product pack.
+- Graph/state slimming: decide which atlas-specific state fields belong in core
+  versus product extension state.
+- Remaining product migration hardening: keep tightening import boundaries only
+  after the current-state map is accepted.
+
+## Verification
+
+- git diff --check - passed before commit.
+- bash scripts/local_pr_review.sh - passed after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~20 |
+| Current-state audit | ~95 |
+| Boundary audit pointer | ~10 |
+| Plan doc | ~60 |
+| **Total** | ~185 |


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Current-State.md

This documentation-only slice reconciles the stale 2026-05-03 reasoning boundary audit and coordination queue with current main. Main already has semantic-cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and extracted-product import guards, so the next reasoning-core code slice should target remaining gaps instead of replaying old PR 4-7 wording.

## Intentional
- No runtime code changes.
- No per-review enrichment pack split in this PR; this only names it as the recommended next code slice.
- No semantic-cache storage implementation inside reasoning core.

## Deferred
- Per-review enrichment pack split from atlas-side EvidenceEngine.
- Graph/state slimming.
- Remaining product migration/import-boundary hardening.

## Verification
- git diff --check: passed.
- bash scripts/local_pr_review.sh: passed locally and via pre-push hook.

## Diff size
6 files, +163 / -6.