### PR TITLE
Split atlas review enrichment pack

### DIFF
--- a/atlas_brain/reasoning/evidence_engine.py
+++ b/atlas_brain/reasoning/evidence_engine.py
@@ -3,8 +3,8 @@
 PR-D7b3 promoted core's slim conclusions+suppression engine into
 :mod:`extracted_reasoning_core.evidence_engine`. Atlas keeps the
 import surface ``atlas_brain.reasoning.evidence_engine`` as a
-subclass wrapper that adds the per-review enrichment methods that
-stay atlas-side per PR-C1's slim-core split:
+subclass wrapper that mixes in the atlas-owned per-review enrichment
+pack from ``atlas_brain.reasoning.review_enrichment``:
 
   - ``compute_urgency``
   - ``override_pain``
@@ -41,7 +41,6 @@ because external products don't ship atlas's settings module.
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 from typing import Any
 
@@ -50,12 +49,16 @@ from extracted_reasoning_core.evidence_engine import (
 )
 from extracted_reasoning_core.types import ConclusionResult, SuppressionResult
 
+from .review_enrichment import ReviewEnrichmentMixin
+
 logger = logging.getLogger("atlas.reasoning.evidence_engine")
 
 _DEFAULT_MAP_PATH = Path(__file__).parent / "evidence_map.yaml"
 
 
-class EvidenceEngine(_CoreEvidenceEngine):
+class EvidenceEngine(ReviewEnrichmentMixin, _CoreEvidenceEngine):
+    # Mixin-first MRO keeps enrichment methods on the atlas product pack and
+    # out of the extracted core slim engine.
     """Core slim engine extended with atlas-side per-review enrichment."""
 
     def _init_from_rules(
@@ -65,246 +68,7 @@ class EvidenceEngine(_CoreEvidenceEngine):
         raw_bytes: bytes,
     ) -> None:
         super()._init_from_rules(rules, map_path_str, raw_bytes)
-        rec = self._enrichment.get("recommend_derivation", {})
-        self._rec_positive = [
-            re.compile(p, re.IGNORECASE)
-            for p in rec.get("positive_patterns", [])
-        ]
-        self._rec_negative = [
-            re.compile(p, re.IGNORECASE)
-            for p in rec.get("negative_patterns", [])
-        ]
-        price = self._enrichment.get("price_complaint_derivation", {})
-        self._price_positive = [
-            re.compile(p, re.IGNORECASE)
-            for p in price.get("positive_patterns", [])
-        ]
-
-    def compute_urgency(
-        self,
-        indicators: dict[str, bool],
-        rating: float | None,
-        rating_max: float,
-        content_type: str,
-        source_weight: float,
-    ) -> float:
-        """Compute urgency_score (0-10) from boolean indicator flags."""
-        cfg = self._enrichment.get("urgency_scoring", {})
-        weights: dict[str, float] = cfg.get("weights", {})
-
-        score = 0.0
-        for key, weight in weights.items():
-            if indicators.get(key):
-                score += weight
-
-        if rating is not None and rating_max > 0:
-            normalized = rating / rating_max
-            for floor in cfg.get("rating_floors", []):
-                if normalized <= floor["max_normalized_rating"]:
-                    score = max(score, floor["min_score"])
-                    break
-
-        for adj in cfg.get("adjustments", []):
-            cond = adj.get("condition", {})
-            if self._check_condition_simple(cond, {"content_type": content_type, "source_weight": source_weight}):
-                score += adj.get("delta", 0.0)
-
-        for gate in cfg.get("gates", []):
-            cond = gate.get("condition", {})
-            if self._check_condition_simple(cond, {"content_type": content_type, "source_weight": source_weight}):
-                score = gate.get("force", score)
-
-        lo, hi = cfg.get("clamp", [0, 10])
-        return round(min(max(score, lo), hi), 1)
-
-    def override_pain(
-        self,
-        pain_category: str,
-        specific_complaints: list[str],
-        quotable_phrases: list[str] | None = None,
-        pricing_phrases: list[str] | None = None,
-        feature_gaps: list[str] | None = None,
-        recommendation_language: list[str] | None = None,
-    ) -> str:
-        """Override generic pain_category using keyword scan."""
-        cfg = self._enrichment.get("pain_override", {})
-        trigger = cfg.get("trigger", {})
-        trigger_values = trigger.get("in")
-        if isinstance(trigger_values, list):
-            if pain_category not in {str(v).strip().lower() for v in trigger_values if str(v).strip()}:
-                return pain_category
-        elif pain_category != trigger.get("eq", "other"):
-            return pain_category
-
-        keyword_map: dict[str, list[str]] = cfg.get("keyword_map", {})
-        scan_fields = cfg.get("scan_fields", ["specific_complaints"])
-
-        texts: list[str] = []
-        if "specific_complaints" in scan_fields:
-            texts.extend(specific_complaints or [])
-        if "quotable_phrases" in scan_fields:
-            texts.extend(quotable_phrases or [])
-        if "pricing_phrases" in scan_fields:
-            texts.extend(pricing_phrases or [])
-        if "feature_gaps" in scan_fields:
-            texts.extend(feature_gaps or [])
-        if "recommendation_language" in scan_fields:
-            texts.extend(recommendation_language or [])
-
-        if not texts:
-            return cfg.get("fallback", "overall_dissatisfaction")
-
-        combined = " ".join(texts).lower()
-
-        def _keyword_hits(keyword: str) -> bool:
-            pattern = rf"(?<!\w){re.escape(str(keyword or '').lower())}(?!\w)"
-            return bool(re.search(pattern, combined))
-
-        scores: dict[str, int] = {}
-        for category, keywords in keyword_map.items():
-            count = sum(1 for kw in keywords if _keyword_hits(str(kw)))
-            if count > 0:
-                scores[category] = count
-
-        if scores:
-            return max(scores, key=scores.get)
-        return cfg.get("fallback", "overall_dissatisfaction")
-
-    def derive_recommend(
-        self,
-        recommendation_language: list[str],
-        rating: float | None,
-        rating_max: float,
-    ) -> bool | None:
-        """Derive would_recommend from extracted language + rating."""
-        cfg = self._enrichment.get("recommend_derivation", {})
-
-        positive_hits = 0
-        negative_hits = 0
-        for phrase in (recommendation_language or []):
-            neg_match = any(pat.search(phrase) for pat in self._rec_negative)
-            if neg_match:
-                negative_hits += 1
-                continue
-            pos_match = any(pat.search(phrase) for pat in self._rec_positive)
-            if pos_match:
-                positive_hits += 1
-
-        if negative_hits > 0 and negative_hits >= positive_hits:
-            return False
-        # Single positive phrase against a clearly negative rating is likely
-        # sarcasm -- require 2+ positive hits to override.
-        fallback = cfg.get("rating_fallback", {})
-        if (
-            positive_hits == 1
-            and negative_hits == 0
-            and rating is not None
-            and rating_max > 0
-            and (rating / rating_max) <= fallback.get("false_below", 0.3)
-        ):
-            return False
-        if positive_hits > 0 and positive_hits > negative_hits:
-            return True
-
-        fallback = cfg.get("rating_fallback", {})
-        if rating is not None and rating_max > 0:
-            normalized = rating / rating_max
-            if normalized >= fallback.get("true_above", 0.7):
-                return True
-            if normalized <= fallback.get("false_below", 0.3):
-                return False
-
-        return cfg.get("default", None)
-
-    def derive_price_complaint(
-        self,
-        enrichment: dict[str, Any],
-    ) -> bool:
-        """Derive price_complaint from Tier 1 flags + extracted phrases.
-
-        Phase 2 (Layer 1 -- subject attribution gate): on v2-tagged
-        enrichments, restrict the rule check to pricing_phrases the LLM
-        marked as subject='subject_vendor'. A self-cost mention like
-        "I pay $X for my own setup" must not flip the price_complaint
-        flag on the vendor being reviewed. v1 enrichments fall through
-        to the legacy code path.
-        """
-        from ..autonomous.tasks._b2b_phrase_metadata import (
-            is_v2_tagged, phrase_metadata_map,
-        )
-
-        cfg = self._enrichment.get("price_complaint_derivation", {})
-
-        rule_input = enrichment
-        if is_v2_tagged(enrichment):
-            meta = phrase_metadata_map(enrichment)
-            raw_pricing = enrichment.get("pricing_phrases") or []
-            filtered: list[str] = []
-            for index, phrase in enumerate(raw_pricing):
-                if not str(phrase or "").strip():
-                    continue
-                row = meta.get(("pricing_phrases", index)) or {}
-                if row.get("subject") != "subject_vendor":
-                    continue
-                # Phase 3 (Layer 2): only negative / mixed pricing phrases
-                # should trip the price_complaint flag.
-                if row.get("polarity") not in ("negative", "mixed"):
-                    continue
-                filtered.append(phrase)
-            rule_input = {**enrichment, "pricing_phrases": filtered}
-
-        pricing_phrases = [
-            str(phrase or "").strip()
-            for phrase in rule_input.get("pricing_phrases") or []
-            if str(phrase or "").strip()
-        ]
-        all_pricing_phrases_positive = bool(pricing_phrases) and all(
-            any(pattern.search(phrase) for pattern in self._price_positive)
-            for phrase in pricing_phrases
-        )
-        for rule in cfg.get("true_if_any", []):
-            if (
-                rule.get("field") == "pricing_phrases"
-                and "min_count" in rule
-                and all_pricing_phrases_positive
-            ):
-                continue
-            if self._check_derivation_rule(rule, rule_input):
-                return True
-        return False
-
-    def derive_budget_authority(
-        self,
-        enrichment: dict[str, Any],
-    ) -> bool:
-        """Derive has_budget_authority from role + language."""
-        cfg = self._enrichment.get("budget_authority_derivation", {})
-        for rule in cfg.get("true_if_any", []):
-            if self._check_derivation_rule(rule, enrichment):
-                return True
-        return False
-
-    def _check_derivation_rule(
-        self, rule: dict[str, Any], enrichment: dict[str, Any],
-    ) -> bool:
-        """Check a derivation true_if_any rule (atlas-only helper)."""
-        field = rule.get("field", "")
-        value = self._resolve_field(enrichment, field)
-
-        if "eq" in rule:
-            return value == rule["eq"]
-        if "in" in rule:
-            return value in rule["in"]
-        if "not_null" in rule and rule["not_null"]:
-            return value is not None and value != ""
-        if "min_count" in rule:
-            return isinstance(value, (list, tuple)) and len(value) >= rule["min_count"]
-        if "contains_any" in rule:
-            if not isinstance(value, (list, tuple)):
-                return False
-            combined = " ".join(str(v) for v in value).lower()
-            return any(kw in combined for kw in rule["contains_any"])
-        return False
+        self._init_review_enrichment()
 
 
 _engine: EvidenceEngine | None = None

--- a/atlas_brain/reasoning/review_enrichment.py
+++ b/atlas_brain/reasoning/review_enrichment.py
@@ -1,0 +1,270 @@
+"""Atlas-owned per-review enrichment pack for evidence rules.
+
+The extracted reasoning core owns the slim conclusions and suppression
+engine. Atlas still owns these review-level enrichment derivations because
+they depend on Atlas review schema and phrase metadata helpers.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+class ReviewEnrichmentMixin:
+    """Mixin that adds Atlas per-review enrichment methods to the slim engine.
+
+    Requires a base class providing ``self._enrichment``,
+    ``self._check_condition_simple(...)``, and ``self._resolve_field(...)``.
+    Designed to be mixed with ``extracted_reasoning_core.evidence_engine.
+    EvidenceEngine`` or a compatible subclass.
+    """
+
+    def _init_review_enrichment(self) -> None:
+        """Precompile enrichment regexes after the core rules are loaded."""
+        rec = self._enrichment.get("recommend_derivation", {})
+        self._rec_positive = [
+            re.compile(p, re.IGNORECASE)
+            for p in rec.get("positive_patterns", [])
+        ]
+        self._rec_negative = [
+            re.compile(p, re.IGNORECASE)
+            for p in rec.get("negative_patterns", [])
+        ]
+        price = self._enrichment.get("price_complaint_derivation", {})
+        self._price_positive = [
+            re.compile(p, re.IGNORECASE)
+            for p in price.get("positive_patterns", [])
+        ]
+
+    def compute_urgency(
+        self,
+        indicators: dict[str, bool],
+        rating: float | None,
+        rating_max: float,
+        content_type: str,
+        source_weight: float,
+    ) -> float:
+        """Compute urgency_score (0-10) from boolean indicator flags."""
+        cfg = self._enrichment.get("urgency_scoring", {})
+        weights: dict[str, float] = cfg.get("weights", {})
+
+        score = 0.0
+        for key, weight in weights.items():
+            if indicators.get(key):
+                score += weight
+
+        if rating is not None and rating_max > 0:
+            normalized = rating / rating_max
+            for floor in cfg.get("rating_floors", []):
+                if normalized <= floor["max_normalized_rating"]:
+                    score = max(score, floor["min_score"])
+                    break
+
+        context = {"content_type": content_type, "source_weight": source_weight}
+        for adj in cfg.get("adjustments", []):
+            cond = adj.get("condition", {})
+            if self._check_condition_simple(cond, context):
+                score += adj.get("delta", 0.0)
+
+        for gate in cfg.get("gates", []):
+            cond = gate.get("condition", {})
+            if self._check_condition_simple(cond, context):
+                score = gate.get("force", score)
+
+        lo, hi = cfg.get("clamp", [0, 10])
+        return round(min(max(score, lo), hi), 1)
+
+    def override_pain(
+        self,
+        pain_category: str,
+        specific_complaints: list[str],
+        quotable_phrases: list[str] | None = None,
+        pricing_phrases: list[str] | None = None,
+        feature_gaps: list[str] | None = None,
+        recommendation_language: list[str] | None = None,
+    ) -> str:
+        """Override generic pain_category using keyword scan."""
+        cfg = self._enrichment.get("pain_override", {})
+        trigger = cfg.get("trigger", {})
+        trigger_values = trigger.get("in")
+        if isinstance(trigger_values, list):
+            normalized = {
+                str(v).strip().lower()
+                for v in trigger_values
+                if str(v).strip()
+            }
+            if pain_category not in normalized:
+                return pain_category
+        elif pain_category != trigger.get("eq", "other"):
+            return pain_category
+
+        keyword_map: dict[str, list[str]] = cfg.get("keyword_map", {})
+        scan_fields = cfg.get("scan_fields", ["specific_complaints"])
+
+        texts: list[str] = []
+        if "specific_complaints" in scan_fields:
+            texts.extend(specific_complaints or [])
+        if "quotable_phrases" in scan_fields:
+            texts.extend(quotable_phrases or [])
+        if "pricing_phrases" in scan_fields:
+            texts.extend(pricing_phrases or [])
+        if "feature_gaps" in scan_fields:
+            texts.extend(feature_gaps or [])
+        if "recommendation_language" in scan_fields:
+            texts.extend(recommendation_language or [])
+
+        if not texts:
+            return cfg.get("fallback", "overall_dissatisfaction")
+
+        combined = " ".join(texts).lower()
+
+        def _keyword_hits(keyword: str) -> bool:
+            pattern = rf"(?<!\w){re.escape(str(keyword or '').lower())}(?!\w)"
+            return bool(re.search(pattern, combined))
+
+        scores: dict[str, int] = {}
+        for category, keywords in keyword_map.items():
+            count = sum(1 for kw in keywords if _keyword_hits(str(kw)))
+            if count > 0:
+                scores[category] = count
+
+        if scores:
+            return max(scores, key=scores.get)
+        return cfg.get("fallback", "overall_dissatisfaction")
+
+    def derive_recommend(
+        self,
+        recommendation_language: list[str],
+        rating: float | None,
+        rating_max: float,
+    ) -> bool | None:
+        """Derive would_recommend from extracted language + rating.
+
+        Negative-bias: a phrase matching both negative and positive
+        patterns counts only as negative. Conservative recommendation
+        semantics should not let a mixed phrase lift the positive count.
+        """
+        cfg = self._enrichment.get("recommend_derivation", {})
+
+        positive_hits = 0
+        negative_hits = 0
+        for phrase in (recommendation_language or []):
+            neg_match = any(pat.search(phrase) for pat in self._rec_negative)
+            if neg_match:
+                negative_hits += 1
+                continue
+            pos_match = any(pat.search(phrase) for pat in self._rec_positive)
+            if pos_match:
+                positive_hits += 1
+
+        if negative_hits > 0 and negative_hits >= positive_hits:
+            return False
+        fallback = cfg.get("rating_fallback", {})
+        if (
+            positive_hits == 1
+            and negative_hits == 0
+            and rating is not None
+            and rating_max > 0
+            and (rating / rating_max) <= fallback.get("false_below", 0.3)
+        ):
+            return False
+        if positive_hits > 0 and positive_hits > negative_hits:
+            return True
+
+        if rating is not None and rating_max > 0:
+            normalized = rating / rating_max
+            if normalized >= fallback.get("true_above", 0.7):
+                return True
+            if normalized <= fallback.get("false_below", 0.3):
+                return False
+
+        return cfg.get("default", None)
+
+    def derive_price_complaint(
+        self,
+        enrichment: dict[str, Any],
+    ) -> bool:
+        """Derive price_complaint from Tier 1 flags + extracted phrases."""
+        # Lazy import keeps this atlas-owned mixin importable without loading
+        # task-layer phrase metadata until the derivation path needs it.
+        from ..autonomous.tasks._b2b_phrase_metadata import (
+            is_v2_tagged,
+            phrase_metadata_map,
+        )
+
+        cfg = self._enrichment.get("price_complaint_derivation", {})
+
+        rule_input = enrichment
+        if is_v2_tagged(enrichment):
+            meta = phrase_metadata_map(enrichment)
+            raw_pricing = enrichment.get("pricing_phrases") or []
+            filtered: list[str] = []
+            for index, phrase in enumerate(raw_pricing):
+                if not str(phrase or "").strip():
+                    continue
+                row = meta.get(("pricing_phrases", index)) or {}
+                if row.get("subject") != "subject_vendor":
+                    continue
+                if row.get("polarity") not in ("negative", "mixed"):
+                    continue
+                filtered.append(phrase)
+            rule_input = {**enrichment, "pricing_phrases": filtered}
+
+        pricing_phrases = [
+            str(phrase or "").strip()
+            for phrase in rule_input.get("pricing_phrases") or []
+            if str(phrase or "").strip()
+        ]
+        all_pricing_phrases_positive = bool(pricing_phrases) and all(
+            any(pattern.search(phrase) for pattern in self._price_positive)
+            for phrase in pricing_phrases
+        )
+        for rule in cfg.get("true_if_any", []):
+            if (
+                rule.get("field") == "pricing_phrases"
+                and "min_count" in rule
+                and all_pricing_phrases_positive
+            ):
+                continue
+            if self._check_derivation_rule(rule, rule_input):
+                return True
+        return False
+
+    def derive_budget_authority(
+        self,
+        enrichment: dict[str, Any],
+    ) -> bool:
+        """Derive has_budget_authority from role + language."""
+        cfg = self._enrichment.get("budget_authority_derivation", {})
+        for rule in cfg.get("true_if_any", []):
+            if self._check_derivation_rule(rule, enrichment):
+                return True
+        return False
+
+    def _check_derivation_rule(
+        self,
+        rule: dict[str, Any],
+        enrichment: dict[str, Any],
+    ) -> bool:
+        """Check a derivation true_if_any rule."""
+        field = rule.get("field", "")
+        value = self._resolve_field(enrichment, field)
+
+        if "eq" in rule:
+            return value == rule["eq"]
+        if "in" in rule:
+            return value in rule["in"]
+        if "not_null" in rule and rule["not_null"]:
+            return value is not None and value != ""
+        if "min_count" in rule:
+            return isinstance(value, (list, tuple)) and len(value) >= rule["min_count"]
+        if "contains_any" in rule:
+            if not isinstance(value, (list, tuple)):
+                return False
+            combined = " ".join(str(v) for v in value).lower()
+            return any(kw in combined for kw in rule["contains_any"])
+        return False
+
+
+__all__ = ["ReviewEnrichmentMixin"]

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T00:53Z by codex-2026-05-16
+Last updated: 2026-05-17T15:35Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #563 | Reconcile extracted reasoning core current state | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`, `docs/extraction/reasoning_boundary_audit_2026-05-03.md`, `plans/PR-Reasoning-Core-Current-State.md` | codex-2026-05-16 | Avoid editing extracted_reasoning_core status, queue, or next-slice recommendation while this reconciles stale reasoning-core docs. |
+| #564 | Split atlas review enrichment pack | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-Reasoning-Enrichment-Pack-Split.md`, `atlas_brain/reasoning/evidence_engine.py`, `atlas_brain/reasoning/review_enrichment.py`, `extracted_reasoning_core/evidence_engine.py`, `tests/test_atlas_reasoning_evidence_engine_aliases.py` | codex-2026-05-17 | Avoid editing the atlas-side evidence enrichment split while this moves the per-review methods into an explicit product pack module. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T00:53Z by codex-2026-05-16
+Last updated: 2026-05-17T15:35Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,4 +10,4 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
 | PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
-| PR-C3-enrichment-pack-split | `extracted_reasoning_core` | unclaimed | PR-C2-current-state-reset | Recommended next code slice: carve atlas-side per-review enrichment into an explicit product pack. |
+| PR-C3-enrichment-pack-split | `extracted_reasoning_core` | codex-2026-05-17 | PR-C2-current-state-reset | Recommended next code slice: carve atlas-side per-review enrichment into an explicit product pack. |

--- a/extracted_reasoning_core/evidence_engine.py
+++ b/extracted_reasoning_core/evidence_engine.py
@@ -8,8 +8,8 @@ sufficient and which report sections should be suppressed or degraded.
 This is the slim-core split documented in PR #82's audit. The
 per-review enrichment surface (`compute_urgency`, `override_pain`,
 `derive_recommend`, `derive_price_complaint`, `derive_budget_authority`)
-is **not** included here -- it stays atlas-side until PR-C1e moves it
-to `atlas_brain/reasoning/review_enrichment.py`. Reasoning core's
+is **not** included here -- it stays outside core in the atlas-owned
+`atlas_brain.reasoning.review_enrichment` pack. Reasoning core's
 public boundary is the conclusions / suppression surface plus the
 public `EvidenceDecision` / `ConclusionResult` / `SuppressionResult`
 types defined in `extracted_reasoning_core.types`.
@@ -66,8 +66,8 @@ class EvidenceEngine:
         callers should use ``from_rules`` instead.
 
     Slim-core split: per-review enrichment lives in
-    `atlas_brain.reasoning.review_enrichment` (will be carved out in
-    PR-C1e). This class only exposes the conclusions + suppression
+    `atlas_brain.reasoning.review_enrichment`. This class only exposes
+    the conclusions + suppression
     surface that the public reasoning core needs.
     """
 

--- a/plans/PR-Reasoning-Enrichment-Pack-Split.md
+++ b/plans/PR-Reasoning-Enrichment-Pack-Split.md
@@ -1,0 +1,84 @@
+# Reasoning Enrichment Pack Split
+
+## Why this slice exists
+
+PR #563 reset the reasoning-core backlog and identified the next concrete gap:
+atlas-side per-review enrichment still lives directly on
+`atlas_brain.reasoning.evidence_engine.EvidenceEngine`. That keeps core slim,
+but the product-specific enrichment policy is still embedded inside the wrapper
+instead of living in an explicit pack module.
+
+This is expected to exceed the 400 LOC soft budget because it moves an existing
+method block into a new module while deleting the same block from the wrapper.
+The behavioral change is intentionally narrow: composition only, no logic
+rewrite.
+
+## Scope (this PR)
+
+1. Move the six atlas-side per-review enrichment methods into a dedicated
+   `atlas_brain.reasoning.review_enrichment` module.
+2. Keep `atlas_brain.reasoning.evidence_engine.EvidenceEngine` as the existing
+   public object shape by mixing in the product pack.
+3. Preserve the current method signatures and behavior.
+4. Update tests that currently pin the wrapper/enrichment boundary.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `plans/PR-Reasoning-Enrichment-Pack-Split.md`
+- `atlas_brain/reasoning/evidence_engine.py`
+- `atlas_brain/reasoning/review_enrichment.py`
+- `extracted_reasoning_core/evidence_engine.py`
+- `tests/test_atlas_reasoning_evidence_engine_aliases.py`
+
+## Mechanism
+
+Add `ReviewEnrichmentMixin` in `atlas_brain.reasoning.review_enrichment`. The
+mixin owns:
+
+- regex precompile setup for recommendation and pricing phrase rules;
+- `compute_urgency`;
+- `override_pain`;
+- `derive_recommend`;
+- `derive_price_complaint`;
+- `derive_budget_authority`;
+- `_check_derivation_rule`.
+
+`atlas_brain.reasoning.evidence_engine.EvidenceEngine` remains the public
+factory product. It subclasses `ReviewEnrichmentMixin` and core's slim
+`EvidenceEngine`, then calls the mixin setup after core loads the YAML rules.
+
+## Intentional
+
+- No behavior change to callers. `get_evidence_engine()` still returns
+  `atlas_brain.reasoning.evidence_engine.EvidenceEngine`.
+- No new public API in `extracted_reasoning_core`. The enrichment pack is
+  atlas/product-owned because `derive_price_complaint` depends on atlas-only
+  phrase metadata helpers.
+- No function signature changes.
+
+## Deferred
+
+- Exporting the enrichment pack for other products. This PR only makes the
+  atlas product pack explicit.
+- Graph/state slimming remains a later reasoning-core slice.
+
+## Verification
+
+- python -m py_compile atlas_brain/reasoning/evidence_engine.py atlas_brain/reasoning/review_enrichment.py extracted_reasoning_core/evidence_engine.py tests/test_atlas_reasoning_evidence_engine_aliases.py - passed.
+- pytest tests/test_atlas_reasoning_evidence_engine_aliases.py tests/test_evidence_engine.py tests/test_b2b_phase2_subject_gate.py tests/test_b2b_phase3_polarity_gate.py - 105 passed.
+- git diff --check - passed.
+- bash scripts/local_pr_review.sh - passed after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~10 |
+| Plan doc | ~85 |
+| New review enrichment module | ~265 |
+| Evidence engine wrapper trim | ~250 |
+| Core docstring update | ~10 |
+| Tests | ~35 |
+| **Total** | ~655 |

--- a/tests/test_atlas_reasoning_evidence_engine_aliases.py
+++ b/tests/test_atlas_reasoning_evidence_engine_aliases.py
@@ -4,7 +4,7 @@ PR-D7b3 promoted the slim conclusions+suppression engine into
 ``extracted_reasoning_core.evidence_engine`` (per PR-C1's slim-core
 split). Atlas keeps the import surface
 ``atlas_brain.reasoning.evidence_engine`` as a subclass wrapper that
-adds the per-review enrichment methods (``compute_urgency`` /
+mixes in the per-review enrichment pack methods (``compute_urgency`` /
 ``override_pain`` / ``derive_recommend`` / ``derive_price_complaint``
 / ``derive_budget_authority``) that stay atlas-side because
 ``derive_price_complaint`` depends on atlas-only
@@ -17,24 +17,36 @@ These tests pin:
     ``evaluate_conclusion`` are inherited, not duplicated).
   - atlas's ``ConclusionResult`` and ``SuppressionResult`` ARE core's
     types -- not look-alike local re-definitions.
-  - the six atlas-side enrichment methods are present on the subclass
-    and return shape-correct values from real YAML.
+  - the six atlas-side enrichment methods are present through the
+    atlas-owned mixin pack and return shape-correct values from real YAML.
   - the wrapper module body has no ``ConclusionResult`` /
     ``SuppressionResult`` / ``EvidenceEngine`` re-definitions
     (subclass pattern means EvidenceEngine IS defined here, so the
     AST guard checks only that the result types are NOT redefined).
+
+Behavioral coverage for these moved methods lives in
+``tests/test_evidence_engine.py``, ``tests/test_b2b_phase2_subject_gate.py``,
+and ``tests/test_b2b_phase3_polarity_gate.py``.
 """
 
 from __future__ import annotations
 
 from atlas_brain.reasoning import evidence_engine as atlas_engine
+from atlas_brain.reasoning import review_enrichment
 from extracted_reasoning_core import evidence_engine as core_engine
 from extracted_reasoning_core import types as core_types
 
 
 def test_evidence_engine_subclasses_core() -> None:
     assert issubclass(atlas_engine.EvidenceEngine, core_engine.EvidenceEngine)
+    assert issubclass(atlas_engine.EvidenceEngine, review_enrichment.ReviewEnrichmentMixin)
     assert atlas_engine.EvidenceEngine is not core_engine.EvidenceEngine
+
+
+def test_review_enrichment_pack_is_atlas_owned() -> None:
+    assert review_enrichment.ReviewEnrichmentMixin.__module__ == (
+        "atlas_brain.reasoning.review_enrichment"
+    )
 
 
 def test_conclusion_result_alias_identity() -> None:
@@ -59,10 +71,13 @@ def test_atlas_enrichment_methods_present() -> None:
     for name in expected:
         attr = getattr(atlas_engine.EvidenceEngine, name, None)
         assert callable(attr), f"missing or non-callable: {name}"
-        # Must be defined on the subclass, not core (else PR-C1's
-        # slim-core split silently regressed)
+        # Must come from the atlas product pack, not core (else PR-C1's
+        # slim-core split silently regressed).
         assert name not in vars(core_engine.EvidenceEngine), (
             f"{name} unexpectedly present on core slim engine"
+        )
+        assert name in vars(review_enrichment.ReviewEnrichmentMixin), (
+            f"{name} missing from atlas review enrichment pack"
         )
 
 


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Enrichment-Pack-Split.md

Move atlas-side per-review enrichment derivations out of the evidence-engine wrapper and into an explicit atlas product pack module. The public object shape stays the same: callers still use atlas_brain.reasoning.evidence_engine.EvidenceEngine.

## Intentional
- No behavior change to callers.
- extracted_reasoning_core.evidence_engine remains slim: conclusions and suppression only.
- The enrichment pack remains atlas-owned because derive_price_complaint depends on atlas-only phrase metadata helpers.

## Deferred
- Exporting the enrichment pack for other products.
- Graph/state slimming remains a later reasoning-core slice.

## Verification
- python -m py_compile atlas_brain/reasoning/evidence_engine.py atlas_brain/reasoning/review_enrichment.py extracted_reasoning_core/evidence_engine.py tests/test_atlas_reasoning_evidence_engine_aliases.py: passed.
- pytest tests/test_atlas_reasoning_evidence_engine_aliases.py tests/test_evidence_engine.py tests/test_b2b_phase2_subject_gate.py tests/test_b2b_phase3_polarity_gate.py: 105 passed.
- git diff --check: passed.
- bash scripts/local_pr_review.sh: passed locally and via pre-push hook.

## Diff size
7 files, +371 / -257.