### PR TITLE
Promote phrase metadata helpers to reasoning

### DIFF
--- a/atlas_brain/autonomous/tasks/_b2b_field_contracts.py
+++ b/atlas_brain/autonomous/tasks/_b2b_field_contracts.py
@@ -456,9 +456,11 @@ FIELD_CONTRACTS: dict[str, FieldContract] = {
         "owner_path": "enrichment_internal",
         "owner_pool": None,
         "stranded": False,
+        # Same-package consumers use local labels; cross-package consumers
+        # use a fully qualified module path to avoid ambiguity.
         "approved_consumers": (
             "backfill_derived_fields",
-            "_b2b_phrase_metadata",
+            "atlas_brain.reasoning.phrase_metadata",
         ),
         "migration_target": None,
     },

--- a/atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py
+++ b/atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py
@@ -1,9 +1,22 @@
 """Compatibility wrapper for phrase metadata helpers.
 
 Canonical helpers live in ``atlas_brain.reasoning.phrase_metadata``.
+
+.. deprecated::
+    Import from ``atlas_brain.reasoning.phrase_metadata`` directly.
+    This module will be removed once all callers have migrated.
 """
 
 from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "atlas_brain.autonomous.tasks._b2b_phrase_metadata is deprecated; "
+    "import from atlas_brain.reasoning.phrase_metadata instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 from atlas_brain.reasoning.phrase_metadata import (
     enrichment_schema_version,

--- a/atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py
+++ b/atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py
@@ -1,132 +1,22 @@
-"""Helpers for reading the v2 phrase_metadata parallel field.
+"""Compatibility wrapper for phrase metadata helpers.
 
-The v2 enrichment schema (enrichment_schema_version >= 4) adds a top-level
-`phrase_metadata` array alongside the six legacy string arrays
-(specific_complaints, pricing_phrases, feature_gaps, quotable_phrases,
-recommendation_language, positive_aspects). The legacy arrays retain their
-`list[str]` semantics unchanged; tags live in `phrase_metadata` keyed by
-`(field, index)`.
-
-These helpers are the ONLY supported way to read the metadata. They
-short-circuit to empty results on v1 (pre-schema-bump) enrichments so
-callers get a safe default path.
-
-Invariants assumed (enforced at write time by b2b_enrichment.py):
-- `phrase_metadata[i].text` equals enrichment[phrase_metadata[i].field][phrase_metadata[i].index].
-- Legacy arrays remain list[str].
-- Every non-empty legacy-array element has exactly one metadata row.
-
-Readers should not reach into phrase_metadata directly. Doing so makes a
-future schema change a multi-file refactor.
+Canonical helpers live in ``atlas_brain.reasoning.phrase_metadata``.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-_V2_SCHEMA_MIN_VERSION = 4
-_LEGACY_PHRASE_FIELDS: tuple[str, ...] = (
-    "specific_complaints",
-    "pricing_phrases",
-    "feature_gaps",
-    "quotable_phrases",
-    "recommendation_language",
-    "positive_aspects",
+from atlas_brain.reasoning.phrase_metadata import (
+    enrichment_schema_version,
+    is_v2_tagged,
+    phrase_metadata_by_field,
+    phrase_metadata_map,
+    phrase_tag,
 )
 
-
-def enrichment_schema_version(enrichment: dict[str, Any] | None) -> int:
-    """Return the integer schema version for an enrichment dict. 0 if missing."""
-    if not isinstance(enrichment, dict):
-        return 0
-    try:
-        return int(enrichment.get("enrichment_schema_version") or 0)
-    except (TypeError, ValueError):
-        return 0
-
-
-def is_v2_tagged(enrichment: dict[str, Any] | None) -> bool:
-    """True if this enrichment carries the v2 phrase_metadata contract.
-
-    A v4 row with `phrase_metadata = []` still counts: it represents a
-    legitimate zero-phrase review that the LLM tagged correctly under the v2
-    schema. Only v<4 or a missing/non-list `phrase_metadata` field returns
-    False. This keeps schema-aware readers from misclassifying empty-but-valid
-    v4 rows as legacy.
-    """
-    if enrichment_schema_version(enrichment) < _V2_SCHEMA_MIN_VERSION:
-        return False
-    if not isinstance(enrichment, dict):
-        return False
-    return isinstance(enrichment.get("phrase_metadata"), list)
-
-
-def phrase_metadata_by_field(
-    enrichment: dict[str, Any] | None,
-    field_name: str,
-) -> list[dict[str, Any]]:
-    """Return metadata rows for `field_name` in index order.
-
-    Empty list when enrichment is v1, phrase_metadata is absent, or no rows
-    match the field.
-    """
-    if not is_v2_tagged(enrichment):
-        return []
-    metadata = enrichment.get("phrase_metadata") or []
-    matches: list[dict[str, Any]] = []
-    for row in metadata:
-        if not isinstance(row, dict):
-            continue
-        if str(row.get("field") or "") != field_name:
-            continue
-        matches.append(row)
-    matches.sort(key=lambda r: _safe_index(r.get("index")))
-    return matches
-
-
-def phrase_metadata_map(
-    enrichment: dict[str, Any] | None,
-) -> dict[tuple[str, int], dict[str, Any]]:
-    """Return a `{(field, index): row}` map for constant-time lookup.
-
-    Empty dict when enrichment is v1 or phrase_metadata is absent.
-    """
-    if not is_v2_tagged(enrichment):
-        return {}
-    result: dict[tuple[str, int], dict[str, Any]] = {}
-    for row in enrichment.get("phrase_metadata") or []:
-        if not isinstance(row, dict):
-            continue
-        field = str(row.get("field") or "")
-        idx = _safe_index(row.get("index"))
-        if not field or idx < 0:
-            continue
-        result[(field, idx)] = row
-    return result
-
-
-def phrase_tag(
-    enrichment: dict[str, Any] | None,
-    field: str,
-    index: int,
-    tag_name: str,
-    default: Any = None,
-) -> Any:
-    """Return a single tag value for a specific phrase, or `default`.
-
-    `default` is returned when enrichment is v1, the metadata row is absent,
-    or the tag is missing on the row.
-    """
-    rows = phrase_metadata_map(enrichment)
-    row = rows.get((field, index))
-    if row is None:
-        return default
-    value = row.get(tag_name)
-    return value if value is not None else default
-
-
-def _safe_index(value: Any) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return -1
+__all__ = [
+    "enrichment_schema_version",
+    "is_v2_tagged",
+    "phrase_metadata_by_field",
+    "phrase_metadata_map",
+    "phrase_tag",
+]

--- a/atlas_brain/autonomous/tasks/_b2b_witnesses.py
+++ b/atlas_brain/autonomous/tasks/_b2b_witnesses.py
@@ -718,7 +718,7 @@ def derive_evidence_spans(
     # Phase 2 (Layer 1): when v2 metadata is present, look up each phrase's
     # subject so the complaint classifier can drop non-subject_vendor
     # phrases. Empty map for v1 enrichments leaves the legacy behavior.
-    from ._b2b_phrase_metadata import is_v2_tagged, phrase_metadata_map
+    from ...reasoning.phrase_metadata import is_v2_tagged, phrase_metadata_map
     phrase_meta = phrase_metadata_map(result) if is_v2_tagged(result) else {}
 
     for signal_type, metadata_field, raw_values, pain_category, competitor in item_sources:

--- a/atlas_brain/autonomous/tasks/b2b_enrichment.py
+++ b/atlas_brain/autonomous/tasks/b2b_enrichment.py
@@ -1055,7 +1055,7 @@ def _is_no_signal_result(result: dict, source_row: dict[str, Any]) -> bool:
 
 # ---------------------------------------------------------------------------
 # Phrase metadata v2 schema (parallel to legacy list[str] phrase arrays).
-# See atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py for the reader API.
+# See atlas_brain.reasoning.phrase_metadata for the reader API.
 # ---------------------------------------------------------------------------
 
 def _coerce_legacy_phrase_arrays(result: dict) -> None:

--- a/atlas_brain/reasoning/evidence_engine.py
+++ b/atlas_brain/reasoning/evidence_engine.py
@@ -10,7 +10,7 @@ pack from ``atlas_brain.reasoning.review_enrichment``:
   - ``override_pain``
   - ``derive_recommend``
   - ``derive_price_complaint`` (depends on atlas-only
-    ``_b2b_phrase_metadata``)
+    ``atlas_brain.reasoning.phrase_metadata``)
   - ``derive_budget_authority``
 
 The subclass pattern keeps existing atlas callers

--- a/atlas_brain/reasoning/phrase_metadata.py
+++ b/atlas_brain/reasoning/phrase_metadata.py
@@ -1,0 +1,121 @@
+"""Helpers for reading the v2 phrase_metadata parallel field.
+
+The v2 enrichment schema (enrichment_schema_version >= 4) adds a top-level
+``phrase_metadata`` array alongside the six legacy string arrays
+(specific_complaints, pricing_phrases, feature_gaps, quotable_phrases,
+recommendation_language, positive_aspects). The legacy arrays retain their
+``list[str]`` semantics unchanged; tags live in ``phrase_metadata`` keyed by
+``(field, index)``.
+
+These helpers are the supported way to read phrase metadata. They short-circuit
+to empty results on v1 enrichments so callers get a safe default path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_V2_SCHEMA_MIN_VERSION = 4
+_LEGACY_PHRASE_FIELDS: tuple[str, ...] = (
+    "specific_complaints",
+    "pricing_phrases",
+    "feature_gaps",
+    "quotable_phrases",
+    "recommendation_language",
+    "positive_aspects",
+)
+
+
+def enrichment_schema_version(enrichment: dict[str, Any] | None) -> int:
+    """Return the integer schema version for an enrichment dict. 0 if missing."""
+    if not isinstance(enrichment, dict):
+        return 0
+    try:
+        return int(enrichment.get("enrichment_schema_version") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def is_v2_tagged(enrichment: dict[str, Any] | None) -> bool:
+    """True if this enrichment carries the v2 phrase_metadata contract.
+
+    A v4 row with ``phrase_metadata = []`` still counts: it represents a
+    legitimate zero-phrase review that the LLM tagged correctly under the v2
+    schema. Only v<4 or a missing/non-list ``phrase_metadata`` field returns
+    False. This keeps schema-aware readers from misclassifying empty-but-valid
+    v4 rows as legacy.
+    """
+    if enrichment_schema_version(enrichment) < _V2_SCHEMA_MIN_VERSION:
+        return False
+    if not isinstance(enrichment, dict):
+        return False
+    return isinstance(enrichment.get("phrase_metadata"), list)
+
+
+def phrase_metadata_by_field(
+    enrichment: dict[str, Any] | None,
+    field_name: str,
+) -> list[dict[str, Any]]:
+    """Return metadata rows for ``field_name`` in index order."""
+    if not is_v2_tagged(enrichment):
+        return []
+    metadata = enrichment.get("phrase_metadata") or []
+    matches: list[dict[str, Any]] = []
+    for row in metadata:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("field") or "") != field_name:
+            continue
+        matches.append(row)
+    matches.sort(key=lambda r: _safe_index(r.get("index")))
+    return matches
+
+
+def phrase_metadata_map(
+    enrichment: dict[str, Any] | None,
+) -> dict[tuple[str, int], dict[str, Any]]:
+    """Return a ``{(field, index): row}`` map for constant-time lookup."""
+    if not is_v2_tagged(enrichment):
+        return {}
+    result: dict[tuple[str, int], dict[str, Any]] = {}
+    for row in enrichment.get("phrase_metadata") or []:
+        if not isinstance(row, dict):
+            continue
+        field = str(row.get("field") or "")
+        idx = _safe_index(row.get("index"))
+        if not field or idx < 0:
+            continue
+        result[(field, idx)] = row
+    return result
+
+
+def phrase_tag(
+    enrichment: dict[str, Any] | None,
+    field: str,
+    index: int,
+    tag_name: str,
+    default: Any = None,
+) -> Any:
+    """Return a single tag value for a specific phrase, or ``default``."""
+    rows = phrase_metadata_map(enrichment)
+    row = rows.get((field, index))
+    if row is None:
+        return default
+    value = row.get(tag_name)
+    return value if value is not None else default
+
+
+def _safe_index(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return -1
+
+
+__all__ = [
+    "enrichment_schema_version",
+    "is_v2_tagged",
+    "phrase_metadata_by_field",
+    "phrase_metadata_map",
+    "phrase_tag",
+]

--- a/atlas_brain/reasoning/review_enrichment.py
+++ b/atlas_brain/reasoning/review_enrichment.py
@@ -186,12 +186,7 @@ class ReviewEnrichmentMixin:
         enrichment: dict[str, Any],
     ) -> bool:
         """Derive price_complaint from Tier 1 flags + extracted phrases."""
-        # Lazy import keeps this atlas-owned mixin importable without loading
-        # task-layer phrase metadata until the derivation path needs it.
-        from ..autonomous.tasks._b2b_phrase_metadata import (
-            is_v2_tagged,
-            phrase_metadata_map,
-        )
+        from .phrase_metadata import is_v2_tagged, phrase_metadata_map
 
         cfg = self._enrichment.get("price_complaint_derivation", {})
 

--- a/atlas_brain/services/b2b/enrichment_contract.py
+++ b/atlas_brain/services/b2b/enrichment_contract.py
@@ -6,7 +6,7 @@ about an enrichment dict without reaching into the JSONB themselves.
 
 It wraps two existing internal pieces:
 
-  - ``atlas_brain.autonomous.tasks._b2b_phrase_metadata`` -- low-level
+  - ``atlas_brain.reasoning.phrase_metadata`` -- low-level
     accessors for the v2 ``phrase_metadata`` parallel field. Re-exported
     here so consumers have one import path.
 
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from ...autonomous.tasks._b2b_phrase_metadata import (
+from ...reasoning.phrase_metadata import (
     enrichment_schema_version,
     is_v2_tagged,
     phrase_metadata_by_field,

--- a/atlas_brain/services/b2b/enrichment_pain_competition.py
+++ b/atlas_brain/services/b2b/enrichment_pain_competition.py
@@ -4,6 +4,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from atlas_brain.reasoning.phrase_metadata import is_v2_tagged, phrase_metadata_map
+
 
 @dataclass(frozen=True)
 class EnrichmentPainCompetitionDeps:
@@ -49,8 +51,6 @@ def subject_vendor_phrase_texts(
     if not raw:
         return []
 
-    from atlas_brain.autonomous.tasks._b2b_phrase_metadata import is_v2_tagged, phrase_metadata_map
-
     if not is_v2_tagged(result):
         return deps.normalize_text_list(raw)
 
@@ -71,8 +71,6 @@ def derive_pain_categories(
     *,
     deps: EnrichmentPainCompetitionDeps,
 ) -> list[dict[str, str]]:
-    from atlas_brain.autonomous.tasks._b2b_phrase_metadata import is_v2_tagged, phrase_metadata_map
-
     if is_v2_tagged(result):
         meta = phrase_metadata_map(result)
         weighted_items: list[tuple[str, float]] = []
@@ -154,8 +152,6 @@ def _count_pain_phrase_matches(
     pattern = deps.pain_patterns.get(pain_category)
     if pattern is None:
         return 0
-
-    from atlas_brain.autonomous.tasks._b2b_phrase_metadata import is_v2_tagged, phrase_metadata_map
 
     count = 0
     if is_v2_tagged(result):

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,6 +1,6 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T16:02Z by codex-2026-05-17
+Last updated: 2026-05-17T16:34Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T15:35Z by codex-2026-05-17
+Last updated: 2026-05-17T16:02Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #564 | Split atlas review enrichment pack | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-Reasoning-Enrichment-Pack-Split.md`, `atlas_brain/reasoning/evidence_engine.py`, `atlas_brain/reasoning/review_enrichment.py`, `extracted_reasoning_core/evidence_engine.py`, `tests/test_atlas_reasoning_evidence_engine_aliases.py` | codex-2026-05-17 | Avoid editing the atlas-side evidence enrichment split while this moves the per-review methods into an explicit product pack module. |
+| #565 | Promote phrase metadata helpers to reasoning utility | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-Reasoning-Phrase-Metadata-Utility.md`, `atlas_brain/reasoning/phrase_metadata.py`, `atlas_brain/reasoning/review_enrichment.py`, `atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py`, `atlas_brain/services/b2b/enrichment_contract.py`, `tests/test_b2b_phrase_metadata.py` | codex-2026-05-17 | Avoid moving phrase metadata helpers or changing review enrichment phrase gating while this promotes the canonical helper import path. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T15:35Z by codex-2026-05-17
+Last updated: 2026-05-17T16:02Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -10,4 +10,5 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | Slice | Product | Owner | Dependencies | Notes |
 |---|---|---|---|---|
 | PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
-| PR-C3-enrichment-pack-split | `extracted_reasoning_core` | codex-2026-05-17 | PR-C2-current-state-reset | Recommended next code slice: carve atlas-side per-review enrichment into an explicit product pack. |
+| PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
+| PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | codex-2026-05-17 | PR-C3-enrichment-pack-split | Promote pure phrase metadata readers into `atlas_brain.reasoning.phrase_metadata` and leave the task module as a compatibility wrapper. |

--- a/plans/PR-Reasoning-Phrase-Metadata-Utility.md
+++ b/plans/PR-Reasoning-Phrase-Metadata-Utility.md
@@ -54,8 +54,9 @@ also import from the new module, keeping one canonical implementation.
 - No helper behavior changes.
 - No public function signature changes.
 - No extraction-core API expansion in this slice.
-- The old `_b2b_phrase_metadata` import path remains supported for callers that
-  have not migrated yet.
+- The old `_b2b_phrase_metadata` import path remains supported via a compat
+  wrapper but now emits `DeprecationWarning` on import to signal migration
+  intent; the wrapper is not a permanent alias.
 
 ## Deferred
 

--- a/plans/PR-Reasoning-Phrase-Metadata-Utility.md
+++ b/plans/PR-Reasoning-Phrase-Metadata-Utility.md
@@ -1,0 +1,87 @@
+# Reasoning Phrase Metadata Utility
+
+## Why this slice exists
+
+PR #564 split Atlas-owned review enrichment into
+`atlas_brain.reasoning.review_enrichment`, but that pack still imported
+phrase metadata helpers from `atlas_brain.autonomous.tasks`. That kept a deep
+reasoning-to-task dependency in the new reasoning boundary.
+
+The helpers are pure readers over enrichment dictionaries. They do not depend
+on task orchestration, storage, LLM calls, or Atlas autonomous task state. This
+slice promotes them into `atlas_brain.reasoning.phrase_metadata` and leaves the
+old task module as a compatibility wrapper.
+
+## Scope
+
+1. Add `atlas_brain.reasoning.phrase_metadata` as the canonical helper module.
+2. Convert `atlas_brain.autonomous.tasks._b2b_phrase_metadata` into a re-export
+   wrapper so existing imports keep working.
+3. Redirect reasoning and B2B service imports to the canonical reasoning
+   module.
+4. Update tests and docs that pin the old helper location.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `plans/PR-Reasoning-Phrase-Metadata-Utility.md`
+- `atlas_brain/reasoning/phrase_metadata.py`
+- `atlas_brain/reasoning/review_enrichment.py`
+- `atlas_brain/reasoning/evidence_engine.py`
+- `atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py`
+- `atlas_brain/autonomous/tasks/_b2b_witnesses.py`
+- `atlas_brain/autonomous/tasks/_b2b_field_contracts.py`
+- `atlas_brain/autonomous/tasks/b2b_enrichment.py`
+- `atlas_brain/services/b2b/enrichment_contract.py`
+- `atlas_brain/services/b2b/enrichment_pain_competition.py`
+- `tests/test_b2b_phrase_metadata.py`
+- `tests/test_atlas_reasoning_evidence_engine_aliases.py`
+
+## Mechanism
+
+`atlas_brain.reasoning.phrase_metadata` becomes the canonical module for
+read-only phrase metadata access. The old task-layer module imports and
+re-exports the same helpers, so existing callers do not break while reasoning
+code can depend on a reasoning-owned utility.
+
+The Atlas review enrichment pack switches its pricing phrase gate to the new
+module. B2B service helpers that already expose phrase metadata as a contract
+also import from the new module, keeping one canonical implementation.
+
+## Intentional
+
+- No helper behavior changes.
+- No public function signature changes.
+- No extraction-core API expansion in this slice.
+- The old `_b2b_phrase_metadata` import path remains supported for callers that
+  have not migrated yet.
+
+## Deferred
+
+- Moving write-time phrase metadata normalization out of B2B enrichment. That
+  path still owns task/service-specific enrichment writes.
+- Updating every historical doc reference outside the touched reasoning and B2B
+  helper boundary.
+
+## Verification
+
+- python -m py_compile on touched Python files - passed.
+- pytest tests/test_b2b_phrase_metadata.py
+  tests/test_atlas_reasoning_evidence_engine_aliases.py
+  tests/test_b2b_phase2_subject_gate.py tests/test_b2b_phase3_polarity_gate.py
+  - 90 passed.
+- pytest tests/test_b2b_enrichment_contract.py - 42 passed.
+- git diff --check - passed.
+- bash scripts/local_pr_review.sh - passed after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~10 |
+| Plan doc | ~70 |
+| New reasoning helper module | ~115 |
+| Compatibility wrapper trim | ~140 |
+| Import/doc/test updates | ~45 |
+| **Total** | ~380 |

--- a/tests/test_atlas_reasoning_evidence_engine_aliases.py
+++ b/tests/test_atlas_reasoning_evidence_engine_aliases.py
@@ -8,7 +8,7 @@ mixes in the per-review enrichment pack methods (``compute_urgency`` /
 ``override_pain`` / ``derive_recommend`` / ``derive_price_complaint``
 / ``derive_budget_authority``) that stay atlas-side because
 ``derive_price_complaint`` depends on atlas-only
-``_b2b_phrase_metadata``.
+``atlas_brain.reasoning.phrase_metadata``.
 
 These tests pin:
   - atlas's ``EvidenceEngine`` is a subclass of core's slim engine

--- a/tests/test_b2b_phrase_metadata.py
+++ b/tests/test_b2b_phrase_metadata.py
@@ -3,7 +3,7 @@
 Covers:
 - `_coerce_legacy_phrase_arrays`: legacy arrays stay list[str] under all inputs
 - `_normalize_phrase_metadata`: canonicalization, text invariant, enum coercion
-- Reader helpers in `_b2b_phrase_metadata`: v1 safe defaults, v2 lookups
+- Reader helpers in `atlas_brain.reasoning.phrase_metadata`: v1 safe defaults, v2 lookups
 - `_compute_derived_fields` integration: conditional version bump 3 vs 4
 """
 
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import copy
 
-from atlas_brain.autonomous.tasks._b2b_phrase_metadata import (
+from atlas_brain.autonomous.tasks import _b2b_phrase_metadata as task_phrase_metadata
+from atlas_brain.reasoning import phrase_metadata as reasoning_phrase_metadata
+from atlas_brain.reasoning.phrase_metadata import (
     enrichment_schema_version,
     is_v2_tagged,
     phrase_metadata_by_field,
@@ -210,8 +212,22 @@ def test_normalize_metadata_missing_entirely_defaults_all():
 
 
 # ---------------------------------------------------------------------------
-# Reader helpers (_b2b_phrase_metadata)
+# Reader helpers (atlas_brain.reasoning.phrase_metadata)
 # ---------------------------------------------------------------------------
+
+
+def test_task_phrase_metadata_module_reexports_reasoning_helpers():
+    assert task_phrase_metadata.enrichment_schema_version is (
+        reasoning_phrase_metadata.enrichment_schema_version
+    )
+    assert task_phrase_metadata.is_v2_tagged is reasoning_phrase_metadata.is_v2_tagged
+    assert task_phrase_metadata.phrase_metadata_by_field is (
+        reasoning_phrase_metadata.phrase_metadata_by_field
+    )
+    assert task_phrase_metadata.phrase_metadata_map is (
+        reasoning_phrase_metadata.phrase_metadata_map
+    )
+    assert task_phrase_metadata.phrase_tag is reasoning_phrase_metadata.phrase_tag
 
 
 def test_reader_helpers_v1_short_circuit():


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Phrase-Metadata-Utility.md

## Summary
- add atlas_brain.reasoning.phrase_metadata as the canonical phrase metadata reader module
- leave atlas_brain.autonomous.tasks._b2b_phrase_metadata as a compatibility wrapper
- redirect reasoning and B2B service imports to the canonical helper path

## Review follow-up
- documented the approved-consumer naming convention for cross-package helpers
- collapsed repeated lazy phrase metadata imports in enrichment_pain_competition.py

## Verification
- pytest tests/test_b2b_phrase_metadata.py tests/test_atlas_reasoning_evidence_engine_aliases.py tests/test_b2b_phase2_subject_gate.py tests/test_b2b_phase3_polarity_gate.py
- pytest tests/test_b2b_enrichment_contract.py
- python -m py_compile on touched Python files
- git diff --check
- bash scripts/local_pr_review.sh