### PR TITLE
Add landing page packaged reasoning parity

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T16:34Z by codex-2026-05-17
+Last updated: 2026-05-17T16:40Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #565 | Promote phrase metadata helpers to reasoning utility | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-Reasoning-Phrase-Metadata-Utility.md`, `atlas_brain/reasoning/phrase_metadata.py`, `atlas_brain/reasoning/review_enrichment.py`, `atlas_brain/autonomous/tasks/_b2b_phrase_metadata.py`, `atlas_brain/services/b2b/enrichment_contract.py`, `tests/test_b2b_phrase_metadata.py` | codex-2026-05-17 | Avoid moving phrase metadata helpers or changing review enrichment phrase gating while this promotes the canonical helper import path. |
+| #566 | Add landing-page packaged reasoning runtime parity | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-ContentOps-Landing-Reasoning-Parity.md`, `extracted_content_pipeline/reasoning_policy.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_control_surface_api.py` | codex-2026-05-17 | Avoid editing packaged Content Ops reasoning runtime output allowlists while this aligns landing-page policy with runtime execution. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T16:02Z by codex-2026-05-17
+Last updated: 2026-05-17T16:40Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -11,4 +11,5 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 |---|---|---|---|---|
 | PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
 | PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
-| PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | codex-2026-05-17 | PR-C3-enrichment-pack-split | Promote pure phrase metadata readers into `atlas_brain.reasoning.phrase_metadata` and leave the task module as a compatibility wrapper. |
+| PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
+| PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | codex-2026-05-17 | Content Ops packaged reasoning runtime | Add `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -193,7 +193,7 @@ source of truth for what remains.
   `multi_pass_structured` so its catalog default matches the packaged runtime;
   hosts that want cheaper blog runs can select `single_pass`.
 - `/content-ops/execute` can construct packaged `multi_pass_structured`
-  reasoning for `blog_post`, `report`, and `sales_brief`, or
+  reasoning for `blog_post`, `report`, `landing_page`, and `sales_brief`, or
   `multi_pass_strict` reasoning for `report` and `sales_brief`, when the
   request explicitly sets `reasoning_preset` and the host supplies an LLM
   provider. Blog posts use the `content_ops_blog` narrative pack; reports and

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -559,7 +559,7 @@ async def _structured_reasoning_contexts(
             status_code=400,
             detail=(
                 "reasoning_preset currently applies only to blog_post, report, "
-                "and sales_brief."
+                "landing_page, and sales_brief."
             ),
         )
     reasoning_definitions: dict[str, Any] = {}
@@ -575,7 +575,7 @@ async def _structured_reasoning_contexts(
                 status_code=400,
                 detail=(
                     "Content Ops packaged reasoning currently supports "
-                    "multi_pass_structured for blog_post and "
+                    "multi_pass_structured for blog_post and landing_page, and "
                     "multi_pass_structured or multi_pass_strict for report "
                     "and sales_brief."
                 ),

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -120,7 +120,7 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
     if definition.id not in runtime_presets:
         raise ValueError(
             "Content Ops packaged reasoning currently supports "
-            "multi_pass_structured for blog_post and "
+            "multi_pass_structured for blog_post and landing_page, and "
             "multi_pass_structured or multi_pass_strict for report and sales_brief."
         )
     return {
@@ -149,7 +149,7 @@ def _validate_reasoning_runtime_request(
     if not runtime_outputs:
         raise ValueError(
             "reasoning_preset currently applies only to blog_post, report, "
-            "and sales_brief."
+            "landing_page, and sales_brief."
         )
     for output in runtime_outputs:
         _reasoning_config_for_output(output, request)
@@ -265,6 +265,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_gates_enabled": request.require_quality_gates,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_reasoning_config_for_output(output, request),
             },
         )
     if output == "sales_brief":

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -130,7 +130,7 @@ _BLOG_POST_PRESETS: tuple[ReasoningPreset, ...] = (
 )
 
 PACKAGED_REASONING_RUNTIME_OUTPUTS: tuple[str, ...] = (
-    "blog_post", "report", "sales_brief",
+    "blog_post", "report", "landing_page", "sales_brief",
 )
 PACKAGED_REASONING_RUNTIME_PRESETS: tuple[ReasoningPreset, ...] = (
     "multi_pass_structured",
@@ -142,6 +142,7 @@ _PACKAGED_REASONING_RUNTIME_PRESETS_BY_OUTPUT: Mapping[
 ] = MappingProxyType({
     "blog_post": ("multi_pass_structured",),
     "report": PACKAGED_REASONING_RUNTIME_PRESETS,
+    "landing_page": ("multi_pass_structured",),
     "sales_brief": PACKAGED_REASONING_RUNTIME_PRESETS,
 })
 NOOP_REASONING_PRESETS: tuple[ReasoningPreset, ...] = tuple(

--- a/plans/PR-ContentOps-Landing-Reasoning-Parity.md
+++ b/plans/PR-ContentOps-Landing-Reasoning-Parity.md
@@ -1,0 +1,76 @@
+# Content Ops Landing Reasoning Parity
+
+## Why this slice exists
+
+Landing pages already support reasoning-aware generation through
+`LandingPageGenerationService.with_reasoning_context`, and the reasoning
+catalog allows `multi_pass_structured` for `landing_page`. The packaged runtime
+allowlist still excludes `landing_page`, so `/plan` and `/execute` reject a
+valid catalog choice.
+
+This slice closes that policy/runtime mismatch without adding a new generator.
+
+## Scope
+
+1. Add `landing_page` to packaged structured reasoning runtime outputs.
+2. Thread structured reasoning config into landing-page generation plan steps.
+3. Update control-surface validation error text and tests.
+4. Clean the merged #565 inflight row and claim this slice.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `plans/PR-ContentOps-Landing-Reasoning-Parity.md`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/STATUS.md`
+- `tests/test_extracted_content_reasoning_policy.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_control_surface_api.py`
+
+## Mechanism
+
+`PACKAGED_REASONING_RUNTIME_OUTPUTS` becomes the shared source of truth for
+blog posts, reports, landing pages, and sales briefs. Landing pages accept only
+`multi_pass_structured`, matching their catalog support and avoiding strict
+falsification semantics that the product policy does not advertise.
+
+The generation-plan landing-page step includes the same informational reasoning
+metadata as other packaged outputs when a runtime preset is requested. The
+control-surface API then builds a `MultiPassCampaignReasoningProvider` for the
+landing-page service through the existing `with_reasoning_context` seam.
+
+## Intentional
+
+- No change to the default landing-page preset (`single_pass`).
+- No strict landing-page reasoning support.
+- No new LLM/provider wiring; this reuses the existing packaged structured
+  provider path.
+
+## Deferred
+
+- Per-output landing-page narrative pack tuning. The default structured pack is
+  used until a dedicated landing-page pack is designed.
+- UI changes for selecting reasoning presets.
+
+## Verification
+
+- python -m py_compile on touched Python files - passed.
+- pytest tests/test_extracted_content_reasoning_policy.py
+  tests/test_extracted_content_generation_plan.py
+  tests/test_extracted_content_control_surface_api.py - 105 passed.
+- git diff --check - passed.
+- bash scripts/local_pr_review.sh - passed after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~10 |
+| Plan doc | ~80 |
+| Runtime policy and validation | ~20 |
+| Tests | ~55 |
+| Status docs | ~5 |
+| **Total** | ~170 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -725,8 +725,17 @@ class _ProviderRecordingService:
         self.providers.append(provider)
         return _ProviderRecordingService(self.providers)
 
-    async def generate(self, *, scope, target_mode, limit=None, filters=None, **kwargs):
-        del scope, target_mode, limit, filters, kwargs
+    async def generate(
+        self,
+        *,
+        scope,
+        target_mode=None,
+        limit=None,
+        filters=None,
+        campaign=None,
+        **kwargs,
+    ):
+        del scope, target_mode, limit, filters, campaign, kwargs
         return {"generated": 1, "saved_ids": ["draft-1"]}
 
 
@@ -939,6 +948,34 @@ async def test_execute_route_builds_blog_specific_structured_reasoning_pack():
     assert len(recorded_providers) == 1
     provider = recorded_providers[0]
     assert provider._config.narrative_plan_pack.name == "content_ops_blog"
+    assert provider._config.output_policy is not None
+    assert provider._config.block_on_validation_failure is False
+
+
+@pytest.mark.asyncio
+async def test_execute_route_builds_structured_reasoning_for_landing_page():
+    recorded_providers = []
+    landing_page = _ProviderRecordingService(recorded_providers)
+
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            landing_page=landing_page,
+        ),
+        llm_provider=lambda: object(),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["landing_page"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {"offer": "Audit", "audience": "RevOps"},
+        }
+    )
+
+    assert len(recorded_providers) == 1
+    provider = recorded_providers[0]
+    assert provider._config.narrative_plan_pack.name == "content_ops_structured"
     assert provider._config.output_policy is not None
     assert provider._config.block_on_validation_failure is False
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -138,6 +138,7 @@ def test_plan_threads_all_packaged_runtime_reasoning_presets(output):
     inputs = {
         "blog_post": {"topic": "Churn pressure"},
         "report": {"opportunity_id": "opp_123"},
+        "landing_page": {"offer": "Audit", "audience": "RevOps"},
         "sales_brief": {"target_account": "Acme"},
     }[output]
 
@@ -182,10 +183,10 @@ def test_plan_rejects_unknown_reasoning_preset_for_report():
             "multi_pass_structured or multi_pass_strict",
         ),
         (
-            "blog_post",
-            {"topic": "Churn pressure"},
+            "landing_page",
+            {"offer": "Audit", "audience": "RevOps"},
             "multi_pass_light",
-            "multi_pass_structured or multi_pass_strict",
+            "multi_pass_structured for blog_post and landing_page",
         ),
         (
             "blog_post",
@@ -215,11 +216,6 @@ def test_plan_rejects_runtime_unsupported_reasoning_preset(
     ("output", "inputs", "preset"),
     (
         (
-            "landing_page",
-            {"offer": "Audit", "audience": "RevOps"},
-            "multi_pass_structured",
-        ),
-        (
             "email_campaign",
             {"target_account": "Acme", "offer": "Audit"},
             "single_pass",
@@ -231,7 +227,10 @@ def test_plan_rejects_runtime_reasoning_when_no_packaged_output_selected(
     inputs,
     preset,
 ):
-    with pytest.raises(ValueError, match="only to blog_post, report, and sales_brief"):
+    with pytest.raises(
+        ValueError,
+        match="only to blog_post, report, landing_page, and sales_brief",
+    ):
         build_generation_plan_from_mapping(
             {
                 "outputs": [output],
@@ -257,6 +256,27 @@ def test_plan_ignores_non_runtime_outputs_when_packaged_output_selected():
     configs = {step["output"]: step["config"] for step in plan["steps"]}
     assert "reasoning_preset" not in configs["email_campaign"]
     assert configs["report"]["reasoning_preset"] == "multi_pass_structured"
+
+
+def test_plan_threads_structured_reasoning_preset_to_landing_page():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "reasoning_preset": "multi_pass_structured",
+            "inputs": {
+                "offer": "Audit",
+                "audience": "RevOps",
+            },
+        }
+    )
+
+    step = plan["steps"][0]
+    assert step["config"]["reasoning_preset"] == "multi_pass_structured"
+    assert step["config"]["reasoning_multi_pass"] is True
+    assert step["config"]["reasoning_narrative_planning"] is True
+    assert step["config"]["reasoning_output_validation"] is True
+    assert step["config"]["reasoning_blocking_validation"] is False
+    assert step["config"]["reasoning_falsification"] is False
 
 
 def test_plan_maps_blog_to_blog_generation_service():

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -70,7 +70,8 @@ def test_packaged_runtime_reasoning_surface_is_catalog_supported() -> None:
     for output in PACKAGED_REASONING_RUNTIME_OUTPUTS:
         assert OUTPUT_CATALOG[output].implemented is True
         policy = output_reasoning_policy(output)
-        assert policy.default_preset in packaged_reasoning_runtime_presets_for_output(output)
+        if output != "landing_page":
+            assert policy.default_preset in packaged_reasoning_runtime_presets_for_output(output)
         for preset in packaged_reasoning_runtime_presets_for_output(output):
             assert policy.supports(preset)
 


### PR DESCRIPTION
Plan: plans/PR-ContentOps-Landing-Reasoning-Parity.md

## Summary
- add landing_page to the packaged structured reasoning runtime output allowlist
- thread structured reasoning metadata into landing-page generation plan steps
- align control-surface API validation and tests with landing-page runtime support

## Verification
- pytest tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_control_surface_api.py
- python -m py_compile on touched Python files
- git diff --check
- bash scripts/local_pr_review.sh

Coordination: claimed in docs/extraction/coordination/inflight.md as TBD; follow-up commit will replace TBD with this PR number.