### PR TITLE
Add email campaign packaged reasoning parity

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T16:40Z by codex-2026-05-17
+Last updated: 2026-05-17T17:18Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #566 | Add landing-page packaged reasoning runtime parity | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-ContentOps-Landing-Reasoning-Parity.md`, `extracted_content_pipeline/reasoning_policy.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_control_surface_api.py` | codex-2026-05-17 | Avoid editing packaged Content Ops reasoning runtime output allowlists while this aligns landing-page policy with runtime execution. |
+| #567 | Add email campaign packaged reasoning runtime parity | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-ContentOps-Email-Packaged-Reasoning.md`, `extracted_content_pipeline/reasoning_policy.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/STATUS.md`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_control_surface_api.py` | codex-2026-05-17 | Avoid editing packaged Content Ops reasoning runtime output allowlists while this aligns email campaign policy with runtime execution. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T16:40Z by codex-2026-05-17
+Last updated: 2026-05-17T17:18Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -12,4 +12,5 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
 | PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
 | PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
-| PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | codex-2026-05-17 | Content Ops packaged reasoning runtime | Add `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
+| PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
+| PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | codex-2026-05-17 | PR-D23-landing-reasoning-parity | Add `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -193,8 +193,9 @@ source of truth for what remains.
   `multi_pass_structured` so its catalog default matches the packaged runtime;
   hosts that want cheaper blog runs can select `single_pass`.
 - `/content-ops/execute` can construct packaged `multi_pass_structured`
-  reasoning for `blog_post`, `report`, `landing_page`, and `sales_brief`, or
-  `multi_pass_strict` reasoning for `report` and `sales_brief`, when the
+  reasoning for `email_campaign`, `blog_post`, `report`, `landing_page`, and
+  `sales_brief`, or `multi_pass_strict` reasoning for `report` and
+  `sales_brief`, when the
   request explicitly sets `reasoning_preset` and the host supplies an LLM
   provider. Blog posts use the `content_ops_blog` narrative pack; reports and
   sales briefs keep the `content_ops_structured` pack. Strict mode uses the

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -558,8 +558,8 @@ async def _structured_reasoning_contexts(
         raise HTTPException(
             status_code=400,
             detail=(
-                "reasoning_preset currently applies only to blog_post, report, "
-                "landing_page, and sales_brief."
+                "reasoning_preset currently applies only to email_campaign, "
+                "blog_post, report, landing_page, and sales_brief."
             ),
         )
     reasoning_definitions: dict[str, Any] = {}
@@ -575,9 +575,9 @@ async def _structured_reasoning_contexts(
                 status_code=400,
                 detail=(
                     "Content Ops packaged reasoning currently supports "
-                    "multi_pass_structured for blog_post and landing_page, and "
-                    "multi_pass_structured or multi_pass_strict for report "
-                    "and sales_brief."
+                    "multi_pass_structured for email_campaign, blog_post, "
+                    "and landing_page, and multi_pass_structured or "
+                    "multi_pass_strict for report and sales_brief."
                 ),
             )
     selected_outputs = [

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -120,8 +120,9 @@ def _reasoning_config_for_output(output: str, request: ContentOpsRequest) -> dic
     if definition.id not in runtime_presets:
         raise ValueError(
             "Content Ops packaged reasoning currently supports "
-            "multi_pass_structured for blog_post and landing_page, and "
-            "multi_pass_structured or multi_pass_strict for report and sales_brief."
+            "multi_pass_structured for email_campaign, blog_post, and "
+            "landing_page, and multi_pass_structured or multi_pass_strict "
+            "for report and sales_brief."
         )
     return {
         "reasoning_preset": definition.id,
@@ -148,8 +149,8 @@ def _validate_reasoning_runtime_request(
     )
     if not runtime_outputs:
         raise ValueError(
-            "reasoning_preset currently applies only to blog_post, report, "
-            "landing_page, and sales_brief."
+            "reasoning_preset currently applies only to email_campaign, "
+            "blog_post, report, landing_page, and sales_brief."
         )
     for output in runtime_outputs:
         _reasoning_config_for_output(output, request)
@@ -232,6 +233,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "quality_prompt_proof_term_limit": config.quality_prompt_proof_term_limit,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
+                **_reasoning_config_for_output(output, request),
             },
         )
     if output == "report":

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -113,9 +113,6 @@ REASONING_PRESETS: Mapping[str, ReasoningPresetDefinition] = MappingProxyType({
 })
 
 
-_MULTI_PASS_OPTIONAL: tuple[ReasoningPreset, ...] = (
-    "none", "context_only", "single_pass", "multi_pass_light",
-)
 _STRUCTURED_PRESETS: tuple[ReasoningPreset, ...] = (
     "none", "context_only", "single_pass", "multi_pass_light",
     "multi_pass_structured", "multi_pass_strict",
@@ -128,9 +125,13 @@ _BLOG_POST_PRESETS: tuple[ReasoningPreset, ...] = (
     "none", "context_only", "single_pass", "multi_pass_light",
     "multi_pass_structured",
 )
+_EMAIL_CAMPAIGN_PRESETS: tuple[ReasoningPreset, ...] = (
+    "none", "context_only", "single_pass", "multi_pass_light",
+    "multi_pass_structured",
+)
 
 PACKAGED_REASONING_RUNTIME_OUTPUTS: tuple[str, ...] = (
-    "blog_post", "report", "landing_page", "sales_brief",
+    "email_campaign", "blog_post", "report", "landing_page", "sales_brief",
 )
 PACKAGED_REASONING_RUNTIME_PRESETS: tuple[ReasoningPreset, ...] = (
     "multi_pass_structured",
@@ -140,6 +141,7 @@ _PACKAGED_REASONING_RUNTIME_PRESETS_BY_OUTPUT: Mapping[
     str,
     tuple[ReasoningPreset, ...],
 ] = MappingProxyType({
+    "email_campaign": ("multi_pass_structured",),
     "blog_post": ("multi_pass_structured",),
     "report": PACKAGED_REASONING_RUNTIME_PRESETS,
     "landing_page": ("multi_pass_structured",),
@@ -161,7 +163,7 @@ OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyTyp
     "email_campaign": OutputReasoningPolicy(
         output="email_campaign",
         default_preset="single_pass",
-        supported_presets=_MULTI_PASS_OPTIONAL,
+        supported_presets=_EMAIL_CAMPAIGN_PRESETS,
     ),
     "landing_page": OutputReasoningPolicy(
         output="landing_page",

--- a/plans/PR-ContentOps-Email-Packaged-Reasoning.md
+++ b/plans/PR-ContentOps-Email-Packaged-Reasoning.md
@@ -1,0 +1,78 @@
+# Content Ops Email Campaign Reasoning Parity
+
+## Why this slice exists
+
+`email_campaign` is the core AI Content Ops output and already supports
+reasoning-aware generation through `CampaignGenerationService.with_reasoning_context`.
+The packaged `/content-ops/execute` runtime still excludes it from structured
+reasoning construction, so hosts can provide campaign context manually but
+cannot opt into the same packaged `multi_pass_structured` path that newer asset
+outputs use.
+
+This slice closes that policy/runtime mismatch without adding a new generator.
+
+## Scope
+
+1. Add `email_campaign` to packaged structured reasoning runtime outputs.
+2. Thread structured reasoning config into email campaign generation plan steps.
+3. Keep strict/falsification support out of scope for campaigns.
+4. Update control-surface validation error text and tests.
+5. Clean the merged #566 inflight row and claim this slice.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `plans/PR-ContentOps-Email-Packaged-Reasoning.md`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `extracted_content_pipeline/STATUS.md`
+- `tests/test_extracted_content_reasoning_policy.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_control_surface_api.py`
+
+## Mechanism
+
+`PACKAGED_REASONING_RUNTIME_OUTPUTS` becomes the shared source of truth for
+email campaigns, blog posts, reports, landing pages, and sales briefs. Email
+campaigns accept only `multi_pass_structured`, matching the campaign service's
+existing reasoning-context seam while avoiding strict falsification semantics
+that the product policy does not advertise for campaigns.
+
+The generation-plan email campaign step includes the same informational
+reasoning metadata as other packaged outputs when a runtime preset is requested.
+The control-surface API then builds a `MultiPassCampaignReasoningProvider` for
+the campaign service through the existing `with_reasoning_context` seam.
+
+## Intentional
+
+- No change to the default email campaign preset (`single_pass`).
+- No strict email campaign reasoning support.
+- No new LLM/provider wiring; this reuses the existing packaged structured
+  provider path.
+- No service signature changes.
+
+## Deferred
+
+- Campaign-specific narrative pack tuning. The default structured pack is used
+  until a dedicated campaign pack is designed.
+- UI changes for selecting reasoning presets.
+
+## Verification
+
+- Python compile on touched Python files - passed.
+- Focused policy, plan, and API tests - 108 passed.
+- Git diff whitespace check - passed.
+- Local PR review - pending after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~10 |
+| Plan doc | ~80 |
+| Runtime policy and validation | ~25 |
+| Tests | ~70 |
+| Status docs | ~5 |
+| **Total** | ~190 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -886,10 +886,11 @@ async def test_execute_route_reasoning_provider_returning_none_rebinds_to_none()
 
 
 @pytest.mark.asyncio
-async def test_execute_route_builds_structured_reasoning_for_report_only():
-    campaign = _ReasoningCapturingService()
-    recorded_providers = []
-    report = _ProviderRecordingService(recorded_providers)
+async def test_execute_route_builds_structured_reasoning_for_campaign_and_report():
+    campaign_providers = []
+    report_providers = []
+    campaign = _ProviderRecordingService(campaign_providers)
+    report = _ProviderRecordingService(report_providers)
 
     router = create_content_ops_control_surface_router(
         execution_services_provider=lambda: ContentOpsExecutionServices(
@@ -912,16 +913,17 @@ async def test_execute_route_builds_structured_reasoning_for_report_only():
         }
     )
 
-    assert len(recorded_providers) == 1
-    provider = recorded_providers[0]
+    assert len(campaign_providers) == 1
+    assert len(report_providers) == 1
+    assert campaign_providers[0] is report_providers[0]
+    provider = report_providers[0]
     assert provider._config.default_goal == "synthesize content reasoning context"
     assert provider._config.narrative_plan_pack.name == "content_ops_structured"
     assert provider._config.output_policy is not None
     assert provider._config.output_policy.require_citations is True
     assert provider._config.block_on_validation_failure is False
-    assert campaign.calls[0]["reasoning_context"] is None
     email_step = next(step for step in payload["steps"] if step["output"] == "email_campaign")
-    assert email_step["reasoning"]["provider_configured"] is False
+    assert email_step["reasoning"]["provider_configured"] is True
 
 
 @pytest.mark.asyncio
@@ -1217,6 +1219,15 @@ async def test_blocking_reasoning_provider_surfaces_validation_blockers():
             },
             400,
             "multi_pass_structured or multi_pass_strict",
+        ),
+        (
+            {
+                "outputs": ["email_campaign"],
+                "reasoning_preset": "multi_pass_strict",
+                "inputs": {"target_account": "Acme", "offer": "Audit"},
+            },
+            400,
+            "not supported",
         ),
         (
             {

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -137,6 +137,7 @@ def test_plan_threads_structured_reasoning_preset_to_blog_post():
 def test_plan_threads_all_packaged_runtime_reasoning_presets(output):
     inputs = {
         "blog_post": {"topic": "Churn pressure"},
+        "email_campaign": {"target_account": "Acme", "offer": "Audit"},
         "report": {"opportunity_id": "opp_123"},
         "landing_page": {"offer": "Audit", "audience": "RevOps"},
         "sales_brief": {"target_account": "Acme"},
@@ -183,10 +184,16 @@ def test_plan_rejects_unknown_reasoning_preset_for_report():
             "multi_pass_structured or multi_pass_strict",
         ),
         (
+            "email_campaign",
+            {"target_account": "Acme", "offer": "Audit"},
+            "multi_pass_light",
+            "multi_pass_structured for email_campaign, blog_post, and landing_page",
+        ),
+        (
             "landing_page",
             {"offer": "Audit", "audience": "RevOps"},
             "multi_pass_light",
-            "multi_pass_structured for blog_post and landing_page",
+            "multi_pass_structured for email_campaign, blog_post, and landing_page",
         ),
         (
             "blog_post",
@@ -212,35 +219,23 @@ def test_plan_rejects_runtime_unsupported_reasoning_preset(
         )
 
 
-@pytest.mark.parametrize(
-    ("output", "inputs", "preset"),
-    (
-        (
-            "email_campaign",
-            {"target_account": "Acme", "offer": "Audit"},
-            "single_pass",
-        ),
-    ),
-)
-def test_plan_rejects_runtime_reasoning_when_no_packaged_output_selected(
-    output,
-    inputs,
-    preset,
-):
+def test_plan_rejects_runtime_reasoning_when_no_packaged_output_selected():
     with pytest.raises(
         ValueError,
-        match="only to blog_post, report, landing_page, and sales_brief",
+        match="only to email_campaign, blog_post, report, landing_page, and sales_brief",
     ):
         build_generation_plan_from_mapping(
             {
-                "outputs": [output],
-                "reasoning_preset": preset,
-                "inputs": inputs,
+                "outputs": ["signal_extraction"],
+                "reasoning_preset": "single_pass",
+                "inputs": {
+                    "source_material": "Pricing pressure came up at renewal.",
+                },
             }
         )
 
 
-def test_plan_ignores_non_runtime_outputs_when_packaged_output_selected():
+def test_plan_threads_structured_reasoning_to_email_and_report():
     plan = build_generation_plan_from_mapping(
         {
             "outputs": ["email_campaign", "report"],
@@ -254,7 +249,8 @@ def test_plan_ignores_non_runtime_outputs_when_packaged_output_selected():
     )
 
     configs = {step["output"]: step["config"] for step in plan["steps"]}
-    assert "reasoning_preset" not in configs["email_campaign"]
+    assert configs["email_campaign"]["reasoning_preset"] == "multi_pass_structured"
+    assert configs["email_campaign"]["reasoning_multi_pass"] is True
     assert configs["report"]["reasoning_preset"] == "multi_pass_structured"
 
 

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -70,7 +70,7 @@ def test_packaged_runtime_reasoning_surface_is_catalog_supported() -> None:
     for output in PACKAGED_REASONING_RUNTIME_OUTPUTS:
         assert OUTPUT_CATALOG[output].implemented is True
         policy = output_reasoning_policy(output)
-        if output != "landing_page":
+        if output not in {"email_campaign", "landing_page"}:
             assert policy.default_preset in packaged_reasoning_runtime_presets_for_output(output)
         for preset in packaged_reasoning_runtime_presets_for_output(output):
             assert policy.supports(preset)
@@ -97,10 +97,15 @@ def test_signal_extraction_only_supports_no_reasoning() -> None:
         resolve_reasoning_policy("signal_extraction", "single_pass")
 
 
-def test_email_campaign_does_not_support_structured_or_strict_presets() -> None:
+def test_email_campaign_supports_structured_but_not_strict_preset() -> None:
     supported = supported_reasoning_presets("email_campaign")
-    assert supported == ("none", "context_only", "single_pass", "multi_pass_light")
-    assert "multi_pass_structured" not in supported
+    assert supported == (
+        "none",
+        "context_only",
+        "single_pass",
+        "multi_pass_light",
+        "multi_pass_structured",
+    )
     assert "multi_pass_strict" not in supported
 
 


### PR DESCRIPTION
Plan: plans/PR-ContentOps-Email-Packaged-Reasoning.md

Summary:
- Add email_campaign to the packaged multi_pass_structured reasoning runtime allowlist.
- Thread structured reasoning metadata into email campaign generation plans.
- Update control-surface validation text, status docs, coordination docs, and focused tests.

Verification:
- pytest tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_control_surface_api.py (108 passed)
- python -m py_compile on touched Python/test files
- git diff --check
- bash scripts/local_pr_review.sh