### PR TITLE
Close out Content Ops reasoning policy backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -111,15 +111,21 @@ Remaining work:
   exists.
 
 **Likely slice:** wait for a real export. If none exists, skip this item.
-If no export appears after the next reasoning-policy pass, decide whether this
-remains roadmap work or should be removed from active backlog.
+No export appeared before the reasoning-policy parity pass closed. Keep this as
+roadmap work, not an active slice, until a real host export fixture exists.
 
 ## Current Pick Recommendation
 
 The host-facing AI Content Ops reasoning-policy arc is complete for the current
-standalone product surface: preset catalog, structured report/sales/blog
-execution, strict report/sales validation, explicit strict falsification rules,
-and blog-specific narrative packs have shipped.
+standalone product surface: preset catalog, packaged structured runtime support
+for all reasoning-aware generated outputs (`email_campaign`, `blog_post`,
+`report`, `landing_page`, `sales_brief`), strict report/sales validation,
+explicit strict falsification rules, and blog-specific narrative packs have
+shipped.
+
+PR #566 and PR #567 were audit-recommended parity closures that landed after
+the previous closeout. They do not reopen the reasoning-policy arc; they
+complete the deferred audit scope that already existed at closeout time.
 
 Do not take another AI Content Ops reasoning-policy slice unless it answers one
 of these concrete needs:
@@ -132,4 +138,6 @@ of these concrete needs:
 
 Until then, pause speculative Content Ops reasoning-policy work. The next
 highest-leverage code should come from either a real source export fixture
-(item 2) or the separate `extracted_reasoning_core` productization track.
+(item 2) or the separate `extracted_reasoning_core` productization track. If a
+future slice touches reasoning policy, it should name the concrete trigger from
+the list above in its plan doc.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T17:18Z by codex-2026-05-17
+Last updated: 2026-05-17T17:41Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #567 | Add email campaign packaged reasoning runtime parity | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `plans/PR-ContentOps-Email-Packaged-Reasoning.md`, `extracted_content_pipeline/reasoning_policy.py`, `extracted_content_pipeline/generation_plan.py`, `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/STATUS.md`, `tests/test_extracted_content_reasoning_policy.py`, `tests/test_extracted_content_generation_plan.py`, `tests/test_extracted_content_control_surface_api.py` | codex-2026-05-17 | Avoid editing packaged Content Ops reasoning runtime output allowlists while this aligns email campaign policy with runtime execution. |
+| #568 | Close out Content Ops reasoning-policy backlog | `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `extracted_content_pipeline/STATUS.md`, `plans/PR-ContentOps-Reasoning-Policy-Closeout-2026-05-17.md` | codex-2026-05-17 | Avoid editing Content Ops reasoning-policy closeout/backlog wording while this reconciles the post-#567 state. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T17:18Z by codex-2026-05-17
+Last updated: 2026-05-17T17:41Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -13,4 +13,4 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
 | PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
 | PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
-| PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | codex-2026-05-17 | PR-D23-landing-reasoning-parity | Add `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |
+| PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | merged #567 | PR-D23-landing-reasoning-parity | Added `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T00:53Z by codex-2026-05-16
+Last updated: 2026-05-17T17:41Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #209 | — | Seller category-intelligence refresh landed. Next decision: hosted orchestration/API trigger and dashboard hardening, or optional subcategory intelligence producer. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
 | `extracted_reasoning_core` | 1 -> 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, and partial product wrappers landed; no standalone env toggle claimed yet) | #163 | #563 | Reconcile current-state audit, then continue with the smallest remaining productization gap: atlas-side per-review enrichment pack split. | reasoning-core status docs |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -211,6 +211,9 @@ source of truth for what remains.
   claim before any falsified claims are dropped. The host config rejects
   `drop_falsified=True` without rules and caps strict falsification rules at 20
   to keep per-claim prompt growth bounded.
+- Packaged structured reasoning runtime support is now at parity for every
+  reasoning-aware generated output. `signal_extraction` remains intentionally
+  outside the reasoning-provider path.
 - `tests/test_extracted_campaign_api_hosted_workflow.py` locks the intended
   host-mounted B2B admin flow: generate drafts, list/review them through the
   B2B router, send queued rows, and refresh analytics while preserving shared

--- a/plans/PR-ContentOps-Reasoning-Policy-Closeout-2026-05-17.md
+++ b/plans/PR-ContentOps-Reasoning-Policy-Closeout-2026-05-17.md
@@ -1,0 +1,69 @@
+# Content Ops Reasoning Policy Closeout
+
+## Why this slice exists
+
+PR #566 and PR #567 closed the remaining audit-recommended packaged runtime
+parity gaps after the earlier Content Ops reasoning closeout. The backlog still
+describes the reasoning-policy arc as complete before those two slices and
+keeps #567 listed as in-flight.
+
+This slice reconciles the coordination and backlog docs with the merged
+runtime state so future sessions do not reopen speculative reasoning-policy
+work.
+
+## Scope
+
+1. Remove merged #567 from the in-flight coordination table and claim this
+   closeout slice.
+2. Mark PR-D24 as merged in the queue.
+3. Update the Content Ops product state to point at #567 and the next
+   non-speculative milestone.
+4. Update the deferred backlog stop condition to explicitly include the
+   audit-recommended parity closures that already shipped.
+5. Add a short STATUS note that packaged runtime parity now covers every
+   reasoning-aware generated output.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/coordination/state.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-ContentOps-Reasoning-Policy-Closeout-2026-05-17.md`
+
+## Mechanism
+
+This is documentation and coordination cleanup only. It does not change
+runtime behavior. The active backlog now says the host-facing reasoning-policy
+arc is complete after email, blog, report, landing page, and sales brief all
+have packaged structured runtime support. The next recommended work is either
+a real host export fixture or the separate `extracted_reasoning_core`
+productization track.
+
+## Intentional
+
+- No runtime code changes.
+- No test fixture changes.
+- No new reasoning preset or output support.
+
+## Deferred
+
+- Real source export fixture work remains deferred until a host supplies a
+  concrete export.
+- Future reasoning-policy work remains gated by real host need, real run
+  metadata, or new stable reasoning-core capabilities.
+
+## Verification
+
+- Local PR review after commit.
+- Git diff whitespace check.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~20 |
+| Backlog/status docs | ~35 |
+| Plan doc | ~70 |
+| **Total** | ~125 |


### PR DESCRIPTION
Plan: plans/PR-ContentOps-Reasoning-Policy-Closeout-2026-05-17.md

Summary:
- Remove merged #567 from in-flight coordination and mark D24 merged.
- Update Content Ops state/backlog to reflect packaged reasoning parity for every reasoning-aware generated output.
- Clarify the stop condition so future reasoning-policy slices need a concrete trigger.

Verification:
- git diff --check
- bash scripts/local_pr_review.sh