### PR TITLE
Add reasoning core manifest and standalone smoke

### DIFF
--- a/.github/workflows/extracted_umbrella_checks.yml
+++ b/.github/workflows/extracted_umbrella_checks.yml
@@ -4,9 +4,17 @@ on:
   pull_request:
     paths:
       - "extracted/**"
+      - "extracted_competitive_intelligence/**"
+      - "extracted_content_pipeline/**"
+      - "extracted_llm_infrastructure/**"
+      - "extracted_reasoning_core/**"
   push:
     paths:
       - "extracted/**"
+      - "extracted_competitive_intelligence/**"
+      - "extracted_content_pipeline/**"
+      - "extracted_llm_infrastructure/**"
+      - "extracted_reasoning_core/**"
 
 jobs:
   extracted-umbrella-checks:
@@ -27,11 +35,14 @@ jobs:
           bash extracted/_shared/scripts/validate_extracted.sh extracted_competitive_intelligence
           bash extracted/_shared/scripts/validate_extracted.sh extracted_llm_infrastructure
           bash extracted/_shared/scripts/validate_extracted.sh extracted_content_pipeline
+          bash extracted/_shared/scripts/validate_extracted.sh extracted_reasoning_core
           bash extracted/_shared/scripts/check_ascii_python.sh extracted_competitive_intelligence
           bash extracted/_shared/scripts/check_ascii_python.sh extracted_llm_infrastructure
+          bash extracted/_shared/scripts/check_ascii_python.sh extracted_reasoning_core
           python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_competitive_intelligence
           python extracted/_shared/scripts/check_extracted_imports.py extracted_llm_infrastructure
           python extracted/_shared/scripts/check_extracted_imports.py extracted_content_pipeline
+          python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_reasoning_core
           python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_competitive_intelligence
           python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_llm_infrastructure
           python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T17:41Z by codex-2026-05-17
+Last updated: 2026-05-17T17:53Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #568 | Close out Content Ops reasoning-policy backlog | `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `extracted_content_pipeline/STATUS.md`, `plans/PR-ContentOps-Reasoning-Policy-Closeout-2026-05-17.md` | codex-2026-05-17 | Avoid editing Content Ops reasoning-policy closeout/backlog wording while this reconciles the post-#567 state. |
+| #569 | Add reasoning-core manifest and standalone smoke | `.github/workflows/extracted_umbrella_checks.yml`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `extracted_reasoning_core/manifest.json`, `plans/PR-Reasoning-Core-Manifest-Smoke-2026-05-17.md`, `scripts/run_extracted_pipeline_checks.sh`, `scripts/smoke_extracted_reasoning_core_standalone.py`, `tests/test_extracted_reasoning_core_manifest.py` | codex-2026-05-17 | Avoid editing reasoning-core manifest, smoke, or shared extracted validation wiring until this PR lands. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T17:41Z by codex-2026-05-17
+Last updated: 2026-05-17T17:53Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -12,5 +12,6 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
 | PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
 | PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
+| PR-C5-manifest-standalone-smoke | `extracted_reasoning_core` | codex-2026-05-17 | PR-C4-phrase-metadata-utility | Add reasoning-core manifest ownership, standalone smoke, and shared validation wiring so the product is covered by the same extraction checks as the other extracted packages. |
 | PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
 | PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | merged #567 | PR-D23-landing-reasoning-parity | Added `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T17:41Z by codex-2026-05-17
+Last updated: 2026-05-17T17:53Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
-| `extracted_reasoning_core` | 1 -> 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, and partial product wrappers landed; no standalone env toggle claimed yet) | #163 | #563 | Reconcile current-state audit, then continue with the smallest remaining productization gap: atlas-side per-review enrichment pack split. | reasoning-core status docs |
+| `extracted_reasoning_core` | 1 -> 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, and partial product wrappers landed; standalone smoke/manifest now being wired) | #565 | TBD | Add manifest-backed standalone smoke and shared validation wiring, then pick the next graph/state wrapper split only if it removes real Atlas coupling. | reasoning-core manifest/smoke wiring |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/extracted_reasoning_core/api.py
+++ b/extracted_reasoning_core/api.py
@@ -1329,14 +1329,14 @@ def validate_reasoning_output(
     Pure deterministic check (no LLM call). Each policy field maps to a
     specific blocker class:
 
-      * ``min_confidence`` → ``confidence_below_min`` blocker if the
+      * ``min_confidence`` -> ``confidence_below_min`` blocker if the
         result's overall confidence is under the threshold.
-      * ``require_citations`` → ``claim_missing_citations:<idx>``
+      * ``require_citations`` -> ``claim_missing_citations:<idx>``
         blocker for each claim with no ``source_ids``.
-      * ``required_claim_types`` → ``missing_required_claim_type:<type>``
+      * ``required_claim_types`` -> ``missing_required_claim_type:<type>``
         blocker for each declared type absent from any claim's
         ``type``/``category`` field.
-      * ``blocked_phrasing`` → ``blocked_phrasing:<phrase>`` blocker if
+      * ``blocked_phrasing`` -> ``blocked_phrasing:<phrase>`` blocker if
         any blocked phrase (case-insensitive, **word-boundary** match)
         appears in the result summary or any claim's prose fields. The
         scanned claim keys are: ``claim``, ``summary``, ``narrative``,

--- a/extracted_reasoning_core/manifest.json
+++ b/extracted_reasoning_core/manifest.json
@@ -1,0 +1,74 @@
+{
+  "mappings": [],
+  "owned": [
+    {
+      "target": "extracted_reasoning_core/__init__.py"
+    },
+    {
+      "target": "extracted_reasoning_core/_synthesis.py"
+    },
+    {
+      "target": "extracted_reasoning_core/api.py"
+    },
+    {
+      "target": "extracted_reasoning_core/archetypes.py"
+    },
+    {
+      "target": "extracted_reasoning_core/domains.py"
+    },
+    {
+      "target": "extracted_reasoning_core/evidence_engine.py"
+    },
+    {
+      "target": "extracted_reasoning_core/evidence_map.yaml"
+    },
+    {
+      "target": "extracted_reasoning_core/graph.py"
+    },
+    {
+      "target": "extracted_reasoning_core/graph_helpers.py"
+    },
+    {
+      "target": "extracted_reasoning_core/graph_nodes.py"
+    },
+    {
+      "target": "extracted_reasoning_core/pack_registry.py"
+    },
+    {
+      "target": "extracted_reasoning_core/ports.py"
+    },
+    {
+      "target": "extracted_reasoning_core/semantic_cache_keys.py"
+    },
+    {
+      "target": "extracted_reasoning_core/skills/__init__.py"
+    },
+    {
+      "target": "extracted_reasoning_core/skills/digest/reasoning_continuation.md"
+    },
+    {
+      "target": "extracted_reasoning_core/skills/digest/reasoning_falsification.md"
+    },
+    {
+      "target": "extracted_reasoning_core/skills/digest/reasoning_synthesis.md"
+    },
+    {
+      "target": "extracted_reasoning_core/skills/registry.py"
+    },
+    {
+      "target": "extracted_reasoning_core/state.py"
+    },
+    {
+      "target": "extracted_reasoning_core/temporal.py"
+    },
+    {
+      "target": "extracted_reasoning_core/tiers.py"
+    },
+    {
+      "target": "extracted_reasoning_core/types.py"
+    },
+    {
+      "target": "extracted_reasoning_core/wedge_registry.py"
+    }
+  ]
+}

--- a/plans/PR-Reasoning-Core-Manifest-Smoke-2026-05-17.md
+++ b/plans/PR-Reasoning-Core-Manifest-Smoke-2026-05-17.md
@@ -1,0 +1,75 @@
+# PR: Reasoning Core Manifest And Standalone Smoke
+
+## Why this slice exists
+
+`extracted_reasoning_core` has a real public API, ports, graph/state modules,
+packs, and tests, but it is the only active extracted product without a
+`manifest.json`. That keeps it out of the shared manifest validation path and
+makes standalone readiness less explicit than the other extracted packages.
+
+## Scope
+
+Add manifest-backed ownership and a lightweight standalone smoke for
+`extracted_reasoning_core`.
+
+### Files touched
+
+- `.github/workflows/extracted_umbrella_checks.yml`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/coordination/state.md`
+- `extracted_reasoning_core/api.py`
+- `extracted_reasoning_core/manifest.json`
+- `plans/PR-Reasoning-Core-Manifest-Smoke-2026-05-17.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/smoke_extracted_reasoning_core_standalone.py`
+- `tests/test_extracted_reasoning_core_manifest.py`
+
+## Mechanism
+
+- Declare every current `extracted_reasoning_core` file as product-owned in a
+  new manifest.
+- Add a standalone smoke script that imports the manifest's Python modules and
+  executes `run_reasoning` with a fake LLM port.
+- Wire shared validation to run manifest sync, ASCII, import, forbidden Atlas
+  reasoning import, and smoke checks for the reasoning core.
+- Add tests proving the manifest is product-owned, all targets exist, Python
+  targets do not import `atlas_brain.reasoning`, and the smoke works at the CLI
+  boundary.
+- Replace four non-ASCII arrows in an existing reasoning-core docstring so the
+  new ASCII check can pass for the full product.
+
+## Intentional
+
+- Keep the manifest fully product-owned. There is no Atlas source mapping for
+  core files because this package is already the canonical reasoning boundary.
+- Keep the smoke offline and port-driven. It uses a fake LLM port and does not
+  touch network, database, provider routing, or Atlas settings.
+- Clean the stale #568 inflight row while claiming this new slice.
+
+## Deferred
+
+- No graph/state wrapper split in this PR.
+- No new `EXTRACTED_REASONING_CORE_STANDALONE` runtime branching. The smoke
+  sets the env var for consistency, but the core has no Atlas fallback path to
+  switch away from.
+- No new reasoning capability or output behavior.
+
+## Verification
+
+- Focused reasoning-core manifest tests pass.
+- Standalone reasoning-core smoke passes.
+- Shared manifest, ASCII, import, and forbidden Atlas reasoning checks pass.
+- Local PR review passes.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Manifest and smoke script | ~150 |
+| Tests | ~60 |
+| Check wiring | ~15 |
+| Coordination docs | ~10 |
+| Plan doc | ~80 |
+| Existing docstring ASCII cleanup | ~5 |
+| **Total** | ~320 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -5,11 +5,16 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 bash scripts/validate_extracted_content_pipeline.sh
+bash extracted/_shared/scripts/validate_extracted.sh extracted_reasoning_core
 bash scripts/check_ascii_python.sh
+bash extracted/_shared/scripts/check_ascii_python.sh extracted_reasoning_core
 python scripts/check_extracted_imports.py
+python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_reasoning_core
 python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_reasoning_core
 python scripts/smoke_extracted_pipeline_imports.py
 python scripts/smoke_extracted_pipeline_standalone.py
+python scripts/smoke_extracted_reasoning_core_standalone.py
 python scripts/audit_extracted_standalone.py --fail-on-debt
 pytest \
   tests/test_extracted_campaign_analytics.py \
@@ -80,6 +85,7 @@ pytest \
   tests/test_extracted_content_pipeline_reasoning_archetypes.py \
   tests/test_extracted_content_pipeline_reasoning_temporal.py \
   tests/test_extracted_content_pipeline_reasoning_evidence_engine.py \
+  tests/test_extracted_reasoning_core_manifest.py \
   tests/test_extracted_reasoning_core_api.py \
   tests/test_extracted_reasoning_core_run_reasoning.py \
   tests/test_extracted_reasoning_core_continue_reasoning.py \

--- a/scripts/smoke_extracted_reasoning_core_standalone.py
+++ b/scripts/smoke_extracted_reasoning_core_standalone.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke the extracted reasoning core as a standalone package."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "extracted_reasoning_core" / "manifest.json"
+ENV_VAR = "EXTRACTED_REASONING_CORE_STANDALONE"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _FakeLLM:
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        max_tokens: int,
+        temperature: float,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        del messages, max_tokens, temperature, metadata
+        return {
+            "response": json.dumps({
+                "summary": "Reasoning core standalone smoke passed.",
+                "claims": [
+                    {
+                        "claim": "Standalone reasoning used local core ports.",
+                        "confidence": "high",
+                        "source_ids": ["smoke-1"],
+                    }
+                ],
+                "confidence": 0.91,
+            }),
+            "usage": {"input_tokens": 4, "output_tokens": 6},
+        }
+
+
+def _module_name(target: str) -> str | None:
+    path = Path(target)
+    if path.suffix != ".py":
+        return None
+    if path.name == "__init__.py":
+        return ".".join(path.parent.parts)
+    return ".".join(path.with_suffix("").parts)
+
+
+def _manifest_python_modules() -> list[str]:
+    data = json.loads(MANIFEST.read_text())
+    modules: list[str] = []
+    for entry in data.get("owned", []):
+        module = _module_name(str(entry.get("target") or ""))
+        if module:
+            modules.append(module)
+    for entry in data.get("mappings", []):
+        module = _module_name(str(entry.get("target") or ""))
+        if module:
+            modules.append(module)
+    return sorted(set(modules))
+
+
+async def _run_smoke() -> dict[str, Any]:
+    # Marker for parity with other extracted product smokes. Reasoning core has
+    # no Atlas fallback path to disable; decoupling is enforced by import gates.
+    os.environ[ENV_VAR] = "1"
+
+    imported: list[str] = []
+    for module in _manifest_python_modules():
+        importlib.import_module(module)
+        imported.append(module)
+
+    from extracted_reasoning_core.api import run_reasoning
+    from extracted_reasoning_core.types import (
+        EvidenceItem,
+        ReasoningInput,
+        ReasoningPack,
+        ReasoningPorts,
+    )
+
+    result = await run_reasoning(
+        ReasoningInput(
+            entity_id="standalone-smoke",
+            entity_type="test",
+            goal="verify standalone reasoning core execution",
+            evidence=(
+                EvidenceItem(
+                    source_type="smoke",
+                    source_id="smoke-1",
+                    text="Standalone host supplies ports.",
+                ),
+            ),
+        ),
+        pack=ReasoningPack(
+            name="reasoning_synthesis",
+            prompts={"reasoning_synthesis": "Return JSON."},
+        ),
+        ports=ReasoningPorts(llm=_FakeLLM()),
+    )
+
+    return {
+        "ok": result.summary == "Reasoning core standalone smoke passed.",
+        "imported_modules": len(imported),
+        "summary": result.summary,
+        "claims": len(result.claims),
+        "tokens_used": result.state.get("tokens_used"),
+    }
+
+
+def main() -> int:
+    result = asyncio.run(_run_smoke())
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_extracted_reasoning_core_manifest.py
+++ b/tests/test_extracted_reasoning_core_manifest.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "extracted_reasoning_core" / "manifest.json"
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST.read_text())
+
+
+def _owned_targets() -> set[str]:
+    return {entry["target"] for entry in _manifest().get("owned", [])}
+
+
+def test_manifest_marks_reasoning_core_as_product_owned() -> None:
+    manifest = _manifest()
+
+    assert manifest["mappings"] == []
+    assert "extracted_reasoning_core/api.py" in _owned_targets()
+    assert "extracted_reasoning_core/types.py" in _owned_targets()
+    assert "extracted_reasoning_core/ports.py" in _owned_targets()
+    assert "extracted_reasoning_core/evidence_map.yaml" in _owned_targets()
+    assert "extracted_reasoning_core/skills/registry.py" in _owned_targets()
+
+
+def test_manifest_targets_exist() -> None:
+    for target in _owned_targets():
+        assert (ROOT / target).exists(), target
+
+
+def test_manifest_python_targets_do_not_import_atlas_reasoning() -> None:
+    for target in _owned_targets():
+        path = ROOT / target
+        if path.suffix != ".py":
+            continue
+        text = path.read_text()
+        assert "from atlas_brain.reasoning" not in text
+        assert "import atlas_brain.reasoning" not in text
+
+
+def test_standalone_smoke_imports_manifest_modules_and_runs_reasoning() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/smoke_extracted_reasoning_core_standalone.py",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is True
+    assert payload["claims"] == 1
+    assert payload["imported_modules"] >= 18
+    assert payload["summary"] == "Reasoning core standalone smoke passed."


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Manifest-Smoke-2026-05-17.md

## Summary
- Add a product-owned manifest for extracted_reasoning_core.
- Add an offline standalone smoke that imports manifest Python modules and runs run_reasoning through a fake LLM port.
- Wire reasoning-core manifest/ascii/import/smoke checks into extracted validation paths and clean stale coordination state.

## Verification
- Focused reasoning-core manifest/API/run_reasoning tests: 19 passed.
- Reasoning-core manifest, ASCII, import, forbidden Atlas reasoning checks: passed.
- Standalone reasoning-core smoke: passed.
- Local PR review: passed.