### PR TITLE
Promote reasoning graph reason node into core

### DIFF
--- a/atlas_brain/reasoning/graph.py
+++ b/atlas_brain/reasoning/graph.py
@@ -246,11 +246,10 @@ async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
     Atlas keeps the prompt builder here because it reads atlas-specific
     extended-state fields (``crm_context``, ``b2b_churn``, ``voice_turns``,
     etc. -- the slots atlas's ``ReasoningAgentState`` adds on top of
-    core's TypedDict per PR-C4b). The LLM round-trip itself goes through
-    core's ``complete_with_json`` helper via the ``AtlasLLMClient``
-    adapter.
+    core's TypedDict per PR-C4b). Core owns the LLM call / parse / fallback
+    behavior via ``node_reason``.
     """
-    from extracted_reasoning_core.graph_helpers import complete_with_json
+    from extracted_reasoning_core.graph_nodes import node_reason
     from .graph_prompts import REASONING_SYSTEM
     from .port_adapters import AtlasLLMClient
     from ..config import settings
@@ -313,63 +312,24 @@ async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
         use_model_override=True,
     )
     if not llm_service:
-        state["reasoning_output"] = ""
-        state["connections_found"] = []
-        state["recommended_actions"] = []
-        state["rationale"] = "Reasoning LLM unavailable"
-        return state
+        return await node_reason(
+            state,
+            None,
+            reasoning_system_prompt=REASONING_SYSTEM,
+            prompt=prompt,
+        )
 
     client = AtlasLLMClient(llm_service)
 
-    try:
-        result = await complete_with_json(
-            client,
-            REASONING_SYSTEM,
-            prompt,
-            max_tokens=settings.reasoning.max_tokens,
-            temperature=settings.reasoning.temperature,
-            json_mode=True,
-            timeout=_GRAPH_LLM_TIMEOUT_S,
-        )
-    except Exception:
-        logger.error("Reasoning node failed", exc_info=True)
-        state["reasoning_output"] = ""
-        state["connections_found"] = []
-        state["recommended_actions"] = []
-        state["rationale"] = "Reasoning failed"
-        return state
-
-    text = result["response"]
-    usage = result["usage"]
-    state["total_input_tokens"] = (
-        state.get("total_input_tokens", 0) + int(usage.get("input_tokens", 0) or 0)
+    return await node_reason(
+        state,
+        client,
+        reasoning_system_prompt=REASONING_SYSTEM,
+        prompt=prompt,
+        max_tokens=settings.reasoning.max_tokens,
+        temperature=settings.reasoning.temperature,
+        timeout=_GRAPH_LLM_TIMEOUT_S,
     )
-    state["total_output_tokens"] = (
-        state.get("total_output_tokens", 0) + int(usage.get("output_tokens", 0) or 0)
-    )
-
-    state["reasoning_output"] = text
-
-    if result["parse_ok"]:
-        parsed = result["parsed"]
-        state["connections_found"] = parsed.get("connections", [])
-        state["recommended_actions"] = parsed.get("actions", [])
-        state["rationale"] = parsed.get("rationale", "")
-        state["should_notify"] = parsed.get("should_notify", False)
-    else:
-        # ``complete_with_json`` returns ``parse_ok=False`` on
-        # JSON-decode failure (or non-object JSON / empty response).
-        # Preserve atlas's pre-extraction behavior: surface the raw
-        # text as rationale + force notify so the human sees the
-        # unparsed reasoning output. ``parse_ok=False`` distinguishes
-        # this from a *valid* empty JSON object, which would
-        # mistakenly trip the same fallback under a truthiness check.
-        state["connections_found"] = []
-        state["recommended_actions"] = []
-        state["rationale"] = text
-        state["should_notify"] = True
-
-    return state
 
 
 async def _node_execute_actions(

--- a/atlas_brain/reasoning/graph.py
+++ b/atlas_brain/reasoning/graph.py
@@ -311,15 +311,7 @@ async def _node_reason(state: ReasoningAgentState) -> ReasoningAgentState:
         settings.reasoning.graph_reasoning_workload,
         use_model_override=True,
     )
-    if not llm_service:
-        return await node_reason(
-            state,
-            None,
-            reasoning_system_prompt=REASONING_SYSTEM,
-            prompt=prompt,
-        )
-
-    client = AtlasLLMClient(llm_service)
+    client = AtlasLLMClient(llm_service) if llm_service else None
 
     return await node_reason(
         state,

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T17:53Z by codex-2026-05-17
+Last updated: 2026-05-17T18:12Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #569 | Add reasoning-core manifest and standalone smoke | `.github/workflows/extracted_umbrella_checks.yml`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `extracted_reasoning_core/manifest.json`, `plans/PR-Reasoning-Core-Manifest-Smoke-2026-05-17.md`, `scripts/run_extracted_pipeline_checks.sh`, `scripts/smoke_extracted_reasoning_core_standalone.py`, `tests/test_extracted_reasoning_core_manifest.py` | codex-2026-05-17 | Avoid editing reasoning-core manifest, smoke, or shared extracted validation wiring until this PR lands. |
+| #570 | Promote reasoning graph reason node into core | `atlas_brain/reasoning/graph.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `extracted_reasoning_core/graph_nodes.py`, `plans/PR-Reasoning-Core-Node-Reason-2026-05-17.md`, `tests/test_extracted_reasoning_core_graph_nodes.py` | codex-2026-05-17 | Avoid editing reasoning graph node execution or graph-state coordination wording until this PR lands. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T17:53Z by codex-2026-05-17
+Last updated: 2026-05-17T18:12Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -12,6 +12,7 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C2-current-state-reset | `extracted_reasoning_core` | codex-2026-05-16 | Latest merged reasoning-core work: #163 | Reconcile current main against the 2026-05-03 reasoning boundary audit. Current main already has public APIs, semantic cache keys/ports, pack registry, graph/state ports, content-pipeline wrappers, atlas wrappers, and import guards. Next code slice should target a remaining gap, not repeat PR-C1/PR-C4 work. |
 | PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
 | PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
-| PR-C5-manifest-standalone-smoke | `extracted_reasoning_core` | codex-2026-05-17 | PR-C4-phrase-metadata-utility | Add reasoning-core manifest ownership, standalone smoke, and shared validation wiring so the product is covered by the same extraction checks as the other extracted packages. |
+| PR-C5-manifest-standalone-smoke | `extracted_reasoning_core` | merged #569 | PR-C4-phrase-metadata-utility | Added reasoning-core manifest ownership, standalone smoke, and shared validation wiring so the product is covered by the same extraction checks as the other extracted packages. |
+| PR-C6-node-reason-core | `extracted_reasoning_core` | codex-2026-05-17 | PR-C5-manifest-standalone-smoke | Promote the graph reason-node LLM call / parse / fallback contract into core while Atlas keeps its host-specific prompt builder. |
 | PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
 | PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | merged #567 | PR-D23-landing-reasoning-parity | Added `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T17:53Z by codex-2026-05-17
+Last updated: 2026-05-17T18:12Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
-| `extracted_reasoning_core` | 1 -> 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, and partial product wrappers landed; standalone smoke/manifest now being wired) | #565 | TBD | Add manifest-backed standalone smoke and shared validation wiring, then pick the next graph/state wrapper split only if it removes real Atlas coupling. | reasoning-core manifest/smoke wiring |
+| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #569 | TBD | Move the reason-node execution contract into core while leaving host-specific prompt construction in Atlas. | reasoning graph reason node |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/extracted_reasoning_core/graph_nodes.py
+++ b/extracted_reasoning_core/graph_nodes.py
@@ -1,21 +1,10 @@
 """LLM-driven graph nodes promoted into core.
 
-PR-C4e2 (this module) is the second sub-slice of the audit's PR 6
-graph-engine extraction. ``node_triage`` and ``node_synthesize`` are
-fully self-contained -- they read only fields declared on core's
-:class:`extracted_reasoning_core.state.ReasoningAgentState` and call
-the LLM through the :class:`extracted_reasoning_core.ports.LLMClient`
-Protocol. Atlas's ``_node_triage`` / ``_node_synthesize`` become thin
-wrappers that resolve an atlas LLM, wrap it in the ``AtlasLLMClient``
-adapter, and delegate here.
-
-``_node_reason`` is *not* moved in this slice -- it reads atlas-
-specific extended-state fields (``crm_context``, ``b2b_churn``, voice
-turns, etc. that atlas adds via the ``ReasoningAgentState`` subclass
-established in PR-C4b). Atlas keeps the prompt builder and calls the
-shared ``complete_with_json`` helper for the LLM round-trip. PR-C4e3
-or a later slice can decide whether to push those fields up to core
-or expose a richer prompt-building hook.
+``node_triage``, ``node_reason``, and ``node_synthesize`` read only fields
+declared on core's :class:`extracted_reasoning_core.state.ReasoningAgentState`
+and call the LLM through the :class:`extracted_reasoning_core.ports.LLMClient`
+Protocol. Hosts keep workload routing and prompt/context assembly in their
+adapters, then delegate the LLM call / parse / fallback behavior here.
 
 Each node accepts ``llm: LLMClient | None``. ``None`` means "LLM
 unavailable" -- the node applies the same conservative fallback
@@ -53,6 +42,20 @@ _TRIAGE_TEMPERATURE = 0.1
 
 _SYNTH_MAX_TOKENS_DEFAULT = 256
 _SYNTH_TEMPERATURE_DEFAULT = 0.3
+_REASON_MAX_TOKENS_DEFAULT = 4096
+_REASON_TEMPERATURE_DEFAULT = 0.3
+
+
+def _reason_list_of_strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def _reason_list_of_dicts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
 
 
 async def node_triage(
@@ -206,4 +209,80 @@ async def node_synthesize(
     return state
 
 
-__all__ = ["node_synthesize", "node_triage"]
+async def node_reason(
+    state: ReasoningAgentState,
+    llm: LLMClient | None,
+    *,
+    reasoning_system_prompt: str,
+    prompt: str,
+    max_tokens: int = _REASON_MAX_TOKENS_DEFAULT,
+    temperature: float = _REASON_TEMPERATURE_DEFAULT,
+    timeout: float | None = None,
+) -> ReasoningAgentState:
+    """Run the deep-reasoning LLM call and normalize its state writes.
+
+    Hosts build the prompt because each product has different context fields.
+    Core owns the provider-port call, usage accounting, parsed JSON projection,
+    and conservative fallbacks.
+    """
+    if llm is None:
+        state["reasoning_output"] = ""
+        state["connections_found"] = []
+        state["recommended_actions"] = []
+        state["rationale"] = "Reasoning LLM unavailable"
+        state["should_notify"] = False
+        return state
+
+    try:
+        result = await complete_with_json(
+            llm,
+            reasoning_system_prompt,
+            prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            json_mode=True,
+            timeout=timeout,
+        )
+    except Exception:
+        logger.error("Reasoning node failed", exc_info=True)
+        state["reasoning_output"] = ""
+        state["connections_found"] = []
+        state["recommended_actions"] = []
+        state["rationale"] = "Reasoning failed"
+        state["should_notify"] = False
+        return state
+
+    text = result["response"]
+    usage = result["usage"]
+    state["total_input_tokens"] = (
+        state.get("total_input_tokens", 0) + int(usage.get("input_tokens", 0) or 0)
+    )
+    state["total_output_tokens"] = (
+        state.get("total_output_tokens", 0) + int(usage.get("output_tokens", 0) or 0)
+    )
+    state["reasoning_output"] = text
+
+    if result["parse_ok"]:
+        parsed = result["parsed"]
+        rationale = parsed.get("rationale", "")
+        should_notify = parsed.get("should_notify", False)
+        state["connections_found"] = _reason_list_of_strings(
+            parsed.get("connections", [])
+        )
+        state["recommended_actions"] = _reason_list_of_dicts(
+            parsed.get("actions", [])
+        )
+        state["rationale"] = rationale if isinstance(rationale, str) else ""
+        state["should_notify"] = (
+            should_notify if isinstance(should_notify, bool) else False
+        )
+    else:
+        state["connections_found"] = []
+        state["recommended_actions"] = []
+        state["rationale"] = text
+        state["should_notify"] = True
+
+    return state
+
+
+__all__ = ["node_reason", "node_synthesize", "node_triage"]

--- a/plans/PR-Reasoning-Core-Node-Reason-2026-05-17.md
+++ b/plans/PR-Reasoning-Core-Node-Reason-2026-05-17.md
@@ -1,0 +1,67 @@
+# PR: Reasoning Core Reason Node
+
+## Why this slice exists
+
+`extracted_reasoning_core.graph_nodes` already owns triage and synthesis node
+execution, but Atlas still owns the reason-node LLM call, JSON parsing, token
+accounting, and fallback behavior. That leaves one graph execution contract
+embedded in Atlas even though the provider port and helper machinery are
+already in core.
+
+## Scope
+
+Promote the reason-node execution contract into core while keeping Atlas's
+host-specific prompt construction in Atlas.
+
+### Files touched
+
+- `atlas_brain/reasoning/graph.py`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/coordination/state.md`
+- `extracted_reasoning_core/graph_nodes.py`
+- `plans/PR-Reasoning-Core-Node-Reason-2026-05-17.md`
+- `tests/test_extracted_reasoning_core_graph_nodes.py`
+
+## Mechanism
+
+- Add `node_reason(...)` to `extracted_reasoning_core.graph_nodes`.
+- Have `node_reason(...)` call `complete_with_json`, accumulate token usage,
+  write `reasoning_output`, project parsed `connections/actions/rationale`, and
+  preserve the unparseable-output fallback that forces notification.
+- Update Atlas `_node_reason` to build the same prompt and delegate execution
+  to core through `AtlasLLMClient`.
+- Add focused tests for happy path, missing LLM, LLM exception, and unparseable
+  output.
+
+## Intentional
+
+- Atlas still builds the prompt from Atlas-only state fields like
+  `crm_context`, `email_history`, `voice_turns`, and `b2b_churn`.
+- Core does not import Atlas prompts, settings, or LLM routing.
+- Existing graph orchestration and action execution stay unchanged.
+
+## Deferred
+
+- No graph-state TypedDict slimming.
+- No migration of Atlas context aggregation, lock checks, action execution, or
+  notification delivery.
+- No change to available reasoning actions or prompt text.
+
+## Verification
+
+- Focused graph-node tests pass.
+- Atlas graph wiring tests pass.
+- Reasoning-core manifest and smoke checks pass.
+- Local PR review passes.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Core node implementation | ~65 |
+| Atlas wrapper delegation | ~45 |
+| Tests | ~95 |
+| Coordination docs | ~10 |
+| Plan doc | ~75 |
+| **Total** | ~290 |

--- a/tests/test_extracted_reasoning_core_graph_nodes.py
+++ b/tests/test_extracted_reasoning_core_graph_nodes.py
@@ -18,7 +18,7 @@ from typing import Any, Mapping, Sequence
 
 import pytest
 
-from extracted_reasoning_core.graph_nodes import node_synthesize, node_triage
+from extracted_reasoning_core.graph_nodes import node_reason, node_synthesize, node_triage
 
 
 _TRIAGE_PROMPT = "You are a triage classifier."
@@ -168,6 +168,132 @@ async def test_node_triage_threads_timeout_through_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_node_reason_writes_parsed_actions_and_accumulates_tokens() -> None:
+    fake = _RecordingLLMClient(
+        response_text=(
+            '{"connections": ["pricing pattern"], '
+            '"actions": [{"tool": "send_notification", "confidence": 0.9}], '
+            '"rationale": "Pricing risk is rising.", '
+            '"should_notify": true}'
+        ),
+        usage={"input_tokens": 20, "output_tokens": 11},
+    )
+    state: dict = {"total_input_tokens": 3, "total_output_tokens": 2}
+
+    await node_reason(
+        state,
+        fake,
+        reasoning_system_prompt="Reason.",
+        prompt="Context.",
+        max_tokens=700,
+        temperature=0.2,
+        timeout=55.0,
+    )
+
+    assert state["reasoning_output"].startswith('{"connections"')
+    assert state["connections_found"] == ["pricing pattern"]
+    assert state["recommended_actions"] == [
+        {"tool": "send_notification", "confidence": 0.9}
+    ]
+    assert state["rationale"] == "Pricing risk is rising."
+    assert state["should_notify"] is True
+    assert state["total_input_tokens"] == 23
+    assert state["total_output_tokens"] == 13
+
+    call = fake.calls[0]
+    assert call["max_tokens"] == 700
+    assert call["temperature"] == 0.2
+    assert call["metadata"]["json_mode"] is True
+    assert call["metadata"]["response_format"] == {"type": "json_object"}
+    assert call["metadata"]["timeout"] == 55.0
+
+
+@pytest.mark.asyncio
+async def test_node_reason_drops_wrong_parsed_shapes() -> None:
+    fake = _RecordingLLMClient(
+        response_text=(
+            '{"connections": {"bad": "shape"}, '
+            '"actions": [{"tool": "send_notification"}, "bad"], '
+            '"rationale": {"bad": "shape"}, '
+            '"should_notify": "yes"}'
+        )
+    )
+    state: dict = {}
+
+    await node_reason(
+        state,
+        fake,
+        reasoning_system_prompt="Reason.",
+        prompt="Context.",
+    )
+
+    assert state["connections_found"] == []
+    assert state["recommended_actions"] == [{"tool": "send_notification"}]
+    assert state["rationale"] == ""
+    assert state["should_notify"] is False
+
+
+@pytest.mark.asyncio
+async def test_node_reason_falls_back_when_llm_is_none() -> None:
+    state: dict = {"should_notify": True}
+    await node_reason(
+        state,
+        None,
+        reasoning_system_prompt="Reason.",
+        prompt="Context.",
+    )
+    assert state["reasoning_output"] == ""
+    assert state["connections_found"] == []
+    assert state["recommended_actions"] == []
+    assert state["rationale"] == "Reasoning LLM unavailable"
+    assert state["should_notify"] is False
+
+
+@pytest.mark.asyncio
+async def test_node_reason_falls_back_when_llm_raises() -> None:
+    fake = _RecordingLLMClient(response_text="")
+    fake.exc = RuntimeError("reasoning failed")
+    state: dict = {"should_notify": True}
+
+    await node_reason(
+        state,
+        fake,
+        reasoning_system_prompt="Reason.",
+        prompt="Context.",
+    )
+
+    assert state["reasoning_output"] == ""
+    assert state["connections_found"] == []
+    assert state["recommended_actions"] == []
+    assert state["rationale"] == "Reasoning failed"
+    assert state["should_notify"] is False
+
+
+@pytest.mark.asyncio
+async def test_node_reason_surfaces_raw_text_on_unparseable_output() -> None:
+    fake = _RecordingLLMClient(
+        response_text="Unstructured reasoning text.",
+        usage={"input_tokens": 5, "output_tokens": 4},
+    )
+    state: dict = {"total_input_tokens": 1, "total_output_tokens": 1}
+
+    await node_reason(
+        state,
+        fake,
+        reasoning_system_prompt="Reason.",
+        prompt="Context.",
+    )
+
+    assert state["reasoning_output"] == "Unstructured reasoning text."
+    assert state["connections_found"] == []
+    assert state["recommended_actions"] == []
+    assert state["rationale"] == "Unstructured reasoning text."
+    assert state["should_notify"] is True
+    assert state["total_input_tokens"] == 6
+    assert state["total_output_tokens"] == 5
+
+
+@pytest.mark.asyncio
 async def test_node_synthesize_threads_timeout_through_metadata() -> None:
     fake = _RecordingLLMClient(response_text="A summary line.")
     state: dict = {
@@ -274,7 +400,7 @@ async def test_node_synthesize_falls_back_on_empty_response() -> None:
         "total_output_tokens": 0,
     }
     await node_synthesize(state, fake, synthesis_system_prompt=_SYNTH_PROMPT)
-    # Empty response → fallback uses connections.
+    # Empty response -> fallback uses connections.
     assert "Vendor signal: pricing pressure" in state["summary"]
     # Tokens still accumulate even when response is empty.
     assert state["total_input_tokens"] == 5


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Node-Reason-2026-05-17.md

## Summary
- Add extracted_reasoning_core.graph_nodes.node_reason for the reason-node LLM call, JSON parsing, token accounting, and fallback behavior.
- Update Atlas _node_reason to keep Atlas-specific prompt assembly but delegate execution to core through AtlasLLMClient.
- Add focused core graph-node tests for parsed output, missing LLM, LLM exception, and unparseable output.
- Update coordination docs after #569 and claim this C6 slice.

## Verification
- python -m py_compile on touched Python files: passed.
- pytest tests/test_extracted_reasoning_core_graph_nodes.py tests/test_atlas_reasoning_run_reasoning_graph_wiring.py: 21 passed.
- reasoning-core manifest/ascii/import/forbidden-import/smoke checks: passed.
- git diff --check: passed.
- bash scripts/local_pr_review.sh: passed.