### PR TITLE
Repair Atlas graph routing tests for port adapter seam

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T18:12Z by codex-2026-05-17
+Last updated: 2026-05-17T19:00Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #570 | Promote reasoning graph reason node into core | `atlas_brain/reasoning/graph.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `extracted_reasoning_core/graph_nodes.py`, `plans/PR-Reasoning-Core-Node-Reason-2026-05-17.md`, `tests/test_extracted_reasoning_core_graph_nodes.py` | codex-2026-05-17 | Avoid editing reasoning graph node execution or graph-state coordination wording until this PR lands. |
+| TBD | Repair Atlas graph routing tests for port adapter seam | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `plans/PR-Reasoning-Core-Graph-Routing-Test-Seam-2026-05-17.md`, `tests/test_reasoning_graph_routing.py`, `tests/test_reasoning_graph_summary.py` | codex-2026-05-17 | Avoid editing Atlas graph-routing tests or reasoning-core coordination state until this PR lands. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T18:12Z by codex-2026-05-17
+Last updated: 2026-05-17T19:00Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -13,6 +13,7 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C3-enrichment-pack-split | `extracted_reasoning_core` | merged #564 | PR-C2-current-state-reset | Atlas-side per-review enrichment now lives in an explicit product pack. |
 | PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
 | PR-C5-manifest-standalone-smoke | `extracted_reasoning_core` | merged #569 | PR-C4-phrase-metadata-utility | Added reasoning-core manifest ownership, standalone smoke, and shared validation wiring so the product is covered by the same extraction checks as the other extracted packages. |
-| PR-C6-node-reason-core | `extracted_reasoning_core` | codex-2026-05-17 | PR-C5-manifest-standalone-smoke | Promote the graph reason-node LLM call / parse / fallback contract into core while Atlas keeps its host-specific prompt builder. |
+| PR-C6-node-reason-core | `extracted_reasoning_core` | merged #570 | PR-C5-manifest-standalone-smoke | Promoted the graph reason-node LLM call / parse / fallback contract into core while Atlas keeps its host-specific prompt builder. |
+| PR-C7-graph-routing-test-seam | `extracted_reasoning_core` | codex-2026-05-17 | PR-C6-node-reason-core | Repair stale Atlas graph routing tests so they exercise the current `AtlasLLMClient` port-adapter seam instead of the old `_llm_generate` helper seam. |
 | PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
 | PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | merged #567 | PR-D23-landing-reasoning-parity | Added `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T18:12Z by codex-2026-05-17
+Last updated: 2026-05-17T19:00Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
-| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #569 | TBD | Move the reason-node execution contract into core while leaving host-specific prompt construction in Atlas. | reasoning graph reason node |
+| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #570 | TBD | Repair Atlas graph routing tests for the current port-adapter seam, then continue graph/state wrapper split work. | Atlas graph routing tests |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/plans/PR-Reasoning-Core-Graph-Routing-Test-Seam-2026-05-17.md
+++ b/plans/PR-Reasoning-Core-Graph-Routing-Test-Seam-2026-05-17.md
@@ -1,0 +1,58 @@
+# Repair Atlas graph routing tests for port adapter seam
+
+## Why this slice exists
+
+PR #570 moved the graph reason node onto the `AtlasLLMClient` port-adapter
+path. A focused check of the older Atlas graph routing tests found four stale
+tests still monkeypatching `atlas_brain.reasoning.graph._llm_generate`. Those
+tests now exercise the fallback path instead of the intended LLM response path.
+
+## Scope
+
+Repair the stale tests so they provide fake LLM services with a `chat(...)`
+method, matching the current `AtlasLLMClient` runtime contract.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Reasoning-Core-Graph-Routing-Test-Seam-2026-05-17.md`
+- `tests/test_reasoning_graph_routing.py`
+- `tests/test_reasoning_graph_summary.py`
+
+## Mechanism
+
+- Add small fake chat-service helpers in the affected tests.
+- Replace stale `_llm_generate` monkeypatches with `get_pipeline_llm` /
+  `_resolve_graph_llm` fakes returning those chat-service helpers.
+- Keep the existing assertions: workload routing, model override behavior,
+  parsed graph outputs, and summary sanitization.
+- Close the merged #570 coordination row and claim this repair slice.
+
+## Intentional
+
+- No production behavior changes.
+- No changes to `AtlasLLMClient`.
+- No changes to the reasoning graph node APIs.
+
+## Deferred
+
+- Further graph/state wrapper split work remains after the tests match the
+  current port seam.
+
+## Verification
+
+- Focused Python compile for the two edited test files.
+- Focused pytest for graph routing and graph summary tests.
+- Focused regression sweep including graph node and graph wiring tests.
+- Git whitespace check.
+- Local PR review script.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Coordination + plan | ~65 |
+| Test seam repair | ~75 |
+| **Total** | ~140 |

--- a/tests/test_reasoning_graph_routing.py
+++ b/tests/test_reasoning_graph_routing.py
@@ -9,6 +9,17 @@ from atlas_brain.reasoning.reflection import run_reflection
 from atlas_brain.pipelines.llm import get_pipeline_llm
 
 
+class _StaticChatService:
+    def __init__(self, response: str, usage: dict | None = None) -> None:
+        self.response = response
+        self.usage = usage or {}
+        self.calls = []
+
+    def chat(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"response": self.response, "usage": dict(self.usage)}
+
+
 def test_reasoning_prompt_exports_are_available_from_both_modules():
     from atlas_brain.reasoning import graph_prompts, prompts
 
@@ -27,16 +38,15 @@ async def test_graph_triage_uses_configured_pipeline_workload(monkeypatch):
     monkeypatch.setattr(settings.reasoning, "graph_triage_workload", "triage")
     monkeypatch.setattr(settings.reasoning, "graph_openrouter_model", "openai/o4-mini")
     calls = []
+    service = _StaticChatService(
+        '{"priority":"high","needs_reasoning":true,"reasoning":"ok"}'
+    )
 
     def _fake_get_pipeline_llm(**kwargs):
         calls.append(kwargs)
-        return object()
+        return service
 
     monkeypatch.setattr("atlas_brain.pipelines.llm.get_pipeline_llm", _fake_get_pipeline_llm)
-    monkeypatch.setattr(
-        "atlas_brain.reasoning.graph._llm_generate",
-        AsyncMock(return_value={"response": '{"priority":"high","needs_reasoning":true,"reasoning":"ok"}', "usage": {}}),
-    )
 
     state = {"event_type": "b2b.high_intent_detected", "source": "test", "entity_type": "company", "entity_id": "Acme", "payload": {}}
     result = await _node_triage(state)
@@ -47,6 +57,7 @@ async def test_graph_triage_uses_configured_pipeline_workload(monkeypatch):
         "auto_activate_ollama": False,
         "openrouter_model": None,
     }]
+    assert service.calls
     assert result["triage_priority"] == "high"
 
 
@@ -55,16 +66,15 @@ async def test_graph_reason_uses_configured_pipeline_workload(monkeypatch):
     monkeypatch.setattr(settings.reasoning, "graph_reasoning_workload", "openrouter")
     monkeypatch.setattr(settings.reasoning, "graph_openrouter_model", "openai/o4-mini")
     calls = []
+    service = _StaticChatService(
+        '{"connections":["pricing"],"actions":[],"rationale":"ok","should_notify":true}'
+    )
 
     def _fake_get_pipeline_llm(**kwargs):
         calls.append(kwargs)
-        return object()
+        return service
 
     monkeypatch.setattr("atlas_brain.pipelines.llm.get_pipeline_llm", _fake_get_pipeline_llm)
-    monkeypatch.setattr(
-        "atlas_brain.reasoning.graph._llm_generate",
-        AsyncMock(return_value={"response": '{"connections":["pricing"],"actions":[],"rationale":"ok","should_notify":true}', "usage": {}}),
-    )
 
     state = {"event_type": "b2b.high_intent_detected", "source": "test", "payload": {}, "b2b_churn": {}}
     result = await _node_reason(state)
@@ -74,6 +84,7 @@ async def test_graph_reason_uses_configured_pipeline_workload(monkeypatch):
         "auto_activate_ollama": False,
         "openrouter_model": "openai/o4-mini",
     }]
+    assert service.calls
     assert result["connections_found"] == ["pricing"]
 
 
@@ -82,16 +93,13 @@ async def test_graph_synthesis_uses_configured_pipeline_workload(monkeypatch):
     monkeypatch.setattr(settings.reasoning, "graph_synthesis_workload", "triage")
     monkeypatch.setattr(settings.reasoning, "graph_openrouter_model", "openai/o4-mini")
     calls = []
+    service = _StaticChatService("Summary")
 
     def _fake_get_pipeline_llm(**kwargs):
         calls.append(kwargs)
-        return object()
+        return service
 
     monkeypatch.setattr("atlas_brain.pipelines.llm.get_pipeline_llm", _fake_get_pipeline_llm)
-    monkeypatch.setattr(
-        "atlas_brain.reasoning.graph._llm_generate",
-        AsyncMock(return_value={"response": "Summary", "usage": {}}),
-    )
 
     state = {"should_notify": True, "event_type": "b2b.high_intent_detected", "action_results": [], "rationale": "ok"}
     result = await _node_synthesize(state)
@@ -102,6 +110,7 @@ async def test_graph_synthesis_uses_configured_pipeline_workload(monkeypatch):
         "auto_activate_ollama": False,
         "openrouter_model": None,
     }]
+    assert service.calls
     assert result["summary"] == "Summary."
 
 

--- a/tests/test_reasoning_graph_summary.py
+++ b/tests/test_reasoning_graph_summary.py
@@ -1,5 +1,3 @@
-from unittest.mock import AsyncMock
-
 import pytest
 
 from atlas_brain.reasoning.graph import (
@@ -7,6 +5,15 @@ from atlas_brain.reasoning.graph import (
     _node_synthesize,
     _sanitize_notification_summary,
 )
+
+
+class _StaticChatService:
+    def __init__(self, response: str, usage: dict | None = None) -> None:
+        self.response = response
+        self.usage = usage or {}
+
+    def chat(self, **kwargs):
+        return {"response": self.response, "usage": dict(self.usage)}
 
 
 def test_sanitize_notification_summary_removes_meta_narration():
@@ -59,22 +66,17 @@ def test_build_notification_fallback_prefers_connections():
 
 @pytest.mark.asyncio
 async def test_node_synthesize_sanitizes_graph_summary(monkeypatch):
-    monkeypatch.setattr(
-        "atlas_brain.reasoning.graph._resolve_graph_llm",
-        lambda workload: object(),
+    service = _StaticChatService(
+        (
+            "**Summarizing Atlas's results**\n\n"
+            "We alerted you about LARKI's reliability concerns and queued a reminder.\n\n"
+            "I'm thinking the owner should follow up soon."
+        ),
+        usage={"input_tokens": 5, "output_tokens": 7},
     )
     monkeypatch.setattr(
-        "atlas_brain.reasoning.graph._llm_generate",
-        AsyncMock(
-            return_value={
-                "response": (
-                    "**Summarizing Atlas's results**\n\n"
-                    "We alerted you about LARKI's reliability concerns and queued a reminder.\n\n"
-                    "I'm thinking the owner should follow up soon."
-                ),
-                "usage": {"input_tokens": 5, "output_tokens": 7},
-            }
-        ),
+        "atlas_brain.reasoning.graph._resolve_graph_llm",
+        lambda workload: service,
     )
 
     state = {


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Graph-Routing-Test-Seam-2026-05-17.md

## Summary
- close the merged #570 coordination row and claim PR-C7
- update Atlas graph routing tests to fake the current `AtlasLLMClient` `chat(...)` seam
- keep routing/model override and summary sanitization assertions intact

## Verification
- `python -m py_compile tests/test_reasoning_graph_routing.py tests/test_reasoning_graph_summary.py`
- `pytest tests/test_reasoning_graph_routing.py tests/test_reasoning_graph_summary.py -q` -> 18 passed
- `pytest tests/test_extracted_reasoning_core_graph_nodes.py tests/test_atlas_reasoning_run_reasoning_graph_wiring.py tests/test_reasoning_graph_routing.py tests/test_reasoning_graph_summary.py -q` -> 40 passed
- `bash scripts/local_pr_review.sh` -> passed