### PR TITLE
Route reflection LLM analysis through port adapter

### DIFF
--- a/atlas_brain/reasoning/graph.py
+++ b/atlas_brain/reasoning/graph.py
@@ -7,15 +7,13 @@ PR-C4e1 promoted the host-agnostic helpers (regex constants, summary
 text post-processing, JSON parsing, UUID validation, the
 ``plan_actions`` filter) into ``extracted_reasoning_core.graph_helpers``.
 This module re-exports them under their existing private names so
-internal callers (notably ``reflection.py`` which imports
-``_parse_llm_json``) keep working without touching their import sites.
-The next sub-slices (PR-C4e2/e3) will move the LLM-driven nodes and
-the orchestrator behind those imports.
+internal callers keep working without touching their import sites. The
+next sub-slices (PR-C4e2/e3) will move the LLM-driven nodes and the
+orchestrator behind those imports.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from typing import Any
@@ -34,11 +32,10 @@ from .state import ReasoningAgentState
 
 logger = logging.getLogger("atlas.reasoning.graph")
 
-# Per-call deadline for the graph's LLM round-trips. Atlas's pre-
-# extraction ``_llm_generate`` enforced 120s via ``asyncio.wait_for``;
-# the new path threads this through Port metadata so ``AtlasLLMClient``
-# can apply the same outer ``wait_for`` (and forward it to ``chat`` as
-# a kwarg, in case the underlying client honors timeouts natively).
+# Per-call deadline for the graph's LLM round-trips. Threaded through Port
+# metadata so ``AtlasLLMClient`` can apply an outer ``asyncio.wait_for`` and
+# forward it to ``chat`` as a kwarg in case the underlying client honors
+# timeouts natively.
 _GRAPH_LLM_TIMEOUT_S: float = 120.0
 
 
@@ -61,48 +58,6 @@ def _resolve_graph_llm(workload: str, *, use_model_override: bool = False):
         auto_activate_ollama=False,
         openrouter_model=model_override,
     )
-
-
-async def _llm_generate(llm, prompt: str, system_prompt: str,
-                         max_tokens: int = 1024, temperature: float = 0.3,
-                         timeout: float = 120.0,
-                         json_mode: bool = False) -> dict[str, Any]:
-    """Call LLM.chat() from async context and return response with usage.
-
-    Args:
-        timeout: Maximum seconds to wait for the LLM response (default 120s).
-                 Raises asyncio.TimeoutError if exceeded.
-        json_mode: When True, pass response_format={"type":"json_object"} to
-                   force structured JSON output (needed for some reasoning
-                   models that may return prose otherwise).
-
-    Returns:
-        Dict with 'response' (str) and 'usage' (dict with input_tokens, output_tokens)
-    """
-    from ..services.protocols import Message
-
-    messages = [
-        Message(role="system", content=system_prompt),
-        Message(role="user", content=prompt),
-    ]
-    kwargs: dict[str, Any] = {
-        "messages": messages,
-        "max_tokens": max_tokens,
-        "temperature": temperature,
-        "timeout": timeout,
-    }
-    if json_mode:
-        kwargs["response_format"] = {"type": "json_object"}
-    # Always use sync chat() via thread -- chat_async() returns only str,
-    # losing the usage dict needed for token tracking.
-    result = await asyncio.wait_for(
-        asyncio.to_thread(llm.chat, **kwargs),
-        timeout=timeout,
-    )
-    return {
-        "response": result.get("response", ""),
-        "usage": result.get("usage", {}),
-    }
 
 
 def _build_atlas_graph_nodes() -> "GraphNodes":

--- a/atlas_brain/reasoning/reflection.py
+++ b/atlas_brain/reasoning/reflection.py
@@ -88,17 +88,20 @@ async def _run_reflection_cycle(ports: "ReasoningPorts") -> dict[str, Any]:
 
     try:
         import asyncio
-        from .graph import _llm_generate, _parse_llm_json
-        result = await asyncio.wait_for(
-            _llm_generate(
-                llm, prompt, REFLECTION_SYSTEM,
-                max_tokens=settings.reasoning.max_tokens,
-                temperature=settings.reasoning.temperature,
-            ),
+        from extracted_reasoning_core.graph_helpers import complete_with_json
+
+        from .port_adapters import AtlasLLMClient
+
+        result = await complete_with_json(
+            AtlasLLMClient(llm),
+            REFLECTION_SYSTEM,
+            prompt,
+            max_tokens=settings.reasoning.max_tokens,
+            temperature=settings.reasoning.temperature,
+            json_mode=True,
             timeout=120.0,
         )
-        text = result["response"]
-        analyzed = _parse_llm_json(text)
+        analyzed = result["parsed"] if result["parse_ok"] else {}
         llm_findings = analyzed.get("findings", [])
     except asyncio.TimeoutError:
         logger.warning("Reflection LLM timed out, using rule-based findings only")

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T19:00Z by codex-2026-05-17
+Last updated: 2026-05-17T19:31Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | Repair Atlas graph routing tests for port adapter seam | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `plans/PR-Reasoning-Core-Graph-Routing-Test-Seam-2026-05-17.md`, `tests/test_reasoning_graph_routing.py`, `tests/test_reasoning_graph_summary.py` | codex-2026-05-17 | Avoid editing Atlas graph-routing tests or reasoning-core coordination state until this PR lands. |
+| TBD | Route reflection LLM analysis through port adapter | `atlas_brain/reasoning/graph.py`, `atlas_brain/reasoning/reflection.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `plans/PR-Reasoning-Core-Reflection-Port-Adapter-2026-05-17.md`, `tests/test_anthropic_timeout.py`, `tests/test_atlas_reasoning_reflection_tracing.py`, `tests/test_reasoning_graph_routing.py` | codex-2026-05-17 | Avoid editing reflection LLM routing, graph legacy helper cleanup, or reasoning-core coordination state until this PR lands. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T19:00Z by codex-2026-05-17
+Last updated: 2026-05-17T19:31Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -14,6 +14,7 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C4-phrase-metadata-utility | `extracted_reasoning_core` | merged #565 | PR-C3-enrichment-pack-split | Pure phrase metadata readers now live in `atlas_brain.reasoning.phrase_metadata`; the task module is a compatibility wrapper. |
 | PR-C5-manifest-standalone-smoke | `extracted_reasoning_core` | merged #569 | PR-C4-phrase-metadata-utility | Added reasoning-core manifest ownership, standalone smoke, and shared validation wiring so the product is covered by the same extraction checks as the other extracted packages. |
 | PR-C6-node-reason-core | `extracted_reasoning_core` | merged #570 | PR-C5-manifest-standalone-smoke | Promoted the graph reason-node LLM call / parse / fallback contract into core while Atlas keeps its host-specific prompt builder. |
-| PR-C7-graph-routing-test-seam | `extracted_reasoning_core` | codex-2026-05-17 | PR-C6-node-reason-core | Repair stale Atlas graph routing tests so they exercise the current `AtlasLLMClient` port-adapter seam instead of the old `_llm_generate` helper seam. |
+| PR-C7-graph-routing-test-seam | `extracted_reasoning_core` | merged #571 | PR-C6-node-reason-core | Repaired stale Atlas graph routing tests so they exercise the current `AtlasLLMClient` port-adapter seam instead of the old `_llm_generate` helper seam. |
+| PR-C8-reflection-port-adapter | `extracted_reasoning_core` | codex-2026-05-17 | PR-C7-graph-routing-test-seam | Route reflection LLM analysis through `AtlasLLMClient` + `complete_with_json`, then remove the legacy `_llm_generate` helper from `atlas_brain.reasoning.graph`. |
 | PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
 | PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | merged #567 | PR-D23-landing-reasoning-parity | Added `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T19:00Z by codex-2026-05-17
+Last updated: 2026-05-17T19:31Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
-| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #570 | TBD | Repair Atlas graph routing tests for the current port-adapter seam, then continue graph/state wrapper split work. | Atlas graph routing tests |
+| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #571 | TBD | Route reflection LLM analysis through the current port-adapter seam, then continue graph/state wrapper split work. | reflection LLM routing |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/plans/PR-Reasoning-Core-Reflection-Port-Adapter-2026-05-17.md
+++ b/plans/PR-Reasoning-Core-Reflection-Port-Adapter-2026-05-17.md
@@ -1,0 +1,70 @@
+# Route reflection LLM analysis through port adapter
+
+## Why this slice exists
+
+After PR #570 and PR #571, the reactive graph nodes use
+`AtlasLLMClient` through the extracted reasoning-core port contract. Reflection
+still calls the legacy `atlas_brain.reasoning.graph._llm_generate` helper. That
+keeps a second LLM call path alive after the graph nodes have moved to the port
+adapter seam.
+
+## Scope (this PR)
+
+Move reflection's LLM analysis onto `AtlasLLMClient` plus
+`extracted_reasoning_core.graph_helpers.complete_with_json`, then remove the
+now-obsolete `_llm_generate` helper from `atlas_brain.reasoning.graph`.
+
+### Files touched
+
+- `atlas_brain/reasoning/graph.py`
+- `atlas_brain/reasoning/reflection.py`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Reasoning-Core-Reflection-Port-Adapter-2026-05-17.md`
+- `tests/test_anthropic_timeout.py`
+- `tests/test_atlas_reasoning_reflection_tracing.py`
+- `tests/test_reasoning_graph_routing.py`
+
+## Mechanism
+
+- Replace reflection's `_llm_generate` / `_parse_llm_json` import with
+  `AtlasLLMClient` and `complete_with_json`.
+- Pass `json_mode=True` for reflection analysis so the port adapter requests a
+  JSON object from providers that support structured output. This is an
+  intentional reliability upgrade over the old best-effort parse-only path.
+- Keep reflection's existing configured workload and fallback behavior.
+- Remove `_llm_generate` from `atlas_brain.reasoning.graph` once reflection no
+  longer imports it.
+- Update tests to fake the current `chat(...)` seam instead of the removed
+  helper.
+- Advance coordination docs from merged #571 to this PR-C8 slice.
+
+## Intentional
+
+- No change to graph node behavior.
+- No change to reflection's notification/action policy.
+- No change to provider routing or configured workload names.
+- Intentional LLM call-shape change: reflection analysis now requests
+  structured JSON output through the same metadata path as graph nodes.
+
+## Deferred
+
+- Further graph/state wrapper split work remains after reflection uses the same
+  LLM port seam as the graph nodes.
+
+## Verification
+
+- Focused Python compile for edited production and test files.
+- Focused pytest for reflection, routing, graph, and Anthropic timeout tests.
+- Git whitespace check.
+- Local PR review script.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Production routing cleanup | ~70 |
+| Tests | ~70 |
+| Coordination + plan | ~80 |
+| **Total** | ~220 |

--- a/tests/test_anthropic_timeout.py
+++ b/tests/test_anthropic_timeout.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from atlas_brain.reasoning.graph import _llm_generate
+from atlas_brain.reasoning.port_adapters import AtlasLLMClient
 from atlas_brain.services.llm.anthropic import AnthropicLLM
 from atlas_brain.services.protocols import Message
 
@@ -43,11 +43,14 @@ def test_anthropic_chat_uses_request_timeout_override():
 
 
 @pytest.mark.asyncio
-async def test_graph_llm_generate_passes_timeout(monkeypatch):
+async def test_atlas_llm_client_passes_timeout_metadata(monkeypatch):
     async def _direct_to_thread(func, /, *args, **kwargs):
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("atlas_brain.reasoning.graph.asyncio.to_thread", _direct_to_thread)
+    monkeypatch.setattr(
+        "atlas_brain.reasoning.port_adapters.asyncio.to_thread",
+        _direct_to_thread,
+    )
 
     class FakeLLM:
         def __init__(self):
@@ -61,13 +64,14 @@ async def test_graph_llm_generate_passes_timeout(monkeypatch):
             }
 
     llm = FakeLLM()
-    result = await _llm_generate(
-        llm,
-        prompt="hello",
-        system_prompt="system",
+    result = await AtlasLLMClient(llm).complete(
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "hello"},
+        ],
         max_tokens=64,
         temperature=0.2,
-        timeout=120.0,
+        metadata={"timeout": 120.0},
     )
 
     assert llm.kwargs["timeout"] == 120.0

--- a/tests/test_atlas_reasoning_reflection_tracing.py
+++ b/tests/test_atlas_reasoning_reflection_tracing.py
@@ -16,12 +16,11 @@ These tests pin:
 - An exception inside the cycle still closes the span -- with status
   ``"error"`` and ``error_message`` / ``error_type`` -- and re-raises
 
-Atlas's heavy chains (services / pipelines / config) plus the
-reflection-internal helpers (patterns detectors, graph helpers, the
-LLM client) are stubbed in ``sys.modules`` so the test runs in
-standalone CI without the full atlas dep stack. Stubs are restored on
-teardown (lesson from PR-C4d's Codex review -- otherwise sibling test
-files in the same pytest invocation would see this file's stubs).
+Atlas's heavy chains (services / pipelines / config) plus the pattern detector
+are stubbed in ``sys.modules`` so the test runs in standalone CI without the
+full atlas dep stack. Stubs are restored on teardown (lesson from PR-C4d's
+Codex review -- otherwise sibling test files in the same pytest invocation
+would see this file's stubs).
 """
 
 from __future__ import annotations
@@ -40,12 +39,12 @@ import pytest
 
 _STUBBED_MODULE_NAMES = (
     "atlas_brain.services",
+    "atlas_brain.services.protocols",
     "atlas_brain.services.tracing",
     "atlas_brain.pipelines",
     "atlas_brain.pipelines.llm",
     "atlas_brain.config",
     "atlas_brain.reasoning.patterns",
-    "atlas_brain.reasoning.graph",
     "atlas_brain.reasoning.graph_prompts",
 )
 
@@ -55,6 +54,14 @@ def _build_atlas_stubs(
 ) -> dict[str, types.ModuleType]:
     services_pkg = types.ModuleType("atlas_brain.services")
     services_pkg.__path__ = []
+    protocols_mod = types.ModuleType("atlas_brain.services.protocols")
+
+    class Message:
+        def __init__(self, role: str, content: str) -> None:
+            self.role = role
+            self.content = content
+
+    protocols_mod.Message = Message
     tracing_mod = types.ModuleType("atlas_brain.services.tracing")
     tracing_mod.tracer = object()  # never reached; explicit ports bypass default
 
@@ -90,29 +97,17 @@ def _build_atlas_stubs(
 
     patterns_mod.run_all_pattern_detectors = _fake_run_all_pattern_detectors
 
-    graph_mod = types.ModuleType("atlas_brain.reasoning.graph")
-
-    async def _fake_llm_generate(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        return {"response": '{"findings": []}', "usage": {}}
-
-    def _fake_parse_llm_json(text: str) -> dict[str, Any]:
-        import json as _json
-        return _json.loads(text)
-
-    graph_mod._llm_generate = _fake_llm_generate
-    graph_mod._parse_llm_json = _fake_parse_llm_json
-
     graph_prompts_mod = types.ModuleType("atlas_brain.reasoning.graph_prompts")
     graph_prompts_mod.REFLECTION_SYSTEM = "system"
 
     return {
         "atlas_brain.services": services_pkg,
+        "atlas_brain.services.protocols": protocols_mod,
         "atlas_brain.services.tracing": tracing_mod,
         "atlas_brain.pipelines": pipelines_pkg,
         "atlas_brain.pipelines.llm": pipelines_llm_mod,
         "atlas_brain.config": config_mod,
         "atlas_brain.reasoning.patterns": patterns_mod,
-        "atlas_brain.reasoning.graph": graph_mod,
         "atlas_brain.reasoning.graph_prompts": graph_prompts_mod,
     }
 

--- a/tests/test_reasoning_graph_routing.py
+++ b/tests/test_reasoning_graph_routing.py
@@ -118,19 +118,16 @@ async def test_graph_synthesis_uses_configured_pipeline_workload(monkeypatch):
 async def test_reflection_uses_configured_pipeline_workload(monkeypatch):
     monkeypatch.setattr(settings.reasoning, "graph_synthesis_workload", "triage")
     calls = []
+    service = _StaticChatService('{"findings":[]}')
 
     def _fake_get_pipeline_llm(**kwargs):
         calls.append(kwargs)
-        return object()
+        return service
 
     monkeypatch.setattr("atlas_brain.pipelines.llm.get_pipeline_llm", _fake_get_pipeline_llm)
     monkeypatch.setattr(
         "atlas_brain.reasoning.patterns.run_all_pattern_detectors",
         AsyncMock(return_value=[{"description": "signal"}]),
-    )
-    monkeypatch.setattr(
-        "atlas_brain.reasoning.graph._llm_generate",
-        AsyncMock(return_value={"response": '{"findings":[]}', "usage": {}}),
     )
 
     result = await run_reflection()
@@ -139,6 +136,8 @@ async def test_reflection_uses_configured_pipeline_workload(monkeypatch):
     assert len(calls) == 1
     assert calls[0]["workload"] == "triage"
     assert calls[0]["auto_activate_ollama"] is False
+    assert service.calls
+    assert service.calls[0]["response_format"] == {"type": "json_object"}
     assert result["findings"] == 1
 
 


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Reflection-Port-Adapter-2026-05-17.md

## Summary
- route reflection LLM analysis through `AtlasLLMClient` + `complete_with_json`
- remove the obsolete `_llm_generate` helper from `atlas_brain.reasoning.graph`
- update routing, reflection tracing, and timeout tests to fake the current `chat(...)` seam
- advance reasoning-core coordination from merged #571 to PR-C8

## Verification
- `python -m py_compile atlas_brain/reasoning/graph.py atlas_brain/reasoning/reflection.py tests/test_anthropic_timeout.py tests/test_atlas_reasoning_reflection_tracing.py tests/test_reasoning_graph_routing.py`
- `pytest tests/test_anthropic_timeout.py tests/test_atlas_reasoning_reflection_tracing.py tests/test_reasoning_graph_routing.py -q` -> 18 passed
- `pytest tests/test_extracted_reasoning_core_graph_nodes.py tests/test_atlas_reasoning_run_reasoning_graph_wiring.py tests/test_reasoning_graph_summary.py -q` -> 29 passed
- `git diff --check` -> passed
- `bash scripts/local_pr_review.sh` -> passed