### PR TITLE
Document reasoning graph boundary closeout

### DIFF
--- a/docs/extraction/coordination/decisions.md
+++ b/docs/extraction/coordination/decisions.md
@@ -1,6 +1,6 @@
 # Decisions Log
 
-Last updated: 2026-05-04T01:37Z by codex-2026-05-03
+Last updated: 2026-05-17T19:46Z by codex-2026-05-17
 
 Append-only chronological log. Never edit historical entries; supersede with a newer entry instead. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -27,3 +27,4 @@ Append-only chronological log. Never edit historical entries; supersede with a n
 - **2026-05-04** — PR-D6 merged as #110. AI Content Ops now has a product-owned JSON/CSV opportunity importer and CLI, so hosts can load customer rows into `campaign_opportunities` before running DB-backed campaign generation.
 - **2026-05-04** — PR-D7 merged as #112. AI Content Ops now has a host install runbook covering DSN setup, migrations, opportunity import, optional reasoning JSON, optional prompt skill roots, DB-backed generation, and output verification.
 - **2026-05-04** — PR-D8 merged as #116. AI Content Ops now has a product-owned read-only campaign draft export path for reviewing generated `b2b_campaigns` rows as JSON/CSV, plus export-specific indexes for account, vendor, company, and status review filters.
+- **2026-05-17** — Reasoning-core graph extraction reached a practical stop point after PR-C6 through PR-C8 (#570-#572). Core owns graph JSON helpers plus the triage/reason/synthesize node contracts; Atlas owns host LLM resolution, prompt assembly, graph orchestration, context aggregation, locks, action execution, notifications, and reflection as a host-side analysis pass through the shared LLM port adapter. Further graph extraction should require a concrete product need, not just parity with the old boundary-audit backlog.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T19:31Z by codex-2026-05-17
+Last updated: 2026-05-17T19:46Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | Route reflection LLM analysis through port adapter | `atlas_brain/reasoning/graph.py`, `atlas_brain/reasoning/reflection.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `plans/PR-Reasoning-Core-Reflection-Port-Adapter-2026-05-17.md`, `tests/test_anthropic_timeout.py`, `tests/test_atlas_reasoning_reflection_tracing.py`, `tests/test_reasoning_graph_routing.py` | codex-2026-05-17 | Avoid editing reflection LLM routing, graph legacy helper cleanup, or reasoning-core coordination state until this PR lands. |
+| TBD | Document reasoning graph boundary closeout | `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/queue.md`, `docs/extraction/coordination/state.md`, `docs/extraction/coordination/decisions.md`, `plans/PR-Reasoning-Core-Graph-Boundary-Closeout-2026-05-17.md` | codex-2026-05-17 | Avoid changing the reasoning-core graph/reflection boundary docs until this lands. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/queue.md
+++ b/docs/extraction/coordination/queue.md
@@ -1,6 +1,6 @@
 # Upcoming Queue
 
-Last updated: 2026-05-17T19:31Z by codex-2026-05-17
+Last updated: 2026-05-17T19:46Z by codex-2026-05-17
 
 Sequence reflects dependencies. Claim a slice (set Owner) before starting code so a parallel session does not pick the same one. See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
@@ -15,6 +15,7 @@ A-series (cost-closure, `extracted_llm_infrastructure`) is fully merged: PR-A1 #
 | PR-C5-manifest-standalone-smoke | `extracted_reasoning_core` | merged #569 | PR-C4-phrase-metadata-utility | Added reasoning-core manifest ownership, standalone smoke, and shared validation wiring so the product is covered by the same extraction checks as the other extracted packages. |
 | PR-C6-node-reason-core | `extracted_reasoning_core` | merged #570 | PR-C5-manifest-standalone-smoke | Promoted the graph reason-node LLM call / parse / fallback contract into core while Atlas keeps its host-specific prompt builder. |
 | PR-C7-graph-routing-test-seam | `extracted_reasoning_core` | merged #571 | PR-C6-node-reason-core | Repaired stale Atlas graph routing tests so they exercise the current `AtlasLLMClient` port-adapter seam instead of the old `_llm_generate` helper seam. |
-| PR-C8-reflection-port-adapter | `extracted_reasoning_core` | codex-2026-05-17 | PR-C7-graph-routing-test-seam | Route reflection LLM analysis through `AtlasLLMClient` + `complete_with_json`, then remove the legacy `_llm_generate` helper from `atlas_brain.reasoning.graph`. |
+| PR-C8-reflection-port-adapter | `extracted_reasoning_core` | merged #572 | PR-C7-graph-routing-test-seam | Routed reflection LLM analysis through `AtlasLLMClient` + `complete_with_json`, then removed the legacy `_llm_generate` helper from `atlas_brain.reasoning.graph`. |
+| PR-C9-graph-boundary-closeout | `extracted_reasoning_core` | codex-2026-05-17 | PR-C8-reflection-port-adapter | Document the post-#570/#571/#572 graph boundary so follow-up work does not keep extracting Atlas orchestration wrappers by inertia. |
 | PR-D23-landing-reasoning-parity | `extracted_content_pipeline` | merged #566 | Content Ops packaged reasoning runtime | Added `landing_page` to the packaged structured reasoning runtime allowlist so catalog support and execution behavior match. |
 | PR-D24-email-campaign-reasoning-parity | `extracted_content_pipeline` | merged #567 | PR-D23-landing-reasoning-parity | Added `email_campaign` to the packaged structured reasoning runtime allowlist so the core campaign output can use packaged multi-pass reasoning. |

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T19:31Z by codex-2026-05-17
+Last updated: 2026-05-17T19:46Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
-| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #571 | TBD | Route reflection LLM analysis through the current port-adapter seam, then continue graph/state wrapper split work. | reflection LLM routing |
+| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #572 | TBD | Document the graph/reflection boundary closeout, then only continue extraction when a concrete product needs more than the current host-wrapper seam. | graph boundary docs |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
+++ b/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
@@ -36,8 +36,52 @@ actually exists.
 |---|---|---|
 | PR 4: Semantic cache split | Mostly shipped at the core boundary | `semantic_cache_keys.py`, `SemanticCacheStore`, `compute_evidence_hash`, and `build_semantic_cache_key` exist. Concrete storage remains outside core, which is the intended port split. |
 | PR 5: Reasoning pack registry | Mostly shipped | `pack_registry.py` exists, and atlas single-pass prompt packs register into it. The remaining gap is per-review enrichment, still atlas-side in `atlas_brain.reasoning.evidence_engine`. |
-| PR 6: Graph/state engine with ports | Partially shipped | Core graph, graph node, graph helper, and state modules exist. Atlas graph still has host-specific LLM resolution and orchestration wrappers. |
+| PR 6: Graph/state engine with ports | Shipped to the intended boundary | Core graph, graph node, graph helper, and state modules exist. After #570-#572, Atlas graph is a host wrapper around core node contracts plus Atlas-owned orchestration. |
 | PR 7: Product migration pass | Partially shipped | `extracted_content_pipeline.reasoning.*` wrappers point at core. Atlas wrappers for archetypes, temporal, evidence engine, and graph helpers are covered by alias tests. Import-boundary guard exists and is wired for extracted products. |
+
+## Graph Boundary Closeout After PR-C6 Through PR-C8
+
+PRs #570, #571, and #572 narrowed the graph/state gap enough that further
+graph extraction should stop unless a concrete product asks for it.
+
+Core now owns:
+
+- `extracted_reasoning_core.graph_helpers`: prompt rendering, JSON parsing,
+  token accounting, and `complete_with_json`.
+- `extracted_reasoning_core.graph_nodes`: `node_triage`, `node_reason`, and
+  `node_synthesize` LLM-call, parse, fallback, and usage-accumulation
+  contracts.
+- `extracted_reasoning_core.graph` and `state`: the package-local graph and
+  state substrate used by extracted products.
+
+Atlas now intentionally owns:
+
+- workload-specific LLM resolution in `_resolve_graph_llm`;
+- Atlas settings, timeout constants, and model override selection;
+- prompt assembly for Atlas event fields in `_node_reason`;
+- LangGraph orchestration and conditional routing;
+- context aggregation from Atlas stores;
+- entity lock checks;
+- action execution and notification side effects;
+- reflection as a host-side analysis pass routed through `AtlasLLMClient` and
+  `complete_with_json`.
+
+That boundary is deliberate. The remaining Atlas code depends on Atlas config,
+event payloads, stores, and side effects. Moving it into core would not make AI
+Content Ops more operational; it would make core own host integration behavior.
+
+### Stop rule
+
+Do not continue graph extraction just to match the old 2026-05-03 backlog.
+Reopen this track only when a product needs one of these concrete capabilities:
+
+1. a product-local event graph that cannot call the current core graph APIs;
+2. a reusable host adapter contract for non-Atlas LLM/workload resolution;
+3. a shared action/notification abstraction used by more than one product;
+4. a slimmed core state model needed by a product runtime.
+
+Until then, the higher-value reasoning work is on product-specific provider
+contracts and generated reasoning contexts, not on moving Atlas wrappers.
 
 ## Remaining Gaps
 
@@ -48,9 +92,9 @@ actually exists.
    and `_check_derivation_rule`. This is the clearest remaining PR 5 gap.
 
 2. **Atlas graph/state host wrapper split.**
-   `atlas_brain.reasoning.graph` still owns host-specific LLM resolution,
-   timeout handling, and orchestration glue. Core owns graph helpers/nodes, but
-   a full migration would be larger and riskier than the enrichment pack split.
+   This is now intentionally closed at the host-wrapper boundary described
+   above. Core owns reusable helpers and node contracts. Atlas owns workload
+   resolution and side-effect orchestration.
 
 3. **Queue/status drift.**
    Coordination docs still pointed at PR-C1 even though the code had advanced
@@ -75,3 +119,6 @@ Take the next code slice as the **per-review enrichment pack split**:
 
 Do not rebuild semantic cache, pack registry, graph helpers, or public API
 surfaces from the old audit wording; those already exist.
+
+Do not keep extracting Atlas graph wrappers unless a product-specific runtime
+needs one of the stop-rule capabilities above.

--- a/plans/PR-Reasoning-Core-Graph-Boundary-Closeout-2026-05-17.md
+++ b/plans/PR-Reasoning-Core-Graph-Boundary-Closeout-2026-05-17.md
@@ -1,0 +1,77 @@
+# Reasoning Core Graph Boundary Closeout
+
+## Why this slice exists
+
+PRs #570, #571, and #572 moved the reusable graph-node LLM contracts into
+`extracted_reasoning_core` and routed Atlas reflection through the same port
+adapter seam. The old boundary audit still says to continue the graph/state
+wrapper split, which now risks extracting Atlas host orchestration by inertia.
+
+This slice closes the planning loop: document what core owns, what Atlas still
+owns intentionally, and the concrete stop rule for reopening graph extraction.
+
+## Scope (this PR)
+
+1. Mark PR-C8 as merged and claim PR-C9 in the coordination queue.
+2. Replace the stale in-flight row with this documentation slice.
+3. Update per-product state so the next milestone is graph boundary closeout,
+   not more blind graph extraction.
+4. Amend the current-state audit with the post-#570/#571/#572 graph boundary.
+5. Record the decision in the coordination decisions log.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/queue.md`
+- `docs/extraction/coordination/state.md`
+- `docs/extraction/coordination/decisions.md`
+- `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`
+- `plans/PR-Reasoning-Core-Graph-Boundary-Closeout-2026-05-17.md`
+
+## Mechanism
+
+This is a documentation-only slice. It reconciles the current code state after
+the graph-node and reflection-port work:
+
+- Core owns `graph_helpers`, `graph_nodes`, package graph/state substrate, and
+  reusable LLM-call contracts.
+- Atlas owns host LLM resolution, prompt assembly for Atlas events, LangGraph
+  routing, context aggregation, locks, actions, notifications, and reflection
+  orchestration.
+
+The audit now includes a stop rule. Future graph work should start only from a
+specific product need, such as a non-Atlas LLM/workload adapter contract or a
+shared state model needed by a product runtime.
+
+## Intentional
+
+- No production code changes. The prior code slices already made the runtime
+  boundary change.
+- No tests added. Documentation-only coordination changes are verified through
+  local review and diff checks.
+- Reflection remains Atlas-side. It now uses the shared LLM port adapter, but
+  its analysis target is the Atlas graph state, not a product-neutral core
+  primitive.
+
+## Deferred
+
+- If a product needs its own event graph, add a focused adapter-contract slice
+  instead of moving Atlas graph orchestration wholesale.
+- If core state shape becomes a blocker for a product runtime, split Atlas-only
+  state fields from shared state in a dedicated state-slimming PR.
+- Continue AI Content Ops reasoning execution work from product needs, not from
+  the old graph/state checklist.
+
+## Verification
+
+- `git diff --check`
+- Local PR review bundle via `scripts/local_pr_review.sh`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~15 |
+| Current-state audit amendment | ~45 |
+| Plan doc | ~65 |
+| **Total** | ~125 |


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Graph-Boundary-Closeout-2026-05-17.md

Document the post-#570/#571/#572 reasoning graph boundary so follow-up work does not keep extracting Atlas host orchestration wrappers by inertia.

## Intentional
- Documentation-only slice; no runtime code changes.
- Reflection remains Atlas-side but routed through the shared LLM port adapter.
- The graph extraction stop rule requires a concrete product runtime need before more wrapper movement.

## Deferred
- Product-specific event graph or non-Atlas workload adapter contract, if a product asks for it.
- Core state slimming if product runtime state shape becomes a blocker.
- Continue AI Content Ops reasoning execution from product needs, not the old graph checklist.

## Verification
- git diff --check
- bash scripts/local_pr_review.sh

## Diff size
6 files, +137 / -11
