### PR TITLE
Close post-575 extraction state drift

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T20:55Z by codex-2026-05-17
+Last updated: 2026-05-17T21:01Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #575 | Refresh Content Ops productization audit | `extracted_content_pipeline/docs/remaining_productization_audit.md`, `plans/PR-Content-Ops-Productization-Audit-Refresh.md` | codex-2026-05-17 | Do not edit `remaining_productization_audit.md` until this lands |
+| #576 | Post-575 extraction state closeout | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`, `plans/PR-Post-575-Extraction-State-Closeout.md` | codex-2026-05-17 | Avoid editing extraction coordination/state or reasoning-core current-state audit |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T19:50Z by codex-2026-05-17
+Last updated: 2026-05-17T21:01Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #567 | — | Packaged reasoning-policy parity is closed for all reasoning-aware generated outputs. Next high-leverage work should come from a real source export fixture or the separate `extracted_reasoning_core` productization track. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #575 | — | Productization audit is current: copied task import blockers are closed, but native product paths should still be driven by real host/runtime gaps. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #573 | — | Graph/reflection boundary is closed at the host-wrapper seam. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
+++ b/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
@@ -1,6 +1,8 @@
 # Extracted Reasoning Core Current State
 
 Date: 2026-05-17
+Current-state refresh: 2026-05-17 after the #564 implementation, surfaced
+during post-#575 cleanup
 
 ## Purpose
 
@@ -28,6 +30,10 @@ actually exists.
   `_synthesis.py`.
 - Graph/state modules: `graph.py`, `graph_nodes.py`, `graph_helpers.py`,
   and `state.py`.
+- Atlas-side product pack split:
+  `atlas_brain.reasoning.review_enrichment.ReviewEnrichmentMixin` owns
+  per-review enrichment methods while `atlas_brain.reasoning.evidence_engine`
+  stays a wrapper over core's slim evidence engine.
 - Core test coverage under `tests/test_extracted_reasoning_core_*.py`.
 
 ## Status Against The Old PR 4-7 Backlog
@@ -35,7 +41,7 @@ actually exists.
 | Old backlog item | Current status | Notes |
 |---|---|---|
 | PR 4: Semantic cache split | Mostly shipped at the core boundary | `semantic_cache_keys.py`, `SemanticCacheStore`, `compute_evidence_hash`, and `build_semantic_cache_key` exist. Concrete storage remains outside core, which is the intended port split. |
-| PR 5: Reasoning pack registry | Mostly shipped | `pack_registry.py` exists, and atlas single-pass prompt packs register into it. The remaining gap is per-review enrichment, still atlas-side in `atlas_brain.reasoning.evidence_engine`. |
+| PR 5: Reasoning pack registry | Shipped for current scope | `pack_registry.py` exists, atlas single-pass prompt packs register into it, and atlas per-review enrichment now lives in `atlas_brain.reasoning.review_enrichment` with `evidence_engine` as a wrapper/mixin host. |
 | PR 6: Graph/state engine with ports | Shipped to the intended boundary | Core graph, graph node, graph helper, and state modules exist. After #570-#572, Atlas graph is a host wrapper around core node contracts plus Atlas-owned orchestration. |
 | PR 7: Product migration pass | Partially shipped | `extracted_content_pipeline.reasoning.*` wrappers point at core. Atlas wrappers for archetypes, temporal, evidence engine, and graph helpers are covered by alias tests. Import-boundary guard exists and is wired for extracted products. |
 
@@ -86,10 +92,14 @@ contracts and generated reasoning contexts, not on moving Atlas wrappers.
 ## Remaining Gaps
 
 1. **Per-review enrichment pack split.**
+   Closed for the current Atlas wrapper boundary. The enrichment methods
+   `compute_urgency`, `override_pain`, `derive_recommend`,
+   `derive_price_complaint`, `derive_budget_authority`, and
+   `_check_derivation_rule` live on
+   `atlas_brain.reasoning.review_enrichment.ReviewEnrichmentMixin`.
    `atlas_brain.reasoning.evidence_engine.EvidenceEngine` subclasses core and
-   keeps atlas-only enrichment methods: `compute_urgency`, `override_pain`,
-   `derive_recommend`, `derive_price_complaint`, `derive_budget_authority`,
-   and `_check_derivation_rule`. This is the clearest remaining PR 5 gap.
+   mixes in that atlas product pack so existing callers keep the same object
+   shape while core stays slim.
 
 2. **Atlas graph/state host wrapper split.**
    This is now intentionally closed at the host-wrapper boundary described
@@ -97,9 +107,10 @@ contracts and generated reasoning contexts, not on moving Atlas wrappers.
    resolution and side-effect orchestration.
 
 3. **Queue/status drift.**
-   Coordination docs still pointed at PR-C1 even though the code had advanced
-   through semantic cache keys, pack registry, graph/state, and migration
-   guards. This PR fixes that planning drift before more code work starts.
+   Coordination docs have now advanced through semantic cache keys, pack
+   registry, graph/state, migration guards, node reasoning, routing, reflection,
+   and graph-boundary closeout. Future drift should be fixed with targeted
+   closeout docs rather than reopening old PR-C1/PR-C5 work.
 
 4. **Standalone-toggle status.**
    The reasoning core is moving toward the phase-2 boundary, but this audit did
@@ -108,17 +119,35 @@ contracts and generated reasoning contexts, not on moving Atlas wrappers.
 
 ## Recommendation
 
-Take the next code slice as the **per-review enrichment pack split**:
+Do not take another reasoning-core code slice from the stale PR 4-7 backlog.
+Semantic cache keys, pack registry, per-review enrichment pack split,
+phrase-metadata utility, manifest smoke, graph node contracts, graph routing,
+and reflection port adapters have all landed for the current boundary.
 
-- Create a product-owned enrichment pack module outside core.
-- Keep `extracted_reasoning_core.evidence_engine` slim.
-- Preserve the atlas wrapper behavior so existing callers still get the same
-  `EvidenceEngine` object shape.
-- Add tests that prove the atlas wrapper delegates slim evidence decisions to
-  core while enrichment methods live in the product pack.
+The next reasoning-core slice should name a concrete runtime need, such as:
 
-Do not rebuild semantic cache, pack registry, graph helpers, or public API
-surfaces from the old audit wording; those already exist.
+1. a non-Atlas product needs a reusable host adapter contract for LLM/workload
+   resolution;
+2. a product asks for a slimmed state model beyond the current core state;
+3. AI Content Ops needs a new stable provider port or capability check after a
+   real generated-asset run exposes an operator/runtime gap.
 
 Do not keep extracting Atlas graph wrappers unless a product-specific runtime
 needs one of the stop-rule capabilities above.
+
+## Recommendation History
+
+- 2026-05-17 original audit: take the per-review enrichment pack split next.
+- 2026-05-17 post-#564 refresh: the split is closed for the current Atlas
+  wrapper boundary. Do not take another slice from the old backlog unless a
+  concrete runtime need appears.
+
+## Refresh Log
+
+### 2026-05-17
+
+- Marked the per-review enrichment pack split as closed after verifying
+  `atlas_brain.reasoning.review_enrichment` and the atlas evidence-engine
+  wrapper tests exist.
+- Reframed the next recommendation around concrete runtime triggers instead of
+  stale PR-C backlog items.

--- a/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
+++ b/docs/extraction/reasoning_core_current_state_audit_2026-05-17.md
@@ -89,7 +89,7 @@ Reopen this track only when a product needs one of these concrete capabilities:
 Until then, the higher-value reasoning work is on product-specific provider
 contracts and generated reasoning contexts, not on moving Atlas wrappers.
 
-## Remaining Gaps
+## Gap Status
 
 1. **Per-review enrichment pack split.**
    Closed for the current Atlas wrapper boundary. The enrichment methods

--- a/plans/PR-Post-575-Extraction-State-Closeout.md
+++ b/plans/PR-Post-575-Extraction-State-Closeout.md
@@ -7,7 +7,7 @@ table still lists #575 as in flight, and the reasoning-core current-state audit
 still recommends the per-review enrichment pack split even though that split
 already landed in code and queue as #564.
 
-## Scope
+## Scope (this PR)
 
 1. Remove merged #575 from the in-flight coordination table.
 2. Update Content Ops state to show #575 as the latest merged productization

--- a/plans/PR-Post-575-Extraction-State-Closeout.md
+++ b/plans/PR-Post-575-Extraction-State-Closeout.md
@@ -1,0 +1,63 @@
+# Post-575 Extraction State Closeout
+
+## Why this slice exists
+
+PR #575 merged the Content Ops productization audit refresh. The coordination
+table still lists #575 as in flight, and the reasoning-core current-state audit
+still recommends the per-review enrichment pack split even though that split
+already landed in code and queue as #564.
+
+## Scope
+
+1. Remove merged #575 from the in-flight coordination table.
+2. Update Content Ops state to show #575 as the latest merged productization
+   audit refresh.
+3. Update the reasoning-core current-state audit so the per-review enrichment
+   pack split is marked closed instead of recommended as next work.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`
+- `plans/PR-Post-575-Extraction-State-Closeout.md`
+
+## Mechanism
+
+This is documentation and coordination cleanup only. It records the verified
+code state: `atlas_brain.reasoning.review_enrichment.ReviewEnrichmentMixin`
+owns per-review enrichment methods, and
+`atlas_brain.reasoning.evidence_engine.EvidenceEngine` wraps core while mixing
+in that atlas product pack.
+
+## Intentional
+
+- No runtime code changes.
+- No test fixture changes.
+- No new reasoning-core extraction work.
+
+## Deferred
+
+- New reasoning-core code remains deferred until a concrete product runtime
+  asks for a capability listed in the graph-boundary stop rule.
+- AI Content Ops source export work remains deferred until a real host export
+  fixture exposes an adapter/runtime gap.
+
+## Verification
+
+The first two checks sanity-check the audit's claims about the already-landed
+reasoning wrapper boundary; they do not validate runtime changes in this slice.
+
+- Command: python -m py_compile atlas_brain/reasoning/evidence_engine.py atlas_brain/reasoning/review_enrichment.py; result: passed.
+- Command: pytest tests/test_atlas_reasoning_evidence_engine_aliases.py; result: 13 passed.
+- Command: git diff --check; result: passed.
+- Command: bash scripts/local_pr_review.sh; result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | ~10 |
+| Reasoning audit | ~55 |
+| Plan doc | ~65 |
+| **Total** | ~130 |


### PR DESCRIPTION
Plan: plans/PR-Post-575-Extraction-State-Closeout.md

## Summary
- Remove merged #575 from the extraction in-flight ledger.
- Update Content Ops coordination state to point at #575.
- Mark the reasoning-core per-review enrichment pack split closed in the current-state audit.

## Verification
- python -m py_compile atlas_brain/reasoning/evidence_engine.py atlas_brain/reasoning/review_enrichment.py
- pytest tests/test_atlas_reasoning_evidence_engine_aliases.py
- git diff --check
- bash scripts/local_pr_review.sh