### PR TITLE
Add reasoning core check runner

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T21:01Z by codex-2026-05-17
+Last updated: 2026-05-17T21:20Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #576 | Post-575 extraction state closeout | `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `docs/extraction/reasoning_core_current_state_audit_2026-05-17.md`, `plans/PR-Post-575-Extraction-State-Closeout.md` | codex-2026-05-17 | Avoid editing extraction coordination/state or reasoning-core current-state audit |
+| #577 | Reasoning core checks wrapper | `scripts/run_extracted_reasoning_core_checks.sh`, `scripts/run_extracted_pipeline_checks.sh`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Reasoning-Core-Checks-Wrapper.md` | codex-2026-05-17 | Avoid editing extracted reasoning/core check runners or extraction coordination state |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T21:01Z by codex-2026-05-17
+Last updated: 2026-05-17T21:20Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -9,7 +9,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
 | `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #575 | — | Productization audit is current: copied task import blockers are closed, but native product paths should still be driven by real host/runtime gaps. | none |
-| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #573 | — | Graph/reflection boundary is closed at the host-wrapper seam. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
+| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #576 | #577 | Product-specific check wrapper is in flight so reasoning core can be verified without using the Content Ops runner as the entry point. | `scripts/run_extracted_reasoning_core_checks.sh`, `scripts/run_extracted_pipeline_checks.sh` |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/plans/PR-Reasoning-Core-Checks-Wrapper.md
+++ b/plans/PR-Reasoning-Core-Checks-Wrapper.md
@@ -1,0 +1,74 @@
+# Reasoning Core Checks Wrapper
+
+## Why this slice exists
+
+`extracted_reasoning_core` has its own manifest, standalone smoke, import
+guards, and product tests, but its full check path is currently embedded inside
+`scripts/run_extracted_pipeline_checks.sh`. That keeps the reasoning product
+operationally tied to the Content Ops runner even though the products are now
+separate.
+
+## Scope
+
+1. Add a dedicated `scripts/run_extracted_reasoning_core_checks.sh` product
+   check wrapper.
+2. Have the broader Content Ops check runner delegate reasoning-core validation
+   to that wrapper instead of duplicating the commands inline.
+3. Remove merged #576 from the in-flight coordination table and claim this
+   slice.
+4. Update reasoning-core coordination state to reflect #576 as the latest
+   merged reasoning-core documentation closeout.
+
+### Files touched
+
+- `scripts/run_extracted_reasoning_core_checks.sh`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Reasoning-Core-Checks-Wrapper.md`
+
+## Mechanism
+
+The new wrapper runs the same reasoning-core gates already present in the full
+extracted pipeline runner:
+
+- manifest validation;
+- ASCII check;
+- no-Atlas-fallback import check;
+- forbidden Atlas reasoning import guard;
+- standalone reasoning-core smoke;
+- focused reasoning-core pytest suite plus the import-guard test.
+
+The Content Ops runner keeps its Content Ops checks and Atlas wrapper tests,
+but calls the reasoning-core wrapper for the core product checks.
+
+## Intentional
+
+- No runtime behavior changes.
+- No new reasoning capability.
+- No product API changes.
+- No broad backlog or audit refresh.
+
+## Deferred
+
+- Any new reasoning-core provider ports or AI Content Ops reasoning behavior
+  remain trigger-driven by a concrete runtime/product need.
+- Removing the in-flight row for this PR after merge remains the standard
+  post-merge coordination step.
+
+## Verification
+
+- Command: python -m pytest -q <reasoning-core test glob> tests/test_forbid_atlas_reasoning_imports.py; result: 295 passed.
+- Command: bash scripts/run_extracted_reasoning_core_checks.sh; result: 295 passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh; result: 1361 passed, 1 existing torch/pynvml warning.
+- Command: bash scripts/local_pr_review.sh; result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| New reasoning-core wrapper | ~20 |
+| Pipeline runner delegation | ~25 |
+| Coordination docs | ~8 |
+| Plan doc | ~70 |
+| **Total** | ~125 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -5,17 +5,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 bash scripts/validate_extracted_content_pipeline.sh
-bash extracted/_shared/scripts/validate_extracted.sh extracted_reasoning_core
 bash scripts/check_ascii_python.sh
-bash extracted/_shared/scripts/check_ascii_python.sh extracted_reasoning_core
 python scripts/check_extracted_imports.py
-python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_reasoning_core
 python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
-python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_reasoning_core
 python scripts/smoke_extracted_pipeline_imports.py
 python scripts/smoke_extracted_pipeline_standalone.py
-python scripts/smoke_extracted_reasoning_core_standalone.py
 python scripts/audit_extracted_standalone.py --fail-on-debt
+bash scripts/run_extracted_reasoning_core_checks.sh
 pytest \
   tests/test_extracted_campaign_analytics.py \
   tests/test_extracted_campaign_install_check.py \
@@ -85,27 +81,6 @@ pytest \
   tests/test_extracted_content_pipeline_reasoning_archetypes.py \
   tests/test_extracted_content_pipeline_reasoning_temporal.py \
   tests/test_extracted_content_pipeline_reasoning_evidence_engine.py \
-  tests/test_extracted_reasoning_core_manifest.py \
-  tests/test_extracted_reasoning_core_api.py \
-  tests/test_extracted_reasoning_core_run_reasoning.py \
-  tests/test_extracted_reasoning_core_continue_reasoning.py \
-  tests/test_extracted_reasoning_core_check_falsification.py \
-  tests/test_extracted_reasoning_core_build_narrative_plan.py \
-  tests/test_extracted_reasoning_core_semantic_cache.py \
-  tests/test_extracted_reasoning_core_load_reasoning_pack.py \
-  tests/test_extracted_reasoning_core_validate_reasoning_output.py \
-  tests/test_extracted_reasoning_core_archetypes.py \
-  tests/test_extracted_reasoning_core_evidence_engine.py \
-  tests/test_extracted_reasoning_core_event_trace_ports.py \
-  tests/test_extracted_reasoning_core_graph.py \
-  tests/test_extracted_reasoning_core_graph_helpers.py \
-  tests/test_extracted_reasoning_core_graph_nodes.py \
-  tests/test_extracted_reasoning_core_pack_registry.py \
-  tests/test_extracted_reasoning_core_semantic_cache_keys.py \
-  tests/test_extracted_reasoning_core_temporal.py \
-  tests/test_extracted_reasoning_core_types.py \
-  tests/test_extracted_reasoning_core_domains.py \
-  tests/test_extracted_reasoning_core_wedge_registry.py \
   tests/test_atlas_reasoning_state_inherits_core.py \
   tests/test_atlas_reasoning_port_adapters.py \
   tests/test_atlas_reasoning_vendor_pressure.py \
@@ -119,7 +94,6 @@ pytest \
   tests/test_atlas_reasoning_temporal_aliases.py \
   tests/test_atlas_reasoning_archetypes_aliases.py \
   tests/test_atlas_reasoning_evidence_engine_aliases.py \
-  tests/test_forbid_atlas_reasoning_imports.py \
   tests/test_extracted_product_utilities.py \
   tests/test_extracted_b2b_batch_utils.py \
   tests/test_extracted_blog_matching.py \

--- a/scripts/run_extracted_reasoning_core_checks.sh
+++ b/scripts/run_extracted_reasoning_core_checks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+bash extracted/_shared/scripts/validate_extracted.sh extracted_reasoning_core
+bash extracted/_shared/scripts/check_ascii_python.sh extracted_reasoning_core
+python extracted/_shared/scripts/check_extracted_imports.py --no-atlas-fallback extracted_reasoning_core
+python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_reasoning_core
+python scripts/smoke_extracted_reasoning_core_standalone.py
+
+python -m pytest -q \
+  tests/test_extracted_reasoning_core_*.py \
+  tests/test_forbid_atlas_reasoning_imports.py
+
+echo "All extracted_reasoning_core checks passed"


### PR DESCRIPTION
Plan: plans/PR-Reasoning-Core-Checks-Wrapper.md

## Summary
- Add a dedicated extracted reasoning-core check wrapper.
- Have the broader extracted pipeline runner delegate reasoning-core checks to that wrapper.
- Remove merged #576 from the in-flight ledger and claim this slice.

## Verification
- python -m pytest -q <reasoning-core test glob> tests/test_forbid_atlas_reasoning_imports.py -> 295 passed
- bash scripts/run_extracted_reasoning_core_checks.sh -> 295 passed
- bash scripts/run_extracted_pipeline_checks.sh -> 1361 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh