### PR TITLE
Add Content Ops ingestion diagnostics

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T21:20Z by codex-2026-05-17
+Last updated: 2026-05-17T21:52Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #577 | Reasoning core checks wrapper | `scripts/run_extracted_reasoning_core_checks.sh`, `scripts/run_extracted_pipeline_checks.sh`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Reasoning-Core-Checks-Wrapper.md` | codex-2026-05-17 | Avoid editing extracted reasoning/core check runners or extraction coordination state |
+| #578 | Content Ops ingestion diagnostics | `extracted_content_pipeline/ingestion_diagnostics.py`, `scripts/inspect_extracted_content_ingestion.py`, `tests/test_extracted_content_ingestion_diagnostics.py`, `scripts/run_extracted_pipeline_checks.sh`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Diagnostics.md` | codex-2026-05-17 | Avoid editing Content Ops ingestion diagnostics, source/import docs, or extracted pipeline checks |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T21:20Z by codex-2026-05-17
+Last updated: 2026-05-17T21:52Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,8 +8,8 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #575 | — | Productization audit is current: copied task import blockers are closed, but native product paths should still be driven by real host/runtime gaps. | none |
-| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #576 | #577 | Product-specific check wrapper is in flight so reasoning core can be verified without using the Content Ops runner as the entry point. | `scripts/run_extracted_reasoning_core_checks.sh`, `scripts/run_extracted_pipeline_checks.sh` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #575 | #578 | Ingestion diagnostics are in flight so hosts can inspect opportunity/source-row exports before import or generation. | `extracted_content_pipeline/ingestion_diagnostics.py`, `scripts/inspect_extracted_content_ingestion.py` |
+| `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 
 Phase legend: 0 = pre-extraction (audit doc only). 1 = byte-for-byte scaffold, still imports from `atlas_brain`. 2 = standalone toggle loads local substrate (per-product env var: `EXTRACTED_LLM_INFRA_STANDALONE`, `EXTRACTED_COMP_INTEL_STANDALONE`, `EXTRACTED_PIPELINE_STANDALONE`, etc.; see `extracted/METHODOLOGY.md` for the canonical list). 3 = full Protocol-based decoupling, no `atlas_brain` runtime imports.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -149,6 +149,16 @@ subscription, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
 and document source rows can be converted into the same opportunity payload
 first. Source rows can be JSON, JSONL, or CSV:
 
+Before converting or importing a customer export, inspect ingestion readiness:
+
+```bash
+python scripts/inspect_extracted_content_ingestion.py \
+  extracted_content_pipeline/examples/campaign_source_rows.jsonl \
+  --source-rows \
+  --source-format jsonl \
+  --json
+```
+
 ```bash
 python scripts/build_extracted_campaign_opportunities_from_sources.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -118,6 +118,23 @@ written into an ambiguous tenant queue.
 
 ## Step 3: Validate Customer Data Offline
 
+Before generating or importing, inspect the file for normalized opportunity
+count, warning groups, missing prompt fields, inferred source types, and sample
+rows:
+
+```bash
+python scripts/inspect_extracted_content_ingestion.py \
+  customer_opportunities.csv \
+  --format csv \
+  --json
+
+python scripts/inspect_extracted_content_ingestion.py \
+  extracted_content_pipeline/examples/campaign_source_rows.jsonl \
+  --source-rows \
+  --source-format jsonl \
+  --json
+```
+
 Before writing to Postgres, validate the same JSON or CSV file through the file
 adapter:
 

--- a/extracted_content_pipeline/ingestion_diagnostics.py
+++ b/extracted_content_pipeline/ingestion_diagnostics.py
@@ -1,0 +1,177 @@
+"""Pre-import diagnostics for AI Content Ops ingestion files."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from .campaign_customer_data import (
+    CampaignOpportunityLoadResult,
+    CustomerDataFormat,
+    load_campaign_opportunities_from_file,
+)
+from .campaign_source_adapters import (
+    SourceDataFormat,
+    load_source_campaign_opportunities_from_file,
+)
+
+
+IngestionMode = Literal["opportunities", "source_rows"]
+
+
+_REQUIRED_FIELDS = ("target_id", "company_name", "vendor_name", "evidence")
+
+
+@dataclass(frozen=True)
+class IngestionDiagnosticsReport:
+    """Structured readiness report for a host ingestion file."""
+
+    mode: IngestionMode
+    source: str
+    opportunities: tuple[dict[str, Any], ...]
+    warnings: tuple[dict[str, Any], ...]
+    warning_counts: Mapping[str, int]
+    missing_field_counts: Mapping[str, int]
+    source_type_counts: Mapping[str, int]
+    sample_limit: int
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.opportunities) and not self.missing_field_counts.get("target_id", 0)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "mode": self.mode,
+            "source": self.source,
+            "opportunity_count": len(self.opportunities),
+            "warning_count": len(self.warnings),
+            "warning_counts": dict(sorted(self.warning_counts.items())),
+            "missing_field_counts": dict(sorted(self.missing_field_counts.items())),
+            "source_type_counts": dict(sorted(self.source_type_counts.items())),
+            "samples": [dict(row) for row in self.opportunities[: self.sample_limit]],
+            "warnings": list(self.warnings),
+        }
+
+
+def inspect_ingestion_file(
+    path: str | Path,
+    *,
+    source_rows: bool = False,
+    file_format: CustomerDataFormat = "auto",
+    source_format: SourceDataFormat = "auto",
+    target_mode: str | None = "vendor_retention",
+    max_source_text_chars: int = 1200,
+    sample_limit: int = 3,
+) -> IngestionDiagnosticsReport:
+    """Inspect a host ingestion file without writing to a database."""
+
+    if sample_limit < 0:
+        raise ValueError("sample_limit must be non-negative")
+    if max_source_text_chars < 1:
+        raise ValueError("max_source_text_chars must be positive")
+
+    source = Path(path)
+    if source_rows:
+        loaded = load_source_campaign_opportunities_from_file(
+            source,
+            file_format=source_format,
+            target_mode=target_mode,
+            max_text_chars=max_source_text_chars,
+        )
+        mode: IngestionMode = "source_rows"
+    else:
+        loaded = load_campaign_opportunities_from_file(
+            source,
+            file_format=file_format,
+            target_mode=target_mode,
+        )
+        mode = "opportunities"
+
+    return build_ingestion_diagnostics(
+        loaded,
+        mode=mode,
+        source=str(source),
+        sample_limit=sample_limit,
+    )
+
+
+def build_ingestion_diagnostics(
+    loaded: CampaignOpportunityLoadResult,
+    *,
+    mode: IngestionMode,
+    source: str | None = None,
+    sample_limit: int = 3,
+) -> IngestionDiagnosticsReport:
+    """Build a diagnostics report from normalized opportunity rows."""
+
+    if sample_limit < 0:
+        raise ValueError("sample_limit must be non-negative")
+
+    opportunities = tuple(dict(row) for row in loaded.opportunities)
+    warnings = tuple(warning.as_dict() for warning in loaded.warnings)
+    return IngestionDiagnosticsReport(
+        mode=mode,
+        source=source or loaded.source or "",
+        opportunities=opportunities,
+        warnings=warnings,
+        warning_counts=_warning_counts(warnings),
+        missing_field_counts=_missing_field_counts(opportunities),
+        source_type_counts=_source_type_counts(opportunities),
+        sample_limit=sample_limit,
+    )
+
+
+def _warning_counts(warnings: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for warning in warnings:
+        code = str(warning.get("code") or "unknown").strip() or "unknown"
+        counts[code] += 1
+    return dict(counts)
+
+
+def _missing_field_counts(opportunities: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in opportunities:
+        for field in _REQUIRED_FIELDS:
+            if not _has_value(row.get(field)):
+                counts[field] += 1
+    return dict(counts)
+
+
+def _source_type_counts(opportunities: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in opportunities:
+        source_type = _row_source_type(row)
+        if source_type:
+            counts[source_type] += 1
+    return dict(counts)
+
+
+def _row_source_type(row: Mapping[str, Any]) -> str:
+    source_type = str(row.get("source_type") or "").strip()
+    if source_type:
+        return source_type
+    evidence = row.get("evidence")
+    if isinstance(evidence, Sequence) and not isinstance(evidence, (str, bytes, bytearray)):
+        for item in evidence:
+            if isinstance(item, Mapping):
+                source_type = str(item.get("source_type") or "").strip()
+                if source_type:
+                    return source_type
+    return ""
+
+
+def _has_value(value: Any) -> bool:
+    return value not in (None, "", [], {})
+
+
+__all__ = [
+    "IngestionDiagnosticsReport",
+    "IngestionMode",
+    "build_ingestion_diagnostics",
+    "inspect_ingestion_file",
+]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -251,6 +251,9 @@
       "target": "extracted_content_pipeline/campaign_source_adapters.py"
     },
     {
+      "target": "extracted_content_pipeline/ingestion_diagnostics.py"
+    },
+    {
       "target": "extracted_content_pipeline/signal_extraction.py"
     },
     {

--- a/plans/PR-Content-Ops-Ingestion-Diagnostics.md
+++ b/plans/PR-Content-Ops-Ingestion-Diagnostics.md
@@ -1,0 +1,79 @@
+# Content Ops Ingestion Diagnostics
+
+## Why this slice exists
+
+AI Content Ops can load ready-made opportunity files and source-row exports,
+but hosts currently need to run conversion, import, or generation before they
+get a structured answer about whether an export is usable. The next ingestion
+slice should make customer data readiness inspectable before database writes or
+LLM calls.
+
+This intentionally ships as one slice even though the diff is over the soft
+budget: the diagnostics module, CLI, manifest coverage, tests, and docs are one
+host-facing seam. Splitting the CLI from the module would leave no usable host
+entry point; splitting docs or runner wiring would make the new command harder
+to discover or easy to miss in extracted checks.
+
+## Scope (this PR)
+
+1. Add a reusable ingestion diagnostics module over the existing opportunity
+   and source-row loaders.
+2. Add a thin CLI that reports readiness for opportunity files or source-row
+   files.
+3. Add tests for report shape, source-type counts, warning grouping, sample
+   limits, and CLI JSON output.
+4. Wire the new test file into the extracted pipeline check runner.
+5. Document the inspection command before conversion/import examples.
+6. Remove merged #577 from coordination and claim this slice.
+
+### Files touched
+
+- `extracted_content_pipeline/ingestion_diagnostics.py`
+- `scripts/inspect_extracted_content_ingestion.py`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/manifest.json`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Ingestion-Diagnostics.md`
+
+## Mechanism
+
+`inspect_ingestion_file(...)` reuses existing loaders instead of creating a
+parallel ingestion path. It builds a report with opportunity counts, warning
+counts, missing required prompt fields, inferred source-type counts, and
+bounded normalized samples.
+
+The CLI prints JSON for automation or a concise text summary for operators.
+
+## Intentional
+
+- No new source aliases or source-type inference rules.
+- No database writes.
+- No LLM calls.
+- No changes to opportunity normalization behavior.
+
+## Deferred
+
+- New adapters remain blocked on a real customer export fixture.
+- DB-backed ingestion APIs are separate from this offline inspection slice.
+- Rich UI rendering of ingestion diagnostics is a later operator-console task.
+
+## Verification
+
+- Command: python -m pytest -q tests/test_extracted_content_ingestion_diagnostics.py; result: 6 passed.
+- Command: python -m py_compile extracted_content_pipeline/ingestion_diagnostics.py scripts/inspect_extracted_content_ingestion.py tests/test_extracted_content_ingestion_diagnostics.py; result: passed.
+- Command: bash scripts/local_pr_review.sh; result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Diagnostics module | ~170 |
+| CLI | ~95 |
+| Tests | ~170 |
+| Docs and runner | ~35 |
+| Coordination and plan | ~90 |
+| **Total** | ~560 |

--- a/scripts/inspect_extracted_content_ingestion.py
+++ b/scripts/inspect_extracted_content_ingestion.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Inspect AI Content Ops ingestion readiness without writing data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.ingestion_diagnostics import inspect_ingestion_file  # noqa: E402
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inspect campaign opportunity or source-row ingestion readiness."
+    )
+    parser.add_argument("path", type=Path, help="Opportunity or source-row JSON/JSONL/CSV file.")
+    parser.add_argument(
+        "--format",
+        choices=("auto", "json", "csv"),
+        default="auto",
+        help="Opportunity file format when --source-rows is not selected.",
+    )
+    parser.add_argument(
+        "--source-rows",
+        action="store_true",
+        help="Treat input as source rows and convert them to opportunities first.",
+    )
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "json", "jsonl", "csv"),
+        default="auto",
+        help="Source-row file format when --source-rows is selected.",
+    )
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument(
+        "--max-source-text-chars",
+        type=int,
+        default=1200,
+        help="Maximum source text characters copied into each evidence row.",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=3,
+        help="Maximum normalized opportunity samples included in the report.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit full JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.sample_limit < 0:
+        raise SystemExit("--sample-limit must be non-negative")
+    if args.max_source_text_chars < 1:
+        raise SystemExit("--max-source-text-chars must be positive")
+
+    report = inspect_ingestion_file(
+        args.path,
+        source_rows=bool(args.source_rows),
+        file_format=args.format,
+        source_format=args.source_format,
+        target_mode=args.target_mode,
+        max_source_text_chars=args.max_source_text_chars,
+        sample_limit=args.sample_limit,
+    )
+    payload = report.as_dict()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            "ok={ok} mode={mode} opportunities={opportunity_count} "
+            "warnings={warning_count} missing={missing}".format(
+                ok=str(payload["ok"]).lower(),
+                mode=payload["mode"],
+                opportunity_count=payload["opportunity_count"],
+                warning_count=payload["warning_count"],
+                missing=payload["missing_field_counts"],
+            )
+        )
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -26,6 +26,7 @@ pytest \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
+  tests/test_extracted_content_ingestion_diagnostics.py \
   tests/test_extracted_blog_generation.py \
   tests/test_extracted_blog_blueprint_ingest.py \
   tests/test_extracted_blog_post_postgres.py \

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from extracted_content_pipeline.ingestion_diagnostics import inspect_ingestion_file
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/inspect_extracted_content_ingestion.py"
+
+
+def test_inspect_opportunity_json_reports_ready_rows(tmp_path: Path) -> None:
+    path = tmp_path / "opportunities.json"
+    path.write_text(json.dumps([
+        {
+            "id": "opp-1",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "email": "buyer@example.com",
+            "evidence": [{"text": "Renewal pricing is under review."}],
+        }
+    ]))
+
+    report = inspect_ingestion_file(path, sample_limit=1)
+    payload = report.as_dict()
+
+    assert payload["ok"] is True
+    assert payload["mode"] == "opportunities"
+    assert payload["opportunity_count"] == 1
+    assert payload["warning_count"] == 0
+    assert payload["missing_field_counts"] == {}
+    assert payload["samples"][0]["target_id"] == "opp-1"
+
+
+def test_inspect_source_rows_counts_source_types_and_warnings(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({
+                "ticket_id": "ticket-1",
+                "company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "message": "Renewal quote jumped before export work finished.",
+            }),
+            json.dumps({
+                "id": "empty-1",
+                "company": "Beta",
+                "vendor": "Zendesk",
+            }),
+        ])
+    )
+
+    report = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="jsonl",
+        sample_limit=2,
+    )
+    payload = report.as_dict()
+
+    assert payload["ok"] is True
+    assert payload["mode"] == "source_rows"
+    assert payload["opportunity_count"] == 1
+    assert payload["warning_counts"] == {
+        "missing_contact_email": 1,
+        "missing_source_text": 1,
+    }
+    assert payload["source_type_counts"] == {"support_ticket": 1}
+    assert payload["samples"][0]["evidence"][0]["source_type"] == "support_ticket"
+
+
+def test_inspect_reports_missing_generation_fields(tmp_path: Path) -> None:
+    path = tmp_path / "opportunities.json"
+    path.write_text(json.dumps([
+        {
+            "id": "opp-1",
+            "company": "Acme Logistics",
+        }
+    ]))
+
+    payload = inspect_ingestion_file(path).as_dict()
+
+    assert payload["ok"] is True
+    assert payload["missing_field_counts"] == {
+        "evidence": 1,
+        "vendor_name": 1,
+    }
+
+
+def test_inspect_sample_limit_bounds_output(tmp_path: Path) -> None:
+    path = tmp_path / "opportunities.json"
+    path.write_text(json.dumps([
+        {
+            "id": f"opp-{index}",
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "evidence": [{"text": "Renewal pricing is under review."}],
+        }
+        for index in range(3)
+    ]))
+
+    payload = inspect_ingestion_file(path, sample_limit=2).as_dict()
+
+    assert payload["opportunity_count"] == 3
+    assert [sample["target_id"] for sample in payload["samples"]] == ["opp-0", "opp-1"]
+
+
+def test_inspection_cli_emits_valid_json_for_source_rows(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(json.dumps({
+        "review_id": "review-1",
+        "reviewer_company": "Acme Logistics",
+        "vendor": "HubSpot",
+        "review_text": "Pricing is hard to justify.",
+    }))
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--source-rows",
+            "--source-format",
+            "jsonl",
+            "--sample-limit",
+            "1",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(proc.stdout)
+
+    assert payload["ok"] is True
+    assert payload["source_type_counts"] == {"review": 1}
+    assert len(payload["samples"]) == 1
+
+
+def test_inspection_cli_rejects_negative_sample_limit(tmp_path: Path) -> None:
+    path = tmp_path / "opportunities.json"
+    path.write_text("[]")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--sample-limit",
+            "-1",
+            "--json",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode != 0
+    assert "--sample-limit must be non-negative" in proc.stderr


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-Diagnostics.md

## Summary
- Add a reusable ingestion diagnostics report over existing opportunity/source-row loaders.
- Add a host-facing CLI for pre-import/pre-generation inspection.
- Document the inspection command and wire the focused tests into extracted pipeline checks.

## Verification
- python -m pytest -q tests/test_extracted_content_ingestion_diagnostics.py -> 6 passed
- python -m py_compile extracted_content_pipeline/ingestion_diagnostics.py scripts/inspect_extracted_content_ingestion.py tests/test_extracted_content_ingestion_diagnostics.py
- bash scripts/local_pr_review.sh