### PR TITLE
Add Content Ops ingestion inspect API

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T21:52Z by codex-2026-05-17
+Last updated: 2026-05-17T22:12Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #578 | Content Ops ingestion diagnostics | `extracted_content_pipeline/ingestion_diagnostics.py`, `scripts/inspect_extracted_content_ingestion.py`, `tests/test_extracted_content_ingestion_diagnostics.py`, `scripts/run_extracted_pipeline_checks.sh`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Diagnostics.md` | codex-2026-05-17 | Avoid editing Content Ops ingestion diagnostics, source/import docs, or extracted pipeline checks |
+| #579 | Content Ops ingestion inspect API | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/ingestion_diagnostics.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/docs/control_surface_preview_api.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Inspect-API.md` | codex-2026-05-17 | Avoid editing Content Ops control-surface API or ingestion diagnostics |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T21:52Z by codex-2026-05-17
+Last updated: 2026-05-17T22:12Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #575 | #578 | Ingestion diagnostics are in flight so hosts can inspect opportunity/source-row exports before import or generation. | `extracted_content_pipeline/ingestion_diagnostics.py`, `scripts/inspect_extracted_content_ingestion.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #578 | #579 | Hosted ingestion inspect API is in flight so operator UIs can call the same diagnostics path as the CLI. | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/ingestion_diagnostics.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -88,6 +88,11 @@ source of truth for what remains.
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or
   send side effects. It accepts both opportunity files and source-row files.
+- `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
+  provide offline readiness reports for opportunity/source-row exports before
+  import or generation. The hosted control-surface API also exposes
+  `POST /content-ops/ingestion/inspect` for inline rows so operator UIs can use
+  the same diagnostics path without reading local files.
 - `campaign_postgres_review` provides a product-owned draft review/status
   update path so hosts can approve, queue, cancel, or expire generated
   `b2b_campaigns` rows after export without handwritten SQL.

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -39,6 +39,7 @@ from ..control_surfaces import (
     resolve_outputs,
 )
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
+from ..ingestion_diagnostics import inspect_ingestion_rows
 from ..reasoning_policy import (
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
     ReasoningPreset,
@@ -73,6 +74,8 @@ logger = logging.getLogger(__name__)
 _MAX_INPUT_KEYS = 50
 _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
+_MAX_INGESTION_ROWS = 500
+_MAX_INGESTION_SAMPLE_LIMIT = 25
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
@@ -351,8 +354,34 @@ if BaseModel is not None:
             _validate_input_shape(value, depth=0)
             return value
 
+    class ContentOpsIngestionInspectModel(BaseModel):
+        """Bounded API request body for offline ingestion diagnostics."""
+
+        model_config = ConfigDict(extra="forbid")
+
+        rows: tuple[dict[str, Any], ...] = Field(
+            default_factory=tuple,
+            max_length=_MAX_INGESTION_ROWS,
+        )
+        source_rows: bool = False
+        source: str | None = Field(default="api", max_length=200)
+        target_mode: str | None = Field(default="vendor_retention", max_length=80)
+        max_source_text_chars: int = Field(1200, ge=1, le=_MAX_INPUT_STRING_CHARS)
+        sample_limit: int = Field(3, ge=0, le=_MAX_INGESTION_SAMPLE_LIMIT)
+
+        @field_validator("rows")
+        @classmethod
+        def _validate_rows(
+            cls,
+            value: tuple[dict[str, Any], ...],
+        ) -> tuple[dict[str, Any], ...]:
+            for row in value:
+                _validate_input_shape(row, depth=0)
+            return value
+
 else:  # pragma: no cover - module import fallback when FastAPI is unavailable.
     ContentOpsRequestModel = Any
+    ContentOpsIngestionInspectModel = Any
 
 
 def create_content_ops_control_surface_router(
@@ -420,6 +449,24 @@ def create_content_ops_control_surface_router(
             return build_generation_plan_from_mapping(_payload_to_mapping(payload))
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post("/ingestion/inspect")
+    async def inspect_ingestion(
+        payload: ContentOpsIngestionInspectModel = Body(...),
+    ) -> dict[str, Any]:
+        data = _ingestion_payload_to_mapping(payload)
+        try:
+            report = inspect_ingestion_rows(
+                data["rows"],
+                source_rows=bool(data.get("source_rows")),
+                source=_clean(data.get("source")) or "api",
+                target_mode=_clean(data.get("target_mode")),
+                max_source_text_chars=int(data.get("max_source_text_chars") or 1200),
+                sample_limit=int(data.get("sample_limit") or 0),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return report.as_dict()
 
     @router.post("/execute")
     async def execute_generation(
@@ -829,6 +876,15 @@ def _payload_to_mapping(payload: Any) -> dict[str, Any]:
         return payload.model_dump()
     try:
         return ContentOpsRequestModel.model_validate(payload).model_dump()
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
+
+
+def _ingestion_payload_to_mapping(payload: Any) -> dict[str, Any]:
+    if BaseModel is not None and isinstance(payload, ContentOpsIngestionInspectModel):
+        return payload.model_dump()
+    try:
+        return ContentOpsIngestionInspectModel.model_validate(payload).model_dump()
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
 

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -55,6 +55,7 @@ size and nesting limits.
 | `GET` | `/content-ops/control-surfaces` | List output types, presets, required inputs, implementation status, execution-service readiness, reasoning-provider readiness, cost estimates, and ingestion profiles. |
 | `POST` | `/content-ops/preview` | Validate a requested preset/output selection and return cost, missing inputs, warnings, and blocked outputs. |
 | `POST` | `/content-ops/plan` | Convert a previewable request into deterministic generation steps. Does not execute generation. |
+| `POST` | `/content-ops/ingestion/inspect` | Inspect inline opportunity rows or source rows and return the same readiness diagnostics as the host CLI. |
 | `POST` | `/content-ops/execute` | Execute a runnable plan through host-injected services. Disabled unless the host configures execution services. |
 
 ## Output Catalog
@@ -213,6 +214,34 @@ preview passes and every selected output maps to a runnable service-shaped step.
 `signal_extraction` is deterministic and offline once the host supplies a
 configured `SignalExtractionService`; without that service, preview and plan can
 pass, but `/execute` reports the output as not configured.
+
+## Ingestion Inspect Route
+
+`POST /content-ops/ingestion/inspect` accepts inline rows and returns the same
+diagnostics shape as `scripts/inspect_extracted_content_ingestion.py`. It does
+not call a database, LLM, sender, or execution service.
+
+```json
+{
+  "source_rows": true,
+  "source": "operator-upload",
+  "rows": [
+    {
+      "call_id": "call-1",
+      "company": "Acme",
+      "vendor": "HubSpot",
+      "transcript": "The renewal process is too manual."
+    }
+  ],
+  "target_mode": "vendor_retention",
+  "sample_limit": 3
+}
+```
+
+The response includes `ok`, `opportunity_count`, `warning_counts`,
+`missing_field_counts`, `source_type_counts`, bounded `samples`, and row-level
+`warnings`. Hosts should use this route for uploaded rows in an operator UI and
+the CLI for local files.
 
 ## Execute Route
 

--- a/extracted_content_pipeline/ingestion_diagnostics.py
+++ b/extracted_content_pipeline/ingestion_diagnostics.py
@@ -12,10 +12,12 @@ from .campaign_customer_data import (
     CampaignOpportunityLoadResult,
     CustomerDataFormat,
     load_campaign_opportunities_from_file,
+    normalize_campaign_opportunity_rows,
 )
 from .campaign_source_adapters import (
     SourceDataFormat,
     load_source_campaign_opportunities_from_file,
+    source_rows_to_campaign_opportunities,
 )
 
 
@@ -99,6 +101,44 @@ def inspect_ingestion_file(
     )
 
 
+def inspect_ingestion_rows(
+    rows: Sequence[Any],
+    *,
+    source_rows: bool = False,
+    source: str | None = "api",
+    target_mode: str | None = "vendor_retention",
+    max_source_text_chars: int = 1200,
+    sample_limit: int = 3,
+) -> IngestionDiagnosticsReport:
+    """Inspect already-loaded host rows without writing to a database."""
+
+    if sample_limit < 0:
+        raise ValueError("sample_limit must be non-negative")
+    if max_source_text_chars < 1:
+        raise ValueError("max_source_text_chars must be positive")
+
+    if source_rows:
+        loaded = source_rows_to_campaign_opportunities(
+            rows,
+            target_mode=target_mode,
+            max_text_chars=max_source_text_chars,
+        )
+        mode: IngestionMode = "source_rows"
+    else:
+        loaded = normalize_campaign_opportunity_rows(
+            rows,
+            target_mode=target_mode,
+        )
+        mode = "opportunities"
+
+    return build_ingestion_diagnostics(
+        loaded,
+        mode=mode,
+        source=source,
+        sample_limit=sample_limit,
+    )
+
+
 def build_ingestion_diagnostics(
     loaded: CampaignOpportunityLoadResult,
     *,
@@ -174,4 +214,5 @@ __all__ = [
     "IngestionMode",
     "build_ingestion_diagnostics",
     "inspect_ingestion_file",
+    "inspect_ingestion_rows",
 ]

--- a/plans/PR-Content-Ops-Ingestion-Inspect-API.md
+++ b/plans/PR-Content-Ops-Ingestion-Inspect-API.md
@@ -1,0 +1,65 @@
+# Content Ops Ingestion Inspect API
+
+## Why this slice exists
+
+PR #578 made Content Ops ingestion readiness inspectable from a host CLI. The
+next practical seam is letting a hosted operator UI inspect inline rows with the
+same diagnostics contract before import, generation, or database writes.
+
+## Scope (this PR)
+
+1. Add an in-memory ingestion diagnostics helper over existing opportunity and
+   source-row normalizers.
+2. Add `POST /content-ops/ingestion/inspect` to the existing control-surface
+   router.
+3. Add focused API tests for source rows, opportunity rows, and request bounds.
+4. Document the route and update product/coordination state.
+
+### Files touched
+
+- `extracted_content_pipeline/ingestion_diagnostics.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Ingestion-Inspect-API.md`
+
+## Mechanism
+
+`inspect_ingestion_rows(...)` reuses `normalize_campaign_opportunity_rows(...)`
+and `source_rows_to_campaign_opportunities(...)`, then builds the same
+`IngestionDiagnosticsReport` used by the file-backed CLI. The API route only
+validates request size and delegates to that helper.
+
+## Intentional
+
+- No file upload or multipart handling.
+- No database writes.
+- No LLM calls.
+- No new source aliases or source-type rules.
+- No UI code.
+
+## Deferred
+
+- Real upload storage/import APIs remain separate.
+- Rich operator-console rendering is still a frontend task.
+- Additional source adapters remain blocked on a real host export fixture.
+
+## Verification
+
+- Run focused control-surface API tests.
+- Run focused ingestion diagnostics tests.
+- Compile touched Python files.
+- Run the local PR review script.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Diagnostics helper | ~35 |
+| API route/model | ~55 |
+| Tests | ~65 |
+| Docs/status/coordination | ~70 |
+| **Total** | ~225 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -443,6 +443,73 @@ async def test_plan_generation_route_rejects_invalid_signal_text_cap_as_400():
 
 
 @pytest.mark.asyncio
+async def test_ingestion_inspect_route_reports_source_rows():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/inspect", "POST")
+    payload = await route.endpoint({
+        "source_rows": True,
+        "source": "fixture",
+        "rows": [{
+            "call_id": "call-1",
+            "company": "Acme",
+            "vendor": "HubSpot",
+            "transcript": "The renewal process is too manual.",
+            "contact_email": "ops@example.com",
+        }],
+    })
+
+    assert payload["ok"] is True
+    assert payload["mode"] == "source_rows"
+    assert payload["source"] == "fixture"
+    assert payload["opportunity_count"] == 1
+    assert payload["source_type_counts"] == {"transcript": 1}
+    assert payload["samples"][0]["source_type"] == "transcript"
+
+
+@pytest.mark.asyncio
+async def test_ingestion_inspect_route_reports_missing_opportunity_fields():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/inspect", "POST")
+    payload = await route.endpoint({
+        "rows": [{
+            "target_id": "opp-1",
+            "company_name": "Acme",
+        }],
+    })
+
+    assert payload["ok"] is True
+    assert payload["mode"] == "opportunities"
+    assert payload["missing_field_counts"] == {
+        "evidence": 1,
+        "vendor_name": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ingestion_inspect_route_rejects_oversized_rows():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/inspect", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "rows": [
+                {"target_id": f"opp-{index}"}
+                for index in range(501)
+            ],
+        })
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_execute_generation_route_runs_configured_services():
     service = _CampaignService()
     router = create_content_ops_control_surface_router(


### PR DESCRIPTION
# Content Ops Ingestion Inspect API

## Why this slice exists

PR #578 made Content Ops ingestion readiness inspectable from a host CLI. The
next practical seam is letting a hosted operator UI inspect inline rows with the
same diagnostics contract before import, generation, or database writes.

## Scope (this PR)

1. Add an in-memory ingestion diagnostics helper over existing opportunity and
   source-row normalizers.
2. Add `POST /content-ops/ingestion/inspect` to the existing control-surface
   router.
3. Add focused API tests for source rows, opportunity rows, and request bounds.
4. Document the route and update product/coordination state.

### Files touched

- `extracted_content_pipeline/ingestion_diagnostics.py`
- `extracted_content_pipeline/api/control_surfaces.py`
- `tests/test_extracted_content_control_surface_api.py`
- `extracted_content_pipeline/docs/control_surface_preview_api.md`
- `extracted_content_pipeline/STATUS.md`
- `docs/extraction/coordination/inflight.md`
- `docs/extraction/coordination/state.md`
- `plans/PR-Content-Ops-Ingestion-Inspect-API.md`

## Mechanism

`inspect_ingestion_rows(...)` reuses `normalize_campaign_opportunity_rows(...)`
and `source_rows_to_campaign_opportunities(...)`, then builds the same
`IngestionDiagnosticsReport` used by the file-backed CLI. The API route only
validates request size and delegates to that helper.

## Intentional

- No file upload or multipart handling.
- No database writes.
- No LLM calls.
- No new source aliases or source-type rules.
- No UI code.

## Deferred

- Real upload storage/import APIs remain separate.
- Rich operator-console rendering is still a frontend task.
- Additional source adapters remain blocked on a real host export fixture.

## Verification

- Run focused control-surface API tests.
- Run focused ingestion diagnostics tests.
- Compile touched Python files.
- Run the local PR review script.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Diagnostics helper | ~35 |
| API route/model | ~55 |
| Tests | ~65 |
| Docs/status/coordination | ~70 |
| **Total** | ~225 |
