### PR TITLE
Add Content Ops ingestion inspect frontend contract

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/ingestion-inspect.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/ingestion-inspect.json
@@ -1,0 +1,38 @@
+{
+  "ok": true,
+  "mode": "source_rows",
+  "source": "operator-upload",
+  "opportunity_count": 1,
+  "warning_count": 1,
+  "warning_counts": {
+    "missing_vendor_name": 1
+  },
+  "missing_field_counts": {
+    "vendor_name": 1
+  },
+  "source_type_counts": {
+    "transcript": 1
+  },
+  "samples": [
+    {
+      "target_id": "call-1",
+      "company_name": "Acme",
+      "source_type": "transcript",
+      "evidence": [
+        {
+          "text": "The renewal process is too manual.",
+          "source_id": "call-1",
+          "source_type": "transcript"
+        }
+      ]
+    }
+  ],
+  "warnings": [
+    {
+      "code": "missing_vendor_name",
+      "message": "Row does not contain a current/incumbent vendor name.",
+      "row_index": 1,
+      "field": "vendor_name"
+    }
+  ]
+}

--- a/atlas-intel-ui/src/api/contentOps.contract.ts
+++ b/atlas-intel-ui/src/api/contentOps.contract.ts
@@ -17,10 +17,12 @@
 import type {
   ContentOpsCatalogResponse,
   ContentOpsExecutionResult,
+  ContentOpsIngestionDiagnosticsResponse,
   ContentOpsPreviewResponse,
   GenerationPlanResponse,
 } from './contentOps'
 import catalogFixture from './__fixtures__/contentOps/catalog.json'
+import ingestionInspectFixture from './__fixtures__/contentOps/ingestion-inspect.json'
 import previewCanRunFixture from './__fixtures__/contentOps/preview-can-run.json'
 import previewBlockedFixture from './__fixtures__/contentOps/preview-blocked.json'
 import planRunnableFixture from './__fixtures__/contentOps/plan-runnable.json'
@@ -50,6 +52,7 @@ type Loosen<T> = T extends string
       : T
 
 export const __catalogContract = catalogFixture satisfies Loosen<ContentOpsCatalogResponse>
+export const __ingestionInspectContract = ingestionInspectFixture satisfies Loosen<ContentOpsIngestionDiagnosticsResponse>
 export const __previewCanRunContract = previewCanRunFixture satisfies Loosen<ContentOpsPreviewResponse>
 export const __previewBlockedContract = previewBlockedFixture satisfies Loosen<ContentOpsPreviewResponse>
 export const __planRunnableContract = planRunnableFixture satisfies Loosen<GenerationPlanResponse>

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -1,12 +1,13 @@
 /**
  * AI Content Ops API adapter.
  *
- * Typed fetch wrappers + wire-shape types for the four
+ * Typed fetch wrappers + wire-shape types for the
  * `/content-ops/*` and `/content-assets/*` routes the backend exposes:
  *
  *   GET  /content-ops/control-surfaces
  *   POST /content-ops/preview
  *   POST /content-ops/plan
+ *   POST /content-ops/ingestion/inspect
  *   POST /content-ops/execute
  *   GET  /content-assets/{asset}/drafts
  *   GET  /content-assets/{asset}/drafts/export
@@ -101,6 +102,37 @@ export interface ContentOpsRequestBody {
   ingestion_profile?: string                       // default "domain_specific"
   require_quality_gates?: boolean                  // default true
   allow_unimplemented_outputs?: boolean            // default false
+}
+
+// POST /content-ops/ingestion/inspect body and response
+
+export interface ContentOpsIngestionInspectRequest {
+  rows: Array<Record<string, unknown>>
+  source_rows?: boolean                             // default false
+  source?: string | null                            // default "api"
+  target_mode?: string | null                       // default "vendor_retention"
+  max_source_text_chars?: number                    // 1..10000
+  sample_limit?: number                             // 0..25
+}
+
+export interface ContentOpsIngestionWarning {
+  code: string
+  message: string
+  row_index?: number
+  field?: string
+}
+
+export interface ContentOpsIngestionDiagnosticsResponse {
+  ok: boolean
+  mode: 'opportunities' | 'source_rows'
+  source: string
+  opportunity_count: number
+  warning_count: number
+  warning_counts: Record<string, number>
+  missing_field_counts: Record<string, number>
+  source_type_counts: Record<string, number>
+  samples: Array<Record<string, unknown>>
+  warnings: ContentOpsIngestionWarning[]
 }
 
 // POST /content-ops/preview response
@@ -341,7 +373,7 @@ async function getJson<T>(path: string): Promise<T> {
   return rawJson<T>(res)
 }
 
-async function postJson<T>(path: string, body: ContentOpsRequestBody): Promise<T> {
+async function postJson<T>(path: string, body: unknown): Promise<T> {
   const url = `${BASE}${path}`
   const doFetch = () =>
     fetchWithApiFallback(url, {
@@ -479,6 +511,13 @@ export function planContentOpsRun(
   body: ContentOpsRequestBody,
 ): Promise<GenerationPlanResponse> {
   return postJson<GenerationPlanResponse>('/plan', body)
+}
+
+/** POST /content-ops/ingestion/inspect -- inspect inline opportunity/source rows. */
+export function inspectContentOpsIngestion(
+  body: ContentOpsIngestionInspectRequest,
+): Promise<ContentOpsIngestionDiagnosticsResponse> {
+  return postJson<ContentOpsIngestionDiagnosticsResponse>('/ingestion/inspect', body)
 }
 
 /**

--- a/atlas-intel-ui/src/domain/contentOps/contract.ts
+++ b/atlas-intel-ui/src/domain/contentOps/contract.ts
@@ -15,10 +15,12 @@
 import type {
   ContentOpsCatalogResponse,
   ContentOpsExecutionResult as WireExecutionResult,
+  ContentOpsIngestionDiagnosticsResponse,
   ContentOpsPreviewResponse,
   GenerationPlanResponse,
 } from '../../api/contentOps'
 import catalogFixture from '../../api/__fixtures__/contentOps/catalog.json'
+import ingestionInspectFixture from '../../api/__fixtures__/contentOps/ingestion-inspect.json'
 import executionBlockedFixture from '../../api/__fixtures__/contentOps/execution-blocked.json'
 import executionCompletedFixture from '../../api/__fixtures__/contentOps/execution-completed.json'
 import executionFailedFixture from '../../api/__fixtures__/contentOps/execution-failed.json'
@@ -30,12 +32,14 @@ import previewCanRunFixture from '../../api/__fixtures__/contentOps/preview-can-
 import {
   fromWireCatalog,
   fromWireExecution,
+  fromWireIngestionDiagnostics,
   fromWirePlan,
   fromWirePreview,
 } from './fromWire'
 import type {
   ContentOpsCatalog,
   ContentOpsExecutionResult,
+  ContentOpsIngestionDiagnostics,
   ControlSurfacePreview,
   GenerationPlan,
 } from './types'
@@ -59,6 +63,10 @@ type Loosen<T> = T extends string
 export const __domainCatalogContract = fromWireCatalog(
   catalogFixture as ContentOpsCatalogResponse,
 ) satisfies Loosen<ContentOpsCatalog>
+
+export const __domainIngestionInspectContract = fromWireIngestionDiagnostics(
+  ingestionInspectFixture as ContentOpsIngestionDiagnosticsResponse,
+) satisfies Loosen<ContentOpsIngestionDiagnostics>
 
 export const __domainPreviewCanRunContract = fromWirePreview(
   previewCanRunFixture as ContentOpsPreviewResponse,

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -12,6 +12,8 @@
 
 import type {
   ContentOpsCatalogResponse,
+  ContentOpsIngestionDiagnosticsResponse,
+  ContentOpsIngestionInspectRequest as WireIngestionInspectRequest,
   ContentOpsExecutionResult as WireExecutionResult,
   ContentOpsOutputDefinition as WireOutputDefinition,
   ContentOpsPreset as WirePreset,
@@ -23,6 +25,8 @@ import type {
 } from '../../api/contentOps'
 import type {
   ContentOpsCatalog,
+  ContentOpsIngestionDiagnostics,
+  ContentOpsIngestionInspectRequest,
   ContentOpsExecutionResult,
   CampaignReasoningContextView,
   ContentOpsRequest,
@@ -158,6 +162,45 @@ export function toWireRequest(
     ingestion_profile: domain.ingestionProfile,
     require_quality_gates: domain.requireQualityGates,
     allow_unimplemented_outputs: domain.allowUnimplementedOutputs,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ingestion inspect
+// ---------------------------------------------------------------------------
+
+export function toWireIngestionInspectRequest(
+  domain: ContentOpsIngestionInspectRequest,
+): WireIngestionInspectRequest {
+  return {
+    rows: domain.rows.map((row) => ({ ...row })),
+    source_rows: domain.sourceRows,
+    source: domain.source,
+    target_mode: domain.targetMode,
+    max_source_text_chars: domain.maxSourceTextChars,
+    sample_limit: domain.sampleLimit,
+  }
+}
+
+export function fromWireIngestionDiagnostics(
+  wire: ContentOpsIngestionDiagnosticsResponse,
+): ContentOpsIngestionDiagnostics {
+  return {
+    ok: wire.ok,
+    mode: wire.mode,
+    source: wire.source,
+    opportunityCount: wire.opportunity_count,
+    warningCount: wire.warning_count,
+    warningCounts: { ...wire.warning_counts },
+    missingFieldCounts: { ...wire.missing_field_counts },
+    sourceTypeCounts: { ...wire.source_type_counts },
+    samples: wire.samples.map((row) => ({ ...row })),
+    warnings: wire.warnings.map((warning) => ({
+      code: warning.code,
+      message: warning.message,
+      rowIndex: warning.row_index,
+      field: warning.field,
+    })),
   }
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -8,6 +8,9 @@
 export type {
   CampaignReasoningContextView,
   ContentOpsCatalog,
+  ContentOpsIngestionDiagnostics,
+  ContentOpsIngestionInspectRequest,
+  ContentOpsIngestionWarning,
   ContentOpsExecutionResult,
   ContentOpsExecutionStatus,
   ContentOpsRequest,
@@ -27,6 +30,7 @@ export type {
 export {
   fromWireCatalog,
   fromWireExecution,
+  fromWireIngestionDiagnostics,
   fromWireOutputDefinition,
   fromWirePlan,
   fromWirePlanStep,
@@ -34,5 +38,6 @@ export {
   fromWirePreview,
   fromWireRequest,
   fromWireStepExecution,
+  toWireIngestionInspectRequest,
   toWireRequest,
 } from './fromWire'

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -85,6 +85,39 @@ export interface ContentOpsRequest {
 }
 
 // ---------------------------------------------------------------------------
+// Ingestion inspect (POST /content-ops/ingestion/inspect)
+// ---------------------------------------------------------------------------
+
+export interface ContentOpsIngestionInspectRequest {
+  rows: Array<Record<string, unknown>>
+  sourceRows: boolean
+  source: string | null
+  targetMode: string | null
+  maxSourceTextChars: number
+  sampleLimit: number
+}
+
+export interface ContentOpsIngestionWarning {
+  code: string
+  message: string
+  rowIndex?: number
+  field?: string
+}
+
+export interface ContentOpsIngestionDiagnostics {
+  ok: boolean
+  mode: 'opportunities' | 'source_rows'
+  source: string
+  opportunityCount: number
+  warningCount: number
+  warningCounts: Record<string, number>
+  missingFieldCounts: Record<string, number>
+  sourceTypeCounts: Record<string, number>
+  samples: Array<Record<string, unknown>>
+  warnings: ContentOpsIngestionWarning[]
+}
+
+// ---------------------------------------------------------------------------
 // Preview (POST /content-ops/preview)
 // ---------------------------------------------------------------------------
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T22:12Z by codex-2026-05-17
+Last updated: 2026-05-17T22:33Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #579 | Content Ops ingestion inspect API | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/ingestion_diagnostics.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/docs/control_surface_preview_api.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Inspect-API.md` | codex-2026-05-17 | Avoid editing Content Ops control-surface API or ingestion diagnostics |
+| #580 | Content Ops ingestion inspect frontend contract | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/api/contentOps.contract.ts`, `atlas-intel-ui/src/api/__fixtures__/contentOps/ingestion-inspect.json`, `atlas-intel-ui/src/domain/contentOps/types.ts`, `atlas-intel-ui/src/domain/contentOps/fromWire.ts`, `atlas-intel-ui/src/domain/contentOps/contract.ts`, `atlas-intel-ui/src/domain/contentOps/index.ts`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Inspect-Frontend-Contract.md` | codex-2026-05-17 | Avoid editing Content Ops frontend API/domain contract files |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T22:12Z by codex-2026-05-17
+Last updated: 2026-05-17T22:33Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #578 | #579 | Hosted ingestion inspect API is in flight so operator UIs can call the same diagnostics path as the CLI. | `extracted_content_pipeline/api/control_surfaces.py`, `extracted_content_pipeline/ingestion_diagnostics.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #579 | #580 | Frontend API/domain contract for hosted ingestion inspection is in flight. | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/domain/contentOps` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -37,13 +37,15 @@ reproduce them") in its inverse: trusting a stale local tree to
 | `GET` | `/content-ops/control-surfaces` | Output catalog + presets + ingestion-profile menu + per-output execution flags |
 | `POST` | `/content-ops/preview` | Preflight validation; returns `ControlSurfacePreview` |
 | `POST` | `/content-ops/plan` | Build runnable plan; returns `GenerationPlan` |
+| `POST` | `/content-ops/ingestion/inspect` | Inspect inline opportunity/source rows before import or generation; returns `ContentOpsIngestionDiagnostics` |
 | `POST` | `/content-ops/execute` | Execute the plan via host-injected services; returns `ContentOpsExecutionResult` |
 
 The router prefix is configurable via `ContentOpsControlSurfaceApiConfig`
-(`api/control_surfaces.py:143`). All four routes share one pydantic
+(`api/control_surfaces.py:143`). Preview, plan, and execute share one pydantic
 body model (`ContentOpsRequestModel`, `api/control_surfaces.py:157-185`)
-with bounded sizes (max 50 input keys, depth 6, string ≤ 10000 chars,
-`outputs` length ≤ 20, `limit` 1–1000).
+with bounded sizes (max 50 input keys, depth 6, string <= 10000 chars,
+`outputs` length <= 20, `limit` 1-1000). The ingestion inspect route has its
+own bounded row-inspection body.
 
 ### Catalog response shape (`/content-ops/control-surfaces`)
 
@@ -96,6 +98,7 @@ top-level `execution.{configured,configured_outputs}` /
 | `OutputDefinition` | `control_surfaces.py:16-30` | `id`, `label`, `description`, `implemented`, `estimated_unit_cost_usd`, `required_inputs`, `default_max_items`, `reasoning_requirement`, `default_parse_retry_attempts` |
 | `ControlSurfacePreset` | `control_surfaces.py:33-40` | `id`, `label`, `outputs`, `description` |
 | `ContentOpsRequest` | `control_surfaces.py:43-55` | `target_mode`, `preset`, `outputs`, `limit`, `max_cost_usd`, `inputs`, `ingestion_profile`, `require_quality_gates`, `allow_unimplemented_outputs` |
+| `ContentOpsIngestionDiagnostics` | `ingestion_diagnostics.py:28-57` | `ok`, counts, bounded samples, and row warnings from inline ingestion inspection |
 | `ControlSurfacePreview` | `control_surfaces.py:58-90` | `can_run`, `outputs`, `estimated_cost_usd`, `missing_inputs`, `blocked_outputs`, `warnings`, `normalized_request` |
 | `GenerationPlanStep` | `generation_plan.py:28-45` | `output`, `runner`, `status`, `config`, `reason` |
 | `GenerationPlan` | `generation_plan.py:48-65` | `can_execute`, `target_mode`, `limit`, `steps`, `preview` |
@@ -480,6 +483,7 @@ src/api/
   contentOpsControlSurfaces.ts   // GET  /content-ops/control-surfaces
   contentOpsPreview.ts           // POST /content-ops/preview
   contentOpsPlan.ts              // POST /content-ops/plan
+  contentOpsIngestionInspect.ts  // POST /content-ops/ingestion/inspect
   contentOpsExecute.ts           // POST /content-ops/execute
 ```
 

--- a/plans/PR-Content-Ops-Ingestion-Inspect-Frontend-Contract.md
+++ b/plans/PR-Content-Ops-Ingestion-Inspect-Frontend-Contract.md
@@ -1,0 +1,62 @@
+# Content Ops Ingestion Inspect Frontend Contract
+
+## Why this slice exists
+
+PR #579 added a hosted `POST /content-ops/ingestion/inspect` route. The Atlas
+Intel frontend API adapter still has no typed wrapper or fixture pin for that
+route, so a future UI would either use raw fetch calls or invent its own shape.
+
+## Scope (this PR)
+
+1. Add wire types and a typed fetch wrapper for ingestion inspection.
+2. Add domain types and a wire-to-domain mapper for the diagnostics response.
+3. Add a canonical fixture and compile-time contract checks.
+4. Refresh the frontend contract doc and coordination state.
+
+### Files touched
+
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/api/contentOps.contract.ts`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/ingestion-inspect.json`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/domain/contentOps/contract.ts`
+- `atlas-intel-ui/src/domain/contentOps/index.ts`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Ingestion-Inspect-Frontend-Contract.md`
+
+## Mechanism
+
+The API adapter posts a bounded `ContentOpsIngestionInspectRequest` to
+`/ingestion/inspect`. The domain mapper preserves raw sample/warning rows as
+records while camel-casing the stable summary fields.
+
+## Intentional
+
+- No new React UI.
+- No file upload handling.
+- No backend changes.
+- No changes to existing preview/plan/execute request types.
+
+## Deferred
+
+- Operator UI for pasting/uploading rows.
+- Browser-side CSV parsing.
+- Runtime tests; current frontend gate is compile-time contract checking.
+
+## Verification
+
+- Run the frontend type/build gate.
+- Run local PR review.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| API wire types/wrapper | ~60 |
+| Domain mapper/types | ~80 |
+| Fixture/contracts | ~55 |
+| Docs/coordination/plan | ~90 |
+| **Total** | ~285 |


### PR DESCRIPTION
# Content Ops Ingestion Inspect Frontend Contract

## Why this slice exists

PR #579 added a hosted `POST /content-ops/ingestion/inspect` route. The Atlas
Intel frontend API adapter still has no typed wrapper or fixture pin for that
route, so a future UI would either use raw fetch calls or invent its own shape.

## Scope (this PR)

1. Add wire types and a typed fetch wrapper for ingestion inspection.
2. Add domain types and a wire-to-domain mapper for the diagnostics response.
3. Add a canonical fixture and compile-time contract checks.
4. Refresh the frontend contract doc and coordination state.

### Files touched

- `atlas-intel-ui/src/api/contentOps.ts`
- `atlas-intel-ui/src/api/contentOps.contract.ts`
- `atlas-intel-ui/src/api/__fixtures__/contentOps/ingestion-inspect.json`
- `atlas-intel-ui/src/domain/contentOps/types.ts`
- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
- `atlas-intel-ui/src/domain/contentOps/contract.ts`
- `atlas-intel-ui/src/domain/contentOps/index.ts`
- `docs/frontend/content_ops_frontend_contract.md`
- `docs/extraction/coordination/inflight.md`
- `docs/extraction/coordination/state.md`
- `plans/PR-Content-Ops-Ingestion-Inspect-Frontend-Contract.md`

## Mechanism

The API adapter posts a bounded `ContentOpsIngestionInspectRequest` to
`/ingestion/inspect`. The domain mapper preserves raw sample/warning rows as
records while camel-casing the stable summary fields.

## Intentional

- No new React UI.
- No file upload handling.
- No backend changes.
- No changes to existing preview/plan/execute request types.

## Deferred

- Operator UI for pasting/uploading rows.
- Browser-side CSV parsing.
- Runtime tests; current frontend gate is compile-time contract checking.

## Verification

- Run the frontend type/build gate.
- Run local PR review.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| API wire types/wrapper | ~60 |
| Domain mapper/types | ~80 |
| Fixture/contracts | ~55 |
| Docs/coordination/plan | ~90 |
| **Total** | ~285 |
