### PR TITLE
Add Content Ops ingestion import API

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -196,6 +196,7 @@ try:
         scope_provider=build_content_ops_scope,
         reasoning_context_provider=select_content_ops_reasoning_context_provider,
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
+        opportunity_import_pool_provider=get_db_pool,
     )
     router.include_router(content_ops_router)
     content_assets_router = create_generated_asset_router(

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-17T22:41Z by codex-2026-05-17
+Last updated: 2026-05-18T02:13Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #581 | Content Ops ingestion inspect UI | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Inspect-UI.md` | codex-2026-05-17 | Avoid editing the Content Ops new-run UI and ingestion-inspect UI docs |
+| #582 | Content Ops ingestion import API | `extracted_content_pipeline/api/control_surfaces.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/docs/control_surface_preview_api.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Import-API.md` | codex-2026-05-17 | Avoid editing Content Ops control-surface ingestion API routes |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-17T22:41Z by codex-2026-05-17
+Last updated: 2026-05-18T02:13Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #580 | #581 | Hosted ingestion inspect is contracted in the frontend; operator UI panel is in flight. | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #581 | #582 | Hosted ingestion inspect is usable in the frontend; hosted ingestion import API is in flight. | `extracted_content_pipeline/api/control_surfaces.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -93,6 +93,10 @@ source of truth for what remains.
   import or generation. The hosted control-surface API also exposes
   `POST /content-ops/ingestion/inspect` for inline rows so operator UIs can use
   the same diagnostics path without reading local files.
+- The hosted control-surface API exposes `POST /content-ops/ingestion/import`
+  for inline rows. It runs the same diagnostics first, fails closed when rows
+  are not import-ready, then writes normalized opportunities through the
+  existing Postgres importer when the host supplies a pool provider.
 - `campaign_postgres_review` provides a product-owned draft review/status
   update path so hosts can approve, queue, cancel, or expire generated
   `b2b_campaigns` rows after export without handwritten SQL.

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -26,6 +26,7 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import TenantScope
+from ..campaign_postgres_import import import_campaign_opportunities
 from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -68,6 +69,7 @@ ReasoningStatusProvider = Callable[
     Mapping[str, Any] | None | Awaitable[Mapping[str, Any] | None],
 ]
 LLMProvider = Callable[[], Any | Awaitable[Any]]
+PoolProvider = Callable[[], Any | Awaitable[Any]]
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +199,7 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_falsification_rules: Sequence[Mapping[str, Any]] = ()
     structured_reasoning_falsification_conservative: bool = True
     structured_reasoning_drop_falsified: bool = False
+    ingestion_opportunity_table: str = "campaign_opportunities"
 
     def __post_init__(self) -> None:
         if not str(self.prefix or "").strip().startswith("/"):
@@ -260,6 +263,8 @@ class ContentOpsControlSurfaceApiConfig:
                 raise ValueError(
                     "structured_reasoning_falsification_rules entries must be mappings"
                 )
+        if not str(self.ingestion_opportunity_table or "").strip():
+            raise ValueError("ingestion_opportunity_table is required")
 
 
 @dataclass(frozen=True)
@@ -379,9 +384,16 @@ if BaseModel is not None:
                 _validate_input_shape(row, depth=0)
             return value
 
+    class ContentOpsIngestionImportModel(ContentOpsIngestionInspectModel):
+        """Bounded API request body for hosted opportunity import."""
+
+        replace_existing: bool = False
+        dry_run: bool = False
+
 else:  # pragma: no cover - module import fallback when FastAPI is unavailable.
     ContentOpsRequestModel = Any
     ContentOpsIngestionInspectModel = Any
+    ContentOpsIngestionImportModel = Any
 
 
 def create_content_ops_control_surface_router(
@@ -392,6 +404,7 @@ def create_content_ops_control_surface_router(
     reasoning_context_provider: ReasoningContextProvider | None = None,
     reasoning_status_provider: ReasoningStatusProvider | None = None,
     llm_provider: LLMProvider | None = None,
+    opportunity_import_pool_provider: PoolProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
     """Create host-mounted AI Content Ops control-surface routes.
@@ -467,6 +480,53 @@ def create_content_ops_control_surface_router(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return report.as_dict()
+
+    @router.post("/ingestion/import")
+    async def import_ingestion(
+        payload: ContentOpsIngestionImportModel = Body(...),
+    ) -> dict[str, Any]:
+        data = _ingestion_import_payload_to_mapping(payload)
+        target_mode = _clean(data.get("target_mode")) or "vendor_retention"
+        try:
+            report = inspect_ingestion_rows(
+                data["rows"],
+                source_rows=bool(data.get("source_rows")),
+                source=_clean(data.get("source")) or "api",
+                target_mode=target_mode,
+                max_source_text_chars=int(data.get("max_source_text_chars") or 1200),
+                sample_limit=int(data.get("sample_limit") or 0),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        diagnostics = report.as_dict()
+        if not report.ok:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "reason": "ingestion_not_ready",
+                    "diagnostics": diagnostics,
+                },
+            )
+        dry_run = bool(data.get("dry_run"))
+        if dry_run:
+            pool = object()
+        else:
+            pool = await _resolve_import_pool(opportunity_import_pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        result = await _import_campaign_opportunities_for_route(
+            pool,
+            report.opportunities,
+            scope=scope,
+            target_mode=target_mode,
+            opportunity_table=resolved_config.ingestion_opportunity_table,
+            replace_existing=bool(data.get("replace_existing")),
+            dry_run=dry_run,
+            source=report.source,
+        )
+        return {
+            "diagnostics": diagnostics,
+            "import": result.as_dict(),
+        }
 
     @router.post("/execute")
     async def execute_generation(
@@ -833,6 +893,153 @@ async def _resolve_scope(provider: ScopeProvider | None) -> TenantScope | None:
     return _scope_from_value(value)
 
 
+async def _resolve_import_pool(provider: PoolProvider | None) -> Any:
+    if provider is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import database is not configured.",
+        )
+    try:
+        pool = await _resolve_provider(provider)
+    except Exception as exc:
+        logger.warning(
+            "Content Ops ingestion import pool provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import database is unavailable.",
+        ) from exc
+    if pool is None or getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import database is unavailable.",
+        )
+    return pool
+
+
+async def _import_campaign_opportunities_for_route(
+    db: Any,
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    scope: TenantScope | None,
+    target_mode: str,
+    opportunity_table: str,
+    replace_existing: bool,
+    dry_run: bool,
+    source: str | None,
+) -> Any:
+    try:
+        return await _import_campaign_opportunities_atomic(
+            db,
+            rows,
+            scope=scope,
+            target_mode=target_mode,
+            opportunity_table=opportunity_table,
+            replace_existing=replace_existing,
+            dry_run=dry_run,
+            source=source,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.warning(
+            "Content Ops ingestion import failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import failed.",
+        ) from exc
+
+
+async def _import_campaign_opportunities_atomic(
+    db: Any,
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    scope: TenantScope | None,
+    target_mode: str,
+    opportunity_table: str,
+    replace_existing: bool,
+    dry_run: bool,
+    source: str | None,
+) -> Any:
+    acquire = getattr(db, "acquire", None)
+    if callable(acquire):
+        async with acquire() as connection:
+            transaction = getattr(connection, "transaction", None)
+            if callable(transaction):
+                async with transaction():
+                    return await _import_campaign_opportunities_direct(
+                        connection,
+                        rows,
+                        scope=scope,
+                        target_mode=target_mode,
+                        opportunity_table=opportunity_table,
+                        replace_existing=replace_existing,
+                        dry_run=dry_run,
+                        source=source,
+                    )
+            return await _import_campaign_opportunities_direct(
+                connection,
+                rows,
+                scope=scope,
+                target_mode=target_mode,
+                opportunity_table=opportunity_table,
+                replace_existing=replace_existing,
+                dry_run=dry_run,
+                source=source,
+            )
+
+    transaction = getattr(db, "transaction", None)
+    if callable(transaction):
+        async with transaction():
+            return await _import_campaign_opportunities_direct(
+                db,
+                rows,
+                scope=scope,
+                target_mode=target_mode,
+                opportunity_table=opportunity_table,
+                replace_existing=replace_existing,
+                dry_run=dry_run,
+                source=source,
+            )
+    return await _import_campaign_opportunities_direct(
+        db,
+        rows,
+        scope=scope,
+        target_mode=target_mode,
+        opportunity_table=opportunity_table,
+        replace_existing=replace_existing,
+        dry_run=dry_run,
+        source=source,
+    )
+
+
+async def _import_campaign_opportunities_direct(
+    db: Any,
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    scope: TenantScope | None,
+    target_mode: str,
+    opportunity_table: str,
+    replace_existing: bool,
+    dry_run: bool,
+    source: str | None,
+) -> Any:
+    return await import_campaign_opportunities(
+        db,
+        rows,
+        scope=scope,
+        target_mode=target_mode,
+        opportunity_table=opportunity_table,
+        replace_existing=replace_existing,
+        dry_run=dry_run,
+        normalize=False,
+        source=source,
+    )
+
+
 async def _resolve_provider(provider: Callable[[], Any] | None) -> Any:
     if provider is None:
         return None
@@ -885,6 +1092,15 @@ def _ingestion_payload_to_mapping(payload: Any) -> dict[str, Any]:
         return payload.model_dump()
     try:
         return ContentOpsIngestionInspectModel.model_validate(payload).model_dump()
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
+
+
+def _ingestion_import_payload_to_mapping(payload: Any) -> dict[str, Any]:
+    if BaseModel is not None and isinstance(payload, ContentOpsIngestionImportModel):
+        return payload.model_dump()
+    try:
+        return ContentOpsIngestionImportModel.model_validate(payload).model_dump()
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
 
@@ -952,6 +1168,7 @@ def _validation_detail(exc: ValidationError) -> list[dict[str, Any]]:
 
 __all__ = [
     "ContentOpsControlSurfaceApiConfig",
+    "ContentOpsIngestionImportModel",
     "ContentOpsRequestModel",
     "create_content_ops_control_surface_router",
 ]

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -56,6 +56,7 @@ size and nesting limits.
 | `POST` | `/content-ops/preview` | Validate a requested preset/output selection and return cost, missing inputs, warnings, and blocked outputs. |
 | `POST` | `/content-ops/plan` | Convert a previewable request into deterministic generation steps. Does not execute generation. |
 | `POST` | `/content-ops/ingestion/inspect` | Inspect inline opportunity rows or source rows and return the same readiness diagnostics as the host CLI. |
+| `POST` | `/content-ops/ingestion/import` | Inspect inline rows, fail closed when not import-ready, then write normalized opportunities into `campaign_opportunities`. |
 | `POST` | `/content-ops/execute` | Execute a runnable plan through host-injected services. Disabled unless the host configures execution services. |
 
 ## Output Catalog
@@ -235,6 +236,53 @@ not call a database, LLM, sender, or execution service.
   ],
   "target_mode": "vendor_retention",
   "sample_limit": 3
+}
+```
+
+## Ingestion Import Route
+
+`POST /content-ops/ingestion/import` accepts the same inline rows as the inspect
+route plus `replace_existing` and `dry_run`. The route runs diagnostics first
+and refuses to write when the rows are not import-ready, for example when every
+row is missing `target_id`.
+
+Hosts must pass `opportunity_import_pool_provider` when mounting the router for
+real writes. `dry_run=true` uses the same normalization and readiness checks but
+does not require a database provider.
+
+```json
+{
+  "source": "operator-upload",
+  "rows": [
+    {
+      "target_id": "opp-1",
+      "company_name": "Acme",
+      "vendor_name": "HubSpot",
+      "evidence": [{"quote": "The renewal process is too manual."}]
+    }
+  ],
+  "replace_existing": true,
+  "dry_run": false
+}
+```
+
+Response:
+
+```json
+{
+  "diagnostics": {
+    "ok": true,
+    "mode": "opportunities",
+    "opportunity_count": 1,
+    "warning_count": 0
+  },
+  "import": {
+    "inserted": 1,
+    "skipped": 0,
+    "dry_run": false,
+    "replace_existing": true,
+    "target_ids": ["opp-1"]
+  }
 }
 ```
 

--- a/plans/PR-Content-Ops-Ingestion-Import-API.md
+++ b/plans/PR-Content-Ops-Ingestion-Import-API.md
@@ -1,0 +1,69 @@
+# PR: Content Ops Ingestion Import API
+
+## Why this slice exists
+
+Hosted Content Ops can inspect pasted opportunity/source rows, but operators
+still need the CLI to write accepted rows into `campaign_opportunities`.
+This slice adds the hosted write seam immediately after diagnostics, reusing
+the existing importer instead of creating a second ingestion path.
+
+## Scope (this PR)
+
+Add a host-wired `POST /content-ops/ingestion/import` route to the Content Ops
+control-surface router and document the route.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `atlas_brain/api/__init__.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Ingestion-Import-API.md`
+
+## Mechanism
+
+- Add an optional pool provider to `create_content_ops_control_surface_router`.
+- Add a bounded import payload model that extends the inspect payload with
+  `replace_existing` and `dry_run`.
+- Run `inspect_ingestion_rows(...)` first, fail closed when diagnostics are not
+  import-ready, then call `import_campaign_opportunities(...)` with
+  `normalize=False` so the inspected rows are the rows written.
+- Wrap writes in a transaction when the host pool/connection supports one, and
+  map unexpected database failures to a safe 503 response.
+- Resolve tenant scope through the existing `scope_provider` seam.
+
+## Intentional
+
+- No frontend import button in this PR.
+- No new table schema.
+- No generated-asset execution changes.
+- Dry-run imports do not require a pool provider.
+
+## Deferred
+
+- New-run UI import action.
+- CSV/file upload import from the browser.
+- Import history/audit UI.
+
+## Verification
+
+- Run the focused `tests/test_extracted_content_control_surface_api.py` pytest file.
+- Compile `extracted_content_pipeline/api/control_surfaces.py`,
+  `atlas_brain/api/__init__.py`, and
+  `tests/test_extracted_content_control_surface_api.py`.
+- `git diff --check`
+- Run `scripts/local_pr_review.sh` from the repo root.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Control-surface import route | ~195 |
+| Atlas route mount wiring | ~1 |
+| API tests | ~165 |
+| Docs/status/coordination | ~35 |
+| Plan doc | ~60 |
+| **Total** | ~456 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -43,6 +43,68 @@ class _FailingCampaignService:
         raise RuntimeError("postgres://user:secret@example/internal")
 
 
+class _Pool:
+    def __init__(self):
+        self.executed = []
+        self.is_initialized = True
+
+    async def execute(self, query, *args):
+        self.executed.append((str(query), args))
+        return "EXECUTE"
+
+
+class _Transaction:
+    def __init__(self):
+        self.entered = False
+        self.exited_with = None
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc, tb
+        self.exited_with = exc_type
+        return False
+
+
+class _Connection(_Pool):
+    def __init__(self, *, fail_on_insert=False):
+        super().__init__()
+        self.fail_on_insert = fail_on_insert
+        self.tx = _Transaction()
+
+    def transaction(self):
+        return self.tx
+
+    async def execute(self, query, *args):
+        self.executed.append((str(query), args))
+        if self.fail_on_insert and "INSERT INTO" in str(query):
+            raise RuntimeError("postgres://user:secret@example/internal")
+        return "EXECUTE"
+
+
+class _Acquire:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return False
+
+
+class _PoolWithAcquire:
+    def __init__(self, connection):
+        self.connection = connection
+        self.is_initialized = True
+
+    def acquire(self):
+        return _Acquire(self.connection)
+
+
 @pytest.mark.asyncio
 async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     router = create_content_ops_control_surface_router()
@@ -507,6 +569,143 @@ async def test_ingestion_inspect_route_rejects_oversized_rows():
         })
 
     assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_dry_run_does_not_require_pool_provider():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/import", "POST")
+    payload = await route.endpoint({
+        "dry_run": True,
+        "source": "operator-upload",
+        "rows": [{
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "evidence": [{"quote": "Renewal process is too manual."}],
+        }],
+    })
+
+    assert payload["diagnostics"]["ok"] is True
+    assert payload["import"]["dry_run"] is True
+    assert payload["import"]["inserted"] == 1
+    assert payload["import"]["source"] == "operator-upload"
+    assert payload["import"]["target_ids"] == ["opp-1"]
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_writes_rows_with_scope_and_replace_existing():
+    pool = _Pool()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=lambda: pool,
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+
+    route = _route(router, "/ops/ingestion/import", "POST")
+    payload = await route.endpoint({
+        "replace_existing": True,
+        "target_mode": "vendor_retention",
+        "rows": [{
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "evidence": [{"quote": "Renewal process is too manual."}],
+        }],
+    })
+
+    assert payload["import"]["inserted"] == 1
+    assert payload["import"]["replace_existing"] is True
+    assert len(pool.executed) == 2
+    delete_query, delete_args = pool.executed[0]
+    insert_query, insert_args = pool.executed[1]
+    assert "DELETE FROM \"campaign_opportunities\"" in delete_query
+    assert delete_args == ("acct-1", "vendor_retention", ["opp-1"])
+    assert "INSERT INTO \"campaign_opportunities\"" in insert_query
+    assert insert_args[0] == "acct-1"
+    assert insert_args[1] == "opp-1"
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_requires_pool_for_write():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/import", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "rows": [{
+                "target_id": "opp-1",
+                "company_name": "Acme",
+                "vendor_name": "HubSpot",
+                "evidence": [{"quote": "Renewal process is too manual."}],
+            }],
+        })
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Content Ops ingestion import database is not configured."
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_rejects_not_ready_diagnostics():
+    pool = _Pool()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=lambda: pool,
+    )
+
+    route = _route(router, "/ops/ingestion/import", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "rows": [{
+                "evidence": [{"quote": "Renewal process is too manual."}],
+            }],
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["reason"] == "ingestion_not_ready"
+    assert exc.value.detail["diagnostics"]["missing_field_counts"] == {
+        "company_name": 1,
+        "target_id": 1,
+        "vendor_name": 1,
+    }
+    assert pool.executed == []
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_wraps_transactional_db_failures(caplog):
+    connection = _Connection(fail_on_insert=True)
+    pool = _PoolWithAcquire(connection)
+    caplog.set_level("WARNING", logger="extracted_content_pipeline.api.control_surfaces")
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=lambda: pool,
+    )
+
+    route = _route(router, "/ops/ingestion/import", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "replace_existing": True,
+            "rows": [{
+                "target_id": "opp-1",
+                "company_name": "Acme",
+                "vendor_name": "HubSpot",
+                "evidence": [{"quote": "Renewal process is too manual."}],
+            }],
+        })
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Content Ops ingestion import failed."
+    assert connection.tx.entered is True
+    assert connection.tx.exited_with is RuntimeError
+    assert any("DELETE FROM" in query for query, _args in connection.executed)
+    assert any("INSERT INTO" in query for query, _args in connection.executed)
+    assert "postgres://" not in str(exc.value.detail)
+    assert "postgres://" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-Import-API.md

## Summary
- add hosted POST /content-ops/ingestion/import beside the existing inspect route
- run diagnostics first and fail closed before writing rows that are not import-ready
- wire Atlas host mount with get_db_pool and tenant scope, plus focused route tests

## Verification
- python -m pytest -q tests/test_extracted_content_control_surface_api.py
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py atlas_brain/api/__init__.py
- git diff --check
- bash scripts/local_pr_review.sh