### PR TITLE
Show Content Ops import diagnostics on failure

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -157,6 +157,13 @@ export interface ContentOpsIngestionImportResponse {
   import: ContentOpsIngestionImportResultResponse
 }
 
+export type ContentOpsIngestionImportOutcome =
+  | { kind: 'success'; response: ContentOpsIngestionImportResponse }
+  | { kind: 'not_ready'; diagnostics: ContentOpsIngestionDiagnosticsResponse }
+  | { kind: 'request_invalid'; detail: string }
+  | { kind: 'validation_error'; detail: unknown }
+  | { kind: 'services_unavailable'; detail: string }
+
 // POST /content-ops/preview response
 
 export interface ContentOpsPreviewResponse {
@@ -543,10 +550,62 @@ export function inspectContentOpsIngestion(
 }
 
 /** POST /content-ops/ingestion/import -- import inspected opportunity/source rows. */
-export function importContentOpsIngestion(
+export async function importContentOpsIngestion(
   body: ContentOpsIngestionImportRequest,
-): Promise<ContentOpsIngestionImportResponse> {
-  return postJson<ContentOpsIngestionImportResponse>('/ingestion/import', body)
+): Promise<ContentOpsIngestionImportOutcome> {
+  const url = `${BASE}/ingestion/import`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(body),
+    })
+  const res = await withRefreshOn401(doFetch)
+
+  if (res.status === 200) {
+    return {
+      kind: 'success',
+      response: await rawJson<ContentOpsIngestionImportResponse>(res),
+    }
+  }
+  if (res.status === 400) {
+    const text = await rawText(res)
+    try {
+      const detail = (JSON.parse(text) as { detail?: unknown })?.detail
+      if (isIngestionNotReadyDetail(detail)) {
+        return { kind: 'not_ready', diagnostics: detail.diagnostics }
+      }
+      return {
+        kind: 'request_invalid',
+        detail: typeof detail === 'string' ? detail : text,
+      }
+    } catch {
+      return { kind: 'request_invalid', detail: text || res.statusText }
+    }
+  }
+  if (res.status === 422) {
+    const text = await rawText(res)
+    let detail: unknown = text
+    try {
+      detail = (JSON.parse(text) as { detail?: unknown })?.detail ?? text
+    } catch {
+      // keep raw text
+    }
+    return { kind: 'validation_error', detail }
+  }
+  if (res.status === 503) {
+    const text = await rawText(res)
+    let detail = text || res.statusText
+    try {
+      const parsed = JSON.parse(text) as { detail?: unknown }
+      if (typeof parsed?.detail === 'string') detail = parsed.detail
+    } catch {
+      // keep raw text
+    }
+    return { kind: 'services_unavailable', detail }
+  }
+  const text = await rawText(res)
+  throw new Error(`API ${res.status}: ${text || res.statusText}`)
 }
 
 /**
@@ -646,4 +705,22 @@ function unwrapDetail<T>(payload: T | { detail: T }): T {
     return (payload as { detail: T }).detail
   }
   return payload as T
+}
+
+function isIngestionNotReadyDetail(
+  value: unknown,
+): value is {
+  reason: 'ingestion_not_ready'
+  diagnostics: ContentOpsIngestionDiagnosticsResponse
+} {
+  if (!value || typeof value !== 'object') return false
+  const detail = value as Record<string, unknown>
+  const diagnostics = detail.diagnostics
+  return (
+    detail.reason === 'ingestion_not_ready' &&
+    !!diagnostics &&
+    typeof diagnostics === 'object' &&
+    'ok' in diagnostics &&
+    'warnings' in diagnostics
+  )
 }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -68,6 +68,7 @@ type IngestionImportState =
   | { kind: 'idle' }
   | { kind: 'submitting' }
   | { kind: 'invalid_input'; message: string }
+  | { kind: 'not_ready'; diagnostics: ContentOpsIngestionDiagnostics }
   | { kind: 'error'; message: string }
   | { kind: 'success'; response: ContentOpsIngestionImportResponse }
 
@@ -383,7 +384,7 @@ export default function ContentOpsNewRun() {
 
     setIngestionImportState({ kind: 'submitting' })
     try {
-      const wire = await importContentOpsIngestion(
+      const outcome = await importContentOpsIngestion(
         toWireIngestionImportRequest({
           rows: parsed.rows,
           sourceRows: ingestionSourceRows,
@@ -396,16 +397,34 @@ export default function ContentOpsNewRun() {
         }),
       )
       if (requestId !== ingestionImportRequestIdRef.current) return
-      setIngestionImportState({
-        kind: 'success',
-        response: fromWireIngestionImportResponse(wire),
-      })
-      if (inspectRequestId === ingestionInspectRequestIdRef.current) {
-        setIngestionInspectState({
+      if (outcome.kind === 'success') {
+        setIngestionImportState({
           kind: 'success',
-          diagnostics: fromWireIngestionDiagnostics(wire.diagnostics),
+          response: fromWireIngestionImportResponse(outcome.response),
         })
+        if (inspectRequestId === ingestionInspectRequestIdRef.current) {
+          setIngestionInspectState({
+            kind: 'success',
+            diagnostics: fromWireIngestionDiagnostics(outcome.response.diagnostics),
+          })
+        }
+        return
       }
+      if (outcome.kind === 'not_ready') {
+        const diagnostics = fromWireIngestionDiagnostics(outcome.diagnostics)
+        setIngestionImportState({ kind: 'not_ready', diagnostics })
+        if (inspectRequestId === ingestionInspectRequestIdRef.current) {
+          setIngestionInspectState({
+            kind: 'success',
+            diagnostics,
+          })
+        }
+        return
+      }
+      setIngestionImportState({
+        kind: 'error',
+        message: importOutcomeMessage(outcome),
+      })
     } catch (err) {
       if (requestId !== ingestionImportRequestIdRef.current) return
       setIngestionImportState({
@@ -1041,6 +1060,32 @@ function IngestionImportResult({ state }: { state: IngestionImportState }) {
       </div>
     )
   }
+  if (state.kind === 'not_ready') {
+    return (
+      <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+        <div className="mb-2 font-medium">
+          Import blocked: rows need attention before they can be written.
+        </div>
+        <div className="mb-2 flex flex-wrap gap-3 text-slate-300">
+          <span>Opportunities: {state.diagnostics.opportunityCount}</span>
+          <span>Warnings: {state.diagnostics.warningCount}</span>
+        </div>
+        {state.diagnostics.warnings.length > 0 && (
+          <Section label="Blocking diagnostics">
+            <ul className="ml-4 list-disc text-xs text-amber-100">
+              {state.diagnostics.warnings
+                .slice(0, INGESTION_SAMPLE_LIMIT)
+                .map((warning, i) => (
+                  <li key={`${warning.code}-${warning.rowIndex ?? i}-${warning.field ?? ''}`}>
+                    {warning.code}: {warning.message}
+                  </li>
+                ))}
+            </ul>
+          </Section>
+        )}
+      </div>
+    )
+  }
 
   const result = state.response.importResult
   return (
@@ -1075,6 +1120,18 @@ function IngestionImportResult({ state }: { state: IngestionImportState }) {
       )}
     </div>
   )
+}
+
+function importOutcomeMessage(
+  outcome: Exclude<
+    Awaited<ReturnType<typeof importContentOpsIngestion>>,
+    { kind: 'success' } | { kind: 'not_ready' }
+  >,
+): string {
+  if (outcome.kind === 'validation_error') {
+    return JSON.stringify(outcome.detail)
+  }
+  return outcome.detail
 }
 
 type ParsedIngestionRows =

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T02:32Z by codex-2026-05-17
+Last updated: 2026-05-18T14:49Z by codex-2026-05-17
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops ingestion import UI | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/api/contentOps.contract.ts`, `atlas-intel-ui/src/api/__fixtures__/contentOps/ingestion-import.json`, `atlas-intel-ui/src/domain/contentOps/types.ts`, `atlas-intel-ui/src/domain/contentOps/fromWire.ts`, `atlas-intel-ui/src/domain/contentOps/contract.ts`, `atlas-intel-ui/src/domain/contentOps/index.ts`, `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Import-UI.md` | codex-2026-05-17 | Avoid editing Content Ops frontend ingestion UI/API files |
+| pending | Content Ops ingestion import diagnostics UI | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-Import-Error-UI.md` | codex-2026-05-17 | Avoid editing Content Ops frontend ingestion import error handling |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T02:32Z by codex-2026-05-17
+Last updated: 2026-05-18T14:49Z by codex-2026-05-17
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #582 | pending | Hosted ingestion import API is merged; New Run import UI is in flight. | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #583 | pending | New Run can import pasted ingestion rows; import diagnostics UI is in flight. | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -541,6 +541,9 @@ Dumb components only. No fetch, no business rules.
    - Supports an ingestion inspector/importer that calls
      `POST /content-ops/ingestion/inspect` for pasted rows and
      `POST /content-ops/ingestion/import` for dry-run or write import.
+     When import returns `reason="ingestion_not_ready"`, render the
+     returned diagnostics instead of collapsing the response into a generic
+     API error.
    - On submit: `POST /content-ops/preview`, render
      `ControlSurfacePreview`.
 

--- a/plans/PR-Content-Ops-Ingestion-Import-Error-UI.md
+++ b/plans/PR-Content-Ops-Ingestion-Import-Error-UI.md
@@ -1,0 +1,59 @@
+# PR: Content Ops Ingestion Import Diagnostics UI
+
+## Why this slice exists
+
+The hosted import route returns structured diagnostics when pasted rows are not
+ready to import, but the frontend import action currently collapses that 400
+response into a generic API error. Operators should see the same row warnings
+they would see from the inspect action.
+
+## Scope (this PR)
+
+Preserve `ingestion_not_ready` diagnostics through the frontend API wrapper and
+render them in the New Run import result panel.
+
+### Files touched
+
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Ingestion-Import-Error-UI.md`
+
+## Mechanism
+
+- Change the import API wrapper to return a discriminated outcome, matching the
+  existing execute wrapper pattern for meaningful non-2xx responses.
+- Decode 400 responses whose detail has `reason="ingestion_not_ready"` and a
+  diagnostics payload.
+- Render that diagnostics payload as an import-blocked state and keep the
+  inspect panel synchronized with the same diagnostics.
+
+## Intentional
+
+- No backend API changes.
+- No changes to successful import response mapping.
+- No file upload or import history UI.
+- No retry behavior for database or validation failures.
+
+## Deferred
+
+- Richer generic validation-error rendering for 422 responses.
+- Browser file upload import flow.
+- Import history/audit browser.
+
+## Verification
+
+- Run the atlas-intel-ui build.
+- Run git diff --check.
+- Run the local PR review script from the repo root.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Import API outcome handling | ~83 |
+| New Run blocked-import UI | ~69 |
+| Docs/coordination/plan | ~73 |
+| **Total** | ~225 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-Import-Error-UI.md

## Summary
- preserve structured ingestion_not_ready diagnostics from POST /content-ops/ingestion/import
- render blocked import diagnostics in the New Run ingestion panel
- update frontend contract and coordination docs

## Verification
- npm --prefix atlas-intel-ui ci
- npm --prefix atlas-intel-ui run build
- git diff --check
- bash scripts/local_pr_review.sh