### PR TITLE
Add Content Ops ingestion CSV file loader

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -670,7 +670,7 @@ export default function ContentOpsNewRun() {
                 className="flex items-center justify-center gap-2 rounded-md border border-slate-600 bg-slate-800/70 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 disabled:opacity-50"
               >
                 <FileUp className="h-3.5 w-3.5" />
-                Load JSON/CSV
+                Load JSON/JSONL/CSV
               </button>
               <input
                 ref={ingestionFileInputRef}
@@ -1319,6 +1319,9 @@ function parseIngestionCsvRows(text: string): ParsedIngestionRows {
       }
       return out
     })
+  if (rows.length === 0) {
+    return { ok: false, message: 'Provide at least one row to inspect.' }
+  }
   return normalizeIngestionRows(rows)
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -670,13 +670,13 @@ export default function ContentOpsNewRun() {
                 className="flex items-center justify-center gap-2 rounded-md border border-slate-600 bg-slate-800/70 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 disabled:opacity-50"
               >
                 <FileUp className="h-3.5 w-3.5" />
-                Load JSON/JSONL
+                Load JSON/CSV
               </button>
               <input
                 ref={ingestionFileInputRef}
                 type="file"
-                accept=".json,.jsonl,.ndjson,application/json,application/x-ndjson"
-                aria-label="Load ingestion JSON or JSONL file"
+                accept=".json,.jsonl,.ndjson,.csv,application/json,application/x-ndjson,text/csv"
+                aria-label="Load ingestion JSON, JSONL, or CSV file"
                 onChange={handleLoadIngestionFile}
                 className="hidden"
               />
@@ -1285,7 +1285,84 @@ function parseIngestionFileRows(
     }
     return normalizeIngestionRows(rows)
   }
+  if (lowerFilename.endsWith('.csv')) {
+    return parseIngestionCsvRows(text)
+  }
   return parseIngestionRowsJson(text)
+}
+
+function parseIngestionCsvRows(text: string): ParsedIngestionRows {
+  const parsed = parseCsv(text)
+  if (!parsed.ok) return parsed
+  const [header, ...bodyRows] = parsed.rows
+  if (!header || header.length === 0) {
+    return { ok: false, message: 'CSV must include a header row.' }
+  }
+  const columns = header.map((value) => value.trim())
+  const seenColumns = new Set<string>()
+  for (const [index, column] of columns.entries()) {
+    if (!column) {
+      return { ok: false, message: `CSV header ${index + 1} is empty.` }
+    }
+    if (seenColumns.has(column)) {
+      return { ok: false, message: `CSV header "${column}" is duplicated.` }
+    }
+    seenColumns.add(column)
+  }
+
+  const rows = bodyRows
+    .filter((row) => row.some((value) => value.trim()))
+    .map((row) => {
+      const out: Record<string, unknown> = {}
+      for (const [index, column] of columns.entries()) {
+        out[column] = row[index] ?? ''
+      }
+      return out
+    })
+  return normalizeIngestionRows(rows)
+}
+
+function parseCsv(text: string): { ok: true; rows: string[][] } | { ok: false; message: string } {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+    const nextChar = text[index + 1]
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        field += '"'
+        index += 1
+      } else {
+        inQuotes = !inQuotes
+      }
+      continue
+    }
+    if (char === ',' && !inQuotes) {
+      row.push(field)
+      field = ''
+      continue
+    }
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+      if (char === '\r' && nextChar === '\n') {
+        index += 1
+      }
+      continue
+    }
+    field += char
+  }
+  if (inQuotes) {
+    return { ok: false, message: 'CSV contains an unterminated quoted field.' }
+  }
+  row.push(field)
+  rows.push(row)
+  return { ok: true, rows }
 }
 
 function extractIngestionRows(value: unknown): ParsedIngestionRows {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1310,19 +1310,25 @@ function parseIngestionCsvRows(text: string): ParsedIngestionRows {
     seenColumns.add(column)
   }
 
-  const rows = bodyRows
-    .filter((row) => row.some((value) => value.trim()))
-    .map((row) => {
-      const out: Record<string, unknown> = {}
-      for (const [index, column] of columns.entries()) {
-        out[column] = row[index] ?? ''
+  const normalizedRows: Array<Record<string, unknown>> = []
+  for (const [index, row] of bodyRows.entries()) {
+    if (!row.some((value) => value.trim())) continue
+    if (row.length > columns.length) {
+      return {
+        ok: false,
+        message: `CSV row ${index + 2} has ${row.length} fields but only ${columns.length} headers.`,
       }
-      return out
-    })
-  if (rows.length === 0) {
+    }
+    const out: Record<string, unknown> = {}
+    for (const [index, column] of columns.entries()) {
+      out[column] = row[index] ?? ''
+    }
+    normalizedRows.push(out)
+  }
+  if (normalizedRows.length === 0) {
     return { ok: false, message: 'Provide at least one row to inspect.' }
   }
-  return normalizeIngestionRows(rows)
+  return normalizeIngestionRows(normalizedRows)
 }
 
 function parseCsv(text: string): { ok: true; rows: string[][] } | { ok: false; message: string } {
@@ -1330,6 +1336,7 @@ function parseCsv(text: string): { ok: true; rows: string[][] } | { ok: false; m
   let row: string[] = []
   let field = ''
   let inQuotes = false
+  let justClosedQuote = false
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index]
@@ -1338,14 +1345,20 @@ function parseCsv(text: string): { ok: true; rows: string[][] } | { ok: false; m
       if (inQuotes && nextChar === '"') {
         field += '"'
         index += 1
+      } else if (inQuotes) {
+        inQuotes = false
+        justClosedQuote = true
+      } else if (!field) {
+        inQuotes = true
       } else {
-        inQuotes = !inQuotes
+        return { ok: false, message: `Unexpected quote at character ${index + 1}.` }
       }
       continue
     }
     if (char === ',' && !inQuotes) {
       row.push(field)
       field = ''
+      justClosedQuote = false
       continue
     }
     if ((char === '\n' || char === '\r') && !inQuotes) {
@@ -1353,18 +1366,24 @@ function parseCsv(text: string): { ok: true; rows: string[][] } | { ok: false; m
       rows.push(row)
       row = []
       field = ''
+      justClosedQuote = false
       if (char === '\r' && nextChar === '\n') {
         index += 1
       }
       continue
+    }
+    if (justClosedQuote) {
+      return { ok: false, message: `Unexpected character after closing quote at character ${index + 1}.` }
     }
     field += char
   }
   if (inQuotes) {
     return { ok: false, message: 'CSV contains an unterminated quoted field.' }
   }
-  row.push(field)
-  rows.push(row)
+  if (field || row.length > 0 || justClosedQuote) {
+    row.push(field)
+    rows.push(row)
+  }
   return { ok: true, rows }
 }
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T15:06Z by codex-2026-05-17
+Last updated: 2026-05-18T16:15Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops ingestion file load UI | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-File-Load-UI.md` | codex-2026-05-17 | Avoid editing Content Ops frontend ingestion file-loading UI |
+| pending | Content Ops ingestion CSV file load UI | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md` | codex-2026-05-18 | Avoid editing Content Ops frontend ingestion file-loading UI |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T15:06Z by codex-2026-05-17
+Last updated: 2026-05-18T16:15Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #583 | pending | New Run shows import diagnostics; JSON/JSONL file loading is in flight. | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #585 | pending | New Run loads JSON/JSONL ingestion files; CSV file loading is in flight. | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -539,7 +539,7 @@ Dumb components only. No fetch, no business rules.
      options (`limit`, `maxCostUsd`, `requireQualityGates`,
      `allowUnimplementedOutputs`, `ingestionProfile`).
    - Supports an ingestion inspector/importer that calls
-     `POST /content-ops/ingestion/inspect` for pasted or loaded JSON/JSONL rows and
+     `POST /content-ops/ingestion/inspect` for pasted or loaded JSON/JSONL/CSV rows and
      `POST /content-ops/ingestion/import` for dry-run or write import.
      When import returns `reason="ingestion_not_ready"`, render the
      returned diagnostics instead of collapsing the response into a generic

--- a/plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md
+++ b/plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md
@@ -1,0 +1,64 @@
+# PR: Content Ops Ingestion CSV File Load UI
+
+## Why this slice exists
+
+The New Run ingestion panel can load JSON, JSONL, and NDJSON files, but customer
+exports commonly arrive as CSV. The backend and host CLI already support CSV
+opportunity/source-row ingestion, so the browser UI should not force operators
+to convert CSV exports before inspection or import.
+
+## Scope (this PR)
+
+Add browser-side CSV parsing to the existing ingestion file loader. CSV rows are
+converted into the same array-of-object JSON shape already pasted into the
+textarea, then the existing inspect/import API calls continue unchanged.
+
+### Files touched
+
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `docs/frontend/content_ops_frontend_contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md`
+
+## Mechanism
+
+- Extend the file picker accept list and visible label from JSON/JSONL to
+  JSON/CSV.
+- Route `.csv` files through a local CSV parser in `ContentOpsNewRun.tsx`.
+- Treat the first CSV row as headers, reject empty or duplicate headers, skip
+  blank body rows, and emit row objects using the header labels as keys.
+- Preserve the existing request-id race guard, loading state, source label
+  behavior, textarea handoff, and inspect/import API path.
+
+## Intentional
+
+- The parser handles commas, quoted fields, escaped double quotes, CRLF, LF, and
+  quoted multiline values.
+- Parsed CSV cell values remain strings because host exports are text-first and
+  the backend normalizer already owns semantic coercion.
+- The UI still shows the loaded rows in the textarea so operators can inspect or
+  edit before running the API calls.
+
+## Deferred
+
+- No server-side file upload endpoint; this remains browser-side conversion into
+  inline rows.
+- No XLSX parser.
+- No automatic source-row toggle based on CSV headers; operators still choose
+  whether rows are source exports.
+
+## Verification
+
+- npm --prefix atlas-intel-ui ci
+- npm --prefix atlas-intel-ui run build
+- git diff --check
+- bash scripts/local_pr_review.sh
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| New Run CSV file loader parsing and labels | ~85 |
+| Docs/coordination/plan | ~60 |
+| **Total** | ~145 |

--- a/plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md
+++ b/plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md
@@ -59,6 +59,6 @@ textarea, then the existing inspect/import API calls continue unchanged.
 
 | Area | Estimated LOC |
 |---|---:|
-| New Run CSV file loader parsing and labels | ~85 |
+| New Run CSV file loader parsing and labels | ~100 |
 | Docs/coordination/plan | ~60 |
-| **Total** | ~145 |
+| **Total** | ~160 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md

Summary:
- Add CSV support to the Content Ops New Run ingestion file loader.
- Convert CSV rows into the existing JSON textarea handoff so inspect/import APIs stay unchanged.
- Update frontend contract and coordination docs after #585 merged.

Verification:
- npm --prefix atlas-intel-ui ci
- npm --prefix atlas-intel-ui run build
- git diff --check
- bash scripts/local_pr_review.sh