### PR TITLE
Close post-586 Content Ops coordination state

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T16:15Z by codex-2026-05-18
+Last updated: 2026-05-18T17:02Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops ingestion CSV file load UI | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/frontend/content_ops_frontend_contract.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Ingestion-CSV-File-Load-UI.md` | codex-2026-05-18 | Avoid editing Content Ops frontend ingestion file-loading UI |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T16:15Z by codex-2026-05-18
+Last updated: 2026-05-18T17:02Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #585 | pending | New Run loads JSON/JSONL ingestion files; CSV file loading is in flight. | `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #586 | — | Hosted ingestion file loading is closed for JSON, JSONL, NDJSON, and CSV. Next work should come from a real source export fixture or extracted_reasoning_core productization need. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/plans/PR-Post-586-Content-Ops-Closeout.md
+++ b/plans/PR-Post-586-Content-Ops-Closeout.md
@@ -1,0 +1,49 @@
+# Post-586 Content Ops Closeout
+
+## Why this slice exists
+
+PR #586 merged the Content Ops CSV ingestion file loader, but the coordination
+ledger still showed that work as pending. That stale claim makes later sessions
+avoid a hot zone that is no longer active.
+
+## Scope (this PR)
+
+Clear the post-merge coordination state for Content Ops ingestion file loading.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Post-586-Content-Ops-Closeout.md`
+
+## Mechanism
+
+- Remove the pending CSV ingestion UI row from the in-flight ledger.
+- Move `extracted_content_pipeline` state from PR #585 / pending to PR #586 / no
+  active PRs.
+- Record that hosted ingestion file loading now covers JSON, JSONL, NDJSON, and
+  CSV.
+
+## Intentional
+
+This is a docs-only coordination closeout. It does not touch frontend code,
+pipeline runtime code, tests, or the hosted ingestion contract.
+
+## Deferred
+
+Further Content Ops ingestion slices should wait for a real host source export
+fixture or a concrete extracted_reasoning_core productization need. The active
+backlog does not currently justify speculative source adapters.
+
+## Verification
+
+- `git diff --check`
+- Local PR review hook
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Coordination docs | 2 line edits |
+| Plan doc | ~40 lines |
+| **Total** | ~55 |


### PR DESCRIPTION
Plan: plans/PR-Post-586-Content-Ops-Closeout.md

## Summary
- remove the stale CSV ingestion UI row from the in-flight ledger
- update extracted_content_pipeline state to PR #586 with no active hot zone
- add the post-586 closeout plan

## Verification
- git diff --check
- bash scripts/local_pr_review.sh
- pre-push hook local PR review