### PR TITLE
Export G2 review sources for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T17:02Z by codex-2026-05-18
+Last updated: 2026-05-18T17:14Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| pending | Content Ops G2 review source export | `scripts/export_content_ops_review_sources.py`, `tests/test_export_content_ops_review_sources.py`, `scripts/run_extracted_pipeline_checks.sh`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-G2-Review-Source-Export.md` | codex-2026-05-18 | Avoid editing Content Ops review-source export or coordination state |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T17:02Z by codex-2026-05-18
+Last updated: 2026-05-18T17:14Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #586 | — | Hosted ingestion file loading is closed for JSON, JSONL, NDJSON, and CSV. Next work should come from a real source export fixture or extracted_reasoning_core productization need. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #586 | pending | G2 review-source export is in flight to feed clean scraped review evidence into Content Ops ingestion. | `scripts/export_content_ops_review_sources.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -149,11 +149,24 @@ subscription, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
 and document source rows can be converted into the same opportunity payload
 first. Source rows can be JSON, JSONL, or CSV:
 
+If Atlas already has scraped B2B review rows, export one reliable source as
+Content Ops source rows before generation. The G2 path is read-only, keeps only
+canonical enriched reviews, and exports the negative/mixed quote-grade phrase
+lane as `text` while preserving the full review for audit:
+
+```bash
+python scripts/export_content_ops_review_sources.py \
+  --source g2 \
+  --vendor Slack \
+  --limit 50 \
+  --output g2_review_sources.jsonl
+```
+
 Before converting or importing a customer export, inspect ingestion readiness:
 
 ```bash
 python scripts/inspect_extracted_content_ingestion.py \
-  extracted_content_pipeline/examples/campaign_source_rows.jsonl \
+  g2_review_sources.jsonl \
   --source-rows \
   --source-format jsonl \
   --json

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -439,6 +439,26 @@ entry per saved row after successful writes. `--validate-opportunities` checks
 each row against active `campaign_opportunities` before saving, which catches
 typoed selectors during larger host imports.
 
+Atlas review rows can seed source-row ingestion when a host wants to test with
+scraped review evidence before wiring its own export. Start with one reliable
+source such as G2 so the generated output does not mix review-site tone with
+community sources:
+
+```bash
+python scripts/export_content_ops_review_sources.py \
+  --source g2 \
+  --vendor Slack \
+  --limit 50 \
+  --output g2_review_sources.jsonl
+
+python scripts/load_extracted_campaign_opportunities.py \
+  g2_review_sources.jsonl \
+  --source-rows \
+  --source-format jsonl \
+  --target-mode vendor_retention \
+  --dry-run
+```
+
 Source-row bundles can also include sales-call and meeting exports under
 `calls`, `call_transcripts`, `meetings`, or `meeting_transcripts`. Use
 `call_id`, `meeting_id`, or `recording_id` as the source identifier and provide

--- a/plans/PR-Content-Ops-G2-Review-Source-Export.md
+++ b/plans/PR-Content-Ops-G2-Review-Source-Export.md
@@ -1,0 +1,78 @@
+# Content Ops G2 Review Source Export
+
+## Why this slice exists
+
+The hosted ingestion path can now load source rows, and the Atlas database has
+clean canonical G2 review rows. We need a read-only bridge that exports one
+reliable review source into Content Ops source-row JSONL without mixing noisy
+community sources or contradictory evidence lanes.
+
+This slice is above the preferred 400 LOC budget because the script and its
+contract tests are one boundary: the reviewer needs to see the SQL filter,
+phrase-lane gate, JSONL shape, and ingestion command together to validate that
+we are not mutating Atlas data or feeding contradictory review text.
+
+## Scope (this PR)
+
+Add a host-facing script that reads canonical enriched `b2b_reviews` rows and
+emits Content Ops source rows, defaulting to G2.
+
+### Files touched
+
+- `scripts/export_content_ops_review_sources.py`
+- `tests/test_export_content_ops_review_sources.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-G2-Review-Source-Export.md`
+
+## Mechanism
+
+- Query only canonical review rows: `duplicate_of_review_id IS NULL`,
+  enriched rows, non-empty review text, and a configurable source.
+- Default source is `g2`.
+- Filter rows to quote-grade subject-vendor phrase metadata with negative or
+  mixed polarity.
+- Export the coherent phrase lane as source-row `text`, while preserving the
+  full review and provenance fields for audit.
+- Render JSONL so the existing `--source-rows --source-format jsonl` ingestion
+  path can consume the file directly.
+
+## Intentional
+
+- Read-only against Atlas Postgres.
+- No mutation of `b2b_reviews` duplicate markers.
+- No Reddit/community source mixing.
+- No Content Ops runtime changes.
+
+## Deferred
+
+- Trustpilot and TrustRadius exports can reuse this script by passing
+  `--source`, but the first verified run stays on G2.
+- Importing the exported rows into a live Content Ops database is a separate
+  operator step using the existing ingestion/import CLI.
+
+## Verification
+
+- Focused pytest for the exporter, source adapters, and ingestion diagnostics -
+  63 passed.
+- Py-compile for the exporter script - passed.
+- ASCII Python check - passed.
+- Live read-only G2 export for Slack - exported 5 rows.
+- Ingestion inspection of the exported JSONL - ok, 5 opportunities.
+- Dry-run source-row import of the exported JSONL - would insert 5 rows.
+- Offline campaign generation from the exported JSONL - generated 2 drafts.
+- Whitespace diff check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Export script | ~395 |
+| Tests | ~220 |
+| Pipeline check wiring | ~5 |
+| README/runbook docs | ~45 |
+| Coordination and plan docs | ~70 |
+| **Total** | ~735 |

--- a/scripts/export_content_ops_review_sources.py
+++ b/scripts/export_content_ops_review_sources.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Export canonical Atlas review rows as Content Ops source-row JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import html
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Iterable, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - host dependency
+    load_dotenv = None
+
+
+DEFAULT_SOURCE = "g2"
+DEFAULT_POLARITIES = ("negative", "mixed")
+DEFAULT_PHRASE_FIELDS = (
+    "specific_complaints",
+    "pricing_phrases",
+    "feature_gaps",
+    "recommendation_language",
+)
+
+
+def _clean_text(value: Any) -> str:
+    return html.unescape(str(value or "").strip())
+
+
+def _safe_json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _text_list(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, str):
+        values = value.split(",")
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        values = value
+    else:
+        values = (value,)
+    out: list[str] = []
+    for item in values:
+        text = _clean_text(item)
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _unique_texts(values: Iterable[Any]) -> list[str]:
+    out: list[str] = []
+    for value in values:
+        text = _clean_text(value)
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _pain_categories(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, Mapping):
+        return _text_list(value.get("category") or value.get("name") or value.get("label"))
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        out: list[str] = []
+        for item in value:
+            for text in _pain_categories(item):
+                if text and text not in out:
+                    out.append(text)
+        return out
+    return _text_list(value)
+
+
+def _phrase_metadata(enrichment: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = enrichment.get("phrase_metadata")
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes, bytearray)):
+        return []
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def quote_grade_review_phrases(
+    enrichment: Mapping[str, Any],
+    *,
+    allowed_polarities: Sequence[str] = DEFAULT_POLARITIES,
+    allowed_fields: Sequence[str] = DEFAULT_PHRASE_FIELDS,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return coherent subject-vendor, verbatim negative/mixed phrases."""
+
+    polarities = {p.strip().lower() for p in allowed_polarities if p.strip()}
+    fields = {f.strip() for f in allowed_fields if f.strip()}
+    phrases: list[dict[str, Any]] = []
+    for entry in _phrase_metadata(enrichment):
+        text = _clean_text(entry.get("text"))
+        if not text:
+            continue
+        if entry.get("verbatim") is not True:
+            continue
+        if _clean_text(entry.get("subject")).lower() != "subject_vendor":
+            continue
+        polarity = _clean_text(entry.get("polarity")).lower()
+        if polarities and polarity not in polarities:
+            continue
+        field = _clean_text(entry.get("field"))
+        if fields and field not in fields:
+            continue
+        phrases.append({
+            "text": text,
+            "field": field,
+            "polarity": polarity,
+            "category_hint": _clean_text(entry.get("category_hint")),
+        })
+        if limit is not None and len(phrases) >= limit:
+            break
+    return phrases
+
+
+def review_row_to_source_row(
+    row: Mapping[str, Any],
+    *,
+    phrase_limit: int = 5,
+    allowed_polarities: Sequence[str] = DEFAULT_POLARITIES,
+    allowed_fields: Sequence[str] = DEFAULT_PHRASE_FIELDS,
+    max_full_review_chars: int = 3000,
+) -> dict[str, Any]:
+    """Convert one canonical review row into a Content Ops source row."""
+
+    enrichment = _safe_json_object(row.get("enrichment"))
+    phrases = quote_grade_review_phrases(
+        enrichment,
+        allowed_polarities=allowed_polarities,
+        allowed_fields=allowed_fields,
+        limit=phrase_limit,
+    )
+    if not phrases:
+        return {}
+
+    review_id = _clean_text(row.get("id"))
+    source = _clean_text(row.get("source")) or DEFAULT_SOURCE
+    source_review_id = _clean_text(row.get("source_review_id"))
+    source_id = source_review_id or review_id
+    phrase_texts = [phrase["text"] for phrase in phrases]
+    pain_points = _unique_texts(
+        text
+        for text in _pain_categories(enrichment.get("pain_category"))
+        + _pain_categories(enrichment.get("pain_categories"))
+        if text != "overall_dissatisfaction"
+    )
+    if not pain_points:
+        pain_points = [
+            phrase["category_hint"]
+            for phrase in phrases
+            if phrase.get("category_hint")
+        ]
+    out: dict[str, Any] = {
+        "id": source_id,
+        "source_id": source_id,
+        "review_id": review_id,
+        "source_type": "review",
+        "source": source,
+        "vendor_name": _clean_text(row.get("vendor_name")),
+        "review_text": _clean_text(row.get("review_text"))[:max_full_review_chars],
+        "text": "\n".join(phrase_texts),
+        "quote_grade_phrases": phrase_texts,
+        "quote_phrase_fields": [phrase["field"] for phrase in phrases if phrase.get("field")],
+        "quote_polarities": sorted({phrase["polarity"] for phrase in phrases if phrase.get("polarity")}),
+    }
+    optional_keys = {
+        "source_url": row.get("source_url"),
+        "source_review_id": source_review_id,
+        "source_title": row.get("summary"),
+        "rating": row.get("rating"),
+        "rating_max": row.get("rating_max"),
+        "reviewed_at": row.get("reviewed_at"),
+        "reviewer_title": row.get("reviewer_title"),
+        "contact_title": row.get("reviewer_title"),
+        "reviewer_company": row.get("reviewer_company"),
+        "company_name": row.get("reviewer_company"),
+        "reviewer_industry": row.get("reviewer_industry"),
+        "urgency_score": enrichment.get("urgency_score"),
+        "pain_points": pain_points,
+    }
+    for key, value in optional_keys.items():
+        if value not in (None, "", [], {}):
+            out[key] = _clean_text(value) if isinstance(value, str) else value
+    return out
+
+
+def build_review_source_query(
+    *,
+    source: str,
+    vendor_name: str | None,
+    min_review_text_chars: int,
+    require_review_url: bool,
+) -> tuple[str, list[Any]]:
+    """Build the read-only Atlas review query and parameter list."""
+
+    where = [
+        "LOWER(r.source) = LOWER($1)",
+        "r.duplicate_of_review_id IS NULL",
+        "r.enrichment_status = 'enriched'",
+        "r.enrichment IS NOT NULL",
+        "NULLIF(BTRIM(r.review_text), '') IS NOT NULL",
+        "length(r.review_text) >= $2",
+    ]
+    args: list[Any] = [source, min_review_text_chars]
+    if vendor_name:
+        args.append(vendor_name)
+        where.append(f"LOWER(r.vendor_name) = LOWER(${len(args)})")
+    if require_review_url:
+        where.append("NULLIF(BTRIM(r.source_url), '') IS NOT NULL")
+    args.extend([0, 0])
+    limit_placeholder = f"${len(args) - 1}"
+    offset_placeholder = f"${len(args)}"
+    query = f"""
+        SELECT r.id, r.source, r.source_url, r.source_review_id,
+               r.vendor_name, r.product_name, r.product_category,
+               r.rating, r.rating_max, r.summary, r.review_text,
+               r.reviewer_title, r.reviewer_company, r.reviewer_industry,
+               r.reviewed_at, r.imported_at, r.enrichment
+        FROM b2b_reviews r
+        WHERE {' AND '.join(where)}
+        ORDER BY CASE
+                   WHEN COALESCE(r.enrichment->>'urgency_score', '') ~ '^-?[0-9]+(\\.[0-9]+)?$'
+                   THEN (r.enrichment->>'urgency_score')::numeric
+                   ELSE 0
+                 END DESC,
+                 r.reviewed_at DESC NULLS LAST,
+                 r.imported_at DESC NULLS LAST,
+                 r.id ASC
+        LIMIT {limit_placeholder}
+        OFFSET {offset_placeholder}
+    """
+    return query, args
+
+
+async def fetch_review_source_rows(
+    pool: Any,
+    *,
+    source: str = DEFAULT_SOURCE,
+    vendor_name: str | None = None,
+    limit: int = 50,
+    min_review_text_chars: int = 80,
+    phrase_limit: int = 5,
+    allowed_polarities: Sequence[str] = DEFAULT_POLARITIES,
+    allowed_fields: Sequence[str] = DEFAULT_PHRASE_FIELDS,
+    require_review_url: bool = True,
+) -> list[dict[str, Any]]:
+    """Fetch and convert canonical review rows from an asyncpg-shaped pool."""
+
+    query, args = build_review_source_query(
+        source=source,
+        vendor_name=vendor_name,
+        min_review_text_chars=min_review_text_chars,
+        require_review_url=require_review_url,
+    )
+    fetch_limit_index = len(args) - 2
+    fetch_offset_index = len(args) - 1
+    rows: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    page_size = max(limit * 3, limit)
+    max_scanned_rows = max(limit * 20, page_size)
+    scanned_rows = 0
+    while len(rows) < limit and scanned_rows < max_scanned_rows:
+        args[fetch_limit_index] = page_size
+        args[fetch_offset_index] = scanned_rows
+        raw_rows = await pool.fetch(query, *args)
+        if not raw_rows:
+            break
+        scanned_rows += len(raw_rows)
+        for raw in raw_rows:
+            row = dict(raw)
+            source_row = review_row_to_source_row(
+                row,
+                phrase_limit=phrase_limit,
+                allowed_polarities=allowed_polarities,
+                allowed_fields=allowed_fields,
+            )
+            if not source_row:
+                continue
+            source_id = _clean_text(source_row.get("source_id"))
+            if source_id in seen_ids:
+                continue
+            seen_ids.add(source_id)
+            rows.append(source_row)
+            if len(rows) >= limit:
+                return rows
+        if len(raw_rows) < page_size:
+            break
+    return rows
+
+
+def render_jsonl(rows: Sequence[Mapping[str, Any]]) -> str:
+    return "\n".join(json.dumps(dict(row), sort_keys=True, default=str) for row in rows)
+
+
+def _parse_csv_list(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in str(value or "").split(",") if part.strip())
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
+
+
+def _default_database_url() -> str | None:
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return None
+    return _clean_text(getattr(db_settings, "dsn", ""))
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export canonical Atlas reviews as Content Ops source-row JSONL."
+    )
+    parser.add_argument("--source", default=DEFAULT_SOURCE)
+    parser.add_argument("--vendor", default=None, help="Optional vendor_name filter.")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--min-review-text-chars", type=int, default=80)
+    parser.add_argument("--phrase-limit", type=int, default=5)
+    parser.add_argument("--polarities", default=",".join(DEFAULT_POLARITIES))
+    parser.add_argument("--phrase-fields", default=",".join(DEFAULT_PHRASE_FIELDS))
+    parser.add_argument("--allow-missing-source-url", action="store_true")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--database-url",
+        default=_default_database_url(),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError("asyncpg is required to export review sources") from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    _load_dotenv_files()
+    args = _parse_args(argv)
+    if args.limit < 1:
+        raise SystemExit("--limit must be positive")
+    if args.min_review_text_chars < 1:
+        raise SystemExit("--min-review-text-chars must be positive")
+    if args.phrase_limit < 1:
+        raise SystemExit("--phrase-limit must be positive")
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+    pool = await _create_pool(args.database_url)
+    try:
+        rows = await fetch_review_source_rows(
+            pool,
+            source=args.source,
+            vendor_name=args.vendor,
+            limit=args.limit,
+            min_review_text_chars=args.min_review_text_chars,
+            phrase_limit=args.phrase_limit,
+            allowed_polarities=_parse_csv_list(args.polarities),
+            allowed_fields=_parse_csv_list(args.phrase_fields),
+            require_review_url=not args.allow_missing_source_url,
+        )
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+
+    payload = render_jsonl(rows)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
+        print(f"exported {len(rows)} source row(s) to {args.output}")
+    else:
+        if payload:
+            print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -26,6 +26,7 @@ pytest \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
+  tests/test_export_content_ops_review_sources.py \
   tests/test_extracted_content_ingestion_diagnostics.py \
   tests/test_extracted_blog_generation.py \
   tests/test_extracted_blog_blueprint_ingest.py \

--- a/tests/test_export_content_ops_review_sources.py
+++ b/tests/test_export_content_ops_review_sources.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/export_content_ops_review_sources.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "export_content_ops_review_sources",
+        CLI,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+class _Pool:
+    def __init__(self, rows) -> None:
+        self.rows = list(rows)
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        return self.rows
+
+
+def _enrichment(*, polarity: str = "negative", verbatim: bool = True, subject: str = "subject_vendor"):
+    return {
+        "pain_category": "overall_dissatisfaction",
+        "pain_categories": [
+            {"category": "pricing", "severity": "primary"},
+            {"category": "overall_dissatisfaction", "severity": "secondary"},
+        ],
+        "urgency_score": 7,
+        "phrase_metadata": [
+            {
+                "text": "The renewal cost became hard to justify.",
+                "field": "pricing_phrases",
+                "subject": subject,
+                "polarity": polarity,
+                "verbatim": verbatim,
+                "category_hint": "pricing",
+            },
+            {
+                "text": "The onboarding team was excellent.",
+                "field": "positive_aspects",
+                "subject": "subject_vendor",
+                "polarity": "positive",
+                "verbatim": True,
+                "category_hint": "support",
+            },
+        ],
+    }
+
+
+def _row(**overrides):
+    row = {
+        "id": "review-1",
+        "source": "g2",
+        "source_url": "https://www.g2.com/reviews/review-1",
+        "source_review_id": "g2-review-1",
+        "vendor_name": "HubSpot",
+        "product_name": "HubSpot",
+        "product_category": "CRM",
+        "rating": 3.5,
+        "rating_max": 5,
+        "summary": "Renewal pricing",
+        "review_text": "Great onboarding, but the renewal cost became hard to justify.",
+        "reviewer_title": "VP Revenue Operations",
+        "reviewer_company": "",
+        "reviewer_industry": "Logistics",
+        "reviewed_at": "2026-05-01T00:00:00+00:00",
+        "imported_at": "2026-05-02T00:00:00+00:00",
+        "enrichment": _enrichment(),
+    }
+    row.update(overrides)
+    return row
+
+
+def test_quote_grade_review_phrases_filters_to_subject_vendor_negative_verbatim() -> None:
+    phrases = mod.quote_grade_review_phrases({
+        "phrase_metadata": [
+            {
+                "text": "Keep",
+                "field": "specific_complaints",
+                "subject": "subject_vendor",
+                "polarity": "negative",
+                "verbatim": True,
+            },
+            {
+                "text": "Drop competitor",
+                "field": "specific_complaints",
+                "subject": "competitor",
+                "polarity": "negative",
+                "verbatim": True,
+            },
+            {
+                "text": "Drop nonverbatim",
+                "field": "specific_complaints",
+                "subject": "subject_vendor",
+                "polarity": "negative",
+                "verbatim": False,
+            },
+            {
+                "text": "Drop positive",
+                "field": "positive_aspects",
+                "subject": "subject_vendor",
+                "polarity": "positive",
+                "verbatim": True,
+            },
+        ]
+    })
+
+    assert phrases == [{
+        "text": "Keep",
+        "field": "specific_complaints",
+        "polarity": "negative",
+        "category_hint": "",
+    }]
+
+
+def test_review_row_to_source_row_uses_phrase_lane_as_text_and_preserves_full_review() -> None:
+    enrichment = _enrichment()
+    enrichment["pain_category"] = "pricing"
+    out = mod.review_row_to_source_row(_row(enrichment=enrichment))
+
+    assert out["id"] == "g2-review-1"
+    assert out["source_id"] == "g2-review-1"
+    assert out["review_id"] == "review-1"
+    assert out["source"] == "g2"
+    assert out["source_type"] == "review"
+    assert out["vendor_name"] == "HubSpot"
+    assert out["text"] == "The renewal cost became hard to justify."
+    assert out["review_text"] == "Great onboarding, but the renewal cost became hard to justify."
+    assert out["quote_grade_phrases"] == ["The renewal cost became hard to justify."]
+    assert out["pain_points"] == ["pricing"]
+    assert out["contact_title"] == "VP Revenue Operations"
+
+
+def test_review_row_to_source_row_unescapes_exported_titles() -> None:
+    out = mod.review_row_to_source_row(_row(reviewer_title="Co-Founder &amp; CEO"))
+
+    assert out["contact_title"] == "Co-Founder & CEO"
+
+
+def test_review_row_to_source_row_drops_rows_without_quote_grade_phrases() -> None:
+    assert mod.review_row_to_source_row(_row(enrichment=_enrichment(verbatim=False))) == {}
+    assert mod.review_row_to_source_row(_row(enrichment=_enrichment(polarity="positive"))) == {}
+    assert mod.review_row_to_source_row(_row(enrichment=_enrichment(subject="competitor"))) == {}
+
+
+def test_review_row_to_source_row_accepts_json_string_enrichment() -> None:
+    out = mod.review_row_to_source_row(_row(enrichment=json.dumps(_enrichment())))
+
+    assert out["quote_grade_phrases"] == ["The renewal cost became hard to justify."]
+
+
+def test_build_review_source_query_filters_canonical_enriched_g2_rows() -> None:
+    query, args = mod.build_review_source_query(
+        source="g2",
+        vendor_name="HubSpot",
+        min_review_text_chars=120,
+        require_review_url=True,
+    )
+
+    assert "LOWER(r.source) = LOWER($1)" in query
+    assert "r.duplicate_of_review_id IS NULL" in query
+    assert "r.enrichment_status = 'enriched'" in query
+    assert "r.enrichment IS NOT NULL" in query
+    assert "length(r.review_text) >= $2" in query
+    assert "LOWER(r.vendor_name) = LOWER($3)" in query
+    assert "NULLIF(BTRIM(r.source_url), '') IS NOT NULL" in query
+    assert "LIMIT $4" in query
+    assert "OFFSET $5" in query
+    assert args == ["g2", 120, "HubSpot", 0, 0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_review_source_rows_dedupes_and_filters_after_fetch() -> None:
+    pool = _Pool([
+        _row(id="review-1", source_review_id="same-id"),
+        _row(id="review-2", source_review_id="same-id"),
+        _row(id="review-3", source_review_id="other-id", enrichment=_enrichment(verbatim=False)),
+        _row(id="review-4", source_review_id="keep-id"),
+    ])
+
+    rows = await mod.fetch_review_source_rows(pool, source="g2", limit=2)
+
+    assert [row["source_id"] for row in rows] == ["same-id", "keep-id"]
+    query, args = pool.fetch_calls[0]
+    assert "FROM b2b_reviews r" in query
+    assert args[0] == "g2"
+    assert args[-2:] == (6, 0)
+
+
+def test_render_jsonl_outputs_one_json_object_per_line() -> None:
+    text = mod.render_jsonl([
+        {"source_id": "a", "text": "one"},
+        {"source_id": "b", "text": "two"},
+    ])
+
+    lines = text.splitlines()
+    assert [json.loads(line)["source_id"] for line in lines] == ["a", "b"]
+
+
+def test_parse_args_defaults_to_database_url_from_helper(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_default_database_url", lambda: "postgres://example/db")
+
+    args = mod._parse_args([])
+
+    assert args.database_url == "postgres://example/db"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-G2-Review-Source-Export.md

Bridge clean Atlas review evidence into Content Ops source-row ingestion, starting with G2. The exporter is read-only, uses canonical enriched review rows, gates to subject-vendor negative/mixed verbatim phrase metadata, and writes JSONL consumable by the existing source-row ingestion path.

## Intentional
- G2 is the default source; other sources can be passed explicitly, but this slice verifies G2 first.
- The exported `text` is the coherent quote-grade phrase lane, while full `review_text` is retained for audit.
- G2 rows often lack company/contact fields, so ingestion warnings are expected unless paired with host account data.
- This PR is over the preferred 400 LOC target because the exporter, SQL/phrase contract tests, docs, and pipeline check wiring are one reviewable boundary.

## Deferred
- Trustpilot/TrustRadius validation.
- Live DB import beyond dry-run.
- Pairing exported review evidence with customer account/contact data for production campaign sends.

## Verification
- Focused pytest: 63 passed
- Py-compile exporter: passed
- ASCII Python check: passed
- Live read-only G2 Slack export: exported 5 rows
- Ingestion inspect: ok, 5 opportunities
- Dry-run import: would insert 5 rows
- Offline campaign generation from export: generated 2 drafts
- git diff --check
- bash scripts/local_pr_review.sh
- pre-push hook local PR review

## Diff size
8 files, +729 / -4