### PR TITLE
Bind source-row evidence to target defaults

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T17:14Z by codex-2026-05-18
+Last updated: 2026-05-18T20:17Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops G2 review source export | `scripts/export_content_ops_review_sources.py`, `tests/test_export_content_ops_review_sources.py`, `scripts/run_extracted_pipeline_checks.sh`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-G2-Review-Source-Export.md` | codex-2026-05-18 | Avoid editing Content Ops review-source export or coordination state |
+| pending | Content Ops source-row target defaults | `extracted_content_pipeline/campaign_source_adapters.py`, `extracted_content_pipeline/ingestion_diagnostics.py`, `extracted_content_pipeline/api/control_surfaces.py`, `scripts/build_extracted_campaign_opportunities_from_sources.py`, `scripts/inspect_extracted_content_ingestion.py`, `scripts/load_extracted_campaign_opportunities.py`, `scripts/run_extracted_campaign_generation_example.py`, `scripts/smoke_extracted_content_pipeline_host.py`, `tests/test_extracted_campaign_source_adapters.py`, `tests/test_extracted_campaign_generation_example.py`, `tests/test_extracted_content_ingestion_diagnostics.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Source-Target-Defaults.md` | codex-2026-05-18 | Avoid editing Content Ops source-row ingestion defaults or ingestion docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T17:14Z by codex-2026-05-18
+Last updated: 2026-05-18T20:17Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #586 | pending | G2 review-source export is in flight to feed clean scraped review evidence into Content Ops ingestion. | `scripts/export_content_ops_review_sources.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #588 | pending | Source-row target defaults are in flight so anonymous review evidence can bind to real account/contact context before inspect/import/generation. | `extracted_content_pipeline/campaign_source_adapters.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -169,6 +169,8 @@ python scripts/inspect_extracted_content_ingestion.py \
   g2_review_sources.jsonl \
   --source-rows \
   --source-format jsonl \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
   --json
 ```
 
@@ -223,6 +225,10 @@ python scripts/load_extracted_campaign_opportunities.py \
 
 For source-row CSV exports, pass `--source-format csv` to the same conversion,
 generation, import, or smoke commands.
+For anonymous review exports such as G2 rows without buyer/contact columns,
+repeat `--default-field key=value` to bind the evidence to a target account at
+conversion, generation, inspection, smoke, or import time. Source-row values
+win when both the row and the default provide the same field.
 For customer bundle JSON files that group collections such as `reviews`,
 `support_tickets`, `surveys`, `calls`, `meetings`, `deals`, `account_notes`,
 `contracts`, `renewals`, or `subscriptions` under shared account metadata, use

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -46,6 +46,9 @@ source of truth for what remains.
   `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
   `examples/campaign_source_rows.jsonl` plus
   `examples/campaign_source_bundle.json` provide packaged starter inputs.
+  Source-row CLIs and hosted ingestion APIs accept fallback `default_fields`
+  so anonymous review evidence can be bound to a real account/contact without
+  editing every exported row; row-specific values still win.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not
   available as one scalar field. Source-row field labels are matched leniently

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -373,6 +373,7 @@ if BaseModel is not None:
         target_mode: str | None = Field(default="vendor_retention", max_length=80)
         max_source_text_chars: int = Field(1200, ge=1, le=_MAX_INPUT_STRING_CHARS)
         sample_limit: int = Field(3, ge=0, le=_MAX_INGESTION_SAMPLE_LIMIT)
+        default_fields: dict[str, Any] = Field(default_factory=dict)
 
         @field_validator("rows")
         @classmethod
@@ -382,6 +383,14 @@ if BaseModel is not None:
         ) -> tuple[dict[str, Any], ...]:
             for row in value:
                 _validate_input_shape(row, depth=0)
+            return value
+
+        @field_validator("default_fields")
+        @classmethod
+        def _validate_default_fields(cls, value: dict[str, Any]) -> dict[str, Any]:
+            if len(value) > 50:
+                raise ValueError("default_fields cannot contain more than 50 entries")
+            _validate_input_shape(value, depth=0)
             return value
 
     class ContentOpsIngestionImportModel(ContentOpsIngestionInspectModel):
@@ -476,6 +485,7 @@ def create_content_ops_control_surface_router(
                 target_mode=_clean(data.get("target_mode")),
                 max_source_text_chars=int(data.get("max_source_text_chars") or 1200),
                 sample_limit=int(data.get("sample_limit") or 0),
+                default_fields=data.get("default_fields"),
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -495,6 +505,7 @@ def create_content_ops_control_surface_router(
                 target_mode=target_mode,
                 max_source_text_chars=int(data.get("max_source_text_chars") or 1200),
                 sample_limit=int(data.get("sample_limit") or 0),
+                default_fields=data.get("default_fields"),
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -230,6 +230,7 @@ def load_source_campaign_opportunities_from_file(
     file_format: SourceDataFormat = "auto",
     target_mode: str | None = None,
     max_text_chars: int = 1200,
+    default_fields: Mapping[str, Any] | None = None,
 ) -> CampaignOpportunityLoadResult:
     """Load review/transcript/document rows as campaign opportunities."""
 
@@ -239,6 +240,7 @@ def load_source_campaign_opportunities_from_file(
         rows,
         target_mode=target_mode,
         max_text_chars=max_text_chars,
+        default_fields=default_fields,
     )
     return CampaignOpportunityLoadResult(
         opportunities=result.opportunities,
@@ -252,11 +254,13 @@ def source_rows_to_campaign_opportunities(
     *,
     target_mode: str | None = None,
     max_text_chars: int = 1200,
+    default_fields: Mapping[str, Any] | None = None,
 ) -> CampaignOpportunityLoadResult:
     """Normalize richer source rows into the existing opportunity contract."""
 
     opportunities: list[dict[str, Any]] = []
     warnings: list[CampaignOpportunityWarning] = []
+    defaults = _clean_default_fields(default_fields)
     for index, row in enumerate(rows, start=1):
         if not isinstance(row, Mapping):
             warnings.append(CampaignOpportunityWarning(
@@ -265,8 +269,9 @@ def source_rows_to_campaign_opportunities(
                 message="Skipped source row because it is not an object.",
             ))
             continue
+        merged_row = {**defaults, **dict(row)} if defaults else row
         opportunity, row_warnings = source_row_to_campaign_opportunity(
-            row,
+            merged_row,
             row_index=index,
             max_text_chars=max_text_chars,
         )
@@ -281,6 +286,31 @@ def source_rows_to_campaign_opportunities(
         opportunities=normalized.opportunities,
         warnings=tuple(warnings) + normalized.warnings,
     )
+
+
+def parse_default_fields(values: Sequence[str] | None) -> dict[str, str]:
+    """Parse repeatable ``key=value`` source-row fallback metadata."""
+
+    out: dict[str, str] = {}
+    for raw in values or ():
+        if "=" not in str(raw):
+            raise ValueError("--default-field values must use key=value")
+        key, value = str(raw).split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError("--default-field key must be non-empty")
+        if value:
+            out[key] = value
+    return out
+
+
+def _clean_default_fields(default_fields: Mapping[str, Any] | None) -> dict[str, Any]:
+    return {
+        str(key): value
+        for key, value in (default_fields or {}).items()
+        if str(key).strip() and value not in (None, "", [], {})
+    }
 
 
 def source_row_to_campaign_opportunity(
@@ -630,6 +660,7 @@ def _compact_field_key(key: str) -> str:
 __all__ = [
     "SourceDataFormat",
     "load_source_campaign_opportunities_from_file",
+    "parse_default_fields",
     "source_row_to_campaign_opportunity",
     "source_rows_to_campaign_opportunities",
 ]

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -144,6 +144,17 @@ _CONTACT_EMAIL_KEYS = ("contact_email", "recipient_email", "email")
 _CONTACT_TITLE_KEYS = ("contact_title", "recipient_title", "job_title")
 _NPS_SCORE_KEYS = ("nps_score", "nps")
 _CSAT_SCORE_KEYS = ("csat_score", "csat")
+_CANONICAL_TEXT_ALIAS_KEYS = (
+    ("company_name", _COMPANY_KEYS),
+    ("vendor_name", _VENDOR_KEYS),
+    ("contact_name", _CONTACT_NAME_KEYS),
+    ("contact_email", _CONTACT_EMAIL_KEYS),
+    ("contact_title", _CONTACT_TITLE_KEYS),
+)
+_CANONICAL_VALUE_ALIAS_KEYS = (
+    ("nps_score", _NPS_SCORE_KEYS),
+    ("csat_score", _CSAT_SCORE_KEYS),
+)
 # Ordered source-type contract for ambiguous rows. Text-bearing source fields
 # win over ids, and note ids win over lifecycle ids because lifecycle ids can
 # travel as context on notes without changing the evidence row type.
@@ -269,7 +280,7 @@ def source_rows_to_campaign_opportunities(
                 message="Skipped source row because it is not an object.",
             ))
             continue
-        merged_row = {**defaults, **dict(row)} if defaults else row
+        merged_row = _merge_default_fields(defaults, row) if defaults else row
         opportunity, row_warnings = source_row_to_campaign_opportunity(
             merged_row,
             row_index=index,
@@ -305,12 +316,69 @@ def parse_default_fields(values: Sequence[str] | None) -> dict[str, str]:
     return out
 
 
+def parse_default_fields_or_exit(values: Sequence[str] | None) -> dict[str, str]:
+    """Parse CLI defaults and return a concise command-line validation error."""
+
+    try:
+        return parse_default_fields(values)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
 def _clean_default_fields(default_fields: Mapping[str, Any] | None) -> dict[str, Any]:
     return {
         str(key): value
         for key, value in (default_fields or {}).items()
         if str(key).strip() and value not in (None, "", [], {})
     }
+
+
+def _merge_default_fields(
+    defaults: Mapping[str, Any],
+    row: Mapping[str, Any],
+) -> dict[str, Any]:
+    row_values = {
+        str(key): value
+        for key, value in row.items()
+        if value not in (None, "", [], {})
+    }
+    row_canonical_keys = _row_canonical_aliases(row_values)
+    return {
+        **{
+            str(key): value
+            for key, value in defaults.items()
+            if (_canonical_alias_key(str(key)) or str(key)) not in row_canonical_keys
+        },
+        **row_values,
+    }
+
+
+def _canonical_alias_key(key: str) -> str | None:
+    normalized_key = _normalized_field_key(key)
+    compact_key = _compact_field_key(key)
+    for canonical_key, keys in (
+        *_CANONICAL_TEXT_ALIAS_KEYS,
+        *_CANONICAL_VALUE_ALIAS_KEYS,
+    ):
+        for alias in keys:
+            if (
+                _normalized_field_key(alias) == normalized_key
+                or _compact_field_key(alias) == compact_key
+            ):
+                return canonical_key
+    return None
+
+
+def _row_canonical_aliases(row: Mapping[str, Any]) -> set[str]:
+    lookup = _SourceFieldLookup(row)
+    out: set[str] = set()
+    for canonical_key, keys in _CANONICAL_TEXT_ALIAS_KEYS:
+        if _first_text(lookup, keys):
+            out.add(canonical_key)
+    for canonical_key, keys in _CANONICAL_VALUE_ALIAS_KEYS:
+        if _has_field_value(lookup, keys):
+            out.add(canonical_key)
+    return out
 
 
 def source_row_to_campaign_opportunity(
@@ -661,6 +729,7 @@ __all__ = [
     "SourceDataFormat",
     "load_source_campaign_opportunities_from_file",
     "parse_default_fields",
+    "parse_default_fields_or_exit",
     "source_row_to_campaign_opportunity",
     "source_rows_to_campaign_opportunities",
 ]

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -218,6 +218,9 @@ Customer bundle JSON can group `reviews`, `support_tickets`, `surveys`,
 `calls`, `meetings`, `deals`, `account_notes`, `contracts`, `renewals`, and
 `subscriptions` under shared account metadata; use `--format json` or
 `--source-format json` for that shape.
+For JSONL or CSV source exports that do not carry shared account metadata,
+repeat `--default-field key=value` on the conversion, inspection, smoke,
+generation, or import command. Defaults are fallbacks; row-specific values win.
 Rows with `deal_id` or `opportunity_id` are inferred as CRM deal evidence; rows
 with `note_id` or `activity_id` are inferred as CRM note evidence.
 Rows with `contract_id`, `renewal_id`, or `subscription_id` are inferred as
@@ -455,6 +458,8 @@ python scripts/load_extracted_campaign_opportunities.py \
   g2_review_sources.jsonl \
   --source-rows \
   --source-format jsonl \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
   --target-mode vendor_retention \
   --dry-run
 ```

--- a/extracted_content_pipeline/ingestion_diagnostics.py
+++ b/extracted_content_pipeline/ingestion_diagnostics.py
@@ -68,6 +68,7 @@ def inspect_ingestion_file(
     target_mode: str | None = "vendor_retention",
     max_source_text_chars: int = 1200,
     sample_limit: int = 3,
+    default_fields: Mapping[str, Any] | None = None,
 ) -> IngestionDiagnosticsReport:
     """Inspect a host ingestion file without writing to a database."""
 
@@ -83,6 +84,7 @@ def inspect_ingestion_file(
             file_format=source_format,
             target_mode=target_mode,
             max_text_chars=max_source_text_chars,
+            default_fields=default_fields,
         )
         mode: IngestionMode = "source_rows"
     else:
@@ -109,6 +111,7 @@ def inspect_ingestion_rows(
     target_mode: str | None = "vendor_retention",
     max_source_text_chars: int = 1200,
     sample_limit: int = 3,
+    default_fields: Mapping[str, Any] | None = None,
 ) -> IngestionDiagnosticsReport:
     """Inspect already-loaded host rows without writing to a database."""
 
@@ -122,6 +125,7 @@ def inspect_ingestion_rows(
             rows,
             target_mode=target_mode,
             max_text_chars=max_source_text_chars,
+            default_fields=default_fields,
         )
         mode: IngestionMode = "source_rows"
     else:

--- a/plans/PR-Content-Ops-Source-Target-Defaults.md
+++ b/plans/PR-Content-Ops-Source-Target-Defaults.md
@@ -1,0 +1,66 @@
+# PR: Content Ops Source Target Defaults
+
+## Why this slice exists
+
+PR #588 made clean G2 review evidence available to AI Content Ops as source-row JSONL. The live smoke showed the next practical gap: review exports often do not carry buyer account or contact columns, so generated campaign copy can fall back to generic target language even when the evidence is good.
+
+This slice adds a small target-binding seam for source-row ingestion. Operators can keep the exported review/source rows untouched and provide shared fallback account metadata at conversion, inspection, smoke, generation, import, or hosted API time.
+
+## Scope (this PR)
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/ingestion_diagnostics.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `scripts/build_extracted_campaign_opportunities_from_sources.py`
+- `scripts/inspect_extracted_content_ingestion.py`
+- `scripts/load_extracted_campaign_opportunities.py`
+- `scripts/run_extracted_campaign_generation_example.py`
+- `scripts/smoke_extracted_content_pipeline_host.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_campaign_generation_example.py`
+- `tests/test_extracted_content_ingestion_diagnostics.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Source-Target-Defaults.md`
+
+## Mechanism
+
+- Add `default_fields` to source-row normalization and ingestion diagnostics.
+- Add repeatable `--default-field key=value` CLI parsing for source-row build, inspect, smoke, generation, and import paths.
+- Keep row-specific values authoritative by applying defaults before each row.
+- Add hosted ingestion API support for `default_fields` on inspect/import requests.
+
+## Intentional
+
+- Defaults are fallback metadata, not forced overrides.
+- The source-row format stays unchanged; exported G2 JSONL remains valid as-is.
+- The change targets source-row ingestion only. Plain opportunity files already carry their own account rows.
+
+## Deferred
+
+- A browser upload UI remains out of scope. This slice only improves the file/API ingestion seams already present.
+- Multi-file joins between separate account CSVs and source JSONL are deferred. Operators can use `--default-field` for shared target context, or source bundle JSON for richer per-account grouping.
+- Additional review-source exporters such as Trustpilot remain separate future slices.
+
+## Verification
+
+- Run focused source adapter, import, generation example, host smoke, ingestion diagnostics, and control-surface API tests.
+- Compile the touched scripts and modules.
+- Run the extracted pipeline local PR review.
+- Run git diff whitespace validation.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source-row default-field plumbing | ~95 |
+| CLI/API wiring | ~95 |
+| Tests | ~150 |
+| Docs and coordination | ~35 |
+| Total | ~375 |

--- a/plans/PR-Content-Ops-Source-Target-Defaults.md
+++ b/plans/PR-Content-Ops-Source-Target-Defaults.md
@@ -6,7 +6,14 @@ PR #588 made clean G2 review evidence available to AI Content Ops as source-row 
 
 This slice adds a small target-binding seam for source-row ingestion. Operators can keep the exported review/source rows untouched and provide shared fallback account metadata at conversion, inspection, smoke, generation, import, or hosted API time.
 
+The estimated diff exceeds the repository's 400 LOC target because the seam must stay consistent across the shared adapter, hosted inspect/import API, five CLI entry points, tests, docs, and coordination files. Splitting the plumbing would create temporarily inconsistent host paths where one source-row command supports target defaults and another rejects or ignores them.
+
 ## Scope (this PR)
+
+1. Add source-row fallback target metadata without changing exported source files.
+2. Wire the same defaults through conversion, inspection, import, smoke, generation, and hosted API paths.
+3. Preserve row-specific values, including supported aliases, over shared defaults.
+4. Document the operational G2 review JSONL plus target-default workflow.
 
 ### Files touched
 
@@ -50,17 +57,18 @@ This slice adds a small target-binding seam for source-row ingestion. Operators 
 
 ## Verification
 
-- Run focused source adapter, import, generation example, host smoke, ingestion diagnostics, and control-surface API tests.
-- Compile the touched scripts and modules.
-- Run the extracted pipeline local PR review.
-- Run git diff whitespace validation.
+- python -m pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_content_ingestion_diagnostics.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_host_smoke.py -q -> 163 passed.
+- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/ingestion_diagnostics.py extracted_content_pipeline/api/control_surfaces.py scripts/build_extracted_campaign_opportunities_from_sources.py scripts/inspect_extracted_content_ingestion.py scripts/load_extracted_campaign_opportunities.py scripts/run_extracted_campaign_generation_example.py scripts/smoke_extracted_content_pipeline_host.py -> passed.
+- Live G2 export, ingestion inspect with default fields, and offline generation with default fields -> passed.
+- bash scripts/local_pr_review.sh -> passed.
+- git diff --check -> passed.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Source-row default-field plumbing | ~95 |
-| CLI/API wiring | ~95 |
-| Tests | ~150 |
-| Docs and coordination | ~35 |
-| Total | ~375 |
+| Source-row default-field plumbing | ~120 |
+| CLI/API wiring | ~110 |
+| Tests | ~210 |
+| Docs and coordination | ~40 |
+| Total | ~480 |

--- a/scripts/build_extracted_campaign_opportunities_from_sources.py
+++ b/scripts/build_extracted_campaign_opportunities_from_sources.py
@@ -15,7 +15,7 @@ if str(ROOT) not in sys.path:
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields,
+    parse_default_fields_or_exit,
 )
 
 
@@ -68,7 +68,7 @@ def main(argv: list[str] | None = None) -> int:
         file_format=args.format,
         target_mode=args.target_mode,
         max_text_chars=args.max_text_chars,
-        default_fields=parse_default_fields(args.default_field),
+        default_fields=parse_default_fields_or_exit(args.default_field),
     )
     payload = loaded.as_payload(
         target_mode=args.target_mode,

--- a/scripts/build_extracted_campaign_opportunities_from_sources.py
+++ b/scripts/build_extracted_campaign_opportunities_from_sources.py
@@ -15,6 +15,7 @@ if str(ROOT) not in sys.path:
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
+    parse_default_fields,
 )
 
 
@@ -42,6 +43,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Maximum source text characters copied into each evidence row.",
     )
     parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every source row when that row omits "
+            "the field. Repeat as key=value, for example company_name=Acme."
+        ),
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="Write opportunity payload JSON to this path instead of stdout.",
@@ -58,6 +68,7 @@ def main(argv: list[str] | None = None) -> int:
         file_format=args.format,
         target_mode=args.target_mode,
         max_text_chars=args.max_text_chars,
+        default_fields=parse_default_fields(args.default_field),
     )
     payload = loaded.as_payload(
         target_mode=args.target_mode,

--- a/scripts/inspect_extracted_content_ingestion.py
+++ b/scripts/inspect_extracted_content_ingestion.py
@@ -14,6 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.ingestion_diagnostics import inspect_ingestion_file  # noqa: E402
+from extracted_content_pipeline.campaign_source_adapters import parse_default_fields  # noqa: E402
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -51,6 +52,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=3,
         help="Maximum normalized opportunity samples included in the report.",
     )
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every source row when --source-rows "
+            "is selected. Repeat as key=value."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit full JSON report.")
     return parser.parse_args(argv)
 
@@ -70,6 +80,7 @@ def main(argv: list[str] | None = None) -> int:
         target_mode=args.target_mode,
         max_source_text_chars=args.max_source_text_chars,
         sample_limit=args.sample_limit,
+        default_fields=parse_default_fields(args.default_field),
     )
     payload = report.as_dict()
     if args.json:

--- a/scripts/inspect_extracted_content_ingestion.py
+++ b/scripts/inspect_extracted_content_ingestion.py
@@ -14,7 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.ingestion_diagnostics import inspect_ingestion_file  # noqa: E402
-from extracted_content_pipeline.campaign_source_adapters import parse_default_fields  # noqa: E402
+from extracted_content_pipeline.campaign_source_adapters import parse_default_fields_or_exit  # noqa: E402
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -80,7 +80,7 @@ def main(argv: list[str] | None = None) -> int:
         target_mode=args.target_mode,
         max_source_text_chars=args.max_source_text_chars,
         sample_limit=args.sample_limit,
-        default_fields=parse_default_fields(args.default_field),
+        default_fields=parse_default_fields_or_exit(args.default_field),
     )
     payload = report.as_dict()
     if args.json:

--- a/scripts/load_extracted_campaign_opportunities.py
+++ b/scripts/load_extracted_campaign_opportunities.py
@@ -24,6 +24,7 @@ from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
+    parse_default_fields,
 )
 
 
@@ -62,6 +63,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=1200,
         help="Maximum source text characters copied into each evidence row.",
+    )
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every source row when --source-rows "
+            "is selected. Repeat as key=value."
+        ),
     )
     parser.add_argument(
         "--target-mode",
@@ -116,6 +126,7 @@ async def _main() -> int:
             file_format=args.source_format,
             target_mode=args.target_mode,
             max_text_chars=args.max_source_text_chars,
+            default_fields=parse_default_fields(args.default_field),
         )
     else:
         loaded = load_campaign_opportunities_from_file(

--- a/scripts/load_extracted_campaign_opportunities.py
+++ b/scripts/load_extracted_campaign_opportunities.py
@@ -24,7 +24,7 @@ from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields,
+    parse_default_fields_or_exit,
 )
 
 
@@ -126,7 +126,7 @@ async def _main() -> int:
             file_format=args.source_format,
             target_mode=args.target_mode,
             max_text_chars=args.max_source_text_chars,
-            default_fields=parse_default_fields(args.default_field),
+            default_fields=parse_default_fields_or_exit(args.default_field),
         )
     else:
         loaded = load_campaign_opportunities_from_file(

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -23,6 +23,7 @@ from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
+    parse_default_fields,
 )
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
@@ -51,12 +52,14 @@ def _load_payload(
     source_rows: bool = False,
     source_format: str = "auto",
     max_source_text_chars: int = 1200,
+    default_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if source_rows:
         loaded = load_source_campaign_opportunities_from_file(
             path,
             file_format=source_format,
             max_text_chars=max_source_text_chars,
+            default_fields=default_fields,
         )
         return loaded.as_payload()
     if file_format == "csv" or (file_format == "auto" and path.suffix.lower() == ".csv"):
@@ -120,6 +123,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=1200,
         help="Maximum source text characters copied into each evidence row.",
+    )
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every source row when --source-rows "
+            "is selected. Repeat as key=value."
+        ),
     )
     parser.add_argument(
         "--limit",
@@ -317,6 +329,7 @@ async def _main() -> int:
         source_rows=bool(args.source_rows),
         source_format=args.source_format,
         max_source_text_chars=int(args.max_source_text_chars),
+        default_fields=parse_default_fields(args.default_field),
     )
     if args.target_mode:
         payload["target_mode"] = args.target_mode

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -23,7 +23,7 @@ from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields,
+    parse_default_fields_or_exit,
 )
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
@@ -329,7 +329,7 @@ async def _main() -> int:
         source_rows=bool(args.source_rows),
         source_format=args.source_format,
         max_source_text_chars=int(args.max_source_text_chars),
-        default_fields=parse_default_fields(args.default_field),
+        default_fields=parse_default_fields_or_exit(args.default_field),
     )
     if args.target_mode:
         payload["target_mode"] = args.target_mode

--- a/scripts/smoke_extracted_content_pipeline_host.py
+++ b/scripts/smoke_extracted_content_pipeline_host.py
@@ -23,6 +23,7 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
+    parse_default_fields,
 )
 
 
@@ -38,12 +39,14 @@ def _load_payload(
     source_rows: bool = False,
     source_format: str = "auto",
     max_source_text_chars: int = 1200,
+    default_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if source_rows:
         loaded = load_source_campaign_opportunities_from_file(
             path,
             file_format=source_format,
             max_text_chars=max_source_text_chars,
+            default_fields=default_fields,
         )
         return loaded.as_payload()
     if file_format == "csv" or (file_format == "auto" and path.suffix.lower() == ".csv"):
@@ -98,6 +101,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Maximum source text characters copied into each evidence row.",
     )
     parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every source row when --source-rows "
+            "is selected. Repeat as key=value."
+        ),
+    )
+    parser.add_argument(
         "--channels",
         default="email_cold,email_followup",
         help="Comma-separated channels to generate for each opportunity.",
@@ -147,6 +159,7 @@ async def _main() -> int:
         source_rows=bool(args.source_rows),
         source_format=args.source_format,
         max_source_text_chars=int(args.max_source_text_chars),
+        default_fields=parse_default_fields(args.default_field),
     )
     payload["limit"] = int(args.limit)
     payload["channels"] = [

--- a/scripts/smoke_extracted_content_pipeline_host.py
+++ b/scripts/smoke_extracted_content_pipeline_host.py
@@ -23,7 +23,7 @@ from extracted_content_pipeline.campaign_example import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields,
+    parse_default_fields_or_exit,
 )
 
 
@@ -159,7 +159,7 @@ async def _main() -> int:
         source_rows=bool(args.source_rows),
         source_format=args.source_format,
         max_source_text_chars=int(args.max_source_text_chars),
-        default_fields=parse_default_fields(args.default_field),
+        default_fields=parse_default_fields_or_exit(args.default_field),
     )
     payload["limit"] = int(args.limit)
     payload["channels"] = [

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -298,6 +298,46 @@ def test_campaign_generation_example_cli_generates_from_source_rows() -> None:
     assert source["contact_email"] == "ops@example.com"
 
 
+def test_campaign_generation_example_cli_applies_source_default_fields(tmp_path) -> None:
+    source_path = tmp_path / "g2_sources.jsonl"
+    source_path.write_text(
+        json.dumps({
+            "id": "g2-review-1",
+            "vendor": "Slack",
+            "review_text": "Search gets slow once message history grows.",
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source_path),
+            "--source-rows",
+            "--source-format",
+            "jsonl",
+            "--default-field",
+            "company_name=Acme Logistics",
+            "--default-field",
+            "contact_email=ops@example.com",
+            "--channels",
+            "email_cold",
+            "--limit",
+            "1",
+            "--llm",
+            "offline",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    source = json.loads(completed.stdout)["drafts"][0]["metadata"]["source_opportunity"]
+    assert source["company_name"] == "Acme Logistics"
+    assert source["contact_email"] == "ops@example.com"
+
+
 def test_campaign_generation_example_cli_generates_from_source_bundle_json() -> None:
     completed = subprocess.run(
         [

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -5,10 +5,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
     parse_default_fields,
+    parse_default_fields_or_exit,
     source_row_to_campaign_opportunity,
     source_rows_to_campaign_opportunities,
 )
@@ -162,9 +165,24 @@ def test_source_rows_apply_default_fields_without_overriding_row_values() -> Non
             },
             {
                 "id": "review-2",
-                "company_name": "Row Company",
+                "company_name": "",
+                "contact_email": None,
                 "vendor": "HubSpot",
                 "review_text": "Reporting exports are blocked.",
+            },
+            {
+                "id": "review-3",
+                "company_name": "Row Company",
+                "contact_email": "row@example.com",
+                "vendor": "HubSpot",
+                "review_text": "Notifications are noisy.",
+            },
+            {
+                "id": "review-4",
+                "company": "Alias Company",
+                "email": "alias@example.com",
+                "vendor": "HubSpot",
+                "review_text": "Admin controls are confusing.",
             },
         ],
         default_fields={
@@ -176,8 +194,34 @@ def test_source_rows_apply_default_fields_without_overriding_row_values() -> Non
     assert loaded.warnings == ()
     assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
     assert loaded.opportunities[0]["contact_email"] == "ops@example.com"
-    assert loaded.opportunities[1]["company_name"] == "Row Company"
+    assert loaded.opportunities[1]["company_name"] == "Acme Logistics"
     assert loaded.opportunities[1]["contact_email"] == "ops@example.com"
+    assert loaded.opportunities[2]["company_name"] == "Row Company"
+    assert loaded.opportunities[2]["contact_email"] == "row@example.com"
+    assert loaded.opportunities[3]["company_name"] == "Alias Company"
+    assert loaded.opportunities[3]["contact_email"] == "alias@example.com"
+
+
+def test_source_rows_row_aliases_override_default_aliases() -> None:
+    loaded = source_rows_to_campaign_opportunities(
+        [
+            {
+                "id": "review-1",
+                "account_name": "Row Company",
+                "recipient_email": "row@example.com",
+                "vendor": "HubSpot",
+                "review_text": "The renewal flow is hard to manage.",
+            },
+        ],
+        default_fields={
+            "company": "Default Company",
+            "email": "default@example.com",
+        },
+    )
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["company_name"] == "Row Company"
+    assert loaded.opportunities[0]["contact_email"] == "row@example.com"
 
 
 def test_parse_default_fields_rejects_invalid_values() -> None:
@@ -186,12 +230,13 @@ def test_parse_default_fields_rejects_invalid_values() -> None:
         "contact_email": "ops@example.com",
     }
 
-    try:
+    with pytest.raises(ValueError, match="key=value"):
         parse_default_fields(["company_name"])
-    except ValueError as exc:
-        assert "key=value" in str(exc)
-    else:  # pragma: no cover - defensive assertion
-        raise AssertionError("expected invalid default field to fail")
+
+
+def test_parse_default_fields_or_exit_raises_clean_system_exit() -> None:
+    with pytest.raises(SystemExit, match="key=value"):
+        parse_default_fields_or_exit(["company_name"])
 
 
 def test_source_document_title_does_not_become_buyer_fields() -> None:
@@ -1247,3 +1292,33 @@ def test_source_adapter_cli_rejects_non_positive_text_limit(tmp_path: Path) -> N
 
     assert completed.returncode == 1
     assert "--max-text-chars must be positive" in completed.stderr
+
+
+def test_source_adapter_cli_rejects_invalid_default_field_cleanly(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        json.dumps({
+            "id": "review-1",
+            "vendor": "HubSpot",
+            "review_text": "Pricing is a problem.",
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--format",
+            "jsonl",
+            "--default-field",
+            "company_name",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "--default-field values must use key=value" in completed.stderr
+    assert "Traceback" not in completed.stderr

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
+    parse_default_fields,
     source_row_to_campaign_opportunity,
     source_rows_to_campaign_opportunities,
 )
@@ -149,6 +150,48 @@ def test_source_rows_normalize_and_warn_for_missing_text() -> None:
     assert first["target_mode"] == "vendor_retention"
     assert first["evidence"][0]["source_type"] == "transcript"
     assert "missing_source_text" in [warning.code for warning in loaded.warnings]
+
+
+def test_source_rows_apply_default_fields_without_overriding_row_values() -> None:
+    loaded = source_rows_to_campaign_opportunities(
+        [
+            {
+                "id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing is a problem.",
+            },
+            {
+                "id": "review-2",
+                "company_name": "Row Company",
+                "vendor": "HubSpot",
+                "review_text": "Reporting exports are blocked.",
+            },
+        ],
+        default_fields={
+            "company_name": "Acme Logistics",
+            "contact_email": "ops@example.com",
+        },
+    )
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
+    assert loaded.opportunities[0]["contact_email"] == "ops@example.com"
+    assert loaded.opportunities[1]["company_name"] == "Row Company"
+    assert loaded.opportunities[1]["contact_email"] == "ops@example.com"
+
+
+def test_parse_default_fields_rejects_invalid_values() -> None:
+    assert parse_default_fields(["company_name=Acme", "contact_email=ops@example.com"]) == {
+        "company_name": "Acme",
+        "contact_email": "ops@example.com",
+    }
+
+    try:
+        parse_default_fields(["company_name"])
+    except ValueError as exc:
+        assert "key=value" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected invalid default field to fail")
 
 
 def test_source_document_title_does_not_become_buyer_fields() -> None:
@@ -626,6 +669,30 @@ def test_load_source_campaign_opportunities_from_csv(tmp_path: Path) -> None:
         "source_id": "review-1",
         "source_type": "review",
     }]
+
+
+def test_load_source_campaign_opportunities_applies_default_fields(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        json.dumps({
+            "id": "g2-review-1",
+            "vendor": "Slack",
+            "review_text": "Search gets slow once message history grows.",
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(
+        path,
+        default_fields={
+            "company_name": "Acme Logistics",
+            "contact_email": "ops@example.com",
+        },
+    )
+
+    assert loaded.warnings == ()
+    assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
+    assert loaded.opportunities[0]["contact_email"] == "ops@example.com"
 
 
 def test_packaged_source_rows_example_loads() -> None:
@@ -1127,6 +1194,39 @@ def test_source_adapter_cli_outputs_csv_generation_payload(tmp_path: Path) -> No
     payload = json.loads(completed.stdout)
     assert payload["opportunities"][0]["target_id"] == "call-1"
     assert payload["opportunities"][0]["evidence"][0]["source_type"] == "transcript"
+
+
+def test_source_adapter_cli_applies_default_fields(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        json.dumps({
+            "id": "g2-review-1",
+            "vendor": "Slack",
+            "review_text": "Search gets slow once message history grows.",
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--format",
+            "jsonl",
+            "--default-field",
+            "company_name=Acme Logistics",
+            "--default-field",
+            "contact_email=ops@example.com",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    opportunity = json.loads(completed.stdout)["opportunities"][0]
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["contact_email"] == "ops@example.com"
 
 
 def test_source_adapter_cli_rejects_non_positive_text_limit(tmp_path: Path) -> None:

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -532,6 +532,32 @@ async def test_ingestion_inspect_route_reports_source_rows():
 
 
 @pytest.mark.asyncio
+async def test_ingestion_inspect_route_applies_source_default_fields():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/inspect", "POST")
+    payload = await route.endpoint({
+        "source_rows": True,
+        "source": "fixture",
+        "default_fields": {
+            "company_name": "Acme Logistics",
+            "contact_email": "ops@example.com",
+        },
+        "rows": [{
+            "id": "g2-review-1",
+            "vendor": "Slack",
+            "review_text": "Search gets slow once message history grows.",
+        }],
+    })
+
+    assert payload["ok"] is True
+    assert payload["samples"][0]["company_name"] == "Acme Logistics"
+    assert payload["samples"][0]["contact_email"] == "ops@example.com"
+
+
+@pytest.mark.asyncio
 async def test_ingestion_inspect_route_reports_missing_opportunity_fields():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -623,6 +623,36 @@ async def test_ingestion_import_route_dry_run_does_not_require_pool_provider():
 
 
 @pytest.mark.asyncio
+async def test_ingestion_import_route_dry_run_applies_source_default_fields():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/import", "POST")
+    payload = await route.endpoint({
+        "dry_run": True,
+        "source_rows": True,
+        "source": "g2-export",
+        "default_fields": {
+            "company_name": "Acme Logistics",
+            "contact_email": "ops@example.com",
+        },
+        "rows": [{
+            "id": "g2-review-1",
+            "vendor": "Slack",
+            "review_text": "Search gets slow once message history grows.",
+        }],
+    })
+
+    sample = payload["diagnostics"]["samples"][0]
+    assert payload["diagnostics"]["ok"] is True
+    assert sample["company_name"] == "Acme Logistics"
+    assert sample["contact_email"] == "ops@example.com"
+    assert payload["import"]["inserted"] == 1
+    assert payload["import"]["target_ids"] == ["g2-review-1"]
+
+
+@pytest.mark.asyncio
 async def test_ingestion_import_route_writes_rows_with_scope_and_replace_existing():
     pool = _Pool()
     router = create_content_ops_control_surface_router(

--- a/tests/test_extracted_content_ingestion_diagnostics.py
+++ b/tests/test_extracted_content_ingestion_diagnostics.py
@@ -72,6 +72,29 @@ def test_inspect_source_rows_counts_source_types_and_warnings(tmp_path: Path) ->
     assert payload["samples"][0]["evidence"][0]["source_type"] == "support_ticket"
 
 
+def test_inspect_source_rows_applies_default_fields(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(json.dumps({
+        "id": "g2-review-1",
+        "vendor": "Slack",
+        "review_text": "Search gets slow once message history grows.",
+    }))
+
+    report = inspect_ingestion_file(
+        path,
+        source_rows=True,
+        source_format="jsonl",
+        default_fields={
+            "company_name": "Acme Logistics",
+            "contact_email": "ops@example.com",
+        },
+    )
+
+    assert report.ok is True
+    assert report.opportunities[0]["company_name"] == "Acme Logistics"
+    assert report.opportunities[0]["contact_email"] == "ops@example.com"
+
+
 def test_inspect_reports_missing_generation_fields(tmp_path: Path) -> None:
     path = tmp_path / "opportunities.json"
     path.write_text(json.dumps([


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-Target-Defaults.md

## Summary
- add fallback default_fields support to source-row normalization, diagnostics, and hosted ingestion inspect/import
- expose repeatable --default-field key=value on source-row build, inspect, smoke, generation, and import CLIs
- document binding anonymous G2/source evidence to target account/contact context without editing exported rows

## Verification
- python -m pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py tests/test_extracted_content_ingestion_diagnostics.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_host_smoke.py -q
- python -m py_compile touched source-row modules and scripts
- live G2 export -> inspect with default fields -> offline generation with default fields
- bash scripts/local_pr_review.sh

## Notes
- PR #588 merged first; this branch starts from that merge commit.
- This remains a file/API ingestion seam, not a browser upload UI.