### PR TITLE
[codex] Add read-only invoicing MCP surface for ChatGPT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ atlas_brain/
 ├── escalation/                  # Security event classification + LLM synthesis
 ├── events/                      # System event broadcast (real-time UI feed)
 ├── jobs/                        # Background jobs (e.g. NightlyMemorySync)
-├── mcp/                         # 9 MCP servers (see "MCP Servers" below)
+├── mcp/                         # 10 MCP servers (see "MCP Servers" below)
 │   └── b2b/                     # B2B-churn server module split
 ├── memory/                      # MemoryService, RAG client, token budgeting
 ├── modes/                       # Operating modes (tool groupings, model prefs)
@@ -230,7 +230,7 @@ atlas_brain/
 └── voice/                       # Local voice-to-voice (wake word, VAD, capture, playback)
 ```
 
-### `atlas_brain/mcp/` MCP servers (9)
+### `atlas_brain/mcp/` MCP servers (10)
 
 | Server                  | Port | Tools | Module                                |
 |-------------------------|------|-------|---------------------------------------|
@@ -239,6 +239,7 @@ atlas_brain/
 | Twilio                  | 8058 | 10    | `atlas_brain.mcp.twilio_server`       |
 | Calendar                | 8059 | 8     | `atlas_brain.mcp.calendar_server`     |
 | Invoicing               | 8060 | 18    | `atlas_brain.mcp.invoicing_server`    |
+| Invoicing Readonly      | 8065 | 8     | `atlas_brain.mcp.invoicing_readonly_server` |
 | Intelligence            | 8061 | 33    | `atlas_brain.mcp.intelligence_server` |
 | B2B Churn Intelligence  | 8062 | 83    | `atlas_brain.mcp.b2b_churn_server` (split across 17 modules in `mcp/b2b/`) |
 | Universal Scraper       | 8063 | 5     | `atlas_brain.mcp.scraper_server`      |
@@ -336,12 +337,13 @@ ATLAS_TOOLS_CALENDAR_REFRESH_TOKEN=your_refresh_token
 # Default transport is stdio. Set ATLAS_MCP_TRANSPORT=sse to expose as HTTP.
 ATLAS_MCP_TRANSPORT=stdio            # stdio (Claude Desktop/Cursor) or sse (HTTP)
 ATLAS_MCP_HOST=0.0.0.0              # Bind host for SSE mode
-ATLAS_MCP_AUTH_TOKEN=                # Bearer token for SSE mode (optional)
+ATLAS_MCP_AUTH_TOKEN=                # Bearer token for SSE mode; required for invoicing-readonly HTTP
 ATLAS_MCP_CRM_ENABLED=true          # Enable/disable individual servers
 ATLAS_MCP_EMAIL_ENABLED=true
 ATLAS_MCP_TWILIO_ENABLED=true
 ATLAS_MCP_CALENDAR_ENABLED=true
 ATLAS_MCP_INVOICING_ENABLED=true
+ATLAS_MCP_INVOICING_READONLY_ENABLED=true
 ATLAS_MCP_INTELLIGENCE_ENABLED=true
 ATLAS_MCP_B2B_CHURN_ENABLED=true
 ATLAS_MCP_CRM_PORT=8056
@@ -349,6 +351,7 @@ ATLAS_MCP_EMAIL_PORT=8057
 ATLAS_MCP_TWILIO_PORT=8058
 ATLAS_MCP_CALENDAR_PORT=8059
 ATLAS_MCP_INVOICING_PORT=8060
+ATLAS_MCP_INVOICING_READONLY_PORT=8065
 ATLAS_MCP_INTELLIGENCE_PORT=8061
 ATLAS_MCP_B2B_CHURN_PORT=8062
 
@@ -385,8 +388,8 @@ service required.
 
 ## MCP Servers
 
-Nine MCP servers expose Atlas capabilities to any MCP client (Claude Desktop, Cursor, custom agents).
-All share `ATLAS_MCP_TRANSPORT` (stdio/sse), `ATLAS_MCP_HOST`, and `ATLAS_MCP_AUTH_TOKEN` config.
+Ten MCP servers expose Atlas capabilities to any MCP client (Claude Desktop, Cursor, custom agents).
+All share `ATLAS_MCP_TRANSPORT` (stdio/sse) and `ATLAS_MCP_HOST`; HTTP deployments should set `ATLAS_MCP_AUTH_TOKEN`, and the read-only invoicing HTTP server refuses to start without it because it exposes customer financial data.
 Each server has an independent enable/disable toggle (`ATLAS_MCP_<NAME>_ENABLED`).
 
 ### CRM MCP Server (10 tools)
@@ -500,6 +503,25 @@ Tools: `create_invoice`, `get_invoice`, `list_invoices`, `update_invoice`,
 `payment_history`, `create_service`, `list_services`, `get_service`,
 `update_service`, `set_service_status`, `search_invoices`,
 `list_pending_drafts`, `approve_and_send`, `export_invoice_pdf`
+
+### Invoicing Readonly MCP Server (8 tools)
+```bash
+# stdio mode (read-only tools only)
+python -m atlas_brain.mcp.invoicing_readonly_server
+
+# SSE HTTP mode (port 8065, requires ATLAS_MCP_AUTH_TOKEN)
+ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.invoicing_readonly_server --sse
+```
+
+Tools: `get_invoice`, `list_invoices`, `search_invoices`,
+`list_pending_drafts`, `customer_balance`, `payment_history`,
+`list_services`, `get_service`
+
+This surface is for authenticated ChatGPT-style connector review when only
+read tools should be available. It deliberately omits
+create/update/approve/send/payment/void/PDF-export and service mutation tools,
+but it still requires bearer auth in HTTP mode because the remaining tools
+expose customer financial data.
 
 ### Intelligence MCP Server (33 tools)
 ```bash
@@ -674,6 +696,11 @@ The wrapper service is started with `start-graphiti.sh` (compose file
     "atlas-invoicing": {
       "command": "python",
       "args": ["-m", "atlas_brain.mcp.invoicing_server"],
+      "cwd": "/path/to/ATLAS"
+    },
+    "atlas-invoicing-readonly": {
+      "command": "python",
+      "args": ["-m", "atlas_brain.mcp.invoicing_readonly_server"],
       "cwd": "/path/to/ATLAS"
     },
     "atlas-intelligence": {

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -10,6 +10,8 @@ from typing import Any, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from .config_defaults import DEFAULT_INVOICING_READONLY_PORT
+
 ENV_FILES = (".env", ".env.local")
 DEFAULT_OPENROUTER_CLAUDE_SONNET_MODEL = "anthropic/claude-sonnet-4-5"
 
@@ -5063,6 +5065,14 @@ class MCPConfig(BaseSettings):
     twilio_port: int = Field(default=8058, description="Port for Twilio MCP server (SSE transport)")
     calendar_port: int = Field(default=8059, description="Port for Calendar MCP server (SSE transport)")
     invoicing_port: int = Field(default=8060, description="Port for Invoicing MCP server (SSE transport)")
+    invoicing_readonly_enabled: bool = Field(default=True, description="Enable read-only Invoicing MCP server")
+    invoicing_readonly_port: int = Field(
+        default=DEFAULT_INVOICING_READONLY_PORT,
+        description=(
+            "Port for authenticated read-only Invoicing MCP server for "
+            "ChatGPT connector review; paired with ATLAS_MCP_INVOICING_READONLY_ENABLED"
+        ),
+    )
     intelligence_port: int = Field(default=8061, description="Port for Intelligence MCP server (SSE transport)")
     b2b_churn_port: int = Field(default=8062, description="Port for B2B Churn Intelligence MCP server (SSE transport)")
     scraper_enabled: bool = Field(default=True, description="Enable Universal Scraper MCP server")

--- a/atlas_brain/config_defaults.py
+++ b/atlas_brain/config_defaults.py
@@ -1,0 +1,4 @@
+"""Shared configuration defaults that must not import runtime settings."""
+
+DEFAULT_MCP_HOST = "0.0.0.0"
+DEFAULT_INVOICING_READONLY_PORT = 8065

--- a/atlas_brain/mcp/__init__.py
+++ b/atlas_brain/mcp/__init__.py
@@ -1,14 +1,16 @@
 """
 Atlas MCP servers package.
 
-Eight standalone MCP servers:
+Ten standalone MCP server entry points:
   - CRM server          (atlas_brain.mcp.crm_server)          -- customer/contact management
   - Email server        (atlas_brain.mcp.email_server)        -- send + read email
   - Twilio server       (atlas_brain.mcp.twilio_server)       -- calls, SMS, recordings
   - Calendar server     (atlas_brain.mcp.calendar_server)     -- calendar events, scheduling
   - Invoicing server    (atlas_brain.mcp.invoicing_server)    -- invoices, payments, services
+  - Invoicing readonly (atlas_brain.mcp.invoicing_readonly_server) -- authenticated invoice review
   - Intelligence server (atlas_brain.mcp.intelligence_server) -- reports, risk, interventions
   - B2B Churn server    (atlas_brain.mcp.b2b_churn_server)    -- B2B churn signals, reviews, pipeline
+  - Universal Scraper   (atlas_brain.mcp.scraper_server)      -- schema-driven web extraction
   - Memory server       (atlas_brain.mcp.memory_server)       -- knowledge graph + conversation history
 
 Each server can run in stdio mode (default, for Claude Desktop / Cursor)
@@ -20,6 +22,9 @@ or SSE/HTTP mode (for network-accessible deployment).
     # Email -- stdio
     python -m atlas_brain.mcp.email_server
 
+    # Invoicing readonly -- stdio
+    python -m atlas_brain.mcp.invoicing_readonly_server
+
     # Memory -- stdio
     python -m atlas_brain.mcp.memory_server
 
@@ -28,6 +33,9 @@ or SSE/HTTP mode (for network-accessible deployment).
 
     # Email -- SSE on port 8057
     python -m atlas_brain.mcp.email_server --sse
+
+    # Invoicing readonly -- SSE on port 8065
+    ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.invoicing_readonly_server --sse
 
     # Memory -- SSE on port 8064
     python -m atlas_brain.mcp.memory_server --sse

--- a/atlas_brain/mcp/invoicing_readonly_server.py
+++ b/atlas_brain/mcp/invoicing_readonly_server.py
@@ -1,0 +1,186 @@
+"""
+Read-only Atlas Invoicing MCP Server.
+
+This server is intentionally separate from atlas_brain.mcp.invoicing_server.
+It exposes invoice/service review tools only, with no mutation, send, payment,
+PDF-export, or approval tools. Use it for authenticated MCP clients such as
+ChatGPT connectors that need to inspect invoices without the ability to change
+state.
+
+Run:
+    python -m atlas_brain.mcp.invoicing_readonly_server
+    ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.invoicing_readonly_server --sse
+"""
+
+import logging
+import os
+import sys
+from contextlib import asynccontextmanager
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from . import invoicing_server as _full
+from ..config_defaults import DEFAULT_INVOICING_READONLY_PORT, DEFAULT_MCP_HOST
+
+logger = logging.getLogger("atlas.mcp.invoicing.readonly")
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    """Initialize DB pool on startup, close on shutdown."""
+    from ..storage.database import close_database, init_database
+
+    await init_database()
+    logger.info("Read-only invoicing MCP: DB pool initialized")
+    yield
+    await close_database()
+
+
+mcp = FastMCP(
+    "atlas-invoicing-readonly",
+    instructions=(
+        "Read-only invoicing server for Atlas. "
+        "Review invoices, draft blockers, services, balances, and payment "
+        "history. This server cannot create, update, approve, send, void, "
+        "record payments, or export PDFs."
+    ),
+    lifespan=_lifespan,
+)
+
+
+@mcp.tool()
+async def get_invoice(invoice_id: str) -> str:
+    """Fetch an invoice by UUID or invoice number."""
+    return await _full.get_invoice(invoice_id)
+
+
+@mcp.tool()
+async def list_invoices(
+    status: Optional[str] = None,
+    contact_id: Optional[str] = None,
+    business_context_id: Optional[str] = None,
+    limit: int = 50,
+) -> str:
+    """List invoices with optional status/contact/business-context filters."""
+    return await _full.list_invoices(
+        status=status,
+        contact_id=contact_id,
+        business_context_id=business_context_id,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def search_invoices(
+    keyword: Optional[str] = None,
+    status: Optional[str] = None,
+    contact_id: Optional[str] = None,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    limit: int = 50,
+) -> str:
+    """Search invoices by keyword, status, contact, or issue-date range."""
+    return await _full.search_invoices(
+        keyword=keyword,
+        status=status,
+        contact_id=contact_id,
+        from_date=from_date,
+        to_date=to_date,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def list_pending_drafts(
+    contact_id: Optional[str] = None,
+    business_context_id: Optional[str] = None,
+    only_blocked: bool = False,
+    limit: int = 100,
+) -> str:
+    """List draft invoices annotated with send blockers and warnings."""
+    return await _full.list_pending_drafts(
+        contact_id=contact_id,
+        business_context_id=business_context_id,
+        only_blocked=only_blocked,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def customer_balance(
+    contact_id: Optional[str] = None,
+    phone: Optional[str] = None,
+    email: Optional[str] = None,
+) -> str:
+    """Get outstanding balance for a customer."""
+    return await _full.customer_balance(contact_id=contact_id, phone=phone, email=email)
+
+
+@mcp.tool()
+async def payment_history(
+    contact_id: Optional[str] = None,
+    phone: Optional[str] = None,
+    email: Optional[str] = None,
+) -> str:
+    """Get payment behavior analytics for a customer."""
+    return await _full.payment_history(contact_id=contact_id, phone=phone, email=email)
+
+
+@mcp.tool()
+async def list_services(
+    contact_id: Optional[str] = None,
+    status: Optional[str] = None,
+) -> str:
+    """List customer service agreements."""
+    return await _full.list_services(contact_id=contact_id, status=status)
+
+
+@mcp.tool()
+async def get_service(service_id: str) -> str:
+    """Get a customer service agreement by UUID."""
+    return await _full.get_service(service_id)
+
+
+def _streamable_http_app():
+    """Build the authenticated streamable HTTP app for read-only tools."""
+    from .auth import apply_auth_middleware
+
+    if not os.environ.get("ATLAS_MCP_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "ATLAS_MCP_AUTH_TOKEN is required for read-only invoicing HTTP mode; "
+            "these tools expose customer financial data."
+        )
+    return apply_auth_middleware(mcp.streamable_http_app())
+
+
+if __name__ == "__main__":
+    if "--sse" in sys.argv:
+        # Streamable HTTP transport for read tools only. It still requires
+        # bearer auth because these tools expose customer financial data.
+        import anyio
+        import uvicorn
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        host = os.environ.get("ATLAS_MCP_HOST", DEFAULT_MCP_HOST)
+        port = int(os.environ.get("ATLAS_MCP_INVOICING_READONLY_PORT", str(DEFAULT_INVOICING_READONLY_PORT)))
+
+        mcp.settings.host = host
+        mcp.settings.port = port
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=False,
+        )
+
+        async def _serve():
+            config = uvicorn.Config(
+                _streamable_http_app(),
+                host=host,
+                port=port,
+                log_level="info",
+            )
+            server = uvicorn.Server(config)
+            await server.serve()
+
+        anyio.run(_serve)
+    else:
+        mcp.run(transport="stdio")

--- a/atlas_brain/services/mcp_client.py
+++ b/atlas_brain/services/mcp_client.py
@@ -211,6 +211,7 @@ class MCPToolProvider:
             ("calendar", settings.mcp.calendar_enabled, "atlas_brain.mcp.calendar_server"),
             ("twilio", settings.mcp.twilio_enabled, "atlas_brain.mcp.twilio_server"),
             ("invoicing", settings.mcp.invoicing_enabled, "atlas_brain.mcp.invoicing_server"),
+            ("invoicing_readonly", settings.mcp.invoicing_readonly_enabled, "atlas_brain.mcp.invoicing_readonly_server"),
             ("intelligence", settings.mcp.intelligence_enabled, "atlas_brain.mcp.intelligence_server"),
             ("b2b_churn", settings.mcp.b2b_churn_enabled, "atlas_brain.mcp.b2b_churn_server"),
             ("memory", settings.mcp.memory_enabled, "atlas_brain.mcp.memory_server"),

--- a/plans/PR-Invoicing-Readonly-ChatGPT-MCP.md
+++ b/plans/PR-Invoicing-Readonly-ChatGPT-MCP.md
@@ -1,0 +1,74 @@
+# PR-Invoicing-Readonly-ChatGPT-MCP
+
+## Why this slice exists
+
+The full Atlas invoicing MCP server exposes read tools and mutating tools on the same surface. That is acceptable for local stdio and bearer-protected HTTP clients, but it is the wrong shape for a ChatGPT-style connector that should not receive write/send/payment tools. The remaining read tools still expose customer financial data, so HTTP mode must stay authenticated even on the read-only surface.
+
+This slice adds a separate authenticated read-only MCP server so connector clients can inspect invoice state without gaining write/send/payment tools.
+
+## Scope (this PR)
+
+1. Add a new `atlas-invoicing-readonly` MCP server that wraps existing invoicing read tools.
+2. Add a dedicated HTTP port for the read-only server.
+3. Update MCP docs and audit mappings so the new server is tracked by the existing local review bundle.
+4. Add tests pinning the exact read-only tool surface.
+
+### Files touched
+
+- `atlas_brain/config.py`
+- `atlas_brain/mcp/__init__.py`
+- `atlas_brain/config_defaults.py`
+- `atlas_brain/mcp/invoicing_readonly_server.py`
+- `atlas_brain/services/mcp_client.py`
+- `scripts/audit_claude_md_claims.py`
+- `scripts/audit_mcp_port_assignments.py`
+- `scripts/audit_mcp_tool_names_match_docs.py`
+- `tests/test_audit_mcp_port_assignments.py`
+- `tests/test_invoicing_readonly_mcp.py`
+- `tests/test_pre_push_audit.py`
+- `CLAUDE.md`
+- `plans/PR-Invoicing-Readonly-ChatGPT-MCP.md`
+
+## Mechanism
+
+The new server creates its own `FastMCP("atlas-invoicing-readonly")` instance and registers only eight read/review tools:
+
+- `get_invoice`
+- `list_invoices`
+- `search_invoices`
+- `list_pending_drafts`
+- `customer_balance`
+- `payment_history`
+- `list_services`
+- `get_service`
+
+Each tool delegates to the existing implementation in `atlas_brain.mcp.invoicing_server`, so business logic stays single-source-of-truth. The `--sse` path requires `ATLAS_MCP_AUTH_TOKEN` and wraps the streamable HTTP app with the existing bearer middleware; safety comes from both authentication and the absence of mutating tools on this server. Runtime host/port are read from `ATLAS_MCP_HOST` / `ATLAS_MCP_INVOICING_READONLY_PORT`, using shared MCP default constants so the config field and entrypoint cannot drift while avoiding global `settings` import during MCP bootstrap.
+
+## Intentional
+
+- No write/send tools are re-exported, including `export_invoice_pdf`, because it writes files by default.
+- The full invoicing server remains unchanged for write actions; the read-only HTTP server also requires bearer auth because read tools expose financial data.
+- The read-only server uses a separate port (`8065`) instead of trying to branch behavior by token or path inside the full server.
+
+## Deferred
+
+- Public Funnel routing is operational, not baked into the Python server. Any public endpoint/path must forward bearer-authenticated requests only.
+- OAuth/tool-security metadata for future ChatGPT write tools is deferred. Write tools should not be exposed to connector traffic until that exists.
+
+## Verification
+
+```bash
+python -m py_compile atlas_brain/mcp/invoicing_readonly_server.py atlas_brain/config.py
+pytest tests/test_invoicing_readonly_mcp.py tests/test_pre_push_audit.py
+python scripts/audit_claude_md_claims.py
+python scripts/audit_mcp_tool_names_match_docs.py
+python scripts/audit_mcp_port_assignments.py
+```
+
+## Estimated diff size
+
+| Scope | Estimated LOC |
+|---|---:|
+| Total | 500 |
+
+One new server, docs, audit mappings, and focused tests. Under the 400 LOC target.

--- a/scripts/audit_claude_md_claims.py
+++ b/scripts/audit_claude_md_claims.py
@@ -17,6 +17,7 @@ HEADER_TO_FILE = {
     "Twilio": "twilio_server.py",
     "Calendar": "calendar_server.py",
     "Invoicing": "invoicing_server.py",
+    "Invoicing Readonly": "invoicing_readonly_server.py",
     "Intelligence": "intelligence_server.py",
     "Universal Scraper": "scraper_server.py",
     "Memory": "memory_server.py",

--- a/scripts/audit_mcp_port_assignments.py
+++ b/scripts/audit_mcp_port_assignments.py
@@ -34,19 +34,51 @@ def _normalize_name(name: str) -> str:
     return name.lower().replace("-", "_").strip("_")
 
 
-def _field_default_int(node: ast.AST | None) -> int | None:
+def _literal_int_constants(tree: ast.Module, config_path: Path | None = None) -> dict[str, int]:
+    constants: dict[str, int] = {}
+    for statement in tree.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if len(statement.targets) != 1 or not isinstance(statement.targets[0], ast.Name):
+            continue
+        if isinstance(statement.value, ast.Constant) and isinstance(statement.value.value, int):
+            constants[statement.targets[0].id] = statement.value.value
+    if config_path is not None:
+        for statement in tree.body:
+            if not isinstance(statement, ast.ImportFrom):
+                continue
+            if statement.module != "config_defaults":
+                continue
+            defaults_path = config_path.parent / "config_defaults.py"
+            if not defaults_path.exists():
+                continue
+            defaults_tree = ast.parse(defaults_path.read_text(encoding="utf-8"))
+            imported = {alias.asname or alias.name for alias in statement.names}
+            for name, value in _literal_int_constants(defaults_tree).items():
+                if name in imported:
+                    constants[name] = value
+    return constants
+
+
+def _field_default_int(node: ast.AST | None, constants: dict[str, int] | None = None) -> int | None:
+    constants = constants or {}
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Field":
         for keyword in node.keywords:
             if keyword.arg == "default" and isinstance(keyword.value, ast.Constant):
                 if isinstance(keyword.value.value, int):
                     return keyword.value.value
+            if keyword.arg == "default" and isinstance(keyword.value, ast.Name):
+                return constants.get(keyword.value.id)
     if isinstance(node, ast.Constant) and isinstance(node.value, int):
         return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
     return None
 
 
-def mcp_config_ports(config_text: str) -> dict[str, int]:
+def mcp_config_ports(config_text: str, config_path: Path | None = None) -> dict[str, int]:
     tree = ast.parse(config_text)
+    constants = _literal_int_constants(tree, config_path=config_path)
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == "MCPConfig":
             ports: dict[str, int] = {}
@@ -58,7 +90,7 @@ def mcp_config_ports(config_text: str) -> dict[str, int]:
                 field_name = statement.target.id
                 if not field_name.endswith("_port"):
                     continue
-                default = _field_default_int(statement.value)
+                default = _field_default_int(statement.value, constants)
                 if default is not None:
                     ports[field_name.removesuffix("_port")] = default
             return ports
@@ -134,7 +166,10 @@ def main() -> int:
         return 2
 
     try:
-        config_ports = mcp_config_ports(config_path.read_text(encoding="utf-8"))
+        config_ports = mcp_config_ports(
+            config_path.read_text(encoding="utf-8"),
+            config_path=config_path,
+        )
     except (SyntaxError, ValueError) as exc:
         print(f"failed to parse MCPConfig: {exc}", file=sys.stderr)
         return 2

--- a/scripts/audit_mcp_tool_names_match_docs.py
+++ b/scripts/audit_mcp_tool_names_match_docs.py
@@ -17,6 +17,7 @@ HEADER_TO_FILE = {
     "Twilio": "twilio_server.py",
     "Calendar": "calendar_server.py",
     "Invoicing": "invoicing_server.py",
+    "Invoicing Readonly": "invoicing_readonly_server.py",
     "Intelligence": "intelligence_server.py",
     "Universal Scraper": "scraper_server.py",
     "Memory": "memory_server.py",

--- a/tests/test_audit_mcp_port_assignments.py
+++ b/tests/test_audit_mcp_port_assignments.py
@@ -52,6 +52,46 @@ def test_mcp_config_ports_extracts_field_defaults():
     }
 
 
+def test_mcp_config_ports_extracts_named_constant_defaults():
+    auditor = load_auditor()
+    config = textwrap.dedent(
+        """\
+        from pydantic import Field
+
+        DEFAULT_INVOICING_READONLY_PORT = 8065
+
+        class MCPConfig:
+            invoicing_readonly_port: int = Field(default=DEFAULT_INVOICING_READONLY_PORT)
+        """
+    )
+
+    assert auditor.mcp_config_ports(config) == {
+        "invoicing_readonly": 8065,
+    }
+
+
+def test_mcp_config_ports_extracts_imported_constant_defaults(tmp_path):
+    auditor = load_auditor()
+    defaults = tmp_path / "config_defaults.py"
+    defaults.write_text("DEFAULT_INVOICING_READONLY_PORT = 8065\n", encoding="utf-8")
+    config = tmp_path / "config.py"
+    config_text = textwrap.dedent(
+        """\
+        from pydantic import Field
+
+        from .config_defaults import DEFAULT_INVOICING_READONLY_PORT
+
+        class MCPConfig:
+            invoicing_readonly_port: int = Field(default=DEFAULT_INVOICING_READONLY_PORT)
+        """
+    )
+    config.write_text(config_text, encoding="utf-8")
+
+    assert auditor.mcp_config_ports(config_text, config_path=config) == {
+        "invoicing_readonly": 8065,
+    }
+
+
 def test_documented_port_claims_parse_env_and_sse_examples():
     auditor = load_auditor()
     doc = textwrap.dedent(

--- a/tests/test_invoicing_readonly_mcp.py
+++ b/tests/test_invoicing_readonly_mcp.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from atlas_brain.mcp.auth import BearerAuthMiddleware
+from atlas_brain.mcp import invoicing_readonly_server as readonly
+
+
+READONLY_TOOLS = {
+    "get_invoice",
+    "list_invoices",
+    "search_invoices",
+    "list_pending_drafts",
+    "customer_balance",
+    "payment_history",
+    "list_services",
+    "get_service",
+}
+
+MUTATING_TOOLS = {
+    "approve_and_send",
+    "create_invoice",
+    "create_service",
+    "export_invoice_pdf",
+    "mark_void",
+    "record_payment",
+    "send_invoice",
+    "set_service_status",
+    "update_invoice",
+    "update_service",
+}
+
+
+def _tool_names() -> set[str]:
+    return set(readonly.mcp._tool_manager._tools)
+
+
+def test_invoicing_readonly_mcp_exposes_exact_read_tool_surface():
+    assert _tool_names() == READONLY_TOOLS
+    assert _tool_names().isdisjoint(MUTATING_TOOLS)
+
+
+@pytest.mark.asyncio
+async def test_invoicing_readonly_mcp_delegates_to_full_read_tool(monkeypatch):
+    calls = []
+
+    async def fake_list_invoices(**kwargs):
+        calls.append(kwargs)
+        return '{"ok": true}'
+
+    monkeypatch.setattr(readonly._full, "list_invoices", fake_list_invoices)
+
+    result = await readonly.list_invoices(
+        status="draft",
+        contact_id="contact-1",
+        business_context_id="firefly",
+        limit=3,
+    )
+
+    assert result == '{"ok": true}'
+    assert calls == [
+        {
+            "status": "draft",
+            "contact_id": "contact-1",
+            "business_context_id": "firefly",
+            "limit": 3,
+        }
+    ]
+
+
+def test_invoicing_readonly_http_requires_bearer_token(monkeypatch):
+    monkeypatch.delenv("ATLAS_MCP_AUTH_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="ATLAS_MCP_AUTH_TOKEN is required"):
+        readonly._streamable_http_app()
+
+
+def test_invoicing_readonly_http_wraps_with_bearer_auth(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", "test-token")
+
+    app = readonly._streamable_http_app()
+
+    assert isinstance(app, BearerAuthMiddleware)

--- a/tests/test_pre_push_audit.py
+++ b/tests/test_pre_push_audit.py
@@ -142,6 +142,7 @@ ATLAS_MCP_EMAIL_PORT=8057
 ATLAS_MCP_TWILIO_PORT=8058
 ATLAS_MCP_CALENDAR_PORT=8059
 ATLAS_MCP_INVOICING_PORT=8060
+ATLAS_MCP_INVOICING_READONLY_PORT=8065
 ATLAS_MCP_INTELLIGENCE_PORT=8061
 ATLAS_MCP_B2B_CHURN_PORT=8062
 
@@ -165,6 +166,10 @@ python -m atlas_brain.mcp.calendar_server --sse
 # SSE HTTP mode (port 8060)
 python -m atlas_brain.mcp.invoicing_server --sse
 {invoicing_tools}
+### Invoicing Readonly MCP Server (8 tools)
+# SSE HTTP mode (port 8065)
+python -m atlas_brain.mcp.invoicing_readonly_server --sse
+{invoicing_readonly_tools}
 ### Intelligence MCP Server (33 tools)
 # SSE HTTP mode (port 8061)
 python -m atlas_brain.mcp.intelligence_server --sse
@@ -187,6 +192,7 @@ python -m atlas_brain.mcp.memory_server --sse
         twilio_tools=_tool_list(10),
         calendar_tools=_tool_list(8),
         invoicing_tools=_tool_list(18),
+        invoicing_readonly_tools=_tool_list(8),
         intelligence_tools=_tool_list(33),
         b2b_tools=_tool_list(83),
         scraper_tools=_tool_list(5),
@@ -206,6 +212,7 @@ class MCPConfig:
     twilio_port: int = Field(default=8058)
     calendar_port: int = Field(default=8059)
     invoicing_port: int = Field(default=8060)
+    invoicing_readonly_port: int = Field(default=8065)
     intelligence_port: int = Field(default=8061)
     b2b_churn_port: int = Field(default=8062)
     scraper_port: int = Field(default=8063)
@@ -223,6 +230,7 @@ def _write_mcp_servers(mcp_dir: Path) -> None:
         "twilio_server.py": 10,
         "calendar_server.py": 8,
         "invoicing_server.py": 18,
+        "invoicing_readonly_server.py": 8,
         "intelligence_server.py": 33,
         "scraper_server.py": 5,
         "memory_server.py": 15,


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Readonly-ChatGPT-MCP.md

Adds a separate authenticated read-only Atlas invoicing MCP server for ChatGPT-style connector review. The full invoicing MCP remains the write/send/payment surface; this new server exposes only invoice/service read and review tools and refuses HTTP mode unless `ATLAS_MCP_AUTH_TOKEN` is set.

## Intentional
- The read-only server has its own FastMCP instance and port (`8065`) instead of branching behavior inside the full invoicing server.
- Write/send/payment/PDF export tools are not re-exported, including `export_invoice_pdf`, because it writes files by default.
- Existing read implementations are reused by delegation so business logic remains single-source-of-truth.
- HTTP mode is authenticated even though the tool surface is read-only because those tools expose customer financial data.
- Host/port defaults live in `atlas_brain/config_defaults.py` so `config.py` and the read-only entrypoint share the same value without importing global `settings` during MCP bootstrap.

## Deferred
- OAuth/tool-security metadata for future write-tool exposure is out of scope.
- Public Funnel routing is operational configuration, not baked into the Python server; any public route must forward bearer-authenticated requests only.

## Verification
- `python -m py_compile atlas_brain/config_defaults.py atlas_brain/mcp/invoicing_readonly_server.py atlas_brain/config.py atlas_brain/services/mcp_client.py scripts/audit_mcp_port_assignments.py`
- `pytest tests/test_invoicing_readonly_mcp.py tests/test_pre_push_audit.py tests/test_audit_mcp_port_assignments.py` -> 14 passed
- `python scripts/audit_claude_md_claims.py` -> all OK
- `python scripts/audit_mcp_tool_names_match_docs.py` -> all OK
- `python scripts/audit_mcp_port_assignments.py` -> all OK
- Public read-only route without token -> `401`
- Public read-only MCP handshake with bearer token -> `tool_count=8`, no mutating tools
- `bash scripts/local_pr_review.sh` passed via pre-push hook

## Diff size
13 files, +485 / -10
