### PR TITLE
Add Content Ops review source readiness summary

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T20:17Z by codex-2026-05-18
+Last updated: 2026-05-18T21:05Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops source-row target defaults | `extracted_content_pipeline/campaign_source_adapters.py`, `extracted_content_pipeline/ingestion_diagnostics.py`, `extracted_content_pipeline/api/control_surfaces.py`, `scripts/build_extracted_campaign_opportunities_from_sources.py`, `scripts/inspect_extracted_content_ingestion.py`, `scripts/load_extracted_campaign_opportunities.py`, `scripts/run_extracted_campaign_generation_example.py`, `scripts/smoke_extracted_content_pipeline_host.py`, `tests/test_extracted_campaign_source_adapters.py`, `tests/test_extracted_campaign_generation_example.py`, `tests/test_extracted_content_ingestion_diagnostics.py`, `tests/test_extracted_content_control_surface_api.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Source-Target-Defaults.md` | codex-2026-05-18 | Avoid editing Content Ops source-row ingestion defaults or ingestion docs |
+| pending | Content Ops review source readiness | `scripts/export_content_ops_review_sources.py`, `tests/test_export_content_ops_review_sources.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Readiness.md` | codex-2026-05-18 | Avoid editing the review-source exporter/readiness docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T20:17Z by codex-2026-05-18
+Last updated: 2026-05-18T21:05Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #588 | pending | Source-row target defaults are in flight so anonymous review evidence can bind to real account/contact context before inspect/import/generation. | `extracted_content_pipeline/campaign_source_adapters.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #589 | pending | Review-source readiness is in flight so operators can see which scraped review sources have quote-grade rows before export. | `scripts/export_content_ops_review_sources.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -156,6 +156,12 @@ lane as `text` while preserving the full review for audit:
 
 ```bash
 python scripts/export_content_ops_review_sources.py \
+  --source-summary \
+  --summary-sources g2,capterra,trustradius,trustpilot
+```
+
+```bash
+python scripts/export_content_ops_review_sources.py \
   --source g2 \
   --vendor Slack \
   --limit 50 \

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -91,6 +91,10 @@ source of truth for what remains.
   offline host smoke test that validates customer-data normalization through
   usable generated draft shape without a database, provider credentials, or
   send side effects. It accepts both opportunity files and source-row files.
+- `scripts/export_content_ops_review_sources.py --source-summary` reports
+  canonical, enriched, export-candidate, and quote-grade row counts for
+  scraped review sources before operators choose a source for Content Ops
+  ingestion.
 - `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
   provide offline readiness reports for opportunity/source-row exports before
   import or generation. The hosted control-surface API also exposes

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -445,7 +445,14 @@ typoed selectors during larger host imports.
 Atlas review rows can seed source-row ingestion when a host wants to test with
 scraped review evidence before wiring its own export. Start with one reliable
 source such as G2 so the generated output does not mix review-site tone with
-community sources:
+community sources. Check source readiness first; `quote_grade_rows` is the
+count that can actually export under the verbatim negative/mixed phrase gate:
+
+```bash
+python scripts/export_content_ops_review_sources.py \
+  --source-summary \
+  --summary-sources g2,capterra,trustradius,trustpilot
+```
 
 ```bash
 python scripts/export_content_ops_review_sources.py \

--- a/plans/PR-Content-Ops-Review-Source-Readiness.md
+++ b/plans/PR-Content-Ops-Review-Source-Readiness.md
@@ -1,0 +1,59 @@
+# PR: Content Ops Review Source Readiness
+
+## Why this slice exists
+
+PR #588 and #589 made G2 review evidence usable for AI Content Ops source-row generation. A live Trustpilot check showed the next risk: a review source can have thousands of enriched rows but still export zero usable source rows when v4 quote-grade phrase metadata is missing.
+
+This slice adds a small readiness summary to the existing review-source exporter so operators can choose G2, Capterra, TrustRadius, or Trustpilot based on quote-grade availability before running an export.
+
+## Scope (this PR)
+
+1. Add a read-only source-readiness summary mode to the existing review-source exporter.
+2. Count canonical enriched rows, export-candidate rows, and quote-grade exportable rows per source.
+3. Document the readiness check before the G2/source-row export workflow.
+
+### Files touched
+
+- `scripts/export_content_ops_review_sources.py`
+- `tests/test_export_content_ops_review_sources.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Source-Readiness.md`
+
+## Mechanism
+
+- Add a summary SQL builder that groups requested review sources and checks the same canonical/enriched/text/url/quote-grade conditions used by export.
+- Add `--source-summary` plus `--summary-sources` to print JSON readiness rows without writing source-row JSONL.
+- Keep normal export behavior unchanged.
+
+## Intentional
+
+- This does not loosen quote-grade export policy.
+- This does not make Trustpilot exportable when phrase metadata is absent.
+- This does not add a second exporter script.
+
+## Deferred
+
+- Re-enriching Trustpilot rows with v4 phrase metadata.
+- Adding browser UI for source-readiness diagnostics.
+- Adding new non-review source families.
+
+## Verification
+
+- python -m pytest tests/test_export_content_ops_review_sources.py -q -> 12 passed.
+- python -m py_compile scripts/export_content_ops_review_sources.py tests/test_export_content_ops_review_sources.py -> passed.
+- python scripts/export_content_ops_review_sources.py --source-summary --summary-sources g2,capterra,trustradius,trustpilot -> passed; reported quote_grade_rows: g2=364, capterra=154, trustradius=31, trustpilot=0.
+- python scripts/export_content_ops_review_sources.py --source capterra --limit 3 --output /tmp/capterra_content_ops_sources.jsonl -> exported 3 rows.
+- git diff --check -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Exporter summary mode | ~140 |
+| Tests | ~80 |
+| Docs and coordination | ~80 |
+| Total | ~300 |

--- a/scripts/export_content_ops_review_sources.py
+++ b/scripts/export_content_ops_review_sources.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover - host dependency
 
 
 DEFAULT_SOURCE = "g2"
+DEFAULT_SUMMARY_SOURCES = ("g2", "capterra", "trustradius", "trustpilot")
 DEFAULT_POLARITIES = ("negative", "mixed")
 DEFAULT_PHRASE_FIELDS = (
     "specific_complaints",
@@ -253,6 +254,60 @@ def build_review_source_query(
     return query, args
 
 
+def build_review_source_summary_query(
+    *,
+    sources: Sequence[str],
+    min_review_text_chars: int,
+    allowed_polarities: Sequence[str],
+    allowed_fields: Sequence[str],
+    require_review_url: bool,
+) -> tuple[str, list[Any]]:
+    """Build a read-only readiness query for review-source exportability."""
+
+    source_url_filter = "AND NULLIF(BTRIM(r.source_url), '') IS NOT NULL" if require_review_url else ""
+    export_candidate_filter = f"""
+        r.duplicate_of_review_id IS NULL
+        AND r.enrichment_status = 'enriched'
+        AND r.enrichment IS NOT NULL
+        AND NULLIF(BTRIM(r.review_text), '') IS NOT NULL
+        AND length(r.review_text) >= $2
+        {source_url_filter}
+    """
+    quote_grade_filter = f"""
+        {export_candidate_filter}
+        AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(COALESCE(r.enrichment->'phrase_metadata', '[]'::jsonb)) pm
+            WHERE lower(BTRIM(pm->>'subject')) = 'subject_vendor'
+              AND pm->'verbatim' = 'true'::jsonb
+              AND (cardinality($3::text[]) = 0 OR lower(pm->>'polarity') = ANY($3::text[]))
+              AND (cardinality($4::text[]) = 0 OR BTRIM(pm->>'field') = ANY($4::text[]))
+        )
+    """
+    query = f"""
+        SELECT lower(r.source) AS source,
+               count(*) AS total_rows,
+               count(*) FILTER (WHERE r.duplicate_of_review_id IS NULL) AS canonical_rows,
+               count(*) FILTER (
+                   WHERE r.duplicate_of_review_id IS NULL
+                     AND r.enrichment_status = 'enriched'
+                     AND r.enrichment IS NOT NULL
+               ) AS enriched_rows,
+               count(*) FILTER (WHERE {export_candidate_filter}) AS export_candidate_rows,
+               count(*) FILTER (WHERE {quote_grade_filter}) AS quote_grade_rows
+        FROM b2b_reviews r
+        WHERE lower(r.source) = ANY($1::text[])
+        GROUP BY lower(r.source)
+        ORDER BY lower(r.source)
+    """
+    return query, [
+        [source.strip().lower() for source in sources if source.strip()],
+        min_review_text_chars,
+        [polarity.strip().lower() for polarity in allowed_polarities if polarity.strip()],
+        [field.strip() for field in allowed_fields if field.strip()],
+    ]
+
+
 async def fetch_review_source_rows(
     pool: Any,
     *,
@@ -309,6 +364,45 @@ async def fetch_review_source_rows(
     return rows
 
 
+async def fetch_review_source_summary(
+    pool: Any,
+    *,
+    sources: Sequence[str] = DEFAULT_SUMMARY_SOURCES,
+    min_review_text_chars: int = 80,
+    allowed_polarities: Sequence[str] = DEFAULT_POLARITIES,
+    allowed_fields: Sequence[str] = DEFAULT_PHRASE_FIELDS,
+    require_review_url: bool = True,
+) -> list[dict[str, Any]]:
+    """Return export-readiness counts for canonical Atlas review sources."""
+
+    requested_sources = [source.strip().lower() for source in sources if source.strip()]
+    if not requested_sources:
+        return []
+    query, args = build_review_source_summary_query(
+        sources=requested_sources,
+        min_review_text_chars=min_review_text_chars,
+        allowed_polarities=allowed_polarities,
+        allowed_fields=allowed_fields,
+        require_review_url=require_review_url,
+    )
+    rows_by_source: dict[str, dict[str, Any]] = {}
+    for raw in await pool.fetch(query, *args):
+        row = dict(raw)
+        rows_by_source[_clean_text(row.get("source")).lower()] = row
+    out: list[dict[str, Any]] = []
+    for source in requested_sources:
+        row = rows_by_source.get(source, {})
+        out.append({
+            "source": source,
+            "total_rows": int(row.get("total_rows") or 0),
+            "canonical_rows": int(row.get("canonical_rows") or 0),
+            "enriched_rows": int(row.get("enriched_rows") or 0),
+            "export_candidate_rows": int(row.get("export_candidate_rows") or 0),
+            "quote_grade_rows": int(row.get("quote_grade_rows") or 0),
+        })
+    return out
+
+
 def render_jsonl(rows: Sequence[Mapping[str, Any]]) -> str:
     return "\n".join(json.dumps(dict(row), sort_keys=True, default=str) for row in rows)
 
@@ -346,6 +440,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--polarities", default=",".join(DEFAULT_POLARITIES))
     parser.add_argument("--phrase-fields", default=",".join(DEFAULT_PHRASE_FIELDS))
     parser.add_argument("--allow-missing-source-url", action="store_true")
+    parser.add_argument(
+        "--source-summary",
+        action="store_true",
+        help="Print JSON readiness counts for review sources instead of exporting JSONL rows.",
+    )
+    parser.add_argument(
+        "--summary-sources",
+        default=",".join(DEFAULT_SUMMARY_SOURCES),
+        help="Comma-separated sources for --source-summary.",
+    )
     parser.add_argument("--output", type=Path, default=None)
     parser.add_argument(
         "--database-url",
@@ -377,17 +481,27 @@ async def _main(argv: list[str] | None = None) -> int:
 
     pool = await _create_pool(args.database_url)
     try:
-        rows = await fetch_review_source_rows(
-            pool,
-            source=args.source,
-            vendor_name=args.vendor,
-            limit=args.limit,
-            min_review_text_chars=args.min_review_text_chars,
-            phrase_limit=args.phrase_limit,
-            allowed_polarities=_parse_csv_list(args.polarities),
-            allowed_fields=_parse_csv_list(args.phrase_fields),
-            require_review_url=not args.allow_missing_source_url,
-        )
+        if args.source_summary:
+            rows = await fetch_review_source_summary(
+                pool,
+                sources=_parse_csv_list(args.summary_sources),
+                min_review_text_chars=args.min_review_text_chars,
+                allowed_polarities=_parse_csv_list(args.polarities),
+                allowed_fields=_parse_csv_list(args.phrase_fields),
+                require_review_url=not args.allow_missing_source_url,
+            )
+        else:
+            rows = await fetch_review_source_rows(
+                pool,
+                source=args.source,
+                vendor_name=args.vendor,
+                limit=args.limit,
+                min_review_text_chars=args.min_review_text_chars,
+                phrase_limit=args.phrase_limit,
+                allowed_polarities=_parse_csv_list(args.polarities),
+                allowed_fields=_parse_csv_list(args.phrase_fields),
+                require_review_url=not args.allow_missing_source_url,
+            )
     finally:
         close = getattr(pool, "close", None)
         if close is not None:
@@ -395,11 +509,12 @@ async def _main(argv: list[str] | None = None) -> int:
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
 
-    payload = render_jsonl(rows)
+    payload = json.dumps(rows, indent=2, sort_keys=True, default=str) if args.source_summary else render_jsonl(rows)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
-        print(f"exported {len(rows)} source row(s) to {args.output}")
+        noun = "source summary row" if args.source_summary else "source row"
+        print(f"exported {len(rows)} {noun}(s) to {args.output}")
     else:
         if payload:
             print(payload)

--- a/scripts/export_content_ops_review_sources.py
+++ b/scripts/export_content_ops_review_sources.py
@@ -273,14 +273,22 @@ def build_review_source_summary_query(
         AND length(r.review_text) >= $2
         {source_url_filter}
     """
+    source_id_expr = "COALESCE(NULLIF(BTRIM(r.source_review_id), ''), r.id::text)"
+    phrase_metadata_expr = """
+        CASE
+            WHEN jsonb_typeof(r.enrichment->'phrase_metadata') = 'array'
+            THEN r.enrichment->'phrase_metadata'
+            ELSE '[]'::jsonb
+        END
+    """
     quote_grade_filter = f"""
         {export_candidate_filter}
         AND EXISTS (
             SELECT 1
-            FROM jsonb_array_elements(COALESCE(r.enrichment->'phrase_metadata', '[]'::jsonb)) pm
+            FROM jsonb_array_elements({phrase_metadata_expr}) pm
             WHERE lower(BTRIM(pm->>'subject')) = 'subject_vendor'
               AND pm->'verbatim' = 'true'::jsonb
-              AND (cardinality($3::text[]) = 0 OR lower(pm->>'polarity') = ANY($3::text[]))
+              AND (cardinality($3::text[]) = 0 OR lower(BTRIM(pm->>'polarity')) = ANY($3::text[]))
               AND (cardinality($4::text[]) = 0 OR BTRIM(pm->>'field') = ANY($4::text[]))
         )
     """
@@ -293,8 +301,8 @@ def build_review_source_summary_query(
                      AND r.enrichment_status = 'enriched'
                      AND r.enrichment IS NOT NULL
                ) AS enriched_rows,
-               count(*) FILTER (WHERE {export_candidate_filter}) AS export_candidate_rows,
-               count(*) FILTER (WHERE {quote_grade_filter}) AS quote_grade_rows
+               count(DISTINCT {source_id_expr}) FILTER (WHERE {export_candidate_filter}) AS export_candidate_rows,
+               count(DISTINCT {source_id_expr}) FILTER (WHERE {quote_grade_filter}) AS quote_grade_rows
         FROM b2b_reviews r
         WHERE lower(r.source) = ANY($1::text[])
         GROUP BY lower(r.source)

--- a/tests/test_export_content_ops_review_sources.py
+++ b/tests/test_export_content_ops_review_sources.py
@@ -198,11 +198,15 @@ def test_build_review_source_summary_query_counts_quote_grade_rows() -> None:
 
     assert "lower(r.source) = ANY($1::text[])" in query
     assert "count(*) AS total_rows" in query
+    assert "COALESCE(NULLIF(BTRIM(r.source_review_id), ''), r.id::text)" in query
+    assert "count(DISTINCT" in query
     assert "AS export_candidate_rows" in query
     assert "AS quote_grade_rows" in query
     assert "jsonb_array_elements" in query
+    assert "jsonb_typeof(r.enrichment->'phrase_metadata') = 'array'" in query
     assert "lower(BTRIM(pm->>'subject')) = 'subject_vendor'" in query
     assert "pm->'verbatim' = 'true'::jsonb" in query
+    assert "lower(BTRIM(pm->>'polarity')) = ANY($3::text[])" in query
     assert "BTRIM(pm->>'field') = ANY($4::text[])" in query
     assert "NULLIF(BTRIM(r.source_url), '') IS NOT NULL" in query
     assert args == [

--- a/tests/test_export_content_ops_review_sources.py
+++ b/tests/test_export_content_ops_review_sources.py
@@ -187,6 +187,32 @@ def test_build_review_source_query_filters_canonical_enriched_g2_rows() -> None:
     assert args == ["g2", 120, "HubSpot", 0, 0]
 
 
+def test_build_review_source_summary_query_counts_quote_grade_rows() -> None:
+    query, args = mod.build_review_source_summary_query(
+        sources=("g2", "trustpilot"),
+        min_review_text_chars=120,
+        allowed_polarities=("negative", "mixed"),
+        allowed_fields=("pricing_phrases",),
+        require_review_url=True,
+    )
+
+    assert "lower(r.source) = ANY($1::text[])" in query
+    assert "count(*) AS total_rows" in query
+    assert "AS export_candidate_rows" in query
+    assert "AS quote_grade_rows" in query
+    assert "jsonb_array_elements" in query
+    assert "lower(BTRIM(pm->>'subject')) = 'subject_vendor'" in query
+    assert "pm->'verbatim' = 'true'::jsonb" in query
+    assert "BTRIM(pm->>'field') = ANY($4::text[])" in query
+    assert "NULLIF(BTRIM(r.source_url), '') IS NOT NULL" in query
+    assert args == [
+        ["g2", "trustpilot"],
+        120,
+        ["negative", "mixed"],
+        ["pricing_phrases"],
+    ]
+
+
 @pytest.mark.asyncio
 async def test_fetch_review_source_rows_dedupes_and_filters_after_fetch() -> None:
     pool = _Pool([
@@ -205,6 +231,49 @@ async def test_fetch_review_source_rows_dedupes_and_filters_after_fetch() -> Non
     assert args[-2:] == (6, 0)
 
 
+@pytest.mark.asyncio
+async def test_fetch_review_source_summary_returns_requested_sources_with_zero_fill() -> None:
+    pool = _Pool([
+        {
+            "source": "g2",
+            "total_rows": 10,
+            "canonical_rows": 9,
+            "enriched_rows": 8,
+            "export_candidate_rows": 7,
+            "quote_grade_rows": 6,
+        }
+    ])
+
+    rows = await mod.fetch_review_source_summary(
+        pool,
+        sources=("g2", "trustpilot"),
+        min_review_text_chars=100,
+    )
+
+    assert rows == [
+        {
+            "source": "g2",
+            "total_rows": 10,
+            "canonical_rows": 9,
+            "enriched_rows": 8,
+            "export_candidate_rows": 7,
+            "quote_grade_rows": 6,
+        },
+        {
+            "source": "trustpilot",
+            "total_rows": 0,
+            "canonical_rows": 0,
+            "enriched_rows": 0,
+            "export_candidate_rows": 0,
+            "quote_grade_rows": 0,
+        },
+    ]
+    query, args = pool.fetch_calls[0]
+    assert "FROM b2b_reviews r" in query
+    assert args[0] == ["g2", "trustpilot"]
+    assert args[1] == 100
+
+
 def test_render_jsonl_outputs_one_json_object_per_line() -> None:
     text = mod.render_jsonl([
         {"source_id": "a", "text": "one"},
@@ -221,3 +290,12 @@ def test_parse_args_defaults_to_database_url_from_helper(monkeypatch) -> None:
     args = mod._parse_args([])
 
     assert args.database_url == "postgres://example/db"
+
+
+def test_parse_args_accepts_source_summary_sources(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_default_database_url", lambda: "postgres://example/db")
+
+    args = mod._parse_args(["--source-summary", "--summary-sources", "g2,trustpilot"])
+
+    assert args.source_summary is True
+    assert args.summary_sources == "g2,trustpilot"


### PR DESCRIPTION
# PR: Content Ops Review Source Readiness

## Why this slice exists

PR #588 and #589 made G2 review evidence usable for AI Content Ops source-row generation. A live Trustpilot check showed the next risk: a review source can have thousands of enriched rows but still export zero usable source rows when v4 quote-grade phrase metadata is missing.

This slice adds a small readiness summary to the existing review-source exporter so operators can choose G2, Capterra, TrustRadius, or Trustpilot based on quote-grade availability before running an export.

## Scope (this PR)

1. Add a read-only source-readiness summary mode to the existing review-source exporter.
2. Count canonical enriched rows, export-candidate rows, and quote-grade exportable rows per source.
3. Document the readiness check before the G2/source-row export workflow.

### Files touched

- `scripts/export_content_ops_review_sources.py`
- `tests/test_export_content_ops_review_sources.py`
- `extracted_content_pipeline/README.md`
- `extracted_content_pipeline/docs/host_install_runbook.md`
- `extracted_content_pipeline/STATUS.md`
- `docs/extraction/coordination/inflight.md`
- `docs/extraction/coordination/state.md`
- `plans/PR-Content-Ops-Review-Source-Readiness.md`

## Mechanism

- Add a summary SQL builder that groups requested review sources and checks the same canonical/enriched/text/url/quote-grade conditions used by export.
- Add `--source-summary` plus `--summary-sources` to print JSON readiness rows without writing source-row JSONL.
- Keep normal export behavior unchanged.

## Intentional

- This does not loosen quote-grade export policy.
- This does not make Trustpilot exportable when phrase metadata is absent.
- This does not add a second exporter script.

## Deferred

- Re-enriching Trustpilot rows with v4 phrase metadata.
- Adding browser UI for source-readiness diagnostics.
- Adding new non-review source families.

## Verification

- python -m pytest tests/test_export_content_ops_review_sources.py -q -> 12 passed.
- python -m py_compile scripts/export_content_ops_review_sources.py tests/test_export_content_ops_review_sources.py -> passed.
- python scripts/export_content_ops_review_sources.py --source-summary --summary-sources g2,capterra,trustradius,trustpilot -> passed; reported quote_grade_rows: g2=364, capterra=154, trustradius=31, trustpilot=0.
- python scripts/export_content_ops_review_sources.py --source capterra --limit 3 --output /tmp/capterra_content_ops_sources.jsonl -> exported 3 rows.
- git diff --check -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Exporter summary mode | ~140 |
| Tests | ~80 |
| Docs and coordination | ~80 |
| Total | ~300 |
