### PR TITLE
Close out Content Ops review source readiness

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -1,7 +1,7 @@
 # AI Content Ops Deferred Backlog
 
 Created: 2026-05-11
-Last updated: 2026-05-16
+Last updated: 2026-05-18
 
 ## Purpose
 
@@ -50,6 +50,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - Source-adapter cumulative audit and decision rules.
 - Source-type precedence consolidation.
 - Source-row field lookup cache for provider-style aliases.
+- Review-source readiness summary for scraped review sources.
 - Host-facing reasoning policy audit for falsification, narrative planning,
   validation, and per-content-type depth.
 - Reasoning preset catalog for host-facing depth choices.
@@ -114,6 +115,13 @@ Remaining work:
 No export appeared before the reasoning-policy parity pass closed. Keep this as
 roadmap work, not an active slice, until a real host export fixture exists.
 
+**Review-source readiness update:** PR #591 shipped a source summary mode for
+the review-source exporter. A live Atlas check reported quote-grade rows for
+G2 (364), Capterra (154), and TrustRadius (31). Trustpilot reported 0
+quote-grade rows, so it should not be used for Content Ops export until those
+reviews are re-enriched with v4 phrase metadata. This closes the "which scraped
+review source is usable now?" uncertainty without adding a new ingestion slice.
+
 ## Current Pick Recommendation
 
 The host-facing AI Content Ops reasoning-policy arc is complete for the current
@@ -141,3 +149,8 @@ highest-leverage code should come from either a real source export fixture
 (item 2) or the separate `extracted_reasoning_core` productization track. If a
 future slice touches reasoning policy, it should name the concrete trigger from
 the list above in its plan doc.
+
+The review-source readiness closeout from PR #591 does not create a new active
+Content Ops implementation backlog. G2, Capterra, and TrustRadius can use the
+existing exporter path. Trustpilot is blocked on data quality, not extractor
+code.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T21:05Z by codex-2026-05-18
+Last updated: 2026-05-18T21:38Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops review source readiness | `scripts/export_content_ops_review_sources.py`, `tests/test_export_content_ops_review_sources.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Readiness.md` | codex-2026-05-18 | Avoid editing the review-source exporter/readiness docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T21:05Z by codex-2026-05-18
+Last updated: 2026-05-18T21:38Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #589 | pending | Review-source readiness is in flight so operators can see which scraped review sources have quote-grade rows before export. | `scripts/export_content_ops_review_sources.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #591 | — | Review-source readiness is shipped. G2, Capterra, and TrustRadius currently have quote-grade review rows; Trustpilot needs v4 phrase metadata before export. No active Content Ops code slice is claimed. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/plans/PR-Content-Ops-Review-Source-Closeout.md
+++ b/plans/PR-Content-Ops-Review-Source-Closeout.md
@@ -1,0 +1,50 @@
+# PR: Content Ops Review Source Readiness Closeout
+
+## Why this slice exists
+
+PR #591 shipped the Content Ops review-source readiness summary, but the shared coordination docs still marked that slice as pending. This closeout prevents other sessions from avoiding a stale hot zone and records the live readiness result in the deferred backlog.
+
+## Scope (this PR)
+
+1. Remove the merged review-source readiness claim from the in-flight ledger.
+2. Update the per-product state row to point at PR #591 and clear the active hot zone.
+3. Record the live G2/Capterra/TrustRadius/Trustpilot readiness outcome in the AI Content Ops backlog.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `plans/PR-Content-Ops-Review-Source-Closeout.md`
+
+## Mechanism
+
+- Edit coordination docs only.
+- Keep the source exporter, tests, and product runtime untouched.
+- Treat Trustpilot as a data-quality blocker because PR #591 showed it has no quote-grade rows yet.
+
+## Intentional
+
+- This does not add another Content Ops code slice.
+- This does not re-enrich Trustpilot reviews.
+- This does not change the review-source exporter behavior from PR #591.
+
+## Deferred
+
+- Real host export fixture aliases and source-specific quality tests.
+- Trustpilot v4 phrase-metadata re-enrichment.
+- Any future reasoning-core-driven AI Content Ops port changes.
+
+## Verification
+
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> passed when run with `bash`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination state | ~7 |
+| Deferred backlog note | ~15 |
+| Plan file | ~50 |
+| Total | ~72 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Source-Closeout.md

## Summary
- remove the merged review-source readiness claim from the in-flight ledger
- update Content Ops state to PR #591 and clear the hot zone
- record the live source-readiness outcome in the AI Content Ops backlog

## Verification
- git diff --check
- bash scripts/local_pr_review.sh