### PR TITLE
Frame review-source campaign evidence as market signal

### DIFF
--- a/atlas_brain/skills/digest/b2b_campaign_generation.md
+++ b/atlas_brain/skills/digest/b2b_campaign_generation.md
@@ -96,7 +96,7 @@ Return a JSON object with the generated content. The structure depends on the ch
 
 1. **Personalize to their pain**: Reference their specific pain points (pricing, features, reliability, support) naturally. Do NOT be generic.
 
-2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space".
+2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space". When the opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence. Do not say the target company itself said, did, evaluated, or intends the thing unless account-specific reasoning or CRM evidence explicitly supports that.
 
 3. **Match tone to role_type**:
    - `economic_buyer` / `decision_maker`: Executive tone, focus on ROI, TCO, strategic value
@@ -155,6 +155,7 @@ Return a JSON object with the generated content. The structure depends on the ch
 24. **CTA is separate**: The `cta` field is a standalone call-to-action string. The body should end naturally leading into the CTA. Include the affiliate/booking URL as an `<a>` tag at the end of the body, not in the `cta` field.
 
 25. **Quote framing is mandatory**: Never drop a bare quote or number into the email as an unframed fact. Wrap evidence with analyst language such as "Buyers are reporting...", "Teams evaluating alternatives are saying...", or "Across the accounts we analyzed..." before the quote or number.
+   For public review/source-row evidence, prefer market framing such as "Teams evaluating [vendor] are reporting..." instead of target-account framing such as "[Company] is evaluating...".
 
 26. **Reasoning-aware messaging**: When `reasoning_context` is present, tailor messaging to the wedge type. Use `reasoning_context.summary` and `reasoning_context.key_signals` for specifics rather than generic wedge language:
    - `price_squeeze`: Lead with cost savings, ROI, value restoration. Reference price increases or billing frustration.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T21:38Z by codex-2026-05-18
+Last updated: 2026-05-18T21:42Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| pending | Content Ops review-evidence copy framing | `extracted_content_pipeline/campaign_example.py`, `atlas_brain/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md`, `tests/test_extracted_campaign_generation_example.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Evidence-Copy-Framing.md` | codex-2026-05-18 | Avoid editing the offline campaign example, campaign generation skill copy rules, or source-row campaign example tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T21:38Z by codex-2026-05-18
+Last updated: 2026-05-18T21:42Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #591 | — | Review-source readiness is shipped. G2, Capterra, and TrustRadius currently have quote-grade review rows; Trustpilot needs v4 phrase metadata before export. No active Content Ops code slice is claimed. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #592 | pending | Fix review-source campaign copy framing so third-party review evidence is treated as market evidence, not direct target-account intent. | `extracted_content_pipeline/campaign_example.py`, `atlas_brain/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -120,6 +120,20 @@ class StaticCampaignSkillStore:
         return self.prompt
 
 
+def _opportunity_uses_review_evidence(opportunity: Mapping[str, Any]) -> bool:
+    if str(opportunity.get("source_type") or "").strip().lower() == "review":
+        return True
+    evidence = opportunity.get("evidence")
+    if not isinstance(evidence, Sequence) or isinstance(evidence, (str, bytes, bytearray)):
+        return False
+    for row in evidence:
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("source_type") or "").strip().lower() == "review":
+            return True
+    return False
+
+
 class DeterministicCampaignLLM:
     """Offline LLM stand-in that proves the product wiring end-to-end."""
 
@@ -148,11 +162,18 @@ class DeterministicCampaignLLM:
         pains = opportunity.get("pain_points") or []
         pain = str(pains[0]) if pains else "workflow friction"
         subject = f"{company}: {pain}"[:80]
-        body = (
-            f"<p>{company} appears to be weighing {vendor} because of {pain}.</p>"
-            "<p>We can turn that signal into a focused account sequence using "
-            "your own data and approval rules.</p>"
-        )
+        if _opportunity_uses_review_evidence(opportunity):
+            body = (
+                f"<p>Teams evaluating {vendor} are reporting pain around {pain}.</p>"
+                f"<p>{company} can pair that market signal with your own data "
+                "and approval rules for a focused account sequence.</p>"
+            )
+        else:
+            body = (
+                f"<p>{company} appears to be weighing {vendor} because of {pain}.</p>"
+                "<p>We can turn that signal into a focused account sequence using "
+                "your own data and approval rules.</p>"
+            )
         return LLMResponse(
             content=json.dumps(
                 {

--- a/extracted_content_pipeline/skills/digest/b2b_campaign_generation.md
+++ b/extracted_content_pipeline/skills/digest/b2b_campaign_generation.md
@@ -96,7 +96,7 @@ Return a JSON object with the generated content. The structure depends on the ch
 
 1. **Personalize to their pain**: Reference their specific pain points (pricing, features, reliability, support) naturally. Do NOT be generic.
 
-2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space".
+2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space". When the opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence. Do not say the target company itself said, did, evaluated, or intends the thing unless account-specific reasoning or CRM evidence explicitly supports that.
 
 3. **Match tone to role_type**:
    - `economic_buyer` / `decision_maker`: Executive tone, focus on ROI, TCO, strategic value
@@ -155,6 +155,7 @@ Return a JSON object with the generated content. The structure depends on the ch
 24. **CTA is separate**: The `cta` field is a standalone call-to-action string. The body should end naturally leading into the CTA. Include the affiliate/booking URL as an `<a>` tag at the end of the body, not in the `cta` field.
 
 25. **Quote framing is mandatory**: Never drop a bare quote or number into the email as an unframed fact. Wrap evidence with analyst language such as "Buyers are reporting...", "Teams evaluating alternatives are saying...", or "Across the accounts we analyzed..." before the quote or number.
+   For public review/source-row evidence, prefer market framing such as "Teams evaluating [vendor] are reporting..." instead of target-account framing such as "[Company] is evaluating...".
 
 26. **Reasoning-aware messaging**: When `reasoning_context` is present, tailor messaging to the wedge type. Use `reasoning_context.summary` and `reasoning_context.key_signals` for specifics rather than generic wedge language:
    - `price_squeeze`: Lead with cost savings, ROI, value restoration. Reference price increases or billing frustration.

--- a/plans/PR-Content-Ops-Review-Evidence-Copy-Framing.md
+++ b/plans/PR-Content-Ops-Review-Evidence-Copy-Framing.md
@@ -1,0 +1,58 @@
+# PR: Content Ops Review Evidence Copy Framing
+
+## Why this slice exists
+
+A live G2 source-row smoke proved the export, inspection, and offline campaign generation path works, but the generated preview copy overstated third-party review evidence as direct target-account intent: "Acme Logistics appears to be weighing Slack." Public review rows should be framed as market evidence unless the opportunity carries account-specific reasoning.
+
+## Scope (this PR)
+
+1. Update the offline deterministic campaign LLM example to use market-level language when the opportunity evidence is sourced from public reviews.
+2. Tighten the campaign generation skill rule so real LLM outputs follow the same policy for review/source-row evidence.
+3. Add/adjust source-row CLI tests to lock the review-evidence copy contract.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_example.py`
+- `atlas_brain/skills/digest/b2b_campaign_generation.md`
+- `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md`
+- `tests/test_extracted_campaign_generation_example.py`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Evidence-Copy-Framing.md`
+
+## Mechanism
+
+- Detect review-sourced evidence from the normalized opportunity evidence rows.
+- Preserve existing account-specific copy for ordinary opportunity rows.
+- Use neutral market framing for review-sourced rows: teams are reporting pain around the vendor; the target account can use that signal for outreach planning.
+
+## Intentional
+
+- This does not change ingestion normalization.
+- This does not change LLM/provider wiring.
+- This does not add a new source type or exporter.
+- This does not make review sources visible in generated copy.
+
+## Deferred
+
+- Real provider-output quality review with pipeline LLM credentials.
+- Broader source-type copy policies for calls, meetings, CRM notes, and support tickets.
+- Trustpilot v4 phrase-metadata re-enrichment.
+
+## Verification
+
+- Focused campaign generation example tests -> 22 passed.
+- Python compile check for `extracted_content_pipeline/campaign_example.py` and `tests/test_extracted_campaign_generation_example.py` -> passed.
+- Live G2/Slack source-row offline generation smoke -> passed; body used market framing.
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Offline campaign example | ~31 |
+| Campaign skill copy rule | ~6 |
+| Tests | ~6 |
+| Coordination and plan | ~63 |
+| Total | ~108 |

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -296,6 +296,9 @@ def test_campaign_generation_example_cli_generates_from_source_rows() -> None:
     assert source["target_id"] == "review-acme-1"
     assert source["evidence"][0]["source_type"] == "review"
     assert source["contact_email"] == "ops@example.com"
+    body = result["drafts"][0]["body"]
+    assert "Teams evaluating" in body
+    assert "appears to be weighing" not in body
 
 
 def test_campaign_generation_example_cli_applies_source_default_fields(tmp_path) -> None:
@@ -336,6 +339,9 @@ def test_campaign_generation_example_cli_applies_source_default_fields(tmp_path)
     source = json.loads(completed.stdout)["drafts"][0]["metadata"]["source_opportunity"]
     assert source["company_name"] == "Acme Logistics"
     assert source["contact_email"] == "ops@example.com"
+    draft = json.loads(completed.stdout)["drafts"][0]
+    assert "Teams evaluating Slack are reporting pain around" in draft["body"]
+    assert "Acme Logistics appears to be weighing Slack" not in draft["body"]
 
 
 def test_campaign_generation_example_cli_generates_from_source_bundle_json() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Evidence-Copy-Framing.md

## Summary
- detect review-sourced evidence in the offline campaign example and avoid target-account intent overclaims
- mirror the campaign skill rule in Atlas and extracted copies so real LLM prompts use market framing for review/source-row evidence
- lock source-row CLI behavior with tests

## Verification
- python -m pytest tests/test_extracted_campaign_generation_example.py -q
- python -m py_compile extracted_content_pipeline/campaign_example.py tests/test_extracted_campaign_generation_example.py
- live G2/Slack source-row offline generation smoke
- git diff --check
- bash scripts/local_pr_review.sh