### PR TITLE
Frame review evidence in report and sales brief prompts

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T21:42Z by codex-2026-05-18
+Last updated: 2026-05-18T21:55Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops review-evidence copy framing | `extracted_content_pipeline/campaign_example.py`, `atlas_brain/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md`, `tests/test_extracted_campaign_generation_example.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Evidence-Copy-Framing.md` | codex-2026-05-18 | Avoid editing the offline campaign example, campaign generation skill copy rules, or source-row campaign example tests |
+| pending | Content Ops review-evidence asset framing | `extracted_content_pipeline/skills/digest/report_generation.md`, `extracted_content_pipeline/skills/digest/sales_brief_generation.md`, `tests/test_extracted_campaign_skill_registry.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Evidence-Asset-Framing.md` | codex-2026-05-18 | Avoid editing report/sales-brief generated-asset prompt framing or packaged skill registry prompt-contract tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T21:42Z by codex-2026-05-18
+Last updated: 2026-05-18T21:55Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #592 | pending | Fix review-source campaign copy framing so third-party review evidence is treated as market evidence, not direct target-account intent. | `extracted_content_pipeline/campaign_example.py`, `atlas_brain/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #593 | pending | Extend review-source market framing to opportunity-row generated assets: report and sales brief prompts. | `extracted_content_pipeline/skills/digest/report_generation.md`, `extracted_content_pipeline/skills/digest/sales_brief_generation.md` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/skills/digest/report_generation.md
+++ b/extracted_content_pipeline/skills/digest/report_generation.md
@@ -30,3 +30,8 @@ Field rules:
 - `report_type`: one of `vendor_pressure`, `market_intel`, `customer_health`, `account_brief`, or another snake_case label that fits the opportunity's `target_mode`. Default to `vendor_pressure` when in doubt.
 
 When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent claim ids that aren't in the reasoning context.
+
+Review/source-row evidence policy:
+- If opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence.
+- Do not say the target account itself said, did, evaluated, or intends the thing unless account-specific reasoning, CRM evidence, call evidence, or meeting evidence explicitly supports that.
+- Use market framing such as "teams evaluating this vendor are reporting..." or "review evidence points to..." and cite the relevant evidence ids.

--- a/extracted_content_pipeline/skills/digest/sales_brief_generation.md
+++ b/extracted_content_pipeline/skills/digest/sales_brief_generation.md
@@ -51,3 +51,8 @@ Field rules:
 When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids` and `evidence_requirements`. Do not invent claim ids that aren't in the reasoning context.
 
 Avoid: weasel words ("powerful", "robust", "synergy"), promises that can't be backed up, comparative claims about specific competitors unless the opportunity provides them. The rep is the one who has to defend every word in the room.
+
+Review/source-row evidence policy:
+- If opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence.
+- Do not say the target account itself said, did, evaluated, or intends the thing unless account-specific reasoning, CRM evidence, call evidence, or meeting evidence explicitly supports that.
+- Use sales-facing market framing such as "buyers evaluating this vendor are reporting..." or "market evidence points to..." and cite the relevant evidence ids.

--- a/plans/PR-Content-Ops-Review-Evidence-Asset-Framing.md
+++ b/plans/PR-Content-Ops-Review-Evidence-Asset-Framing.md
@@ -1,0 +1,55 @@
+# PR: Content Ops Review Evidence Asset Framing
+
+## Why this slice exists
+
+PR #593 fixed public review/source-row copy framing for campaign emails. Reports and sales briefs also consume normalized opportunity rows, so the same third-party review evidence can reach those generated assets. Their packaged prompts currently say to structure output from opportunity evidence but do not tell the model to avoid target-account intent overclaims when that evidence is public review/source-row material.
+
+## Scope (this PR)
+
+1. Add review/source-row market-framing guidance to the packaged report prompt.
+2. Add the same guidance to the packaged sales-brief prompt.
+3. Add packaged skill-registry assertions so the prompt contract remains visible in tests.
+
+### Files touched
+
+- `extracted_content_pipeline/skills/digest/report_generation.md`
+- `extracted_content_pipeline/skills/digest/sales_brief_generation.md`
+- `tests/test_extracted_campaign_skill_registry.py`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Evidence-Asset-Framing.md`
+
+## Mechanism
+
+- Keep the rule prompt-only because report and sales brief generation already pass the normalized opportunity payload through unchanged.
+- Instruct the model to treat `source_type: "review"` or source-row evidence as third-party market evidence.
+- Tell the model not to say the target account said, did, evaluated, or intends something unless account-specific reasoning or CRM evidence supports it.
+
+## Intentional
+
+- This does not change report or sales-brief runtime code.
+- This does not touch campaign email framing, which shipped in PR #593.
+- This does not touch landing pages or blog posts because their inputs are marketing-campaign and blueprint shaped, not normalized opportunity rows.
+
+## Deferred
+
+- Real provider-output quality review with pipeline LLM credentials.
+- Source-type-specific copy policies for calls, meetings, CRM notes, support tickets, surveys, and contracts.
+- Trustpilot v4 phrase-metadata re-enrichment.
+
+## Verification
+
+- Focused packaged skill registry tests -> 8 passed.
+- Python compile check for `tests/test_extracted_campaign_skill_registry.py` -> passed.
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Report prompt | ~5 |
+| Sales brief prompt | ~5 |
+| Tests | ~18 |
+| Coordination and plan | ~61 |
+| Total | ~91 |

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -18,6 +18,24 @@ def test_local_skill_registry_reads_packaged_campaign_prompt() -> None:
     assert registry.get_prompt("digest/b2b_campaign_generation") == skill.content
 
 
+def test_packaged_report_prompt_frames_review_evidence_as_market_signal() -> None:
+    prompt = get_skill_registry().get_prompt("digest/report_generation")
+
+    assert prompt is not None
+    assert 'source_type: "review"' in prompt
+    assert "third-party market evidence" in prompt
+    assert "Do not say the target account itself" in prompt
+
+
+def test_packaged_sales_brief_prompt_frames_review_evidence_as_market_signal() -> None:
+    prompt = get_skill_registry().get_prompt("digest/sales_brief_generation")
+
+    assert prompt is not None
+    assert 'source_type: "review"' in prompt
+    assert "third-party market evidence" in prompt
+    assert "Do not say the target account itself" in prompt
+
+
 def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:
     skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
     skill_path.parent.mkdir()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Evidence-Asset-Framing.md

## Summary
- add review/source-row market-framing policy to report generation prompt
- add the same policy to sales brief generation prompt
- lock both packaged prompts with skill registry tests

## Verification
- python -m pytest tests/test_extracted_campaign_skill_registry.py -q
- python -m py_compile tests/test_extracted_campaign_skill_registry.py
- git diff --check
- bash scripts/local_pr_review.sh