### PR TITLE
Add review-source generation smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T21:55Z by codex-2026-05-18
+Last updated: 2026-05-18T22:24Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops review-evidence asset framing | `extracted_content_pipeline/skills/digest/report_generation.md`, `extracted_content_pipeline/skills/digest/sales_brief_generation.md`, `tests/test_extracted_campaign_skill_registry.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Evidence-Asset-Framing.md` | codex-2026-05-18 | Avoid editing report/sales-brief generated-asset prompt framing or packaged skill registry prompt-contract tests |
+| #595 | Content Ops review-source generation smoke | `scripts/smoke_content_ops_review_source_generation.py`, `tests/test_smoke_content_ops_review_source_generation.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Generation-Smoke.md` | codex-2026-05-18 | Avoid editing the review-source smoke script, host runbook source-row smoke docs, or related smoke tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T21:55Z by codex-2026-05-18
+Last updated: 2026-05-18T22:24Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #593 | pending | Extend review-source market framing to opportunity-row generated assets: report and sales brief prompts. | `extracted_content_pipeline/skills/digest/report_generation.md`, `extracted_content_pipeline/skills/digest/sales_brief_generation.md` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #594 | #595 | Add a repeatable review-source generation smoke for readiness, export, ingestion inspect, and offline draft generation. | `scripts/smoke_content_ops_review_source_generation.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -168,6 +168,20 @@ python scripts/export_content_ops_review_sources.py \
   --output g2_review_sources.jsonl
 ```
 
+To prove the full review-source path in one command, run the operator smoke.
+It checks readiness, exports quote-grade rows, validates source-row ingestion,
+and generates offline drafts without a live LLM:
+
+```bash
+python scripts/smoke_content_ops_review_source_generation.py \
+  --source g2 \
+  --vendor Slack \
+  --limit 2 \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
+  --json
+```
+
 Before converting or importing a customer export, inspect ingestion readiness:
 
 ```bash

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -95,6 +95,10 @@ source of truth for what remains.
   canonical, enriched, export-candidate, and quote-grade row counts for
   scraped review sources before operators choose a source for Content Ops
   ingestion.
+- `scripts/smoke_content_ops_review_source_generation.py` runs the live
+  review-source readiness/export path through source-row ingestion inspection
+  and offline campaign draft generation, so operators can prove a source such
+  as G2 produces usable drafts before import or live provider generation.
 - `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
   provide offline readiness reports for opportunity/source-row exports before
   import or generation. The hosted control-surface API also exposes

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -460,7 +460,27 @@ python scripts/export_content_ops_review_sources.py \
   --vendor Slack \
   --limit 50 \
   --output g2_review_sources.jsonl
+```
 
+For a single end-to-end smoke before import, use the review-source generation
+smoke. It keeps generation offline while exercising readiness, export,
+ingestion inspection, and draft shape:
+
+```bash
+python scripts/smoke_content_ops_review_source_generation.py \
+  --source g2 \
+  --vendor Slack \
+  --limit 2 \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
+  --json
+```
+
+If the smoke reports ingestion warnings, bind the anonymous review evidence to
+the target account/contact with additional `--default-field` values before
+importing.
+
+```bash
 python scripts/load_extracted_campaign_opportunities.py \
   g2_review_sources.jsonl \
   --source-rows \

--- a/plans/PR-Content-Ops-Review-Source-Generation-Smoke.md
+++ b/plans/PR-Content-Ops-Review-Source-Generation-Smoke.md
@@ -1,0 +1,63 @@
+# PR: Content Ops Review Source Generation Smoke
+
+## Why this slice exists
+
+The live G2 run proved AI Content Ops can take Atlas review rows through readiness, source-row export, ingestion inspection, and offline campaign draft generation. Today that proof is a manual chain of commands. This slice turns it into one repeatable operator smoke so future sessions can verify "feed it data and see output" without reconstructing the sequence.
+
+This exceeds the 400 LOC soft cap because the operator smoke is only useful as one route through readiness, export, ingestion inspection, and draft validation. Splitting the script, tests, and docs would leave a partial smoke that cannot prove the end-to-end operator contract.
+
+## Scope (this PR)
+
+1. Add a host/operator smoke script that checks review-source readiness, exports quote-grade rows, validates ingestion, and generates offline drafts.
+2. Require source-row ingestion warnings to be resolved by default, so anonymous review exports need explicit `--default-field` account/contact bindings.
+3. Document the smoke in the Content Ops README, host runbook, and status page.
+4. Add tests for the smoke's pass/fail contracts without hitting a live database.
+
+### Files touched
+
+- `scripts/smoke_content_ops_review_source_generation.py`
+- `tests/test_smoke_content_ops_review_source_generation.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Source-Generation-Smoke.md`
+
+## Mechanism
+
+- Reuse `scripts/export_content_ops_review_sources.py` functions for readiness and source-row export.
+- Reuse `inspect_ingestion_file` for source-row readiness.
+- Reuse `generate_campaign_drafts_from_payload` for offline draft generation.
+- Fail if generated review-source drafts regress to target-account intent phrasing.
+
+## Intentional
+
+- This does not add a second exporter.
+- This does not use a live LLM provider.
+- This does not write generated drafts to Postgres.
+- This does not make Trustpilot usable without v4 phrase metadata.
+
+## Deferred
+
+- Live provider generation smoke with `EXTRACTED_CAMPAIGN_LLM_*`.
+- Postgres import/persistence smoke over exported review rows.
+- Real customer export fixture coverage.
+
+## Verification
+
+- Focused smoke tests -> `4 passed`.
+- Python compile check for smoke script/tests -> passed.
+- Live G2/Slack smoke against local Atlas database -> passed; generated 2 offline drafts from 1 exported review-source row.
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Smoke script | 331 |
+| Tests | 174 |
+| Docs/status | 38 |
+| Coordination and plan | 61 |
+| Total | 604 |

--- a/scripts/smoke_content_ops_review_source_generation.py
+++ b/scripts/smoke_content_ops_review_source_generation.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Smoke-test review-source export through offline Content Ops generation."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_example import (  # noqa: E402
+    generate_campaign_drafts_from_payload,
+)
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
+    inspect_ingestion_file,
+)
+
+
+def _load_review_exporter_module():
+    path = ROOT / "scripts/export_content_ops_review_sources.py"
+    spec = importlib.util.spec_from_file_location("content_ops_review_source_exporter", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load review source exporter: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_review_exporter = _load_review_exporter_module()
+DEFAULT_PHRASE_FIELDS = _review_exporter.DEFAULT_PHRASE_FIELDS
+DEFAULT_POLARITIES = _review_exporter.DEFAULT_POLARITIES
+DEFAULT_SUMMARY_SOURCES = _review_exporter.DEFAULT_SUMMARY_SOURCES
+_create_pool = _review_exporter._create_pool
+_default_database_url = _review_exporter._default_database_url
+_load_dotenv_files = _review_exporter._load_dotenv_files
+fetch_review_source_rows = _review_exporter.fetch_review_source_rows
+fetch_review_source_summary = _review_exporter.fetch_review_source_summary
+render_jsonl = _review_exporter.render_jsonl
+
+
+DEFAULT_CHANNELS = ("email_cold", "email_followup")
+DEFAULT_FORBIDDEN_PHRASES = ("appears to be weighing",)
+
+
+def _csv_list(value: str | Sequence[str]) -> tuple[str, ...]:
+    if isinstance(value, str):
+        raw = value.split(",")
+    else:
+        raw = value
+    return tuple(str(item or "").strip() for item in raw if str(item or "").strip())
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test Atlas review-source rows through Content Ops source "
+            "export, ingestion inspection, and offline draft generation."
+        )
+    )
+    parser.add_argument("--source", default="g2")
+    parser.add_argument("--vendor", default=None, help="Optional vendor_name filter.")
+    parser.add_argument("--limit", type=int, default=2)
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--channels", default=",".join(DEFAULT_CHANNELS))
+    parser.add_argument("--min-drafts", type=int, default=None)
+    parser.add_argument("--min-quote-grade-rows", type=int, default=1)
+    parser.add_argument("--min-review-text-chars", type=int, default=80)
+    parser.add_argument("--phrase-limit", type=int, default=5)
+    parser.add_argument("--polarities", default=",".join(DEFAULT_POLARITIES))
+    parser.add_argument("--phrase-fields", default=",".join(DEFAULT_PHRASE_FIELDS))
+    parser.add_argument("--summary-sources", default=",".join(DEFAULT_SUMMARY_SOURCES))
+    parser.add_argument("--allow-missing-source-url", action="store_true")
+    parser.add_argument("--allow-ingestion-warnings", action="store_true")
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every exported review source row. "
+            "Repeat as key=value."
+        ),
+    )
+    parser.add_argument(
+        "--forbidden-phrase",
+        action="append",
+        default=list(DEFAULT_FORBIDDEN_PHRASES),
+        help="Fail if generated draft bodies contain this phrase. Repeatable.",
+    )
+    parser.add_argument("--output-source-rows", type=Path, default=None)
+    parser.add_argument("--output-drafts", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--database-url",
+        default=_default_database_url(),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.limit) < 1:
+        raise SystemExit("--limit must be positive")
+    if int(args.min_quote_grade_rows) < 1:
+        raise SystemExit("--min-quote-grade-rows must be positive")
+    if int(args.min_review_text_chars) < 1:
+        raise SystemExit("--min-review-text-chars must be positive")
+    if int(args.phrase_limit) < 1:
+        raise SystemExit("--phrase-limit must be positive")
+    if args.min_drafts is not None and int(args.min_drafts) < 1:
+        raise SystemExit("--min-drafts must be positive")
+    if not _csv_list(args.channels):
+        raise SystemExit("--channels must include at least one channel")
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+
+def _row_for_source(summary_rows: Sequence[Mapping[str, Any]], source: str) -> dict[str, Any]:
+    normalized = str(source or "").strip().lower()
+    for row in summary_rows:
+        if str(row.get("source") or "").strip().lower() == normalized:
+            return dict(row)
+    return {
+        "source": normalized,
+        "total_rows": 0,
+        "canonical_rows": 0,
+        "enriched_rows": 0,
+        "export_candidate_rows": 0,
+        "quote_grade_rows": 0,
+    }
+
+
+def _write_jsonl(rows: Sequence[Mapping[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = render_jsonl(rows)
+    path.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
+
+
+def _draft_errors(
+    result: Mapping[str, Any],
+    *,
+    min_drafts: int,
+    forbidden_phrases: Sequence[str],
+) -> list[str]:
+    drafts = result.get("drafts")
+    if not isinstance(drafts, list):
+        return ["result.drafts is missing or not a list"]
+    if len(drafts) < min_drafts:
+        return [f"expected at least {min_drafts} draft(s), got {len(drafts)}"]
+    errors: list[str] = []
+    forbidden = [phrase.lower() for phrase in forbidden_phrases if phrase]
+    for index, draft in enumerate(drafts[:min_drafts], start=1):
+        if not isinstance(draft, Mapping):
+            errors.append(f"draft {index} is not an object")
+            continue
+        for field in ("subject", "body", "target_id", "channel"):
+            if not str(draft.get(field) or "").strip():
+                errors.append(f"draft {index} missing {field}")
+        body = str(draft.get("body") or "").lower()
+        for phrase in forbidden:
+            if phrase in body:
+                errors.append(f"draft {index} contains forbidden phrase: {phrase}")
+    return errors
+
+
+async def _fetch_review_inputs(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    pool = await _create_pool(str(args.database_url))
+    try:
+        summary_rows = await fetch_review_source_summary(
+            pool,
+            sources=_csv_list(args.summary_sources),
+            min_review_text_chars=int(args.min_review_text_chars),
+            allowed_polarities=_csv_list(args.polarities),
+            allowed_fields=_csv_list(args.phrase_fields),
+            require_review_url=not bool(args.allow_missing_source_url),
+        )
+        source_summary = _row_for_source(summary_rows, str(args.source))
+        if int(source_summary.get("quote_grade_rows") or 0) < int(args.min_quote_grade_rows):
+            return source_summary, []
+        source_rows = await fetch_review_source_rows(
+            pool,
+            source=str(args.source),
+            vendor_name=args.vendor,
+            limit=int(args.limit),
+            min_review_text_chars=int(args.min_review_text_chars),
+            phrase_limit=int(args.phrase_limit),
+            allowed_polarities=_csv_list(args.polarities),
+            allowed_fields=_csv_list(args.phrase_fields),
+            require_review_url=not bool(args.allow_missing_source_url),
+        )
+        return source_summary, source_rows
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+
+
+async def run_review_source_generation_smoke(
+    args: argparse.Namespace,
+    *,
+    source_rows_path: Path,
+) -> tuple[int, dict[str, Any]]:
+    default_fields = parse_default_fields_or_exit(args.default_field)
+    channels = _csv_list(args.channels)
+    min_drafts = (
+        int(args.min_drafts)
+        if args.min_drafts is not None
+        else int(args.limit) * len(channels)
+    )
+    source_summary, source_rows = await _fetch_review_inputs(args)
+    errors: list[str] = []
+    quote_grade_ready = int(source_summary.get("quote_grade_rows") or 0) >= int(
+        args.min_quote_grade_rows
+    )
+    if not quote_grade_ready:
+        errors.append(
+            "source has fewer quote-grade rows than required: "
+            f"{source_summary.get('quote_grade_rows', 0)}"
+        )
+    if quote_grade_ready and len(source_rows) < int(args.limit):
+        errors.append(f"expected {int(args.limit)} exported source row(s), got {len(source_rows)}")
+
+    drafts_result: dict[str, Any] | None = None
+    ingestion_report: dict[str, Any] | None = None
+    if not errors:
+        _write_jsonl(source_rows, source_rows_path)
+        report = inspect_ingestion_file(
+            source_rows_path,
+            source_rows=True,
+            source_format="jsonl",
+            target_mode=str(args.target_mode),
+            default_fields=default_fields,
+        )
+        ingestion_report = report.as_dict()
+        if not report.ok:
+            errors.append("ingestion inspection failed")
+        if report.warnings and not bool(args.allow_ingestion_warnings):
+            errors.append(
+                "ingestion inspection produced warnings; provide --default-field "
+                "bindings or pass --allow-ingestion-warnings"
+            )
+        if not errors:
+            payload = load_source_campaign_opportunities_from_file(
+                source_rows_path,
+                file_format="jsonl",
+                default_fields=default_fields,
+            ).as_payload()
+            payload["target_mode"] = str(args.target_mode)
+            payload["limit"] = int(args.limit)
+            payload["channels"] = list(channels)
+            drafts_result = await generate_campaign_drafts_from_payload(payload)
+            errors.extend(
+                _draft_errors(
+                    drafts_result,
+                    min_drafts=min_drafts,
+                    forbidden_phrases=args.forbidden_phrase,
+                )
+            )
+
+    payload = {
+        "ok": not errors,
+        "source": str(args.source),
+        "vendor": args.vendor,
+        "source_summary": source_summary,
+        "source_rows": len(source_rows),
+        "source_rows_path": str(source_rows_path),
+        "ingestion": ingestion_report,
+        "drafts": drafts_result,
+        "errors": errors,
+    }
+    if args.output_drafts and drafts_result is not None:
+        args.output_drafts.parent.mkdir(parents=True, exist_ok=True)
+        args.output_drafts.write_text(
+            json.dumps(drafts_result, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+        payload["drafts_path"] = str(args.output_drafts)
+    return (0 if not errors else 1), payload
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
+        return
+    if payload.get("ok"):
+        drafts = payload.get("drafts") if isinstance(payload.get("drafts"), Mapping) else {}
+        result = drafts.get("result") if isinstance(drafts.get("result"), Mapping) else {}
+        print(
+            "Content Ops review-source smoke passed: "
+            f"source={payload.get('source')} "
+            f"source_rows={payload.get('source_rows')} "
+            f"generated={result.get('generated', 0)}"
+        )
+        return
+    print("Content Ops review-source smoke failed:", file=sys.stderr)
+    for error in payload.get("errors") or []:
+        print(f"- {error}", file=sys.stderr)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    _load_dotenv_files()
+    args = _parse_args(argv)
+    _validate_args(args)
+    if args.output_source_rows:
+        code, payload = await run_review_source_generation_smoke(
+            args,
+            source_rows_path=args.output_source_rows,
+        )
+    else:
+        with tempfile.TemporaryDirectory(prefix="content-ops-review-source-") as tmpdir:
+            code, payload = await run_review_source_generation_smoke(
+                args,
+                source_rows_path=Path(tmpdir) / "review_sources.jsonl",
+            )
+    _print_payload(payload, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_smoke_content_ops_review_source_generation.py
+++ b/tests/test_smoke_content_ops_review_source_generation.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_review_source_generation.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_review_source_generation",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+class _Pool:
+    def __init__(self, *, summary_rows, review_rows):
+        self.summary_rows = list(summary_rows)
+        self.review_rows = list(review_rows)
+        self.fetch_calls = 0
+        self.closed = False
+
+    async def fetch(self, query, *args):
+        del query
+        del args
+        self.fetch_calls += 1
+        if self.fetch_calls == 1:
+            return self.summary_rows
+        return self.review_rows
+
+    async def close(self):
+        self.closed = True
+
+
+async def _return_pool(pool):
+    return pool
+
+
+def _summary_row(*, quote_grade_rows=3):
+    return {
+        "source": "g2",
+        "total_rows": 10,
+        "canonical_rows": 10,
+        "enriched_rows": 8,
+        "export_candidate_rows": 5,
+        "quote_grade_rows": quote_grade_rows,
+    }
+
+
+def _review_row(*, source_review_id="g2-review-1"):
+    return {
+        "id": "review-uuid-1",
+        "source": "g2",
+        "source_url": f"https://example.test/{source_review_id}",
+        "source_review_id": source_review_id,
+        "vendor_name": "Slack",
+        "rating": "4.0",
+        "rating_max": "5",
+        "review_text": "Slack notifications are noisy enough to slow the team down.",
+        "reviewer_title": "Ops Manager",
+        "reviewed_at": "2026-04-01T00:00:00Z",
+        "enrichment": {
+            "urgency_score": 7,
+            "pain_category": ["performance"],
+            "phrase_metadata": [
+                {
+                    "text": "notifications are noisy enough to slow the team down",
+                    "field": "specific_complaints",
+                    "polarity": "negative",
+                    "subject": "subject_vendor",
+                    "verbatim": True,
+                    "category_hint": "performance",
+                }
+            ],
+        },
+    }
+
+
+def _args(**overrides):
+    values = {
+        "source": "g2",
+        "vendor": "Slack",
+        "limit": 1,
+        "target_mode": "vendor_retention",
+        "channels": "email_cold",
+        "min_drafts": None,
+        "min_quote_grade_rows": 1,
+        "min_review_text_chars": 1,
+        "phrase_limit": 5,
+        "polarities": "negative,mixed",
+        "phrase_fields": "specific_complaints,pricing_phrases,feature_gaps,recommendation_language",
+        "summary_sources": "g2,capterra,trustradius,trustpilot",
+        "allow_missing_source_url": False,
+        "allow_ingestion_warnings": False,
+        "default_field": [
+            "company_name=Acme Logistics",
+            "contact_email=ops@example.com",
+            "contact_name=Jordan Lee",
+        ],
+        "forbidden_phrase": list(smoke.DEFAULT_FORBIDDEN_PHRASES),
+        "output_source_rows": None,
+        "output_drafts": None,
+        "json": False,
+        "database_url": "postgres://example",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_review_source_smoke_exports_inspects_and_generates(monkeypatch, tmp_path: Path):
+    pool = _Pool(summary_rows=[_summary_row()], review_rows=[_review_row()])
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_generation_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["source_summary"]["quote_grade_rows"] == 3
+    assert payload["source_rows"] == 1
+    assert payload["ingestion"]["ok"] is True
+    assert payload["drafts"]["result"]["generated"] == 1
+    body = payload["drafts"]["drafts"][0]["body"]
+    assert "Teams evaluating Slack are reporting pain around" in body
+    assert "appears to be weighing" not in body
+    assert pool.closed is True
+
+
+@pytest.mark.asyncio
+async def test_review_source_smoke_fails_on_unresolved_ingestion_warnings(monkeypatch, tmp_path: Path):
+    pool = _Pool(summary_rows=[_summary_row()], review_rows=[_review_row()])
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_generation_smoke(
+        _args(default_field=[]),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert any("ingestion inspection produced warnings" in error for error in payload["errors"])
+    assert payload["drafts"] is None
+
+
+@pytest.mark.asyncio
+async def test_review_source_smoke_fails_when_source_has_no_quote_grade_rows(monkeypatch, tmp_path: Path):
+    pool = _Pool(summary_rows=[_summary_row(quote_grade_rows=0)], review_rows=[_review_row()])
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_generation_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert payload["source_rows"] == 0
+    assert any("fewer quote-grade rows" in error for error in payload["errors"])
+
+
+def test_print_payload_keeps_json_stdout_clean(capsys):
+    smoke._print_payload({"ok": False, "errors": ["bad"]}, as_json=True)
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {"ok": False, "errors": ["bad"]}
+    assert captured.err == ""

--- a/tests/test_smoke_content_ops_review_source_generation.py
+++ b/tests/test_smoke_content_ops_review_source_generation.py
@@ -164,6 +164,7 @@ async def test_review_source_smoke_fails_when_source_has_no_quote_grade_rows(mon
     assert code == 1
     assert payload["source_rows"] == 0
     assert any("fewer quote-grade rows" in error for error in payload["errors"])
+    assert not any("expected 1 exported source row(s)" in error for error in payload["errors"])
 
 
 def test_print_payload_keeps_json_stdout_clean(capsys):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Source-Generation-Smoke.md

## Summary
- add an operator smoke for review-source readiness, export, ingestion inspection, and offline draft generation
- document the G2 review-source smoke in README, host runbook, and status
- cover pass/fail contracts without hitting a live database

## Verification
- python -m pytest tests/test_smoke_content_ops_review_source_generation.py -q
- python -m py_compile scripts/smoke_content_ops_review_source_generation.py tests/test_smoke_content_ops_review_source_generation.py
- python scripts/smoke_content_ops_review_source_generation.py --source g2 --vendor Slack --limit 1 --default-field company_name="Acme Logistics" --default-field contact_email=ops@example.com --default-field contact_name="Jordan Lee" --json
- bash scripts/local_pr_review.sh