### PR TITLE
Harden read-only invoicing MCP connector ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ service required.
 ## MCP Servers
 
 Ten MCP servers expose Atlas capabilities to any MCP client (Claude Desktop, Cursor, custom agents).
-All share `ATLAS_MCP_TRANSPORT` (stdio/sse) and `ATLAS_MCP_HOST`; HTTP deployments should set `ATLAS_MCP_AUTH_TOKEN`, and the read-only invoicing HTTP server refuses to start without it because it exposes customer financial data.
+All share `ATLAS_MCP_TRANSPORT` (stdio/sse) and `ATLAS_MCP_HOST`; HTTP deployments should set `ATLAS_MCP_AUTH_TOKEN`, and the read-only invoicing HTTP server refuses to start without a non-placeholder token of at least 24 characters because it exposes customer financial data.
 Each server has an independent enable/disable toggle (`ATLAS_MCP_<NAME>_ENABLED`).
 
 ### CRM MCP Server (10 tools)
@@ -511,6 +511,11 @@ python -m atlas_brain.mcp.invoicing_readonly_server
 
 # SSE HTTP mode (port 8065, requires ATLAS_MCP_AUTH_TOKEN)
 ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.invoicing_readonly_server --sse
+
+# connector boundary smoke (auth + exact read-only tool list; no invoice reads)
+python scripts/check_invoicing_readonly_mcp_connector.py \
+  --url http://127.0.0.1:8065/mcp \
+  --token "$ATLAS_MCP_AUTH_TOKEN"
 ```
 
 Tools: `get_invoice`, `list_invoices`, `search_invoices`,
@@ -522,6 +527,11 @@ read tools should be available. It deliberately omits
 create/update/approve/send/payment/void/PDF-export and service mutation tools,
 but it still requires bearer auth in HTTP mode because the remaining tools
 expose customer financial data.
+
+Do not use placeholder or session-local tokens such as `test-token` or
+`test-readonly-token` for public HTTP exposure. Generate a long random token,
+start the server with that value, then run the connector boundary smoke above
+before attaching a ChatGPT-style connector.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/atlas_brain/mcp/invoicing_readonly_server.py
+++ b/atlas_brain/mcp/invoicing_readonly_server.py
@@ -25,6 +25,18 @@ from ..config_defaults import DEFAULT_INVOICING_READONLY_PORT, DEFAULT_MCP_HOST
 
 logger = logging.getLogger("atlas.mcp.invoicing.readonly")
 
+_MIN_HTTP_AUTH_TOKEN_LENGTH = 24
+_PLACEHOLDER_HTTP_AUTH_TOKENS = {
+    "<token>",
+    "changeme",
+    "change-me",
+    "password",
+    "secret",
+    "test-readonly-token",
+    "test-token",
+    "token",
+}
+
 
 @asynccontextmanager
 async def _lifespan(server):
@@ -146,12 +158,29 @@ def _streamable_http_app():
     """Build the authenticated streamable HTTP app for read-only tools."""
     from .auth import apply_auth_middleware
 
-    if not os.environ.get("ATLAS_MCP_AUTH_TOKEN", "").strip():
+    _require_http_auth_token()
+    return apply_auth_middleware(mcp.streamable_http_app())
+
+
+def _require_http_auth_token() -> str:
+    """Return a production-shaped auth token or fail before serving HTTP."""
+    token = os.environ.get("ATLAS_MCP_AUTH_TOKEN", "").strip()
+    if not token:
         raise RuntimeError(
             "ATLAS_MCP_AUTH_TOKEN is required for read-only invoicing HTTP mode; "
             "these tools expose customer financial data."
         )
-    return apply_auth_middleware(mcp.streamable_http_app())
+    if token.lower() in _PLACEHOLDER_HTTP_AUTH_TOKENS or token.startswith("<"):
+        raise RuntimeError(
+            "ATLAS_MCP_AUTH_TOKEN must not be a placeholder value for read-only "
+            "invoicing HTTP mode."
+        )
+    if len(token) < _MIN_HTTP_AUTH_TOKEN_LENGTH:
+        raise RuntimeError(
+            "ATLAS_MCP_AUTH_TOKEN must be at least "
+            f"{_MIN_HTTP_AUTH_TOKEN_LENGTH} characters for read-only invoicing HTTP mode."
+        )
+    return token
 
 
 if __name__ == "__main__":

--- a/plans/PR-Invoicing-Readonly-Ops-Hardening.md
+++ b/plans/PR-Invoicing-Readonly-Ops-Hardening.md
@@ -1,0 +1,66 @@
+## Why this slice exists
+
+PR #590 added an authenticated read-only invoicing MCP surface for ChatGPT-style connectors. During verification, the endpoint was briefly exposed with a session-local test token, which is exactly the kind of operator mistake this public financial-data surface should make hard.
+
+This slice adds a narrow runtime guard against placeholder or trivially weak read-only MCP tokens and adds a connector smoke command so operators can verify unauthenticated rejection plus authenticated tool-list shape without invoking invoice reads or mutating data.
+
+## Scope (this PR)
+
+1. Reject missing, placeholder, or too-short `ATLAS_MCP_AUTH_TOKEN` values when starting the read-only invoicing HTTP app.
+2. Add a read-only connector smoke script that checks:
+   - unauthenticated HTTP requests are rejected with `401`;
+   - authenticated MCP initialization succeeds;
+   - exactly the eight read-only invoicing tools are exposed;
+   - no known mutating invoicing tools are exposed.
+3. Document the production token guidance and smoke command.
+4. Add focused tests for token validation and smoke-script validation behavior.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_readonly_server.py`
+- `scripts/check_invoicing_readonly_mcp_connector.py`
+- `tests/test_invoicing_readonly_mcp.py`
+- `tests/test_check_invoicing_readonly_mcp_connector.py`
+- `CLAUDE.md`
+- `plans/PR-Invoicing-Readonly-Ops-Hardening.md`
+
+## Mechanism
+
+`invoicing_readonly_server._streamable_http_app()` routes through a local `_require_http_auth_token()` helper before wrapping the Streamable HTTP app. The helper is deliberately scoped to this server because the surface exposes customer financial data; the general MCP auth middleware remains unchanged for other servers.
+
+The new script uses a plain unauthenticated HTTP probe for the `401` boundary and the MCP Streamable HTTP client for authenticated tool discovery. It fails closed on missing token, missing tools, extra tools, and any known mutating invoice tool.
+
+## Intentional
+
+- This does not rotate or store tokens. Operators still provide `ATLAS_MCP_AUTH_TOKEN`; the code only rejects obvious unsafe values.
+- The smoke command does not call invoice tools. Listing tools is enough to verify connector auth and surface shape without touching customer data.
+- The token minimum length is specific to the read-only invoicing HTTP server. It is stricter than the generic middleware because this endpoint is intended for public connector access.
+
+## Deferred
+
+- A managed secret-rotation workflow is deferred until Atlas has a broader MCP secret operations lane.
+- A hosted health endpoint is deferred; the smoke script is enough for local and operator verification now.
+
+## Verification
+
+Commands run:
+
+```bash
+.venv/bin/python -m py_compile atlas_brain/mcp/invoicing_readonly_server.py scripts/check_invoicing_readonly_mcp_connector.py tests/test_check_invoicing_readonly_mcp_connector.py tests/test_invoicing_readonly_mcp.py
+.venv/bin/python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_check_invoicing_readonly_mcp_connector.py
+bash scripts/local_pr_review.sh --allow-dirty
+```
+
+Focused pytest result: 15 passed.
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Server token guard | ~35 |
+| Connector smoke script | ~150 |
+| Focused tests | ~105 |
+| Docs and plan | ~70 |
+| **Total** | **~360** |
+
+This stays under the 400 LOC PR target.

--- a/scripts/check_invoicing_readonly_mcp_connector.py
+++ b/scripts/check_invoicing_readonly_mcp_connector.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Verify the read-only invoicing MCP connector boundary.
+
+This check is intentionally read-only. It verifies auth behavior and the tool
+surface only; it does not call invoice, service, balance, or payment tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = "http://127.0.0.1:8065/mcp"
+
+EXPECTED_READONLY_TOOLS = {
+    "customer_balance",
+    "get_invoice",
+    "get_service",
+    "list_invoices",
+    "list_pending_drafts",
+    "list_services",
+    "payment_history",
+    "search_invoices",
+}
+
+KNOWN_MUTATING_TOOLS = {
+    "approve_and_send",
+    "create_invoice",
+    "create_service",
+    "export_invoice_pdf",
+    "mark_void",
+    "record_payment",
+    "send_invoice",
+    "set_service_status",
+    "update_invoice",
+    "update_service",
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke-check the authenticated read-only invoicing MCP connector."
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("ATLAS_INVOICING_READONLY_MCP_URL", DEFAULT_URL),
+        help=(
+            "Full Streamable HTTP MCP URL. Defaults to "
+            "ATLAS_INVOICING_READONLY_MCP_URL or http://127.0.0.1:8065/mcp."
+        ),
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("ATLAS_MCP_AUTH_TOKEN", ""),
+        help="Bearer token. Defaults to ATLAS_MCP_AUTH_TOKEN.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _unauth_status_code(url: str, timeout: float) -> int:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
+async def _list_tools(url: str, token: str, timeout: float) -> set[str]:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    headers = {"Authorization": f"Bearer {token}"}
+    async with streamablehttp_client(
+        url,
+        headers=headers,
+        timeout=timeout,
+        sse_read_timeout=timeout,
+    ) as (read_stream, write_stream, _get_session_id):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            return {tool.name for tool in result.tools}
+
+
+def _tool_surface_errors(tool_names: set[str]) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(EXPECTED_READONLY_TOOLS - tool_names)
+    extra = sorted(tool_names - EXPECTED_READONLY_TOOLS)
+    mutating = sorted(tool_names & KNOWN_MUTATING_TOOLS)
+
+    if missing:
+        errors.append("missing read-only tools: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected tools exposed: " + ", ".join(extra))
+    if mutating:
+        errors.append("mutating tools exposed: " + ", ".join(mutating))
+    return errors
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    token = args.token.strip()
+    if not token:
+        print("ATLAS_MCP_AUTH_TOKEN or --token is required", file=sys.stderr)
+        return 2
+
+    try:
+        unauth_status = _unauth_status_code(args.url, args.timeout)
+    except Exception as exc:
+        print(f"unauthenticated probe failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    if unauth_status != 401:
+        print(
+            f"expected unauthenticated request to return 401, got {unauth_status}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        tool_names = asyncio.run(_list_tools(args.url, token, args.timeout))
+    except Exception as exc:
+        print(f"authenticated MCP tool-list failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _tool_surface_errors(tool_names)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(f"OK: {args.url} exposes {len(tool_names)} read-only invoicing tools")
+    for name in sorted(tool_names):
+        print(f"- {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_check_invoicing_readonly_mcp_connector.py
+++ b/tests/test_check_invoicing_readonly_mcp_connector.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_readonly_mcp_connector.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_readonly_mcp_connector",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tool_surface_errors_accept_exact_readonly_tools() -> None:
+    module = _load_script_module()
+
+    assert module._tool_surface_errors(set(module.EXPECTED_READONLY_TOOLS)) == []
+
+
+def test_tool_surface_errors_reject_missing_readonly_tool() -> None:
+    module = _load_script_module()
+    tools = set(module.EXPECTED_READONLY_TOOLS)
+    tools.remove("get_invoice")
+
+    errors = module._tool_surface_errors(tools)
+
+    assert errors == ["missing read-only tools: get_invoice"]
+
+
+def test_tool_surface_errors_reject_extra_and_mutating_tools() -> None:
+    module = _load_script_module()
+    tools = set(module.EXPECTED_READONLY_TOOLS)
+    tools.update({"approve_and_send", "surprise_tool"})
+
+    errors = module._tool_surface_errors(tools)
+
+    assert "unexpected tools exposed: approve_and_send, surprise_tool" in errors
+    assert "mutating tools exposed: approve_and_send" in errors
+
+
+def test_main_requires_token_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fail_probe(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv("ATLAS_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(module, "_unauth_status_code", fail_probe)
+
+    result = module._main(["--url", "http://example.invalid/mcp"])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "ATLAS_MCP_AUTH_TOKEN or --token is required" in captured.err
+
+
+def test_main_rejects_non_401_unauthenticated_probe(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "_unauth_status_code", lambda *_args: 200)
+
+    result = module._main(["--url", "http://example.invalid/mcp", "--token", "token-value"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "expected unauthenticated request to return 401, got 200" in captured.err
+
+
+def test_main_reports_authenticated_tool_surface(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "_unauth_status_code", lambda *_args: 401)
+
+    async def fake_list_tools(*_args, **_kwargs):
+        return set(module.EXPECTED_READONLY_TOOLS)
+
+    monkeypatch.setattr(module, "_list_tools", fake_list_tools)
+
+    result = module._main(["--url", "http://example.invalid/mcp", "--token", "token-value"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "exposes 8 read-only invoicing tools" in captured.out
+    assert "- get_invoice" in captured.out

--- a/tests/test_invoicing_readonly_mcp.py
+++ b/tests/test_invoicing_readonly_mcp.py
@@ -76,8 +76,23 @@ def test_invoicing_readonly_http_requires_bearer_token(monkeypatch):
 
 
 def test_invoicing_readonly_http_wraps_with_bearer_auth(monkeypatch):
-    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", "test-token-with-enough-entropy")
 
     app = readonly._streamable_http_app()
 
     assert isinstance(app, BearerAuthMiddleware)
+
+
+@pytest.mark.parametrize("token", ["<token>", "token", "test-token", "test-readonly-token"])
+def test_invoicing_readonly_http_rejects_placeholder_tokens(monkeypatch, token):
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", token)
+
+    with pytest.raises(RuntimeError, match="must not be a placeholder"):
+        readonly._streamable_http_app()
+
+
+def test_invoicing_readonly_http_rejects_short_tokens(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", "short-token-value")
+
+    with pytest.raises(RuntimeError, match="at least 24 characters"):
+        readonly._streamable_http_app()


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Readonly-Ops-Hardening.md

PR #590 added the authenticated read-only invoicing MCP surface. This follow-up makes the public HTTP path harder to expose with placeholder credentials and adds an operator smoke command that verifies auth plus exact read-only tool shape without touching invoice data.

## Intentional
- The stricter token policy is local to the read-only financial-data HTTP server; generic MCP auth behavior is unchanged.
- The smoke command lists tools only and does not call invoice or service read tools.
- Token rotation/storage is not introduced here; operators still provide ATLAS_MCP_AUTH_TOKEN.

## Deferred
- Managed secret rotation remains deferred to a broader MCP secret operations lane.
- A hosted health endpoint is deferred; the smoke script covers local/operator verification now.

## Verification
- .venv/bin/python -m py_compile atlas_brain/mcp/invoicing_readonly_server.py scripts/check_invoicing_readonly_mcp_connector.py tests/test_check_invoicing_readonly_mcp_connector.py tests/test_invoicing_readonly_mcp.py
- .venv/bin/python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_check_invoicing_readonly_mcp_connector.py -> 15 passed
- bash scripts/local_pr_review.sh
- git diff --check

## Diff size
6 files, +365 / -4. Under the 400 LOC target.