### PR TITLE
Add review-source Postgres smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T22:24Z by codex-2026-05-18
+Last updated: 2026-05-18T22:32Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| #595 | Content Ops review-source generation smoke | `scripts/smoke_content_ops_review_source_generation.py`, `tests/test_smoke_content_ops_review_source_generation.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Generation-Smoke.md` | codex-2026-05-18 | Avoid editing the review-source smoke script, host runbook source-row smoke docs, or related smoke tests |
+| pending | Content Ops review-source Postgres smoke | `scripts/smoke_content_ops_review_source_postgres.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md` | codex-2026-05-18 | Avoid editing the review-source Postgres smoke script, host runbook review-source DB smoke docs, or related tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T22:24Z by codex-2026-05-18
+Last updated: 2026-05-18T22:32Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #594 | #595 | Add a repeatable review-source generation smoke for readiness, export, ingestion inspect, and offline draft generation. | `scripts/smoke_content_ops_review_source_generation.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #595 | pending | Add a repeatable review-source Postgres smoke for readiness, source-row import, and DB-backed offline draft persistence. | `scripts/smoke_content_ops_review_source_postgres.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -182,6 +182,22 @@ python scripts/smoke_content_ops_review_source_generation.py \
   --json
 ```
 
+To prove the same source can run through the Postgres-backed path, use the
+database smoke. It imports source rows into `campaign_opportunities` under the
+provided account id, replaces matching imported opportunities by default, and
+persists offline generated drafts:
+
+```bash
+python scripts/smoke_content_ops_review_source_postgres.py \
+  --source g2 \
+  --vendor Slack \
+  --limit 1 \
+  --account-id acct_123 \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
+  --json
+```
+
 Before converting or importing a customer export, inspect ingestion readiness:
 
 ```bash

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -99,6 +99,10 @@ source of truth for what remains.
   review-source readiness/export path through source-row ingestion inspection
   and offline campaign draft generation, so operators can prove a source such
   as G2 produces usable drafts before import or live provider generation.
+- `scripts/smoke_content_ops_review_source_postgres.py` extends that same
+  review-source path through scoped source-row import and DB-backed offline
+  campaign draft persistence. It replaces matching imported opportunities by
+  default so repeated smoke runs do not duplicate `campaign_opportunities`.
 - `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
   provide offline readiness reports for opportunity/source-row exports before
   import or generation. The hosted control-surface API also exposes

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -480,6 +480,22 @@ If the smoke reports ingestion warnings, bind the anonymous review evidence to
 the target account/contact with additional `--default-field` values before
 importing.
 
+For a DB-backed smoke, use the Postgres variant. It imports the exported
+source rows into `campaign_opportunities`, replaces matching imported
+opportunities by default, runs offline draft generation through the product
+Postgres runner, and reports persisted campaign ids:
+
+```bash
+python scripts/smoke_content_ops_review_source_postgres.py \
+  --source g2 \
+  --vendor Slack \
+  --limit 1 \
+  --account-id acct_123 \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
+  --json
+```
+
 ```bash
 python scripts/load_extracted_campaign_opportunities.py \
   g2_review_sources.jsonl \

--- a/plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md
+++ b/plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md
@@ -1,0 +1,65 @@
+# PR: Content Ops Review Source Postgres Smoke
+
+## Why this slice exists
+
+PR #595 proved that quote-grade G2 review rows can be exported, inspected, and turned into offline campaign drafts. It stops before the database-backed product loop. The next operator proof is that the same review-source rows can be imported into `campaign_opportunities` and used by the Postgres generation runner to persist drafts.
+
+This exceeds the 400 LOC soft cap because the smoke is only useful as one route through readiness, export, ingestion inspection, import, and DB-backed generation. Splitting the script, tests, and docs would leave a partial smoke that cannot prove the persistence contract.
+
+## Scope (this PR)
+
+1. Add a host/operator smoke script for review-source export -> source-row import -> Postgres draft generation.
+2. Require an explicit `--account-id` so repeated smoke runs stay tenant-scoped.
+3. Replace matching imported opportunities by default so review rows do not duplicate in `campaign_opportunities`.
+4. Document the Postgres smoke in the Content Ops README, host runbook, and status page.
+5. Add tests for pass/fail contracts without hitting a live database.
+
+### Files touched
+
+- `scripts/smoke_content_ops_review_source_postgres.py`
+- `tests/test_smoke_content_ops_review_source_postgres.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md`
+
+## Mechanism
+
+- Reuse the review-source exporter functions for readiness and source-row export.
+- Reuse `inspect_ingestion_file` and the source-row adapter before import.
+- Reuse `import_campaign_opportunities` with scoped replace-existing semantics.
+- Reuse `generate_campaign_drafts_from_postgres` with deterministic offline LLM and packaged skills so the smoke does not need provider credentials.
+- Fail if generated review-source drafts regress to target-account intent phrasing.
+
+## Intentional
+
+- This does not add a new importer or generator.
+- This does not use a live LLM provider.
+- This does not delete generated `b2b_campaigns` rows; the smoke reports saved ids for operator cleanup/review.
+- This does not make Trustpilot usable without v4 phrase metadata.
+
+## Deferred
+
+- A cleanup command for smoke-generated campaign drafts.
+- Live provider generation over imported review-source rows.
+- Hosted API route smoke for the same review-source import/generation loop.
+
+## Verification
+
+- Focused Postgres smoke tests -> `6 passed`.
+- Python compile check for smoke script/tests -> passed.
+- Live G2/Slack Postgres smoke -> reached readiness/export/ingestion, then failed cleanly with `UndefinedTableError: relation "campaign_opportunities" does not exist`; host database needs extracted migrations before the smoke can pass live.
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Smoke script | 472 |
+| Tests | 358 |
+| Docs/status | 36 |
+| Coordination and plan | 72 |
+| Total | 938 |

--- a/plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md
+++ b/plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md
@@ -48,7 +48,7 @@ This exceeds the 400 LOC soft cap because the smoke is only useful as one route 
 
 ## Verification
 
-- Focused Postgres smoke tests -> `6 passed`.
+- Focused Postgres smoke tests -> `7 passed`.
 - Python compile check for smoke script/tests -> passed.
 - Live G2/Slack Postgres smoke -> reached readiness/export/ingestion, then failed cleanly with `UndefinedTableError: relation "campaign_opportunities" does not exist`; host database needs extracted migrations before the smoke can pass live.
 - `git diff --check` -> passed.
@@ -58,8 +58,8 @@ This exceeds the 400 LOC soft cap because the smoke is only useful as one route 
 
 | Area | Estimated LOC |
 |---|---:|
-| Smoke script | 472 |
-| Tests | 358 |
+| Smoke script | 480 |
+| Tests | 381 |
 | Docs/status | 36 |
 | Coordination and plan | 72 |
-| Total | 938 |
+| Total | 969 |

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Smoke-test review-source export through Postgres-backed draft persistence."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_example import (  # noqa: E402
+    DeterministicCampaignLLM,
+    StaticCampaignSkillStore,
+)
+from extracted_content_pipeline.campaign_generation import (  # noqa: E402
+    CampaignGenerationConfig,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
+    generate_campaign_drafts_from_postgres,
+)
+from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
+    import_campaign_opportunities,
+)
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
+    inspect_ingestion_file,
+)
+
+
+def _load_script_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_source_smoke = _load_script_module(
+    "content_ops_review_source_generation_smoke",
+    ROOT / "scripts" / "smoke_content_ops_review_source_generation.py",
+)
+
+DEFAULT_CHANNELS = _source_smoke.DEFAULT_CHANNELS
+DEFAULT_FORBIDDEN_PHRASES = _source_smoke.DEFAULT_FORBIDDEN_PHRASES
+DEFAULT_PHRASE_FIELDS = _source_smoke.DEFAULT_PHRASE_FIELDS
+DEFAULT_POLARITIES = _source_smoke.DEFAULT_POLARITIES
+DEFAULT_SUMMARY_SOURCES = _source_smoke.DEFAULT_SUMMARY_SOURCES
+_create_pool = _source_smoke._create_pool
+_csv_list = _source_smoke._csv_list
+_default_database_url = _source_smoke._default_database_url
+_draft_errors = _source_smoke._draft_errors
+_load_dotenv_files = _source_smoke._load_dotenv_files
+_row_for_source = _source_smoke._row_for_source
+_write_jsonl = _source_smoke._write_jsonl
+fetch_review_source_rows = _source_smoke.fetch_review_source_rows
+fetch_review_source_summary = _source_smoke.fetch_review_source_summary
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test Atlas review-source rows through Content Ops source "
+            "export, Postgres import, and DB-backed offline draft generation."
+        )
+    )
+    parser.add_argument("--source", default="g2")
+    parser.add_argument("--vendor", default=None, help="Optional vendor_name filter.")
+    parser.add_argument("--limit", type=int, default=1)
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--channels", default=",".join(DEFAULT_CHANNELS))
+    parser.add_argument("--min-drafts", type=int, default=None)
+    parser.add_argument("--min-quote-grade-rows", type=int, default=1)
+    parser.add_argument("--min-review-text-chars", type=int, default=80)
+    parser.add_argument("--phrase-limit", type=int, default=5)
+    parser.add_argument("--polarities", default=",".join(DEFAULT_POLARITIES))
+    parser.add_argument("--phrase-fields", default=",".join(DEFAULT_PHRASE_FIELDS))
+    parser.add_argument("--summary-sources", default=",".join(DEFAULT_SUMMARY_SOURCES))
+    parser.add_argument("--allow-missing-source-url", action="store_true")
+    parser.add_argument("--allow-ingestion-warnings", action="store_true")
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata applied to every exported review source row. "
+            "Repeat as key=value."
+        ),
+    )
+    parser.add_argument(
+        "--account-id",
+        required=True,
+        help="Tenant/account id used to scope imported opportunities and drafts.",
+    )
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument(
+        "--opportunity-table",
+        default="campaign_opportunities",
+        help="Target opportunity table for import and generation.",
+    )
+    parser.add_argument(
+        "--keep-existing-opportunities",
+        action="store_true",
+        help="Append imported opportunities instead of replacing matching target ids.",
+    )
+    parser.add_argument(
+        "--forbidden-phrase",
+        action="append",
+        default=list(DEFAULT_FORBIDDEN_PHRASES),
+        help="Fail if generated draft bodies contain this phrase. Repeatable.",
+    )
+    parser.add_argument("--output-source-rows", type=Path, default=None)
+    parser.add_argument("--output-result", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--database-url",
+        default=_default_database_url(),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.limit) < 1:
+        raise SystemExit("--limit must be positive")
+    if int(args.min_quote_grade_rows) < 1:
+        raise SystemExit("--min-quote-grade-rows must be positive")
+    if int(args.min_review_text_chars) < 1:
+        raise SystemExit("--min-review-text-chars must be positive")
+    if int(args.phrase_limit) < 1:
+        raise SystemExit("--phrase-limit must be positive")
+    if args.min_drafts is not None and int(args.min_drafts) < 1:
+        raise SystemExit("--min-drafts must be positive")
+    if not _csv_list(args.channels):
+        raise SystemExit("--channels must include at least one channel")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+
+async def _fetch_review_inputs(
+    pool: Any,
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    summary_rows = await fetch_review_source_summary(
+        pool,
+        sources=_csv_list(args.summary_sources),
+        min_review_text_chars=int(args.min_review_text_chars),
+        allowed_polarities=_csv_list(args.polarities),
+        allowed_fields=_csv_list(args.phrase_fields),
+        require_review_url=not bool(args.allow_missing_source_url),
+    )
+    source_summary = _row_for_source(summary_rows, str(args.source))
+    if int(source_summary.get("quote_grade_rows") or 0) < int(args.min_quote_grade_rows):
+        return source_summary, []
+    source_rows = await fetch_review_source_rows(
+        pool,
+        source=str(args.source),
+        vendor_name=args.vendor,
+        limit=int(args.limit),
+        min_review_text_chars=int(args.min_review_text_chars),
+        phrase_limit=int(args.phrase_limit),
+        allowed_polarities=_csv_list(args.polarities),
+        allowed_fields=_csv_list(args.phrase_fields),
+        require_review_url=not bool(args.allow_missing_source_url),
+    )
+    return source_summary, source_rows
+
+
+async def run_review_source_postgres_smoke(
+    args: argparse.Namespace,
+    *,
+    source_rows_path: Path,
+) -> tuple[int, dict[str, Any]]:
+    default_fields = parse_default_fields_or_exit(args.default_field)
+    channels = _csv_list(args.channels)
+    min_drafts = (
+        int(args.min_drafts)
+        if args.min_drafts is not None
+        else int(args.limit) * len(channels)
+    )
+    pool = await _create_pool(str(args.database_url))
+    source_summary: dict[str, Any] = {}
+    source_rows: list[dict[str, Any]] = []
+    ingestion_report: dict[str, Any] | None = None
+    import_result: dict[str, Any] | None = None
+    drafts_result: dict[str, Any] | None = None
+    saved_drafts: list[dict[str, Any]] = []
+    errors: list[str] = []
+    imported_target_ids: list[str] = []
+    try:
+        try:
+            source_summary, source_rows = await _fetch_review_inputs(pool, args)
+            quote_grade_ready = int(source_summary.get("quote_grade_rows") or 0) >= int(
+                args.min_quote_grade_rows
+            )
+            if not quote_grade_ready:
+                errors.append(
+                    "source has fewer quote-grade rows than required: "
+                    f"{source_summary.get('quote_grade_rows', 0)}"
+                )
+            if quote_grade_ready and len(source_rows) < int(args.limit):
+                errors.append(
+                    f"expected {int(args.limit)} exported source row(s), got {len(source_rows)}"
+                )
+
+            if not errors:
+                _write_jsonl(source_rows, source_rows_path)
+                report = inspect_ingestion_file(
+                    source_rows_path,
+                    source_rows=True,
+                    source_format="jsonl",
+                    target_mode=str(args.target_mode),
+                    default_fields=default_fields,
+                )
+                ingestion_report = report.as_dict()
+                if not report.ok:
+                    errors.append("ingestion inspection failed")
+                if report.warnings and not bool(args.allow_ingestion_warnings):
+                    errors.append(
+                        "ingestion inspection produced warnings; provide --default-field "
+                        "bindings or pass --allow-ingestion-warnings"
+                    )
+
+            if not errors:
+                loaded = load_source_campaign_opportunities_from_file(
+                    source_rows_path,
+                    file_format="jsonl",
+                    target_mode=str(args.target_mode),
+                    default_fields=default_fields,
+                )
+                imported = await import_campaign_opportunities(
+                    pool,
+                    loaded.opportunities,
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                    target_mode=str(args.target_mode),
+                    opportunity_table=str(args.opportunity_table),
+                    replace_existing=not bool(args.keep_existing_opportunities),
+                    normalize=False,
+                    warnings=loaded.warnings,
+                    source=loaded.source,
+                )
+                import_result = imported.as_dict()
+                imported_target_ids = list(imported.target_ids)
+                if imported.skipped:
+                    errors.append(f"import skipped {imported.skipped} row(s)")
+                if imported.inserted < int(args.limit):
+                    errors.append(
+                        f"expected {int(args.limit)} imported opportunity row(s), "
+                        f"got {imported.inserted}"
+                    )
+
+            if not errors:
+                drafts_result = await _generate_imported_target_drafts(
+                    pool=pool,
+                    args=args,
+                    channels=channels,
+                    target_ids=imported_target_ids,
+                )
+                saved_drafts = await _fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
+                if drafts_result.get("errors"):
+                    errors.append(
+                        f"generation reported {len(drafts_result.get('errors') or [])} error(s)"
+                    )
+                if int(drafts_result.get("skipped") or 0):
+                    errors.append(f"generation skipped {drafts_result.get('skipped')} draft(s)")
+                errors.extend(
+                    _draft_errors(
+                        {"drafts": saved_drafts},
+                        min_drafts=min_drafts,
+                        forbidden_phrases=args.forbidden_phrase,
+                    )
+                )
+                if int(drafts_result.get("generated") or 0) < min_drafts:
+                    errors.append(
+                        f"expected at least {min_drafts} persisted draft(s), "
+                        f"got {drafts_result.get('generated', 0)}"
+                    )
+                errors.extend(_saved_draft_target_errors(saved_drafts, imported_target_ids))
+        except Exception as exc:  # pragma: no cover - exercised by live host DBs
+            errors.append(f"{type(exc).__name__}: {exc}")
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+
+    payload = {
+        "ok": not errors,
+        "source": str(args.source),
+        "vendor": args.vendor,
+        "source_summary": source_summary,
+        "source_rows": len(source_rows),
+        "source_rows_path": str(source_rows_path),
+        "ingestion": ingestion_report,
+        "import": import_result,
+        "drafts": drafts_result,
+        "saved_drafts": saved_drafts,
+        "errors": errors,
+    }
+    if args.output_result:
+        args.output_result.parent.mkdir(parents=True, exist_ok=True)
+        args.output_result.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+    return (0 if not errors else 1), payload
+
+
+async def _generate_imported_target_drafts(
+    *,
+    pool: Any,
+    args: argparse.Namespace,
+    channels: Sequence[str],
+    target_ids: Sequence[str],
+) -> dict[str, Any]:
+    saved_ids: list[str] = []
+    errors: list[Mapping[str, Any]] = []
+    requested = 0
+    generated = 0
+    skipped = 0
+    reasoning_contexts_used = 0
+    for target_id in target_ids:
+        result = await generate_campaign_drafts_from_postgres(
+            pool,
+            scope={"account_id": args.account_id, "user_id": args.user_id},
+            target_mode=str(args.target_mode),
+            channel=channels[0],
+            channels=tuple(channels),
+            limit=1,
+            filters={"target_id": target_id},
+            llm=DeterministicCampaignLLM(),
+            skills=StaticCampaignSkillStore(),
+            config=CampaignGenerationConfig(channels=tuple(channels), limit=1),
+            opportunity_table=str(args.opportunity_table),
+        )
+        data = result.as_dict()
+        requested += int(data.get("requested") or 0)
+        generated += int(data.get("generated") or 0)
+        skipped += int(data.get("skipped") or 0)
+        reasoning_contexts_used += int(data.get("reasoning_contexts_used") or 0)
+        saved_ids.extend(str(item) for item in data.get("saved_ids") or ())
+        errors.extend(error for error in data.get("errors") or () if isinstance(error, Mapping))
+    return {
+        "requested": requested,
+        "generated": generated,
+        "skipped": skipped,
+        "reasoning_contexts_used": reasoning_contexts_used,
+        "saved_ids": saved_ids,
+        "errors": [dict(error) for error in errors],
+    }
+
+
+async def _fetch_saved_drafts(pool: Any, saved_ids: Sequence[Any]) -> list[dict[str, Any]]:
+    if not isinstance(saved_ids, Sequence) or isinstance(saved_ids, (str, bytes)):
+        return []
+    ids = [str(item) for item in saved_ids if str(item or "").strip()]
+    if not ids:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT id, subject, body, target_mode, channel, metadata
+          FROM b2b_campaigns
+         WHERE id::text = ANY($1::text[])
+        """,
+        ids,
+    )
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        metadata = _metadata_object(_row_value(row, "metadata"))
+        source_opportunity = metadata.get("source_opportunity")
+        if not isinstance(source_opportunity, Mapping):
+            source_opportunity = {}
+        target_id = metadata.get("target_id") or source_opportunity.get("target_id")
+        out.append({
+            "id": str(_row_value(row, "id") or ""),
+            "target_id": str(target_id or ""),
+            "subject": _row_value(row, "subject"),
+            "body": _row_value(row, "body"),
+            "target_mode": _row_value(row, "target_mode"),
+            "channel": _row_value(row, "channel"),
+        })
+    return out
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return row[key]
+
+
+def _metadata_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _saved_draft_target_errors(
+    saved_drafts: Sequence[Mapping[str, Any]],
+    imported_target_ids: Sequence[str],
+) -> list[str]:
+    imported = {str(target_id) for target_id in imported_target_ids}
+    errors: list[str] = []
+    for draft in saved_drafts:
+        target_id = str(draft.get("target_id") or "")
+        if target_id and target_id not in imported:
+            errors.append(f"persisted draft target_id was not imported: {target_id}")
+    return errors
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
+        return
+    if payload.get("ok"):
+        imported = payload.get("import") if isinstance(payload.get("import"), Mapping) else {}
+        drafts = payload.get("drafts") if isinstance(payload.get("drafts"), Mapping) else {}
+        print(
+            "Content Ops review-source Postgres smoke passed: "
+            f"source={payload.get('source')} "
+            f"source_rows={payload.get('source_rows')} "
+            f"imported={imported.get('inserted', 0)} "
+            f"generated={drafts.get('generated', 0)}"
+        )
+        return
+    print("Content Ops review-source Postgres smoke failed:", file=sys.stderr)
+    for error in payload.get("errors") or []:
+        print(f"- {error}", file=sys.stderr)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    _load_dotenv_files()
+    args = _parse_args(argv)
+    _validate_args(args)
+    if args.output_source_rows:
+        code, payload = await run_review_source_postgres_smoke(
+            args,
+            source_rows_path=args.output_source_rows,
+        )
+    else:
+        with tempfile.TemporaryDirectory(prefix="content-ops-review-source-db-") as tmpdir:
+            code, payload = await run_review_source_postgres_smoke(
+                args,
+                source_rows_path=Path(tmpdir) / "review_sources.jsonl",
+            )
+    _print_payload(payload, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -423,8 +423,12 @@ def _saved_draft_target_errors(
     imported = {str(target_id) for target_id in imported_target_ids}
     errors: list[str] = []
     for draft in saved_drafts:
+        draft_id = str(draft.get("id") or "")
         target_id = str(draft.get("target_id") or "")
-        if target_id and target_id not in imported:
+        if not target_id:
+            errors.append(f"persisted draft missing target_id metadata: {draft_id or '<unknown>'}")
+            continue
+        if target_id not in imported:
             errors.append(f"persisted draft target_id was not imported: {target_id}")
     return errors
 

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -423,7 +423,8 @@ def _saved_draft_target_errors(
     imported = {str(target_id) for target_id in imported_target_ids}
     errors: list[str] = []
     for draft in saved_drafts:
-        draft_id = str(draft.get("id") or "")
+        draft_id_value = draft.get("id")
+        draft_id = str(draft_id_value) if draft_id_value is not None else ""
         target_id = str(draft.get("target_id") or "")
         if not target_id:
             errors.append(f"persisted draft missing target_id metadata: {draft_id or '<unknown>'}")

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -425,7 +425,8 @@ def _saved_draft_target_errors(
     for draft in saved_drafts:
         draft_id_value = draft.get("id")
         draft_id = str(draft_id_value) if draft_id_value is not None else ""
-        target_id = str(draft.get("target_id") or "")
+        target_id_value = draft.get("target_id")
+        target_id = str(target_id_value) if target_id_value is not None else ""
         if not target_id:
             errors.append(f"persisted draft missing target_id metadata: {draft_id or '<unknown>'}")
             continue

--- a/tests/test_smoke_content_ops_review_source_postgres.py
+++ b/tests/test_smoke_content_ops_review_source_postgres.py
@@ -356,3 +356,27 @@ async def test_review_source_postgres_smoke_fails_on_wrong_persisted_target(
 
     assert code == 1
     assert any("persisted draft target_id was not imported" in error for error in payload["errors"])
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_fails_on_missing_persisted_target(
+    monkeypatch,
+    tmp_path,
+):
+    row = _saved_draft_row()
+    row["metadata"] = {}
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[row],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("persisted draft missing target_id metadata" in error for error in payload["errors"])

--- a/tests/test_smoke_content_ops_review_source_postgres.py
+++ b/tests/test_smoke_content_ops_review_source_postgres.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_review_source_postgres.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_review_source_postgres",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+class _Pool:
+    def __init__(
+        self,
+        *,
+        summary_rows,
+        source_rows,
+        opportunity_rows=None,
+        saved_draft_rows=None,
+    ):
+        self.summary_rows = list(summary_rows)
+        self.source_rows = list(source_rows)
+        self.opportunity_rows = list(opportunity_rows or [])
+        self.saved_draft_rows = list(saved_draft_rows or [])
+        self.fetch_calls = []
+        self.execute_calls = []
+        self.fetchval_calls = []
+        self.fetchval_results = ["campaign-1", "campaign-2"]
+        self.closed = False
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        call_number = len(self.fetch_calls)
+        if call_number == 1:
+            return self.summary_rows
+        if call_number == 2:
+            return self.source_rows
+        if call_number == 3:
+            return self.opportunity_rows
+        return self.saved_draft_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return "EXECUTE"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+async def _return_pool(pool):
+    return pool
+
+
+def _summary_row(*, quote_grade_rows=3):
+    return {
+        "source": "g2",
+        "total_rows": 10,
+        "canonical_rows": 10,
+        "enriched_rows": 8,
+        "export_candidate_rows": 5,
+        "quote_grade_rows": quote_grade_rows,
+    }
+
+
+def _source_row():
+    return {
+        "id": "review-1",
+        "source": "g2",
+        "source_url": "https://example.test/review-1",
+        "source_review_id": "review-1",
+        "vendor_name": "Slack",
+        "rating": "4.0",
+        "rating_max": "5",
+        "review_text": "Notifications are noisy enough to slow the team down.",
+        "reviewer_title": "Ops Manager",
+        "reviewed_at": "2026-04-01T00:00:00Z",
+        "enrichment": {
+            "urgency_score": 7,
+            "pain_category": ["performance"],
+            "phrase_metadata": [
+                {
+                    "text": "Notifications are noisy enough to slow the team down.",
+                    "field": "specific_complaints",
+                    "polarity": "negative",
+                    "subject": "subject_vendor",
+                    "verbatim": True,
+                    "category_hint": "performance",
+                }
+            ],
+        },
+    }
+
+
+def _opportunity_row():
+    return {
+        "target_id": "review-1",
+        "company_name": "Acme Logistics",
+        "vendor_name": "Slack",
+        "contact_email": "ops@example.com",
+        "contact_name": "Jordan Lee",
+        "pain_points": ["performance"],
+        "evidence": [
+            {
+                "source_id": "review-1",
+                "source_type": "review",
+                "text": "Notifications are noisy enough to slow the team down.",
+            }
+        ],
+        "raw_payload": {
+            "target_id": "review-1",
+            "company_name": "Acme Logistics",
+            "vendor_name": "Slack",
+            "contact_email": "ops@example.com",
+            "source_type": "review",
+        },
+    }
+
+
+def _saved_draft_row(*, body=None):
+    return {
+        "id": "campaign-1",
+        "subject": "Acme Logistics: performance",
+        "body": body
+        or (
+            "<p>Teams evaluating Slack are reporting pain around performance.</p>"
+        ),
+        "target_mode": "vendor_retention",
+        "channel": "email_cold",
+        "metadata": {
+            "target_id": "review-1",
+            "source_opportunity": {
+                "target_id": "review-1",
+            },
+        },
+    }
+
+
+class _GenerationResult:
+    def __init__(self, data):
+        self._data = dict(data)
+
+    def as_dict(self):
+        return dict(self._data)
+
+
+def _args(**overrides):
+    values = {
+        "source": "g2",
+        "vendor": "Slack",
+        "limit": 1,
+        "target_mode": "vendor_retention",
+        "channels": "email_cold",
+        "min_drafts": None,
+        "min_quote_grade_rows": 1,
+        "min_review_text_chars": 80,
+        "phrase_limit": 5,
+        "polarities": ",".join(smoke.DEFAULT_POLARITIES),
+        "phrase_fields": ",".join(smoke.DEFAULT_PHRASE_FIELDS),
+        "summary_sources": ",".join(smoke.DEFAULT_SUMMARY_SOURCES),
+        "allow_missing_source_url": False,
+        "allow_ingestion_warnings": False,
+        "default_field": [
+            "company_name=Acme Logistics",
+            "contact_email=ops@example.com",
+            "contact_name=Jordan Lee",
+        ],
+        "account_id": "acct-smoke",
+        "user_id": None,
+        "opportunity_table": "campaign_opportunities",
+        "keep_existing_opportunities": False,
+        "forbidden_phrase": list(smoke.DEFAULT_FORBIDDEN_PHRASES),
+        "output_source_rows": None,
+        "output_result": None,
+        "json": False,
+        "database_url": "postgres://example",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_imports_and_persists(monkeypatch, tmp_path):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["source_rows"] == 1
+    assert payload["import"]["inserted"] == 1
+    assert payload["import"]["replace_existing"] is True
+    assert payload["drafts"]["generated"] == 1
+    assert payload["saved_drafts"][0]["body"].startswith(
+        "<p>Teams evaluating Slack are reporting pain around"
+    )
+    assert payload["saved_drafts"][0]["target_id"] == "review-1"
+    assert pool.closed is True
+    assert "DELETE FROM \"campaign_opportunities\"" in pool.execute_calls[0]["query"]
+    assert "INSERT INTO \"campaign_opportunities\"" in pool.execute_calls[1]["query"]
+    assert pool.execute_calls[0]["args"] == (
+        "acct-smoke",
+        "vendor_retention",
+        ["review-1"],
+    )
+    assert "INSERT INTO b2b_campaigns" in pool.fetchval_calls[0]["query"]
+    assert "FROM b2b_campaigns" in pool.fetch_calls[-1]["query"]
+    assert pool.fetch_calls[2]["args"] == ("vendor_retention", "acct-smoke", "review-1", 1)
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_can_keep_existing_opportunities(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(keep_existing_opportunities=True),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["import"]["replace_existing"] is False
+    assert all("DELETE FROM" not in call["query"] for call in pool.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_skips_export_error_when_quote_gate_fails(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row(quote_grade_rows=0)],
+        source_rows=[_source_row()],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert payload["source_rows"] == 0
+    assert any("fewer quote-grade rows" in error for error in payload["errors"])
+    assert all("expected 1 exported" not in error for error in payload["errors"])
+    assert pool.execute_calls == []
+    assert pool.fetchval_calls == []
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_fails_on_forbidden_persisted_body(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row(body="<p>Acme appears to be weighing Slack.</p>")],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert any("forbidden phrase" in error for error in payload["errors"])
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_fails_on_generation_errors_and_skips(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    async def generate_with_error(*_args, **_kwargs):
+        return _GenerationResult({
+            "requested": 1,
+            "generated": 1,
+            "skipped": 1,
+            "reasoning_contexts_used": 0,
+            "saved_ids": ["campaign-1"],
+            "errors": [{"target_id": "review-1", "reason": "bad"}],
+        })
+
+    monkeypatch.setattr(smoke, "generate_campaign_drafts_from_postgres", generate_with_error)
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(min_drafts=1),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("generation reported 1 error" in error for error in payload["errors"])
+    assert any("generation skipped 1 draft" in error for error in payload["errors"])
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_fails_on_wrong_persisted_target(
+    monkeypatch,
+    tmp_path,
+):
+    row = _saved_draft_row()
+    row["metadata"] = {"target_id": "other-review"}
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[row],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("persisted draft target_id was not imported" in error for error in payload["errors"])


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md

## Summary
- add an operator smoke for review-source readiness, source-row import, and DB-backed offline campaign draft persistence
- keep imported opportunities repeatable by replacing matching target ids by default
- document the Postgres smoke in README, host runbook, and status

## Verification
- python -m pytest tests/test_smoke_content_ops_review_source_postgres.py -q
- python -m py_compile scripts/smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_review_source_postgres.py
- python scripts/smoke_content_ops_review_source_postgres.py --source g2 --vendor Slack --limit 1 --account-id content_ops_smoke --default-field company_name="Acme Logistics" --default-field contact_email=ops@example.com --default-field contact_name="Jordan Lee" --json (fails cleanly because local host DB is missing campaign_opportunities)
- bash scripts/local_pr_review.sh