### PR TITLE
Preflight review-source Postgres smoke schema

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-18T22:32Z by codex-2026-05-18
+Last updated: 2026-05-19T01:30Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops review-source Postgres smoke | `scripts/smoke_content_ops_review_source_postgres.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Postgres-Smoke.md` | codex-2026-05-18 | Avoid editing the review-source Postgres smoke script, host runbook review-source DB smoke docs, or related tests |
+| pending | Content Ops review-source schema preflight | `scripts/smoke_content_ops_review_source_postgres.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `extracted_content_pipeline/STATUS.md`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `plans/PR-Content-Ops-Review-Source-Schema-Preflight.md` | codex-2026-05-18 | Avoid editing the review-source Postgres smoke script, host runbook review-source DB smoke docs, or related tests |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-18T22:32Z by codex-2026-05-18
+Last updated: 2026-05-19T01:30Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #595 | pending | Add a repeatable review-source Postgres smoke for readiness, source-row import, and DB-backed offline draft persistence. | `scripts/smoke_content_ops_review_source_postgres.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #597 | pending | Add schema preflight to the review-source Postgres smoke so missing extracted migrations fail with an actionable instruction. | `scripts/smoke_content_ops_review_source_postgres.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -185,7 +185,8 @@ python scripts/smoke_content_ops_review_source_generation.py \
 To prove the same source can run through the Postgres-backed path, use the
 database smoke. It imports source rows into `campaign_opportunities` under the
 provided account id, replaces matching imported opportunities by default, and
-persists offline generated drafts:
+persists offline generated drafts. If the required Content Ops tables are not
+present, the smoke fails before import and points at the migration runner:
 
 ```bash
 python scripts/smoke_content_ops_review_source_postgres.py \

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -102,7 +102,9 @@ source of truth for what remains.
 - `scripts/smoke_content_ops_review_source_postgres.py` extends that same
   review-source path through scoped source-row import and DB-backed offline
   campaign draft persistence. It replaces matching imported opportunities by
-  default so repeated smoke runs do not duplicate `campaign_opportunities`.
+  default so repeated smoke runs do not duplicate `campaign_opportunities`,
+  and it preflights required Content Ops tables before import so hosts get a
+  migration-runner instruction instead of a late `UndefinedTableError`.
 - `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
   provide offline readiness reports for opportunity/source-row exports before
   import or generation. The hosted control-surface API also exposes

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -483,7 +483,10 @@ importing.
 For a DB-backed smoke, use the Postgres variant. It imports the exported
 source rows into `campaign_opportunities`, replaces matching imported
 opportunities by default, runs offline draft generation through the product
-Postgres runner, and reports persisted campaign ids:
+Postgres runner, and reports persisted campaign ids. The smoke checks for the
+required `campaign_opportunities` and `b2b_campaigns` tables before import; if
+either is missing, run `scripts/run_extracted_content_pipeline_migrations.py`
+against the same database first:
 
 ```bash
 python scripts/smoke_content_ops_review_source_postgres.py \

--- a/plans/PR-Content-Ops-Review-Source-Schema-Preflight.md
+++ b/plans/PR-Content-Ops-Review-Source-Schema-Preflight.md
@@ -1,0 +1,65 @@
+# PR-Content-Ops-Review-Source-Schema-Preflight
+
+## Why this slice exists
+
+The live G2 review-source Postgres smoke now proves readiness, export, and
+ingestion inspection, but on a host database without extracted Content Ops
+migrations it fails late with `UndefinedTableError` when import reaches
+`campaign_opportunities`. Operators need the smoke to fail before import with
+the migration command to run.
+
+## Scope (this PR)
+
+- Add a schema preflight to `scripts/smoke_content_ops_review_source_postgres.py`.
+- Verify the configured opportunity table and `b2b_campaigns` exist before
+  importing source rows or generating persisted drafts.
+- Add a regression test for a missing `campaign_opportunities` table.
+- Update README, host runbook, status, and coordination docs.
+
+### Files touched
+
+- `scripts/smoke_content_ops_review_source_postgres.py`
+- `tests/test_smoke_content_ops_review_source_postgres.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Source-Schema-Preflight.md`
+
+## Mechanism
+
+The smoke uses `SELECT to_regclass($1)::text` for the configured opportunity
+table and `b2b_campaigns` after source export and ingestion inspection pass.
+If either relation is missing, the smoke returns `ok=false` with an actionable
+`scripts/run_extracted_content_pipeline_migrations.py` instruction and skips
+import/generation.
+
+## Intentional
+
+- Keep migrations explicit; the smoke does not apply schema changes.
+- Preserve the existing success path and target-id validation.
+- Keep the opportunity table configurable through the existing
+  `--opportunity-table` argument.
+
+## Deferred
+
+- Live migration execution on the local Atlas database.
+- A broader host DB readiness command for every generated-asset table.
+- Automatic migration application from the smoke command.
+
+## Verification
+
+- Focused Postgres smoke tests -> `8 passed`.
+- Python compile check for smoke script/tests -> passed.
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Smoke script | 30 |
+| Tests | 36 |
+| Docs/status | 16 |
+| Coordination and plan | 69 |
+| Total | 151 |

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -237,6 +237,9 @@ async def run_review_source_postgres_smoke(
                     )
 
             if not errors:
+                errors.extend(await _schema_readiness_errors(pool, args))
+
+            if not errors:
                 loaded = load_source_campaign_opportunities_from_file(
                     source_rows_path,
                     file_format="jsonl",
@@ -364,6 +367,33 @@ async def _generate_imported_target_drafts(
         "saved_ids": saved_ids,
         "errors": [dict(error) for error in errors],
     }
+
+
+async def _schema_readiness_errors(pool: Any, args: argparse.Namespace) -> list[str]:
+    required_tables = (
+        str(args.opportunity_table),
+        "b2b_campaigns",
+    )
+    missing: list[str] = []
+    for table_name in required_tables:
+        exists = await _relation_exists(pool, table_name)
+        if not exists:
+            missing.append(table_name)
+    if not missing:
+        return []
+    command = (
+        "python scripts/run_extracted_content_pipeline_migrations.py "
+        "--database-url \"$EXTRACTED_DATABASE_URL\""
+    )
+    return [
+        "required Content Ops table(s) missing: "
+        f"{', '.join(missing)}. Run {command} before this smoke."
+    ]
+
+
+async def _relation_exists(pool: Any, table_name: str) -> bool:
+    value = await pool.fetchval("SELECT to_regclass($1)::text", table_name)
+    return bool(value)
 
 
 async def _fetch_saved_drafts(pool: Any, saved_ids: Sequence[Any]) -> list[dict[str, Any]]:

--- a/tests/test_smoke_content_ops_review_source_postgres.py
+++ b/tests/test_smoke_content_ops_review_source_postgres.py
@@ -27,11 +27,15 @@ class _Pool:
         source_rows,
         opportunity_rows=None,
         saved_draft_rows=None,
+        existing_relations=None,
     ):
         self.summary_rows = list(summary_rows)
         self.source_rows = list(source_rows)
         self.opportunity_rows = list(opportunity_rows or [])
         self.saved_draft_rows = list(saved_draft_rows or [])
+        self.existing_relations = set(
+            existing_relations or ("campaign_opportunities", "b2b_campaigns")
+        )
         self.fetch_calls = []
         self.execute_calls = []
         self.fetchval_calls = []
@@ -55,6 +59,8 @@ class _Pool:
 
     async def fetchval(self, query, *args):
         self.fetchval_calls.append({"query": str(query), "args": args})
+        if "to_regclass" in str(query):
+            return args[0] if args and args[0] in self.existing_relations else None
         return self.fetchval_results.pop(0)
 
     async def close(self):
@@ -225,9 +231,37 @@ async def test_review_source_postgres_smoke_imports_and_persists(monkeypatch, tm
         "vendor_retention",
         ["review-1"],
     )
-    assert "INSERT INTO b2b_campaigns" in pool.fetchval_calls[0]["query"]
+    assert any("INSERT INTO b2b_campaigns" in call["query"] for call in pool.fetchval_calls)
     assert "FROM b2b_campaigns" in pool.fetch_calls[-1]["query"]
     assert pool.fetch_calls[2]["args"] == ("vendor_retention", "acct-smoke", "review-1", 1)
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_fails_before_import_when_schema_missing(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        existing_relations={"b2b_campaigns"},
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("required Content Ops table(s) missing" in error for error in payload["errors"])
+    assert any("campaign_opportunities" in error for error in payload["errors"])
+    assert any(
+        "run_extracted_content_pipeline_migrations.py" in error
+        for error in payload["errors"]
+    )
+    assert pool.execute_calls == []
+    assert all("INSERT INTO b2b_campaigns" not in call["query"] for call in pool.fetchval_calls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR-Content-Ops-Review-Source-Schema-Preflight

## Why this slice exists

The live G2 review-source Postgres smoke now proves readiness, export, and
ingestion inspection, but on a host database without extracted Content Ops
migrations it fails late with `UndefinedTableError` when import reaches
`campaign_opportunities`. Operators need the smoke to fail before import with
the migration command to run.

## Scope (this PR)

- Add a schema preflight to `scripts/smoke_content_ops_review_source_postgres.py`.
- Verify the configured opportunity table and `b2b_campaigns` exist before
  importing source rows or generating persisted drafts.
- Add a regression test for a missing `campaign_opportunities` table.
- Update README, host runbook, status, and coordination docs.

### Files touched

- `scripts/smoke_content_ops_review_source_postgres.py`
- `tests/test_smoke_content_ops_review_source_postgres.py`
- `extracted_content_pipeline/README.md`
- `extracted_content_pipeline/docs/host_install_runbook.md`
- `extracted_content_pipeline/STATUS.md`
- `docs/extraction/coordination/inflight.md`
- `docs/extraction/coordination/state.md`
- `plans/PR-Content-Ops-Review-Source-Schema-Preflight.md`

## Mechanism

The smoke uses `SELECT to_regclass($1)::text` for the configured opportunity
table and `b2b_campaigns` after source export and ingestion inspection pass.
If either relation is missing, the smoke returns `ok=false` with an actionable
`scripts/run_extracted_content_pipeline_migrations.py` instruction and skips
import/generation.

## Intentional

- Keep migrations explicit; the smoke does not apply schema changes.
- Preserve the existing success path and target-id validation.
- Keep the opportunity table configurable through the existing
  `--opportunity-table` argument.

## Deferred

- Live migration execution on the local Atlas database.
- A broader host DB readiness command for every generated-asset table.
- Automatic migration application from the smoke command.

## Verification

- Focused Postgres smoke tests -> `8 passed`.
- Python compile check for smoke script/tests -> passed.
- `git diff --check` -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Smoke script | 30 |
| Tests | 36 |
| Docs/status | 16 |
| Coordination and plan | 69 |
| Total | 151 |
