### PR TITLE
Add OAuth mode for read-only invoicing MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,10 @@ ATLAS_TOOLS_CALENDAR_REFRESH_TOKEN=your_refresh_token
 ATLAS_MCP_TRANSPORT=stdio            # stdio (Claude Desktop/Cursor) or sse (HTTP)
 ATLAS_MCP_HOST=0.0.0.0              # Bind host for SSE mode
 ATLAS_MCP_AUTH_TOKEN=                # Bearer token for SSE mode; required for invoicing-readonly HTTP
+ATLAS_MCP_INVOICING_READONLY_AUTH_MODE=bearer  # bearer (direct clients) or oauth (ChatGPT)
+ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL=
+ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL=
+ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=
 ATLAS_MCP_CRM_ENABLED=true          # Enable/disable individual servers
 ATLAS_MCP_EMAIL_ENABLED=true
 ATLAS_MCP_TWILIO_ENABLED=true
@@ -512,6 +516,13 @@ python -m atlas_brain.mcp.invoicing_readonly_server
 # SSE HTTP mode (port 8065, requires ATLAS_MCP_AUTH_TOKEN)
 ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.invoicing_readonly_server --sse
 
+# ChatGPT-compatible OAuth mode
+ATLAS_MCP_INVOICING_READONLY_AUTH_MODE=oauth \
+ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL=https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly \
+ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL=https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp \
+ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=<long-operator-token> \
+python -m atlas_brain.mcp.invoicing_readonly_server --sse
+
 # connector boundary smoke (auth + exact read-only tool list; no invoice reads)
 python scripts/check_invoicing_readonly_mcp_connector.py \
   --url http://127.0.0.1:8065/mcp \
@@ -532,6 +543,15 @@ Do not use placeholder or session-local tokens such as `test-token` or
 `test-readonly-token` for public HTTP exposure. Generate a long random token,
 start the server with that value, then run the connector boundary smoke above
 before attaching a ChatGPT-style connector.
+
+ChatGPT online should use OAuth mode, not raw bearer mode. OAuth mode adds MCP
+authorization-server metadata, protected-resource metadata, dynamic client
+registration, and an operator approval page at `/oauth/approve`. The approval
+page requires `ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN`, so the
+connector is not silently auto-approved. Because the current public URL is
+path-prefixed under `/invoicing-readonly`, the OAuth `/.well-known/...`
+metadata routes may require an additional Tailscale serve route or a dedicated
+hostname before ChatGPT can discover the OAuth server.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/atlas_brain/mcp/invoicing_readonly_oauth.py
+++ b/atlas_brain/mcp/invoicing_readonly_oauth.py
@@ -1,0 +1,289 @@
+"""OAuth support for the read-only invoicing MCP server.
+
+The provider is intentionally small and process-local. It exists to let
+ChatGPT-style remote MCP clients complete a standard OAuth authorization-code
+flow without exposing mutating invoice tools or accepting anonymous access.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass
+from html import escape
+from typing import Any
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    AuthorizeError,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+    TokenError,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyHttpUrl
+from starlette.datastructures import FormData
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, Response
+
+
+DEFAULT_READONLY_SCOPE = "invoices.read"
+
+
+@dataclass(frozen=True)
+class PendingAuthorization:
+    request_id: str
+    client_id: str
+    params: AuthorizationParams
+    scopes: list[str]
+    expires_at: float
+
+
+class InvoicingReadonlyOAuthProvider(
+    OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]
+):
+    """Single-operator in-memory OAuth provider for read-only invoice access."""
+
+    def __init__(
+        self,
+        *,
+        issuer_url: str,
+        approval_token: str,
+        scopes: list[str] | None = None,
+        authorization_ttl_seconds: int = 300,
+        access_token_ttl_seconds: int = 3600,
+    ) -> None:
+        self.issuer_url = issuer_url.rstrip("/")
+        self.approval_token = approval_token
+        self.scopes = scopes or [DEFAULT_READONLY_SCOPE]
+        self.authorization_ttl_seconds = authorization_ttl_seconds
+        self.access_token_ttl_seconds = access_token_ttl_seconds
+
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+        self._pending: dict[str, PendingAuthorization] = {}
+        self._authorization_codes: dict[str, AuthorizationCode] = {}
+        self._refresh_tokens: dict[str, RefreshToken] = {}
+        self._access_tokens: dict[str, AccessToken] = {}
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        if not client_info.client_id:  # pragma: no cover - registration handler sets this
+            client_info.client_id = secrets.token_urlsafe(24)
+        self._clients[client_info.client_id] = client_info
+
+    async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
+        if not client.client_id:
+            raise AuthorizeError("invalid_request", "client_id is required")
+
+        scopes = params.scopes or list(self.scopes)
+        for scope in scopes:
+            if scope not in self.scopes:
+                raise AuthorizeError("invalid_scope", f"Unsupported scope: {scope}")
+
+        request_id = secrets.token_urlsafe(24)
+        self._pending[request_id] = PendingAuthorization(
+            request_id=request_id,
+            client_id=client.client_id,
+            params=params,
+            scopes=scopes,
+            expires_at=time.time() + self.authorization_ttl_seconds,
+        )
+        return f"{self.issuer_url}/oauth/approve?request_id={request_id}"
+
+    async def load_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: str,
+    ) -> AuthorizationCode | None:
+        code = self._authorization_codes.get(authorization_code)
+        if code is None or code.client_id != client.client_id:
+            return None
+        return code
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        if not client.client_id:
+            raise TokenError("invalid_client", "client_id is required")
+
+        self._authorization_codes.pop(authorization_code.code, None)
+        access_token = secrets.token_urlsafe(32)
+        refresh_token = secrets.token_urlsafe(32)
+        expires_at = int(time.time()) + self.access_token_ttl_seconds
+
+        self._access_tokens[access_token] = AccessToken(
+            token=access_token,
+            client_id=client.client_id,
+            scopes=authorization_code.scopes,
+            expires_at=expires_at,
+            resource=authorization_code.resource,
+        )
+        self._refresh_tokens[refresh_token] = RefreshToken(
+            token=refresh_token,
+            client_id=client.client_id,
+            scopes=authorization_code.scopes,
+        )
+        return OAuthToken(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in=self.access_token_ttl_seconds,
+            scope=" ".join(authorization_code.scopes),
+        )
+
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        token = self._refresh_tokens.get(refresh_token)
+        if token is None or token.client_id != client.client_id:
+            return None
+        return token
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        if not client.client_id:
+            raise TokenError("invalid_client", "client_id is required")
+        if refresh_token.client_id != client.client_id:
+            raise TokenError("invalid_grant", "refresh token does not belong to client")
+        if not scopes:
+            scopes = refresh_token.scopes
+        if any(scope not in refresh_token.scopes for scope in scopes):
+            raise TokenError("invalid_scope", "Requested scope was not granted")
+
+        access_token = secrets.token_urlsafe(32)
+        expires_at = int(time.time()) + self.access_token_ttl_seconds
+        self._access_tokens[access_token] = AccessToken(
+            token=access_token,
+            client_id=client.client_id,
+            scopes=scopes,
+            expires_at=expires_at,
+        )
+        return OAuthToken(
+            access_token=access_token,
+            refresh_token=refresh_token.token,
+            expires_in=self.access_token_ttl_seconds,
+            scope=" ".join(scopes),
+        )
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        return self._access_tokens.get(token)
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        self._access_tokens.pop(token.token, None)
+        self._refresh_tokens.pop(token.token, None)
+
+    def approve_pending_authorization(self, *, request_id: str, approval_token: str) -> str:
+        """Approve a pending authorization request and return the redirect URI."""
+        if not secrets.compare_digest(approval_token, self.approval_token):
+            raise PermissionError("Invalid approval token")
+
+        pending = self._pending.pop(request_id, None)
+        if pending is None:
+            raise KeyError("Authorization request not found")
+        if pending.expires_at < time.time():
+            raise TimeoutError("Authorization request expired")
+
+        code = secrets.token_urlsafe(32)
+        self._authorization_codes[code] = AuthorizationCode(
+            code=code,
+            scopes=pending.scopes,
+            expires_at=time.time() + self.authorization_ttl_seconds,
+            client_id=pending.client_id,
+            code_challenge=pending.params.code_challenge,
+            redirect_uri=pending.params.redirect_uri,
+            redirect_uri_provided_explicitly=pending.params.redirect_uri_provided_explicitly,
+            resource=pending.params.resource,
+        )
+        return construct_redirect_uri(str(pending.params.redirect_uri), code=code, state=pending.params.state)
+
+    def pending_authorization(self, request_id: str) -> PendingAuthorization | None:
+        return self._pending.get(request_id)
+
+
+def approval_page(
+    provider: InvoicingReadonlyOAuthProvider,
+    request_id: str,
+    *,
+    form_action: str = "",
+) -> Response:
+    pending = provider.pending_authorization(request_id)
+    if pending is None:
+        return HTMLResponse("<h1>Authorization request not found</h1>", status_code=404)
+    if pending.expires_at < time.time():
+        return HTMLResponse("<h1>Authorization request expired</h1>", status_code=410)
+
+    client = escape(pending.client_id)
+    scopes = escape(", ".join(pending.scopes))
+    request_value = escape(request_id)
+    action_value = escape(form_action, quote=True)
+    return HTMLResponse(
+        f"""
+<!doctype html>
+<html>
+  <head><title>Approve Atlas Invoicing Connector</title></head>
+  <body>
+    <h1>Approve Atlas read-only invoicing access</h1>
+    <p>Client: <code>{client}</code></p>
+    <p>Scopes: <code>{scopes}</code></p>
+    <p>This grants read-only invoice review tools. It does not grant invoice creation, sending, payment recording, voiding, or service mutation tools.</p>
+    <form method="post" action="{action_value}">
+      <input type="hidden" name="request_id" value="{request_value}" />
+      <label>Approval token <input name="approval_token" type="password" /></label>
+      <button type="submit">Approve connector</button>
+    </form>
+  </body>
+</html>
+""".strip()
+    )
+
+
+async def handle_approval_request(provider: InvoicingReadonlyOAuthProvider, request: Request) -> Response:
+    """Handle GET/POST requests for the operator approval page."""
+    if request.method == "GET":
+        request_id = request.query_params.get("request_id", "")
+        return approval_page(provider, request_id, form_action=request.scope.get("root_path", "") + request.url.path)
+
+    form: FormData = await request.form()
+    request_id = str(form.get("request_id") or "")
+    approval_token = str(form.get("approval_token") or "")
+    try:
+        redirect_uri = provider.approve_pending_authorization(
+            request_id=request_id,
+            approval_token=approval_token,
+        )
+    except PermissionError:
+        return HTMLResponse("<h1>Invalid approval token</h1>", status_code=403)
+    except KeyError:
+        return HTMLResponse("<h1>Authorization request not found</h1>", status_code=404)
+    except TimeoutError:
+        return HTMLResponse("<h1>Authorization request expired</h1>", status_code=410)
+    return RedirectResponse(redirect_uri, status_code=302)
+
+
+def validate_oauth_settings(*, issuer_url: str, resource_server_url: str, approval_token: str) -> None:
+    """Fail fast on missing OAuth settings before exposing financial data."""
+    if not issuer_url.strip():
+        raise RuntimeError("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL is required in oauth mode")
+    if not resource_server_url.strip():
+        raise RuntimeError("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL is required in oauth mode")
+    if len(approval_token.strip()) < 24:
+        raise RuntimeError(
+            "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN must be at least 24 characters in oauth mode"
+        )
+
+
+def as_any_http_url(value: str) -> AnyHttpUrl:
+    """Validate a string URL for MCP auth settings."""
+    return AnyHttpUrl(value)

--- a/atlas_brain/mcp/invoicing_readonly_server.py
+++ b/atlas_brain/mcp/invoicing_readonly_server.py
@@ -21,10 +21,19 @@ from typing import Optional
 from mcp.server.fastmcp import FastMCP
 
 from . import invoicing_server as _full
+from .invoicing_readonly_oauth import (
+    DEFAULT_READONLY_SCOPE,
+    InvoicingReadonlyOAuthProvider,
+    as_any_http_url,
+    handle_approval_request,
+    validate_oauth_settings,
+)
 from ..config_defaults import DEFAULT_INVOICING_READONLY_PORT, DEFAULT_MCP_HOST
 
 logger = logging.getLogger("atlas.mcp.invoicing.readonly")
 
+_AUTH_MODE_BEARER = "bearer"
+_AUTH_MODE_OAUTH = "oauth"
 _MIN_HTTP_AUTH_TOKEN_LENGTH = 24
 _PLACEHOLDER_HTTP_AUTH_TOKENS = {
     "<token>",
@@ -36,6 +45,7 @@ _PLACEHOLDER_HTTP_AUTH_TOKENS = {
     "test-token",
     "token",
 }
+_oauth_provider: InvoicingReadonlyOAuthProvider | None = None
 
 
 @asynccontextmanager
@@ -59,6 +69,16 @@ mcp = FastMCP(
     ),
     lifespan=_lifespan,
 )
+
+
+@mcp.custom_route("/oauth/approve", methods=["GET", "POST"], include_in_schema=False)
+async def _oauth_approve(request):
+    """Operator approval page for ChatGPT-style OAuth connectors."""
+    if _oauth_provider is None:
+        from starlette.responses import HTMLResponse
+
+        return HTMLResponse("<h1>OAuth mode is not enabled</h1>", status_code=404)
+    return await handle_approval_request(_oauth_provider, request)
 
 
 @mcp.tool()
@@ -158,8 +178,21 @@ def _streamable_http_app():
     """Build the authenticated streamable HTTP app for read-only tools."""
     from .auth import apply_auth_middleware
 
+    if _http_auth_mode() == _AUTH_MODE_OAUTH:
+        _configure_oauth_auth()
+        return mcp.streamable_http_app()
+
     _require_http_auth_token()
     return apply_auth_middleware(mcp.streamable_http_app())
+
+
+def _http_auth_mode() -> str:
+    mode = os.environ.get("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", _AUTH_MODE_BEARER).strip().lower()
+    if mode not in {_AUTH_MODE_BEARER, _AUTH_MODE_OAUTH}:
+        raise RuntimeError(
+            "ATLAS_MCP_INVOICING_READONLY_AUTH_MODE must be either 'bearer' or 'oauth'"
+        )
+    return mode
 
 
 def _require_http_auth_token() -> str:
@@ -181,6 +214,46 @@ def _require_http_auth_token() -> str:
             f"{_MIN_HTTP_AUTH_TOKEN_LENGTH} characters for read-only invoicing HTTP mode."
         )
     return token
+
+
+def _configure_oauth_auth() -> InvoicingReadonlyOAuthProvider:
+    """Configure FastMCP's built-in OAuth auth for ChatGPT connectors."""
+    global _oauth_provider
+
+    if _oauth_provider is not None:
+        return _oauth_provider
+
+    from mcp.server.auth.provider import ProviderTokenVerifier
+    from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
+
+    issuer_url = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", "").strip()
+    resource_url = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", "").strip()
+    approval_token = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN", "").strip()
+    validate_oauth_settings(
+        issuer_url=issuer_url,
+        resource_server_url=resource_url,
+        approval_token=approval_token,
+    )
+
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url=issuer_url,
+        approval_token=approval_token,
+        scopes=[DEFAULT_READONLY_SCOPE],
+    )
+    mcp.settings.auth = AuthSettings(
+        issuer_url=as_any_http_url(issuer_url),
+        resource_server_url=as_any_http_url(resource_url),
+        required_scopes=[DEFAULT_READONLY_SCOPE],
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=[DEFAULT_READONLY_SCOPE],
+            default_scopes=[DEFAULT_READONLY_SCOPE],
+        ),
+    )
+    mcp._auth_server_provider = provider
+    mcp._token_verifier = ProviderTokenVerifier(provider)
+    _oauth_provider = provider
+    return provider
 
 
 if __name__ == "__main__":

--- a/plans/PR-Invoicing-Readonly-ChatGPT-OAuth.md
+++ b/plans/PR-Invoicing-Readonly-ChatGPT-OAuth.md
@@ -1,0 +1,62 @@
+## Why this slice exists
+
+The read-only invoicing MCP endpoint works with direct MCP clients that can send a static `Authorization: Bearer ...` header, but ChatGPT online did not connect. The likely mismatch is authentication: ChatGPT custom MCP connectors expect OAuth or no auth, while the current read-only server requires a raw bearer token before discovery.
+
+This slice adds a library-backed OAuth mode for the read-only invoicing MCP server while preserving the existing bearer-token mode.
+
+## Scope (this PR)
+
+1. Add a minimal single-operator OAuth provider for the read-only invoicing MCP server.
+2. Wire `ATLAS_MCP_INVOICING_READONLY_AUTH_MODE=oauth` to FastMCP's built-in OAuth/resource-server auth routes.
+3. Keep `bearer` mode as the default for existing direct clients.
+4. Add focused tests for OAuth provider registration, authorization-code exchange, approval-token enforcement, and server auth-mode wiring.
+5. Document the ChatGPT OAuth environment variables and the remaining public-route requirement.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_readonly_oauth.py`
+- `atlas_brain/mcp/invoicing_readonly_server.py`
+- `tests/test_invoicing_readonly_oauth.py`
+- `CLAUDE.md`
+- `plans/PR-Invoicing-Readonly-ChatGPT-OAuth.md`
+
+## Mechanism
+
+`invoicing_readonly_oauth.py` implements the MCP package's `OAuthAuthorizationServerProvider` protocol with in-memory client, authorization-code, refresh-token, and access-token stores. The provider supports dynamic client registration, PKCE authorization-code exchange through the MCP library's token handler, and a local approval page that requires `ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN`.
+
+When `ATLAS_MCP_INVOICING_READONLY_AUTH_MODE=oauth`, `_streamable_http_app()` configures the existing `FastMCP` instance with `AuthSettings`, `ClientRegistrationOptions`, the provider, and `ProviderTokenVerifier`, then returns the library-authenticated Streamable HTTP app. In bearer mode, the existing static-token middleware remains unchanged.
+
+## Intentional
+
+- OAuth mode uses in-memory state. This is enough for a single hosted connector process; persistence/rotation can be added later if needed.
+- The approval step is not auto-approved. Someone who discovers the URL still needs the operator approval token to complete OAuth.
+- This does not expose mutating invoicing tools. The underlying MCP tool surface stays the eight read-only tools from PR #590.
+
+## Deferred
+
+- Durable OAuth client/token persistence is deferred until this needs multi-process or restart-resilient connector sessions.
+- A dedicated public hostname or extra Tailscale route for OAuth `/.well-known/...` metadata may be required operationally because the current MCP URL is path-prefixed under `/invoicing-readonly`.
+
+## Verification
+
+Commands run:
+
+```bash
+.venv/bin/python -m py_compile atlas_brain/mcp/invoicing_readonly_oauth.py atlas_brain/mcp/invoicing_readonly_server.py
+.venv/bin/python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_check_invoicing_readonly_mcp_connector.py
+bash scripts/local_pr_review.sh --allow-dirty
+```
+
+Focused pytest result: 23 passed.
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| OAuth provider | ~275 |
+| Server wiring/docs | ~80 |
+| Tests | ~265 |
+| Plan | ~70 |
+| **Total** | **~710** |
+
+This is over the 400 LOC soft target because OAuth support needs a protocol provider plus tests; splitting the provider from server wiring would leave no runnable ChatGPT path.

--- a/tests/test_invoicing_readonly_oauth.py
+++ b/tests/test_invoicing_readonly_oauth.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from atlas_brain.mcp import invoicing_readonly_server as readonly
+from atlas_brain.mcp.invoicing_readonly_oauth import (
+    DEFAULT_READONLY_SCOPE,
+    InvoicingReadonlyOAuthProvider,
+    validate_oauth_settings,
+)
+from mcp.server.auth.provider import AuthorizationParams, TokenError
+from mcp.shared.auth import OAuthClientInformationFull
+
+
+def _client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="client-1",
+        client_secret="secret-1",
+        redirect_uris=["https://chat.openai.com/aip/callback"],
+        token_endpoint_auth_method="client_secret_post",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=DEFAULT_READONLY_SCOPE,
+    )
+
+
+def _other_client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="client-2",
+        client_secret="secret-2",
+        redirect_uris=["https://chat.openai.com/aip/callback"],
+        token_endpoint_auth_method="client_secret_post",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=DEFAULT_READONLY_SCOPE,
+    )
+
+
+def _params() -> AuthorizationParams:
+    return AuthorizationParams(
+        state="state-1",
+        scopes=None,
+        code_challenge=_challenge("verifier-1"),
+        redirect_uri="https://chat.openai.com/aip/callback",
+        redirect_uri_provided_explicitly=True,
+        resource="https://atlas.example.com/invoicing-readonly/mcp",
+    )
+
+
+def _challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def _reset_readonly_auth_state() -> None:
+    readonly._oauth_provider = None
+    readonly.mcp.settings.auth = None
+    readonly.mcp._auth_server_provider = None
+    readonly.mcp._token_verifier = None
+    readonly.mcp._session_manager = None
+
+
+@pytest.fixture(autouse=True)
+def reset_readonly_auth_state():
+    _reset_readonly_auth_state()
+    yield
+    _reset_readonly_auth_state()
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_requires_operator_approval_before_token_exchange():
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    await provider.register_client(client)
+
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+
+    with pytest.raises(PermissionError):
+        provider.approve_pending_authorization(
+            request_id=request_id,
+            approval_token="wrong-token",
+        )
+
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    token = await provider.exchange_authorization_code(client, auth_code)
+
+    assert token.token_type == "Bearer"
+    assert token.scope == DEFAULT_READONLY_SCOPE
+    access = await provider.load_access_token(token.access_token)
+    assert access is not None
+    assert access.scopes == [DEFAULT_READONLY_SCOPE]
+    assert access.resource == "https://atlas.example.com/invoicing-readonly/mcp"
+    assert await provider.load_authorization_code(client, code) is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_binds_authorization_codes_to_client():
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    other_client = _other_client()
+    await provider.register_client(client)
+    await provider.register_client(other_client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+
+    assert await provider.load_authorization_code(other_client, code) is None
+    assert await provider.load_authorization_code(client, code) is not None
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_refresh_token_issues_new_access_token():
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    await provider.register_client(client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    first_token = await provider.exchange_authorization_code(client, auth_code)
+    assert first_token.refresh_token is not None
+
+    refresh = await provider.load_refresh_token(client, first_token.refresh_token)
+    assert refresh is not None
+    second_token = await provider.exchange_refresh_token(client, refresh, [DEFAULT_READONLY_SCOPE])
+
+    assert second_token.access_token != first_token.access_token
+    assert second_token.refresh_token == first_token.refresh_token
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_binds_refresh_tokens_to_client():
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    other_client = _other_client()
+    await provider.register_client(client)
+    await provider.register_client(other_client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    token = await provider.exchange_authorization_code(client, auth_code)
+    assert token.refresh_token is not None
+
+    assert await provider.load_refresh_token(other_client, token.refresh_token) is None
+    refresh = await provider.load_refresh_token(client, token.refresh_token)
+    assert refresh is not None
+
+    with pytest.raises(TokenError, match="refresh token does not belong to client"):
+        await provider.exchange_refresh_token(other_client, refresh, [DEFAULT_READONLY_SCOPE])
+
+
+def test_validate_oauth_settings_requires_approval_token():
+    with pytest.raises(RuntimeError, match="OAUTH_APPROVAL_TOKEN"):
+        validate_oauth_settings(
+            issuer_url="https://atlas.example.com/invoicing-readonly",
+            resource_server_url="https://atlas.example.com/invoicing-readonly/mcp",
+            approval_token="short",
+        )
+
+
+def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", "oauth")
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL",
+        "https://atlas.example.com/invoicing-readonly",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL",
+        "https://atlas.example.com/invoicing-readonly/mcp",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN",
+        "approval-token-with-enough-entropy",
+    )
+
+    app = readonly._streamable_http_app()
+
+    with TestClient(app) as client:
+        auth_metadata = client.get("/.well-known/oauth-authorization-server")
+        assert auth_metadata.status_code == 200
+        assert auth_metadata.json()["registration_endpoint"] == (
+            "https://atlas.example.com/invoicing-readonly/register"
+        )
+
+        resource_metadata = client.get(
+            "/.well-known/oauth-protected-resource/invoicing-readonly/mcp"
+        )
+        assert resource_metadata.status_code == 200
+        assert resource_metadata.json()["resource"] == (
+            "https://atlas.example.com/invoicing-readonly/mcp"
+        )
+
+        response = client.get("/mcp")
+        assert response.status_code == 401
+        assert "resource_metadata=" in response.headers["www-authenticate"]
+
+
+def test_approval_page_uses_current_request_path_for_prefixed_mount(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", "oauth")
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL",
+        "https://atlas.example.com/invoicing-readonly",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL",
+        "https://atlas.example.com/invoicing-readonly/mcp",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN",
+        "approval-token-with-enough-entropy",
+    )
+
+    app = readonly._streamable_http_app()
+    provider = readonly._oauth_provider
+    assert provider is not None
+    pending = type(
+        "Pending",
+        (),
+        {
+            "client_id": "client-1",
+            "scopes": [DEFAULT_READONLY_SCOPE],
+            "expires_at": 9999999999,
+        },
+    )()
+    provider._pending["request-1"] = pending  # type: ignore[assignment]
+
+    with TestClient(app, root_path="/invoicing-readonly") as client:
+        response = client.get("/oauth/approve?request_id=request-1")
+
+    assert response.status_code == 200
+    assert 'action="/invoicing-readonly/oauth/approve"' in response.text
+
+
+def test_streamable_http_app_rejects_invalid_auth_mode(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", "open")
+
+    with pytest.raises(RuntimeError, match="AUTH_MODE"):
+        readonly._streamable_http_app()


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Readonly-ChatGPT-OAuth.md

ChatGPT online could not connect to the read-only invoicing MCP endpoint because the current server only supports raw bearer-header auth. This adds a ChatGPT-compatible OAuth mode using the MCP library's auth routes while preserving bearer mode for direct clients.

## Intentional
- OAuth state is in-memory for the single hosted connector process.
- The authorization step requires an operator approval token and does not auto-approve unknown clients.
- The tool surface remains the eight read-only invoicing tools only.

## Deferred
- Durable OAuth client/token persistence is deferred until multi-process or restart-resilient connector sessions are needed.
- Public OAuth metadata routing may need a Tailscale serve route or dedicated hostname because the current MCP URL is path-prefixed under /invoicing-readonly.

## Verification
- .venv/bin/python -m py_compile atlas_brain/mcp/invoicing_readonly_oauth.py atlas_brain/mcp/invoicing_readonly_server.py
- .venv/bin/python -m pytest tests/test_invoicing_readonly_mcp.py tests/test_invoicing_readonly_oauth.py tests/test_check_invoicing_readonly_mcp_connector.py -> 20 passed
- bash scripts/local_pr_review.sh
- git diff --check

## Diff size
5 files, +608 / -0. Over the 400 LOC soft cap because OAuth requires a protocol provider plus tests; splitting provider from server wiring would leave no runnable ChatGPT path.